### PR TITLE
DRILL-481 libthrift-0.8.0 causes drillbit to fail while querying Hive ta...

### DIFF
--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -55,6 +55,10 @@
           <artifactId>asm</artifactId>
           <groupId>asm</groupId>
         </exclusion>
+          <exclusion>
+            <artifactId>libthrift</artifactId>
+            <groupId>org.apache.thrift</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
...bles

exclude lib thrift in hbase pom
