### PR TITLE
DRILL-554: maven-compiler-plugin only supports 'm' suffix for 'maxmem' o...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
-          <maxmem>2g</maxmem>
+          <maxmem>2048m</maxmem>
           <fork>true</fork>
         </configuration>
       </plugin>


### PR DESCRIPTION
...ption
