### PR TITLE
DRILL-496 drill stuck in loop when query parquet file and eventually ran...

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/NullableColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/NullableColumnReader.java
@@ -116,7 +116,9 @@ abstract class NullableColumnReader extends ColumnReader{
         totalValuesRead += recordsReadInThisIteration;
         pageReadStatus.valuesRead += recordsReadInThisIteration;
         if (readStartInBytes + readLength >= pageReadStatus.byteLength && bitsUsed == 0) {
-          pageReadStatus.next();
+          if (!pageReadStatus.next()) {
+            break;
+          }
         } else {
           pageReadStatus.readPosInBytes = readStartInBytes + readLength;
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/PageReadStatus.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/PageReadStatus.java
@@ -76,6 +76,8 @@ final class PageReadStatus {
    */
   public boolean next() throws IOException {
 
+    currentPage = null;
+
     if(!dataReader.hasRemainder()) return false;
 
     // next, we need to decompress the bytes


### PR DESCRIPTION
... out of memory

Added condition in NullableColumnReader to break out of loop when there are no more pages to read.
