### PR TITLE
DRILL-3778: Add missed part of DRILL-3160 (making JDBC Javadoc available).

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/PathScanner.java
+++ b/common/src/main/java/org/apache/drill/common/util/PathScanner.java
@@ -133,7 +133,7 @@ public class PathScanner {
    * @param  classLoaders  set of class loaders in which to look up resource;
    *           none (empty array) to specify to use current thread's context
    *           class loader and {@link Reflections}'s class loader
-   * @returns  ...; empty set if none
+   * @return  ...; empty set if none
    */
   public static Set<URL> forResource(final String resourcePathname,
                                      final boolean returnRootPathname,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/RawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/RawBatchBuffer.java
@@ -35,7 +35,7 @@ public interface RawBatchBuffer extends RawFragmentBatchProvider {
    * @param batch
    *          Batch to enqueue
    * @throws IOException
-   * @returns Whether response should be returned.
+   * @return Whether response should be returned.
    */
   public void enqueue(RawFragmentBatch batch) throws IOException;
 }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -392,37 +392,37 @@
            <filter>
              <artifact>*:*</artifact>
              <excludes>
-                <exclude>**/logback.xml</exclude>
-                <exclude>**/LICENSE.txt</exclude>
-                <exclude>**/*.java</exclude>
-                <exclude>**/META-INF/**</exclude>
-                <exclude>**/org.codehaus.commons.compiler.properties</exclude>
-                <exclude>**/*.SF</exclude>
-                <exclude>**/*.RSA</exclude>
-                <exclude>**/*.DSA</exclude>
-                <exclude>javax/**</exclude>
-                <exclude>rest/**</exclude>
-                <exclude>*.tokens</exclude>
-                <exclude>com/google/common/math</exclude>
-                <exclude>com/google/common/net</exclude>
-                <exclude>com/google/common/primitives</exclude>
-                <exclude>com/google/common/reflect</exclude>
-                <exclude>com/google/common/util</exclude>
-                <exclude>com/google/common/cache</exclude>
-                <exclude>com/google/common/collect/Tree*</exclude>
-                <exclude>com/google/common/collect/Standard*</exclude>
-                <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
-                <exclude>org/apache/drill/exec/expr/fn/**</exclude>
-                <exclude>org/apache/drill/exec/proto/beans/**</exclude>
-                <exclude>org/apache/drill/exec/compile/**</exclude>
-                <exclude>org/apache/drill/exec/planner/**</exclude>
-                <exclude>org/apache/drill/exec/physical/**</exclude>
-                <exclude>org/apache/drill/exec/store/**</exclude>
-                <exclude>org/apache/drill/exec/server/rest/**</exclude>
-                <exclude>org/apache/drill/exec/rpc/data/**</exclude>
-                <exclude>org/apache/drill/exec/rpc/control/**</exclude>
-                <exclude>org/apache/drill/exec/work/**</exclude>
-              </excludes>
+               <exclude>**/logback.xml</exclude>
+               <exclude>**/LICENSE.txt</exclude>
+               <exclude>**/*.java</exclude>
+               <exclude>**/META-INF/**</exclude>
+               <exclude>**/org.codehaus.commons.compiler.properties</exclude>
+               <exclude>**/*.SF</exclude>
+               <exclude>**/*.RSA</exclude>
+               <exclude>**/*.DSA</exclude>
+               <exclude>javax/**</exclude>
+               <exclude>rest/**</exclude>
+               <exclude>*.tokens</exclude>
+               <exclude>com/google/common/math</exclude>
+               <exclude>com/google/common/net</exclude>
+               <exclude>com/google/common/primitives</exclude>
+               <exclude>com/google/common/reflect</exclude>
+               <exclude>com/google/common/util</exclude>
+               <exclude>com/google/common/cache</exclude>
+               <exclude>com/google/common/collect/Tree*</exclude>
+               <exclude>com/google/common/collect/Standard*</exclude>
+               <exclude>org/apache/drill/exec/expr/annotations/**</exclude>
+               <exclude>org/apache/drill/exec/expr/fn/**</exclude>
+               <exclude>org/apache/drill/exec/proto/beans/**</exclude>
+               <exclude>org/apache/drill/exec/compile/**</exclude>
+               <exclude>org/apache/drill/exec/planner/**</exclude>
+               <exclude>org/apache/drill/exec/physical/**</exclude>
+               <exclude>org/apache/drill/exec/store/**</exclude>
+               <exclude>org/apache/drill/exec/server/rest/**</exclude>
+               <exclude>org/apache/drill/exec/rpc/data/**</exclude>
+               <exclude>org/apache/drill/exec/rpc/control/**</exclude>
+               <exclude>org/apache/drill/exec/work/**</exclude>
+             </excludes>
            </filter>
          </filters>
         </configuration>
@@ -462,14 +462,43 @@
                 </goals>
                 <inherited>false</inherited>
                 <configuration>
-                  <!-- Only inlcude the published interface in the java-doc. Unfortunately,
-                       the javadoc tool and in turn, the plugin does not support inclusion
-                       pattern and hence we have to rely on exclusion pattern. -->
-                  <excludePackageNames>org.apache.drill.jdbc.impl</excludePackageNames>
                   <includeDependencySources>true</includeDependencySources>
                   <dependencySourceIncludes>
                     <dependencySourceInclude>org.apache.drill.exec:drill-jdbc</dependencySourceInclude>
                   </dependencySourceIncludes>
+                  <!-- Include only the published interface in the Javadoc-
+                       generated documentation.  Unfortunately, the plugin does
+                       not support inclusion patterns and hence we have to rely
+                       on an exclusion pattern. -->
+                  <excludePackageNames>org.apache.drill.jdbc.impl</excludePackageNames>
+
+                  <!-- windowtitle: common part of window titles (goes in
+                       parentheses at end of window title, after in-page title
+                       (e.g., package name)) -->
+                  <windowtitle>
+                    Apache Drill JDBC Driver v. ${project.version}
+                  </windowtitle>
+
+                  <!-- header, footer:  small text at right edge of
+                       top, bottom Overview/Package/etc. menu bars -->
+                  <header>Apache Drill JDBC Driver v. ${project.version}</header>
+                  <footer>Apache Drill JDBC Driver v. ${project.version}</footer>
+
+                  <!-- doctitle:  in-page title for overview page  -->
+                  <doctitle>
+                    Apache Drill JDBC Driver version ${project.version}
+                  </doctitle>
+                  <groups>
+                    <group>
+                      <title>Drill JDBC Driver</title>
+                      <packages>org.apache.drill.jdbc</packages>
+                    </group>
+                    <group>
+                      <title>Tracing Proxy JDBC Driver</title>
+                      <packages>org.apache.drill.jdbc.proxy</packages>
+                    </group>
+                  </groups>
+
                 </configuration>
               </execution>
             </executions>
@@ -478,7 +507,7 @@
       </build>
     </profile>
     <!-- mondrian data includes 10s of MBs of JSON file if you want to include 
-      them run maven with -Pwith-mondrian-data -->
+         them run maven with -Pwith-mondrian-data -->
     <profile>
       <id>with-mondrian-data</id>
       <activation>

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/AlreadyClosedSqlException.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/AlreadyClosedSqlException.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.jdbc;
 
-import java.sql.Statement;
+import java.sql.Statement;  // (for Javadoc reference(s))
 
 
 /**

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillConnection.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillConnection.java
@@ -80,7 +80,7 @@ public interface DrillConnection extends Connection {
   /**
    * <strong>Drill</strong>:
    * Not supported.  Always throws {@link SQLFeatureNotSupportedException} (or
-   * {@link AlreadyClosedSqlException})..
+   * {@link AlreadyClosedSqlException}).
    */
   @Override
   void commit() throws SQLException;

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillConnectionConfig.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillConnectionConfig.java
@@ -29,7 +29,6 @@ import net.hydromatic.avatica.ConnectionConfigImpl;
 // org.apache.drill.jdbc to class in implementation package
 // org.apache.drill.jdbc.impl.
 /**
- *  ...
  *  <p>
  *    NOTE:  DrillConnectionConfig will be changed from a class to an interface.
  *  </p>

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillResultSet.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillResultSet.java
@@ -103,10 +103,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code byte} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert
+   *   to convert to {@code byte}
    */
   @Override
-  byte getByte(int columnIndex) throws SQLException;
+  byte getByte(int columnIndex) throws SQLConversionOverflowException,
+                                       SQLException;
 
   /**
    * {@inheritDoc}
@@ -130,10 +131,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code short} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert
+   *   to convert to {@code short}
    */
   @Override
-  short getShort(int columnIndex) throws SQLException;
+  short getShort(int columnIndex) throws SQLConversionOverflowException,
+                                         SQLException;
 
   /**
    * {@inheritDoc}
@@ -157,10 +159,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code int} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert to int
+   *   to convert to {@code int}
    */
   @Override
-  int getInt(int columnIndex) throws SQLException;
+  int getInt(int columnIndex) throws SQLConversionOverflowException,
+                                     SQLException;
 
   /**
    * {@inheritDoc}
@@ -184,10 +187,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code long} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert
+   *   to convert to {@code long}
    */
   @Override
-  long getLong(int columnIndex) throws SQLException;
+  long getLong(int columnIndex) throws SQLConversionOverflowException,
+                                       SQLException;
 
   /**
    * {@inheritDoc}
@@ -211,10 +215,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code float} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert
+   *   to convert to {@code float}
    */
   @Override
-  float getFloat(int columnIndex) throws SQLException;
+  float getFloat(int columnIndex) throws SQLConversionOverflowException,
+                                         SQLException;
 
   /**
    * {@inheritDoc}
@@ -238,10 +243,11 @@ public interface DrillResultSet extends ResultSet  {
    *   value whose magnitude is outside the range of {@code double} values.
    * </p>
    * @throws  SQLConversionOverflowException  if a source value was too large
-   *   to convert
+   *   to convert to {@code double}
    */
   @Override
-  double getDouble(int columnIndex) throws SQLException;
+  double getDouble(int columnIndex) throws SQLConversionOverflowException,
+                                           SQLException;
 
   /**
    * {@inheritDoc}
@@ -295,7 +301,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  byte getByte(String columnLabel) throws SQLException;
+  byte getByte(String columnLabel) throws SQLConversionOverflowException,
+                                          SQLException;
 
   /**
    * {@inheritDoc}
@@ -305,7 +312,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  short getShort(String columnLabel) throws SQLException;
+  short getShort(String columnLabel) throws SQLConversionOverflowException,
+                                            SQLException;
 
   /**
    * {@inheritDoc}
@@ -315,7 +323,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  int getInt(String columnLabel) throws SQLException;
+  int getInt(String columnLabel) throws SQLConversionOverflowException,
+                                        SQLException;
 
   /**
    * {@inheritDoc}
@@ -325,7 +334,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  long getLong(String columnLabel) throws SQLException;
+  long getLong(String columnLabel) throws SQLConversionOverflowException,
+                                          SQLException;
 
   /**
    * {@inheritDoc}
@@ -335,7 +345,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  float getFloat(String columnLabel) throws SQLException;
+  float getFloat(String columnLabel) throws SQLConversionOverflowException,
+                                            SQLException;
 
   /**
    * {@inheritDoc}
@@ -345,7 +356,8 @@ public interface DrillResultSet extends ResultSet  {
    * </p>
    */
   @Override
-  double getDouble(String columnLabel) throws SQLException;
+  double getDouble(String columnLabel) throws SQLConversionOverflowException,
+                                              SQLException;
 
   /**
    * {@inheritDoc}

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/InvalidCursorStateSqlException.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/InvalidCursorStateSqlException.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.jdbc;
 
-import java.sql.ResultSet;
+import java.sql.ResultSet;  // (for Javadoc reference(s))
 
 
 /**

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/JdbcApiSqlException.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/JdbcApiSqlException.java
@@ -21,8 +21,9 @@ import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
-import java.sql.SQLSyntaxErrorException;
-import java.sql.SQLTransientException;
+import java.sql.SQLSyntaxErrorException;  // (for Javadoc reference(s))
+import java.sql.SQLTransientException;  // (for Javadoc reference(s))
+import java.sql.ResultSet;  // (for Javadoc reference(s))
 
 
 /**

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/package-info.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,7 +19,13 @@
 /**
  * JDBC driver for Drill.
  * <p>
- *   Drill's JDBC driver class is {@link org.apache.drill.jdbc.Driver}.
+ *   Drill's JDBC driver class is
+ *   {@link org.apache.drill.jdbc.Driver org.apache.drill.jdbc.Driver}.
  * </p>
+ *
+ * @see
+ * <a href="http://drill.apache.org/docs/using-the-jdbc-driver">Using the JDBC Driver</a>
+ * in the on-line
+ * <a href="http://drill.apache.org/docs">Apache Drill Documentation</a>
  */
 package org.apache.drill.jdbc;

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/TracingProxyDriver.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/TracingProxyDriver.java
@@ -76,8 +76,8 @@ import static org.slf4j.LoggerFactory.getLogger;
  * </ul>
  * <p><strong>Output:</strong></p>
  * <p>
- *   Currently, the tracing output line are simply written to {@link System#out}
- *   ({@code stdout} or "standard output").
+ *   Currently, the tracing output lines are simply written to
+ *   {@link System#out} ({@code stdout} or "standard output").
  * </p>
  */
 public class TracingProxyDriver implements java.sql.Driver {

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/package-info.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/package-info.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Tracing proxy JDBC driver.  Traces calls to another JDBC driver.
  *


### PR DESCRIPTION
Main:
Configured Javadoc generation (title, package groups, version in headers).
Added link to JDBC page in Drill documentation site.
Edited/fixed some JDBC Javadoc comments.
Added explicit SQLConversionOverflowException to throws clauses for Javadoc
effect.
Added some imports for Javadoc references.

Misc.:
Fixed a couple Javadoc syntax errors.
Fixed POM indentation.