### PR TITLE
DRILL-3596: Allow only (<expression>) or (<expression>, 1) for LEAD a…

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
@@ -22,8 +22,10 @@ import java.util.Properties;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.DrillTestWrapper;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -274,6 +276,29 @@ public class TestWindowFrame extends BaseTestQuery {
       .baselineColumns("ntile")
       .build()
       .run();
+  }
+
+  @Test
+  public void testLeadParams() throws Exception {
+    // make sure we only support default arguments for LEAD/LAG functions
+    final String query = "SELECT %s OVER(PARTITION BY col7 ORDER BY col8) FROM dfs_test.`%s/window/3648.parquet`";
+
+    test(query, "LEAD(col8, 1)", TEST_RES_PATH);
+    test(query, "LAG(col8, 1)", TEST_RES_PATH);
+
+    try {
+      test(query, "LEAD(col8, 2)", TEST_RES_PATH);
+      Assert.fail("query should fail");
+    } catch (UserRemoteException e) {
+      Assert.assertEquals(ErrorType.UNSUPPORTED_OPERATION, e.getErrorType());
+    }
+
+    try {
+      test(query, "LAG(col8, 2)", TEST_RES_PATH);
+      Assert.fail("query should fail");
+    } catch (UserRemoteException e) {
+      Assert.assertEquals(ErrorType.UNSUPPORTED_OPERATION, e.getErrorType());
+    }
   }
 
   @Test


### PR DESCRIPTION
…nd LAG window functions as input parameters