### PR TITLE
DRILL-4180: When clear() is called on BitVector, ensure valueCount is…

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -445,4 +445,9 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
 
   }
 
+  @Override
+  public void clear() {
+    this.valueCount = 0;
+    super.clear();
+  }
 }


### PR DESCRIPTION
… set to zero