### PR TITLE
Fix ORDER BY and UNION after upgrade to optiq-0.4.9.

### DIFF
--- a/sandbox/prototype/sqlparser/src/main/java/org/apache/drill/optiq/DrillSortRule.java
+++ b/sandbox/prototype/sqlparser/src/main/java/org/apache/drill/optiq/DrillSortRule.java
@@ -33,10 +33,11 @@ public class DrillSortRule extends RelOptRule {
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    final SortRel sort = (SortRel) call.rel(0);
+    final SortRel sort = call.rel(0);
     final RelNode input = call.rel(1);
     final RelTraitSet traits = sort.getTraitSet().plus(DrillRel.CONVENTION);
-    final RelNode convertedInput = convert(input, traits);
+    final RelTraitSet inputTraits = input.getTraitSet().plus(DrillRel.CONVENTION);
+    final RelNode convertedInput = convert(input, inputTraits);
     call.transformTo(new DrillSortRel(sort.getCluster(), traits, convertedInput, sort.getCollation()));
   }
 }

--- a/sandbox/prototype/sqlparser/src/main/java/org/apache/drill/optiq/DrillUnionRel.java
+++ b/sandbox/prototype/sqlparser/src/main/java/org/apache/drill/optiq/DrillUnionRel.java
@@ -22,8 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.hydromatic.linq4j.Ord;
 import org.eigenbase.rel.UnionRelBase;
 import org.eigenbase.rel.RelNode;
-import org.eigenbase.relopt.RelOptCluster;
-import org.eigenbase.relopt.RelTraitSet;
+import org.eigenbase.relopt.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +44,12 @@ public class DrillUnionRel extends UnionRelBase implements DrillRel {
   }
 
   @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner) {
+    // divide cost by two to ensure cheaper than EnumerableDrillRel
+    return super.computeSelfCost(planner).multiplyBy(.5);
+  }
+
+  @Override
   public int implement(DrillImplementor implementor) {
     List<Integer> inputIds = new ArrayList<>();
     for (Ord<RelNode> input : Ord.zip(inputs)) {
@@ -54,8 +59,8 @@ public class DrillUnionRel extends UnionRelBase implements DrillRel {
     E.g. {
       op: "union",
       distinct: true,
-	    inputs: [2, 4]
-	  }
+	  inputs: [2, 4]
+	}
 */
     final ObjectNode union = implementor.mapper.createObjectNode();
     union.put("op", "union");


### PR DESCRIPTION
ORDER BY ... DESC is still broken. Nulls should appear first.
