### PR TITLE
DRILL-475: TestJdbcQuery fails on Windows due to resource leak

### DIFF
--- a/sqlparser/pom.xml
+++ b/sqlparser/pom.xml
@@ -79,6 +79,13 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <inherited>true</inherited>


### PR DESCRIPTION
This fixes the test failure issue by launching each individual test in 'sql-parser' module in its own JVM.
