### PR TITLE
Add the _id when using a * projection see JIRA : DRILL-3505

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -102,6 +102,8 @@ public class MongoRecordReader extends AbstractRecordReader {
         this.fields.put(fieldName, Integer.valueOf(1));
       }
     } else {
+      // Tale all the fields including the _id
+      this.fields.remove(DrillMongoConstants.ID);
       transformed.add(AbstractRecordReader.STAR_COLUMN);
     }
     return transformed;


### PR DESCRIPTION
When the user is doing STAR_COLUMN , the system now asks mongodb to return the _id.

Behing the scene the mongo query does not have any field  in the projection, so it returns all fields including the _id.

I was not able to run succesfully any test in the current branch so I could not add test. (will ask question on ml)