### PR TITLE
DRILL-3455: If fragments on unregistered Drillbits finished successfu…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/DrillbitStatusListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/DrillbitStatusListener.java
@@ -26,19 +26,17 @@ import java.util.Set;
  * Interface to define the listener to take actions when the set of active drillbits is changed.
  */
 public interface DrillbitStatusListener {
-  // TODO this doesn't belong here
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillbitStatusListener.class);
 
   /**
    * The action to taken when a set of drillbits are unregistered from the cluster.
    * @param  unregisteredDrillbits the set of newly unregistered drillbits.
    */
-  public void drillbitUnregistered(Set<CoordinationProtos.DrillbitEndpoint> unregisteredDrillbits);
+  void drillbitUnregistered(Set<CoordinationProtos.DrillbitEndpoint> unregisteredDrillbits);
 
   /**
    * The action to taken when a set of new drillbits are registered to the cluster.
    * @param  registeredDrillbits the set of newly registered drillbits. Note: the complete set of currently registered bits could be different.
    */
-  public void drillbitRegistered(Set<CoordinationProtos.DrillbitEndpoint> registeredDrillbits);
+  void drillbitRegistered(Set<CoordinationProtos.DrillbitEndpoint> registeredDrillbits);
 
 }


### PR DESCRIPTION
…lly, do not fail the query

+ DRILL-3448: Flipped the atLeastOneFailure condition in QueryManager
+ fixes in DrillbitStatusListener interface
+ logs from implementations of DrillbitStatusListener

Already got a +1 on [RB](https://reviews.apache.org/r/36208/), rebased on master. @adeneche can you review/ merge this?