### PR TITLE
DRILL-4201 : Allow partial filter to be pushed down project for bette…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushFilterPastProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushFilterPastProjectRule.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.logical;
 
 import java.util.List;
 
+import com.google.common.collect.Lists;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.logical.LogicalFilter;
@@ -29,6 +30,7 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitor;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.util.Util;
@@ -88,17 +90,31 @@ public class DrillPushFilterPastProjectRule extends RelOptRule {
     Filter filterRel = call.rel(0);
     Project projRel = call.rel(1);
 
-    // Don't push Filter past Project if the Filter is referencing an ITEM or a FLATTEN expression
-    // from the Project.
-    //\TODO: Ideally we should split up the filter conditions into ones that
-    // reference the ITEM expression and ones that don't and push the latter past the Project
-    if (findItemOrFlatten(filterRel.getCondition(), projRel.getProjects()) != null) {
+    // get a conjunctions of the filter condition. For each conjunction, if it refers to ITEM or FLATTEN expression
+    // then we could not pushed down. Otherwise, it's qualified to be pushed down.
+    final List<RexNode> predList = RelOptUtil.conjunctions(filterRel.getCondition());
+
+    final List<RexNode> qualifiedPredList = Lists.newArrayList();
+    final List<RexNode> unqualifiedPredList = Lists.newArrayList();
+
+
+    for (final RexNode pred : predList) {
+      if (findItemOrFlatten(pred, projRel.getProjects()) == null) {
+        qualifiedPredList.add(pred);
+      } else {
+        unqualifiedPredList.add(pred);
+      }
+    }
+
+    final RexNode qualifedPred =RexUtil.composeConjunction(filterRel.getCluster().getRexBuilder(), qualifiedPredList, true);
+
+    if (qualifedPred == null) {
       return;
     }
 
     // convert the filter to one that references the child of the project
     RexNode newCondition =
-        RelOptUtil.pushFilterPastProject(filterRel.getCondition(), projRel);
+        RelOptUtil.pushFilterPastProject(qualifedPred, projRel);
 
     Filter newFilterRel = LogicalFilter.create(projRel.getInput(), newCondition);
 
@@ -108,7 +124,21 @@ public class DrillPushFilterPastProjectRule extends RelOptRule {
             projRel.getNamedProjects(),
             false);
 
-    call.transformTo(newProjRel);
+    final RexNode unqualifiedPred = RexUtil.composeConjunction(filterRel.getCluster().getRexBuilder(), unqualifiedPredList, true);
+
+    if (unqualifiedPred == null) {
+      call.transformTo(newProjRel);
+    } else {
+      // if there are filters not qualified to be pushed down, then we have to put those filters on top of
+      // the new Project operator.
+      // Filter -- unqualified filters
+      //   \
+      //    Project
+      //     \
+      //      Filter  -- qualified filters
+      Filter filterNotPushed = LogicalFilter.create(newProjRel, unqualifiedPred);
+      call.transformTo(filterNotPushed);
+    }
   }
 
 }

--- a/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1995/Q1/orders_95_q1.json
+++ b/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1995/Q1/orders_95_q1.json
@@ -1,0 +1,104 @@
+{
+  "o_orderkey" : 65,
+  "o_custkey" : 163,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 95469.44,
+  "o_orderdate" : "1995-03-18T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000632",
+  "o_shippriority" : 0,
+  "o_comment" : "ular requests are blithely pending orbits-- even requests against the deposit",
+  "o_items":[{"item": "iphone", "providers": ["BestBuy", "Target"] },
+             {"item": "computerdesk", "providers": ["HomeDepot", "OfficeDepot"]} 
+             ]
+} {
+  "o_orderkey" : 386,
+  "o_custkey" : 602,
+  "o_orderstatus" : "F",
+  "o_totalprice" : 119718.02,
+  "o_orderdate" : "1995-01-25T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000648",
+  "o_shippriority" : 0,
+  "o_comment" : " haggle quickly. stealthily bold asymptotes haggle among the furiously even re"
+} {
+  "o_orderkey" : 450,
+  "o_custkey" : 475,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 213638.07,
+  "o_orderdate" : "1995-03-05T00:00:00.000-08:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000293",
+  "o_shippriority" : 0,
+  "o_comment" : "d theodolites. boldly bold foxes since the pack"
+} {
+  "o_orderkey" : 643,
+  "o_custkey" : 578,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 261882.19,
+  "o_orderdate" : "1995-03-25T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000354",
+  "o_shippriority" : 0,
+  "o_comment" : "g dependencies. regular accounts "
+} {
+  "o_orderkey" : 775,
+  "o_custkey" : 1333,
+  "o_orderstatus" : "F",
+  "o_totalprice" : 75392.93,
+  "o_orderdate" : "1995-03-18T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000191",
+  "o_shippriority" : 0,
+  "o_comment" : "kly express requests. fluffily silent accounts poach furiously"
+} {
+  "o_orderkey" : 802,
+  "o_custkey" : 1367,
+  "o_orderstatus" : "F",
+  "o_totalprice" : 192178.48,
+  "o_orderdate" : "1995-01-05T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000516",
+  "o_shippriority" : 0,
+  "o_comment" : "posits. ironic, pending requests cajole. even theodol"
+} {
+  "o_orderkey" : 897,
+  "o_custkey" : 490,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 88281.28,
+  "o_orderdate" : "1995-03-20T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000316",
+  "o_shippriority" : 0,
+  "o_comment" : " wake quickly against "
+} {
+  "o_orderkey" : 928,
+  "o_custkey" : 658,
+  "o_orderstatus" : "F",
+  "o_totalprice" : 315638.02,
+  "o_orderdate" : "1995-03-02T00:00:00.000-08:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000450",
+  "o_shippriority" : 0,
+  "o_comment" : "ithely express pinto beans. "
+} {
+  "o_orderkey" : 1056,
+  "o_custkey" : 275,
+  "o_orderstatus" : "F",
+  "o_totalprice" : 41838.38,
+  "o_orderdate" : "1995-02-11T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000125",
+  "o_shippriority" : 0,
+  "o_comment" : "t, even deposits hang about the slyly special i"
+} {
+  "o_orderkey" : 1092,
+  "o_custkey" : 1232,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 131664.83,
+  "o_orderdate" : "1995-03-04T00:00:00.000-08:00",
+  "o_orderpriority" : "3-MEDIUM",
+  "o_clerk" : "Clerk#000000006",
+  "o_shippriority" : 0,
+  "o_comment" : "re quickly along the blithe"
+}

--- a/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1995/Q2/orders_95_q2.json
+++ b/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1995/Q2/orders_95_q2.json
@@ -1,0 +1,105 @@
+{
+  "o_orderkey" : 162,
+  "o_custkey" : 142,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 3553.15,
+  "o_orderdate" : "1995-05-08T00:00:00.000-07:00",
+  "o_orderpriority" : "3-MEDIUM",
+  "o_clerk" : "Clerk#000000378",
+  "o_shippriority" : 0,
+  "o_comment" : "nts hinder fluffily ironic instructions. express, express excuses ",
+  "o_items":[{"item": "iphone", "providers": ["BestBuy", "Target"] },
+             {"item": "computerdesk", "providers": ["HomeDepot", "OfficeDepot"]} 
+             ]
+}
+{
+  "o_orderkey" : 197,
+  "o_custkey" : 326,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 155247.48,
+  "o_orderdate" : "1995-04-07T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000969",
+  "o_shippriority" : 0,
+  "o_comment" : "solve quickly about the even braids. carefully express deposits affix care"
+} {
+  "o_orderkey" : 225,
+  "o_custkey" : 331,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 226028.98,
+  "o_orderdate" : "1995-05-25T00:00:00.000-07:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000177",
+  "o_shippriority" : 0,
+  "o_comment" : "s. blithely ironic accounts wake quickly fluffily special acc"
+} {
+  "o_orderkey" : 326,
+  "o_custkey" : 760,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 325448.68,
+  "o_orderdate" : "1995-06-04T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000466",
+  "o_shippriority" : 0,
+  "o_comment" : " requests. furiously ironic asymptotes mold carefully alongside of the blit"
+} {
+  "o_orderkey" : 327,
+  "o_custkey" : 1447,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 32302.12,
+  "o_orderdate" : "1995-04-17T00:00:00.000-07:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000992",
+  "o_shippriority" : 0,
+  "o_comment" : "ng the slyly final courts. slyly even escapades eat "
+} {
+  "o_orderkey" : 418,
+  "o_custkey" : 949,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 39431.46,
+  "o_orderdate" : "1995-04-13T00:00:00.000-07:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000643",
+  "o_shippriority" : 0,
+  "o_comment" : ". furiously ironic instruc"
+} {
+  "o_orderkey" : 512,
+  "o_custkey" : 631,
+  "o_orderstatus" : "P",
+  "o_totalprice" : 183939.48,
+  "o_orderdate" : "1995-05-20T00:00:00.000-07:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000814",
+  "o_shippriority" : 0,
+  "o_comment" : "ding requests. carefully express theodolites was quickly. furious"
+} {
+  "o_orderkey" : 513,
+  "o_custkey" : 607,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 78769.71,
+  "o_orderdate" : "1995-05-01T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000522",
+  "o_shippriority" : 0,
+  "o_comment" : "regular packages. pinto beans cajole carefully against the even"
+} {
+  "o_orderkey" : 551,
+  "o_custkey" : 898,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 64301.4,
+  "o_orderdate" : "1995-05-30T00:00:00.000-07:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000179",
+  "o_shippriority" : 0,
+  "o_comment" : "xpress accounts boost quic"
+} {
+  "o_orderkey" : 613,
+  "o_custkey" : 1384,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 56355.92,
+  "o_orderdate" : "1995-06-18T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000172",
+  "o_shippriority" : 0,
+  "o_comment" : "ts hinder among the deposits. fluffily ironic depos"
+}

--- a/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1996/Q1/orders_96_q1.json
+++ b/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1996/Q1/orders_96_q1.json
@@ -1,0 +1,104 @@
+{
+  "o_orderkey" : 1,
+  "o_custkey" : 370,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 172799.49,
+  "o_orderdate" : "1996-01-02T00:00:00.000-08:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000951",
+  "o_shippriority" : 0,
+  "o_comment" : "nstructions sleep furiously among ",
+  "o_items":[{"item": "iphone", "providers": ["BestBuy", "Target"] },
+             {"item": "computerdesk", "providers": ["HomeDepot", "OfficeDepot"]} 
+             ]
+} {
+  "o_orderkey" : 7,
+  "o_custkey" : 392,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 271885.66,
+  "o_orderdate" : "1996-01-10T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000470",
+  "o_shippriority" : 0,
+  "o_comment" : "ly special requests "
+} {
+  "o_orderkey" : 101,
+  "o_custkey" : 280,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 118448.39,
+  "o_orderdate" : "1996-03-17T00:00:00.000-08:00",
+  "o_orderpriority" : "3-MEDIUM",
+  "o_clerk" : "Clerk#000000419",
+  "o_shippriority" : 0,
+  "o_comment" : "ding accounts above the slyly final asymptote"
+} {
+  "o_orderkey" : 199,
+  "o_custkey" : 530,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 95867.7,
+  "o_orderdate" : "1996-03-07T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000489",
+  "o_shippriority" : 0,
+  "o_comment" : "g theodolites. special packag"
+} {
+  "o_orderkey" : 354,
+  "o_custkey" : 1384,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 231311.22,
+  "o_orderdate" : "1996-03-14T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000511",
+  "o_shippriority" : 0,
+  "o_comment" : "ly regular ideas wake across the slyly silent ideas. final deposits eat b"
+} {
+  "o_orderkey" : 385,
+  "o_custkey" : 331,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 75866.47,
+  "o_orderdate" : "1996-03-22T00:00:00.000-08:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000600",
+  "o_shippriority" : 0,
+  "o_comment" : "hless accounts unwind bold pain"
+} {
+  "o_orderkey" : 482,
+  "o_custkey" : 1252,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 197194.23,
+  "o_orderdate" : "1996-03-26T00:00:00.000-08:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000295",
+  "o_shippriority" : 0,
+  "o_comment" : "ts. deposits wake: final acco"
+} {
+  "o_orderkey" : 486,
+  "o_custkey" : 509,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 286150.09,
+  "o_orderdate" : "1996-03-11T00:00:00.000-08:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000803",
+  "o_shippriority" : 0,
+  "o_comment" : "riously dolphins. fluffily ironic requ"
+} {
+  "o_orderkey" : 608,
+  "o_custkey" : 260,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 100151.2,
+  "o_orderdate" : "1996-02-28T00:00:00.000-08:00",
+  "o_orderpriority" : "3-MEDIUM",
+  "o_clerk" : "Clerk#000000995",
+  "o_shippriority" : 0,
+  "o_comment" : "nic waters wake slyly slyly expre"
+} {
+  "o_orderkey" : 1284,
+  "o_custkey" : 1340,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 147647.95,
+  "o_orderdate" : "1996-01-07T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000492",
+  "o_shippriority" : 0,
+  "o_comment" : "s. blithely silent deposits s"
+}

--- a/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1996/Q2/orders_96_q2.json
+++ b/exec/java-exec/src/test/resources/multilevel/jsoncomplex/1996/Q2/orders_96_q2.json
@@ -1,0 +1,104 @@
+{
+  "o_orderkey" : 103,
+  "o_custkey" : 292,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 118745.16,
+  "o_orderdate" : "1996-06-20T00:00:00.000-07:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000090",
+  "o_shippriority" : 0,
+  "o_comment" : "ges. carefully unusual instructions haggle quickly regular f",
+  "o_items":[{"item": "iphone", "providers": ["BestBuy", "Target"] },
+             {"item": "computerdesk", "providers": ["HomeDepot", "OfficeDepot"]} 
+             ]
+} {
+  "o_orderkey" : 423,
+  "o_custkey" : 1034,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 31900.6,
+  "o_orderdate" : "1996-06-01T00:00:00.000-07:00",
+  "o_orderpriority" : "1-URGENT",
+  "o_clerk" : "Clerk#000000674",
+  "o_shippriority" : 0,
+  "o_comment" : "quests. deposits cajole quickly. furiously bold accounts haggle q"
+} {
+  "o_orderkey" : 514,
+  "o_custkey" : 749,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 123202.51,
+  "o_orderdate" : "1996-04-04T00:00:00.000-08:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000094",
+  "o_shippriority" : 0,
+  "o_comment" : " cajole furiously. slyly final excuses cajole. slyly special instructions "
+} {
+  "o_orderkey" : 547,
+  "o_custkey" : 983,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 137852.72,
+  "o_orderdate" : "1996-06-22T00:00:00.000-07:00",
+  "o_orderpriority" : "3-MEDIUM",
+  "o_clerk" : "Clerk#000000976",
+  "o_shippriority" : 0,
+  "o_comment" : "ing accounts eat. carefully regular packa"
+} {
+  "o_orderkey" : 806,
+  "o_custkey" : 1309,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 39072.3,
+  "o_orderdate" : "1996-06-20T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000240",
+  "o_shippriority" : 0,
+  "o_comment" : " the ironic packages wake carefully fina"
+} {
+  "o_orderkey" : 1089,
+  "o_custkey" : 481,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 140302.14,
+  "o_orderdate" : "1996-05-04T00:00:00.000-07:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000226",
+  "o_shippriority" : 0,
+  "o_comment" : "ns haggle ruthlessly. even requests are quickly abov"
+} {
+  "o_orderkey" : 1153,
+  "o_custkey" : 1196,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 328207.15,
+  "o_orderdate" : "1996-04-18T00:00:00.000-07:00",
+  "o_orderpriority" : "5-LOW",
+  "o_clerk" : "Clerk#000000059",
+  "o_shippriority" : 0,
+  "o_comment" : " across the pending deposi"
+} {
+  "o_orderkey" : 1158,
+  "o_custkey" : 1414,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 43176.15,
+  "o_orderdate" : "1996-06-30T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000549",
+  "o_shippriority" : 0,
+  "o_comment" : "integrate slyly furiously ironic deposit"
+} {
+  "o_orderkey" : 1188,
+  "o_custkey" : 199,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 79030.59,
+  "o_orderdate" : "1996-04-11T00:00:00.000-07:00",
+  "o_orderpriority" : "2-HIGH",
+  "o_clerk" : "Clerk#000000256",
+  "o_shippriority" : 0,
+  "o_comment" : "ully ironic deposits. slyl"
+} {
+  "o_orderkey" : 1223,
+  "o_custkey" : 91,
+  "o_orderstatus" : "O",
+  "o_totalprice" : 50645.67,
+  "o_orderdate" : "1996-05-25T00:00:00.000-07:00",
+  "o_orderpriority" : "4-NOT SPECIFIED",
+  "o_clerk" : "Clerk#000000238",
+  "o_shippriority" : 0,
+  "o_comment" : "posits was blithely fr"
+}


### PR DESCRIPTION
…r performance.

Partial filter pushdown has performance benefits because:
1) enable partition pruning, if the pushed down involves partitioning columns,
2) allow the filter to be applied in upper stream.