### PR TITLE
DRILL-3735: For partition pruning divide up the partition lists into …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Abstract base class for file system based partition descriptors and Hive partition descriptors.
+ *
+ */
+public abstract class AbstractPartitionDescriptor implements PartitionDescriptor, Iterable<List<PartitionLocation>> {
+
+  /**
+   * A sequence of sublists of partition locations combined into a single super list.
+   * The size of each sublist is at most {@link PartitionDescriptor.PARTITION_BATCH_SIZE}
+   * For example if the size is 3, the complete list could be: {(a, b, c), {d, e, f), (g, h)}
+   */
+  protected List<List<PartitionLocation>> locationSuperList;
+  /**
+   * Flag to indicate if the sublists of the partition locations has been created
+   */
+  protected boolean sublistsCreated = false;
+
+  /**
+   * Create sublists of the partition locations, each sublist of size
+   * at most {@link PartitionDescriptor.PARTITION_BATCH_SIZE}
+   */
+  protected abstract void createPartitionSublists() ;
+
+  /**
+   * Iterator that traverses over the super list of partition locations and
+   * each time returns a single sublist of partition locations.
+   */
+  @Override
+  public Iterator<List<PartitionLocation>> iterator() {
+    if (!sublistsCreated) {
+      createPartitionSublists();
+    }
+    return locationSuperList.iterator();
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
@@ -17,21 +17,20 @@
  */
 package org.apache.drill.exec.planner;
 
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.physical.base.GroupScan;
-import org.apache.drill.exec.planner.logical.DrillScanRel;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.vector.ValueVector;
 
-import java.io.IOException;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 
 // Interface used to describe partitions. Currently used by file system based partitions and hive partitions
-public interface PartitionDescriptor {
+public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
+
+  public static final int PARTITION_BATCH_SIZE = Character.MAX_VALUE;
 
   /* Get the hierarchy index of the given partition
    * For eg: if we have the partition laid out as follows
@@ -56,12 +55,10 @@ public interface PartitionDescriptor {
 
   public GroupScan createNewGroupScan(List<String> newFiles) throws Exception;
 
-  public List<PartitionLocation> getPartitions();
-
   /**
    * Method creates an in memory representation of all the partitions. For each level of partitioning we
    * will create a value vector which this method will populate for all the partitions with the values of the
-   * partioning key
+   * partitioning key
    * @param vectors - Array of vectors in the container that need to be populated
    * @param partitions - List of all the partitions that exist in the table
    * @param partitionColumnBitSet - Partition columns selected in the query

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
@@ -168,6 +168,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
     }
 
     if (partitionColumnBitSet.isEmpty()) {
+      logger.debug("No partition columns are projected from the scan..continue.");
       return;
     }
 
@@ -176,81 +177,103 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
     RexNode pruneCondition = c.getFinalCondition();
 
     if (pruneCondition == null) {
+      logger.debug("No conditions were found eligible for partition pruning.");
       return;
     }
 
 
     // set up the partitions
-    final GroupScan groupScan = scanRel.getGroupScan();
-    List<PartitionLocation> partitions = descriptor.getPartitions();
+    List<String> newFiles = Lists.newArrayList();
+    long numTotal = 0; // total number of partitions
+    int batchIndex = 0;
+    String firstLocation = null;
 
-    if (partitions.size() > Character.MAX_VALUE) {
-      return;
+    // Outer loop: iterate over a list of batches of PartitionLocations
+    for (List<PartitionLocation> partitions : descriptor) {
+      numTotal += partitions.size();
+      logger.debug("Evaluating partition pruning for batch {}", batchIndex);
+      if (batchIndex == 0) { // save the first location in case everything is pruned
+        firstLocation = partitions.get(0).getEntirePartitionLocation();
+      }
+      final NullableBitVector output = new NullableBitVector(MaterializedField.create("", Types.optional(MinorType.BIT)), allocator);
+      final VectorContainer container = new VectorContainer();
+
+      try {
+        final ValueVector[] vectors = new ValueVector[descriptor.getMaxHierarchyLevel()];
+          for (int partitionColumnIndex : BitSets.toIter(partitionColumnBitSet)) {
+          SchemaPath column = SchemaPath.getSimplePath(fieldNameMap.get(partitionColumnIndex));
+          MajorType type = descriptor.getVectorType(column, settings);
+          MaterializedField field = MaterializedField.create(column, type);
+          ValueVector v = TypeHelper.getNewVector(field, allocator);
+          v.allocateNew();
+          vectors[partitionColumnIndex] = v;
+          container.add(v);
+        }
+
+        // populate partition vectors.
+        descriptor.populatePartitionVectors(vectors, partitions, partitionColumnBitSet, fieldNameMap);
+
+        // materialize the expression
+        logger.debug("Attempting to prune {}", pruneCondition);
+        final LogicalExpression expr = DrillOptiq.toDrill(new DrillParseContext(settings), scanRel, pruneCondition);
+        final ErrorCollectorImpl errors = new ErrorCollectorImpl();
+
+        LogicalExpression materializedExpr = ExpressionTreeMaterializer.materialize(expr, container, errors, optimizerContext.getFunctionRegistry());
+        // Make sure pruneCondition's materialized expression is always of BitType, so that
+        // it's same as the type of output vector.
+        if (materializedExpr.getMajorType().getMode() == TypeProtos.DataMode.REQUIRED) {
+          materializedExpr = ExpressionTreeMaterializer.convertToNullableType(
+              materializedExpr,
+              materializedExpr.getMajorType().getMinorType(),
+              optimizerContext.getFunctionRegistry(),
+              errors);
+        }
+
+        if (errors.getErrorCount() != 0) {
+          logger.warn("Failure while materializing expression [{}].  Errors: {}", expr, errors);
+        }
+
+        output.allocateNew(partitions.size());
+        InterpreterEvaluator.evaluate(partitions.size(), optimizerContext, container, output, materializedExpr);
+        int recordCount = 0;
+        int qualifiedCount = 0;
+
+        // Inner loop: within each batch iterate over the PartitionLocations
+        for(PartitionLocation part: partitions){
+          if(!output.getAccessor().isNull(recordCount) && output.getAccessor().get(recordCount) == 1){
+            newFiles.add(part.getEntirePartitionLocation());
+            qualifiedCount++;
+          }
+          recordCount++;
+        }
+        logger.debug("Within batch {}: total records: {}, qualified records: {}", batchIndex, recordCount, qualifiedCount);
+        batchIndex++;
+      } catch (Exception e) {
+        logger.warn("Exception while trying to prune partition.", e);
+      } finally {
+        container.clear();
+        if (output != null) {
+          output.clear();
+        }
+      }
     }
 
-    final NullableBitVector output = new NullableBitVector(MaterializedField.create("", Types.optional(MinorType.BIT)), allocator);
-    final VectorContainer container = new VectorContainer();
-
     try {
-      final ValueVector[] vectors = new ValueVector[descriptor.getMaxHierarchyLevel()];
-      for (int partitionColumnIndex : BitSets.toIter(partitionColumnBitSet)) {
-        SchemaPath column = SchemaPath.getSimplePath(fieldNameMap.get(partitionColumnIndex));
-        MajorType type = descriptor.getVectorType(column, settings);
-        MaterializedField field = MaterializedField.create(column, type);
-        ValueVector v = TypeHelper.getNewVector(field, allocator);
-        v.allocateNew();
-        vectors[partitionColumnIndex] = v;
-        container.add(v);
-      }
-
-      // populate partition vectors.
-      descriptor.populatePartitionVectors(vectors, partitions, partitionColumnBitSet, fieldNameMap);
-
-      // materialize the expression
-      logger.debug("Attempting to prune {}", pruneCondition);
-      final LogicalExpression expr = DrillOptiq.toDrill(new DrillParseContext(settings), scanRel, pruneCondition);
-      final ErrorCollectorImpl errors = new ErrorCollectorImpl();
-
-      LogicalExpression materializedExpr = ExpressionTreeMaterializer.materialize(expr, container, errors, optimizerContext.getFunctionRegistry());
-      // Make sure pruneCondition's materialized expression is always of BitType, so that
-      // it's same as the type of output vector.
-      if (materializedExpr.getMajorType().getMode() == TypeProtos.DataMode.REQUIRED) {
-        materializedExpr = ExpressionTreeMaterializer.convertToNullableType(
-            materializedExpr,
-            materializedExpr.getMajorType().getMinorType(),
-            optimizerContext.getFunctionRegistry(),
-            errors);
-      }
-
-      if (errors.getErrorCount() != 0) {
-        logger.warn("Failure while materializing expression [{}].  Errors: {}", expr, errors);
-      }
-
-      output.allocateNew(partitions.size());
-      InterpreterEvaluator.evaluate(partitions.size(), optimizerContext, container, output, materializedExpr);
-      int record = 0;
-
-      List<String> newFiles = Lists.newArrayList();
-      for(PartitionLocation part: partitions){
-        if(!output.getAccessor().isNull(record) && output.getAccessor().get(record) == 1){
-          newFiles.add(part.getEntirePartitionLocation());
-        }
-        record++;
-      }
 
       boolean canDropFilter = true;
 
       if (newFiles.isEmpty()) {
-        newFiles.add(partitions.get(0).getEntirePartitionLocation());
+        assert firstLocation != null;
+        newFiles.add(firstLocation);
         canDropFilter = false;
       }
 
-      if (newFiles.size() == partitions.size()) {
+      if (newFiles.size() == numTotal) {
+        logger.info("No partitions were eligible for pruning");
         return;
       }
 
-      logger.debug("Pruned {} => {}", partitions.size(), newFiles.size());
-
+      logger.info("Pruned {} partitions down to {}", numTotal, newFiles.size());
 
       List<RexNode> conjuncts = RelOptUtil.conjunctions(condition);
       List<RexNode> pruneConjuncts = RelOptUtil.conjunctions(pruneCondition);
@@ -284,12 +307,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
       }
 
     } catch (Exception e) {
-      logger.warn("Exception while trying to prune partition.", e);
-    } finally {
-      container.clear();
-      if (output != null) {
-        output.clear();
-      }
+      logger.warn("Exception while using the pruned partitions.", e);
     }
   }
 


### PR DESCRIPTION
…sublists of 64K each and iterate over each sublist.

Add abstract base class for various partition descriptors.  Add logging messages in PruneScanRule for better debuggability.