### PR TITLE
Updates to storage-mongo

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -31,7 +31,7 @@
   <properties>
      <mongo.TestSuite>**/MongoTestSuit.class</mongo.TestSuite>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -43,7 +43,7 @@
   <dependency>
     <groupId>org.mongodb</groupId>
     <artifactId>mongo-java-driver</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
   </dependency>
 
     <!-- Test dependencie -->
@@ -94,5 +94,5 @@
       </plugin>
     </plugins>
   </build>
-  
+
 </project>

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoFilterBuilder.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoFilterBuilder.java
@@ -26,11 +26,11 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
 import org.apache.drill.exec.store.mongo.common.MongoCompareOp;
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.mongodb.BasicDBObject;
 
 public class MongoFilterBuilder extends
     AbstractExprVisitor<MongoScanSpec, Void, RuntimeException> implements
@@ -58,7 +58,7 @@ public class MongoFilterBuilder extends
 
   private MongoScanSpec mergeScanSpecs(String functionName,
       MongoScanSpec leftScanSpec, MongoScanSpec rightScanSpec) {
-    BasicDBObject newFilter = null;
+    Document newFilter = new Document();
 
     switch (functionName) {
     case "booleanAnd":
@@ -199,15 +199,15 @@ public class MongoFilterBuilder extends
     }
 
     if (compareOp != null) {
-      BasicDBObject queryFilter = new BasicDBObject();
+      Document queryFilter = new Document();
       if (compareOp == MongoCompareOp.IFNULL) {
         queryFilter.put(fieldName,
-            new BasicDBObject(MongoCompareOp.EQUAL.getCompareOp(), null));
+            new Document(MongoCompareOp.EQUAL.getCompareOp(), null));
       } else if (compareOp == MongoCompareOp.IFNOTNULL) {
         queryFilter.put(fieldName,
-            new BasicDBObject(MongoCompareOp.NOT_EQUAL.getCompareOp(), null));
+            new Document(MongoCompareOp.NOT_EQUAL.getCompareOp(), null));
       } else {
-        queryFilter.put(fieldName, new BasicDBObject(compareOp.getCompareOp(),
+        queryFilter.put(fieldName, new Document(compareOp.getCompareOp(),
             fieldValue));
       }
       return new MongoScanSpec(groupScan.getScanSpec().getDbName(), groupScan

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoScanSpec.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoScanSpec.java
@@ -17,15 +17,16 @@
  */
 package org.apache.drill.exec.store.mongo;
 
+import org.bson.Document;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mongodb.BasicDBObject;
 
 public class MongoScanSpec {
   private String dbName;
   private String collectionName;
 
-  private BasicDBObject filters;
+  private Document filters;
 
   @JsonCreator
   public MongoScanSpec(@JsonProperty("dbName") String dbName,
@@ -35,7 +36,7 @@ public class MongoScanSpec {
   }
 
   public MongoScanSpec(String dbName, String collectionName,
-      BasicDBObject filters) {
+      Document filters) {
     this.dbName = dbName;
     this.collectionName = collectionName;
     this.filters = filters;
@@ -49,7 +50,7 @@ public class MongoScanSpec {
     return collectionName;
   }
 
-  public BasicDBObject getFilters() {
+  public Document getFilters() {
     return filters;
   }
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
-import com.mongodb.BasicDBObject;
 
 @JsonTypeName("mongo-shard-read")
 public class MongoSubScan extends AbstractBase implements SubScan {
@@ -130,7 +130,7 @@ public class MongoSubScan extends AbstractBase implements SubScan {
     protected Map<String, Object> minFilters;
     protected Map<String, Object> maxFilters;
 
-    protected BasicDBObject filter;
+    protected Document filter;
 
     @JsonCreator
     public MongoSubScanSpec(@JsonProperty("dbName") String dbName,
@@ -138,7 +138,7 @@ public class MongoSubScan extends AbstractBase implements SubScan {
         @JsonProperty("hosts") List<String> hosts,
         @JsonProperty("minFilters") Map<String, Object> minFilters,
         @JsonProperty("maxFilters") Map<String, Object> maxFilters,
-        @JsonProperty("filters") BasicDBObject filters) {
+        @JsonProperty("filters") Document filters) {
       this.dbName = dbName;
       this.collectionName = collectionName;
       this.hosts = hosts;
@@ -196,11 +196,11 @@ public class MongoSubScan extends AbstractBase implements SubScan {
       return this;
     }
 
-    public BasicDBObject getFilter() {
+    public Document getFilter() {
       return filter;
     }
 
-    public MongoSubScanSpec setFilter(BasicDBObject filter) {
+    public MongoSubScanSpec setFilter(Document filter) {
       this.filter = filter;
       return this;
     }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoUtils.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoUtils.java
@@ -24,51 +24,51 @@ import java.util.Map.Entry;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.mongodb.BasicDBObject;
+import org.bson.Document;
 
 public class MongoUtils {
 
-  public static BasicDBObject andFilterAtIndex(BasicDBObject leftFilter,
-      BasicDBObject rightFilter) {
-    BasicDBObject andQueryFilter = new BasicDBObject();
-    List<BasicDBObject> filters = new ArrayList<BasicDBObject>();
+  public static Document andFilterAtIndex(Document leftFilter,
+      Document rightFilter) {
+    Document andQueryFilter = new Document();
+    List<Document> filters = new ArrayList<Document>();
     filters.add(leftFilter);
     filters.add(rightFilter);
     andQueryFilter.put("$and", filters);
     return andQueryFilter;
   }
 
-  public static BasicDBObject orFilterAtIndex(BasicDBObject leftFilter,
-      BasicDBObject rightFilter) {
-    BasicDBObject orQueryFilter = new BasicDBObject();
-    List<BasicDBObject> filters = new ArrayList<BasicDBObject>();
+  public static Document orFilterAtIndex(Document leftFilter,
+       Document rightFilter) {
+    Document orQueryFilter = new Document();
+    List<Document> filters = new ArrayList<Document>();
     filters.add(leftFilter);
     filters.add(rightFilter);
     orQueryFilter.put("$or", filters);
     return orQueryFilter;
   }
 
-  public static Map<String, List<BasicDBObject>> mergeFilters(
+  public static Map<String, List<Document>> mergeFilters(
       Map<String, Object> minFilters, Map<String, Object> maxFilters) {
-    Map<String, List<BasicDBObject>> filters = Maps.newHashMap();
+    Map<String, List<Document>> filters = Maps.newHashMap();
 
     for (Entry<String, Object> entry : minFilters.entrySet()) {
-      List<BasicDBObject> list = filters.get(entry.getKey());
+      List<Document> list = filters.get(entry.getKey());
       if (list == null) {
         list = Lists.newArrayList();
         filters.put(entry.getKey(), list);
       }
-      list.add(new BasicDBObject(entry.getKey(), new BasicDBObject("$gte",
+      list.add(new Document(entry.getKey(), new Document("$gte",
           entry.getValue())));
     }
 
     for (Entry<String, Object> entry : maxFilters.entrySet()) {
-      List<BasicDBObject> list = filters.get(entry.getKey());
+      List<Document> list = filters.get(entry.getKey());
       if (list == null) {
         list = Lists.newArrayList();
         filters.put(entry.getKey(), list);
       }
-      list.add(new BasicDBObject(entry.getKey(), new BasicDBObject("$lt", entry
+      list.add(new Document(entry.getKey(), new Document("$lt", entry
           .getValue())));
     }
     return filters;

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/config/MongoPStoreProvider.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/config/MongoPStoreProvider.java
@@ -18,24 +18,22 @@
 package org.apache.drill.exec.store.mongo.config;
 
 import java.io.IOException;
-import java.util.concurrent.ConcurrentMap;
 
 import org.apache.drill.exec.store.mongo.DrillMongoConstants;
-import org.apache.drill.exec.store.sys.EStore;
 import org.apache.drill.exec.store.sys.PStore;
 import org.apache.drill.exec.store.sys.PStoreConfig;
 import org.apache.drill.exec.store.sys.PStoreProvider;
 import org.apache.drill.exec.store.sys.PStoreRegistry;
+import org.apache.drill.exec.store.sys.local.LocalEStoreProvider;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.WriteConcern;
-import org.apache.drill.exec.store.sys.local.LocalEStoreProvider;
-import org.apache.drill.exec.store.sys.local.MapEStore;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Indexes;
 
 public class MongoPStoreProvider implements PStoreProvider, DrillMongoConstants {
 
@@ -46,7 +44,7 @@ public class MongoPStoreProvider implements PStoreProvider, DrillMongoConstants 
 
   private MongoClient client;
 
-  private DBCollection collection;
+  private MongoCollection<Document> collection;
 
   private final String mongoURL;
   private final LocalEStoreProvider localEStoreProvider;
@@ -60,10 +58,9 @@ public class MongoPStoreProvider implements PStoreProvider, DrillMongoConstants 
   public void start() throws IOException {
     MongoClientURI clientURI = new MongoClientURI(mongoURL);
     client = new MongoClient(clientURI);
-    DB db = client.getDB(clientURI.getDatabase());
-    collection = db.getCollection(clientURI.getCollection());
-    collection.setWriteConcern(WriteConcern.JOURNALED);
-    DBObject index = new BasicDBObject(1).append(pKey, Integer.valueOf(1));
+    MongoDatabase db = client.getDatabase(clientURI.getDatabase());
+    collection = db.getCollection(clientURI.getCollection()).withWriteConcern(WriteConcern.JOURNALED);
+    Bson index = Indexes.ascending(pKey);
     collection.createIndex(index);
   }
 

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
@@ -39,7 +39,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
-
+import com.mongodb.client.model.Indexes;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
@@ -226,7 +226,7 @@ public class MongoTestSuit implements MongoTestConstants {
     }
     IndexOptions indexOptions = new IndexOptions().unique(true)
         .background(false).name(indexFieldName);
-    Bson keys = new Document(indexFieldName, Integer.valueOf(1));
+    Bson keys = Indexes.ascending(indexFieldName);
     mongoCollection.createIndex(keys, indexOptions);
   }
 


### PR DESCRIPTION
I made the following updates to the Mongo storage code:

+ Depends on the latest Mongo Java driver (3.2.0)
+ Uses MongoDatabase rather than the deprecated DB class
+ Uses Document and Bson types rather than the legacy DBObject type

Its not a massive change as it already relied on a 3.x Mongo Java driver but should stop any users getting deprecation warnings in their logs from calling `MongoClient.getDB`.