### PR TITLE
DRILL-2961: Throw SQLException when attempting to set query timeout

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillStatement.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillStatement.java
@@ -84,4 +84,8 @@ public abstract class DrillStatement extends AvaticaStatement
     connection1.openStatementsRegistry.removeStatement(this);
   }
 
+  @Override
+  public void setQueryTimeout(int seconds) throws SQLException {
+	throw new SQLException("Method is not supported");
+  }
 }


### PR DESCRIPTION
Statement.setQueryTimeout(int seconds) is a No-Op, leading the user to
believe that a timeout has been set. This provides the correct response
(SQLException for 'method not supported')