### PR TITLE
DRILL-3751: Reduce zookeeper's retry time to 10

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkAbstractStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkAbstractStore.java
@@ -136,6 +136,10 @@ public abstract class ZkAbstractStore<V> implements AutoCloseable {
     }
   }
 
+  protected final void cleanCache() {
+    childrenCache.clear();
+  }
+
   public abstract void createNodeInZK (String key, V value);
 
   private class Iter implements Iterator<Entry<String, V>>{

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStore.java
@@ -41,6 +41,7 @@ public class ZkEStore<V> extends ZkAbstractStore<V> implements EStore<V>{
         framework.delete().forPath(p(key));
       }
     } catch (Exception e) {
+      cleanCache();
       throw new RuntimeException("Failure while accessing Zookeeper. " + e.getMessage(), e);
     }
   }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -98,7 +98,7 @@ drill.exec: {
   refresh: 500,
   timeout: 5000,
     retry: {
-      count: 7200,
+      count: 10,
       delay: 500
     }
   },


### PR DESCRIPTION
After Drillbit gives up connecting to zookeeper, clean the cache of zookeeper at Drillbit