### PR TITLE
DRILL-4108: Query on csv file w/ header fails with an exception when non existing column is requested

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
@@ -146,6 +146,9 @@ public class CompliantTextRecordReader extends AbstractRecordReader {
     assert (settings.isHeaderExtractionEnabled());
     assert (oContext != null);
 
+    // don't skip header in case skipFirstLine is set true
+    settings.setSkipFirstLine(false);
+
     // setup Output using OutputMutator
     // we should use a separate output mutator to avoid reshaping query output with header data
     HeaderOutputMutator hOutputMutator = new HeaderOutputMutator();

--- a/exec/java-exec/src/test/resources/bootstrap-storage-plugins.json
+++ b/exec/java-exec/src/test/resources/bootstrap-storage-plugins.json
@@ -57,6 +57,13 @@
           extensions: [ "csvh" ],
           delimiter: ",",
           extractHeader: true
+        },
+        "csvh-test" : {
+          type: "text",
+          extensions: [ "csvh-test" ],
+          delimiter: ",",
+          extractHeader: true,
+          skipFirstLine: true
         }
       }
     }

--- a/exec/java-exec/src/test/resources/store/text/data/cars.csvh-test
+++ b/exec/java-exec/src/test/resources/store/text/data/cars.csvh-test
@@ -1,0 +1,6 @@
+Year,Make,Model,Description,Price
+1997,Ford,E350,"ac, abs, moon",3000.00
+1999,Chevy,"Venture ""Extended Edition""","",4900.00
+1999,Chevy,"Venture ""Extended Edition, Very Large""",,5000.00
+1996,Jeep,Grand Cherokee,"MUST SELL!
+air, moon roof, loaded",4799.00

--- a/exec/java-exec/src/test/resources/store/text/data/d2/cars1.csvh
+++ b/exec/java-exec/src/test/resources/store/text/data/d2/cars1.csvh
@@ -1,0 +1,6 @@
+Year,Make,Model,Description,Price
+1997,Ford,E350,"ac, abs, moon",3000.00
+1999,Chevy,"Venture ""Extended Edition""","",4900.00
+1999,Chevy,"Venture ""Extended Edition, Very Large""",,5000.00
+1996,Jeep,Grand Cherokee,"MUST SELL!
+air, moon roof, loaded",4799.00

--- a/exec/java-exec/src/test/resources/store/text/data/d2/cars2.csvh
+++ b/exec/java-exec/src/test/resources/store/text/data/d2/cars2.csvh
@@ -1,0 +1,5 @@
+Year,Make,Category,Description,Price
+1997,Ford,E350,"ac, abs, moon",3000.00
+1999,Chevy,"Venture ""Extended Edition""","",4900.00
+1999,Chevy,"Venture ""Extended Edition, Very Large""",,5000.00
+1996,Jeep,Grand Cherokee,"MUST SELL! air, moon roof, loaded",4799.00

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
             <exclude>**/git.properties</exclude>
             <exclude>**/*.csv</exclude>
             <exclude>**/*.csvh</exclude>
+            <exclude>**/*.csvh-test</exclude>
             <exclude>**/*.tsv</exclude>
             <exclude>**/*.txt</exclude>
             <exclude>**/*.ssv</exclude>


### PR DESCRIPTION
- fix non existing header column request
- fix reading header row even if skipFirstLine is set true
- will update on regression test results