### PR TITLE
DRILL-3876: Avoid an extra copy of the original list when flattening

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
@@ -94,6 +94,10 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
     }
     List<RexNode> complexExprs = exprSplitter.getComplexExprs();
 
+    if (complexExprs.size() == 1) {
+      return project;
+    }
+
     ProjectPrel childProject;
 
     List<RexNode> allExprs = new ArrayList();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlattenPlanning.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlattenPlanning.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.flatten;
+
+import org.apache.drill.PlanTestBase;
+import org.junit.Test;
+
+public class TestFlattenPlanning extends PlanTestBase {
+
+  @Test
+  public void testFlattenPlanningAvoidUnnecessaryProject() throws Exception {
+    testPlanSubstrPatterns("select flatten(complex), rownum from cp.`/store/json/test_flatten_mappify2.json`",
+        new String[]{"Project(EXPR$0=[$1], rownum=[$0])"}, new String[]{"Project(EXPR$0=[$0], EXPR$1=[$1], EXPR$3=[$1])"});
+  }
+}


### PR DESCRIPTION
This only fixes a basic case, a more complete refactoring of the rewrite rule could avoid copies in cases with multiple flattens, this will be addressed in DRILL-3899.