### PR TITLE
DRILL-3911: Upgrade Hadoop version

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationMetadata.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationMetadata.java
@@ -276,8 +276,7 @@ public class TestImpersonationMetadata extends BaseTestImpersonation {
 
     final String query = "CREATE VIEW " + viewName + " AS SELECT " +
         "c_custkey, c_nationkey FROM cp.`tpch/customer.parquet` ORDER BY c_custkey;";
-    final String expErrorMsg = "PERMISSION ERROR: Permission denied: user=drillTestUser2, access=WRITE, " +
-        "inode=\"/drillTestGrp0_755\"";
+    final String expErrorMsg = "PERMISSION ERROR: Permission denied: user=drillTestUser2, access=WRITE, inode=\"/drillTestGrp0_755/";
     errorMsgTestHelper(query, expErrorMsg);
 
     // SHOW TABLES is expected to return no records as view creation fails above.
@@ -358,7 +357,7 @@ public class TestImpersonationMetadata extends BaseTestImpersonation {
 
     assertNotNull("UserRemoteException is expected", ex);
     assertThat(ex.getMessage(),
-        containsString("Permission denied: user=drillTestUser2, access=WRITE, inode=\"/drillTestGrp0_755\""));
+        containsString("SYSTEM ERROR: RemoteException: Permission denied: user=drillTestUser2, access=WRITE, inode=\"/drillTestGrp0_755/"));
   }
 
   @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       Apache Hive 1.0.0. If the version is changed, make sure the jars and their dependencies are updated.
     -->
     <hive.version>1.0.0</hive.version>
-    <hadoop.version>2.4.1</hadoop.version>
+    <hadoop.version>2.7.1</hadoop.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This commit upgrades the Hadoop version from 2.4.1 to 2.7.1.

The only change that needed to be made here was to modify the error
message that we expect to get back for failed impersonation requests.