### PR TITLE
DRILL-533: Queries fail with NPE if dfs/cp schema has no default workspa...

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -88,6 +88,11 @@ public class FileSystemPlugin extends AbstractStoragePlugin{
         for(Map.Entry<String, String> space : config.workspaces.entrySet()){
           factories.add(new WorkspaceSchemaFactory(this, space.getKey(), name, fs, space.getValue(), matchers));
         }
+
+        // if the "default" workspace is not given add one.
+        if (!config.workspaces.containsKey("default")) {
+          factories.add(new WorkspaceSchemaFactory(this, "default", name, fs, "/", matchers));
+        }
       }
       this.schemaFactory = new FileSystemSchemaFactory(name, factories);
     }catch(IOException e){

--- a/sqlparser/src/test/resources/storage-plugins.json
+++ b/sqlparser/src/test/resources/storage-plugins.json
@@ -4,7 +4,6 @@
       type: "file",
       connection: "file:///",
       workspaces: {
-        default: "/",
         home: "/"
       },
       formats: {


### PR DESCRIPTION
...ce but has non-default workspace

We currently add the "default" workspace only if there are no workspaces defined, but we always choose the workspace with "default" name as the default workspace. As in the repro case there is no default workspace, we end with a null.

Fix: Add default workspace if there is no "default" given in storage-engines.json
