### PR TITLE
DRILL-3874: flattening large JSON objects uses too much direct memory

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/FixedValueVectors.java
+++ b/exec/java-exec/src/main/codegen/templates/FixedValueVectors.java
@@ -60,6 +60,14 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+    return valueCount * ${type.width};
+  }
+
+  @Override
   public int getValueCapacity(){
     return (int) (data.capacity() *1.0 / ${type.width});
   }

--- a/exec/java-exec/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/java-exec/src/main/codegen/templates/NullableValueVectors.java
@@ -103,6 +103,16 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+
+    return values.getBufferSizeFor(valueCount)
+        + bits.getBufferSizeFor(valueCount);
+  }
+
+  @Override
   public DrillBuf getBuffer() {
     return values.getBuffer();
   }

--- a/exec/java-exec/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/java-exec/src/main/codegen/templates/VariableLengthVectors.java
@@ -89,6 +89,16 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+
+    final int idx = offsetVector.getAccessor().get(valueCount);
+    return offsetVector.getBufferSizeFor(valueCount + 1) + idx;
+  }
+
+  @Override
   public int getValueCapacity(){
     return Math.max(offsetVector.getValueCapacity() - 1, 0);
   }
@@ -302,6 +312,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
     try {
       final int requestedSize = (int)curAllocationSize;
       data = allocator.buffer(requestedSize);
+      allocationSizeInBytes = requestedSize;
       offsetVector.allocateNew();
     } catch (OutOfMemoryRuntimeException e) {
       clear();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/memory/TopLevelAllocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/memory/TopLevelAllocator.java
@@ -51,18 +51,6 @@ public class TopLevelAllocator implements BufferAllocator {
   private final DrillBuf empty;
   private final DrillConfig config;
 
-  /* TODO(cwestin) remove
-  @Deprecated
-  TopLevelAllocator() {
-    this(DrillConfig.getMaxDirectMemory());
-  }
-
-  @Deprecated
-  TopLevelAllocator(long maximumAllocation) {
-    this(null, maximumAllocation, true);
-  }
-  */
-
   private TopLevelAllocator(DrillConfig config, long maximumAllocation, boolean errorOnLeak){
     MAXIMUM_DIRECT_MEMORY = maximumAllocation;
     this.config=(config!=null) ? config : DrillConfig.create();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
@@ -23,12 +23,11 @@ import javax.inject.Named;
 
 import org.apache.drill.exec.exception.OversizedAllocationException;
 import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TransferPair;
-import org.apache.drill.exec.record.selection.SelectionVector2;
-import org.apache.drill.exec.record.selection.SelectionVector4;
 
 import com.google.common.collect.ImmutableList;
 
@@ -40,14 +39,22 @@ public abstract class FlattenTemplate implements Flattener {
   private static final Logger logger = LoggerFactory.getLogger(FlattenTemplate.class);
 
   private static final int OUTPUT_BATCH_SIZE = 4*1024;
+  private static final int OUTPUT_MEMORY_LIMIT = 512 * 1024 * 1024;
 
   private ImmutableList<TransferPair> transfers;
-  private SelectionVector2 vector2;
-  private SelectionVector4 vector4;
+  private BufferAllocator outputAllocator;
   private SelectionVectorMode svMode;
   private RepeatedValueVector fieldToFlatten;
   private RepeatedValueVector.RepeatedAccessor accessor;
   private int valueIndex;
+  private boolean bigRecords = false;
+  private int bigRecordsBufferSize;
+
+  /**
+   * The output batch limit starts at OUTPUT_BATCH_SIZE, but may be decreased
+   * if records are found to be large.
+   */
+  private int outputLimit = OUTPUT_BATCH_SIZE;
 
   // this allows for groups to be written between batches if we run out of space, for cases where we have finished
   // a batch on the boundary it will be set to 0
@@ -69,7 +76,8 @@ public abstract class FlattenTemplate implements Flattener {
   }
 
   @Override
-  public final int flattenRecords(final int recordCount, final int firstOutputIndex) {
+  public final int flattenRecords(final int recordCount, final int firstOutputIndex,
+      final Flattener.Monitor monitor) {
     switch (svMode) {
       case FOUR_BYTE:
         throw new UnsupportedOperationException("Flatten does not support selection vector inputs.");
@@ -81,6 +89,7 @@ public abstract class FlattenTemplate implements Flattener {
         if (innerValueIndex == -1) {
           innerValueIndex = 0;
         }
+
         final int initialInnerValueIndex = currentInnerValueIndex;
         // restore state to local stack
         int valueIndexLocal = valueIndex;
@@ -88,23 +97,101 @@ public abstract class FlattenTemplate implements Flattener {
         int currentInnerValueIndexLocal = currentInnerValueIndex;
         outer: {
           int outputIndex = firstOutputIndex;
+          int recordsThisCall = 0;
           final int valueCount = accessor.getValueCount();
           for ( ; valueIndexLocal < valueCount; valueIndexLocal++) {
             final int innerValueCount = accessor.getInnerValueCountAt(valueIndexLocal);
             for ( ; innerValueIndexLocal < innerValueCount; innerValueIndexLocal++) {
-              if (outputIndex == OUTPUT_BATCH_SIZE) {
+              // If we've hit the batch size limit, stop and flush what we've got so far.
+              if (recordsThisCall == outputLimit) {
+                if (bigRecords) {
+                  /*
+                   * We got to the limit we used before, but did we go over
+                   * the bigRecordsBufferSize in the second half of the batch? If
+                   * so, we'll need to adjust the batch limits.
+                   */
+                  adjustBatchLimits(1, monitor, recordsThisCall);
+                }
+
+                // Flush this batch.
                 break outer;
               }
+
+              /*
+               * At the moment, the output record includes the input record, so for very
+               * large records that we're flattening, we're carrying forward the original
+               * record as well as the flattened element. We've seen a case where flattening a 4MB
+               * record with a 20,000 element array causing memory usage to explode. To avoid
+               * that until we can push down the selected fields to operators like this, we
+               * also limit the amount of memory in use at one time.
+               *
+               * We have to have written at least one record to be able to get a buffer that will
+               * have a real allocator, so we have to do this lazily. We won't check the limit
+               * for the first two records, but that keeps this simple.
+               */
+              if (bigRecords) {
+                /*
+                 * If we're halfway through the outputLimit, check on our memory
+                 * usage so far.
+                 */
+                if (recordsThisCall == outputLimit / 2) {
+                  /*
+                   * If we've used more than half the space we've used for big records
+                   * in the past, we've seen even bigger records than before, so stop and
+                   * see if we need to flush here before we go over bigRecordsBufferSize
+                   * memory usage, and reduce the outputLimit further before we continue
+                   * with the next batch.
+                   */
+                  if (adjustBatchLimits(2, monitor, recordsThisCall)) {
+                    break outer;
+                  }
+                }
+              } else {
+                if (outputAllocator.getAllocatedMemory() > OUTPUT_MEMORY_LIMIT) {
+                  /*
+                   * We're dealing with big records. Reduce the outputLimit to
+                   * the current record count, and take note of how much space the
+                   * vectors report using for that. We'll use those numbers as limits
+                   * going forward in order to avoid allocating more memory.
+                   */
+                  bigRecords = true;
+                  outputLimit = Math.min(recordsThisCall, outputLimit);
+                  if (outputLimit < 1) {
+                    throw new IllegalStateException("flatten outputLimit (" + outputLimit
+                        + ") won't make progress");
+                  }
+
+                  /*
+                   * This will differ from what the allocator reports because of
+                   * overhead. But the allocator check is much cheaper to do, so we
+                   * only compute this at selected times.
+                   */
+                  bigRecordsBufferSize = monitor.getBufferSizeFor(recordsThisCall);
+
+                  // Stop and flush.
+                  break outer;
+                }
+              }
+
               try {
                 doEval(valueIndexLocal, outputIndex);
               } catch (OversizedAllocationException ex) {
                 // unable to flatten due to a soft buffer overflow. split the batch here and resume execution.
                 logger.debug("Reached allocation limit. Splitting the batch at input index: {} - inner index: {} - current completed index: {}",
                     valueIndexLocal, innerValueIndexLocal, currentInnerValueIndexLocal) ;
+
+                /*
+                 * TODO
+                 * We can't further reduce the output limits here because it won't have
+                 * any effect. The vectors have already gotten large, and there's currently
+                 * no way to reduce their size. Ideally, we could reduce the outputLimit,
+                 * and reduce the size of the currently used vectors.
+                 */
                 break outer;
               }
               outputIndex++;
               currentInnerValueIndexLocal++;
+              ++recordsThisCall;
             }
             innerValueIndexLocal = 0;
           }
@@ -125,6 +212,68 @@ public abstract class FlattenTemplate implements Flattener {
     }
   }
 
+  /**
+   * Determine if the current batch record limit needs to be adjusted (when handling
+   * bigRecord mode). If so, adjust the limit, and return true, otherwise return false.
+   *
+   * <p>If the limit is adjusted, it will always be adjusted down, because we need to operate
+   * based on the largest sized record we've ever seen.</p>
+   *
+   * <p>If the limit is adjusted, then the current batch should be flushed, because
+   * continuing would lead to going over the large memory limit that has already been
+   * established.</p>
+   *
+   * @param multiplier Multiply currently used memory (according to the monitor) before
+   *   checking against past memory limits. This allows for checking the currently used
+   *   memory after processing a fraction of the expected batch limit, but using that as
+   *   a predictor of the full batch's size. For example, if this is checked after half
+   *   the batch size limit's records are processed, then using a multiplier of two will
+   *   do the check under the assumption that processing the full batch limit will use
+   *   twice as much memory.
+   * @param monitor the Flattener.Monitor instance to use for the current memory usage check
+   * @param recordsThisCall the number of records processed so far during this call to
+   *   flattenRecords().
+   * @return true if the batch size limit was adjusted, false otherwise
+   */
+  private boolean adjustBatchLimits(final int multiplier, final Flattener.Monitor monitor,
+      final int recordsThisCall) {
+    assert bigRecords : "adjusting batch limits when no big records";
+    final int bufferSize = multiplier * monitor.getBufferSizeFor(recordsThisCall);
+
+    /*
+     * If the amount of space we've used so far is below the amount that triggered
+     * the bigRecords mode, then no adjustment is needed.
+     */
+    if (bufferSize <= bigRecordsBufferSize) {
+      return false;
+    }
+
+    /*
+     * We've used more space than we've used for big records in the past, we've seen
+     * even bigger records, so we need to adjust our limits, and flush what we've got so far.
+     *
+     * We should reduce the outputLimit proportionately to get the predicted
+     * amount of memory used back down to bigRecordsBufferSize.
+     *
+     * The number of records to limit is therefore
+     * outputLimit *
+     *   (1 - (bufferSize - bigRecordsBufferSize) / bigRecordsBufferSize)
+     *
+     * Doing some algebra on the multiplier:
+     * (bigRecordsBufferSize - (bufferSize - bigRecordsBufferSize)) / bigRecordsBufferSize
+     * (bigRecordsBufferSize - bufferSize + bigRecordsBufferSize) / bigRecordsBufferSize
+     * (2 * bigRecordsBufferSize - bufferSize) / bigRecordsBufferSize
+     *
+     * If bufferSize has gotten so big that this would be negative, we'll
+     * just go down to one record per batch. We need to check for that on
+     * outputLimit anyway, in order to make sure that we make progress.
+     */
+    final int newLimit = (int)
+        (outputLimit * (2.0 * ((double) bigRecordsBufferSize) - bufferSize) / bigRecordsBufferSize);
+    outputLimit = Math.max(1, newLimit);
+    return true;
+  }
+
   @Override
   public final void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException{
 
@@ -136,10 +285,9 @@ public abstract class FlattenTemplate implements Flattener {
         throw new UnsupportedOperationException("Flatten does not support selection vector inputs.");
     }
     this.transfers = ImmutableList.copyOf(transfers);
+    outputAllocator = outgoing.getOutgoingContainer().getOperatorContext().getAllocator();
     doSetup(context, incoming, outgoing);
   }
-
-
 
   @Override
   public void resetGroupIndex() {
@@ -149,5 +297,4 @@ public abstract class FlattenTemplate implements Flattener {
 
   public abstract void doSetup(@Named("context") FragmentContext context, @Named("incoming") RecordBatch incoming, @Named("outgoing") RecordBatch outgoing);
   public abstract boolean doEval(@Named("inIndex") int inIndex, @Named("outIndex") int outIndex);
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/Flattener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/Flattener.java
@@ -27,13 +27,24 @@ import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 
 public interface Flattener {
+  public void setup(FragmentContext context, RecordBatch incoming,  RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException;
 
-  public abstract void setup(FragmentContext context, RecordBatch incoming,  RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException;
-  public abstract int flattenRecords(int recordCount, int firstOutputIndex);
+  public interface Monitor {
+    /**
+     * Get the required buffer size for the specified number of records.
+     * {@see ValueVector#getBufferSizeFor(int)} for the meaning of this.
+     *
+     * @param recordCount the number of records processed so far
+     * @return the buffer size the vectors report as being in use
+     */
+    public int getBufferSizeFor(int recordCount);
+  };
+
+  public int flattenRecords(int recordCount, int firstOutputIndex, Monitor monitor);
+
   public void setFlattenField(RepeatedValueVector repeatedColumn);
   public RepeatedValueVector getFlattenField();
   public void resetGroupIndex();
 
-  public static TemplateClassDefinition<Flattener> TEMPLATE_DEFINITION = new TemplateClassDefinition<Flattener>(Flattener.class, FlattenTemplate.class);
-
+  public static final TemplateClassDefinition<Flattener> TEMPLATE_DEFINITION = new TemplateClassDefinition<Flattener>(Flattener.class, FlattenTemplate.class);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccessible {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorContainer.class);
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorContainer.class);
 
   protected final List<VectorWrapper<?>> wrappers = Lists.newArrayList();
   private BatchSchema schema;
@@ -52,6 +52,15 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
 
   public VectorContainer( OperatorContext oContext) {
     this.oContext = oContext;
+  }
+
+  /**
+   * Get the OperatorContext.
+   *
+   * @return the OperatorContext; may be null
+   */
+  public OperatorContext getOperatorContext() {
+    return oContext;
   }
 
   public boolean isSchemaChanged() {
@@ -79,7 +88,7 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
   public <T extends ValueVector> T addOrGet(final MaterializedField field, final SchemaChangeCallBack callBack) {
     final TypedFieldId id = getValueVectorId(field.getPath());
     final ValueVector vector;
-    final Class clazz = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getType().getMode());
+    final Class<?> clazz = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getType().getMode());
     if (id != null) {
       vector = getValueAccessorById(id.getFieldIds()).getValueVector();
       if (id.getFieldIds().length == 1 && clazz != null && !clazz.isAssignableFrom(vector.getClass())) {
@@ -205,7 +214,7 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
     schema = null;
     schemaChanged = true;
     int i = 0;
-    for (VectorWrapper w : wrappers){
+    for (VectorWrapper<?> w : wrappers){
       if (!w.isHyper() && old == w.getValueVector()) {
         w.clear();
         wrappers.set(i, new SimpleVectorWrapper<ValueVector>(newVector));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -62,6 +62,11 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
     return getSizeFromCount(valueCount);
   }
 
+  @Override
+  public int getBufferSizeFor(final int valueCount) {
+    return getSizeFromCount(valueCount);
+  }
+
   private int getSizeFromCount(int valueCount) {
     return (int) Math.ceil(valueCount / 8.0);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
@@ -32,10 +32,9 @@ import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 
-public class ObjectVector extends BaseValueVector{
-
-  private Accessor accessor = new Accessor();
-  private Mutator mutator = new Mutator();
+public class ObjectVector extends BaseValueVector {
+  private final Accessor accessor = new Accessor();
+  private final Mutator mutator = new Mutator();
   private int maxCount = 0;
   private int count = 0;
   private int allocationSize = 4096;
@@ -126,6 +125,11 @@ public class ObjectVector extends BaseValueVector{
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    throw new UnsupportedOperationException("ObjectVector does not support this");
+  }
+
+  @Override
   public void close() {
     clear();
   }
@@ -193,7 +197,6 @@ public class ObjectVector extends BaseValueVector{
   }
 
   public final class Accessor extends BaseAccessor {
-
     @Override
     public Object getObject(int index) {
       int listOffset = index / allocationSize;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -56,7 +56,6 @@ import org.apache.drill.exec.vector.complex.reader.FieldReader;
  * </blockquote>
  */
 public interface ValueVector extends Closeable, Iterable<ValueVector> {
-
   /**
    * Allocate new buffers. ValueVector implements logic to determine how much to allocate.
    * @throws OutOfMemoryRuntimeException Thrown if no memory can be allocated.
@@ -140,6 +139,19 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   int getBufferSize();
 
   /**
+   * Returns the number of bytes that is used by this vector if it holds the given number
+   * of values. The result will be the same as if Mutator.setValueCount() were called, followed
+   * by calling getBufferSize(), but without any of the closing side-effects that setValueCount()
+   * implies wrt finishing off the population of a vector. Some operations might wish to use
+   * this to determine how much memory has been used by a vector so far, even though it is
+   * not finished being populated.
+   *
+   * @param valueCount the number of values to assume this vector contains
+   * @return the buffer size if this vector is holding valueCount values
+   */
+  int getBufferSizeFor(int valueCount);
+
+  /**
    * Return the underlying buffers associated with this vector. Note that this doesn't impact the reference counts for
    * this buffer so it only should be used for in-context access. Also note that this buffer changes regularly thus
    * external classes shouldn't hold a reference to it (unless they change it).
@@ -206,5 +218,4 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
     @Deprecated
     void generateTestData(int values);
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -118,6 +118,11 @@ public class ZeroVector implements ValueVector {
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    return 0;
+  }
+
+  @Override
   public DrillBuf[] getBuffers(boolean clear) {
     return new DrillBuf[0];
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
@@ -123,6 +123,15 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   @Override
+  public int getBufferSizeFor(int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+
+    return offsets.getBufferSizeFor(valueCount + 1) + vector.getBufferSizeFor(valueCount);
+  }
+
+  @Override
   public Iterator<ValueVector> iterator() {
     return Collections.singleton(getDataVector()).iterator();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -102,8 +101,7 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    final Iterable<ValueVector> container = this;
-    for (ValueVector v : container) {
+    for (final ValueVector v : (Iterable<ValueVector>) this) {
       v.setInitialCapacity(numRecords);
     }
   }
@@ -119,6 +117,20 @@ public class MapVector extends AbstractMapVector {
     }
 
     return (int) buffer;
+  }
+
+  @Override
+  public int getBufferSizeFor(final int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+
+    long bufferSize = 0;
+    for (final ValueVector v : (Iterable<ValueVector>) this) {
+      bufferSize += v.getBufferSizeFor(valueCount);
+    }
+
+    return (int) bufferSize;
   }
 
   @Override
@@ -295,7 +307,7 @@ public class MapVector extends AbstractMapVector {
 
     @Override
     public Object getObject(int index) {
-      Map<String, Object> vv = new JsonStringHashMap();
+      Map<String, Object> vv = new JsonStringHashMap<>();
       for (String child:getChildFieldNames()) {
         ValueVector v = getChild(child);
         if (v != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
@@ -329,6 +329,11 @@ public class RepeatedListVector extends AbstractContainerVector
   }
 
   @Override
+  public int getBufferSizeFor(final int valueCount) {
+    return delegate.getBufferSizeFor(valueCount);
+  }
+
+  @Override
   public void close() {
     delegate.close();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
@@ -90,8 +90,7 @@ public class RepeatedMapVector extends AbstractMapVector
   @Override
   public void setInitialCapacity(int numRecords) {
     offsets.setInitialCapacity(numRecords + 1);
-    final Iterable<ValueVector> container = this;
-    for(final ValueVector v : container) {
+    for(final ValueVector v : (Iterable<ValueVector>) this) {
       v.setInitialCapacity(numRecords * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
     }
   }
@@ -133,11 +132,25 @@ public class RepeatedMapVector extends AbstractMapVector
     if (getAccessor().getValueCount() == 0) {
       return 0;
     }
-    long buffer = offsets.getBufferSize();
+    long bufferSize = offsets.getBufferSize();
     for (final ValueVector v : (Iterable<ValueVector>) this) {
-      buffer += v.getBufferSize();
+      bufferSize += v.getBufferSize();
     }
-    return (int) buffer;
+    return (int) bufferSize;
+  }
+
+  @Override
+  public int getBufferSizeFor(final int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+
+    long bufferSize = 0;
+    for (final ValueVector v : (Iterable<ValueVector>) this) {
+      bufferSize += v.getBufferSizeFor(valueCount);
+    }
+
+    return (int) bufferSize;
   }
 
   @Override
@@ -479,7 +492,7 @@ public class RepeatedMapVector extends AbstractMapVector
   public class RepeatedMapAccessor implements RepeatedAccessor {
     @Override
     public Object getObject(int index) {
-      final List<Object> list = new JsonStringArrayList();
+      final List<Object> list = new JsonStringArrayList<>();
       final int end = offsets.getAccessor().get(index+1);
       String fieldName;
       for (int i =  offsets.getAccessor().get(index); i < end; i++) {


### PR DESCRIPTION
- add getBufferSizeFor() to ValueVector interface
- add implememtations of getBufferSizeFor() for all ValueVector derivatives
- add adaptive algorithm for adjusting batch size to flatten operator