### PR TITLE
DRILL-3848:  Increase timeout time on several tests that time out frequently.

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -27,10 +27,15 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 public class TestExampleQueries extends BaseTestQuery {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestExampleQueries.class);
+
+  @Rule
+  public final TestRule TIMEOUT = TestTools.getTimeoutRule(90_000 /* ms */);
 
   @Test // see DRILL-2328
   public void testConcatOnNull() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
@@ -17,17 +17,24 @@
  */
 package org.apache.drill;
 
+import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.expr.fn.impl.DateUtility;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import java.math.BigDecimal;
 
 public class TestFunctionsQuery extends BaseTestQuery {
+
+  @Rule
+  public final TestRule TIMEOUT = TestTools.getTimeoutRule(90_000 /* ms */);
+
 
   // enable decimal data type
   @BeforeClass

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
@@ -46,7 +46,9 @@ import static org.junit.Assert.assertNull;
  * any particular order of execution. We ignore the results.
  */
 public class TestTpchDistributedConcurrent extends BaseTestQuery {
-  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(120000); // Longer timeout than usual.
+  // Longer timeout than usual:
+  @Rule
+  public final TestRule TIMEOUT = TestTools.getTimeoutRule(180_000 /* ms */);
 
   /*
    * Valid test names taken from TestTpchDistributed. Fuller path prefixes are


### PR DESCRIPTION
Tests:
- TestTpchDistributedConcurrent
- TestExampleQueries
- TestFunctionsQuery