### PR TITLE
DRILL-3822:  Have PathScanner use own, not thread-context, class loader.

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/PathScanner.java
+++ b/common/src/main/java/org/apache/drill/common/util/PathScanner.java
@@ -130,9 +130,10 @@ public class PathScanner {
    *           to scan for (relative to specified class loaders' classpath roots)
    * @param  returnRootPathname  whether to collect classpath root portion of
    *           URL for each resource instead of full URL of each resource
-   * @param  classLoaders  set of class loaders in which to look up resource;
-   *           none (empty array) to specify to use current thread's context
-   *           class loader and {@link Reflections}'s class loader
+   * @param  classLoaders  not currently used (was: "set of class loaders in
+   *           which to look up resource; none (empty array) to specify to use
+   *           current thread's context class loader and {@link Reflections}'s
+   *           class loader")
    * @returns  ...; empty set if none
    */
   public static Set<URL> forResource(final String resourcePathname,
@@ -142,7 +143,7 @@ public class PathScanner {
                  resourcePathname);
     final Set<URL> resultUrlSet = Sets.newHashSet();
 
-    final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    final ClassLoader classLoader = PathScanner.class.getClassLoader();
     try {
       final Enumeration<URL> resourceUrls =
           classLoader.getResources(resourcePathname);


### PR DESCRIPTION

    DRILL-3822:  Have PathScanner use own, not thread-context, class loader