### PR TITLE
DRILL-4119: Modify hash32 functions to combine the msb and lsb bytes …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32AsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32AsDouble.java
@@ -39,22 +39,18 @@ import org.apache.drill.exec.expr.holders.NullableFloat4Holder;
 import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
 import org.apache.drill.exec.expr.holders.NullableIntHolder;
 
-/*
- * Class contains hash64 function definitions for different data types.
- *
- * NOTE: These functions are used internally by Drill to perform hash distribution and in hash join. For
- * numeric data types we would like to apply implicit casts in the join method however for this to work
- * as expected we would need to hash the same value represented in different data types (int, bigint, float etc)
- * to hash to the same node, this is why we cast all numeric values to double before performing the actual hash.
+/**
+ * hash32 function definitions for numeric data types. These functions cast the input numeric value to a
+ * double before doing the hashing. See comments in {@link Hash64AsDouble} for the reason for doing this.
  */
-public class Hash64AsDouble {
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+public class Hash32AsDouble {
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableFloatHash implements DrillSimpleFunc {
 
     @Param
     NullableFloat4Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -63,34 +59,34 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class FloatHash implements DrillSimpleFunc {
 
     @Param
     Float4Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDoubleHash implements DrillSimpleFunc {
 
     @Param
     NullableFloat8Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -99,34 +95,34 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class DoubleHash implements DrillSimpleFunc {
 
     @Param
     Float8Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableBigIntHash implements DrillSimpleFunc {
 
     @Param
     NullableBigIntHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -135,17 +131,17 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableIntHash implements DrillSimpleFunc {
     @Param
     NullableIntHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -154,65 +150,64 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class BigIntHash implements DrillSimpleFunc {
 
     @Param
     BigIntHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class IntHash implements DrillSimpleFunc {
     @Param
     IntHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
-      // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal9Hash implements DrillSimpleFunc {
     @Param
     Decimal9Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal9Hash implements DrillSimpleFunc {
     @Param
     NullableDecimal9Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -222,33 +217,33 @@ public class Hash64AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal18Hash implements DrillSimpleFunc {
     @Param
     Decimal18Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal18Hash implements DrillSimpleFunc {
     @Param
     NullableDecimal18Holder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -258,17 +253,17 @@ public class Hash64AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal28Hash implements DrillSimpleFunc {
     @Param
     Decimal28SparseHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -276,16 +271,16 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal28Hash implements DrillSimpleFunc {
     @Param
     NullableDecimal28SparseHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -296,17 +291,17 @@ public class Hash64AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal38Hash implements DrillSimpleFunc {
     @Param
     Decimal38SparseHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -314,16 +309,16 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal38Hash implements DrillSimpleFunc {
     @Param
     NullableDecimal38SparseHolder in;
     @Output
-    BigIntHolder out;
+    IntHolder out;
 
     public void setup() {
     }
@@ -334,7 +329,7 @@ public class Hash64AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
@@ -1,0 +1,541 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.holders.BigIntHolder;
+import org.apache.drill.exec.expr.holders.BitHolder;
+import org.apache.drill.exec.expr.holders.DateHolder;
+import org.apache.drill.exec.expr.holders.Decimal18Holder;
+import org.apache.drill.exec.expr.holders.Decimal28SparseHolder;
+import org.apache.drill.exec.expr.holders.Decimal38SparseHolder;
+import org.apache.drill.exec.expr.holders.Decimal9Holder;
+import org.apache.drill.exec.expr.holders.Float4Holder;
+import org.apache.drill.exec.expr.holders.Float8Holder;
+import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.expr.holders.NullableBigIntHolder;
+import org.apache.drill.exec.expr.holders.NullableBitHolder;
+import org.apache.drill.exec.expr.holders.NullableDateHolder;
+import org.apache.drill.exec.expr.holders.NullableDecimal18Holder;
+import org.apache.drill.exec.expr.holders.NullableDecimal28SparseHolder;
+import org.apache.drill.exec.expr.holders.NullableDecimal38SparseHolder;
+import org.apache.drill.exec.expr.holders.NullableDecimal9Holder;
+import org.apache.drill.exec.expr.holders.NullableFloat4Holder;
+import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
+import org.apache.drill.exec.expr.holders.NullableIntHolder;
+import org.apache.drill.exec.expr.holders.NullableTimeHolder;
+import org.apache.drill.exec.expr.holders.NullableTimeStampHolder;
+import org.apache.drill.exec.expr.holders.NullableVar16CharHolder;
+import org.apache.drill.exec.expr.holders.NullableVarBinaryHolder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.TimeHolder;
+import org.apache.drill.exec.expr.holders.TimeStampHolder;
+import org.apache.drill.exec.expr.holders.Var16CharHolder;
+import org.apache.drill.exec.expr.holders.VarBinaryHolder;
+import org.apache.drill.exec.expr.holders.VarCharHolder;
+
+public class Hash32Functions {
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableFloatHash implements DrillSimpleFunc {
+
+    @Param NullableFloat4Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class FloatHash implements DrillSimpleFunc {
+
+    @Param Float4Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableDoubleHash implements DrillSimpleFunc {
+
+    @Param NullableFloat8Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class DoubleHash implements DrillSimpleFunc {
+
+    @Param Float8Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableVarBinaryHash implements DrillSimpleFunc {
+
+    @Param NullableVarBinaryHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableVarCharHash implements DrillSimpleFunc {
+
+    @Param NullableVarCharHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableVar16CharHash implements DrillSimpleFunc {
+
+    @Param NullableVar16CharHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableBigIntHash implements DrillSimpleFunc {
+
+    @Param NullableBigIntHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      }
+      else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableIntHash implements DrillSimpleFunc {
+    @Param NullableIntHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      }
+      else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class VarBinaryHash implements DrillSimpleFunc {
+
+    @Param VarBinaryHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class VarCharHash implements DrillSimpleFunc {
+
+    @Param VarCharHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class Var16CharHash implements DrillSimpleFunc {
+
+    @Param Var16CharHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class BigIntHash implements DrillSimpleFunc {
+
+    @Param BigIntHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class IntHash implements DrillSimpleFunc {
+    @Param IntHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class DateHash implements DrillSimpleFunc {
+    @Param  DateHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableDateHash implements DrillSimpleFunc {
+    @Param  NullableDateHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class TimeStampHash implements DrillSimpleFunc {
+    @Param  TimeStampHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableTimeStampHash implements DrillSimpleFunc {
+    @Param  NullableTimeStampHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class TimeHash implements DrillSimpleFunc {
+    @Param  TimeHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32" ,"hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableTimeHash implements DrillSimpleFunc {
+    @Param  NullableTimeHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class Decimal9Hash implements DrillSimpleFunc {
+    @Param  Decimal9Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableDecimal9Hash implements DrillSimpleFunc {
+    @Param  NullableDecimal9Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class Decimal18Hash implements DrillSimpleFunc {
+    @Param  Decimal18Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableDecimal18Hash implements DrillSimpleFunc {
+    @Param  NullableDecimal18Holder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class Decimal28Hash implements DrillSimpleFunc {
+    @Param  Decimal28SparseHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+
+      int xor = 0;
+      for (int i = 0; i < in.nDecimalDigits; i++) {
+        xor = xor ^ Decimal28SparseHolder.getInteger(i, in.start, in.buffer);
+      }
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableDecimal28Hash implements DrillSimpleFunc {
+    @Param  NullableDecimal28SparseHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        int xor = 0;
+        for (int i = 0; i < in.nDecimalDigits; i++) {
+          xor = xor ^ NullableDecimal28SparseHolder.getInteger(i, in.start, in.buffer);
+        }
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class Decimal38Hash implements DrillSimpleFunc {
+    @Param  Decimal38SparseHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+
+      int xor = 0;
+      for (int i = 0; i < in.nDecimalDigits; i++) {
+        xor = xor ^ Decimal38SparseHolder.getInteger(i, in.start, in.buffer);
+      }
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class NullableDecimal38Hash implements DrillSimpleFunc {
+    @Param  NullableDecimal38SparseHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        int xor = 0;
+        for (int i = 0; i < in.nDecimalDigits; i++) {
+          xor = xor ^ NullableDecimal38SparseHolder.getInteger(i, in.start, in.buffer);
+        }
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class NullableBitHash implements DrillSimpleFunc {
+
+    @Param NullableBitHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      if (in.isSet == 0) {
+        out.value = 0;
+      } else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      }
+    }
+  }
+
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  public static class BitHash implements DrillSimpleFunc {
+
+    @Param BitHolder in;
+    @Output IntHolder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+    }
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32FunctionsWithSeed.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32FunctionsWithSeed.java
@@ -53,490 +53,532 @@ import org.apache.drill.exec.expr.holders.Var16CharHolder;
 import org.apache.drill.exec.expr.holders.VarBinaryHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
-public class HashFunctions {
-
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+/*
+ * Class contains hash32 function definitions for different data types.
+ */
+public class Hash32FunctionsWithSeed {
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableFloatHash implements DrillSimpleFunc {
 
     @Param NullableFloat4Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class FloatHash implements DrillSimpleFunc {
 
     @Param Float4Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableDoubleHash implements DrillSimpleFunc {
 
     @Param NullableFloat8Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class DoubleHash implements DrillSimpleFunc {
 
     @Param Float8Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableVarBinaryHash implements DrillSimpleFunc {
 
     @Param NullableVarBinaryHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableVarCharHash implements DrillSimpleFunc {
 
     @Param NullableVarCharHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableVar16CharHash implements DrillSimpleFunc {
 
     @Param NullableVar16CharHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableBigIntHash implements DrillSimpleFunc {
 
     @Param NullableBigIntHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableIntHash implements DrillSimpleFunc {
     @Param NullableIntHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class VarBinaryHash implements DrillSimpleFunc {
 
     @Param VarBinaryHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class VarCharHash implements DrillSimpleFunc {
 
     @Param VarCharHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Var16CharHash implements DrillSimpleFunc {
 
     @Param Var16CharHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
-  public static class HashBigInt implements DrillSimpleFunc {
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  public static class BigIntHash implements DrillSimpleFunc {
 
     @Param BigIntHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class IntHash implements DrillSimpleFunc {
     @Param IntHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class DateHash implements DrillSimpleFunc {
     @Param  DateHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDateHash implements DrillSimpleFunc {
     @Param  NullableDateHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class TimeStampHash implements DrillSimpleFunc {
     @Param  TimeStampHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableTimeStampHash implements DrillSimpleFunc {
     @Param  NullableTimeStampHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class TimeHash implements DrillSimpleFunc {
     @Param  TimeHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableTimeHash implements DrillSimpleFunc {
     @Param  NullableTimeHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal9Hash implements DrillSimpleFunc {
     @Param  Decimal9Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal9Hash implements DrillSimpleFunc {
     @Param  NullableDecimal9Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal18Hash implements DrillSimpleFunc {
     @Param  Decimal18Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal18Hash implements DrillSimpleFunc {
     @Param  NullableDecimal18Holder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal28Hash implements DrillSimpleFunc {
     @Param  Decimal28SparseHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-
-      int xor = 0;
-      for (int i = 0; i < in.nDecimalDigits; i++) {
-        xor = xor ^ Decimal28SparseHolder.getInteger(i, in.start, in.buffer);
-      }
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + Decimal28SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal28Hash implements DrillSimpleFunc {
     @Param  NullableDecimal28SparseHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        int xor = 0;
-        for (int i = 0; i < in.nDecimalDigits; i++) {
-          xor = xor ^ NullableDecimal28SparseHolder.getInteger(i, in.start, in.buffer);
-        }
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + NullableDecimal28SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal38Hash implements DrillSimpleFunc {
     @Param  Decimal38SparseHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-
-      int xor = 0;
-      for (int i = 0; i < in.nDecimalDigits; i++) {
-        xor = xor ^ Decimal38SparseHolder.getInteger(i, in.start, in.buffer);
-      }
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + Decimal38SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal38Hash implements DrillSimpleFunc {
     @Param  NullableDecimal38SparseHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        int xor = 0;
-        for (int i = 0; i < in.nDecimalDigits; i++) {
-          xor = xor ^ NullableDecimal38SparseHolder.getInteger(i, in.start, in.buffer);
-        }
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + NullableDecimal38SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableBitHash implements DrillSimpleFunc {
 
     @Param NullableBitHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
+  @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class BitHash implements DrillSimpleFunc {
 
     @Param BitHolder in;
+    @Param IntHolder seed;
     @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
-  }
-
-}
+  }}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32WithSeedAsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32WithSeedAsDouble.java
@@ -19,9 +19,9 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
 import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
-import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
 import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.Decimal18Holder;
 import org.apache.drill.exec.expr.holders.Decimal28SparseHolder;
@@ -39,236 +39,234 @@ import org.apache.drill.exec.expr.holders.NullableFloat4Holder;
 import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
 import org.apache.drill.exec.expr.holders.NullableIntHolder;
 
-/*
- * Class contains hash64 function definitions for different data types.
- *
- * NOTE: These functions are used internally by Drill to perform hash distribution and in hash join. For
- * numeric data types we would like to apply implicit casts in the join method however for this to work
- * as expected we would need to hash the same value represented in different data types (int, bigint, float etc)
- * to hash to the same node, this is why we cast all numeric values to double before performing the actual hash.
+/**
+ * hash32 with seed function definitions for numeric data types. These functions cast the input numeric value to a
+ * double before doing the hashing. See comments in {@link Hash64AsDouble} for the reason for doing this.
  */
-public class Hash64AsDouble {
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+public class Hash32WithSeedAsDouble {
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableFloatHash implements DrillSimpleFunc {
 
-    @Param
-    NullableFloat4Holder in;
-    @Output
-    BigIntHolder out;
+    @Param NullableFloat4Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class FloatHash implements DrillSimpleFunc {
 
-    @Param
-    Float4Holder in;
-    @Output
-    BigIntHolder out;
+    @Param Float4Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class NullableDoubleHash implements DrillSimpleFunc {
 
-    @Param
-    NullableFloat8Holder in;
-    @Output
-    BigIntHolder out;
+    @Param NullableFloat8Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL )
   public static class DoubleHash implements DrillSimpleFunc {
 
-    @Param
-    Float8Holder in;
-    @Output
-    BigIntHolder out;
+    @Param Float8Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableBigIntHash implements DrillSimpleFunc {
 
-    @Param
-    NullableBigIntHolder in;
-    @Output
-    BigIntHolder out;
+    @Param NullableBigIntHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
-      } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = seed.value;
+      }
+      else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableIntHash implements DrillSimpleFunc {
-    @Param
-    NullableIntHolder in;
-    @Output
-    BigIntHolder out;
+    @Param NullableIntHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
-      } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = seed.value;
+      }
+      else {
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class BigIntHash implements DrillSimpleFunc {
 
-    @Param
-    BigIntHolder in;
-    @Output
-    BigIntHolder out;
+    @Param BigIntHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class IntHash implements DrillSimpleFunc {
-    @Param
-    IntHolder in;
-    @Output
-    BigIntHolder out;
+    @Param IntHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal9Hash implements DrillSimpleFunc {
-    @Param
-    Decimal9Holder in;
-    @Output
-    BigIntHolder out;
+    @Param  Decimal9Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal9Hash implements DrillSimpleFunc {
-    @Param
-    NullableDecimal9Holder in;
-    @Output
-    BigIntHolder out;
+    @Param  NullableDecimal9Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal18Hash implements DrillSimpleFunc {
-    @Param
-    Decimal18Holder in;
-    @Output
-    BigIntHolder out;
+    @Param  Decimal18Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal18Hash implements DrillSimpleFunc {
-    @Param
-    NullableDecimal18Holder in;
-    @Output
-    BigIntHolder out;
+    @Param  NullableDecimal18Holder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal28Hash implements DrillSimpleFunc {
-    @Param
-    Decimal28SparseHolder in;
-    @Output
-    BigIntHolder out;
+    @Param  Decimal28SparseHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
@@ -276,37 +274,37 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal28Hash implements DrillSimpleFunc {
-    @Param
-    NullableDecimal28SparseHolder in;
-    @Output
-    BigIntHolder out;
+    @Param  NullableDecimal28SparseHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class Decimal38Hash implements DrillSimpleFunc {
-    @Param
-    Decimal38SparseHolder in;
-    @Output
-    BigIntHolder out;
+    @Param  Decimal38SparseHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
@@ -314,28 +312,29 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
     }
   }
 
-  @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableDecimal38Hash implements DrillSimpleFunc {
-    @Param
-    NullableDecimal38SparseHolder in;
-    @Output
-    BigIntHolder out;
+    @Param  NullableDecimal38SparseHolder in;
+    @Param IntHolder seed;
+    @Output IntHolder out;
+
 
     public void setup() {
     }
 
     public void eval() {
       if (in.isSet == 0) {
-        out.value = 0;
+        out.value = seed.value;
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
       }
     }
   }
 }
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64Functions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64Functions.java
@@ -277,7 +277,7 @@ public class Hash64Functions {
   }
 
   @FunctionTemplate(name = "hash64", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
-  public static class HashBigInt implements DrillSimpleFunc {
+  public static class BigIntHash implements DrillSimpleFunc {
 
     @Param
     BigIntHolder in;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64FunctionsWithSeed.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64FunctionsWithSeed.java
@@ -279,7 +279,7 @@ public class Hash64FunctionsWithSeed {
   }
 
   @FunctionTemplate(name = "hash64", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
-  public static class HashBigInt implements DrillSimpleFunc {
+  public static class BigIntHash implements DrillSimpleFunc {
 
     @Param BigIntHolder in;
     @Param BigIntHolder seed;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64WithSeedAsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64WithSeedAsDouble.java
@@ -162,7 +162,7 @@ public class Hash64WithSeedAsDouble {
   }
 
   @FunctionTemplate(name = "hash64AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
-  public static class HashBigInt implements DrillSimpleFunc {
+  public static class BigIntHash implements DrillSimpleFunc {
 
     @Param BigIntHolder in;
     @Param BigIntHolder seed;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/XXHash.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/XXHash.java
@@ -180,23 +180,36 @@ public final class XXHash {
 
   /* 32 bit variations */
   public static int hash32(int val, long seed){
-    return (int) hash64(val, seed);
+    return convert64To32(hash64(val, seed));
   }
 
   public static int hash32(long val, long seed){
-    return (int) hash64(val, seed);
+    return convert64To32(hash64(val, seed));
   }
 
   public static int hash32(float val, long seed){
-    return (int) hash64(val, seed);
+    return convert64To32(hash64(val, seed));
   }
 
   public static int hash32(double val, long seed){
-    return (int) hash64(val, seed);
+    return convert64To32(hash64(val, seed));
   }
 
   public static int hash32(int start, int end, DrillBuf buffer, long seed){
-    return (int) hash64(start, end, buffer, seed);
+    return convert64To32(hash64(start, end, buffer, seed));
+  }
+
+  /**
+   * Convert a 64 bit hash value to a 32 bit by taking the XOR of the
+   * most significant 4 bytes with the least significant 4 bytes.
+   * @param val the input 64 bit hash value
+   * @return converted 32 bit hash value
+   */
+  private static int convert64To32(long val) {
+
+    int msb = (int) ((val >>> 32) & 0xFFFFFFFF);
+    int lsb = (int) (val);
+    return (msb ^ lsb);
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
@@ -593,7 +593,7 @@ public class TestFunctionsQuery extends BaseTestQuery {
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("hash_date", "hash_dec9", "hash_dec38")
-        .baselineValues(818600896, 262164233, 1799649913)
+        .baselineValues(312993367, 292570647, 337328302)
         .go();
   }
 
@@ -834,6 +834,29 @@ public class TestFunctionsQuery extends BaseTestQuery {
         "hash64AsDouble(cast(employee_id as decimal(9, 0))) = hash64AsDouble(cast(employee_id as decimal(18, 0))) col5, " +
         "hash64AsDouble(cast(employee_id as decimal(18, 0))) = hash64AsDouble(cast(employee_id as decimal(28, 0))) col6, " +
         "hash64AsDouble(cast(employee_id as decimal(28, 0))) = hash64AsDouble(cast(employee_id as decimal(38, 0))) col7 " +
+        "from cp.`employee.json` where employee_id = 1";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("col1", "col2", "col3", "col4", "col5", "col6", "col7")
+        .baselineValues(true, true, true, true, true, true, true)
+        .go();
+  }
+
+  /*
+   * hash32 version of the above test
+   */
+  @Test
+  public void testHash32() throws Exception {
+    String query = "select " +
+        "hash32AsDouble(cast(employee_id as int)) = hash32AsDouble(cast(employee_id as bigint)) col1, " +
+        "hash32AsDouble(cast(employee_id as bigint)) = hash32AsDouble(cast(employee_id as float)) col2, " +
+        "hash32AsDouble(cast(employee_id as float)) = hash32AsDouble(cast(employee_id as double)) col3, " +
+        "hash32AsDouble(cast(employee_id as double)) = hash32AsDouble(cast(employee_id as decimal(9, 0))) col4, " +
+        "hash32AsDouble(cast(employee_id as decimal(9, 0))) = hash32AsDouble(cast(employee_id as decimal(18, 0))) col5, " +
+        "hash32AsDouble(cast(employee_id as decimal(18, 0))) = hash32AsDouble(cast(employee_id as decimal(28, 0))) col6, " +
+        "hash32AsDouble(cast(employee_id as decimal(28, 0))) = hash32AsDouble(cast(employee_id as decimal(38, 0))) col7 " +
         "from cp.`employee.json` where employee_id = 1";
 
     testBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestLocalExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestLocalExchange.java
@@ -208,7 +208,7 @@ public class TestLocalExchange extends PlanTestBase {
     final String plan = getPlanInString("EXPLAIN PLAN FOR " + groupByMultipleQuery, JSON_FORMAT);
     System.out.println("Plan: " + plan);
 
-    jsonExchangeOrderChecker(plan, false, 1, "castint\\(hash64asdouble\\(.*, hash64asdouble\\(.*, hash64asdouble\\(.*\\) \\) \\) \\) ");
+    jsonExchangeOrderChecker(plan, false, 1, "hash32asdouble\\(.*, hash32asdouble\\(.*, hash32asdouble\\(.*\\) \\) \\) ");
 
     // Run the query and verify the output
     final TestBuilder testBuilder = testBuilder()
@@ -286,7 +286,7 @@ public class TestLocalExchange extends PlanTestBase {
     if ( isMuxOn ) {
       // # of hash exchanges should be = # of mux exchanges + # of demux exchanges
       assertEquals("HashExpr on the hash column should not happen", 2*expectedNumMuxes+expectedNumDeMuxes, StringUtils.countMatches(plan, HASH_EXPR_NAME));
-      jsonExchangeOrderChecker(plan, isDeMuxOn, expectedNumMuxes, "castint\\(hash64asdouble\\(.*\\) \\) ");
+      jsonExchangeOrderChecker(plan, isDeMuxOn, expectedNumMuxes, "hash32asdouble\\(.*\\) ");
     } else {
       assertEquals("HashExpr on the hash column should not happen", 0, StringUtils.countMatches(plan, HASH_EXPR_NAME));
     }


### PR DESCRIPTION
…of a 64-bit hash value (previously, we were casting to integer).

 - Use this new set of functions (for all data types) for creating the hash values needed for hash distribution, hash joins etc.
 - Rename HashFunctions to Hash32Functions to be consistent with the Hash64 counterpart.
 - Many data types did not have a hash32AsDouble equivalent...added these.
 - Add hash32 functions with seed.
 - Fix unit tests, add "hash" as a synonym for "hash32".