### PR TITLE
DRILL-478 sqlline fails with latest build

### DIFF
--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -55,6 +55,10 @@
           <artifactId>asm</artifactId>
           <groupId>asm</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>jruby-complete</artifactId>
+          <groupId>org.jruby</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Exclude jruby-complete in hbase pom
