### PR TITLE
DRILL-444: Support using (NOT) LIKE and (NOT) SIMILAR TO in SQL queries

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -20,10 +20,6 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import io.netty.buffer.ByteBuf;
 
-import org.apache.drill.common.expression.OutputTypeDeterminer;
-import org.apache.drill.common.types.TypeProtos;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
@@ -33,11 +29,8 @@ import org.apache.drill.exec.expr.annotations.Param;
 import org.apache.drill.exec.expr.annotations.Workspace;
 import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.BitHolder;
-import org.apache.drill.exec.expr.holders.VarBinaryHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 import org.apache.drill.exec.record.RecordBatch;
-
-import com.fasterxml.jackson.databind.ser.std.NumberSerializers.IntegerSerializer;
 
 public class StringFunctions{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StringFunctions.class);
@@ -65,7 +58,7 @@ public class StringFunctions{
     }
   }
 
-  @FunctionTemplate(name = "similar", scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
+  @FunctionTemplate(names = {"similar", "similar to"}, scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
   public static class Similar implements DrillSimpleFunc{    
     @Param VarCharHolder input;
     @Param(constant=true) VarCharHolder pattern;

--- a/sqlparser/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
+++ b/sqlparser/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
@@ -59,9 +59,12 @@ public class JdbcAssert {
   public static ModelAndSchema withFull(String schema) {
     final Properties info = new Properties();
     info.setProperty("schema", schema);
-    return new ModelAndSchema(info, false);
+    return new ModelAndSchema(info);
   }
 
+  public static ModelAndSchema withNoDefaultSchema() {
+    return new ModelAndSchema();
+  }
 
   static String toString(ResultSet resultSet, int expectedRecordCount) throws SQLException {
     StringBuilder buf = new StringBuilder();
@@ -122,11 +125,11 @@ public class JdbcAssert {
     private final Properties info;
     private final ConnectionFactory connectionFactory;
 
-    public ModelAndSchema(Properties info) {
-      this(info, true);
+    public ModelAndSchema() {
+      this(null);
     }
 
-    public ModelAndSchema(Properties info, final boolean ref) {
+    public ModelAndSchema(Properties info) {
       this.info = info;
       this.connectionFactory = new ConnectionFactory() {
         public Connection createConnection() throws Exception {

--- a/sqlparser/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
+++ b/sqlparser/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
@@ -155,7 +155,28 @@ public class TestJdbcQuery {
     }finally{
       if(!success) Thread.sleep(2000);
     }
-    
-    
+  }
+
+  @Test
+  public void testLikeNotLike() throws Exception{
+    JdbcAssert.withNoDefaultSchema()
+      .sql("SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+        "WHERE TABLE_NAME NOT LIKE 'C%' AND COLUMN_NAME LIKE 'TABLE_%E'")
+      .returns(
+        "TABLE_NAME=VIEWS; COLUMN_NAME=TABLE_NAME\n" +
+        "TABLE_NAME=TABLES; COLUMN_NAME=TABLE_NAME\n" +
+        "TABLE_NAME=TABLES; COLUMN_NAME=TABLE_TYPE\n"
+      );
+  }
+
+  @Test
+  public void testSimilarNotSimilar() throws Exception{
+    JdbcAssert.withNoDefaultSchema()
+      .sql("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.`TABLES` "+
+        "WHERE TABLE_NAME SIMILAR TO '%(H|I)E%' AND TABLE_NAME NOT SIMILAR TO 'C%'")
+      .returns(
+        "TABLE_NAME=VIEWS\n" +
+        "TABLE_NAME=SCHEMATA\n"
+      );
   }
 }


### PR DESCRIPTION
Adds support for LIKE and SIMILAR TO. There are more that needs to be supported in Optiq to Drill conversion (tracking JIRAs DRILL-437 and DRILL-439)
