### PR TITLE
DRILL-3171: handle concurrent Zookeeper node creation gracefully

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStore.java
@@ -17,40 +17,25 @@
  */
 package org.apache.drill.exec.store.sys.zk;
 
+import java.io.IOException;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.drill.exec.store.sys.EStore;
 import org.apache.drill.exec.store.sys.PStoreConfig;
 import org.apache.zookeeper.CreateMode;
 
-import java.io.IOException;
-
 /**
  * Implementation of EStore using Zookeeper's EPHEMERAL node.
  * @param <V>
  */
-public class ZkEStore<V> extends ZkAbstractStore<V> implements EStore<V>{
+public class ZkEStore<V> extends ZkAbstractStore<V> implements EStore<V> {
 
-  public ZkEStore(CuratorFramework framework, PStoreConfig<V> config) throws IOException{
+  public ZkEStore(CuratorFramework framework, PStoreConfig<V> config) throws IOException {
     super(framework,config);
   }
 
   @Override
-  public void delete(String key) {
-    try {
-      if (framework.checkExists().forPath(p(key)) != null) {
-        framework.delete().forPath(p(key));
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failure while accessing Zookeeper. " + e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public void createNodeInZK(String key, V value) {
-    try {
-      framework.create().withMode(CreateMode.EPHEMERAL).forPath(p(key), config.getSerializer().serialize(value));
-    } catch (Exception e) {
-      throw new RuntimeException("Failure while accessing Zookeeper", e);
-    }
+  protected CreateMode getCreateMode() {
+    return CreateMode.EPHEMERAL;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkEStoreProvider.java
@@ -18,15 +18,14 @@
 
 package org.apache.drill.exec.store.sys.zk;
 
+import java.io.IOException;
+
+import com.google.common.base.Preconditions;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.drill.exec.store.sys.EStore;
 import org.apache.drill.exec.store.sys.EStoreProvider;
 import org.apache.drill.exec.store.sys.PStoreConfig;
 import org.apache.drill.exec.store.sys.PStoreConfig.Mode;
-
-import com.google.common.base.Preconditions;
-
-import java.io.IOException;
 
 public class ZkEStoreProvider implements EStoreProvider{
   private final CuratorFramework curator;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkPStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkPStore.java
@@ -28,23 +28,14 @@ import org.apache.zookeeper.CreateMode;
  * Implementation of PStore using Zookeeper's PERSISTENT node.
  * @param <V>
  */
-public class ZkPStore<V> extends ZkAbstractStore<V> implements PStore<V>{
+public class ZkPStore<V> extends ZkAbstractStore<V> implements PStore<V> {
 
-  ZkPStore(CuratorFramework framework, PStoreConfig<V> config)
-      throws IOException {
+  public ZkPStore(CuratorFramework framework, PStoreConfig<V> config) throws IOException {
     super(framework, config);
   }
 
   @Override
-  public void createNodeInZK(String key, V value) {
-    try {
-      framework.create().withMode(CreateMode.PERSISTENT).forPath(p(key), config.getSerializer().serialize(value));
-    } catch (Exception e) {
-      throw new RuntimeException("Failure while accessing Zookeeper", e);
-    }
+  protected CreateMode getCreateMode() {
+    return CreateMode.PERSISTENT;
   }
-
-
-
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkPStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/zk/ZkPStoreProvider.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.sys.zk;
 
 import java.io.IOException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.coord.ClusterCoordinator;
@@ -32,8 +33,6 @@ import org.apache.drill.exec.store.sys.PStoreProvider;
 import org.apache.drill.exec.store.sys.PStoreRegistry;
 import org.apache.drill.exec.store.sys.local.FilePStore;
 import org.apache.hadoop.fs.Path;
-
-import com.google.common.annotations.VisibleForTesting;
 
 public class ZkPStoreProvider implements PStoreProvider {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ZkPStoreProvider.class);


### PR DESCRIPTION
Make ZK node creation/updates logic optimistic.
Refactor ZkAbstractStore to eliminate redundant code around node creation logic.
Enhanced documentation.