### PR TITLE
Update 020-using-jdbc-with-squirrel-on-windows.md

### DIFF
--- a/_docs/odbc-jdbc-interfaces/020-using-jdbc-with-squirrel-on-windows.md
+++ b/_docs/odbc-jdbc-interfaces/020-using-jdbc-with-squirrel-on-windows.md
@@ -30,7 +30,7 @@ machine:
     <drill_installation_directory>/jars/jdbc-driver/drill-jdbc-all-<version>.jar
 
 Or, you can download the [apache-
-drill-1.0.0.tar.gz](http://apache.osuosl.org/drill/drill-1.0.0/apache-drill-1.0.0-src.tar.gz) file to a location on your Windows machine, and
+drill-1.0.0.tar.gz](http://apache.osuosl.org/drill/drill-1.0.0/apache-drill-1.0.0.tar.gz) file to a location on your Windows machine, and
 extract the contents of the file. You may need to use a decompression utility,
 such as [7-zip](http://www.7-zip.org/) to extract the archive. Once extracted,
 you can locate the driver in the following directory:


### PR DESCRIPTION
Fixed a link to the Drill packaged to go to the binary package instead of the source package.