### PR TITLE
DRILL-3916: Add JDBC plugin to assembly

### DIFF
--- a/distribution/src/assemble/bin.xml
+++ b/distribution/src/assemble/bin.xml
@@ -92,6 +92,7 @@
         <include>org.apache.drill.contrib.data:tpch-sample-data:jar</include>
         <include>org.apache.drill.contrib:drill-mongo-storage</include>
         <include>org.apache.drill.contrib:drill-storage-hbase</include>
+        <include>org.apache.drill.contrib:drill-jdbc-storage</include>
       </includes>
       <excludes>
         <exclude>org.apache.drill.contrib.storage-hive:drill-storage-hive-core:jar:tests</exclude>


### PR DESCRIPTION
This commits adds the JDBC plugin jar to the assembly so that it can be
loaded by Drill as a storage plugin.