### PR TITLE
DRILL-4063: Missing files/classes needed for S3a access

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -75,6 +75,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
     </dependency>
     <dependency>

--- a/distribution/src/assemble/bin.xml
+++ b/distribution/src/assemble/bin.xml
@@ -307,5 +307,9 @@
       <source>src/resources/drill-override-example.conf</source>
       <outputDirectory>conf</outputDirectory>
     </file>
+    <file>
+      <source>src/resources/core-site.xml</source>
+      <outputDirectory>conf</outputDirectory>
+    </file>
   </files>
 </assembly>

--- a/distribution/src/resources/core-site.xml
+++ b/distribution/src/resources/core-site.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>ENTER_YOUR_ACCESSKEY</value>
+    </property>
+
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>ENTER_YOUR_SECRETKEY</value>
+    </property>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -591,6 +591,18 @@
     <dependencies>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-aws</artifactId>
+        <version>${hadoop.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-api</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>


### PR DESCRIPTION
Pulling s3a support dep jars from hadoop-aws