### PR TITLE
DRILL-3153: Fix JDBC's getIdentifierQuoteString() to report Drill's backquote.

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillDatabaseMetaData.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillDatabaseMetaData.java
@@ -53,7 +53,20 @@ public interface DrillDatabaseMetaData extends DatabaseMetaData {
   //  storesUpperCaseQuotedIdentifiers()
   //  storesLowerCaseQuotedIdentifiers()
   //  storesMixedCaseQuotedIdentifiers()
-  //  getIdentifierQuoteString()
+
+
+  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
+  /**
+   * <strong>Drill</strong>:
+   * Reports that the SQL identifier quoting character is the back-quote
+   * character ("{@code `}"; Unicode U+0060; "GRAVE ACCENT").
+   * @return "{@code `}"
+   */
+  @Override
+  String getIdentifierQuoteString() throws SQLException;
+
+
+  // For matching order of java.sql.DatabaseMetaData:
   //  getSQLKeywords()
   //  getNumericFunctions()
   //  getStringFunctions()

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
@@ -78,6 +78,13 @@ class DrillDatabaseMetaDataImpl extends AvaticaDatabaseMetaData
     return false;
   }
 
+  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
+  @Override
+  public String getIdentifierQuoteString() throws SQLException {
+    checkNotClosed();
+    return "`";
+  }
+
 
   // For now, check whether connection is closed for most important methods
   // (DRILL-2565 (partial fix for DRILL-2489)):

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
@@ -68,10 +68,19 @@ public class DatabaseMetaDataTest {
   //  getURL()
   //  getUserName()
   //  isReadOnly()
-  //  nullsAreSortedHigh()
-  //  nullsAreSortedLow()
-  //  nullsAreSortedAtStart()
-  //  nullsAreSortedAtEnd()
+
+  @Test
+  public void testNullsAreSortedMethodsSaySortedHigh() throws SQLException {
+    assertThat( "DatabaseMetadata.nullsAreSortedHigh()",
+                dbmd.nullsAreSortedHigh(), equalTo( true ) );
+    assertThat( "DatabaseMetadata.nullsAreSortedLow()",
+                dbmd.nullsAreSortedLow(), equalTo( false ) );
+    assertThat( "DatabaseMetadata.nullsAreSortedAtEnd()",
+                dbmd.nullsAreSortedAtEnd(), equalTo( false ) );
+    assertThat( "DatabaseMetadata.nullsAreSortedAtStart()",
+                dbmd.nullsAreSortedAtStart(), equalTo( false ) );
+  }
+
   //  getDatabaseProductName()
   //  getDatabaseProductVersion()
   //  getDriverName()
@@ -88,7 +97,15 @@ public class DatabaseMetaDataTest {
   //  storesUpperCaseQuotedIdentifiers()
   //  storesLowerCaseQuotedIdentifiers()
   //  storesMixedCaseQuotedIdentifiers()
-  //  getIdentifierQuoteString()
+
+  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
+  @Test
+  public void testGetIdentifierQuoteStringSaysBackquote() throws SQLException {
+    assertThat( dbmd.getIdentifierQuoteString(), equalTo( "`" ) );
+  }
+
+  // For matching order of java.sql.DatabaseMetaData:
+  //
   //  getSQLKeywords()
   //  getNumericFunctions()
   //  getStringFunctions()

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
@@ -1,10 +1,10 @@
 /**
- * Licensed to the Apache Software Foundation ( ASF ) under one
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 ( the
- * "License" ); you may not use this file except in compliance
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -69,6 +69,7 @@ public class DatabaseMetaDataTest {
   //  getUserName()
   //  isReadOnly()
 
+
   @Test
   public void testNullsAreSortedMethodsSaySortedHigh() throws SQLException {
     assertThat( "DatabaseMetadata.nullsAreSortedHigh()",
@@ -81,6 +82,9 @@ public class DatabaseMetaDataTest {
                 dbmd.nullsAreSortedAtStart(), equalTo( false ) );
   }
 
+
+  // For matching order of java.sql.DatabaseMetaData:
+  //
   //  getDatabaseProductName()
   //  getDatabaseProductVersion()
   //  getDriverName()
@@ -98,11 +102,13 @@ public class DatabaseMetaDataTest {
   //  storesLowerCaseQuotedIdentifiers()
   //  storesMixedCaseQuotedIdentifiers()
 
+
   // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
   @Test
   public void testGetIdentifierQuoteStringSaysBackquote() throws SQLException {
     assertThat( dbmd.getIdentifierQuoteString(), equalTo( "`" ) );
   }
+
 
   // For matching order of java.sql.DatabaseMetaData:
   //
@@ -406,6 +412,7 @@ public class DatabaseMetaDataTest {
   }
   // TODO:  Later, test more (e.g., right columns (even if/though zero rows)).
 
+
   // For matching order of java.sql.DatabaseMetaData:
   //
   //  supportsStoredFunctionsUsingCallSyntax()
@@ -419,10 +426,10 @@ public class DatabaseMetaDataTest {
   }
   // TODO:  Later, test more (e.g., right columns (even if/though zero rows)).
 
+
   // For matching order of java.sql.DatabaseMetaData:
   //
   //   generatedKeyAlwaysReturned()
-
 
 
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcNullOrderingAndGroupingTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcNullOrderingAndGroupingTest.java
@@ -53,26 +53,6 @@ public class JdbcNullOrderingAndGroupingTest extends JdbcTestQueryBase {
   }
 
 
-  @Test
-  public void testNullsOrderInJdbcMetaData() throws SQLException {
-    try (Connection conn =
-             DriverManager.getConnection( "jdbc:drill:zk=local", null ) ) {
-      DatabaseMetaData dbMetaData = conn.getMetaData();
-
-      assertThat( "DatabaseMetadata.nullsAreSortedHigh()",
-                  dbMetaData.nullsAreSortedHigh(), equalTo( true ) );
-
-      assertThat( "DatabaseMetadata.nullsAreSortedLow()",
-                  dbMetaData.nullsAreSortedLow(), equalTo( false ) );
-      assertThat( "DatabaseMetadata.nullsAreSortedAtEnd()",
-                  dbMetaData.nullsAreSortedAtEnd(), equalTo( false ) );
-      assertThat( "DatabaseMetadata.nullsAreSortedAtStart()",
-                  dbMetaData.nullsAreSortedAtStart(), equalTo( false ) );
-    }
-  }
-
-
-
   ////////////////////
   // DonutsTopping3:
 


### PR DESCRIPTION
Added override of Avatica's default implementation returning SQL standard value.  Added Javadoc.  Added unit test.

Also moved unit test for nullsAreSortedXxx methods.