### PR TITLE
DRILL-3921: Initialize the underlying record reader lazily in HiveRec…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeScanBatchCreator.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeScanBatchCreator.java
@@ -39,6 +39,7 @@ import org.apache.drill.exec.store.AbstractRecordReader;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.parquet.DirectCodecFactory;
 import org.apache.drill.exec.store.parquet.columnreaders.ParquetRecordReader;
+import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -150,7 +151,8 @@ public class HiveDrillNativeScanBatchCreator implements BatchCreator<HiveDrillNa
     // If there are no readers created (which is possible when the table is empty or no row groups are matched),
     // create an empty RecordReader to output the schema
     if (readers.size() == 0) {
-      readers.add(new HiveRecordReader(table, null, null, columns, context, hiveConfigOverride));
+      readers.add(new HiveRecordReader(table, null, null, columns, context, hiveConfigOverride,
+        ImpersonationUtil.createProxyUgi(config.getUserName(), context.getQueryUserName())));
     }
 
     return new ScanBatch(config, context, oContext, readers.iterator(), partitionColumns, selectedPartitionColumns);

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveTextRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveTextRecordReader.java
@@ -48,7 +48,7 @@ public class HiveTextRecordReader extends HiveRecordReader {
   private final int numCols;
 
   public HiveTextRecordReader(Table table, Partition partition, InputSplit inputSplit, List<SchemaPath> projectedColumns, FragmentContext context) throws ExecutionSetupException {
-    super(table, partition, inputSplit, projectedColumns, context, null);
+    super(table, partition, inputSplit, projectedColumns, context, null, null);
     String d = table.getSd().getSerdeInfo().getParameters().get("field.delim");
     if (d != null) {
       delimiter = d.getBytes()[0];

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.impersonation.hive;
 
 import org.apache.drill.TestBuilder;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.dotdrill.DotDrillType;
 import org.apache.drill.exec.impersonation.BaseTestImpersonation;
@@ -33,7 +32,6 @@ import org.apache.hadoop.hive.shims.ShimLoader;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
@@ -54,6 +52,9 @@ public class BaseTestHiveImpersonation extends BaseTestImpersonation {
       "(voter_id int,name varchar(30), age tinyint, registration string, " +
       "contributions double,voterzone smallint,create_time timestamp) " +
       "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE";
+  protected static final String partitionStudentDef = "CREATE TABLE %s.%s" +
+      "(rownum INT, name STRING, gpa FLOAT, studentnum BIGINT) " +
+      "partitioned by (age INT) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE";
 
   protected static void prepHiveConfAndData() throws Exception {
     hiveConf = new HiveConf();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorContext.java
@@ -17,16 +17,19 @@
  */
 package org.apache.drill.exec.ops;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.buffer.DrillBuf;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.concurrent.Callable;
 
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 
 public abstract class OperatorContext {
 
@@ -43,6 +46,17 @@ public abstract class OperatorContext {
   public abstract ExecutionControls getExecutionControls();
 
   public abstract DrillFileSystem newFileSystem(Configuration conf) throws IOException;
+
+  /**
+   * Run the callable as the given proxy user.
+   *
+   * @param proxyUgi proxy user group information
+   * @param callable callable to run
+   * @param <RESULT> result type
+   * @return Future<RESULT> future with the result of calling the callable
+   */
+  public abstract <RESULT> ListenableFuture<RESULT> runCallableAs(UserGroupInformation proxyUgi,
+                                                                  Callable<RESULT> callable);
 
   public static int getChildCount(PhysicalOperator popConfig) {
     Iterator<PhysicalOperator> iter = popConfig.iterator();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
@@ -206,10 +206,6 @@ public class WorkManager implements AutoCloseable {
     }
   }
 
-  private void shutdownAndAwaitTermination(long timeInSeconds) {
-
-  }
-
   public DrillbitContext getContext() {
     return dContext;
   }


### PR DESCRIPTION
…ordReader

@vkorukanti and @jacques-n can you please take a look. I need to add unit tests.

For my setup with 20K files, LIMIT 1 query now takes 53 seconds (~48 seconds for planning). Previously the query took 1300 seconds  (~45 seconds for planning).