### PR TITLE
DRILL-3543: Add stats for external sort to a query profile

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.physical.impl.join.HashJoinBatch;
 import org.apache.drill.exec.physical.impl.mergereceiver.MergingRecordBatch;
 import org.apache.drill.exec.physical.impl.partitionsender.PartitionSenderRootExec;
 import org.apache.drill.exec.physical.impl.unorderedreceiver.UnorderedReceiverBatch;
+import org.apache.drill.exec.physical.impl.xsort.ExternalSortBatch;
 import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 /**
@@ -45,6 +46,7 @@ public class OperatorMetricRegistry {
     register(CoreOperatorType.UNORDERED_RECEIVER_VALUE, UnorderedReceiverBatch.Metric.class);
     register(CoreOperatorType.HASH_AGGREGATE_VALUE, HashAggTemplate.Metric.class);
     register(CoreOperatorType.HASH_JOIN_VALUE, HashJoinBatch.Metric.class);
+    register(CoreOperatorType.EXTERNAL_SORT_VALUE, ExternalSortBatch.Metric.class);
   }
 
   private static void register(final int operatorType, final Class<? extends MetricDef> metricDef) {


### PR DESCRIPTION
added the following metrics to ExternalSortRecordBatch:

metric | description
-------- | --------------
SPILL_COUNT | number of times operator spilled to disk
PEAK_SIZE_IN_MEMORY | peak value for totalSizeInMemory (1)
PEAK_BATCHES_IN_MEMORY | maximum number of batches kept in memory

(1) how much memory sort estimated it's using so far. See [DRILL-4121](https://issues.apache.org/jira/browse/DRILL-4121) for a case where this won't be enough