### PR TITLE
DRILL-3930: Remove direct references to TopLevelAllocator from unit t…

### DIFF
--- a/common/src/main/java/org/apache/drill/common/DrillAutoCloseables.java
+++ b/common/src/main/java/org/apache/drill/common/DrillAutoCloseables.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common;
+
+/**
+ * Provides functionality comparable to Guava's Closeables for AutoCloseables.
+ */
+public class DrillAutoCloseables {
+  /**
+   * Constructor. Prevents construction for class of static utilities.
+   */
+  private DrillAutoCloseables() {
+  }
+
+  /**
+   * close() an {@see java.lang.AutoCloseable} without throwing a (checked)
+   * {@see java.lang.Exception}. This wraps the close() call with a
+   * try-catch that will rethrow an Exception wrapped with a
+   * {@see java.lang.RuntimeException}, providing a way to call close()
+   * without having to do the try-catch everywhere or propagate the Exception.
+   *
+   * @param closeable the AutoCloseable to close; may be null
+   * @throws RuntimeException if an Exception occurs; the Exception is
+   *   wrapped by the RuntimeException
+   */
+  public static void closeNoChecked(final AutoCloseable autoCloseable) {
+    if (autoCloseable != null) {
+      try {
+        autoCloseable.close();
+      } catch(final Exception e) {
+        throw new RuntimeException("Exception while closing", e);
+      }
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
@@ -138,7 +138,7 @@ public class TestOptiqPlans extends ExecTest {
           final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
             final Object o = vv.getAccessor().getObject(i);
-            System.out.println(vv.getAccessor().getObject(i));
+            System.out.println(o);
           }
         }
         loader.clear();
@@ -167,7 +167,7 @@ public class TestOptiqPlans extends ExecTest {
           final ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
             final Object o = vv.getAccessor().getObject(i);
-            System.out.println(vv.getAccessor().getObject(i));
+            System.out.println(o);
           }
         }
         loader.clear();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAgg.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
-import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
@@ -128,7 +127,5 @@ public class TestAgg extends ExecTest {
       throw exec.getContext().getFailureCause();
     }
     assertTrue(!exec.getContext().isFailed());
-
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/TestHashTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/TestHashTable.java
@@ -31,7 +31,6 @@ import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
-import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/project/TestSimpleProjection.java
@@ -30,7 +30,6 @@ import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
-import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceMultiRecordBatch.java
@@ -27,7 +27,6 @@ import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
-import org.apache.drill.exec.memory.TopLevelAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -36,6 +36,7 @@ import org.apache.drill.QueryTestUtil;
 import org.apache.drill.SingleRowListener;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.concurrent.ExtendedLatch;
+import org.apache.drill.common.DrillAutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -119,7 +120,6 @@ public class TestDrillbitResilience extends DrillTest {
     }
 
     try {
-      @SuppressWarnings("resource")
       final Drillbit drillbit = Drillbit.start(zkHelper.getConfig(), remoteServiceSet);
       drillbits.put(name, drillbit);
     } catch (final DrillbitStartupException e) {
@@ -133,7 +133,6 @@ public class TestDrillbitResilience extends DrillTest {
    * @param name name of the drillbit
    */
   private static void stopDrillbit(final String name) {
-    @SuppressWarnings("resource")
     final Drillbit drillbit = drillbits.get(name);
     if (drillbit == null) {
       throw new IllegalStateException("No Drillbit named \"" + name + "\" found");
@@ -273,7 +272,7 @@ public class TestDrillbitResilience extends DrillTest {
 
           @Override
           public void cleanup() {
-            bufferAllocator.close();
+            DrillAutoCloseables.closeNoChecked(bufferAllocator);
           }
         };
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestDirectCodecFactory.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestDirectCodecFactory.java
@@ -46,7 +46,7 @@ public class TestDirectCodecFactory extends ExecTest {
     ON_HEAP, OFF_HEAP, DRILLBUF
   }
 
-  private void test(int size, CompressionCodecName codec, boolean useOnHeapCompression, Decompression decomp) {
+  private void test(int size, CompressionCodecName codec, boolean useOnHeapCompression, Decompression decomp) throws Exception {
     DrillBuf rawBuf = null;
     DrillBuf outBuf = null;
     try (final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.vector;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -25,7 +29,6 @@ import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.NullableVarCharVector.Accessor;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSplitAndTransfer {
@@ -37,21 +40,23 @@ public class TestSplitAndTransfer {
     final NullableVarCharVector varCharVector = new NullableVarCharVector(field, allocator);
     varCharVector.allocateNew(10000, 1000);
 
-    final String[] compareArray = new String[500];
+    final int valueCount = 500;
+    final String[] compareArray = new String[valueCount];
 
-    for (int i = 0; i < 500; i += 3) {
+    final NullableVarCharVector.Mutator mutator = varCharVector.getMutator();
+    for (int i = 0; i < valueCount; i += 3) {
       final String s = String.format("%010d", i);
-      varCharVector.getMutator().set(i, s.getBytes());
+      mutator.set(i, s.getBytes());
       compareArray[i] = s;
     }
-    varCharVector.getMutator().setValueCount(500);
+    mutator.setValueCount(valueCount);
 
     final TransferPair tp = varCharVector.getTransferPair();
     final NullableVarCharVector newVarCharVector = (NullableVarCharVector) tp.getTo();
     final Accessor accessor = newVarCharVector.getAccessor();
     final int[][] startLengths = {{0, 201}, {201, 200}, {401, 99}};
 
-    for (int[] startLength : startLengths) {
+    for (final int[] startLength : startLengths) {
       final int start = startLength[0];
       final int length = startLength[1];
       tp.splitAndTransfer(start, length);
@@ -60,17 +65,16 @@ public class TestSplitAndTransfer {
         final boolean expectedSet = ((start + i) % 3) == 0;
         if (expectedSet) {
           final byte[] expectedValue = compareArray[start + i].getBytes();
-          Assert.assertFalse(accessor.isNull(i));
-//          System.out.println(new String(accessor.get(i)));
-          Assert.assertArrayEquals(expectedValue, accessor.get(i));
+          assertFalse(accessor.isNull(i));
+          assertArrayEquals(expectedValue, accessor.get(i));
         } else {
-          Assert.assertTrue(accessor.isNull(i));
+          assertTrue(accessor.isNull(i));
         }
       }
       newVarCharVector.clear();
     }
 
-    varCharVector.clear();
+    varCharVector.close();
     allocator.close();
   }
 }


### PR DESCRIPTION
…ests

Ensure RootAllocatorFactory is used throughout the code so
that we can change allocators via configuration or software. Use
DrillAutoCloseables to handle exceptions that could happen from some
allocator close() calls when the allocator is in an improper state. Additional
minor cleanup.

Unit tests pass
Regression suite passes, except for
- a couple of the known "Selected column 'dir0' must have name 'columns' or must be plain '*'"