### PR TITLE
DRILL-3340: Add operator metrics registry for metric definitions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
@@ -26,8 +26,11 @@ import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 
+/**
+ * Holds statistics of a particular (minor) fragment.
+ */
 public class FragmentStats {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentStats.class);
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentStats.class);
 
   private List<OperatorStats> operators = Lists.newArrayList();
   private final long startTime;
@@ -50,9 +53,16 @@ public class FragmentStats {
     }
   }
 
-  public OperatorStats getOperatorStats(OpProfileDef profileDef, BufferAllocator allocator){
-    OperatorStats stats = new OperatorStats(profileDef, allocator);
-    if(profileDef.operatorType != -1){
+  /**
+   * Creates a new holder for operator statistics within this holder for fragment statistics.
+   *
+   * @param profileDef operator profile definition
+   * @param allocator the allocator being used
+   * @return a new operator statistics holder
+   */
+  public OperatorStats newOperatorStats(final OpProfileDef profileDef, final BufferAllocator allocator) {
+    final OperatorStats stats = new OperatorStats(profileDef, allocator);
+    if(profileDef.operatorType != -1) {
       operators.add(stats);
     }
     return stats;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/MetricDef.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/MetricDef.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.ops;
 
+/**
+ * Interface that defines a metric. For example, {@link org.apache.drill.exec.physical.impl.join.HashJoinBatch.Metric}.
+ */
 public interface MetricDef {
   public String name();
   public int metricId();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorContextImpl.java
@@ -50,7 +50,7 @@ class OperatorContextImpl extends OperatorContext implements AutoCloseable {
     this.popConfig = popConfig;
 
     OpProfileDef def = new OpProfileDef(popConfig.getOperatorId(), popConfig.getOperatorType(), getChildCount(popConfig));
-    this.stats = context.getStats().getOperatorStats(def, allocator);
+    stats = context.getStats().newOperatorStats(def, allocator);
     executionControls = context.getExecutionControls();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import org.apache.drill.exec.physical.impl.ScreenCreator;
+import org.apache.drill.exec.physical.impl.SingleSenderCreator;
+import org.apache.drill.exec.physical.impl.aggregate.HashAggTemplate;
+import org.apache.drill.exec.physical.impl.broadcastsender.BroadcastSenderRootExec;
+import org.apache.drill.exec.physical.impl.join.HashJoinBatch;
+import org.apache.drill.exec.physical.impl.mergereceiver.MergingRecordBatch;
+import org.apache.drill.exec.physical.impl.partitionsender.PartitionSenderRootExec;
+import org.apache.drill.exec.physical.impl.unorderedreceiver.UnorderedReceiverBatch;
+import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
+
+/**
+ * Registry of operator metrics.
+ */
+public class OperatorMetricRegistry {
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OperatorMetricRegistry.class);
+
+  // Mapping: operator type --> metric id --> metric name
+  private static final String[][] OPERATOR_METRICS = new String[CoreOperatorType.values().length][];
+
+  static {
+    register(CoreOperatorType.SCREEN_VALUE, ScreenCreator.ScreenRoot.Metric.class);
+    register(CoreOperatorType.SINGLE_SENDER_VALUE, SingleSenderCreator.SingleSenderRootExec.Metric.class);
+    register(CoreOperatorType.BROADCAST_SENDER_VALUE, BroadcastSenderRootExec.Metric.class);
+    register(CoreOperatorType.HASH_PARTITION_SENDER_VALUE, PartitionSenderRootExec.Metric.class);
+    register(CoreOperatorType.MERGING_RECEIVER_VALUE, MergingRecordBatch.Metric.class);
+    register(CoreOperatorType.UNORDERED_RECEIVER_VALUE, UnorderedReceiverBatch.Metric.class);
+    register(CoreOperatorType.HASH_AGGREGATE_VALUE, HashAggTemplate.Metric.class);
+    register(CoreOperatorType.HASH_JOIN_VALUE, HashJoinBatch.Metric.class);
+  }
+
+  private static void register(final int operatorType, final Class<? extends MetricDef> metricDef) {
+    // Currently registers a metric def that has enum constants
+    final MetricDef[] enumConstants = metricDef.getEnumConstants();
+    if (enumConstants != null) {
+      final String[] names = new String[enumConstants.length];
+      for (int i = 0; i < enumConstants.length; i++) {
+        names[i] = enumConstants[i].name();
+      }
+      OPERATOR_METRICS[operatorType] = names;
+    }
+  }
+
+  /**
+   * Given an operator type, this method returns an array of metric names (indexable by metric id).
+   *
+   * @param operatorType the operator type
+   * @return metric names if operator was registered, null otherwise
+   */
+  public static String[] getMetricNames(final int operatorType) {
+    return OPERATOR_METRICS[operatorType];
+  }
+
+  // to prevent instantiation
+  private OperatorMetricRegistry() {
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
@@ -50,7 +50,7 @@ public class ScreenCreator implements RootCreator<Screen> {
     return new ScreenRoot(context, children.iterator().next(), config);
   }
 
-  static class ScreenRoot extends BaseRootExec {
+  public static class ScreenRoot extends BaseRootExec {
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ScreenRoot.class);
     private final RecordBatch incoming;
     private final FragmentContext context;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -22,7 +22,9 @@ import java.util.List;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.drill.exec.ops.OperatorMetricRegistry;
 import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
+import org.apache.drill.exec.proto.UserBitShared.MetricValue;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
 import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
 
@@ -33,9 +35,10 @@ public class OperatorWrapper {
   private static final String format = " (%s)";
 
   private final int major;
-  private final List<ImmutablePair<OperatorProfile, Integer>> ops;
+  private final List<ImmutablePair<OperatorProfile, Integer>> ops; // operator profile --> minor fragment number
   private final OperatorProfile firstProfile;
   private final CoreOperatorType operatorType;
+  private final String operatorName;
   private final int size;
 
   public OperatorWrapper(int major, List<ImmutablePair<OperatorProfile, Integer>> ops) {
@@ -43,13 +46,14 @@ public class OperatorWrapper {
     this.major = major;
     firstProfile = ops.get(0).getLeft();
     operatorType = CoreOperatorType.valueOf(firstProfile.getOperatorType());
+    operatorName = operatorType == null ? "UNKNOWN_OPERATOR" : operatorType.toString();
     this.ops = ops;
     size = ops.size();
   }
 
   public String getDisplayName() {
     final String path = new OperatorPathBuilder().setMajor(major).setOperator(firstProfile).build();
-    return String.format("%s - %s", path, operatorType == null ? "UNKNOWN_OPERATOR" : operatorType.toString());
+    return String.format("%s - %s", path, operatorName);
   }
 
   public String getId() {
@@ -94,7 +98,7 @@ public class OperatorWrapper {
 
     String path = new OperatorPathBuilder().setMajor(major).setOperator(firstProfile).build();
     tb.appendCell(path, null);
-    tb.appendCell(operatorType == null ? "UNKNOWN_OPERATOR" : operatorType.toString(), null);
+    tb.appendCell(operatorName, null);
 
     double setupSum = 0.0;
     double processSum = 0.0;
@@ -129,5 +133,51 @@ public class OperatorWrapper {
     final ImmutablePair<OperatorProfile, Integer> peakMem = Collections.max(ops, Comparators.operatorPeakMemory);
     tb.appendBytes(Math.round(memSum / size), null);
     tb.appendBytes(peakMem.getLeft().getPeakLocalMemoryAllocated(), null);
+  }
+
+  public String getMetricsTable() {
+    if (operatorType == null) {
+      return "";
+    }
+    final String[] metricNames = OperatorMetricRegistry.getMetricNames(operatorType.getNumber());
+    if (metricNames == null) {
+      return "";
+    }
+
+    final String[] metricsTableColumnNames = new String[metricNames.length + 1];
+    metricsTableColumnNames[0] = "Minor Fragment";
+    int i = 1;
+    for (final String metricName : metricNames) {
+      metricsTableColumnNames[i++] = metricName;
+    }
+    final TableBuilder builder = new TableBuilder(metricsTableColumnNames);
+    for (final ImmutablePair<OperatorProfile, Integer> ip : ops) {
+      final OperatorProfile op = ip.getLeft();
+
+      builder.appendCell(
+          new OperatorPathBuilder()
+              .setMajor(major)
+              .setMinor(ip.getRight())
+              .setOperator(op)
+              .build(),
+          null);
+
+      final Number[] values = new Number[metricNames.length];
+      for (final MetricValue metric : op.getMetricList()) {
+        if (metric.hasLongValue()) {
+          values[metric.getMetricId()] = metric.getLongValue();
+        } else if (metric.hasDoubleValue()) {
+          values[metric.getMetricId()] = metric.getDoubleValue();
+        }
+      }
+      for (final Number value : values) {
+        if (value != null) {
+          builder.appendFormattedNumber(value, null);
+        } else {
+          builder.appendCell("", null);
+        }
+      }
+    }
+    return builder.build();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -32,7 +32,7 @@ import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 
 /**
- * This class contains information presented in the query profile web UI.
+ * Wrapper class for a {@link #profile query profile}, so it to be presented through web UI.
  */
 public class ProfileWrapper {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileWrapper.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/TableBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/TableBuilder.java
@@ -48,7 +48,6 @@ class TableBuilder {
     width = columns.length;
 
     format.setMaximumFractionDigits(3);
-    format.setMinimumFractionDigits(3);
 
     sb.append("<table class=\"table table-bordered text-right\">\n<tr>");
     for (final String cn : columns) {

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -176,6 +176,20 @@
         <div class="panel-body">
           ${op.getContent()}
         </div>
+        <div class="panel panel-info">
+          <div class="panel-heading">
+            <h4 class="panel-title">
+              <a data-toggle="collapse" href="#${op.getId()}-metrics">
+                Operator Metrics
+              </a>
+            </h4>
+          </div>
+          <div id="${op.getId()}-metrics" class="panel-collapse collapse">
+            <div class="panel-body">
+              ${op.getMetricsTable()}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     </#list>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
@@ -128,7 +128,7 @@ public class TestAllocators {
     //Use some bogus operator type to create a new operator context.
     def = new OpProfileDef(physicalOperator1.getOperatorId(), UserBitShared.CoreOperatorType.MOCK_SUB_SCAN_VALUE,
         OperatorContext.getChildCount(physicalOperator1));
-    stats = fragmentContext1.getStats().getOperatorStats(def, fragmentContext1.getAllocator());
+    stats = fragmentContext1.getStats().newOperatorStats(def, fragmentContext1.getAllocator());
 
 
     // Add a couple of Operator Contexts
@@ -143,7 +143,7 @@ public class TestAllocators {
 
     def = new OpProfileDef(physicalOperator4.getOperatorId(), UserBitShared.CoreOperatorType.TEXT_WRITER_VALUE,
         OperatorContext.getChildCount(physicalOperator4));
-    stats = fragmentContext2.getStats().getOperatorStats(def, fragmentContext2.getAllocator());
+    stats = fragmentContext2.getStats().newOperatorStats(def, fragmentContext2.getAllocator());
     OperatorContext oContext22 = fragmentContext2.newOperatorContext(physicalOperator4, stats, true);
     DrillBuf b22=oContext22.getAllocator().buffer(2000000);
 
@@ -157,7 +157,7 @@ public class TestAllocators {
     // New fragment starts an operator that allocates an amount within the limit
     def = new OpProfileDef(physicalOperator5.getOperatorId(), UserBitShared.CoreOperatorType.UNION_VALUE,
         OperatorContext.getChildCount(physicalOperator5));
-    stats = fragmentContext3.getStats().getOperatorStats(def, fragmentContext3.getAllocator());
+    stats = fragmentContext3.getStats().newOperatorStats(def, fragmentContext3.getAllocator());
     OperatorContext oContext31 = fragmentContext3.newOperatorContext(physicalOperator5, stats, true);
 
     DrillBuf b31a = oContext31.getAllocator().buffer(200000);


### PR DESCRIPTION
+ Display metrics as a table within an operator profile panel
+ Rename FragmentStats#getOperatorStats to newOperatorStats