### PR TITLE
Drill 4127: Reduce Hive metastore client API call in HiveSchema

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
@@ -42,6 +42,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -53,6 +54,11 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillHiveMetaStoreClient.class);
 
   protected final Map<String, String> hiveConfigOverride;
+
+  protected final LoadingCache<String, List<String>> databases;
+  protected final LoadingCache<String, List<String>> tableNameLoader;
+  protected final LoadingCache<TableName, HiveReadEntry> tableLoaders;
+
 
   /**
    * Create a DrillHiveMetaStoreClient for cases where:
@@ -71,8 +77,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
    * @throws MetaException
    */
   public static DrillHiveMetaStoreClient createClientWithAuthz(final DrillHiveMetaStoreClient processUserMetaStoreClient,
-      final HiveConf hiveConf, final Map<String, String> hiveConfigOverride, final String userName,
-      final boolean ignoreAuthzErrors) throws MetaException {
+      final HiveConf hiveConf, final Map<String, String> hiveConfigOverride, final String userName) throws MetaException {
     try {
       boolean delegationTokenGenerated = false;
 
@@ -89,7 +94,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
           // delegation tokens).
           String delegationToken = processUserMetaStoreClient.getDelegationToken(userName, userName);
           try {
-            ShimLoader.getHadoopShims().setTokenStr(ugiForRpc, delegationToken, HiveClientWithAuthz.DRILL2HMS_TOKEN);
+            ShimLoader.getHadoopShims().setTokenStr(ugiForRpc, delegationToken, HiveClientWithAuthzWithCaching.DRILL2HMS_TOKEN);
           } catch (IOException e) {
             throw new DrillRuntimeException("Couldn't setup delegation token in the UGI for Hive MetaStoreClient", e);
           }
@@ -100,7 +105,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       final HiveConf hiveConfForClient;
       if (delegationTokenGenerated) {
         hiveConfForClient = new HiveConf(hiveConf);
-        hiveConfForClient.set("hive.metastore.token.signature", HiveClientWithAuthz.DRILL2HMS_TOKEN);
+        hiveConfForClient.set("hive.metastore.token.signature", HiveClientWithAuthzWithCaching.DRILL2HMS_TOKEN);
       } else {
         hiveConfForClient = hiveConf;
       }
@@ -108,7 +113,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       return ugiForRpc.doAs(new PrivilegedExceptionAction<DrillHiveMetaStoreClient>() {
         @Override
         public DrillHiveMetaStoreClient run() throws Exception {
-          return new HiveClientWithAuthz(hiveConfForClient, hiveConfigOverride, ugiForRpc, userName, ignoreAuthzErrors);
+          return new HiveClientWithAuthzWithCaching(hiveConfForClient, hiveConfigOverride, ugiForRpc, userName);
         }
       });
     } catch (final Exception e) {
@@ -133,15 +138,30 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       throws MetaException {
     super(hiveConf);
     this.hiveConfigOverride = hiveConfigOverride;
-  }
 
+    databases = CacheBuilder //
+        .newBuilder() //
+        .expireAfterWrite(1, TimeUnit.MINUTES) //
+        .build(new DatabaseLoader());
+
+    tableNameLoader = CacheBuilder //
+        .newBuilder() //
+        .expireAfterWrite(1, TimeUnit.MINUTES) //
+        .build(new TableNameLoader());
+
+    tableLoaders = CacheBuilder //
+        .newBuilder() //
+        .expireAfterWrite(1, TimeUnit.MINUTES) //
+        .build(new TableLoader());
+
+  }
 
   /**
    * Higher level API that returns the databases in Hive.
    * @return
    * @throws TException
    */
-  public abstract List<String> getDatabases() throws TException;
+  public abstract List<String> getDatabases(boolean ignoreAuthzErrors) throws TException;
 
   /**
    * Higher level API that returns the tables in given database.
@@ -149,7 +169,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
    * @return
    * @throws TException
    */
-  public abstract List<String> getTableNames(final String dbName) throws TException;
+  public abstract List<String> getTableNames(final String dbName, boolean ignoreAuthzErrors) throws TException;
 
   /**
    * Higher level API that returns the {@link HiveReadEntry} for given database and table.
@@ -158,7 +178,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
    * @return
    * @throws TException
    */
-  public abstract HiveReadEntry getHiveReadEntry(final String dbName, final String tableName) throws TException;
+  public abstract HiveReadEntry getHiveReadEntry(final String dbName, final String tableName, boolean ignoreAuthzErrors) throws TException;
 
   /** Helper method which gets database. Retries once if the first call to fetch the metadata fails */
   protected static List<String> getDatabasesHelper(final IMetaStoreClient mClient) throws TException {
@@ -222,19 +242,17 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
    * HiveMetaStoreClient to create and maintain (reconnection cases) connection to Hive metastore with given user
    * credentials and check authorization privileges if set.
    */
-  private static class HiveClientWithAuthz extends DrillHiveMetaStoreClient {
+  private static class HiveClientWithAuthzWithCaching extends DrillHiveMetaStoreClient {
     public static final String DRILL2HMS_TOKEN = "DrillDelegationTokenForHiveMetaStoreServer";
 
     private final UserGroupInformation ugiForRpc;
-    private final boolean ignoreAuthzErrors;
     private HiveAuthorizationHelper authorizer;
 
-    private HiveClientWithAuthz(final HiveConf hiveConf, final Map<String, String> hiveConfigOverride,
-        final UserGroupInformation ugiForRpc, final String userName, final boolean ignoreAuthzErrors)
+    private HiveClientWithAuthzWithCaching(final HiveConf hiveConf, final Map<String, String> hiveConfigOverride,
+        final UserGroupInformation ugiForRpc, final String userName)
         throws TException {
       super(hiveConf, hiveConfigOverride);
       this.ugiForRpc = ugiForRpc;
-      this.ignoreAuthzErrors = ignoreAuthzErrors;
       this.authorizer = new HiveAuthorizationHelper(this, hiveConf, userName);
     }
 
@@ -257,7 +275,8 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       super.reconnect();
     }
 
-    public List<String> getDatabases() throws TException {
+    @Override
+    public List<String> getDatabases(boolean ignoreAuthzErrors) throws TException {
       try {
         authorizer.authorizeShowDatabases();
       } catch (final HiveAccessControlException e) {
@@ -266,64 +285,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
         }
         throw UserException.permissionError(e).build(logger);
       }
-      return getDatabasesHelper(this);
-    }
 
-    public List<String> getTableNames(final String dbName) throws TException {
-      try {
-        authorizer.authorizeShowTables(dbName);
-      } catch (final HiveAccessControlException e) {
-        if (ignoreAuthzErrors) {
-          return Collections.emptyList();
-        }
-        throw UserException.permissionError(e).build(logger);
-      }
-      return getTableNamesHelper(this, dbName);
-    }
-
-    public HiveReadEntry getHiveReadEntry(final String dbName, final String tableName) throws TException {
-      try {
-        authorizer.authorizeReadTable(dbName, tableName);
-      } catch (final HiveAccessControlException e) {
-        if (!ignoreAuthzErrors) {
-          throw UserException.permissionError(e).build(logger);
-        }
-      }
-      return getHiveReadEntryHelper(this, dbName, tableName, hiveConfigOverride);
-    }
-  }
-
-  /**
-   * HiveMetaStoreClient that provides a shared MetaStoreClient implementation with caching.
-   */
-  private static class NonCloseableHiveClientWithCaching extends DrillHiveMetaStoreClient {
-    private final LoadingCache<String, List<String>> databases;
-    private final LoadingCache<String, List<String>> tableNameLoader;
-    private final LoadingCache<String, LoadingCache<String, HiveReadEntry>> tableLoaders;
-
-    private NonCloseableHiveClientWithCaching(final HiveConf hiveConf,
-        final Map<String, String> hiveConfigOverride) throws MetaException {
-      super(hiveConf, hiveConfigOverride);
-
-      databases = CacheBuilder //
-          .newBuilder() //
-          .expireAfterWrite(1, TimeUnit.MINUTES) //
-          .build(new DatabaseLoader());
-
-      tableNameLoader = CacheBuilder //
-          .newBuilder() //
-          .expireAfterWrite(1, TimeUnit.MINUTES) //
-          .build(new TableNameLoader());
-
-      tableLoaders = CacheBuilder //
-          .newBuilder() //
-          .expireAfterAccess(4, TimeUnit.HOURS) //
-          .maximumSize(20) //
-          .build(new TableLoaderLoader());
-    }
-
-    @Override
-    public List<String> getDatabases() throws TException {
       try {
         return databases.get("databases");
       } catch (final ExecutionException e) {
@@ -332,7 +294,16 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
     }
 
     @Override
-    public List<String> getTableNames(final String dbName) throws TException {
+    public List<String> getTableNames(final String dbName, boolean ignoreAuthzErrors) throws TException {
+      try {
+        authorizer.authorizeShowTables(dbName);
+      } catch (final HiveAccessControlException e) {
+        if (ignoreAuthzErrors) {
+          return Collections.emptyList();
+        }
+        throw UserException.permissionError(e).build(logger);
+      }
+
       try {
         return tableNameLoader.get(dbName);
       } catch (final ExecutionException e) {
@@ -341,9 +312,55 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
     }
 
     @Override
-    public HiveReadEntry getHiveReadEntry(final String dbName, final String tableName) throws TException {
+    public HiveReadEntry getHiveReadEntry(final String dbName, final String tableName, boolean ignoreAuthzErrors) throws TException {
       try {
-        return tableLoaders.get(dbName).get(tableName);
+        authorizer.authorizeReadTable(dbName, tableName);
+      } catch (final HiveAccessControlException e) {
+        if (!ignoreAuthzErrors) {
+          throw UserException.permissionError(e).build(logger);
+        }
+      }
+
+      try {
+        return tableLoaders.get(TableName.table(dbName,tableName));
+      } catch (final ExecutionException e) {
+        throw new TException(e);
+      }
+    }
+
+  }
+
+  /**
+   * HiveMetaStoreClient that provides a shared MetaStoreClient implementation with caching.
+   */
+  private static class NonCloseableHiveClientWithCaching extends DrillHiveMetaStoreClient {
+    private NonCloseableHiveClientWithCaching(final HiveConf hiveConf,
+        final Map<String, String> hiveConfigOverride) throws MetaException {
+      super(hiveConf, hiveConfigOverride);
+    }
+
+    @Override
+    public List<String> getDatabases(boolean ignoreAuthzErrors) throws TException {
+      try {
+        return databases.get("databases");
+      } catch (final ExecutionException e) {
+        throw new TException(e);
+      }
+    }
+
+    @Override
+    public List<String> getTableNames(final String dbName, boolean ignoreAuthzErrors) throws TException {
+      try {
+        return tableNameLoader.get(dbName);
+      } catch (final ExecutionException e) {
+        throw new TException(e);
+      }
+    }
+
+    @Override
+    public HiveReadEntry getHiveReadEntry(final String dbName, final String tableName, boolean ignoreAuthzErrors) throws TException {
+      try {
+        return tableLoaders.get(TableName.table(dbName,tableName));
       } catch (final ExecutionException e) {
         throw new TException(e);
       }
@@ -361,50 +378,82 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       // No-op.
     }
 
-    private class DatabaseLoader extends CacheLoader<String, List<String>> {
-      @Override
-      public List<String> load(String key) throws Exception {
-        if (!"databases".equals(key)) {
-          throw new UnsupportedOperationException();
-        }
-        synchronized (NonCloseableHiveClientWithCaching.this) {
-          return getDatabasesHelper(NonCloseableHiveClientWithCaching.this);
-        }
+  }
+
+  private class DatabaseLoader extends CacheLoader<String, List<String>> {
+    @Override
+    public List<String> load(String key) throws Exception {
+      if (!"databases".equals(key)) {
+        throw new UnsupportedOperationException();
       }
-    }
-
-    private class TableNameLoader extends CacheLoader<String, List<String>> {
-      @Override
-      public List<String> load(String dbName) throws Exception {
-        synchronized (NonCloseableHiveClientWithCaching.this) {
-          return getTableNamesHelper(NonCloseableHiveClientWithCaching.this, dbName);
-        }
-      }
-    }
-
-    private class TableLoaderLoader extends CacheLoader<String, LoadingCache<String, HiveReadEntry>> {
-      @Override
-      public LoadingCache<String, HiveReadEntry> load(String key) throws Exception {
-        return CacheBuilder
-            .newBuilder()
-            .expireAfterWrite(1, TimeUnit.MINUTES)
-            .build(new TableLoader(key));
-      }
-    }
-
-    private class TableLoader extends CacheLoader<String, HiveReadEntry> {
-      private final String dbName;
-
-      public TableLoader(final String dbName) {
-        this.dbName = dbName;
-      }
-
-      @Override
-      public HiveReadEntry load(String key) throws Exception {
-        synchronized (NonCloseableHiveClientWithCaching.this) {
-          return getHiveReadEntryHelper(NonCloseableHiveClientWithCaching.this, dbName, key, hiveConfigOverride);
-        }
+      synchronized (DrillHiveMetaStoreClient.this) {
+        return getDatabasesHelper(DrillHiveMetaStoreClient.this);
       }
     }
   }
+
+  private class TableNameLoader extends CacheLoader<String, List<String>> {
+    @Override
+    public List<String> load(String dbName) throws Exception {
+      synchronized (DrillHiveMetaStoreClient.this) {
+        return getTableNamesHelper(DrillHiveMetaStoreClient.this, dbName);
+      }
+    }
+  }
+
+  private class TableLoader extends CacheLoader<TableName, HiveReadEntry> {
+    @Override
+    public HiveReadEntry load(TableName key) throws Exception {
+      synchronized (DrillHiveMetaStoreClient.this) {
+        return getHiveReadEntryHelper(DrillHiveMetaStoreClient.this, key.getDatabaseName(), key.getTableName(), hiveConfigOverride);
+      }
+    }
+  }
+
+  static class TableName {
+    private final String databaseName;
+    private final String tableName;
+
+    private TableName(String databaseName, String tableName) {
+      this.databaseName = databaseName;
+      this.tableName = tableName;
+    }
+
+    public static TableName table(String databaseName, String tableName) {
+      return new TableName(databaseName, tableName);
+    }
+
+    public String getDatabaseName() {
+      return databaseName;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("databaseName:%s, tableName:%s", databaseName, tableName).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      TableName other = (TableName) o;
+      return Objects.equals(databaseName, other.databaseName) &&
+          Objects.equals(tableName, other.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(databaseName, tableName);
+    }
+  }
+
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
@@ -120,15 +120,13 @@ public class HiveSchemaFactory implements SchemaFactory {
 
     @Override
     public AbstractSchema getSubSchema(String name) {
-      List<String> tables;
       try {
-        List<String> dbs = mClient.getDatabases();
+        List<String> dbs = mClient.getDatabases(schemaConfig.getIgnoreAuthErrors());
         if (!dbs.contains(name)) {
           logger.debug("Database '{}' doesn't exists in Hive storage '{}'", name, schemaName);
           return null;
         }
-        tables = mClient.getTableNames(name);
-        HiveDatabaseSchema schema = new HiveDatabaseSchema(tables, this, name);
+        HiveDatabaseSchema schema = getSubSchemaKnownExists(name);
         if (name.equals("default")) {
           this.defaultSchema = schema;
         }
@@ -137,12 +135,17 @@ public class HiveSchemaFactory implements SchemaFactory {
         logger.warn("Failure while attempting to access HiveDatabase '{}'.", name, e.getCause());
         return null;
       }
+    }
 
+    /** Help method to get subschema when we know it exists (already checks the existence) */
+    private HiveDatabaseSchema getSubSchemaKnownExists(String name) {
+      HiveDatabaseSchema schema = new HiveDatabaseSchema(this, name, mClient, schemaConfig);
+      return schema;
     }
 
     void setHolder(SchemaPlus plusOfThis) {
       for (String s : getSubSchemaNames()) {
-        plusOfThis.add(s, getSubSchema(s));
+        plusOfThis.add(s, getSubSchemaKnownExists(s));
       }
     }
 
@@ -154,7 +157,7 @@ public class HiveSchemaFactory implements SchemaFactory {
     @Override
     public Set<String> getSubSchemaNames() {
       try {
-        List<String> dbs = mClient.getDatabases();
+        List<String> dbs = mClient.getDatabases(schemaConfig.getIgnoreAuthErrors());
         return Sets.newHashSet(dbs);
       } catch (final TException e) {
         logger.warn("Failure while getting Hive database list.", e);
@@ -214,13 +217,6 @@ public class HiveSchemaFactory implements SchemaFactory {
     @Override
     public String getTypeName() {
       return HiveStoragePluginConfig.NAME;
-    }
-
-    @Override
-    public void close() throws Exception {
-      if (mClient != null) {
-        mClient.close();
-      }
     }
   }
 

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
@@ -21,7 +21,15 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import org.apache.calcite.schema.SchemaPlus;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
@@ -48,6 +56,9 @@ public class HiveSchemaFactory implements SchemaFactory {
 
   // MetaStoreClient created using process user credentials
   private final DrillHiveMetaStoreClient processUserMetastoreClient;
+  // MetasStoreClient created using SchemaConfig credentials
+  private final LoadingCache<String, DrillHiveMetaStoreClient> metaStoreClientLoadingCache;
+
   private final HiveStoragePlugin plugin;
   private final Map<String, String> hiveConfigOverride;
   private final String schemaName;
@@ -55,7 +66,7 @@ public class HiveSchemaFactory implements SchemaFactory {
   private final boolean isDrillImpersonationEnabled;
   private final boolean isHS2DoAsSet;
 
-  public HiveSchemaFactory(HiveStoragePlugin plugin, String name, Map<String, String> hiveConfigOverride) throws ExecutionSetupException {
+  public HiveSchemaFactory(final HiveStoragePlugin plugin, final String name, final Map<String, String> hiveConfigOverride) throws ExecutionSetupException {
     this.schemaName = name;
     this.plugin = plugin;
 
@@ -79,6 +90,25 @@ public class HiveSchemaFactory implements SchemaFactory {
     } catch (MetaException e) {
       throw new ExecutionSetupException("Failure setting up Hive metastore client.", e);
     }
+
+    metaStoreClientLoadingCache = CacheBuilder
+        .newBuilder()
+        .expireAfterAccess(10, TimeUnit.MINUTES)
+        .maximumSize(5) // Up to 5 clients for impersonation-enabled.
+        .removalListener(new RemovalListener<String, DrillHiveMetaStoreClient>() {
+          @Override
+          public void onRemoval(RemovalNotification<String, DrillHiveMetaStoreClient> notification) {
+            DrillHiveMetaStoreClient client = notification.getValue();
+            client.close();
+          }
+        })
+        .build(new CacheLoader<String, DrillHiveMetaStoreClient>() {
+          @Override
+          public DrillHiveMetaStoreClient load(String userName) throws Exception {
+            return DrillHiveMetaStoreClient.createClientWithAuthz(processUserMetastoreClient, hiveConf,
+                HiveSchemaFactory.this.hiveConfigOverride, userName);
+          }
+        });
   }
 
   /**
@@ -94,9 +124,8 @@ public class HiveSchemaFactory implements SchemaFactory {
     DrillHiveMetaStoreClient mClientForSchemaTree = processUserMetastoreClient;
     if (isDrillImpersonationEnabled) {
       try {
-        mClientForSchemaTree = DrillHiveMetaStoreClient.createClientWithAuthz(processUserMetastoreClient, hiveConf,
-            hiveConfigOverride, schemaConfig.getUserName(), schemaConfig.getIgnoreAuthErrors());
-      } catch (final TException e) {
+        mClientForSchemaTree = metaStoreClientLoadingCache.get(schemaConfig.getUserName());
+      } catch (final ExecutionException e) {
         throw new IOException("Failure setting up Hive metastore client.", e);
       }
     }
@@ -202,7 +231,7 @@ public class HiveSchemaFactory implements SchemaFactory {
         dbName = "default";
       }
       try{
-        return mClient.getHiveReadEntry(dbName, t);
+        return mClient.getHiveReadEntry(dbName, t, schemaConfig.getIgnoreAuthErrors());
       }catch(final TException e) {
         logger.warn("Exception occurred while trying to read table. {}.{}", dbName, t, e.getCause());
         return null;


### PR DESCRIPTION
Also, it has commit for DRILL-4126: Add cache to HiveSchema in order to reduce long planning time or execution time caused by slow Hive meta store.

Both DRILL-4127 and DRILL-4126 address the long delay caused by slow hive meta store. 
 
Passed unit, pre-commit regression, and additional impersonation test, before rebasing onto latest master.

Will re-run the above tests. 

@vkorukanti , could you please review the two patches? Thanks.
