### PR TITLE
DRILL-3739: (part 2) Fix issues in reading Hive tables with StorageHa…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
@@ -36,9 +36,11 @@ import org.apache.drill.exec.planner.physical.PrelUtil;
 import org.apache.drill.exec.planner.sql.DrillSqlOperator;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
 import org.apache.drill.exec.store.hive.HiveDrillNativeParquetScan;
+import org.apache.drill.exec.store.hive.HiveReadEntry;
 import org.apache.drill.exec.store.hive.HiveScan;
 import org.apache.drill.exec.store.hive.HiveTable.HivePartition;
 import org.apache.drill.exec.store.hive.HiveUtilities;
+import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -46,9 +48,11 @@ import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Convert Hive scan to use Drill's native parquet reader instead of Hive's native reader. It also adds a
@@ -91,7 +95,8 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
     final HiveScan hiveScan = (HiveScan) scanRel.getGroupScan();
     final Table hiveTable = hiveScan.hiveReadEntry.getTable();
 
-    final Class<? extends InputFormat> tableInputFormat = getInputFormatFromSD(hiveTable, hiveTable.getSd());
+    final Class<? extends InputFormat> tableInputFormat =
+        getInputFormatFromSD(MetaStoreUtils.getTableMetadata(hiveTable), hiveScan.hiveReadEntry, hiveTable.getSd());
     if (tableInputFormat == null || !tableInputFormat.equals(MapredParquetInputFormat.class)) {
       return false;
     }
@@ -105,7 +110,8 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
     // Make sure all partitions have the same input format as the table input format
     for (HivePartition partition : partitions) {
       final StorageDescriptor partitionSD = partition.getPartition().getSd();
-      Class<? extends InputFormat> inputFormat = getInputFormatFromSD(hiveTable, partitionSD);
+      Class<? extends InputFormat> inputFormat = getInputFormatFromSD(
+          HiveUtilities.getPartitionMetadata(partition.getPartition(), hiveTable), hiveScan.hiveReadEntry, partitionSD);
       if (inputFormat == null || !inputFormat.equals(tableInputFormat)) {
         return false;
       }
@@ -127,14 +133,19 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
 
   /**
    * Get the input format from given {@link StorageDescriptor}
-   * @param hiveTable
+   * @param properties
+   * @param hiveReadEntry
    * @param sd
    * @return {@link InputFormat} class or null if a failure has occurred. Failure is logged as warning.
    */
-  private Class<? extends InputFormat> getInputFormatFromSD(final Table hiveTable, final StorageDescriptor sd) {
+  private Class<? extends InputFormat> getInputFormatFromSD(final Properties properties,
+      final HiveReadEntry hiveReadEntry, final StorageDescriptor sd) {
+    final Table hiveTable = hiveReadEntry.getTable();
     try {
-      return (Class<? extends InputFormat>) Class.forName(sd.getInputFormat());
-    } catch (ReflectiveOperationException e) {
+      final JobConf job = new JobConf();
+      HiveUtilities.addConfToJob(job, properties, hiveReadEntry.hiveConfigOverride);
+      return HiveUtilities.getInputFormatClass(job, sd, hiveTable);
+    } catch (final Exception e) {
       logger.warn("Failed to get InputFormat class from Hive table '{}.{}'. StorageDescriptor [{}]",
           hiveTable.getDbName(), hiveTable.getTableName(), sd.toString(), e);
       return null;

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
@@ -240,7 +240,7 @@ public class HiveMetadataProvider {
           final List<InputSplitWrapper> splits = Lists.newArrayList();
           final JobConf job = new JobConf();
           HiveUtilities.addConfToJob(job, properties, hiveReadEntry.hiveConfigOverride);
-          HiveUtilities.setInputFormatClass(job, sd, hiveReadEntry.getTable());
+          job.setInputFormat(HiveUtilities.getInputFormatClass(job, sd, hiveReadEntry.getTable()));
           final Path path = new Path(sd.getLocation());
           final FileSystem fs = path.getFileSystem(job);
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -386,6 +386,22 @@ public class TestHiveStorage extends HiveTestBase {
         .go();
   }
 
+  @Test // DRILL-3739
+  public void readingFromStorageHandleBasedTable2() throws Exception {
+    try {
+      test(String.format("alter session set `%s` = true", ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS));
+
+      testBuilder()
+          .sqlQuery("SELECT * FROM hive.kv_sh ORDER BY key LIMIT 2")
+          .ordered()
+          .baselineColumns("key", "value")
+          .expectsEmptyResultSet()
+          .go();
+    } finally {
+      test(String.format("alter session set `%s` = false", ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS));
+    }
+  }
+
   @AfterClass
   public static void shutdownOptions() throws Exception {
     test(String.format("alter session set `%s` = false", PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY));


### PR DESCRIPTION
…ndler configuration (eg. Hive-HBase tables)

Same issue (StorageHandler based tables don't store InputFormat class in MetaStore), but this particular instance reproes when Hive native reader is enabled (store.hive.optimize_scan_with_native_readers = true). 

Added unititest.