### PR TITLE
DRILL-1942-readers:

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveRecordReader.java
@@ -133,7 +133,7 @@ public class HiveRecordReader extends AbstractRecordReader {
     String inputFormatName = (partition == null) ? table.getSd().getInputFormat() : partition.getSd().getInputFormat();
     try {
       format = (InputFormat) Class.forName(inputFormatName).getConstructor().newInstance();
-      Class c = Class.forName(sLib);
+      Class<?> c = Class.forName(sLib);
       serde = (SerDe) c.getConstructor().newInstance();
       serde.initialize(job, properties);
     } catch (ReflectiveOperationException | SerDeException e) {
@@ -286,7 +286,6 @@ public class HiveRecordReader extends AbstractRecordReader {
   }
 
   private boolean readHiveRecordAndInsertIntoRecordBatch(Object deSerializedValue, int outputRecordIndex) {
-    boolean success;
     for (int i = 0; i < selectedColumnNames.size(); i++) {
       String columnName = selectedColumnNames.get(i);
       Object hiveValue = sInspector.getStructFieldData(deSerializedValue, sInspector.getStructFieldRef(columnName));
@@ -311,7 +310,7 @@ public class HiveRecordReader extends AbstractRecordReader {
   }
 
   @Override
-  public void cleanup() {
+  public void close() {
     try {
       if (reader != null) {
         reader.close();

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcRecordReader.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcRecordReader.java
@@ -229,7 +229,7 @@ class JdbcRecordReader extends AbstractRecordReader {
   }
 
   @Override
-  public void cleanup() {
+  public void close() {
     AutoCloseables.close(resultSet, logger);
     AutoCloseables.close(statement, logger);
     AutoCloseables.close(connection, logger);

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -52,7 +52,7 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 
 public class MongoRecordReader extends AbstractRecordReader {
-  static final Logger logger = LoggerFactory.getLogger(MongoRecordReader.class);
+  private static final Logger logger = LoggerFactory.getLogger(MongoRecordReader.class);
 
   private MongoCollection<Document> collection;
   private MongoCursor<Document> cursor;
@@ -187,7 +187,7 @@ public class MongoRecordReader extends AbstractRecordReader {
   }
 
   @Override
-  public void cleanup() {
+  public void close() {
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/RecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/RecordReader.java
@@ -26,30 +26,27 @@ import org.apache.drill.exec.physical.impl.OutputMutator;
 import org.apache.drill.exec.record.MaterializedField.Key;
 import org.apache.drill.exec.vector.ValueVector;
 
-public interface RecordReader {
-
+public interface RecordReader extends AutoCloseable {
   public static final long ALLOCATOR_INITIAL_RESERVATION = 1*1024*1024;
   public static final long ALLOCATOR_MAX_RESERVATION = 20L*1000*1000*1000;
 
   /**
    * Configure the RecordReader with the provided schema and the record batch that should be written to.
    *
+   * @param context operator context for the reader
    * @param output
    *          The place where output for a particular scan should be written. The record reader is responsible for
    *          mutating the set of schema values for that particular record.
    * @throws ExecutionSetupException
    */
-  public abstract void setup(OperatorContext context, OutputMutator output) throws ExecutionSetupException;
+  void setup(OperatorContext context, OutputMutator output) throws ExecutionSetupException;
 
-  public abstract void allocate(Map<Key, ValueVector> vectorMap) throws OutOfMemoryException;
+  void allocate(Map<Key, ValueVector> vectorMap) throws OutOfMemoryException;
 
   /**
    * Increment record reader forward, writing into the provided output batch.
    *
    * @return The number of additional records added to the output.
    */
-  public abstract int next();
-
-  public abstract void cleanup();
-
+  int next();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
@@ -351,7 +351,7 @@ public class AvroRecordReader extends AbstractRecordReader {
   }
 
   @Override
-  public void cleanup() {
+  public void close() {
     if (reader != null) {
       try {
         reader.close();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
@@ -144,7 +144,7 @@ public class CompliantTextRecordReader extends AbstractRecordReader {
    * This would internally close the input stream we are reading from.
    */
   @Override
-  public void cleanup() {
+  public void close() {
     try {
       if (reader != null) {
         reader.close();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoRecordReader.java
@@ -123,7 +123,7 @@ public class PojoRecordReader<T> extends AbstractRecordReader {
 
   @Override
   public void allocate(Map<Key, ValueVector> vectorMap) throws OutOfMemoryException {
-    for (ValueVector v : vectorMap.values()) {
+    for (final ValueVector v : vectorMap.values()) {
       AllocationHelper.allocate(v, Character.MAX_VALUE, 50, 10);
     }
   }
@@ -146,7 +146,6 @@ public class PojoRecordReader<T> extends AbstractRecordReader {
     injector.injectPause(operatorContext.getExecutionControls(), "read-next", logger);
     try {
       int i =0;
-      outside:
       while (doCurrent || iterator.hasNext()) {
         if (doCurrent) {
           doCurrent = false;
@@ -175,7 +174,6 @@ public class PojoRecordReader<T> extends AbstractRecordReader {
   }
 
   @Override
-  public void cleanup() {
+  public void close() {
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonRecordReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonRecordReader.java
@@ -27,11 +27,11 @@ import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertTrue;
 
-public class TestJsonRecordReader extends BaseTestQuery{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestJsonRecordReader.class);
+public class TestJsonRecordReader extends BaseTestQuery {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestJsonRecordReader.class);
 
   @Test
-  public void testComplexJsonInput() throws Exception{
+  public void testComplexJsonInput() throws Exception {
 //  test("select z[0]['orange']  from cp.`jsoninput/input2.json` limit 10");
     test("select `integer`, x['y'] as x1, x['y'] as x2, z[0], z[0]['orange'], z[1]['pink']  from cp.`jsoninput/input2.json` limit 10 ");
 //    test("select x from cp.`jsoninput/input2.json`");
@@ -45,14 +45,14 @@ public class TestJsonRecordReader extends BaseTestQuery{
   }
 
   @Test
-  public void testComplexMultipleTimes() throws Exception{
-    for(int i =0 ; i < 5; i++){
+  public void testComplexMultipleTimes() throws Exception {
+    for(int i =0 ; i < 5; i++) {
     test("select * from cp.`join/merge_join.json`");
     }
   }
 
   @Test
-  public void trySimpleQueryWithLimit() throws Exception{
+  public void trySimpleQueryWithLimit() throws Exception {
     test("select * from cp.`limit/test1.json` limit 10");
   }
 
@@ -90,9 +90,7 @@ public class TestJsonRecordReader extends BaseTestQuery{
 
   @Test //DRILL-1832
   public void testJsonWithNulls1() throws Exception {
-
     final String query="select * from cp.`jsoninput/twitter_43.json`";
-
     testBuilder()
             .sqlQuery(query)
             .unOrdered()
@@ -102,9 +100,7 @@ public class TestJsonRecordReader extends BaseTestQuery{
 
   @Test //DRILL-1832
   public void testJsonWithNulls2() throws Exception {
-
     final String query="select SUM(1) as `sum_Number_of_Records_ok` from cp.`/jsoninput/twitter_43.json` having (COUNT(1) > 0)";
-
     testBuilder()
             .sqlQuery(query)
             .unOrdered()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -386,7 +386,6 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     }
   }
 
-
   private void validateContains(MessageType schema, PageReadStore pages, String[] path, int values, BytesInput bytes)
       throws IOException {
     PageReader pageReader = pages.getPageReader(schema.getColumnDescription(path));
@@ -394,7 +393,6 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     assertEquals(values, page.getValueCount());
     assertArrayEquals(bytes.toByteArray(), page.getBytes().toByteArray());
   }
-
 
   @Test
   public void testMultipleRowGroups() throws Exception {
@@ -544,7 +542,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     testParquetFullEngineEventBased(false, false, "/parquet/parquet_scan_screen_read_entry_replace.json", readEntries,
         "unused, no file is generated", 1, props, QueryType.LOGICAL);
 
-    fields = new HashMap();
+    fields = new HashMap<>();
     props = new ParquetTestProperties(1, 100000, DEFAULT_BYTES_PER_PAGE, fields);
     TestFileGenerator.populatePigTPCHSupplierFields(props);
     readEntries = "\"/tmp/tpc-h/supplier\"";
@@ -602,11 +600,6 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     testParquetFullEngineEventBased(true, false, "/parquet/parquet_selective_column_read.json", null, "/tmp/test.parquet", 1, props, QueryType.PHYSICAL);
   }
 
-  public static void main(String[] args) throws Exception {
-    // TODO - not sure why this has a main method, test below can be run directly
-    //new ParquetRecordReaderTest().testPerformance();
-  }
-
   @Test
   @Ignore
   public void testPerformance(@Injectable final DrillbitContext bitContext,
@@ -656,7 +649,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
         totalRowCount += rowCount;
       }
       System.out.println(String.format("Time completed: %s. ", watch.elapsed(TimeUnit.MILLISECONDS)));
-      rr.cleanup();
+      rr.close();
     }
 
     allocator.close();


### PR DESCRIPTION
- add extends AutoCloseable to RecordReader, and rename cleanup() to close() on derived classes.
- fix many warnings
- formatting fixes

unit tests pass
presubmit regression and customer passes
presubmit tpc-h SF100 passes
