### PR TITLE
DRILL-392: Support SHOW TABLES/SCHEMAS and DESCRIBE TABLE.

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -336,18 +336,66 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <copy todir="${project.build.directory}/codegen">
+                  <fileset dir="src/main/codegen"/>
+                </copy>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Extract parser grammar template from optiq-core.jar and put it under
+             ${project.build.directory} where all freemarker templates are. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>unpack-parser-template</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>net.hydromatic</groupId>
+                  <artifactId>optiq-core</artifactId>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                  <includes>**/CombinedParser.jj</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.googlecode.fmpp-maven-plugin</groupId>
         <artifactId>fmpp-maven-plugin</artifactId>
         <version>1.0</version>
         <configuration>
-          <cfgFile>src/main/codegen/config.fmpp</cfgFile>
+          <cfgFile>${project.build.directory}/codegen/config.fmpp</cfgFile>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <templateDirectory>src/main/codegen/templates</templateDirectory>
+          <templateDirectory>${project.build.directory}/codegen/templates</templateDirectory>
         </configuration>
         <executions>
           <execution>
             <id>generate-fmpp-sources</id>
-            <phase>validate</phase>
+            <phase>initialize</phase>
             <goals>
               <goal>generate</goal>
             </goals>
@@ -409,7 +457,28 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>javacc-maven-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>javacc</id>
+            <goals>
+              <goal>javacc</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/generated-sources/</sourceDirectory>
+              <includes>
+                <include>**/CombinedParser.jj</include>
+              </includes>
+              <lookAhead>2</lookAhead>
+              <isStatic>false</isStatic>
+              <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/exec/java-exec/src/main/codegen/config.fmpp
+++ b/exec/java-exec/src/main/codegen/config.fmpp
@@ -23,8 +23,9 @@ data: {
     drillOI:tdd(../data/HiveTypes.tdd),
     aggrtypes1: tdd(../data/AggrTypes1.tdd),
     aggrtypes2: tdd(../data/AggrTypes2.tdd),
-    date: tdd(../data/DateTypes.tdd)
-    extract: tdd(../data/ExtractTypes.tdd)
+    date: tdd(../data/DateTypes.tdd),
+    extract: tdd(../data/ExtractTypes.tdd),
+    parser: tdd(../data/Parser.tdd)
 }
 freemarkerLinks: {
     includes: includes/

--- a/exec/java-exec/src/main/codegen/data/Parser.tdd
+++ b/exec/java-exec/src/main/codegen/data/Parser.tdd
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http:# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+  # Generated parser implementation class package and name
+  package: "org.apache.drill.exec.planner.sql.parser.impl",
+  class: "DrillParserImpl",
+
+  # List of import statements.
+  imports: [
+    "org.apache.drill.exec.planner.sql.parser.*",
+    "org.eigenbase.util.*",
+    "java.util.*"
+  ]
+
+  # List of keywords.
+  keywords: [
+    "DATABASES",
+    "SCHEMAS",
+    "SHOW",
+    "TABLES"
+  ]
+
+  # List of methods for parsing custom SQL statements.
+  statementParserMethods: [
+    "SqlShowTables()",
+    "SqlShowSchemas()",
+    "SqlDescribeTable()"
+  ]
+
+  # List of methods for parsing custom literals.
+  # Example: ParseJsonLiteral().
+  literalParserMethods: [
+  ]
+
+  # List of methods for parsing custom data types.
+  dataTypeParserMethods: [
+  ]
+
+  # List of files in @includes directory that have parser method
+  # implementations for custom SQL statements, literals or types
+  # given as part of "statementParserMethods", "literalParserMethods" or
+  # "dataTypeParserMethods".
+  implementationFiles: [
+    "parserImpls.ftl"
+  ]
+}

--- a/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
+++ b/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
@@ -1,0 +1,102 @@
+<#-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+
+<#--
+  Add implementations of additional parser statements here.
+  Each implementation should return an object of SqlNode type.
+
+  Example of SqlShowTables() implementation:
+  SqlNode SqlShowTables()
+  {
+    ...local variables...
+  }
+  {
+    <SHOW> <TABLES>
+    ...
+    {
+      return SqlShowTables(...)
+    }
+  }
+-->
+/**
+ * Parses statement
+ *   SHOW TABLES [{FROM | IN} db_name] [LIKE 'pattern' | WHERE expr]
+ */
+SqlNode SqlShowTables() :
+{
+    SqlParserPos pos;
+    SqlIdentifier db = null;
+    SqlNode likePattern = null;
+    SqlNode where = null;
+}
+{
+    <SHOW> { pos = getPos(); }
+    <TABLES>
+    [
+        (<FROM> | <IN>) { db = CompoundIdentifier(); }
+    ]
+    [
+        <LIKE> { likePattern = StringLiteral(); }
+        |
+        <WHERE> { where = Expression(ExprContext.ACCEPT_SUBQUERY); }
+    ]
+    {
+        return new SqlShowTables(pos, db, likePattern, where);
+    }
+}
+
+/**
+ * Parses statement SHOW {DATABASES | SCHEMAS} [LIKE 'pattern' | WHERE expr]
+ */
+SqlNode SqlShowSchemas() :
+{
+    SqlParserPos pos;
+    SqlNode likePattern = null;
+    SqlNode where = null;
+}
+{
+    <SHOW> { pos = getPos(); }
+    (<DATABASES> | <SCHEMAS>)
+    [
+        <LIKE> { likePattern = StringLiteral(); }
+        |
+        <WHERE> { where = Expression(ExprContext.ACCEPT_SUBQUERY); }
+    ]
+    {
+        return new SqlShowSchemas(pos, likePattern, where);
+    }
+}
+
+/**
+ * Parses statement
+ *   { DESCRIBE | DESC } tblname [col_name | wildcard ]
+ */
+SqlNode SqlDescribeTable() :
+{
+    SqlParserPos pos;
+    SqlIdentifier table;
+    SqlIdentifier column = null;
+    SqlNode columnPattern = null;
+}
+{
+    (<DESCRIBE> | <DESC>) { pos = getPos(); }
+    table = CompoundIdentifier()
+    (
+        column = CompoundIdentifier()
+        |
+        columnPattern = StringLiteral()
+        |
+        E()
+    )
+    {
+        return new SqlDescribeTable(pos, table, column, columnPattern);
+    }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import net.hydromatic.optiq.tools.Planner;
 import net.hydromatic.optiq.tools.RelConversionException;
-import net.hydromatic.optiq.tools.RuleSet;
 import net.hydromatic.optiq.tools.ValidationException;
 
 import org.apache.drill.common.logical.PlanProperties;
@@ -51,7 +50,7 @@ import org.eigenbase.sql.SqlNode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
-import com.google.hive12.common.collect.Lists;
+import com.google.common.collect.Lists;
 
 public class DefaultSqlHandler implements SqlHandler{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DefaultSqlHandler.class);
@@ -83,7 +82,8 @@ public class DefaultSqlHandler implements SqlHandler{
   @Override
   public PhysicalPlan getPlan(SqlNode sqlNode) throws ValidationException, RelConversionException, IOException {
 
-    SqlNode validated = validateNode(sqlNode);
+    SqlNode rewrittenSqlNode = rewrite(sqlNode);
+    SqlNode validated = validateNode(rewrittenSqlNode);
     RelNode rel = convertToRel(validated);
     log("Optiq Logical", rel);
     DrillRel drel = convertToDrel(rel);
@@ -161,6 +161,18 @@ public class DefaultSqlHandler implements SqlHandler{
       return null;
     }
 
+  }
+
+  /**
+   * Rewrite the parse tree. Used before validating the parse tree.
+   * Useful if a particular statement needs to converted into another statement.
+   *
+   * @param node
+   * @return Rewritten sql parse tree
+   * @throws RelConversionException
+   */
+  public SqlNode rewrite(SqlNode node) throws RelConversionException{
+    return node;
   }
 
   public static <T> T unwrap(Object o, Class<T> clazz) throws RelConversionException{

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.planner.sql.handlers;
+
+import com.google.common.collect.ImmutableList;
+import net.hydromatic.optiq.tools.Planner;
+import net.hydromatic.optiq.tools.RelConversionException;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
+import org.apache.drill.exec.planner.sql.parser.SqlDescribeTable;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.fun.SqlStdOperatorTable;
+import org.eigenbase.sql.parser.SqlParserPos;
+import org.eigenbase.util.Util;
+
+import java.util.List;
+
+import static org.apache.drill.exec.planner.sql.parser.DrillParserUtil.CHARSET;
+
+public class DescribeTableHandler extends DefaultSqlHandler {
+
+  public DescribeTableHandler(Planner planner, QueryContext context) { super(planner, context); }
+
+  /** Rewrite the parse tree as SELECT ... FROM INFORMATION_SCHEMA.COLUMNS ... */
+  @Override
+  public SqlNode rewrite(SqlNode sqlNode) throws RelConversionException{
+    SqlDescribeTable node = unwrap(sqlNode, SqlDescribeTable.class);
+
+    List<SqlNode> selectList = ImmutableList.of((SqlNode)new SqlIdentifier("COLUMN_NAME", SqlParserPos.ZERO),
+        new SqlIdentifier("DATA_TYPE", SqlParserPos.ZERO),
+        new SqlIdentifier("IS_NULLABLE", SqlParserPos.ZERO));
+
+    SqlNode fromClause = new SqlIdentifier(
+        ImmutableList.of("INFORMATION_SCHEMA", "COLUMNS"), null, SqlParserPos.ZERO, null);
+
+    final SqlIdentifier table = node.getTable();
+    final int numLevels = table.names.size();
+
+    SqlNode schemaCondition = null;
+    if (numLevels > 1) {
+      schemaCondition = DrillParserUtil.createCondition(
+          new SqlIdentifier("TABLE_SCHEMA", SqlParserPos.ZERO),
+          SqlStdOperatorTable.EQUALS,
+          SqlLiteral.createCharString(Util.sepList(table.names.subList(0, numLevels - 1), "."),
+              CHARSET, SqlParserPos.ZERO)
+      );
+    }
+
+    SqlNode where = DrillParserUtil.createCondition(
+        new SqlIdentifier("TABLE_NAME", SqlParserPos.ZERO),
+        SqlStdOperatorTable.EQUALS,
+        SqlLiteral.createCharString(table.names.get(numLevels-1), CHARSET, SqlParserPos.ZERO));
+
+    where = DrillParserUtil.createCondition(schemaCondition, SqlStdOperatorTable.AND, where);
+
+    SqlNode columnFilter = null;
+    if (node.getColumn() != null) {
+      columnFilter = DrillParserUtil.createCondition(new SqlIdentifier("COLUMN_NAME", SqlParserPos.ZERO),
+          SqlStdOperatorTable.EQUALS,
+          SqlLiteral.createCharString(node.getColumn().toString(), CHARSET, SqlParserPos.ZERO));
+    } else if (node.getColumnQualifier() != null) {
+      columnFilter = DrillParserUtil.createCondition(new SqlIdentifier("COLUMN_NAME", SqlParserPos.ZERO),
+          SqlStdOperatorTable.LIKE, node.getColumnQualifier());
+    }
+
+    where = DrillParserUtil.createCondition(where, SqlStdOperatorTable.AND, columnFilter);
+
+    return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
+        fromClause, where, null, null, null, null, null, null);
+  }
+}
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
@@ -51,8 +51,7 @@ public class ExplainHandler extends DefaultSqlHandler{
 
   @Override
   public PhysicalPlan getPlan(SqlNode node) throws ValidationException, RelConversionException, IOException {
-    SqlExplain explain = unwrap(node, SqlExplain.class);
-    SqlNode sqlNode = rewrite(explain);
+    SqlNode sqlNode = rewrite(node);
     SqlNode validated = validateNode(sqlNode);
     RelNode rel = convertToRel(validated);
     DrillRel drel = convertToDrel(rel);
@@ -69,8 +68,10 @@ public class ExplainHandler extends DefaultSqlHandler{
     return DirectPlan.createDirectPlan(context, physicalResult);
   }
 
-  private SqlNode rewrite(SqlExplain node) {
-    SqlLiteral op = (SqlLiteral) node.operand(2);
+  @Override
+  public SqlNode rewrite(SqlNode sqlNode) throws RelConversionException{
+    SqlExplain node = unwrap(sqlNode, SqlExplain.class);
+    SqlLiteral op = node.operand(2);
     SqlExplain.Depth depth = (SqlExplain.Depth) op.getValue();
 
     switch(depth){

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowSchemasHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowSchemasHandler.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.planner.sql.handlers;
+
+import com.google.common.collect.ImmutableList;
+import net.hydromatic.optiq.tools.Planner;
+import net.hydromatic.optiq.tools.RelConversionException;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
+import org.apache.drill.exec.planner.sql.parser.SqlShowSchemas;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.fun.SqlStdOperatorTable;
+import org.eigenbase.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+public class ShowSchemasHandler extends DefaultSqlHandler {
+
+  public ShowSchemasHandler(Planner planner, QueryContext context) { super(planner, context); }
+
+  /** Rewrite the parse tree as SELECT ... FROM INFORMATION_SCHEMA.SCHEMATA ... */
+  @Override
+  public SqlNode rewrite(SqlNode sqlNode) throws RelConversionException{
+    SqlShowSchemas node = unwrap(sqlNode, SqlShowSchemas.class);
+    List<SqlNode> selectList = ImmutableList.of((SqlNode) new SqlIdentifier("SCHEMA_NAME", SqlParserPos.ZERO));
+
+    SqlNode fromClause = new SqlIdentifier(
+        ImmutableList.of("INFORMATION_SCHEMA", "SCHEMATA"), null, SqlParserPos.ZERO, null);
+
+    SqlNode where = null;
+    final SqlNode likePattern = node.getLikePattern();
+    if (likePattern != null) {
+      where = DrillParserUtil.createCondition(new SqlIdentifier("SCHEMA_NAME", SqlParserPos.ZERO),
+          SqlStdOperatorTable.LIKE, likePattern);
+    } else if (node.getWhereClause() != null) {
+      where = node.getWhereClause();
+    }
+
+    return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
+        fromClause, where, null, null, null, null, null, null);
+  }
+}
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.planner.sql.handlers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import net.hydromatic.optiq.tools.Planner;
+import net.hydromatic.optiq.tools.RelConversionException;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
+import org.apache.drill.exec.planner.sql.parser.SqlShowTables;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.fun.SqlStdOperatorTable;
+import org.eigenbase.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+import static org.apache.drill.exec.planner.sql.parser.DrillParserUtil.CHARSET;
+
+public class ShowTablesHandler extends DefaultSqlHandler {
+
+  public ShowTablesHandler(Planner planner, QueryContext context) { super(planner, context); }
+
+  /** Rewrite the parse tree as SELECT ... FROM INFORMATION_SCHEMA.`TABLES` ... */
+  @Override
+  public SqlNode rewrite(SqlNode sqlNode) throws RelConversionException{
+    SqlShowTables node = unwrap(sqlNode, SqlShowTables.class);
+    List<SqlNode> selectList = Lists.newArrayList();
+    SqlNode fromClause;
+    SqlNode where = null;
+
+    // create select columns
+    selectList.add(new SqlIdentifier("TABLE_SCHEMA", SqlParserPos.ZERO));
+    selectList.add(new SqlIdentifier("TABLE_NAME", SqlParserPos.ZERO));
+
+    fromClause = new SqlIdentifier(ImmutableList.of("INFORMATION_SCHEMA", "TABLES"), SqlParserPos.ZERO);
+
+    final SqlIdentifier db = node.getDb();
+    if (db != null) {
+      where = DrillParserUtil.createCondition(
+          new SqlIdentifier("TABLE_SCHEMA", SqlParserPos.ZERO),
+          SqlStdOperatorTable.EQUALS,
+          SqlLiteral.createCharString(db.toString(), CHARSET, db.getParserPosition()));
+    }
+
+    SqlNode filter = null;
+    final SqlNode likePattern = node.getLikePattern();
+    if (likePattern != null) {
+      filter = DrillParserUtil.createCondition(
+          new SqlIdentifier("TABLE_NAME", SqlParserPos.ZERO),
+          SqlStdOperatorTable.LIKE,
+          likePattern);
+    } else if (node.getWhereClause() != null) {
+      filter = node.getWhereClause();
+    }
+
+    where = DrillParserUtil.createCondition(where, SqlStdOperatorTable.AND, filter);
+
+    return new SqlSelect(SqlParserPos.ZERO, null, new SqlNodeList(selectList, SqlParserPos.ZERO),
+        fromClause, where, null, null, null, null, null, null);
+  }
+}
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/DrillParserUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/DrillParserUtil.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.planner.sql.parser;
+
+import com.beust.jcommander.internal.Lists;
+import org.eigenbase.sql.SqlNode;
+import org.eigenbase.sql.SqlOperator;
+import org.eigenbase.sql.parser.SqlParserPos;
+import org.eigenbase.sql.parser.SqlParserUtil;
+
+import java.util.List;
+
+/**
+ * Helper methods or constants used in parsing a SQL query.
+ */
+public class DrillParserUtil {
+
+  public static final String CHARSET = "ISO-8859-1";
+
+  public static SqlNode createCondition(SqlNode left, SqlOperator op, SqlNode right) {
+
+    // if one of the operands is null, return the other
+    if (left == null || right == null)
+      return left != null ? left : right;
+
+    List<Object> listCondition = Lists.newArrayList();
+    listCondition.add(left);
+    listCondition.add(new SqlParserUtil.ToTreeListItem(op, SqlParserPos.ZERO));
+    listCondition.add(right);
+
+    return SqlParserUtil.toTree(listCondition);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDescribeTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDescribeTable.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import com.google.common.collect.Lists;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+/**
+ * Sql parser tree node to represent statement:
+ * { DESCRIBE | DESC } tblname [col_name | wildcard ]
+ */
+public class SqlDescribeTable extends SqlCall {
+
+  private final SqlIdentifier table;
+  private final SqlIdentifier column;
+  private final SqlNode columnQualifier;
+
+  public static final SqlSpecialOperator OPERATOR =
+    new SqlSpecialOperator("DESCRIBE_TABLE", SqlKind.OTHER);
+
+  public SqlDescribeTable(SqlParserPos pos, SqlIdentifier table, SqlIdentifier column, SqlNode columnQualifier) {
+    super(pos);
+    this.table = table;
+    this.column = column;
+    this.columnQualifier = columnQualifier;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    List<SqlNode> opList = Lists.newArrayList();
+    opList.add(table);
+    if (column != null) opList.add(column);
+    if (columnQualifier != null) opList.add(columnQualifier);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DESCRIBE");
+    writer.keyword("TABLE");
+    table.unparse(writer, leftPrec, rightPrec);
+    if (column != null) column.unparse(writer, leftPrec, rightPrec);
+    if (columnQualifier != null) columnQualifier.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public SqlIdentifier getTable() { return table; }
+  public SqlIdentifier getColumn() { return column; }
+  public SqlNode getColumnQualifier() { return columnQualifier; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlShowSchemas.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlShowSchemas.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import com.google.common.collect.Lists;
+import net.hydromatic.optiq.tools.Planner;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.planner.sql.handlers.DefaultSqlHandler;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+/**
+ * Sql parse tree node to represent statement:
+ * SHOW {DATABASES | SCHEMAS} [LIKE 'pattern' | WHERE expr]
+ */
+public class SqlShowSchemas extends SqlCall {
+
+  private final SqlNode likePattern;
+  private final SqlNode whereClause;
+
+  public static final SqlSpecialOperator OPERATOR =
+    new SqlSpecialOperator("SHOW_SCHEMAS", SqlKind.OTHER);
+
+  public SqlShowSchemas(SqlParserPos pos, SqlNode likePattern, SqlNode whereClause) {
+    super(pos);
+    this.likePattern = likePattern;
+    this.whereClause = whereClause;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    List<SqlNode> opList = Lists.newArrayList();
+    if (likePattern != null) opList.add(likePattern);
+    if (whereClause != null) opList.add(whereClause);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW");
+    writer.keyword("SCHEMAS");
+    if (likePattern != null) {
+      writer.keyword("LIKE");
+      likePattern.unparse(writer, leftPrec, rightPrec);
+    }
+    if (whereClause != null) whereClause.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public SqlNode getLikePattern() { return likePattern; }
+  public SqlNode getWhereClause() { return whereClause; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlShowTables.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlShowTables.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import com.google.common.collect.Lists;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.parser.SqlParserPos;
+
+import java.util.List;
+
+/**
+ * Sql parse tree node to represent statement:
+ * SHOW TABLES [{FROM | IN} db_name] [LIKE 'pattern' | WHERE expr]
+ */
+public class SqlShowTables extends SqlCall {
+
+  private final SqlIdentifier db;
+  private final SqlNode likePattern;
+  private final SqlNode whereClause;
+
+  public static final SqlSpecialOperator OPERATOR =
+    new SqlSpecialOperator("SHOW_TABLES", SqlKind.OTHER);
+
+  public SqlShowTables(SqlParserPos pos, SqlIdentifier db, SqlNode likePattern, SqlNode whereClause) {
+    super(pos);
+    this.db = db;
+    this.likePattern = likePattern;
+    this.whereClause = whereClause;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    List<SqlNode> opList = Lists.newArrayList();
+    if (db != null) opList.add(db);
+    if (likePattern != null) opList.add(likePattern);
+    if (whereClause != null) opList.add(whereClause);
+    return opList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW");
+    writer.keyword("TABLES");
+    if (db != null) db.unparse(writer, leftPrec, rightPrec);
+    if (likePattern != null) {
+      writer.keyword("LIKE");
+      likePattern.unparse(writer, leftPrec, rightPrec);
+    }
+    if (whereClause != null) whereClause.unparse(writer, leftPrec, rightPrec);
+  }
+
+  public SqlIdentifier getDb() { return db; }
+  public SqlNode getLikePattern() { return likePattern; }
+  public SqlNode getWhereClause() { return whereClause; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/OptiqProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/OptiqProvider.java
@@ -59,7 +59,8 @@ public class OptiqProvider  {
   static public class Schemata extends Abstract {
     @Override
     public boolean visitSchema(String schemaName, Schema schema) {
-      if (schemaName != null && schemaName != "") {
+      if (schemaName != null && schemaName != "" &&
+          !schemaName.equals("metadata") /* workaround until Drill upgrades to Optiq version which has the fix for #256 */) {
           writeRow("DRILL", schemaName, "<owner>");
       }
       return false;
@@ -173,7 +174,9 @@ public class OptiqProvider  {
      *    If the schema visitor returns true, then visit the tables.
      *    If the table visitor returns true, then visit the fields (columns).
      */
-    public boolean visitSchema(String schemaName, Schema schema){return true;}
+    public boolean visitSchema(String schemaName, Schema schema){
+      return !schemaName.equals("metadata"); //workaround until Drill upgrades to Optiq version which has the fix for #256
+    }
     public boolean visitTableName(String schemaName, String tableName){return true;}
     public boolean visitTable(String schemaName, String tableName, Table table){return true;}
     public boolean visitField(String schemaName, String tableName, RelDataTypeField field){return true;}


### PR DESCRIPTION
Use Optiq parser template to generate Drill parser
a) exec/java-exec/pom.xml changes:
1. Write a plugin to move current existing codegen directory to target
     (fmpp can't handle more than one directory as template input dir).
2. Change template directory path in fmpp plugin.
3. Extract CombinedParser.jj into target/codegen/templates directory.
4. Plugin to compile CombinedParser.jj using javacc.

b) Add parser.tdd to define values for freemarker variables in CombinedParser.jj template.
c) Define grammar and SqlCall types for new DDL statements.
d) Handlers to rewrite newly added SqlCall DDL statements as select queries from INFORMATION_SCHEMA.
