### PR TITLE
DRILL-3598: use a factory to create the root allocator.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/PrintingResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/PrintingResultsListener.java
@@ -28,7 +28,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.client.QuerySubmitter.Format;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.proto.UserBitShared.QueryData;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
@@ -54,7 +54,7 @@ public class PrintingResultsListener implements UserResultsListener {
   Stopwatch w = new Stopwatch();
 
   public PrintingResultsListener(DrillConfig config, Format format, int columnWidth) {
-    this.allocator = new TopLevelAllocator(config);
+    this.allocator = RootAllocatorFactory.newRoot(config);
     loader = new RecordBatchLoader(allocator);
     this.format = format;
     this.columnWidth = columnWidth;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/memory/RootAllocatorFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/memory/RootAllocatorFactory.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.memory;
+
+import org.apache.drill.common.config.DrillConfig;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class RootAllocatorFactory {
+  /**
+   * Constructor to prevent instantiation of this static utility class.
+   */
+  private RootAllocatorFactory() {}
+
+  /**
+   * Factory method.
+   *
+   * @param drillConfig the DrillConfig
+   * @return a new root allocator
+   */
+  public static BufferAllocator newRoot(final DrillConfig drillConfig) {
+/* TODO(DRILL-1942)
+    if (BaseAllocator.DEBUG) {
+      return new TopLevelAllocator(drillConfig);
+    }
+*/
+
+    return new TopLevelAllocator(drillConfig);
+  }
+
+  /**
+   * Factory method for testing, where a DrillConfig may not be available.
+   *
+   * @param allocationPolicy the allocation policy
+   * @param initAllocation initial allocation from parent
+   * @param maxReservation maximum amount of memory this can hand out
+   * @param flags one of BufferAllocator's F_* flags
+   * @return a new root allocator
+   */
+/* TODO(DRILL-1942)
+  @VisibleForTesting
+  public static BufferAllocator newRoot(
+      final AllocationPolicy allocationPolicy,
+      final long initAllocation, final long maxReservation, final int flags) {
+    if (BaseAllocator.DEBUG) {
+      return new RootAllocatorDebug(allocationPolicy, initAllocation, maxReservation, flags);
+    }
+
+    return new RootAllocator(allocationPolicy, initAllocation, maxReservation, flags);
+  }
+*/
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/memory/TopLevelAllocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/memory/TopLevelAllocator.java
@@ -51,15 +51,17 @@ public class TopLevelAllocator implements BufferAllocator {
   private final DrillBuf empty;
   private final DrillConfig config;
 
+  /* TODO(cwestin) remove
   @Deprecated
-  public TopLevelAllocator() {
+  TopLevelAllocator() {
     this(DrillConfig.getMaxDirectMemory());
   }
 
   @Deprecated
-  public TopLevelAllocator(long maximumAllocation) {
+  TopLevelAllocator(long maximumAllocation) {
     this(null, maximumAllocation, true);
   }
+  */
 
   private TopLevelAllocator(DrillConfig config, long maximumAllocation, boolean errorOnLeak){
     MAXIMUM_DIRECT_MEMORY = maximumAllocation;
@@ -70,7 +72,7 @@ public class TopLevelAllocator implements BufferAllocator {
     this.childrenMap = ENABLE_ACCOUNTING ? new IdentityHashMap<ChildAllocator, StackTraceElement[]>() : null;
   }
 
-  public TopLevelAllocator(DrillConfig config) {
+  TopLevelAllocator(DrillConfig config) {
     this(config, Math.min(DrillConfig.getMaxDirectMemory(), config.getLong(ExecConstants.TOP_LEVEL_MAX_ALLOC)),
         config.getBoolean(ExecConstants.ERROR_ON_MEMORY_LEAK)
         );

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -24,15 +24,15 @@ import java.io.Closeable;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.metrics.DrillMetrics;
 import org.apache.drill.exec.rpc.TransportCheck;
 
 import com.codahale.metrics.MetricRegistry;
 
 // TODO:  Doc.  What kind of context?  (For what aspects, RPC?  What kind of data?)
-public class BootStrapContext implements Closeable{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BootStrapContext.class);
+public class BootStrapContext implements Closeable {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BootStrapContext.class);
 
   private final DrillConfig config;
   private final EventLoopGroup loop;
@@ -41,12 +41,11 @@ public class BootStrapContext implements Closeable{
   private final BufferAllocator allocator;
 
   public BootStrapContext(DrillConfig config) {
-    super();
     this.config = config;
     this.loop = TransportCheck.createEventLoopGroup(config.getInt(ExecConstants.BIT_SERVER_RPC_THREADS), "BitServer-");
     this.loop2 = TransportCheck.createEventLoopGroup(config.getInt(ExecConstants.BIT_SERVER_RPC_THREADS), "BitClient-");
     this.metrics = DrillMetrics.getInstance();
-    this.allocator = new TopLevelAllocator(config);
+    this.allocator = RootAllocatorFactory.newRoot(config);
   }
 
   public DrillConfig getConfig() {
@@ -69,10 +68,10 @@ public class BootStrapContext implements Closeable{
     return allocator;
   }
 
+  @Override
   public void close() {
     DrillMetrics.resetMetrics();
     loop.shutdownGracefully();
     allocator.close();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -22,14 +22,15 @@ import java.net.URL;
 
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
+
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.jdbc.SimpleCalciteSchema;
-
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
@@ -54,7 +55,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 
 public class PlanningBase extends ExecTest{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlanningBase.class);
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlanningBase.class);
 
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(10000);
 
@@ -63,16 +64,14 @@ public class PlanningBase extends ExecTest{
 
   @Mocked QueryContext context;
 
-  TopLevelAllocator allocator = new TopLevelAllocator();
+  BufferAllocator allocator = RootAllocatorFactory.newRoot(config);
 
   protected void testSqlPlanFromFile(String file) throws Exception {
     testSqlPlan(getFile(file));
   }
 
   protected void testSqlPlan(String sqlCommands) throws Exception {
-    String[] sqlStrings = sqlCommands.split(";");
-
-
+    final String[] sqlStrings = sqlCommands.split(";");
     final LocalPStoreProvider provider = new LocalPStoreProvider(config);
     provider.start();
 
@@ -134,18 +133,17 @@ public class PlanningBase extends ExecTest{
       }
     };
 
-    for (String sql : sqlStrings) {
+    for (final String sql : sqlStrings) {
       if (sql.trim().isEmpty()) {
         continue;
       }
-      DrillSqlWorker worker = new DrillSqlWorker(context);
-      PhysicalPlan p = worker.getPlan(sql);
+      final DrillSqlWorker worker = new DrillSqlWorker(context);
+      final PhysicalPlan p = worker.getPlan(sql);
     }
-
   }
 
-  protected String getFile(String resource) throws IOException{
-    URL url = Resources.getResource(resource);
+  protected static String getFile(String resource) throws IOException {
+    final URL url = Resources.getResource(resource);
     if (url == null) {
       throw new IOException(String.format("Unable to find path %s.", resource));
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
@@ -30,7 +30,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -58,9 +58,9 @@ import com.google.common.io.Files;
  * which will produce a dump file.  The dump file will be input into DumpCat to test query mode and batch mode.
  */
 
-public class DumpCatTest  extends ExecTest{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DumpCatTest.class);
-  DrillConfig c = DrillConfig.create();
+public class DumpCatTest  extends ExecTest {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DumpCatTest.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
   public void testDumpCat(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable
@@ -68,22 +68,22 @@ public class DumpCatTest  extends ExecTest{
 
       new NonStrictExpectations(){{
           bitContext.getMetrics(); result = new MetricRegistry();
-          bitContext.getAllocator(); result = new TopLevelAllocator();
+          bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
           bitContext.getConfig(); result = c;
           bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
           bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       }};
 
-      PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-      PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/trace/simple_trace.json"), Charsets.UTF_8));
-      FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-      FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-      SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+      final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+      final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/trace/simple_trace.json"), Charsets.UTF_8));
+      final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+      final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+      final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-      while(exec.next()){
+      while(exec.next()) {
       }
 
-      if(context.getFailureCause() != null){
+      if(context.getFailureCause() != null) {
           throw context.getFailureCause();
       }
       assertTrue(!context.isFailed());
@@ -95,37 +95,34 @@ public class DumpCatTest  extends ExecTest{
       /* Form the file name to which the trace output will dump the record batches */
       String qid = QueryIdHelper.getQueryId(handle.getQueryId());
 
-      int majorFragmentId = handle.getMajorFragmentId();
-      int minorFragmentId = handle.getMinorFragmentId();
+      final int majorFragmentId = handle.getMajorFragmentId();
+      final int minorFragmentId = handle.getMinorFragmentId();
 
-      String logLocation = c.getString(ExecConstants.TRACE_DUMP_DIRECTORY);
+      final String logLocation = c.getString(ExecConstants.TRACE_DUMP_DIRECTORY);
 
       System.out.println("Found log location: " + logLocation);
 
-      String filename = String.format("%s//%s_%d_%d_mock-scan", logLocation, qid, majorFragmentId, minorFragmentId);
+      final String filename = String.format("%s//%s_%d_%d_mock-scan", logLocation, qid, majorFragmentId, minorFragmentId);
 
       System.out.println("File Name: " + filename);
 
-      Configuration conf = new Configuration();
+      final Configuration conf = new Configuration();
       conf.set(FileSystem.FS_DEFAULT_NAME_KEY, c.getString(ExecConstants.TRACE_DUMP_FILESYSTEM));
 
-      FileSystem fs = FileSystem.get(conf);
-      Path path = new Path(filename);
+      final FileSystem fs = FileSystem.get(conf);
+      final Path path = new Path(filename);
       assertTrue("Trace file does not exist", fs.exists(path));
 
-      DumpCat dumpCat = new DumpCat();
+      final DumpCat dumpCat = new DumpCat();
 
       //Test Query mode
-      FileInputStream input = new FileInputStream(filename);
-
-      dumpCat.doQuery(input);
-      input.close();
+      try (final FileInputStream input = new FileInputStream(filename)) {
+        dumpCat.doQuery(input);
+      }
 
       //Test Batch mode
-      input = new FileInputStream(filename);
-      dumpCat.doBatch(input,0,true);
-
-      input.close();
+      try(final FileInputStream input = new FileInputStream(filename)) {
+        dumpCat.doBatch(input, 0, true);
+      }
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestByteComparisonFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestByteComparisonFunctions.java
@@ -23,25 +23,26 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.expr.fn.impl.ByteFunctionHelpers;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.vector.ValueHolderHelper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestByteComparisonFunctions extends ExecTest{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestByteComparisonFunctions.class);
+public class TestByteComparisonFunctions extends ExecTest {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestByteComparisonFunctions.class);
 
-  static TopLevelAllocator allocator;
-  static VarCharHolder hello;
-  static VarCharHolder goodbye;
-  static VarCharHolder helloLong;
-  static VarCharHolder goodbyeLong;
+  private static BufferAllocator allocator;
+  private static VarCharHolder hello;
+  private static VarCharHolder goodbye;
+  private static VarCharHolder helloLong;
+  private static VarCharHolder goodbyeLong;
 
   @BeforeClass
-  public static void setup(){
+  public static void setup() {
     DrillConfig c= DrillConfig.create();
-    allocator = new TopLevelAllocator(c);
+    allocator = RootAllocatorFactory.newRoot(c);
     hello = ValueHolderHelper.getVarCharHolder(allocator, "hello");
     goodbye = ValueHolderHelper.getVarCharHolder(allocator, "goodbye");
     helloLong = ValueHolderHelper.getVarCharHolder(allocator, "hellomyfriend");
@@ -49,7 +50,7 @@ public class TestByteComparisonFunctions extends ExecTest{
   }
 
   @AfterClass
-  public static void teardown(){
+  public static void teardown() {
     hello.buffer.release();
     helloLong.buffer.release();
     goodbye.buffer.release();
@@ -58,72 +59,72 @@ public class TestByteComparisonFunctions extends ExecTest{
   }
 
   @Test
-  public void testAfter(){
-    VarCharHolder left = hello;
-    VarCharHolder right = goodbye;
+  public void testAfter() {
+    final VarCharHolder left = hello;
+    final VarCharHolder right = goodbye;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 1);
   }
 
   @Test
-  public void testBefore(){
-    VarCharHolder left = goodbye;
-    VarCharHolder right = hello;
+  public void testBefore() {
+    final VarCharHolder left = goodbye;
+    final VarCharHolder right = hello;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == -1);
   }
 
   @Test
-  public void testEqualCompare(){
-    VarCharHolder left = hello;
-    VarCharHolder right = hello;
+  public void testEqualCompare() {
+    final VarCharHolder left = hello;
+    final VarCharHolder right = hello;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 0);
   }
 
   @Test
-  public void testEqual(){
-    VarCharHolder left = hello;
-    VarCharHolder right = hello;
+  public void testEqual() {
+    final VarCharHolder left = hello;
+    final VarCharHolder right = hello;
     assertTrue(ByteFunctionHelpers.equal(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 1);
   }
 
   @Test
-  public void testNotEqual(){
-    VarCharHolder left = hello;
-    VarCharHolder right = goodbye;
+  public void testNotEqual() {
+    final VarCharHolder left = hello;
+    final VarCharHolder right = goodbye;
     assertTrue(ByteFunctionHelpers.equal(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 0);
   }
 
   @Test
-  public void testAfterLong(){
-    VarCharHolder left = helloLong;
-    VarCharHolder right = goodbyeLong;
+  public void testAfterLong() {
+    final VarCharHolder left = helloLong;
+    final VarCharHolder right = goodbyeLong;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 1);
   }
 
   @Test
-  public void testBeforeLong(){
-    VarCharHolder left = goodbyeLong;
-    VarCharHolder right = helloLong;
+  public void testBeforeLong() {
+    final VarCharHolder left = goodbyeLong;
+    final VarCharHolder right = helloLong;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == -1);
   }
 
   @Test
-  public void testEqualCompareLong(){
-    VarCharHolder left = helloLong;
-    VarCharHolder right = helloLong;
+  public void testEqualCompareLong() {
+    final VarCharHolder left = helloLong;
+    final VarCharHolder right = helloLong;
     assertTrue(ByteFunctionHelpers.compare(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 0);
   }
 
   @Test
-  public void testEqualLong(){
-    VarCharHolder left = helloLong;
-    VarCharHolder right = helloLong;
+  public void testEqualLong() {
+    final VarCharHolder left = helloLong;
+    final VarCharHolder right = helloLong;
     assertTrue(ByteFunctionHelpers.equal(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 1);
   }
 
   @Test
-  public void testNotEqualLong(){
-    VarCharHolder left = helloLong;
-    VarCharHolder right = goodbyeLong;
+  public void testNotEqualLong() {
+    final VarCharHolder left = helloLong;
+    final VarCharHolder right = goodbyeLong;
     assertTrue(ByteFunctionHelpers.equal(left.buffer, left.start, left.end, right.buffer, right.start, right.end) == 0);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestMathFunctions.java
@@ -30,7 +30,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -52,44 +52,41 @@ import com.google.common.io.Files;
 
 
 public class TestMathFunctions extends ExecTest {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestMathFunctions.class);
+  private final DrillConfig c = DrillConfig.create();
 
-    static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestMathFunctions.class);
-    DrillConfig c = DrillConfig.create();
+  @Test
+  public void testBasicMathFunctions(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable
+  {
+    new NonStrictExpectations() {{
+      bitContext.getMetrics(); result = new MetricRegistry();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
+      bitContext.getConfig(); result = c;
+      bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
+      bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
+    }};
 
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/simple_math_functions.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, BitControl.PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    @Test
-    public void testBasicMathFunctions(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable
-    {
-
-        new NonStrictExpectations(){{
-            bitContext.getMetrics(); result = new MetricRegistry();
-            bitContext.getAllocator(); result = new TopLevelAllocator();
-            bitContext.getConfig(); result = c;
-            bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
-            bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
-        }};
-
-        PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-        PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/simple_math_functions.json"), Charsets.UTF_8));
-        FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-        FragmentContext context = new FragmentContext(bitContext, BitControl.PlanFragment.getDefaultInstance(), connection, registry);
-        SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
-
-        while(exec.next()) {
-            IntVector intMulVector = exec.getValueVectorById(new SchemaPath("INTMUL", ExpressionPosition.UNKNOWN), IntVector.class);
-            Float8Vector floatMulVector = exec.getValueVectorById(new SchemaPath("FLOATMUL", ExpressionPosition.UNKNOWN), Float8Vector.class);
-            IntVector intAddVector = exec.getValueVectorById(new SchemaPath("INTADD", ExpressionPosition.UNKNOWN), IntVector.class);
-            Float8Vector floatAddVector = exec.getValueVectorById(new SchemaPath("FLOATADD", ExpressionPosition.UNKNOWN), Float8Vector.class);
-            assertEquals(exec.getRecordCount(), 1);
-            assertEquals(intMulVector.getAccessor().get(0), 2);
-            assertEquals(floatMulVector.getAccessor().get(0), (1.1 * 2.2), 0);
-            assertEquals(intAddVector.getAccessor().get(0), 3);
-            assertEquals(floatAddVector.getAccessor().get(0), (1.1 + 2.2), 0);
-        }
-
-        if(context.getFailureCause() != null){
-            throw context.getFailureCause();
-        }
-        assertTrue(!context.isFailed());
+    while(exec.next()) {
+      final IntVector intMulVector = exec.getValueVectorById(new SchemaPath("INTMUL", ExpressionPosition.UNKNOWN), IntVector.class);
+      final Float8Vector floatMulVector = exec.getValueVectorById(new SchemaPath("FLOATMUL", ExpressionPosition.UNKNOWN), Float8Vector.class);
+      final IntVector intAddVector = exec.getValueVectorById(new SchemaPath("INTADD", ExpressionPosition.UNKNOWN), IntVector.class);
+      final Float8Vector floatAddVector = exec.getValueVectorById(new SchemaPath("FLOATADD", ExpressionPosition.UNKNOWN), Float8Vector.class);
+      assertEquals(exec.getRecordCount(), 1);
+      assertEquals(intMulVector.getAccessor().get(0), 2);
+      assertEquals(floatMulVector.getAccessor().get(0), (1.1 * 2.2), 0);
+      assertEquals(intAddVector.getAccessor().get(0), 3);
+      assertEquals(floatAddVector.getAccessor().get(0), (1.1 + 2.2), 0);
     }
+
+    if(context.getFailureCause() != null) {
+      throw context.getFailureCause();
+    }
+    assertTrue(!context.isFailed());
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestRepeatedFunction.java
@@ -29,7 +29,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -50,42 +50,38 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestRepeatedFunction extends ExecTest{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRepeatedFunction.class);
-  DrillConfig c = DrillConfig.create();
-
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRepeatedFunction.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void testRepeated(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
+  public void testRepeated(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
 //    System.out.println(System.getProperty("java.class.path"));
-
-
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/physical_repeated_1.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/physical_repeated_1.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     boolean oneIsOne = false;
     int size = 0;
-    int[] sizes = {1,2,0,6};
+    final int[] sizes = {1, 2, 0, 6};
 
-    while(exec.next()){
-      IntVector c1 = exec.getValueVectorById(new SchemaPath("cnt", ExpressionPosition.UNKNOWN), IntVector.class);
-      BitVector c2 = exec.getValueVectorById(new SchemaPath("has_min", ExpressionPosition.UNKNOWN), BitVector.class);
+    while(exec.next()) {
+      final IntVector c1 = exec.getValueVectorById(new SchemaPath("cnt", ExpressionPosition.UNKNOWN), IntVector.class);
+      final BitVector c2 = exec.getValueVectorById(new SchemaPath("has_min", ExpressionPosition.UNKNOWN), BitVector.class);
 
-      for(int i =0; i < exec.getRecordCount(); i++){
-        int curSize = sizes[size % sizes.length];
+      for(int i = 0; i < exec.getRecordCount(); i++) {
+        final int curSize = sizes[size % sizes.length];
         assertEquals(curSize, c1.getAccessor().get(i));
-        switch(curSize){
+        switch(curSize) {
         case 1:
           assertEquals(oneIsOne, 1 == c2.getAccessor().get(i));
           oneIsOne = !oneIsOne;
@@ -104,11 +100,9 @@ public class TestRepeatedFunction extends ExecTest{
       }
     }
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
-
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestEndianess.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestEndianess.java
@@ -20,22 +20,23 @@ package org.apache.drill.exec.memory;
 import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecTest;
 import org.junit.Test;
 
 
-
-public class TestEndianess extends ExecTest{
-
+public class TestEndianess extends ExecTest {
   @Test
-  public void testLittleEndian(){
-    TopLevelAllocator a = new TopLevelAllocator(Long.MAX_VALUE);
-    ByteBuf b = a.buffer(4);
+  public void testLittleEndian() {
+    final DrillConfig drillConfig = DrillConfig.create();
+    final BufferAllocator a = RootAllocatorFactory.newRoot(drillConfig);
+    final ByteBuf b = a.buffer(4);
     b.setInt(0, 35);
-    assertEquals((int) b.getByte(0), 35);
-    assertEquals((int) b.getByte(1), 0);
-    assertEquals((int) b.getByte(2), 0);
-    assertEquals((int) b.getByte(3), 0);
+    assertEquals(b.getByte(0), 35);
+    assertEquals(b.getByte(1), 0);
+    assertEquals(b.getByte(2), 0);
+    assertEquals(b.getByte(3), 0);
+    b.release();
+    a.close();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestCastFunctions.java
@@ -40,7 +40,7 @@ import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.expr.holders.VarBinaryHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -69,19 +69,16 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestCastFunctions extends PopUnitTestBase{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleFunctions.class);
-
-  DrillConfig c = DrillConfig.create();
-
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleFunctions.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
   // cast to bigint.
   public void testCastBigInt(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
 
-    final BufferAllocator allocator = new TopLevelAllocator();
-
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -89,19 +86,18 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastBigInt.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastBigInt.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      BigIntVector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast", ExpressionPosition.UNKNOWN), BigIntVector.class);
-      BigIntVector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final BigIntVector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast", ExpressionPosition.UNKNOWN), BigIntVector.class);
+      final BigIntVector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
           BigIntHolder holder0 = new BigIntHolder();
           a0.get(i, holder0);
           assertEquals(1256, holder0.value);
@@ -116,7 +112,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -125,11 +121,11 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //cast to int
   public void testCastInt(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
 
-    final BufferAllocator allocator = new TopLevelAllocator();
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
 
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -137,24 +133,22 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastInt.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastInt.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      IntVector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast", ExpressionPosition.UNKNOWN), IntVector.class);
-      IntVector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final IntVector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast", ExpressionPosition.UNKNOWN), IntVector.class);
+      final IntVector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          IntHolder holder0 = new IntHolder();
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
+          final IntHolder holder0 = new IntHolder();
           a0.get(i, holder0);
           assertEquals(1256, holder0.value);
           ++count;
-
       }
       assertEquals(5, count);
     }
@@ -164,7 +158,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -173,9 +167,9 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //cast to float4
   public void testCastFloat4(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    final BufferAllocator allocator = new TopLevelAllocator();
-    new NonStrictExpectations(){{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -183,20 +177,19 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastFloat4.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastFloat4.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      Float4Vector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast2", ExpressionPosition.UNKNOWN), Float4Vector.class);
-      Float4Vector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final Float4Vector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast2", ExpressionPosition.UNKNOWN), Float4Vector.class);
+      final Float4Vector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          Float4Holder holder0 = new Float4Holder();
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
+          final Float4Holder holder0 = new Float4Holder();
           a0.get(i, holder0);
           assertEquals(12.56, holder0.value, 0.001);
           ++count;
@@ -210,7 +203,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -219,10 +212,9 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //cast to float8
   public void testCastFloat8(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
-
-    final BufferAllocator allocator = new TopLevelAllocator();
-    new NonStrictExpectations(){{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -230,20 +222,19 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastFloat8.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastFloat8.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      Float8Vector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast2", ExpressionPosition.UNKNOWN), Float8Vector.class);
-      Float8Vector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final Float8Vector c0 = exec.getValueVectorById(new SchemaPath("varchar_cast2", ExpressionPosition.UNKNOWN), Float8Vector.class);
+      final Float8Vector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
       for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          Float8Holder holder0 = new Float8Holder();
+          final Float8Holder holder0 = new Float8Holder();
           a0.get(i, holder0);
           assertEquals(12.56, holder0.value, 0.001);
           ++count;
@@ -257,7 +248,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -266,10 +257,10 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //cast to varchar(length)
   public void testCastVarChar(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
 
-    final BufferAllocator allocator = new TopLevelAllocator();
-    new NonStrictExpectations(){{
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -277,24 +268,22 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastVarChar.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastVarChar.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      VarCharVector c0 = exec.getValueVectorById(new SchemaPath("int_lit_cast", ExpressionPosition.UNKNOWN), VarCharVector.class);
-      VarCharVector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final VarCharVector c0 = exec.getValueVectorById(new SchemaPath("int_lit_cast", ExpressionPosition.UNKNOWN), VarCharVector.class);
+      final VarCharVector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          VarCharHolder holder0 = new VarCharHolder();
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
+          final VarCharHolder holder0 = new VarCharHolder();
           a0.get(i, holder0);
           assertEquals("123", StringFunctionHelpers.toStringFromUTF8(holder0.start, holder0.end, holder0.buffer));
           ++count;
-
       }
       assertEquals(5, count);
     }
@@ -304,7 +293,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -313,11 +302,10 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //cast to varbinary(length)
   public void testCastVarBinary(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
 
-    final BufferAllocator allocator = new TopLevelAllocator();
-
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -325,20 +313,19 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastVarBinary.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastVarBinary.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      VarBinaryVector c0 = exec.getValueVectorById(new SchemaPath("int_lit_cast", ExpressionPosition.UNKNOWN), VarBinaryVector.class);
-      VarBinaryVector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final VarBinaryVector c0 = exec.getValueVectorById(new SchemaPath("int_lit_cast", ExpressionPosition.UNKNOWN), VarBinaryVector.class);
+      final VarBinaryVector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          VarBinaryHolder holder0 = new VarBinaryHolder();
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
+          final VarBinaryHolder holder0 = new VarBinaryHolder();
           a0.get(i, holder0);
           assertEquals("123", StringFunctionHelpers.toStringFromUTF8(holder0.start, holder0.end, holder0.buffer));
           ++count;
@@ -351,7 +338,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
@@ -360,10 +347,10 @@ public class TestCastFunctions extends PopUnitTestBase{
   @Test
   //nested: cast is nested in another cast, or another function.
   public void testCastNested(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
 
-    final BufferAllocator allocator = new TopLevelAllocator();
-    new NonStrictExpectations(){{
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -371,20 +358,19 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastNested.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastNested.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
-      IntVector c0 = exec.getValueVectorById(new SchemaPath("add_cast", ExpressionPosition.UNKNOWN),IntVector.class);
-      IntVector.Accessor a0;
-      a0 = c0.getAccessor();
+    while(exec.next()) {
+      final IntVector c0 = exec.getValueVectorById(new SchemaPath("add_cast", ExpressionPosition.UNKNOWN),IntVector.class);
+      final IntVector.Accessor a0 = c0.getAccessor();
 
       int count = 0;
-      for(int i = 0; i < c0.getAccessor().getValueCount(); i++){
-          IntHolder holder0 = new IntHolder();
+      for(int i = 0; i < c0.getAccessor().getValueCount(); i++) {
+          final IntHolder holder0 = new IntHolder();
           a0.get(i, holder0);
           assertEquals(300, holder0.value);
           ++count;
@@ -397,7 +383,7 @@ public class TestCastFunctions extends PopUnitTestBase{
     context.close();
     allocator.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
 
@@ -407,11 +393,10 @@ public class TestCastFunctions extends PopUnitTestBase{
 
   @Test(expected = NumberFormatException.class)
   public void testCastNumException(@Injectable final DrillbitContext bitContext,
-                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                            @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
 
-    final BufferAllocator allocator = new TopLevelAllocator();
-
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
       bitContext.getAllocator(); result = allocator;
       bitContext.getConfig(); result = c;
@@ -419,13 +404,13 @@ public class TestCastFunctions extends PopUnitTestBase{
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastNumException.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastNumException.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    while(exec.next()){
+    while(exec.next()) {
     }
 
     exec.close();
@@ -435,32 +420,30 @@ public class TestCastFunctions extends PopUnitTestBase{
 
     assertTrue(context.isFailed());
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
-
   }
 
   @Test
   public void testCastFromNullablCol() throws Throwable {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-
-    try(Drillbit bit = new Drillbit(CONFIG, serviceSet);
-        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+    try(final Drillbit bit = new Drillbit(CONFIG, serviceSet);
+        final DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit.run();
 
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Files.toString(FileUtils.getResourceAsFile("/functions/cast/testCastVarCharNull.json"), Charsets.UTF_8).replace("#{TEST_FILE}", "/jsoninput/input1.json"));
 
-      QueryDataBatch batch = results.get(0);
+      final QueryDataBatch batch = results.get(0);
 
-      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      final RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
       batchLoader.load(batch.getHeader().getDef(), batch.getData());
 
-      Object [][] result = getRunResult(batchLoader);
+      final Object [][] result = getRunResult(batchLoader);
 
-      Object [][] expected = new Object[2][2];
+      final Object [][] expected = new Object[2][2];
 
       expected[0][0] = new String("2001");
       expected[0][1] = new String("1.2");
@@ -477,24 +460,23 @@ public class TestCastFunctions extends PopUnitTestBase{
         }
       }
       batchLoader.clear();
-      for(QueryDataBatch b : results){
+      for(final QueryDataBatch b : results){
         b.release();
       }
-
     }
   }
 
   private Object[][] getRunResult(VectorAccessible va) {
     int size = 0;
-    for (VectorWrapper v : va) {
+    for (final VectorWrapper v : va) {
       size++;
     }
 
-    Object[][] res = new Object [va.getRecordCount()][size];
+    final Object[][] res = new Object [va.getRecordCount()][size];
     for (int j = 0; j < va.getRecordCount(); j++) {
       int i = 0;
-      for (VectorWrapper v : va) {
-        Object o =  v.getValueVector().getAccessor().getObject(j);
+      for (final VectorWrapper v : va) {
+        final Object o =  v.getValueVector().getAccessor().getObject(j);
         if (o instanceof byte[]) {
           res[j][i++] =  new String((byte[]) o);
         } else {
@@ -504,5 +486,4 @@ public class TestCastFunctions extends PopUnitTestBase{
     }
     return res;
  }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestImplicitCastFunctions.java
@@ -26,7 +26,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -43,22 +43,22 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 public class TestImplicitCastFunctions extends ExecTest {
-    static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestImplicitCastFunctions.class);
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestImplicitCastFunctions.class);
 
-  DrillConfig c = DrillConfig.create();
-  PhysicalPlanReader reader;
-  FunctionImplementationRegistry registry;
-  FragmentContext context;
+  private final DrillConfig c = DrillConfig.create();
+  private PhysicalPlanReader reader;
+  private FunctionImplementationRegistry registry;
+  private FragmentContext context;
 
   public Object[] getRunResult(SimpleRootExec exec) {
     int size = 0;
-    for (ValueVector v : exec) {
+    for (final ValueVector v : exec) {
       size++;
     }
 
-    Object[] res = new Object [size];
+    final Object[] res = new Object [size];
     int i = 0;
-    for (ValueVector v : exec) {
+    for (final ValueVector v : exec) {
       res[i++] = v.getAccessor().getObject(0);
     }
     return res;
@@ -69,13 +69,13 @@ public class TestImplicitCastFunctions extends ExecTest {
 
     new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-    String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
+    final String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
     if (reader == null) {
       reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
     }
@@ -85,16 +85,16 @@ public class TestImplicitCastFunctions extends ExecTest {
     if (context == null) {
       context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
     }
-    PhysicalPlan plan = reader.readPhysicalPlan(planString);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlan plan = reader.readPhysicalPlan(planString);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
 
     exec.next(); // skip schema batch
     while (exec.next()) {
-      Object [] res = getRunResult(exec);
+      final Object [] res = getRunResult(exec);
       assertEquals("return count does not match", res.length, expectedResults.length);
 
-      for (int i = 0; i<res.length; i++) {
+      for (int i = 0; i < res.length; i++) {
         assertEquals(String.format("column %s does not match", i),  res[i], expectedResults[i]);
       }
     }
@@ -109,7 +109,7 @@ public class TestImplicitCastFunctions extends ExecTest {
   @Test
   public void testImplicitCastWithConstant(@Injectable final DrillbitContext bitContext,
                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[21];
+    final Object [] expected = new Object[21];
     expected [0] = new Double (30.1);
     expected [1] = new Double (30.1);
     expected [2] = new Double (30.1);
@@ -141,7 +141,7 @@ public class TestImplicitCastFunctions extends ExecTest {
   @Test
   public void testImplicitCastWithMockColumn(@Injectable final DrillbitContext bitContext,
                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[5];
+    final Object [] expected = new Object[5];
     expected [0] = new Integer (0);
     expected [1] = new Integer (0);
     expected [2] = new Float (-2.14748365E9);
@@ -154,7 +154,7 @@ public class TestImplicitCastFunctions extends ExecTest {
   @Test
   public void testImplicitCastWithNullExpression(@Injectable final DrillbitContext bitContext,
                            @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[10];
+    final Object [] expected = new Object[10];
 
     expected [0] = Boolean.TRUE;
     expected [1] = Boolean.FALSE;
@@ -170,5 +170,4 @@ public class TestImplicitCastFunctions extends ExecTest {
 
     runTest(bitContext, connection, expected, "functions/cast/testICastNullExp.json");
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
@@ -30,7 +30,7 @@ import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.holders.VarBinaryHolder;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.opt.BasicOptimizer;
@@ -66,28 +66,28 @@ import com.google.common.io.Resources;
 
 @Ignore
 public class TestOptiqPlans extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestOptiqPlans.class);
-  DrillConfig c = DrillConfig.create();
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestOptiqPlans.class);
+  private final DrillConfig config = DrillConfig.create();
 
   @Test
   public void orderBy(@Injectable final BootStrapContext ctxt, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
       @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_order.json", coord, com, controller, workBus);
+    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_order.json", coord, com, controller, workBus);
   }
 
   @Test
   public void stringFilter(@Injectable final BootStrapContext ctxt, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
       @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_string_filter.json", coord, com, controller, workBus);
+    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_string_filter.json", coord, com, controller, workBus);
   }
 
   @Test
   public void groupBy(@Injectable final BootStrapContext bitContext, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
       @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    SimpleRootExec exec = doLogicalTest(bitContext, connection, "/logical_group.json", coord, com, controller, workBus);
+    final SimpleRootExec exec = doLogicalTest(bitContext, connection, "/logical_group.json", coord, com, controller, workBus);
   }
 
   private SimpleRootExec doLogicalTest(final BootStrapContext context, UserClientConnection connection, String file,
@@ -97,24 +97,23 @@ public class TestOptiqPlans extends ExecTest {
         context.getMetrics();
         result = new MetricRegistry();
         context.getAllocator();
-        result = new TopLevelAllocator();
+        result = RootAllocatorFactory.newRoot(config);
         context.getConfig();
-        result = c;
+        result = config;
       }
     };
-    RemoteServiceSet lss = RemoteServiceSet.getLocalServiceSet();
-    DrillbitContext bitContext = new DrillbitContext(DrillbitEndpoint.getDefaultInstance(), context, coord, controller,
-        com, workBus, new LocalPStoreProvider(DrillConfig.create()), null);
-    QueryContext qc = new QueryContext(UserSession.Builder.newBuilder().setSupportComplexTypes(true).build(),
+    final RemoteServiceSet lss = RemoteServiceSet.getLocalServiceSet();
+    final DrillbitContext bitContext = new DrillbitContext(DrillbitEndpoint.getDefaultInstance(), context, coord, controller,
+        com, workBus, new LocalPStoreProvider(config), null);
+    final QueryContext qc = new QueryContext(UserSession.Builder.newBuilder().setSupportComplexTypes(true).build(),
         bitContext);
-    PhysicalPlanReader reader = bitContext.getPlanReader();
-    LogicalPlan plan = reader.readLogicalPlan(Files.toString(FileUtils.getResourceAsFile(file), Charsets.UTF_8));
-    PhysicalPlan pp = new BasicOptimizer(qc, connection).optimize(new BasicOptimizer.BasicOptimizationContext(qc), plan);
+    final PhysicalPlanReader reader = bitContext.getPlanReader();
+    final LogicalPlan plan = reader.readLogicalPlan(Files.toString(FileUtils.getResourceAsFile(file), Charsets.UTF_8));
+    final PhysicalPlan pp = new BasicOptimizer(qc, connection).optimize(new BasicOptimizer.BasicOptimizationContext(qc), plan);
 
-
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext fctxt = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(fctxt, (FragmentRoot) pp.getSortedOperators(false)
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(config);
+    final FragmentContext fctxt = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(fctxt, (FragmentRoot) pp.getSortedOperators(false)
         .iterator().next()));
     return exec;
 
@@ -122,24 +121,23 @@ public class TestOptiqPlans extends ExecTest {
 
   @Test
   public void testFilterPlan() throws Exception {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-    DrillConfig config = DrillConfig.create();
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet);
-        DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
+    try (final Drillbit bit1 = new Drillbit(config, serviceSet);
+        final DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Resources.toString(Resources.getResource("physical_filter.json"), Charsets.UTF_8));
-      RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
-      for (QueryDataBatch b : results) {
+      final RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
+      for (final QueryDataBatch b : results) {
         System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
         loader.load(b.getHeader().getDef(), b.getData());
-        for (VectorWrapper<?> vw : loader) {
+        for (final VectorWrapper<?> vw : loader) {
           System.out.println(vw.getValueVector().getField().toExpr());
-          ValueVector vv = vw.getValueVector();
+          final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-            Object o = vv.getAccessor().getObject(i);
+            final Object o = vv.getAccessor().getObject(i);
             System.out.println(vv.getAccessor().getObject(i));
           }
         }
@@ -152,24 +150,23 @@ public class TestOptiqPlans extends ExecTest {
 
   @Test
   public void testJoinPlan() throws Exception {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-    DrillConfig config = DrillConfig.create();
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet);
-        DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
+    try (final Drillbit bit1 = new Drillbit(config, serviceSet);
+        final DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Resources.toString(Resources.getResource("physical_join.json"), Charsets.UTF_8));
-      RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
-      for (QueryDataBatch b : results) {
+      final RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
+      for (final QueryDataBatch b : results) {
         System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
         loader.load(b.getHeader().getDef(), b.getData());
-        for (VectorWrapper<?> vw : loader) {
+        for (final VectorWrapper<?> vw : loader) {
           System.out.println(vw.getValueVector().getField().toExpr());
-          ValueVector vv = vw.getValueVector();
+          final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-            Object o = vv.getAccessor().getObject(i);
+            final Object o = vv.getAccessor().getObject(i);
             System.out.println(vv.getAccessor().getObject(i));
           }
         }
@@ -182,27 +179,26 @@ public class TestOptiqPlans extends ExecTest {
 
   @Test
   public void testFilterString() throws Exception {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-    DrillConfig config = DrillConfig.create();
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet);
-        DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
+    try (final Drillbit bit1 = new Drillbit(config, serviceSet);
+        final DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.LOGICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.LOGICAL,
           Resources.toString(Resources.getResource("logical_string_filter.json"), Charsets.UTF_8));
-      RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
-      for (QueryDataBatch b : results) {
+      final RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
+      for (final QueryDataBatch b : results) {
         System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
         loader.load(b.getHeader().getDef(), b.getData());
-        for (VectorWrapper<?> vw : loader) {
+        for (final VectorWrapper<?> vw : loader) {
           System.out.println(vw.getValueVector().getField().toExpr());
-          ValueVector vv = vw.getValueVector();
+          final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-            Object o = vv.getAccessor().getObject(i);
+            final Object o = vv.getAccessor().getObject(i);
             if (vv instanceof VarBinaryVector) {
-              VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
-              VarBinaryHolder vbh = new VarBinaryHolder();
+              final VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
+              final VarBinaryHolder vbh = new VarBinaryHolder();
               x.get(i, vbh);
               System.out.printf("%d..%d", vbh.start, vbh.end);
 
@@ -222,27 +218,26 @@ public class TestOptiqPlans extends ExecTest {
 
   @Test
   public void testLogicalJsonScan() throws Exception {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-    DrillConfig config = DrillConfig.create();
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet);
-        DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
+    try (final Drillbit bit1 = new Drillbit(config, serviceSet);
+        final DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.LOGICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.LOGICAL,
           Resources.toString(Resources.getResource("logical_json_scan.json"), Charsets.UTF_8));
-      RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
-      for (QueryDataBatch b : results) {
+      final RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
+      for (final QueryDataBatch b : results) {
         System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
         loader.load(b.getHeader().getDef(), b.getData());
-        for (VectorWrapper vw : loader) {
+        for (final VectorWrapper vw : loader) {
           System.out.println(vw.getValueVector().getField().toExpr());
-          ValueVector vv = vw.getValueVector();
+          final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-            Object o = vv.getAccessor().getObject(i);
+            final Object o = vv.getAccessor().getObject(i);
             if (vv instanceof VarBinaryVector) {
-              VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
-              VarBinaryHolder vbh = new VarBinaryHolder();
+              final VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
+              final VarBinaryHolder vbh = new VarBinaryHolder();
               x.get(i, vbh);
               System.out.printf("%d..%d", vbh.start, vbh.end);
 
@@ -262,27 +257,26 @@ public class TestOptiqPlans extends ExecTest {
 
   @Test
   public void testOrderVarbinary() throws Exception {
-    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-    DrillConfig config = DrillConfig.create();
+    final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet);
-        DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
+    try (final Drillbit bit1 = new Drillbit(config, serviceSet);
+        final DrillClient client = new DrillClient(config, serviceSet.getCoordinator());) {
       bit1.run();
       client.connect();
-      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+      final List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
           Resources.toString(Resources.getResource("physical_order_varbinary.json"), Charsets.UTF_8));
-      RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
-      for (QueryDataBatch b : results) {
+      final RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
+      for (final QueryDataBatch b : results) {
         System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
         loader.load(b.getHeader().getDef(), b.getData());
-        for (VectorWrapper vw : loader) {
+        for (final VectorWrapper vw : loader) {
           System.out.println(vw.getValueVector().getField().toExpr());
-          ValueVector vv = vw.getValueVector();
+          final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-            Object o = vv.getAccessor().getObject(i);
+            final Object o = vv.getAccessor().getObject(i);
             if (vv instanceof VarBinaryVector) {
-              VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
-              VarBinaryHolder vbh = new VarBinaryHolder();
+              final VarBinaryVector.Accessor x = ((VarBinaryVector) vv).getAccessor();
+              final VarBinaryHolder vbh = new VarBinaryHolder();
               x.get(i, vbh);
               System.out.printf("%d..%d", vbh.start, vbh.end);
 
@@ -307,22 +301,21 @@ public class TestOptiqPlans extends ExecTest {
         bitContext.getMetrics();
         result = new MetricRegistry();
         bitContext.getAllocator();
-        result = new TopLevelAllocator();
+        result = RootAllocatorFactory.newRoot(config);
         bitContext.getConfig();
-        result = c;
+        result = config;
       }
     };
 
-    StoragePluginRegistry reg = new StoragePluginRegistry(bitContext);
+    final StoragePluginRegistry reg = new StoragePluginRegistry(bitContext);
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(),
+    final PhysicalPlanReader reader = new PhysicalPlanReader(config, config.getMapper(),
         CoordinationProtos.DrillbitEndpoint.getDefaultInstance(), reg);
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile(file), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false)
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile(file), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(config);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false)
         .iterator().next()));
     return exec;
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
@@ -26,7 +26,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -44,22 +44,22 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 public class TestStringFunctions extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestStringFunctions.class);
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestStringFunctions.class);
 
-  DrillConfig c = DrillConfig.create();
-  PhysicalPlanReader reader;
-  FunctionImplementationRegistry registry;
-  FragmentContext context;
+  private final DrillConfig c = DrillConfig.create();
+  private PhysicalPlanReader reader;
+  private FunctionImplementationRegistry registry;
+  private FragmentContext context;
 
   public Object[] getRunResult(SimpleRootExec exec) {
     int size = 0;
-    for (ValueVector v : exec) {
+    for (final ValueVector v : exec) {
       size++;
     }
 
-    Object[] res = new Object [size];
+    final Object[] res = new Object [size];
     int i = 0;
-    for (ValueVector v : exec) {
+    for (final ValueVector v : exec) {
       if  (v instanceof VarCharVector) {
         res[i++] = new String( ((VarCharVector) v).getAccessor().get(0), Charsets.UTF_8);
       } else {
@@ -73,13 +73,13 @@ public class TestStringFunctions extends ExecTest {
                       @Injectable UserServer.UserClientConnection connection, Object[] expectedResults, String planPath) throws Throwable {
     new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-    String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
+    final String planString = Resources.toString(Resources.getResource(planPath), Charsets.UTF_8);
     if (reader == null) {
       reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
     }
@@ -89,12 +89,12 @@ public class TestStringFunctions extends ExecTest {
     if (context == null) {
       context =  new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry); //new FragmentContext(bitContext, ExecProtos.FragmentHandle.getDefaultInstance(), connection, registry);
     }
-    PhysicalPlan plan = reader.readPhysicalPlan(planString);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlan plan = reader.readPhysicalPlan(planString);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     exec.next(); // skip schema batch
     while(exec.next()) {
-      Object [] res = getRunResult(exec);
+      final Object [] res = getRunResult(exec);
       assertEquals("return count does not match", expectedResults.length, res.length);
 
       for (int i = 0; i<res.length; i++) {
@@ -110,148 +110,130 @@ public class TestStringFunctions extends ExecTest {
 
   @Test
   public void testCharLength(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
     Object [] expected = new Object[] {new Long(8), new Long(0), new Long(5), new Long(5),
                                        new Long(8), new Long(0), new Long(5), new Long(5),
                                        new Long(8), new Long(0), new Long(5), new Long(5),};
-
     runTest(bitContext, connection, expected, "functions/string/testCharLength.json");
   }
 
   @Test
   public void testLike(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE};
     runTest(bitContext, connection, expected, "functions/string/testLike.json");
   }
 
   @Test
   public void testSimilar(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.FALSE};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.FALSE};
     runTest(bitContext, connection, expected, "functions/string/testSimilar.json");
   }
 
   @Test
   public void testLtrim(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"def", "abcdef", "dabc", "", "", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"def", "abcdef", "dabc", "", "", ""};
     runTest(bitContext, connection, expected, "functions/string/testLtrim.json");
   }
 
   @Test
   public void testTrim(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"fghI", "", "", "!", " aaa "};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"fghI", "", "", "!", " aaa "};
     runTest(bitContext, connection, expected, "functions/string/testTrim.json");
   }
 
   @Test
   public void testReplace(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"aABABcdf", "ABABbABbcdf", "aababcdf", "acdf", "ABCD", "abc"};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"aABABcdf", "ABABbABbcdf", "aababcdf", "acdf", "ABCD", "abc"};
     runTest(bitContext, connection, expected, "functions/string/testReplace.json");
   }
 
   @Test
   public void testRtrim(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"abc", "abcdef", "ABd", "", "", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"abc", "abcdef", "ABd", "", "", ""};
     runTest(bitContext, connection, expected, "functions/string/testRtrim.json");
   }
 
   @Test
   public void testConcat(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"abcABC", "abc", "ABC", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"abcABC", "abc", "ABC", ""};
     runTest(bitContext, connection, expected, "functions/string/testConcat.json");
   }
 
   @Test
   public void testLower(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"abcefgh", "abc", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"abcefgh", "abc", ""};
     runTest(bitContext, connection, expected, "functions/string/testLower.json");
   }
 
   @Test
   public void testPosition(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {new Long(2), new Long(0), new Long(0), new Long(0),
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {new Long(2), new Long(0), new Long(0), new Long(0),
                                        new Long(2), new Long(0), new Long(0), new Long(0)};
-
     runTest(bitContext, connection, expected, "functions/string/testPosition.json");
   }
 
   @Test
   public void testRight(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"ef", "abcdef", "abcdef", "cdef", "f", "", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"ef", "abcdef", "abcdef", "cdef", "f", "", ""};
     runTest(bitContext, connection, expected, "functions/string/testRight.json");
   }
 
 
   @Test
   public void testSubstr(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"abc", "bcd", "bcdef", "bcdef", "", "", "", "", "भारत", "वर्ष", "वर्ष", "cdef", "", "", "", "ड्रिल"};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"abc", "bcd", "bcdef", "bcdef", "", "", "", "", "भारत", "वर्ष", "वर्ष", "cdef", "", "", "", "ड्रिल"};
     runTest(bitContext, connection, expected, "functions/string/testSubstr.json");
   }
 
   @Test
   public void testLeft(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"ab", "abcdef", "abcdef", "abcd", "a", "", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"ab", "abcdef", "abcdef", "abcd", "a", "", ""};
     runTest(bitContext, connection, expected, "functions/string/testLeft.json");
   }
 
   @Test
   public void testLpad(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"", "", "abcdef", "ab", "ab", "abcdef", "AAAAabcdef", "ABABabcdef", "ABCAabcdef", "ABCDabcdef"};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"", "", "abcdef", "ab", "ab", "abcdef", "AAAAabcdef", "ABABabcdef", "ABCAabcdef", "ABCDabcdef"};
     runTest(bitContext, connection, expected, "functions/string/testLpad.json");
   }
 
   @Test
   public void testRegexpReplace(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"ThM", "Th", "Thomas"};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"ThM", "Th", "Thomas"};
     runTest(bitContext, connection, expected, "functions/string/testRegexpReplace.json");
   }
 
   @Test
   public void testRpad(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"", "", "abcdef", "ab", "ab", "abcdef", "abcdefAAAA", "abcdefABAB", "abcdefABCA", "abcdefABCD"};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"", "", "abcdef", "ab", "ab", "abcdef", "abcdefAAAA", "abcdefABAB", "abcdefABCA", "abcdefABCD"};
     runTest(bitContext, connection, expected, "functions/string/testRpad.json");
   }
 
   @Test
   public void testUpper(@Injectable final DrillbitContext bitContext,
-                           @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {"ABCEFGH", "ABC", ""};
-
+                           @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {"ABCEFGH", "ABC", ""};
     runTest(bitContext, connection, expected, "functions/string/testUpper.json");
   }
 
   @Test
-  public void testNewStringFuncs(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    Object [] expected = new Object[] {97, 65, -32, "A", "btrim", "Peace Peace Peace ", "हकुना मताता हकुना मताता ", "katcit", "\u00C3\u00A2pple", "नदम"};
+  public void testNewStringFuncs(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    final Object [] expected = new Object[] {97, 65, -32, "A", "btrim", "Peace Peace Peace ", "हकुना मताता हकुना मताता ", "katcit", "\u00C3\u00A2pple", "नदम"};
     runTest(bitContext, connection, expected, "functions/string/testStringFuncs.json");
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/TestHashTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/TestHashTable.java
@@ -17,13 +17,20 @@
  */
 package org.apache.drill.exec.physical.impl.common;
 
+import mockit.Injectable;
 import mockit.NonStrictExpectations;
 
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.NamedExpression;
 import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
@@ -36,50 +43,52 @@ import org.apache.drill.exec.proto.BitControl.PlanFragment;
 import org.apache.drill.exec.proto.CoordinationProtos;
 import org.apache.drill.exec.rpc.user.UserServer.UserClientConnection;
 import org.apache.drill.exec.server.DrillbitContext;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestHashTable extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestHashTable.class);
-  DrillConfig c = DrillConfig.create();
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestHashTable.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @SuppressWarnings("deprecation")
 private SimpleRootExec doTest(final DrillbitContext bitContext, UserClientConnection connection, String plan_path) throws Exception{
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-
-
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile(plan_path), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile(plan_path), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
     return exec;
   }
+
+
 /*
   @Test
   public void testHashTable1(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
-    String plan_path = "/common/test_hashtable1.json";
-    SimpleRootExec exec = doTest(bitContext, connection, plan_path);
+    final String plan_path = "/common/test_hashtable1.json";
+    final SimpleRootExec exec = doTest(bitContext, connection, plan_path);
 
-    SchemaPath regionkey = new SchemaPath("regionkey", ExpressionPosition.UNKNOWN);
-    SchemaPath nationkey = new SchemaPath("nationkey", ExpressionPosition.UNKNOWN);
+    final SchemaPath regionkey = new SchemaPath("regionkey", ExpressionPosition.UNKNOWN);
+    final SchemaPath nationkey = new SchemaPath("nationkey", ExpressionPosition.UNKNOWN);
 
-    NamedExpression[] keyExprs = new NamedExpression[1];
+    final NamedExpression[] keyExprs = new NamedExpression[1];
     keyExprs[0] = new NamedExpression(regionkey, new FieldReference(regionkey));
 
-    HashTableConfig htConfig = new HashTableConfig(HashTable.DEFAULT_INITIAL_CAPACITY, HashTable.DEFAULT_LOAD_FACTOR, keyExprs);
-    ChainedHashTable cht = new ChainedHashTable(htConfig, exec.getContext(), exec.getIncoming(), null);
-    HashTable htable = cht.createAndSetupHashTable();
-    IntHolder htIdxHolder = new IntHolder();
+    final HashTableConfig htConfig = new HashTableConfig(HashTable.DEFAULT_INITIAL_CAPACITY, HashTable.DEFAULT_LOAD_FACTOR, keyExprs);
+    final ChainedHashTable cht = new ChainedHashTable(htConfig, exec.getContext(), exec.getIncoming(), null);
+    final HashTable htable = cht.createAndSetupHashTable();
+    final IntHolder htIdxHolder = new IntHolder();
 
     for (int i = 0; i < exec.getRecordCount(); i++) {
       HashTable.PutStatus putStatus = htable.put(i, htIdxHolder);
@@ -87,5 +96,5 @@ private SimpleRootExec doTest(final DrillbitContext bitContext, UserClientConnec
     }
     assertEquals(htable.size(), 5);
   }
-  */
+*/
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
@@ -27,7 +27,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -47,58 +47,53 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSimpleFilter extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleFilter.class);
-  DrillConfig c = DrillConfig.create();
-
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleFilter.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void testFilter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
+  public void testFilter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
 //    System.out.println(System.getProperty("java.class.path"));
-
-
-    new NonStrictExpectations(){{
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/filter/test1.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
-    while(exec.next()){
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/filter/test1.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    while(exec.next()) {
       assertEquals(50, exec.getRecordCount());
     }
 
     exec.close();
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
-
   }
 
   @Test
   @Ignore ("Filter does not support SV4")
-  public void testSV4Filter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
-    new NonStrictExpectations(){{
+  public void testSV4Filter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/filter/test_sv4.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/filter/test_sv4.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
     int recordCount = 0;
     while(exec.next()) {
       for (int i = 0; i < exec.getSelectionVector4().getCount(); i++) {
@@ -109,11 +104,9 @@ public class TestSimpleFilter extends ExecTest {
     exec.close();
     assertEquals(50, recordCount);
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
-
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestSimpleLimit.java
@@ -27,7 +27,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -48,13 +48,13 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSimpleLimit extends ExecTest {
-  DrillConfig c = DrillConfig.create();
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void testLimit(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    new NonStrictExpectations(){{
+  public void testLimit(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
@@ -64,10 +64,10 @@ public class TestSimpleLimit extends ExecTest {
   }
 
   @Test
-  public void testLimitNoEnd(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable{
-    new NonStrictExpectations(){{
+  public void testLimitNoEnd(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
@@ -82,19 +82,19 @@ public class TestSimpleLimit extends ExecTest {
   // However, when evaluate the increasingBitInt(0), if the outgoing batch could not hold the new value, doEval() return false, and start the
   // next batch. But the value has already been increased by 1 in the prior failed try. Therefore, the sum of the generated number could be different,
   // depending on the size of each outgoing batch, and when the batch could not hold any more values.
-  public void testLimitAcrossBatches(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable{
+  public void testLimitAcrossBatches(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable {
     new NonStrictExpectations(){{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
     verifyLimitCount(bitContext, connection, "test2.json", 69999);
-    long start = 30000;
-    long end = 100000;
-    long expectedSum = (end - start) * (end + start - 1) / 2; //Formula for sum of series
+    final long start = 30000;
+    final long end = 100000;
+    final long expectedSum = (end - start) * (end + start - 1) / 2; //Formula for sum of series
 
     verifySum(bitContext, connection, "test4.json", 70000, expectedSum);
 
@@ -102,19 +102,19 @@ public class TestSimpleLimit extends ExecTest {
   }
 
   private void verifyLimitCount(DrillbitContext bitContext, UserServer.UserClientConnection connection, String testPlan, int expectedCount) throws Throwable {
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
     int recordCount = 0;
-    while(exec.next()){
+    while(exec.next()) {
       recordCount += exec.getRecordCount();
     }
 
     assertEquals(expectedCount, recordCount);
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
 
@@ -122,16 +122,16 @@ public class TestSimpleLimit extends ExecTest {
   }
 
   private void verifySum(DrillbitContext bitContext, UserServer.UserClientConnection connection, String testPlan, int expectedCount, long expectedSum) throws Throwable {
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/limit/" + testPlan), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
     int recordCount = 0;
     long sum = 0;
-    while(exec.next()){
+    while(exec.next()) {
       recordCount += exec.getRecordCount();
-      BigIntVector v = (BigIntVector) exec.iterator().next();
+      final BigIntVector v = (BigIntVector) exec.iterator().next();
       for (int i = 0; i < v.getAccessor().getValueCount(); i++) {
         sum += v.getAccessor().get(i);
       }
@@ -140,7 +140,7 @@ public class TestSimpleLimit extends ExecTest {
     assertEquals(expectedCount, recordCount);
     assertEquals(expectedSum, sum);
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
@@ -29,6 +29,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
@@ -50,34 +51,32 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSimpleProjection extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleProjection.class);
-  DrillConfig c = DrillConfig.create();
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleProjection.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void project(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
-
+  public void project(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
     new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/project/test1.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/project/test1.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     while (exec.next()) {
       VectorUtil.showVectorAccessibleContent(exec.getIncoming(), "\t");
-      NullableBigIntVector c1 = exec.getValueVectorById(new SchemaPath("col1", ExpressionPosition.UNKNOWN), NullableBigIntVector.class);
-      NullableBigIntVector c2 = exec.getValueVectorById(new SchemaPath("col2", ExpressionPosition.UNKNOWN), NullableBigIntVector.class);
+      final NullableBigIntVector c1 = exec.getValueVectorById(new SchemaPath("col1", ExpressionPosition.UNKNOWN), NullableBigIntVector.class);
+      final NullableBigIntVector c2 = exec.getValueVectorById(new SchemaPath("col2", ExpressionPosition.UNKNOWN), NullableBigIntVector.class);
       int x = 0;
-      NullableBigIntVector.Accessor a1, a2;
-      a1 = c1.getAccessor();
-      a2 = c2.getAccessor();
+      final NullableBigIntVector.Accessor a1 = c1.getAccessor();
+      final NullableBigIntVector.Accessor a2 = c2.getAccessor();
 
       for (int i =0; i < c1.getAccessor().getValueCount(); i++) {
         if (!a1.isNull(i)) {
@@ -92,5 +91,4 @@ public class TestSimpleProjection extends ExecTest {
     }
     assertTrue(!context.isFailed());
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
@@ -29,7 +29,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -56,10 +56,10 @@ public class TestSimpleSort extends ExecTest {
   private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void sortOneKeyAscending(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
-    new NonStrictExpectations(){{
+  public void sortOneKeyAscending(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
@@ -100,10 +100,10 @@ public class TestSimpleSort extends ExecTest {
   }
 
   @Test
-  public void sortTwoKeysOneAscendingOneDescending(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable{
+  public void sortTwoKeysOneAscendingOneDescending(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
     new NonStrictExpectations(){{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
@@ -113,7 +113,7 @@ public class TestSimpleSort extends ExecTest {
     final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/sort/two_key_sort.json"), Charsets.UTF_8));
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     int previousInt = Integer.MIN_VALUE;
     long previousLong = Long.MAX_VALUE;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
@@ -26,6 +26,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
@@ -54,39 +55,36 @@ import com.google.common.io.Files;
  * incoming container of the trace operator.
  */
 public class TestTraceMultiRecordBatch extends ExecTest {
-    static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTraceOutputDump.class);
-    DrillConfig c = DrillConfig.create();
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTraceOutputDump.class);
+  private final DrillConfig c = DrillConfig.create();
 
+  @Test
+  public void testFilter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
+      bitContext.getMetrics(); result = new MetricRegistry();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
+      bitContext.getConfig(); result = c;
+      bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
+      bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
+    }};
 
-    @Test
-    public void testFilter(@Injectable final DrillbitContext bitContext, @Injectable UserClientConnection connection) throws Throwable
-    {
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-        new NonStrictExpectations(){{
-            bitContext.getMetrics(); result = new MetricRegistry();
-            bitContext.getAllocator(); result = new TopLevelAllocator();
-            bitContext.getConfig(); result = c;
-            bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
-            bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
-        }};
-
-        PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-        PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/trace/multi_record_batch_trace.json"), Charsets.UTF_8));
-        FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-        FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-        SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
-
-        while(exec.next()) {
-          for(ValueVector vv: exec){
-            vv.clear();
-          }
-        }
-
-        exec.close();
-
-        if(context.getFailureCause() != null){
-            throw context.getFailureCause();
-        }
-        assertTrue(!context.isFailed());
+    while(exec.next()) {
+      for(final ValueVector vv: exec){
+        vv.clear();
+      }
     }
+
+    exec.close();
+
+    if(context.getFailureCause() != null) {
+      throw context.getFailureCause();
+    }
+    assertTrue(!context.isFailed());
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
@@ -27,7 +27,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -46,41 +46,35 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestSimpleUnion extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleUnion.class);
-  DrillConfig c = DrillConfig.create();
-
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleUnion.class);
+  private final DrillConfig c = DrillConfig.create();
 
   @Test
-  public void testUnion(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable{
-
-
-    new NonStrictExpectations(){{
+  public void testUnion(@Injectable final DrillbitContext bitContext, @Injectable UserServer.UserClientConnection connection) throws Throwable {
+    new NonStrictExpectations() {{
       bitContext.getMetrics(); result = new MetricRegistry();
-      bitContext.getAllocator(); result = new TopLevelAllocator();
+      bitContext.getAllocator(); result = RootAllocatorFactory.newRoot(c);
       bitContext.getOperatorCreatorRegistry(); result = new OperatorCreatorRegistry(c);
       bitContext.getConfig(); result = c;
       bitContext.getCompiler(); result = CodeCompiler.getTestCompiler(c);
     }};
 
+    final PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
+    final PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/union/test1.json"), Charsets.UTF_8));
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
+    final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
-    PhysicalPlanReader reader = new PhysicalPlanReader(c, c.getMapper(), CoordinationProtos.DrillbitEndpoint.getDefaultInstance());
-    PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(FileUtils.getResourceAsFile("/union/test1.json"), Charsets.UTF_8));
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), connection, registry);
-    SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
-
-    int[] counts = new int[]{100,50};
-    int i=0;
-    while(exec.next()){
+    final int[] counts = new int[]{100,50};
+    int i = 0;
+    while(exec.next()) {
       System.out.println("iteration count:" + exec.getRecordCount());
       assertEquals(counts[i++], exec.getRecordCount());
     }
 
-    if(context.getFailureCause() != null){
+    if(context.getFailureCause() != null) {
       throw context.getFailureCause();
     }
     assertTrue(!context.isFailed());
-
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.charset.Charset;
 
 import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.exception.OversizedAllocationException;
@@ -38,7 +39,8 @@ import org.apache.drill.exec.expr.holders.RepeatedFloat4Holder;
 import org.apache.drill.exec.expr.holders.RepeatedVarBinaryHolder;
 import org.apache.drill.exec.expr.holders.UInt4Holder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.BaseValueVector;
 import org.apache.drill.exec.vector.BitVector;
@@ -62,11 +64,13 @@ public class TestValueVector extends ExecTest {
   private final static byte[] STR2 = new String("BBBBBBBBB2").getBytes(Charset.forName("UTF-8"));
   private final static byte[] STR3 = new String("CCCC3").getBytes(Charset.forName("UTF-8"));
 
-  private TopLevelAllocator allocator;
+  private DrillConfig drillConfig;
+  private BufferAllocator allocator;
 
   @Before
   public void init() {
-    allocator = new TopLevelAllocator();
+    drillConfig = DrillConfig.create();
+    allocator = RootAllocatorFactory.newRoot(drillConfig);
   }
 
   @After

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -46,7 +46,7 @@ import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.physical.impl.ScreenCreator;
 import org.apache.drill.exec.physical.impl.SingleSenderCreator.SingleSenderRootExec;
 import org.apache.drill.exec.physical.impl.mergereceiver.MergingRecordBatch;
@@ -234,7 +234,7 @@ public class TestDrillbitResilience extends DrillTest {
    */
   private static void assertDrillbitsOk() {
       final SingleRowListener listener = new SingleRowListener() {
-          private final BufferAllocator bufferAllocator = new TopLevelAllocator(zkHelper.getConfig());
+          private final BufferAllocator bufferAllocator = RootAllocatorFactory.newRoot(zkHelper.getConfig());
           private final RecordBatchLoader loader = new RecordBatchLoader(bufferAllocator);
 
           @Override
@@ -929,7 +929,7 @@ public class TestDrillbitResilience extends DrillTest {
   @Test // DRILL-3065
   public void failsAfterMSorterSorting() {
     final String query = "select n_name from cp.`tpch/nation.parquet` order by n_name";
-    Class<? extends Exception> typeOfException = RuntimeException.class;
+    final Class<? extends Exception> typeOfException = RuntimeException.class;
 
     final long before = countAllocatedMemory();
     final String controls = Controls.newBuilder()
@@ -944,7 +944,7 @@ public class TestDrillbitResilience extends DrillTest {
   @Test // DRILL-3085
   public void failsAfterMSorterSetup() {
     final String query = "select n_name from cp.`tpch/nation.parquet` order by n_name";
-    Class<? extends Exception> typeOfException = RuntimeException.class;
+    final Class<? extends Exception> typeOfException = RuntimeException.class;
 
     final long before = countAllocatedMemory();
     final String controls = Controls.newBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -41,7 +41,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.impl.OutputMutator;
 import org.apache.drill.exec.proto.BitControl;
@@ -611,9 +611,9 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
   @Ignore
   public void testPerformance(@Injectable final DrillbitContext bitContext,
                               @Injectable UserServer.UserClientConnection connection) throws Exception {
-    DrillConfig c = DrillConfig.create();
-    FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
-    FragmentContext context = new FragmentContext(bitContext, BitControl.PlanFragment.getDefaultInstance(), connection, registry);
+    final DrillConfig c = DrillConfig.create();
+    final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
+    final FragmentContext context = new FragmentContext(bitContext, BitControl.PlanFragment.getDefaultInstance(), connection, registry);
 
 //    new NonStrictExpectations() {
 //      {
@@ -642,7 +642,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     int totalRowCount = 0;
 
     final FileSystem fs = new CachedSingleFileSystem(fileName);
-    final BufferAllocator allocator = new TopLevelAllocator();
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(c);
     for(int i = 0; i < 25; i++) {
       final ParquetRecordReader rr = new ParquetRecordReader(context, 256000, fileName, 0, fs,
           new DirectCodecFactory(dfsConfig, allocator), f.getParquetMetadata(), columns);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -17,10 +17,11 @@
  */
 package org.apache.drill.exec.vector;
 
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.NullableVarCharVector.Accessor;
@@ -28,37 +29,37 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSplitAndTransfer {
-
   @Test
   public void test() throws Exception {
-    BufferAllocator allocator = new TopLevelAllocator();
-    MaterializedField field = MaterializedField.create("field", Types.optional(MinorType.VARCHAR));
-    NullableVarCharVector varCharVector = new NullableVarCharVector(field, allocator);
+    final DrillConfig drillConfig = DrillConfig.create();
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
+    final MaterializedField field = MaterializedField.create("field", Types.optional(MinorType.VARCHAR));
+    final NullableVarCharVector varCharVector = new NullableVarCharVector(field, allocator);
     varCharVector.allocateNew(10000, 1000);
 
-    String[] compareArray = new String[500];
+    final String[] compareArray = new String[500];
 
     for (int i = 0; i < 500; i += 3) {
-      String s = String.format("%010d", i);
+      final String s = String.format("%010d", i);
       varCharVector.getMutator().set(i, s.getBytes());
       compareArray[i] = s;
     }
     varCharVector.getMutator().setValueCount(500);
 
-    TransferPair tp = varCharVector.getTransferPair();
-    NullableVarCharVector newVarCharVector = (NullableVarCharVector) tp.getTo();
-    Accessor accessor = newVarCharVector.getAccessor();
-    int[][] startLengths = {{0, 201}, {201, 200}, {401, 99}};
+    final TransferPair tp = varCharVector.getTransferPair();
+    final NullableVarCharVector newVarCharVector = (NullableVarCharVector) tp.getTo();
+    final Accessor accessor = newVarCharVector.getAccessor();
+    final int[][] startLengths = {{0, 201}, {201, 200}, {401, 99}};
 
     for (int[] startLength : startLengths) {
-      int start = startLength[0];
-      int length = startLength[1];
+      final int start = startLength[0];
+      final int length = startLength[1];
       tp.splitAndTransfer(start, length);
       newVarCharVector.getMutator().setValueCount(length);
       for (int i = 0; i < length; i++) {
-        boolean expectedSet = ((start + i) % 3) == 0;
+        final boolean expectedSet = ((start + i) % 3) == 0;
         if (expectedSet) {
-          byte[] expectedValue = compareArray[start + i].getBytes();
+          final byte[] expectedValue = compareArray[start + i].getBytes();
           Assert.assertFalse(accessor.isNull(i));
 //          System.out.println(new String(accessor.get(i)));
           Assert.assertArrayEquals(expectedValue, accessor.get(i));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/TestEmptyPopulation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/TestEmptyPopulation.java
@@ -19,9 +19,11 @@ package org.apache.drill.exec.vector.complex;
 
 import static org.apache.drill.TestBuilder.listOf;
 import static org.apache.drill.TestBuilder.mapOf;
+
 import org.apache.drill.BaseTestQuery;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +38,8 @@ public class TestEmptyPopulation extends BaseTestQuery {
   private UInt4Vector.Accessor accessor;
   private UInt4Vector.Mutator mutator;
   private EmptyValuePopulator populator;
-  private BufferAllocator allocator = new TopLevelAllocator();
+  private final DrillConfig drillConfig = DrillConfig.create();
+  private final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
 
 
   @Before
@@ -310,5 +313,4 @@ public class TestEmptyPopulation extends BaseTestQuery {
         .baselineValues(listOf(listOf(listOf(2L), listOf()), listOf()))
         .go();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
@@ -20,10 +20,11 @@ package org.apache.drill.exec.vector.complex.writer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.vector.complex.MapVector;
 import org.apache.drill.exec.vector.complex.fn.JsonWriter;
 import org.apache.drill.exec.vector.complex.impl.ComplexWriterImpl;
@@ -41,11 +42,12 @@ import com.google.common.base.Charsets;
 public class TestRepeated {
   // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRepeated.class);
 
+  private static final DrillConfig drillConfig = DrillConfig.create();
   private static BufferAllocator allocator;
 
   @BeforeClass
   public static void setupAllocator() {
-    allocator = new TopLevelAllocator();
+    allocator = RootAllocatorFactory.newRoot(drillConfig);
   }
 
   @AfterClass

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java
@@ -38,7 +38,7 @@ import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.TopLevelAllocator;
+import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
@@ -89,7 +89,7 @@ class DrillConnectionImpl extends AvaticaConnection
         }
 
         final DrillConfig dConfig = DrillConfig.create(info);
-        this.allocator = new TopLevelAllocator(dConfig);
+        this.allocator = RootAllocatorFactory.newRoot(dConfig);
         RemoteServiceSet set = GlobalServiceSetReference.SETS.get();
         if (set == null) {
           // We're embedded; start a local drill bit.
@@ -119,12 +119,12 @@ class DrillConnectionImpl extends AvaticaConnection
         this.client.connect(null, info);
       } else if(config.isDirect()) {
         final DrillConfig dConfig = DrillConfig.forClient();
-        this.allocator = new TopLevelAllocator(dConfig);
+        this.allocator = RootAllocatorFactory.newRoot(dConfig);
         this.client = new DrillClient(dConfig, true); // Get a direct connection
         this.client.connect(config.getZookeeperConnectionString(), info);
       } else {
         final DrillConfig dConfig = DrillConfig.forClient();
-        this.allocator = new TopLevelAllocator(dConfig);
+        this.allocator = RootAllocatorFactory.newRoot(dConfig);
         // TODO:  Check:  Why does new DrillClient() create another DrillConfig,
         // with enableServerConfigs true, and cause scanning for function
         // implementations (needed by a server, but not by a client-only


### PR DESCRIPTION
- made the constructor for TopLevelAllocator package private to enforce this
- other file cleanup in files the factory was added to

Unit tests pass. Precommit suite passes.