### PR TITLE
requireJavaVersion and requireMavenVersion overly restrictive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,10 +288,10 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0.4,4)</version>
+                  <version>[3.0.4,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.7,1.8)</version>
+                  <version>[1.7,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
The current settings don't work with JDK 1.8.0_60
