### PR TITLE
DRILL-451 Throw runtime exception when json reader encounters parse exception

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -159,6 +159,7 @@ public class JSONRecordReader implements RecordReader {
 
     } catch (IOException | SchemaChangeException e) {
       logger.error("Error reading next in Json reader", e);
+      throw new DrillRuntimeException(e);
     }
 
     for (VectorHolder holder : valueVectorMap.values()) {


### PR DESCRIPTION
This change is to throw an exception when the json reader catches a JsonParseException. Previously we were simply logging an error.

In the future, we should consider adding support for skipping malformed records, but for now we should simply throw an exception.
