### PR TITLE
[DRILL-3723] Remove unused RemoteServiceSet method

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/RemoteServiceSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/RemoteServiceSet.java
@@ -20,13 +20,10 @@ package org.apache.drill.exec.server;
 import java.io.Closeable;
 import java.io.IOException;
 
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.coord.local.LocalClusterCoordinator;
-import org.apache.drill.exec.memory.BufferAllocator;
 
 public class RemoteServiceSet implements Closeable {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RemoteServiceSet.class);
 
   private final ClusterCoordinator coordinator;
 
@@ -48,9 +45,4 @@ public class RemoteServiceSet implements Closeable {
   public static RemoteServiceSet getLocalServiceSet() {
     return new RemoteServiceSet(new LocalClusterCoordinator());
   }
-
-  public static RemoteServiceSet getServiceSetWithFullCache(DrillConfig config, BufferAllocator allocator) throws Exception{
-    return new RemoteServiceSet(new LocalClusterCoordinator());
-  }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -169,11 +169,7 @@ public class BaseTestQuery extends ExecTest {
 
   private static void openClient() throws Exception {
     allocator = RootAllocatorFactory.newRoot(config);
-    if (config.hasPath(ENABLE_FULL_CACHE) && config.getBoolean(ENABLE_FULL_CACHE)) {
-      serviceSet = RemoteServiceSet.getServiceSetWithFullCache(config, allocator);
-    } else {
-      serviceSet = RemoteServiceSet.getLocalServiceSet();
-    }
+    serviceSet = RemoteServiceSet.getLocalServiceSet();
 
     dfsTestTmpSchemaLocation = TestUtilities.createTempDir();
 


### PR DESCRIPTION
RemoteServiceSet.getServiceSetWithFullCache() was not using any of the
arguments passed to it. It was identical to getLocalServiceSet().