### PR TITLE
DRILL-3920 Add vector loading tests

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/BaseValueVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/BaseValueVector.java
@@ -17,10 +17,13 @@
  */
 package org.apache.drill.exec.vector;
 
+import io.netty.buffer.DrillBuf;
+
 import java.util.Iterator;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
+
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
@@ -91,10 +94,10 @@ public abstract class BaseValueVector implements ValueVector {
     protected BaseMutator() { }
 
     @Override
-    public void generateTestData(int values) { }
+    public void generateTestData(int values) {}
 
     //TODO: consider making mutator stateless(if possible) on another issue.
-    public void reset() { }
+    public void reset() {}
   }
 
   @Override
@@ -102,5 +105,14 @@ public abstract class BaseValueVector implements ValueVector {
     return Iterators.emptyIterator();
   }
 
+  public static boolean checkBufRefs(final ValueVector vv) {
+    for(final DrillBuf buffer : vv.getBuffers(false)) {
+      if (buffer.refCnt() <= 0) {
+        throw new IllegalStateException("zero refcount");
+      }
+    }
+
+    return true;
+  }
 }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.vector;
 
-import io.netty.buffer.DrillBuf;
-
 import java.io.Closeable;
+
+import io.netty.buffer.DrillBuf;
 
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.exec.memory.OutOfMemoryRuntimeException;
@@ -80,8 +80,9 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   int getValueCapacity();
 
   /**
-   * Alternative to clear(). Allows use as closeable in try-with-resources.
+   * Alternative to clear(). Allows use as an AutoCloseable in try-with-resources.
    */
+  @Override
   void close();
 
   /**
@@ -155,9 +156,8 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    * Return the underlying buffers associated with this vector. Note that this doesn't impact the reference counts for
    * this buffer so it only should be used for in-context access. Also note that this buffer changes regularly thus
    * external classes shouldn't hold a reference to it (unless they change it).
-   *
-   * @param clear
-   *          Whether to clear vector
+   * @param clear Whether to clear vector before returning; the buffers will still be refcounted;
+   *   but the returned array will be the only reference to them
    *
    * @return The underlying {@link io.netty.buffer.DrillBuf buffers} that is used by this vector instance.
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
@@ -36,6 +36,7 @@ import java.util.List;
  * Base class for MapVectors. Currently used by RepeatedMapVector and MapVector
  */
 public abstract class AbstractMapVector extends AbstractContainerVector {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractContainerVector.class);
 
   // Maintains a map with key as field name and value is the vector itself
   private final MapWithOrdinal<String, ValueVector> vectors =  new MapWithOrdinal<>();
@@ -46,11 +47,21 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
     // create the hierarchy of the child vectors based on the materialized field
     for (MaterializedField child : clonedField.getChildren()) {
       if (!child.equals(BaseRepeatedValueVector.OFFSETS_FIELD)) {
-        String fieldName = child.getLastName();
-        ValueVector v = TypeHelper.getNewVector(child, allocator, callBack);
+        final String fieldName = child.getLastName();
+        final ValueVector v = TypeHelper.getNewVector(child, allocator, callBack);
         putVector(fieldName, v);
       }
     }
+  }
+
+  @Override
+  public void close() {
+    for(final ValueVector valueVector : vectors.values()) {
+      valueVector.close();
+    }
+    vectors.clear();
+
+    super.close();
   }
 
   @Override
@@ -62,8 +73,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
      */
     boolean success = false;
     try {
-
-      for (ValueVector v : vectors.values()) {
+      for (final ValueVector v : vectors.values()) {
         if (!v.allocateNewSafe()) {
           return false;
         }
@@ -105,13 +115,14 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    *
    * @return resultant {@link org.apache.drill.exec.vector.ValueVector}
    */
+  @Override
   public <T extends ValueVector> T addOrGet(String name, TypeProtos.MajorType type, Class<T> clazz) {
     final ValueVector existing = getChild(name);
     boolean create = false;
     if (existing == null) {
       create = true;
     } else if (clazz.isAssignableFrom(existing.getClass())) {
-      return (T)existing;
+      return (T) existing;
     } else if (nullFilled(existing)) {
       existing.clear();
       create = true;
@@ -129,7 +140,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
   }
 
   private boolean nullFilled(ValueVector vector) {
-    for (int r=0; r<vector.getAccessor().getValueCount(); r++) {
+    for (int r = 0; r < vector.getAccessor().getValueCount(); r++) {
       if (!vector.getAccessor().isNull(r)) {
         return false;
       }
@@ -148,8 +159,9 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    * Returns a {@link org.apache.drill.exec.vector.ValueVector} instance of subtype of <T> corresponding to the given
    * field name if exists or null.
    */
+  @Override
   public <T extends ValueVector> T getChild(String name, Class<T> clazz) {
-    ValueVector v = vectors.get(name.toLowerCase());
+    final ValueVector v = vectors.get(name.toLowerCase());
     if (v == null) {
       return null;
     }
@@ -172,7 +184,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    * @param vector  vector to be inserted
    */
   protected void putVector(String name, ValueVector vector) {
-    ValueVector old = vectors.put(
+    final ValueVector old = vectors.put(
         Preconditions.checkNotNull(name, "field name cannot be null").toLowerCase(),
         Preconditions.checkNotNull(vector, "vector cannot be null")
     );
@@ -192,6 +204,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
   /**
    * Returns the number of underlying child vectors.
    */
+  @Override
   public int size() {
     return vectors.size();
   }
@@ -205,8 +218,8 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    * Returns a list of scalar child vectors recursing the entire vector hierarchy.
    */
   public List<ValueVector> getPrimitiveVectors() {
-    List<ValueVector> primitiveVectors = Lists.newArrayList();
-    for (ValueVector v : vectors.values()) {
+    final List<ValueVector> primitiveVectors = Lists.newArrayList();
+    for (final ValueVector v : vectors.values()) {
       if (v instanceof AbstractMapVector) {
         AbstractMapVector mapVector = (AbstractMapVector) v;
         primitiveVectors.addAll(mapVector.getPrimitiveVectors());
@@ -220,6 +233,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
   /**
    * Returns a vector with its corresponding ordinal mapping if field exists or null.
    */
+  @Override
   public VectorWithOrdinal getChildVectorWithOrdinal(String name) {
     final int ordinal = vectors.getOrdinal(name.toLowerCase());
     if (ordinal < 0) {
@@ -231,13 +245,13 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
 
   @Override
   public DrillBuf[] getBuffers(boolean clear) {
-    List<DrillBuf> buffers = Lists.newArrayList();
+    final List<DrillBuf> buffers = Lists.newArrayList();
 
-    for (ValueVector vector : vectors.values()) {
-      for (DrillBuf buf : vector.getBuffers(false)) {
+    for (final ValueVector vector : vectors.values()) {
+      for (final DrillBuf buf : vector.getBuffers(false)) {
         buffers.add(buf);
         if (clear) {
-          buf.retain();
+          buf.retain(1);
         }
       }
       if (clear) {
@@ -252,20 +266,11 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
   public int getBufferSize() {
     int actualBufSize = 0 ;
 
-    for (ValueVector v : vectors.values()) {
-      for (DrillBuf buf : v.getBuffers(false)) {
+    for (final ValueVector v : vectors.values()) {
+      for (final DrillBuf buf : v.getBuffers(false)) {
         actualBufSize += buf.writerIndex();
       }
     }
     return actualBufSize;
-  }
-
-  @Override
-  public void close() {
-   for(final ValueVector valueVector : vectors.values()) {
-     valueVector.close();
-   }
-
-   super.close();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -22,6 +22,7 @@ import com.google.common.primitives.Ints;
 
 import io.netty.buffer.DrillBuf;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import com.google.common.base.Preconditions;
 
 public class MapVector extends AbstractMapVector {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MapVector.class);
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MapVector.class);
 
   public final static MajorType TYPE = Types.required(MinorType.MAP);
 
@@ -112,7 +113,7 @@ public class MapVector extends AbstractMapVector {
       return 0;
     }
     long buffer = 0;
-    for (ValueVector v : (Iterable<ValueVector>)this) {
+    for (final ValueVector v : (Iterable<ValueVector>)this) {
       buffer += v.getBufferSize();
     }
 
@@ -149,7 +150,7 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
-    return new MapTransferPair(this, (MapVector)to);
+    return new MapTransferPair(this, (MapVector) to);
   }
 
   @Override
@@ -194,7 +195,7 @@ public class MapVector extends AbstractMapVector {
         // (This is similar to what happens in ScanBatch where the children cannot be added till they are
         // read). To take care of this, we ensure that the hashCode of the MaterializedField does not
         // include the hashCode of the children but is based only on MaterializedField$key.
-        ValueVector newVector = to.addOrGet(child, vector.getField().getType(), vector.getClass());
+        final ValueVector newVector = to.addOrGet(child, vector.getField().getType(), vector.getClass());
         if (allocate && to.size() != preSize) {
           newVector.allocateNew();
         }
@@ -202,10 +203,9 @@ public class MapVector extends AbstractMapVector {
       }
     }
 
-
     @Override
     public void transfer() {
-      for (TransferPair p : pairs) {
+      for (final TransferPair p : pairs) {
         p.transfer();
       }
       to.valueCount = from.valueCount;
@@ -231,7 +231,6 @@ public class MapVector extends AbstractMapVector {
       }
       to.getMutator().setValueCount(length);
     }
-
   }
 
   @Override
@@ -329,7 +328,6 @@ public class MapVector extends AbstractMapVector {
     public int getValueCount() {
       return valueCount;
     }
-
   }
 
   public ValueVector getVectorById(int id) {
@@ -340,7 +338,7 @@ public class MapVector extends AbstractMapVector {
 
     @Override
     public void setValueCount(int valueCount) {
-      for (ValueVector v : getChildren()) {
+      for (final ValueVector v : getChildren()) {
         v.getMutator().setValueCount(valueCount);
       }
       MapVector.this.valueCount = valueCount;
@@ -355,17 +353,19 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void clear() {
-    valueCount = 0;
-    for (ValueVector v : getChildren()) {
+    for (final ValueVector v : getChildren()) {
       v.clear();
     }
+    valueCount = 0;
   }
 
   @Override
   public void close() {
-    for (final ValueVector v : getChildren()) {
+    final Collection<ValueVector> vectors = getChildren();
+    for (final ValueVector v : vectors) {
       v.close();
     }
+    vectors.clear();
     valueCount = 0;
 
     super.close();


### PR DESCRIPTION
Additional tests added to TestValueVectors for serialization and loading; these tests were used to find and debug issues with DrillBuf slicing. Some light cleanup of a few vector implementations.

Unit tests pass.
Regression suite has a few (known recurring) failures:
- timeouts while waiting to send intermediate work fragments
- timeouts for "Fetch parquet metadata" tasks not complete
- Selected column 'dir0' must have name 'columns' or must be plain '*'