### PR TITLE
DRILL-3566: Fix:  PreparedStatement.executeQuery() got ClassCastException.

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
@@ -103,9 +103,9 @@ public class DrillJdbc41Factory extends DrillFactory {
                                          TimeZone timeZone) {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, prepareResult.getColumnList());
-    return new DrillResultSetImpl( (DrillStatementImpl) statement,
-                                   (DrillPrepareResult) prepareResult,
-                                   metaData, timeZone);
+    return new DrillResultSetImpl(statement,
+                                  (DrillPrepareResult) prepareResult,
+                                  metaData, timeZone);
   }
 
   @Override

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillJdbc41Factory.java
@@ -103,9 +103,7 @@ public class DrillJdbc41Factory extends DrillFactory {
                                          TimeZone timeZone) {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, prepareResult.getColumnList());
-    return new DrillResultSetImpl(statement,
-                                  (DrillPrepareResult) prepareResult,
-                                  metaData, timeZone);
+    return new DrillResultSetImpl(statement, prepareResult, metaData, timeZone);
   }
 
   @Override

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
@@ -30,7 +30,8 @@ import net.hydromatic.avatica.AvaticaPreparedStatement;
  * Implementation of {@link java.sql.PreparedStatement} for Drill.
  *
  * <p>
- * This class has sub-classes which implement JDBC 3.0 and JDBC 4.0 APIs; it is instantiated using
+ * This class has sub-classes which implement JDBC 3.0 and JDBC 4.0 APIs; it is
+ * instantiated using
  * {@link net.hydromatic.avatica.AvaticaFactory#newPreparedStatement}.
  * </p>
  */

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.hydromatic.avatica.AvaticaPrepareResult;
 import net.hydromatic.avatica.AvaticaResultSet;
+import net.hydromatic.avatica.AvaticaStatement;
 
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
@@ -75,7 +76,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
   private static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(DrillResultSetImpl.class);
 
-  private final DrillStatementImpl statement;
+  private final DrillConnectionImpl connection;
 
   SchemaChangeListener changeListener;
   final ResultsListener resultsListener;
@@ -87,12 +88,12 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
   boolean hasPendingCancelationNotification;
 
 
-  DrillResultSetImpl(DrillStatementImpl statement, AvaticaPrepareResult prepareResult,
+  DrillResultSetImpl(AvaticaStatement statement, AvaticaPrepareResult prepareResult,
                      ResultSetMetaData resultSetMetaData, TimeZone timeZone) {
     super(statement, prepareResult, resultSetMetaData, timeZone);
-    this.statement = statement;
+    connection = (DrillConnectionImpl) statement.getConnection();
     final int batchQueueThrottlingThreshold =
-        this.getStatement().getConnection().getClient().getConfig().getInt(
+        connection.getClient().getConfig().getInt(
             ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
     resultsListener = new ResultsListener( batchQueueThrottlingThreshold );
     DrillConnection c = (DrillConnection) statement.getConnection();
@@ -107,7 +108,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
    * ResultSet is closed.
    *
    * @throws  ExecutionCanceledSqlException  if ResultSet is closed because of
-   *          cancelation and no QueryCanceledSqlException had been thrown yet
+   *          cancelation and no QueryCanceledSqlException has been thrown yet
    *          for this ResultSet
    * @throws  AlreadyClosedSqlException  if ResultSet is closed
    * @throws  SQLException  if error in calling {@link #isClosed()}
@@ -850,9 +851,9 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
   }
 
   @Override
-  public DrillStatementImpl getStatement() {
+  public AvaticaStatement getStatement() {
     // Note:  No already-closed exception for close().
-    return statement;
+    return super.getStatement();
   }
 
   @Override
@@ -1334,8 +1335,6 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
 
   @Override
   protected DrillResultSetImpl execute() throws SQLException{
-    DrillConnectionImpl connection = (DrillConnectionImpl) statement.getConnection();
-
     connection.getClient().runQuery(QueryType.SQL, this.prepareResult.getSql(),
                                     resultsListener);
     connection.getDriver().handler.onStatementExecute(statement, null);

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
@@ -92,14 +92,12 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
                      ResultSetMetaData resultSetMetaData, TimeZone timeZone) {
     super(statement, prepareResult, resultSetMetaData, timeZone);
     connection = (DrillConnectionImpl) statement.getConnection();
+    client = connection.getClient();
     final int batchQueueThrottlingThreshold =
-        connection.getClient().getConfig().getInt(
+        client.getConfig().getInt(
             ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
-    resultsListener = new ResultsListener( batchQueueThrottlingThreshold );
-    DrillConnection c = (DrillConnection) statement.getConnection();
-    DrillClient client = c.getClient();
+    resultsListener = new ResultsListener(batchQueueThrottlingThreshold);
     batchLoader = new RecordBatchLoader(client.getAllocator());
-    this.client = client;
     cursor = new DrillCursor(this);
   }
 
@@ -852,7 +850,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
 
   @Override
   public AvaticaStatement getStatement() {
-    // Note:  No already-closed exception for close().
+    // Note:  No already-closed exception for getStatement().
     return super.getStatement();
   }
 
@@ -1335,8 +1333,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
 
   @Override
   protected DrillResultSetImpl execute() throws SQLException{
-    connection.getClient().runQuery(QueryType.SQL, this.prepareResult.getSql(),
-                                    resultsListener);
+    client.runQuery(QueryType.SQL, this.prepareResult.getSql(), resultsListener);
     connection.getDriver().handler.onStatementExecute(statement, null);
 
     super.execute();

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
@@ -43,7 +43,8 @@ import org.junit.runner.Description;
 //   (e.g., the reusing of connections, the automatic interception of test
 //   failures and resetting of connections, etc.).
 public class JdbcTestBase extends ExecTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestBase.class);
+  @SuppressWarnings("unused")
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestBase.class);
 
   @Rule
   public final TestRule watcher = new TestWatcher() {


### PR DESCRIPTION
Main:
Restored DrillResultSetImpl(...)'s statement parameter from overly
restrictive DrillStatementImpl to AvaticaStatement and removed caller
cast that was throwing.  (Relatedly, adjusted getStatement() and moved
internal casting from statement to connection.)

Added basic test of querying via PreparedStatement.  [PreparedStatementTest]
Added some case test of statement-creation methods.  [ConnectionTest]