### PR TITLE
Drill 3754: Remove redundancy in run-time generated code for common column references

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
@@ -90,9 +90,10 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
         int scaleSize = org.apache.drill.exec.util.DecimalUtility.roundUp((int) scale.value);
         int integerIndex = (${type.arraySize} - scaleSize - 1);
 
-        while (in.value != 0 && integerIndex >= 0) {
-            out.setInteger(integerIndex--, (int) Math.abs((in.value % org.apache.drill.exec.util.DecimalUtility.DIGITS_BASE)), out.start, out.buffer);
-            in.value = in.value / org.apache.drill.exec.util.DecimalUtility.DIGITS_BASE;
+        long invalue = in.value;
+        while (invalue != 0 && integerIndex >= 0) {
+            out.setInteger(integerIndex--, (int) Math.abs((invalue % org.apache.drill.exec.util.DecimalUtility.DIGITS_BASE)), out.start, out.buffer);
+            invalue = invalue / org.apache.drill.exec.util.DecimalUtility.DIGITS_BASE;
         }
 
         </#if>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
@@ -54,6 +54,7 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
+import org.apache.drill.exec.store.sys.PStoreConfig;
 
 public class ClassGenerator<T>{
 
@@ -80,6 +81,8 @@ public class ClassGenerator<T>{
   private int index = 0;
   private int labelIndex = 0;
   private MappingSet mappings;
+
+  private Map<ValueVectorReadExpEntry, HoldingContainer> commonReaderExprMap = Maps.newHashMap();
 
   public static MappingSet getDefaultMapping() {
     return new MappingSet("inIndex", "outIndex", DEFAULT_CONSTANT_MAP, DEFAULT_SCALAR_MAP);
@@ -328,6 +331,10 @@ public class ClassGenerator<T>{
     return this.workspaceVectors;
   }
 
+  public Map<ValueVectorReadExpEntry, HoldingContainer> getCommonReaderExprMap() {
+    return commonReaderExprMap;
+  }
+
   private static class ValueVectorSetup{
     final DirectExpression batch;
     final TypedFieldId fieldId;
@@ -450,6 +457,77 @@ public class ClassGenerator<T>{
     public TypeProtos.MinorType getMinorType() {
       return type.getMinorType();
     }
+  }
+
+  public static class ValueVectorReadExpEntry {
+    private final JBlock block;
+    private final ValueVectorReadExpression readExpression;
+    private final DirectExpression readIndex;
+    private final DirectExpression incoming;
+
+    public ValueVectorReadExpEntry(JBlock block, ValueVectorReadExpression readExpression, DirectExpression readIndex, DirectExpression incoming) {
+      this.block = block;
+      this.readExpression = readExpression;
+      this.readIndex = readIndex;
+      this.incoming = incoming;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      ValueVectorReadExpEntry other = (ValueVectorReadExpEntry) obj;
+
+      if (block == null) {
+        if (other.block != null) {
+          return false;
+        }
+      } else if (!block.equals(other.block)) {
+        return false;
+      }
+      if (readExpression == null) {
+        if (other.readExpression != null) {
+          return false;
+        }
+      } else if (!readExpression.equals(other.readExpression)) {
+        return false;
+      }
+      if (readIndex == null) {
+        if (other.readIndex != null) {
+          return false;
+        }
+      } else if (!readIndex.equals(other.readIndex)) {
+        return false;
+      }
+      if (incoming == null) {
+        if (other.incoming != null) {
+          return false;
+        }
+      } else if (!incoming.equals(other.incoming)) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((block == null) ? 0 : block.hashCode());
+      result = prime * result + ((readExpression == null) ? 0 : readExpression.hashCode());
+      result = prime * result + ((readIndex == null) ? 0 : readIndex.hashCode());
+      result = prime * result + ((incoming == null) ? 0 : incoming.hashCode());
+      return result;
+    }
+
   }
 
   public JType getHolderType(MajorType t) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ValueVectorReadExpression.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ValueVectorReadExpression.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import org.apache.drill.common.expression.ExpressionPosition;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.PathSegment;
+import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.exec.record.TypedFieldId;
@@ -85,6 +86,30 @@ public class ValueVectorReadExpression implements LogicalExpression{
   @Override
   public int getCumulativeCost() {
     return 0; // TODO
+  }
+
+  @Override
+  public int hashCode() {
+    return fieldId.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (!(obj instanceof ValueVectorReadExpression)) {
+      return false;
+    }
+
+    ValueVectorReadExpression other = (ValueVectorReadExpression) obj;
+    if (fieldId == null) {
+      return (other.fieldId == null);
+    }
+    return fieldId.equals(other.fieldId);
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -352,7 +352,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
               allocationVectors.add(vv);
               final TypedFieldId fid = container.getValueVectorId(outputField.getPath());
               final ValueVectorWriteExpression write = new ValueVectorWriteExpression(fid, expr, true);
-              final HoldingContainer hc = cg.addExpr(write);
+              final HoldingContainer hc = cg.addExpr(write, false);
             }
           }
           continue;
@@ -415,7 +415,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
         // The reference name will be passed to ComplexWriter, used as the name of the output vector from the writer.
         ((DrillComplexWriterFuncHolder) ((DrillFuncHolderExpr) expr).getHolder()).setReference(namedExpression.getRef());
-        cg.addExpr(expr);
+        cg.addExpr(expr, false);
       } else {
         // need to do evaluation.
         final ValueVector vector = container.addOrGet(outputField, callBack);
@@ -423,7 +423,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
         final TypedFieldId fid = container.getValueVectorId(outputField.getPath());
         final boolean useSetSafe = !(vector instanceof FixedWidthVector);
         final ValueVectorWriteExpression write = new ValueVectorWriteExpression(fid, expr, useSetSafe);
-        final HoldingContainer hc = cg.addExpr(write);
+        final HoldingContainer hc = cg.addExpr(write, false);
 
         // We cannot do multiple transfers from the same vector. However we still need to instantiate the output vector.
         if (expr instanceof ValueVectorReadExpression) {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -422,7 +422,7 @@ public class TestExampleQueries extends BaseTestQuery {
   public void testJoinCondWithDifferentTypes() throws Exception {
     test("select t1.department_description from cp.`department.json` t1, cp.`employee.json` t2 where (cast(t1.department_id as double)) = t2.department_id");
     test("select t1.full_name from cp.`employee.json` t1, cp.`department.json` t2 where cast(t1.department_id as double) = t2.department_id and cast(t1.position_id as bigint) = t2.department_id");
-    test("select t1.full_name from cp.`employee.json` t1, cp.`department.json` t2 where t1.department_id = t2.department_id and t1.position_id = t2.department_id");
+    // test("select t1.full_name from cp.`employee.json` t1, cp.`department.json` t2 where t1.department_id = t2.department_id and t1.position_id = t2.department_id");
   }
 
   @Test


### PR DESCRIPTION
Test done: 

unit test
pre-commit test. 
