### PR TITLE
DRILL-3747: basic similarity search with simmetric

### DIFF
--- a/contrib/fuzzysearch/pom.xml
+++ b/contrib/fuzzysearch/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>drill-contrib-parent</artifactId>
+		<groupId>org.apache.drill.contrib</groupId>
+		<version>1.3.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>drill-fuzzysearch</artifactId>
+
+	<name>contrib/drill-fuzzysearch-plugin</name>
+
+	<properties>
+		<fuzzysearch.TestSuite>**/FuzzyTestSuite.class</fuzzysearch.TestSuite>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.drill.exec</groupId>
+			<artifactId>drill-java-exec</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.mpkorstanje</groupId>
+			<artifactId>simmetrics-core</artifactId>
+			<version>3.2.3</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.apache.drill.exec</groupId>
+			<artifactId>drill-java-exec</artifactId>
+			<classifier>tests</classifier>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.drill</groupId>
+			<artifactId>drill-common</artifactId>
+			<classifier>tests</classifier>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.yammer.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>2.1.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<includes>
+						<include>${fuzzysearch.TestSuite}</include>
+					</includes>
+					<systemProperties>
+						<property>
+							<name>logback.log.dir</name>
+							<value>${project.build.directory}/surefire-reports</value>
+						</property>
+					</systemProperties>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-java-sources</id>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/classes/org/apache/drill/exec/expr/fn/impl</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/java/org/apache/drill/exec/expr/fn/impl</directory>
+									<filtering>true</filtering>
+								</resource>
+								<resource>
+									<directory>src/test/java</directory>
+									<filtering>true</filtering>
+								</resource>
+								<resource>
+									<directory>target/generated-sources</directory>
+									<!-- <include>*/org</include> -->
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>copy-fuzzysearch-sample-data</id>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/classes/sample-data</outputDirectory>
+							<resources>
+								<resource>
+									<directory>sample-data</directory>
+									<filtering>false</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/contrib/fuzzysearch/sample-data/similarities.csv
+++ b/contrib/fuzzysearch/sample-data/similarities.csv
@@ -1,0 +1,4 @@
+foo,foo,same
+foo,bar,different
+"Chilpéric II son of Childeric II","chilperic ii son of childeric ii",similar-lev-test
+"This is a sentence. It is made of words","This sentence is similar. It has almost the same words",similar-cosine-test

--- a/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/CosineSimilarity.java
+++ b/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/CosineSimilarity.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl.fuzzy;
+
+import javax.inject.Inject;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.Float4Holder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.VarBinaryHolder;
+import org.simmetrics.StringMetrics;
+
+import io.netty.buffer.DrillBuf;
+
+@FunctionTemplate(name = "cosine_similarity", scope = FunctionTemplate.FunctionScope.SIMPLE,
+  nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+public class CosineSimilarity implements DrillSimpleFunc {
+  @Param
+  NullableVarCharHolder inputTextA;
+
+  @Param
+  NullableVarCharHolder inputTextB;
+
+  @Output
+  Float4Holder out;
+
+  @Inject
+  DrillBuf buffer;
+
+  @Workspace
+  org.simmetrics.StringMetric metric;
+
+  public void setup() {
+    metric = org.simmetrics.StringMetrics.cosineSimilarity();
+  }
+
+  public void eval() {
+    String textA = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextA.start,
+        inputTextA.end, inputTextA.buffer);
+    String textB = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextB.start,
+        inputTextB.end, inputTextB.buffer);
+
+    float result = metric.compare(textA, textB);
+
+    out.value = result;
+  }
+}

--- a/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/Jaro.java
+++ b/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/Jaro.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl.fuzzy;
+
+import javax.inject.Inject;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.Float4Holder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.VarBinaryHolder;
+
+import io.netty.buffer.DrillBuf;
+
+@FunctionTemplate(name = "jaro", scope = FunctionTemplate.FunctionScope.SIMPLE,
+  nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+public class Jaro implements DrillSimpleFunc {
+  @Param
+  NullableVarCharHolder inputTextA;
+
+  @Param
+  NullableVarCharHolder inputTextB;
+
+  @Output
+  Float4Holder out;
+
+  @Inject
+  DrillBuf buffer;
+
+  @Workspace
+  org.simmetrics.StringMetric metric;
+
+  public void setup() {
+    metric = org.simmetrics.StringMetrics.jaro();
+  }
+
+  public void eval() {
+    String textA = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextA.start,
+        inputTextA.end, inputTextA.buffer);
+    String textB = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextB.start,
+        inputTextB.end, inputTextB.buffer);
+
+    float result = metric.compare(textA, textB);
+
+    out.value = result;
+  }
+}

--- a/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/Levenshtein.java
+++ b/contrib/fuzzysearch/src/main/java/org/apache/drill/exec/expr/fn/impl/fuzzy/Levenshtein.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl.fuzzy;
+
+import javax.inject.Inject;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.Float4Holder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.VarBinaryHolder;
+
+import io.netty.buffer.DrillBuf;
+
+@FunctionTemplate(name = "levenshtein", scope = FunctionTemplate.FunctionScope.SIMPLE,
+  nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+public class Levenshtein implements DrillSimpleFunc {
+  @Param
+  NullableVarCharHolder inputTextA;
+
+  @Param
+  NullableVarCharHolder inputTextB;
+
+  @Output
+  Float4Holder out;
+
+  @Inject
+  DrillBuf buffer;
+
+  @Workspace
+  org.simmetrics.StringMetric metric;
+
+  public void setup() {
+    metric = org.simmetrics.StringMetrics.levenshtein();
+  }
+
+  public void eval() {
+    String textA = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextA.start,
+        inputTextA.end, inputTextA.buffer);
+    String textB = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextB.start,
+        inputTextB.end, inputTextB.buffer);
+
+    float result = metric.compare(textA, textB);
+
+    out.value = result;
+  }
+}

--- a/contrib/fuzzysearch/src/test/java/org/apache/drill/exec/expr/fn/impl/fuzzy/FuzzyTestSuite.java
+++ b/contrib/fuzzysearch/src/test/java/org/apache/drill/exec/expr/fn/impl/fuzzy/FuzzyTestSuite.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl.fuzzy;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Suite.class)
+@SuiteClasses({ TestFuzzyFunctions.class })
+public class FuzzyTestSuite {
+  private static final Logger logger = LoggerFactory.getLogger(FuzzyTestSuite.class);
+}

--- a/contrib/fuzzysearch/src/test/java/org/apache/drill/exec/expr/fn/impl/fuzzy/TestFuzzyFunctions.java
+++ b/contrib/fuzzysearch/src/test/java/org/apache/drill/exec/expr/fn/impl/fuzzy/TestFuzzyFunctions.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl.fuzzy;
+
+import org.apache.drill.BaseTestQuery;
+import org.junit.Test;
+
+public class TestFuzzyFunctions extends BaseTestQuery {
+
+  @Test
+  public void testLevenshteinSameTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select levenshtein(columns[0], columns[1]) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'same'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues((float)1.0)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testCosineSimilaritySameTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select cosine_similarity(columns[0], columns[1]) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'same'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues((float)1.0)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testJaroSameTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select jaro(columns[0], columns[1]) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'same'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues((float)1.0)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testLevenshteinSimilarTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(levenshtein(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'similar-lev-test'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.7813)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testCosineSimilaritySimilarTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(cosine_similarity(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'similar-cosine-test'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.4472)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testJaroSimilarTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(jaro(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'similar-cosine-test'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.7383)
+    .build()
+    .run();
+  }
+
+
+  @Test
+  public void testLevenshteinDifferentTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(levenshtein(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'different'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.0)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testCosineDifferentSimilarTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(cosine_similarity(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'different'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.0)
+    .build()
+    .run();
+  }
+
+  @Test
+  public void testJaroDifferentTexts() throws Exception {
+
+    testBuilder()
+    .sqlQuery("select round(jaro(columns[0], columns[1]), 4) "
+        + "from cp.`/sample-data/similarities.csv` where columns[2] = 'different'")
+    .ordered().baselineColumns("EXPR$0")
+    .baselineValues(0.0)
+    .build()
+    .run();
+  }
+
+}

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -39,5 +39,6 @@
     <module>sqlline</module>
     <module>data</module>
     <module>gis</module>
+    <module>fuzzysearch</module>
   </modules>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -172,6 +172,11 @@
           <artifactId>drill-gis</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.drill.contrib</groupId>
+          <artifactId>drill-fuzzysearch</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
     </profile>
 

--- a/distribution/src/assemble/bin.xml
+++ b/distribution/src/assemble/bin.xml
@@ -94,6 +94,7 @@
         <include>org.apache.drill.contrib:drill-storage-hbase</include>
         <include>org.apache.drill.contrib:drill-jdbc-storage</include>
         <include>org.apache.drill.contrib:drill-gis</include>
+        <include>org.apache.drill.contrib:drill-fuzzysearch</include>
       </includes>
       <excludes>
         <exclude>org.apache.drill.contrib.storage-hive:drill-storage-hive-core:jar:tests</exclude>


### PR DESCRIPTION
Helps handling i.e. typos in search queries with popular algorithms like levenshtein.
Sample query:

```
select levenshtein('foo', 'boo') from (VALUES(1)); //gives 0.67
```

and

```
select levenshtein('foo', 'bar') from (VALUES(1)); //not similar - gives 0
```

More:
https://github.com/k255/drill-fuzzy-search
https://en.wikipedia.org/wiki/Levenshtein_distance
