### PR TITLE
DRILL-3983: Small test improvements

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.coord.zk.ZKClusterCoordinator;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
+import org.apache.drill.exec.rpc.user.AwaitableUserResultsListener;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.util.VectorUtil;
@@ -148,8 +149,6 @@ public class QuerySubmitter {
 
   public int submitQuery(DrillClient client, String plan, String type, String format, int width) throws Exception {
 
-    PrintingResultsListener listener;
-
     String[] queries;
     QueryType queryType;
     type = type.toLowerCase();
@@ -189,7 +188,8 @@ public class QuerySubmitter {
     }
     Stopwatch watch = new Stopwatch();
     for (String query : queries) {
-      listener = new PrintingResultsListener(client.getConfig(), outputFormat, width);
+      AwaitableUserResultsListener listener =
+          new AwaitableUserResultsListener(new PrintingResultsListener(client.getConfig(), outputFormat, width));
       watch.start();
       client.runQuery(queryType, query, listener);
       int rows = listener.await();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/AwaitableUserResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/AwaitableUserResultsListener.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.rpc.user;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
+
+/**
+ * General mechanism for waiting on the query to be executed
+ */
+public class AwaitableUserResultsListener implements UserResultsListener {
+
+  private final AtomicInteger count = new AtomicInteger();
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private volatile UserException exception;
+  private final UserResultsListener child;
+
+  /**
+   * @param child the listener responsible for consuming the data
+   */
+  public AwaitableUserResultsListener(UserResultsListener child) {
+    if (child == null) {
+      throw new NullPointerException("child should not be null");
+    }
+    this.child = child;
+  }
+
+  @Override
+  public void queryIdArrived(QueryId queryId) {
+    child.queryIdArrived(queryId);
+  }
+
+  @Override
+  public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
+    count.addAndGet(result.getHeader().getRowCount());
+    child.dataArrived(result, throttle);
+  }
+
+  @Override
+  public void submissionFailed(UserException ex) {
+    exception = ex;
+    latch.countDown();
+    child.submissionFailed(ex);
+  }
+
+  @Override
+  public void queryCompleted(QueryState state) {
+    latch.countDown();
+    child.queryCompleted(state);
+  }
+
+  public int await() throws Exception {
+    latch.await();
+    if (exception != null) {
+      exception.addSuppressed(new DrillRuntimeException("Exception in executor threadpool"));
+      throw exception;
+    }
+    return count.get();
+  }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -122,6 +122,9 @@ public class BaseTestQuery extends ExecTest {
     config = DrillConfig.create(TEST_CONFIGURATIONS);
     classpathScan = ClassPathScanner.fromPrescan(config);
     openClient();
+    // turns on the verbose errors in tests
+    // sever side stacktraces are added to the message before sending back to the client
+    test("ALTER SESSION SET `exec.errors.verbose` = true");
   }
 
   protected static void updateTestCluster(int newDrillbitCount, DrillConfig newConfig) {

--- a/exec/java-exec/src/test/java/org/apache/drill/QueryTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/QueryTestUtil.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.drill.BaseTestQuery.SilentListener;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
@@ -31,6 +32,7 @@ import org.apache.drill.exec.client.QuerySubmitter.Format;
 import org.apache.drill.exec.memory.OutOfMemoryException;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.rpc.RpcException;
+import org.apache.drill.exec.rpc.user.AwaitableUserResultsListener;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.rpc.user.UserResultsListener;
 import org.apache.drill.exec.server.RemoteServiceSet;
@@ -40,6 +42,9 @@ import org.apache.drill.exec.util.VectorUtil;
  * Utilities useful for tests that issue SQL queries.
  */
 public class QueryTestUtil {
+
+  public static final String TEST_QUERY_PRINTING_SILENT = "drill.test.query.printing.silent";
+
   /**
    * Constructor. All methods are static.
    */
@@ -101,8 +106,13 @@ public class QueryTestUtil {
   public static int testRunAndPrint(
       final DrillClient drillClient, final QueryType type, final String queryString) throws Exception {
     final String query = normalizeQuery(queryString);
-    PrintingResultsListener resultListener =
-        new PrintingResultsListener(drillClient.getConfig(), Format.TSV, VectorUtil.DEFAULT_COLUMN_WIDTH);
+    DrillConfig config = drillClient.getConfig();
+    AwaitableUserResultsListener resultListener =
+        new AwaitableUserResultsListener(
+            config.getBoolean(TEST_QUERY_PRINTING_SILENT) ?
+                new SilentListener() :
+                new PrintingResultsListener(config, Format.TSV, VectorUtil.DEFAULT_COLUMN_WIDTH)
+        );
     drillClient.runQuery(type, query, resultListener);
     return resultListener.await();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.physical.impl.writer;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
 
@@ -656,5 +659,23 @@ public class TestParquetWriter extends BaseTestQuery {
             .baselineValues("2013-07-05 17:01:00")
             .baselineValues((Object)null)
             .go();
+  }
+
+  @Test
+  public void testSchemaChange() throws Exception {
+    File dir = new File("target/" + this.getClass());
+    if ((!dir.exists() && !dir.mkdirs()) || (dir.exists() && !dir.isDirectory())) {
+      throw new RuntimeException("can't create dir " + dir);
+    }
+    File input1 = new File(dir, "1.json");
+    File input2 = new File(dir, "2.json");
+    try (FileWriter fw = new FileWriter(input1)) {
+      fw.append("{\"a\":\"foo\"}\n");
+    }
+    try (FileWriter fw = new FileWriter(input2)) {
+      fw.append("{\"b\":\"foo\"}\n");
+    }
+    test("select * from " + "dfs.`" + dir.getAbsolutePath() + "`");
+    runTestAndValidate("*", "*", "dfs.`" + dir.getAbsolutePath() + "`", "schema_change_parquet");
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.junit.Test;
+
+public class TestDrillSQLWorker {
+
+  private void validateFormattedIs(String sql, SqlParserPos pos, String expected) {
+    String formatted = DrillSqlWorker.formatSQLParsingError(sql, pos);
+    assertEquals(expected, formatted);
+  }
+
+  @Test
+  public void testErrorFormating() {
+    String sql = "Select * from Foo\nwhere tadadidada;\n";
+    validateFormattedIs(sql, new SqlParserPos(1, 2),
+        "Select * from Foo\n"
+      + " ^\n"
+      + "where tadadidada;\n");
+    validateFormattedIs(sql, new SqlParserPos(2, 2),
+        "Select * from Foo\n"
+      + "where tadadidada;\n"
+      + " ^\n" );
+    validateFormattedIs(sql, new SqlParserPos(1, 10),
+        "Select * from Foo\n"
+      + "         ^\n"
+      + "where tadadidada;\n");
+    validateFormattedIs(sql, new SqlParserPos(-11, -10), sql);
+    validateFormattedIs(sql, new SqlParserPos(0, 10), sql);
+    validateFormattedIs(sql, new SqlParserPos(100, 10), sql);
+  }
+}

--- a/exec/java-exec/src/test/resources/drill-module.conf
+++ b/exec/java-exec/src/test/resources/drill-module.conf
@@ -10,6 +10,7 @@ drill: {
     packages += "org.apache.drill.exec.testing",
     packages += "org.apache.drill.exec.rpc.user.security.testing"
   }
+  test.query.printing.silent : true, 
   exec: {
   cluster-id: "drillbits1"
   rpc: {

--- a/pom.xml
+++ b/pom.xml
@@ -199,22 +199,22 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.12.1</version>
+        <configuration>
+          <includes>**/*.java</includes>
+          <encoding>UTF-8</encoding>
+          <failsOnError>true</failsOnError>
+          <consoleOutput>true</consoleOutput>
+          <includeResources>true</includeResources>
+          <includeTestResources>true</includeTestResources>
+          <resourceIncludes>**/*.properties,**/*.conf,**/*.json,**/*.xml</resourceIncludes>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <configLocation>src/main/resources/checkstyle-config.xml</configLocation>
+          <suppressionsLocation>src/main/resources/checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
         <executions>
           <execution>
             <id>checkstyle-validation</id>
             <phase>verify</phase>
-            <configuration>
-              <includes>**/*.java</includes>
-              <encoding>UTF-8</encoding>
-              <failsOnError>true</failsOnError>
-              <consoleOutput>true</consoleOutput>
-              <includeResources>true</includeResources>
-              <includeTestResources>true</includeTestResources>
-              <resourceIncludes>**/*.properties,**/*.conf,**/*.json,**/*.xml</resourceIncludes>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <configLocation>src/main/resources/checkstyle-config.xml</configLocation>
-              <suppressionsLocation>src/main/resources/checkstyle-suppressions.xml</suppressionsLocation>
-            </configuration>
             <goals>
               <goal>check</goal>
             </goals>

--- a/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
+++ b/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
@@ -137,6 +137,9 @@ public class FMPPMojo extends AbstractMojo {
             getLog().info(format("Freemarker generation took %dms", sw.elapsed(TimeUnit.MILLISECONDS)));
             sw.reset();
             Report report = moveIfChanged(tmp, tmpPathNormalized);
+            if (!tmp.delete()) {
+              throw new MojoFailureException(format("can not delete %s", tmp));
+            }
             getLog().info(format("Incremental output update took %dms", sw.elapsed(TimeUnit.MILLISECONDS)));
             getLog().info(format("new: %d", report.newFiles));
             getLog().info(format("changed: %d", report.changedFiles));


### PR DESCRIPTION
improve error message when SQL parsing error
add a simple test to Parquet writer
make errors verbose by default in tests