### PR TITLE
Add Drill version, from Manifest, same as SqlLine in the sys.version …

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/DrillVersionInfo.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillVersionInfo.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+
+/**
+ * Get access to the Drill Version
+ */
+public class DrillVersionInfo {
+
+  /**
+   * Get the Drill version from the Manifest file
+   * @return the version number as x.y.z
+   */
+  public static String getVersion() {
+    String appName = "";
+    String appVersion = "Unknown";
+    try {
+      Enumeration<URL> resources = DrillVersionInfo.class.getClassLoader()
+              .getResources("META-INF/MANIFEST.MF");
+      while (resources.hasMoreElements()) {
+        Manifest manifest = new Manifest(resources.nextElement().openStream());
+        // check that this is your manifest and do what you need or
+        // get the next one
+        appName = manifest.getMainAttributes()
+                .getValue("Implementation-Title");
+        if (appName != null && appName.toLowerCase().contains("drill")) {
+          appVersion = manifest.getMainAttributes()
+                  .getValue("Implementation-Version");
+        }
+      }
+    } catch (IOException except) {
+      appVersion = "Unknown";
+    }
+    return appVersion;
+  }
+
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
@@ -19,10 +19,13 @@ package org.apache.drill.exec.store.sys;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.jar.Manifest;
 
 import com.google.common.io.Resources;
+import org.apache.drill.common.util.DrillVersionInfo;
 
 public class VersionIterator implements Iterator<Object>{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VersionIterator.class);
@@ -30,6 +33,7 @@ public class VersionIterator implements Iterator<Object>{
   public boolean beforeFirst = true;
 
   public static class VersionInfo {
+    public String version = "Unknown";
     public String commit_id = "Unknown";
     public String commit_message = "";
     public String commit_time = "";
@@ -38,6 +42,7 @@ public class VersionIterator implements Iterator<Object>{
 
     public VersionInfo(){
       try {
+        version = DrillVersionInfo.getVersion(); // get drill version (x.y.z)
         URL u = Resources.getResource("git.properties");
         if(u != null){
           Properties p = new Properties();
@@ -54,6 +59,7 @@ public class VersionIterator implements Iterator<Object>{
       }
     }
   }
+
   @Override
   public boolean hasNext() {
     return beforeFirst;
@@ -72,6 +78,5 @@ public class VersionIterator implements Iterator<Object>{
   public void remove() {
     throw new UnsupportedOperationException();
   }
-
 
 }


### PR DESCRIPTION
…see [DRILL-2726](https://issues.apache.org/jira/browse/DRILL-2726)

This PR does the following:
```
apache drill 1.2.0-SNAPSHOT
"got drill?"
0: jdbc:drill:zk=local> select * from sys.version;
+-----------------+-------------------------------------------+-----------------------------------------------------------------+-----------------------------+--------------------+-----------------------------+
| version_number  |                 commit_id                 |                         commit_message                          |         commit_time         |    build_email     |         build_time          |
+-----------------+-------------------------------------------+-----------------------------------------------------------------+-----------------------------+--------------------+-----------------------------+
| 1.2.0-SNAPSHOT  | b4d47c56b6484eedbf3f44516338da4cdbfbb7b4  | DRILL-3918: During expansion save the metadata for future use.  | 11.10.2015 @ 21:30:38 CEST  | tugdual@gmail.com  | 13.10.2015 @ 04:49:00 CEST  |
+-----------------+-------------------------------------------+-----------------------------------------------------------------+-----------------------------+--------------------+-----------------------------+
1 row selected (1.84 seconds)
```