### PR TITLE
DRILL-3500: Add OptimizerRulesContext which exposes information neede…

### DIFF
--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePlugin.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePlugin.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.apache.calcite.schema.SchemaPlus;
 
 import org.apache.drill.common.JSONOptions;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
@@ -76,7 +77,7 @@ public class HBaseStoragePlugin extends AbstractStoragePlugin {
   }
 
   @Override
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     return ImmutableSet.of(HBasePushFilterIntoScan.INSTANCE);
   }
 

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
@@ -28,6 +28,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.planner.sql.logical.HivePushPartitionFilterIntoScan;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
@@ -85,7 +86,9 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
   public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
     schemaFactory.registerSchemas(schemaConfig, parent);
   }
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+
+  @Override
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     return ImmutableSet.of(HivePushPartitionFilterIntoScan.HIVE_FILTER_ON_PROJECT, HivePushPartitionFilterIntoScan.HIVE_FILTER_ON_SCAN);
   }
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
@@ -96,7 +97,8 @@ public class MongoStoragePlugin extends AbstractStoragePlugin {
     return new MongoGroupScan(userName, this, mongoScanSpec, null);
   }
 
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+  @Override
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     return ImmutableSet.of(MongoPushDownFilterForScan.INSTANCE);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -37,7 +37,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import org.apache.drill.exec.server.options.OptionManager;
 
-public class FunctionImplementationRegistry {
+public class FunctionImplementationRegistry implements FunctionLookupContext {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FunctionImplementationRegistry.class);
 
   private DrillFunctionRegistry drillFuncRegistry;
@@ -101,6 +101,7 @@ public class FunctionImplementationRegistry {
    * @param functionCall
    * @return
    */
+  @Override
   public DrillFuncHolder findDrillFunction(FunctionResolver functionResolver, FunctionCall functionCall) {
     return functionResolver.getBestMatch(drillFuncRegistry.getMethods(functionReplacement(functionCall)), functionCall);
   }
@@ -147,6 +148,7 @@ public class FunctionImplementationRegistry {
    * @param functionCall
    * @return
    */
+  @Override
   public AbstractFuncHolder findNonDrillFunction(FunctionCall functionCall) {
     for(PluggableFunctionRegistry registry : pluggableFuncRegistries) {
       AbstractFuncHolder h = registry.getFunction(functionCall);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionLookupContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionLookupContext.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn;
+
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.exec.resolver.FunctionResolver;
+
+public interface FunctionLookupContext {
+
+  /**
+   * Method returns the materialized drill function corresponding to the functioncall that
+   * is passed in
+   *
+   * @param functionResolver - Type of resolver to use.
+   *                           Specifies if the arguments should match exactly or can use implicit cast
+   * @param functionCall - Specifies function name and type of arguments
+   * @return DrillFuncHolder
+   */
+  public DrillFuncHolder findDrillFunction(FunctionResolver functionResolver, FunctionCall functionCall);
+
+  /**
+   * Find function implementation for given <code>functionCall</code> in non-Drill function registries such as Hive UDF
+   * registry.
+   *
+   * Note: Order of searching is same as order of {@link org.apache.drill.exec.expr.fn.PluggableFunctionRegistry}
+   * implementations found on classpath.
+   *
+   * @param functionCall - Specifies function name and type of arguments
+   * @return
+   */
+  public AbstractFuncHolder findNonDrillFunction(FunctionCall functionCall);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OptimizerRulesContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OptimizerRulesContext.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+
+public interface OptimizerRulesContext extends UdfUtilities {
+  /**
+   * Method returns the function registry
+   * @return FunctionImplementationRegistry
+   */
+  public FunctionImplementationRegistry getFunctionRegistry();
+
+  /**
+   * Method returns the allocator
+   * @return BufferAllocator
+   */
+  public BufferAllocator getAllocator();
+
+  /**
+   * Method returns the planner options
+   * @return PlannerSettings
+   */
+  public PlannerSettings getPlannerSettings();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -54,7 +54,7 @@ import org.apache.drill.exec.util.Utilities;
 // TODO the many methods that just return drillbitContext.getXxx() should be replaced with getDrillbitContext()
 // TODO - consider re-name to PlanningContext, as the query execution context actually appears
 // in fragment contexts
-public class QueryContext implements AutoCloseable, UdfUtilities {
+public class QueryContext implements AutoCloseable, OptimizerRulesContext {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryContext.class);
 
   private static final int INITIAL_OFF_HEAP_ALLOCATION_IN_BYTES = 1024 * 1024;
@@ -105,6 +105,7 @@ public class QueryContext implements AutoCloseable, UdfUtilities {
     schemaTreesToClose = Lists.newArrayList();
   }
 
+  @Override
   public PlannerSettings getPlannerSettings() {
     return plannerSettings;
   }
@@ -113,6 +114,7 @@ public class QueryContext implements AutoCloseable, UdfUtilities {
     return session;
   }
 
+  @Override
   public BufferAllocator getAllocator() {
     return allocator;
   }
@@ -205,6 +207,7 @@ public class QueryContext implements AutoCloseable, UdfUtilities {
     return drillbitContext.getConfig();
   }
 
+  @Override
   public FunctionImplementationRegistry getFunctionRegistry() {
     return drillbitContext.getFunctionImplementationRegistry();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
@@ -121,7 +121,7 @@ public class DrillSqlWorker {
         DrillRuleSets.getDrillUserConfigurableLogicalRules(context));
     RuleSet drillPhysicalMem = DrillRuleSets.mergedRuleSets(
         DrillRuleSets.getPhysicalRules(context),
-        storagePluginRegistry.getStoragePluginRuleSet());
+        storagePluginRegistry.getStoragePluginRuleSet(context));
 
     // Following is used in LOPT join OPT.
     RuleSet logicalConvertRules = DrillRuleSets.mergedRuleSets(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 
 import com.google.common.collect.ImmutableSet;
@@ -44,7 +45,7 @@ public abstract class AbstractStoragePlugin implements StoragePlugin{
   }
 
   @Override
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     return ImmutableSet.of();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 
 public interface StoragePlugin extends SchemaFactory {
@@ -31,7 +32,7 @@ public interface StoragePlugin extends SchemaFactory {
 
   public boolean supportsWrite();
 
-  public Set<StoragePluginOptimizerRule> getOptimizerRules();
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerContext);
 
   /**
    * Get the physical scan operator for the particular GroupScan (read) node.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
@@ -42,6 +42,7 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.util.PathScanner;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.drill.exec.planner.logical.DrillRuleSets;
@@ -283,11 +284,11 @@ public class StoragePluginRegistry implements Iterable<Map.Entry<String, Storage
     return plugins.entrySet().iterator();
   }
 
-  public RuleSet getStoragePluginRuleSet() {
+  public RuleSet getStoragePluginRuleSet(OptimizerRulesContext optimizerRulesContext) {
     // query registered engines for optimizer rules and build the storage plugin RuleSet
     Builder<RelOptRule> setBuilder = ImmutableSet.builder();
     for (StoragePlugin plugin : this.plugins.values()) {
-      Set<StoragePluginOptimizerRule> rules = plugin.getOptimizerRules();
+      Set<StoragePluginOptimizerRule> rules = plugin.getOptimizerRules(optimizerRulesContext);
       if (rules != null && rules.size() > 0) {
         setBuilder.addAll(rules);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -29,6 +29,7 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.server.DrillbitContext;
@@ -144,7 +145,7 @@ public class FileSystemPlugin extends AbstractStoragePlugin{
   }
 
   @Override
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     Builder<StoragePluginOptimizerRule> setBuilder = ImmutableSet.builder();
     for(FormatPlugin plugin : this.formatPluginsByName.values()){
       Set<StoragePluginOptimizerRule> rules = plugin.getOptimizerRules();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaStoragePlugin.java
@@ -30,6 +30,7 @@ import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.*;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
@@ -107,7 +108,7 @@ public class InfoSchemaStoragePlugin extends AbstractStoragePlugin {
   }
 
   @Override
-  public Set<StoragePluginOptimizerRule> getOptimizerRules() {
+  public Set<StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerRulesContext) {
     return ImmutableSet.of(
         InfoSchemaPushFilterIntoRecordGenerator.IS_FILTER_ON_PROJECT,
         InfoSchemaPushFilterIntoRecordGenerator.IS_FILTER_ON_SCAN);


### PR DESCRIPTION
…d by storage plugin specific optimizer rules

1. Add a new interface OptimizerRulesContext that will be implemented by QueryContext. It will contain all the information needed by the rules. This context will be passed to the storage plugin method while getting the optimizer rules specific to that storage plugin.
2. Restrict existing internal rules to only accept OptimizerRulesContext instead of QueryContext so information in QueryContext has better encapsulation.
