### PR TITLE
DRILL-4205: Reset readStart every time a new page is read.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
@@ -73,6 +73,7 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
         currentDefinitionLevel = -1;
         definitionLevelsRead = 0;
         recordsReadInThisIteration = 0;
+        readStartInBytes = 0;
       }
 
       nullRunLength = 0;


### PR DESCRIPTION
The readStart index was not being reset every time a new page was read and caused an array index out of bounds.
