### PR TITLE
DRILL-3566: Fix:  PreparedStatement.executeQuery() got ClassCastException

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
@@ -103,9 +103,9 @@ public class DrillJdbc41Factory extends DrillFactory {
                                          TimeZone timeZone) {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, prepareResult.getColumnList());
-    return new DrillResultSetImpl( (DrillStatementImpl) statement,
-                                   (DrillPrepareResult) prepareResult,
-                                   metaData, timeZone);
+    return new DrillResultSetImpl(statement,
+                                  (DrillPrepareResult) prepareResult,
+                                  metaData, timeZone);
   }
 
   @Override

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
@@ -30,7 +30,8 @@ import net.hydromatic.avatica.AvaticaPreparedStatement;
  * Implementation of {@link java.sql.PreparedStatement} for Drill.
  *
  * <p>
- * This class has sub-classes which implement JDBC 3.0 and JDBC 4.0 APIs; it is instantiated using
+ * This class has sub-classes which implement JDBC 3.0 and JDBC 4.0 APIs; it is
+ * instantiated using
  * {@link net.hydromatic.avatica.AvaticaFactory#newPreparedStatement}.
  * </p>
  */

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
@@ -43,7 +43,8 @@ import org.junit.runner.Description;
 //   (e.g., the reusing of connections, the automatic interception of test
 //   failures and resetting of connections, etc.).
 public class JdbcTestBase extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestBase.class);
+  @SuppressWarnings("unused")
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestBase.class);
 
   @Rule
   public final TestRule watcher = new TestWatcher() {


### PR DESCRIPTION
Main:
Restored DrillResultSetImpl(...)'s statement parameter from overly
restrictive DrillStatementImpl to AvaticaStatement and removed caller
cast that was throwing.  (Relatedly, adjusted getStatement() and moved
internal casting from statement to connection.)

Added basic test of querying via Prepared Statement.  [PreparedStatementTest]
Added some case test of statement-creation methods.  [Connection Test]