### PR TITLE
DRILL-3623: Use shorter query path for LIMIT 0 queries on schema-ed tables

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.hive;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.PlanTestBase;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.hadoop.fs.FileSystem;
 import org.joda.time.DateTime;
@@ -39,6 +40,25 @@ public class TestHiveStorage extends HiveTestBase {
   @Test
   public void hiveReadWithDb() throws Exception {
     test("select * from hive.kv");
+  }
+
+  @Test
+  public void simpleLimitZero() throws Exception {
+    testBuilder()
+        .sqlQuery("select * from hive.kv limit 0")
+        .expectsEmptyResultSet()
+        .baselineColumns("key", "value")
+        .go();
+  }
+
+  @Test
+  public void simpleLimitZeroPlan() throws Exception {
+    final String[] expectedPlan = {
+      ".*Limit.*\n" +
+          ".*Values.*"
+    };
+    final String[] excludedPlan = {};
+    PlanTestBase.testPlanMatchingPatterns("select * from hive.kv limit 0", expectedPlan, excludedPlan);
   }
 
   @Test
@@ -159,6 +179,66 @@ public class TestHiveStorage extends HiveTestBase {
             new DateTime(Timestamp.valueOf("2013-07-05 17:01:00").getTime()),
             new DateTime(Date.valueOf("2013-07-05").getTime()))
         .go();
+  }
+
+  @Test
+  public void limitZeroVariousTypes() throws Exception {
+    testBuilder().sqlQuery("SELECT * FROM (SELECT boolean_field, tinyint_field, decimal0_field," +
+        "decimal9_field, decimal18_field, decimal28_field, decimal38_field, double_field, float_field, int_field, " +
+        "bigint_field, smallint_field, string_field, varchar_field, timestamp_field, date_field, " +
+        "boolean_part, tinyint_part, decimal0_part, decimal9_part, decimal18_part, decimal28_part, decimal38_part, " +
+        "double_part, float_part, int_part, bigint_part, smallint_part, string_part, varchar_part, timestamp_part, " +
+        "date_part FROM hive.readtest) T LIMIT 0")
+        .baselineColumns(
+            "boolean_field",
+            "tinyint_field",
+            "decimal0_field",
+            "decimal9_field",
+            "decimal18_field",
+            "decimal28_field",
+            "decimal38_field",
+            "double_field",
+            "float_field",
+            "int_field",
+            "bigint_field",
+            "smallint_field",
+            "string_field",
+            "varchar_field",
+            "timestamp_field",
+            "date_field",
+            "boolean_part",
+            "tinyint_part",
+            "decimal0_part",
+            "decimal9_part",
+            "decimal18_part",
+            "decimal28_part",
+            "decimal38_part",
+            "double_part",
+            "float_part",
+            "int_part",
+            "bigint_part",
+            "smallint_part",
+            "string_part",
+            "varchar_part",
+            "timestamp_part",
+            "date_part")
+        .expectsEmptyResultSet()
+        .go();
+  }
+
+  @Test
+  public void limitZeroVariousTypesPlan() throws Exception {
+    PlanTestBase.testPlanMatchingPatterns("SELECT * FROM (SELECT boolean_field, tinyint_field, decimal0_field," +
+            "decimal9_field, decimal18_field, decimal28_field, decimal38_field, double_field, float_field, int_field, " +
+            "bigint_field, smallint_field, string_field, varchar_field, timestamp_field, date_field, " +
+            "boolean_part, tinyint_part, decimal0_part, decimal9_part, decimal18_part, decimal28_part, decimal38_part, " +
+            "double_part, float_part, int_part, bigint_part, smallint_part, string_part, varchar_part, timestamp_part, " +
+            "date_part FROM hive.readtest) T LIMIT 0",
+        new String[] {
+            ".*Limit.*\n" +
+                ".*Values.*"
+        },
+        new String[] {});
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillConstExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillConstExecutor.java
@@ -58,6 +58,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.planner.sql.handlers.FindLimit0Visitor;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -70,6 +71,9 @@ public class DrillConstExecutor implements RelOptPlanner.Executor {
 
   private final PlannerSettings plannerSettings;
 
+  /**
+   * NOTE: Ensure changes are reflected in {@link FindLimit0Visitor#TYPES}.
+   */
   public static ImmutableMap<TypeProtos.MinorType, SqlTypeName> DRILL_TO_CALCITE_TYPE_MAPPING =
       ImmutableMap.<TypeProtos.MinorType, SqlTypeName> builder()
       .put(TypeProtos.MinorType.INT, SqlTypeName.INTEGER)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillValuesRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillValuesRel.java
@@ -65,7 +65,7 @@ public class DrillValuesRel extends AbstractRelNode implements DrillRel {
   private final JSONOptions options;
   private final double rowCount;
 
-  protected DrillValuesRel(RelOptCluster cluster, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples, RelTraitSet traits) {
+  public DrillValuesRel(RelOptCluster cluster, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples, RelTraitSet traits) {
     super(cluster, traits);
     assert getConvention() == DRILL_LOGICAL;
     verifyRowType(tuples, rowType);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -204,6 +204,15 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
    * @throws RelConversionException
    */
   protected DrillRel convertToDrel(RelNode relNode) throws SqlUnsupportedException, RelConversionException {
+    // If the query contains a limit 0 clause, disable distributed mode since it is overkill for determining schema
+    // And if the schema is known, return the schema directly
+    if (FindLimit0Visitor.containsLimit0(relNode)) {
+      context.getPlannerSettings().forceSingleMode();
+      final DrillRel valuesRel = FindLimit0Visitor.getValuesRelIfFullySchemaed(relNode);
+      if (valuesRel != null) {
+        return valuesRel;
+      }
+    }
     try {
       final DrillRel convertedRelNode;
 
@@ -216,12 +225,6 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       if (convertedRelNode instanceof DrillStoreRel) {
         throw new UnsupportedOperationException();
       } else {
-
-        // If the query contains a limit 0 clause, disable distributed mode since it is overkill for determining schema.
-        if (FindLimit0Visitor.containsLimit0(convertedRelNode)) {
-          context.getPlannerSettings().forceSingleMode();
-        }
-
         return convertedRelNode;
       }
     } catch (RelOptPlanner.CannotPlanException ex) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/FindLimit0Visitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/FindLimit0Visitor.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.planner.sql.handlers;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -25,10 +28,19 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalMinus;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.exec.planner.logical.DrillConstExecutor;
 import org.apache.drill.exec.planner.logical.DrillLimitRel;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.DrillValuesRel;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * Visitor that will identify whether the root portion of the RelNode tree contains a limit 0 pattern. In this case, we
@@ -36,14 +48,60 @@ import org.apache.drill.exec.planner.logical.DrillLimitRel;
  * executing a schema-only query.
  */
 public class FindLimit0Visitor extends RelShuttleImpl {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FindLimit0Visitor.class);
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FindLimit0Visitor.class);
+
+  /**
+   * Values in the {@link DrillConstExecutor#DRILL_TO_CALCITE_TYPE_MAPPING} map.
+   * + without {@link SqlTypeName#ANY} (avoid late binding)
+   * + without {@link SqlTypeName#VARBINARY} ({@link DrillValuesRel values} does not support this)
+   * + with {@link SqlTypeName#CHAR} ({@link DrillValuesRel values} supports this, but the above mapping does not
+   *   contain this type.
+   */
+  private static final ImmutableSet<SqlTypeName> TYPES = ImmutableSet.<SqlTypeName>builder()
+      .add(SqlTypeName.INTEGER, SqlTypeName.BIGINT, SqlTypeName.FLOAT, SqlTypeName.DOUBLE, SqlTypeName.VARCHAR,
+          SqlTypeName.BOOLEAN, SqlTypeName.DATE, SqlTypeName.DECIMAL, SqlTypeName.TIME, SqlTypeName.TIMESTAMP,
+          SqlTypeName.INTERVAL_YEAR_MONTH, SqlTypeName.INTERVAL_DAY_TIME, SqlTypeName.MAP, SqlTypeName.ARRAY,
+          SqlTypeName.TINYINT, SqlTypeName.SMALLINT, SqlTypeName.CHAR)
+      .build();
 
   private boolean contains = false;
 
+  /**
+   * Checks if the root portion of the RelNode tree contains a limit 0 pattern.
+   */
   public static boolean containsLimit0(RelNode rel) {
     FindLimit0Visitor visitor = new FindLimit0Visitor();
     rel.accept(visitor);
     return visitor.isContains();
+  }
+
+  /**
+   * If all field types of the given node are {@link #TYPES recognized types}, then this method returns the tree:
+   *   DrillLimitRel(0)
+   *     \
+   *     DrillValuesRel(field types)
+   * Otherwise, the method returns null.
+   */
+  public static DrillRel getValuesRelIfFullySchemaed(final RelNode rel) {
+    final List<RelDataTypeField> fieldList = rel.getRowType().getFieldList();
+    final ImmutableList.Builder<RexLiteral> tupleBuilder = new ImmutableList.Builder<>();
+    final RexBuilder literalBuilder = new RexBuilder(rel.getCluster().getTypeFactory());
+    for (final RelDataTypeField field : fieldList) {
+      if (!TYPES.contains(field.getType().getSqlTypeName())) {
+        return null;
+      } else {
+        tupleBuilder.add((RexLiteral) literalBuilder.makeLiteral(null, field.getType(), false));
+      }
+    }
+
+    final ImmutableList<ImmutableList<RexLiteral>> tuples = new ImmutableList.Builder<ImmutableList<RexLiteral>>()
+        .add(tupleBuilder.build())
+        .build();
+    final RelTraitSet traits = rel.getTraitSet().plus(DrillRel.DRILL_LOGICAL);
+    // TODO: ideally, we want the limit to be pushed into values
+    final DrillValuesRel values = new DrillValuesRel(rel.getCluster(), rel.getRowType(), tuples, traits);
+    return new DrillLimitRel(rel.getCluster(), traits, values, literalBuilder.makeExactLiteral(BigDecimal.ZERO),
+        literalBuilder.makeExactLiteral(BigDecimal.ZERO));
   }
 
   private FindLimit0Visitor() {
@@ -76,18 +134,6 @@ public class FindLimit0Visitor extends RelShuttleImpl {
     }
 
     return super.visit(sort);
-  }
-
-  @Override
-  public RelNode visit(RelNode other) {
-    if (other instanceof DrillLimitRel) {
-      if (isLimit0(((DrillLimitRel) other).getFetch())) {
-        contains = true;
-        return other;
-      }
-    }
-
-    return super.visit(other);
   }
 
   // The following set of RelNodes should terminate a search for the limit 0 pattern as they want convey its meaning.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestLimit0.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestLimit0.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.limit;
+
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.PlanTestBase;
+import org.junit.Test;
+
+public class TestLimit0 extends BaseTestQuery {
+
+  @Test
+  public void simpleLimit0() throws Exception {
+    testBuilder()
+        .sqlQuery("SELECT * FROM (" +
+        "SELECT * FROM (VALUES (1, 1.0, DATE '2008-2-23', TIME '12:23:34', TIMESTAMP '2008-2-23 12:23:34.456', " +
+        "INTERVAL '1' YEAR, INTERVAL '2' DAY), (1, 1.0, DATE '2008-2-23', TIME '12:23:34', " +
+        "TIMESTAMP '2008-2-23 12:23:34.456', INTERVAL '1' YEAR, INTERVAL '2' DAY)) AS " +
+        "Example(myInt, myFloat, myDate, myTime, myTimestamp, int1, int2)) T LIMIT 0")
+        .expectsEmptyResultSet()
+        .baselineColumns("myInt", "myFloat", "myDate", "myTime", "myTimestamp", "int1", "int2")
+        .go();
+  }
+
+  @Test
+  public void simpleLimit0Plan() throws Exception {
+    PlanTestBase.testPlanMatchingPatterns("SELECT * FROM (" +
+        "SELECT * FROM (VALUES (1, 1.0, DATE '2008-2-23', TIME '12:23:34', TIMESTAMP '2008-2-23 12:23:34.456', " +
+        "INTERVAL '1' YEAR, INTERVAL '2' DAY), (1, 1.0, DATE '2008-2-23', TIME '12:23:34', " +
+        "TIMESTAMP '2008-2-23 12:23:34.456', INTERVAL '1' YEAR, INTERVAL '2' DAY)) AS " +
+        "Example(myInt, myFloat, myDate, myTime, myTimestamp, int1, int2)) T LIMIT 0",
+        new String[] {
+            ".*Limit.*\n" +
+                ".*Values.*"
+        },
+        new String[] {});
+  }
+
+  @Test
+  public void countDistinctLimit0() throws Exception {
+    testBuilder()
+        .sqlQuery("SELECT * FROM " +
+        "(SELECT CAST(COUNT(employee_id) AS BIGINT) as c1, " +
+        "CAST(SUM(employee_id) AS INT) as s1, " +
+        "CAST(COUNT(DISTINCT employee_id) AS BIGINT) as c2 " +
+        "FROM cp.`employee.json`) " +
+        "T LIMIT 0")
+        .baselineColumns("c1", "s1", "c2")
+        .expectsEmptyResultSet()
+        .go();
+  }
+
+  @Test
+  public void countDistinctLimit0Plan() throws Exception {
+    PlanTestBase.testPlanMatchingPatterns("SELECT * FROM " +
+            "(SELECT CAST(COUNT(employee_id) AS BIGINT) as c1, " +
+            "CAST(SUM(employee_id) AS INT) as s1, " +
+            "CAST(COUNT(DISTINCT employee_id) AS BIGINT) as c2 " +
+            "FROM cp.`employee.json`) " +
+            "T LIMIT 0",
+        new String[] {
+            ".*Limit.*\n" +
+                ".*Values.*"
+        },
+        new String[] {});
+  }
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2288GetColumnsMetadataWhenNoRowsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2288GetColumnsMetadataWhenNoRowsTest.java
@@ -56,6 +56,19 @@ public class Drill2288GetColumnsMetadataWhenNoRowsTest {
     connection.close();
   }
 
+  protected void checkForSchemaAndNoRows(final String query) throws Exception {
+    try (final Statement stmt = connection.createStatement();
+         final ResultSet results = stmt.executeQuery(query)) {
+
+      // Result set should still have columns even though there are no rows:
+      ResultSetMetaData metadata = results.getMetaData();
+      assertThat("ResultSetMetaData.getColumnCount() should have been > 0",
+          metadata.getColumnCount(), not(equalTo(0)));
+
+      assertThat("Unexpected non-empty results. Test rot?",
+          false, equalTo(results.next()));
+    }
+  }
 
   /**
    * Tests that an empty JSON file (having zero records) no longer triggers
@@ -64,16 +77,7 @@ public class Drill2288GetColumnsMetadataWhenNoRowsTest {
    */
   @Test
   public void testEmptyJsonFileDoesntSuppressNetSchema1() throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results = stmt.executeQuery( "SELECT a, b, c, * FROM cp.`empty.json`" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT a, b, c, * FROM cp.`empty.json`");
   }
 
   @Test
@@ -98,87 +102,32 @@ public class Drill2288GetColumnsMetadataWhenNoRowsTest {
    */
   @Test
   public void testInfoSchemaTablesZeroRowsBy_TABLE_SCHEMA_works() throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results =
-        stmt.executeQuery( "SELECT * FROM INFORMATION_SCHEMA.`TABLES`"
-                           + " WHERE TABLE_SCHEMA = ''" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_SCHEMA = ''");
   }
 
   /** (Worked before (because TABLE_CATALOG test not pushed down).) */
   @Test
   public void testInfoSchemaTablesZeroRowsBy_TABLE_CATALOG_works() throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results =
-        stmt.executeQuery( "SELECT * FROM INFORMATION_SCHEMA.`TABLES`"
-                           + " WHERE TABLE_CATALOG = ''" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_CATALOG = ''");
   }
 
   /** (Failed before (because TABLE_NAME test is pushed down).) */
   @Test
   public void testInfoSchemaTablesZeroRowsBy_TABLE_NAME_works()
       throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results =
-        stmt.executeQuery(
-            "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME = ''" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME = ''");
   }
 
   /** (Worked before.) */
   @Test
   public void testInfoSchemaTablesZeroRowsByLimitWorks() throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results =
-        stmt.executeQuery(
-            "SELECT * FROM INFORMATION_SCHEMA.`TABLES` LIMIT 0" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT * FROM INFORMATION_SCHEMA.`TABLES` LIMIT 0");
   }
 
   /** (Worked before.) */
   @Test
   public void testInfoSchemaTablesZeroRowsByWhereFalseWorks() throws Exception {
-    Statement stmt = connection.createStatement();
-    ResultSet results =
-        stmt.executeQuery(
-            "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE FALSE" );
-
-    // Result set should still have columns even though there are no rows:
-    ResultSetMetaData metadata = results.getMetaData();
-    assertThat( "ResultSetMetaData.getColumnCount() should have been > 0",
-                metadata.getColumnCount(), not( equalTo( 0 ) ) );
-
-    assertThat( "Unexpected non-empty results.  Test rot?",
-                false, equalTo( results.next() ) );
+    checkForSchemaAndNoRows("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE FALSE");
   }
 
   /** (Failed before (because table schema and name tests are pushed down).) */
@@ -196,6 +145,5 @@ public class Drill2288GetColumnsMetadataWhenNoRowsTest {
     assertThat( "Unexpected non-empty results.  Test rot?",
                 false, equalTo( results.next() ) );
   }
-
 
 }


### PR DESCRIPTION
Initial patch.

DrillTable#providesDeferredSchema function is used by the NonDeferredSchemaTableLimit0Visitor to check if the table can provide schema directly, and if so the result is directly returned.

It seems the shorter query path for this query needs a hacky "otherPlan" in the DefaultSqlHandler without major refactoring (Should I go ahead and make changes?). This also means that "EXPLAIN PLAN ..." returns a plan that is different the actual query plan (without a check in ExplainHandler, another hack).

I think the classes need more meaningful names (NonDeferredSchemaTableLimit0Visitor).

Also, note the type conversion using CALCITE_TO_DRILL_TYPE_MAPPING.