### PR TITLE
DRILL-4246: Fix Allocator concurrency bug and improve error detection

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -405,6 +405,12 @@
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -31,14 +31,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.drill.common.HistoricalLog;
-import org.apache.drill.exec.memory.AllocatorManager.BufferLedger;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.memory.BaseAllocator.Verbosity;
 import org.apache.drill.exec.memory.BoundsChecking;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.BufferManager;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
@@ -48,7 +47,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   private final long id = idGenerator.incrementAndGet();
   private final AtomicInteger refCnt;
-  private final UnsafeDirectLittleEndian byteBuf;
+  private final UnsafeDirectLittleEndian udle;
   private final long addr;
   private final int offset;
   private final BufferLedger ledger;
@@ -56,7 +55,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   private final ByteBufAllocator alloc;
   private final boolean isEmpty;
   private volatile int length;
-
   private final HistoricalLog historicalLog = BaseAllocator.DEBUG ?
       new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH, "DrillBuf[%d]", id) : null;
 
@@ -71,7 +69,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
       boolean isEmpty) {
     super(byteBuf.maxCapacity());
     this.refCnt = refCnt;
-    this.byteBuf = byteBuf;
+    this.udle = byteBuf;
     this.isEmpty = isEmpty;
     this.bufManager = manager;
     this.alloc = alloc;
@@ -123,18 +121,20 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
         historicalLog.logHistory(logger);
       }
       throw new IndexOutOfBoundsException(String.format(
-              "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
+          "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
     }
   }
 
   /**
    * Allows a function to determine whether not reading a particular string of bytes is valid.
    *
-   * Will throw an exception if the memory is not readable for some reason.  Only doesn't something in the
-   * case that AssertionUtil.BOUNDS_CHECKING_ENABLED is true.
+   * Will throw an exception if the memory is not readable for some reason. Only doesn't something in the case that
+   * AssertionUtil.BOUNDS_CHECKING_ENABLED is true.
    *
-   * @param start The starting position of the bytes to be read.
-   * @param end The exclusive endpoint of the bytes to be read.
+   * @param start
+   *          The starting position of the bytes to be read.
+   * @param end
+   *          The exclusive endpoint of the bytes to be read.
    */
   public void checkBytes(int start, int end) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
@@ -161,24 +161,24 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
    *
    * This operation has no impact on the reference count of this DrillBuf. The newly created DrillBuf with either have a
    * reference count of 1 (in the case that this is the first time this memory is being associated with the new
-   * allocator) or the current value of the reference count + 1 for the other AllocatorManager/BufferLedger combination
+   * allocator) or the current value of the reference count + 1 for the other AllocationManager/BufferLedger combination
    * in the case that the provided allocator already had an association to this underlying memory.
    *
-   * @param allocator
+   * @param target
    *          The target allocator to create an association with.
    * @return A new DrillBuf which shares the same underlying memory as this DrillBuf.
    */
-  public DrillBuf retain(BufferAllocator allocator) {
+  public DrillBuf retain(BufferAllocator target) {
 
     if (isEmpty) {
       return this;
     }
 
     if (BaseAllocator.DEBUG) {
-      historicalLog.recordEvent("retain(%s)", allocator.getName());
+      historicalLog.recordEvent("retain(%s)", target.getName());
     }
-    BufferLedger otherLedger = this.ledger.getLedgerForAllocator(allocator);
-    return otherLedger.newDrillBuf(offset, length, null, true);
+    final BufferLedger otherLedger = this.ledger.getLedgerForAllocator(target);
+    return otherLedger.newDrillBuf(offset, length, null);
   }
 
   /**
@@ -190,7 +190,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
    *
    * This operation has no impact on the reference count of this DrillBuf. The newly created DrillBuf with either have a
    * reference count of 1 (in the case that this is the first time this memory is being associated with the new
-   * allocator) or the current value of the reference count for the other AllocatorManager/BufferLedger combination in
+   * allocator) or the current value of the reference count for the other AllocationManager/BufferLedger combination in
    * the case that the provided allocator already had an association to this underlying memory.
    *
    * Transfers will always succeed, even if that puts the other allocator into an overlimit situation. This is possible
@@ -212,7 +212,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     }
 
     final BufferLedger otherLedger = this.ledger.getLedgerForAllocator(target);
-    final DrillBuf newBuf = otherLedger.newDrillBuf(offset, length, null, true);
+    final DrillBuf newBuf = otherLedger.newDrillBuf(offset, length, null);
     final boolean allocationFit = this.ledger.transferBalance(otherLedger);
     return new TransferResult(allocationFit, newBuf);
   }
@@ -245,10 +245,11 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
-   * Release the provided number of reference counts.  If this is a root buffer, will decrease accounting if the local reference count returns to zero.
+   * Release the provided number of reference counts.
    */
   @Override
-  public synchronized boolean release(int decrement) {
+  public boolean release(int decrement) {
+
     if (isEmpty) {
       return false;
     }
@@ -258,7 +259,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
           decrement, toVerboseString()));
     }
 
-    final int refCnt = this.refCnt.addAndGet(-decrement);
+    final int refCnt = ledger.decrement(decrement);
 
     if (BaseAllocator.DEBUG) {
       historicalLog.recordEvent("release(%d). original value: %d", decrement, refCnt + decrement);
@@ -267,14 +268,10 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     if (refCnt < 0) {
       throw new IllegalStateException(
           String.format("DrillBuf[%d] refCnt has gone negative. Buffer Info: %s", id, toVerboseString()));
-
-    }
-    if (refCnt == 0) {
-      ledger.release();
-      return true;
     }
 
-    return false;
+    return refCnt == 0;
+
   }
 
   @Override
@@ -301,7 +298,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBufAllocator alloc() {
-    return byteBuf.alloc();
+    return udle.alloc();
   }
 
   @Override
@@ -316,7 +313,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBuf unwrap() {
-    return byteBuf;
+    return udle;
   }
 
   @Override
@@ -370,9 +367,8 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     }
 
     /*
-     * Re the behavior of reference counting,
-     * see http://netty.io/wiki/reference-counted-objects.html#wiki-h3-5, which explains
-     * that derived buffers share their reference count with their parent
+     * Re the behavior of reference counting, see http://netty.io/wiki/reference-counted-objects.html#wiki-h3-5, which
+     * explains that derived buffers share their reference count with their parent
      */
     final DrillBuf newBuf = ledger.newDrillBuf(offset + index, length);
     newBuf.writerIndex(length);
@@ -396,37 +392,37 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBuffer nioBuffer(int index, int length) {
-    return byteBuf.nioBuffer(offset + index, length);
+    return udle.nioBuffer(offset + index, length);
   }
 
   @Override
   public ByteBuffer internalNioBuffer(int index, int length) {
-    return byteBuf.internalNioBuffer(offset + index, length);
+    return udle.internalNioBuffer(offset + index, length);
   }
 
   @Override
   public ByteBuffer[] nioBuffers() {
-    return new ByteBuffer[]{nioBuffer()};
+    return new ByteBuffer[] { nioBuffer() };
   }
 
   @Override
   public ByteBuffer[] nioBuffers(int index, int length) {
-    return new ByteBuffer[]{nioBuffer(index, length)};
+    return new ByteBuffer[] { nioBuffer(index, length) };
   }
 
   @Override
   public boolean hasArray() {
-    return byteBuf.hasArray();
+    return udle.hasArray();
   }
 
   @Override
   public byte[] array() {
-    return byteBuf.array();
+    return udle.array();
   }
 
   @Override
   public int arrayOffset() {
-    return byteBuf.arrayOffset();
+    return udle.arrayOffset();
   }
 
   @Override
@@ -441,7 +437,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public String toString() {
-    return toString(0, 0, Charsets.UTF_8);
+    return String.format("DrillBuf[%d], udle: [%d %d..%d]", id, udle.id, offset, offset + capacity());
   }
 
   @Override
@@ -451,24 +447,12 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public String toString(int index, int length, Charset charset) {
-    final String basics =
-        String.format("{DrillBuf[%d], udle identityHashCode == %d, identityHashCode == %d}",
-            id, System.identityHashCode(byteBuf), System.identityHashCode(refCnt));
 
     if (length == 0) {
-      return basics;
+      return "";
     }
 
-    final ByteBuffer nioBuffer;
-    if (nioBufferCount() == 1) {
-      nioBuffer = nioBuffer(index, length);
-    } else {
-      nioBuffer = ByteBuffer.allocate(length);
-      getBytes(index, nioBuffer);
-      nioBuffer.flip();
-    }
-
-    return basics + '\n' + ByteBufUtil.decodeString(nioBuffer, charset);
+    return ByteBufUtil.decodeString(nioBuffer(index, length), charset);
   }
 
   @Override
@@ -494,7 +478,8 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
       historicalLog.recordEvent("retain(%d)", increment);
     }
 
-    refCnt.addAndGet(increment);
+    final int originalReferenceCount = refCnt.getAndAdd(increment);
+    Preconditions.checkArgument(originalReferenceCount > 0);
     return this;
   }
 
@@ -641,13 +626,13 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-    byteBuf.getBytes(index + offset, dst, dstIndex, length);
+    udle.getBytes(index + offset, dst, dstIndex, length);
     return this;
   }
 
   @Override
   public ByteBuf getBytes(int index, ByteBuffer dst) {
-    byteBuf.getBytes(index + offset, dst);
+    udle.getBytes(index + offset, dst);
     return this;
   }
 
@@ -658,12 +643,12 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
-  public void setByte(int index, byte b){
+  public void setByte(int index, byte b) {
     chk(index, 1);
     PlatformDependent.putByte(addr(index), b);
   }
 
-  public void writeByteUnsafe(byte b){
+  public void writeByteUnsafe(byte b) {
     PlatformDependent.putByte(addr(readerIndex), b);
     readerIndex++;
   }
@@ -715,13 +700,13 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-    byteBuf.getBytes(index + offset, dst, dstIndex, length);
+    udle.getBytes(index + offset, dst, dstIndex, length);
     return this;
   }
 
   @Override
   public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-    byteBuf.getBytes(index + offset, out, length);
+    udle.getBytes(index + offset, out, length);
     return this;
   }
 
@@ -729,18 +714,18 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   protected int _getUnsignedMedium(int index) {
     final long addr = addr(index);
     return (PlatformDependent.getByte(addr) & 0xff) << 16 |
-            (PlatformDependent.getByte(addr + 1) & 0xff) << 8 |
-            PlatformDependent.getByte(addr + 2) & 0xff;
+        (PlatformDependent.getByte(addr + 1) & 0xff) << 8 |
+        PlatformDependent.getByte(addr + 2) & 0xff;
   }
 
   @Override
   public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
-    return byteBuf.getBytes(index + offset, out, length);
+    return udle.getBytes(index + offset, out, length);
   }
 
   @Override
   public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-    byteBuf.setBytes(index + offset, src, srcIndex, length);
+    udle.setBytes(index + offset, src, srcIndex, length);
     return this;
   }
 
@@ -751,12 +736,12 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
           length);
     } else {
       if (srcIndex == 0 && src.capacity() == length) {
-        byteBuf.setBytes(index + offset, src);
+        udle.setBytes(index + offset, src);
       } else {
         ByteBuffer newBuf = src.duplicate();
         newBuf.position(srcIndex);
         newBuf.limit(srcIndex + length);
-        byteBuf.setBytes(index + offset, src);
+        udle.setBytes(index + offset, src);
       }
     }
 
@@ -765,24 +750,24 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-    byteBuf.setBytes(index + offset, src, srcIndex, length);
+    udle.setBytes(index + offset, src, srcIndex, length);
     return this;
   }
 
   @Override
   public ByteBuf setBytes(int index, ByteBuffer src) {
-    byteBuf.setBytes(index + offset, src);
+    udle.setBytes(index + offset, src);
     return this;
   }
 
   @Override
   public int setBytes(int index, InputStream in, int length) throws IOException {
-    return byteBuf.setBytes(index + offset, in, length);
+    return udle.setBytes(index + offset, in, length);
   }
 
   @Override
   public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
-    return byteBuf.setBytes(index + offset, in, length);
+    return udle.setBytes(index + offset, in, length);
   }
 
   @Override
@@ -820,6 +805,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
   /**
    * Return the buffer's byte contents in the form of a hex dump.
+   *
    * @param start
    *          the starting byte index
    * @param length
@@ -831,13 +817,13 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
 
     final StringBuilder sb = new StringBuilder("buffer byte dump\n");
     int index = roundedStart;
-    for(int nLogged = 0; nLogged < length; nLogged += LOG_BYTES_PER_ROW) {
+    for (int nLogged = 0; nLogged < length; nLogged += LOG_BYTES_PER_ROW) {
       sb.append(String.format(" [%05d-%05d]", index, index + LOG_BYTES_PER_ROW - 1));
-      for(int i = 0; i < LOG_BYTES_PER_ROW; ++i) {
+      for (int i = 0; i < LOG_BYTES_PER_ROW; ++i) {
         try {
           final byte b = getByte(index++);
           sb.append(String.format(" 0x%02x", b));
-        } catch(IndexOutOfBoundsException ioob) {
+        } catch (IndexOutOfBoundsException ioob) {
           sb.append(" <ioob>");
         }
       }
@@ -854,7 +840,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   public long getId() {
     return id;
   }
-
 
   public String toVerboseString() {
     if (isEmpty) {

--- a/exec/memory/base/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -29,6 +29,9 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class UnsafeDirectLittleEndian extends WrappedByteBuf {
   private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+  private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
+
+  public final long id = ID_GENERATOR.incrementAndGet();
   private final AbstractByteBuf wrapped;
   private final long memoryAddress;
 
@@ -249,6 +252,11 @@ public final class UnsafeDirectLittleEndian extends WrappedByteBuf {
       bufferSize.addAndGet(-initCap);
     }
     return released;
+  }
+
+  @Override
+  public int hashCode() {
+    return System.identityHashCode(this);
   }
 
   public static final boolean ASSERT_ENABLED;

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.drill.common.HistoricalLog;
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.memory.AllocatorManager.BufferLedger;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.ops.BufferManager;
 import org.apache.drill.exec.util.AssertionUtil;
 
@@ -41,7 +41,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   public static final String DEBUG_ALLOCATOR = "drill.memory.debug.allocator";
 
   private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
-  private static final int CHUNK_SIZE = AllocatorManager.INNER_ALLOCATOR.getChunkSize();
+  private static final int CHUNK_SIZE = AllocationManager.INNER_ALLOCATOR.getChunkSize();
 
   public static final int DEBUG_LOG_LENGTH = 6;
   public static final boolean DEBUG = AssertionUtil.isAssertionsEnabled()
@@ -86,7 +86,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
     // TODO: DRILL-4131
     // this.thisAsByteBufAllocator = new DrillByteBufAllocator(this);
-    this.thisAsByteBufAllocator = AllocatorManager.INNER_ALLOCATOR.allocator;
+    this.thisAsByteBufAllocator = AllocationManager.INNER_ALLOCATOR.allocator;
 
     if (DEBUG) {
       childAllocators = new IdentityHashMap<>();
@@ -103,6 +103,15 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   }
 
+  public void assertOpen() {
+    if (AssertionUtil.ASSERT_ENABLED) {
+      if (isClosed) {
+        throw new IllegalStateException("Attempting operation on allocator when allocator is closed.\n"
+            + toVerboseString());
+      }
+    }
+  }
+
   @Override
   public String getName() {
     return name;
@@ -110,14 +119,16 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public DrillBuf getEmpty() {
+    assertOpen();
     return empty;
   }
 
   /**
-   * For debug/verification purposes only. Allows an AllocatorManager to tell the allocator that we have a new ledger
+   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that we have a new ledger
    * associated with this allocator.
    */
   void associateLedger(BufferLedger ledger) {
+    assertOpen();
     if (DEBUG) {
       synchronized (DEBUG_LOCK) {
         childLedgers.put(ledger, null);
@@ -126,10 +137,11 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * For debug/verification purposes only. Allows an AllocatorManager to tell the allocator that we are removing a
+   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that we are removing a
    * ledger associated with this allocator
    */
   void dissociateLedger(BufferLedger ledger) {
+    assertOpen();
     if (DEBUG) {
       synchronized (DEBUG_LOCK) {
         if (!childLedgers.containsKey(ledger)) {
@@ -147,6 +159,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
    *          The child allocator that has been closed.
    */
   private void childClosed(final BaseAllocator childAllocator) {
+    assertOpen();
+
     if (DEBUG) {
       Preconditions.checkArgument(childAllocator != null, "child allocator can't be null");
 
@@ -174,15 +188,20 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public DrillBuf buffer(final int initialRequestSize) {
+    assertOpen();
+
     return buffer(initialRequestSize, null);
   }
 
   private DrillBuf createEmpty(){
-    return new DrillBuf(new AtomicInteger(), null, AllocatorManager.INNER_ALLOCATOR.empty, null, null, 0, 0, true);
+    assertOpen();
+
+    return new DrillBuf(new AtomicInteger(), null, AllocationManager.INNER_ALLOCATOR.empty, null, null, 0, 0, true);
   }
 
   @Override
   public DrillBuf buffer(final int initialRequestSize, BufferManager manager) {
+    assertOpen();
 
     Preconditions.checkArgument(initialRequestSize >= 0, "the requested size must be non-negative");
 
@@ -217,9 +236,11 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
    * with creating a new buffer.
    */
   private DrillBuf bufferWithoutReservation(final int size, BufferManager bufferManager) throws OutOfMemoryException {
-    AllocatorManager manager = new AllocatorManager(this, size);
-    BufferLedger ledger = manager.associate(this);
-    DrillBuf buffer = ledger.newDrillBuf(0, size, bufferManager, true);
+    assertOpen();
+
+    final AllocationManager manager = new AllocationManager(this, size);
+    final BufferLedger ledger = manager.associate(this); // +1 ref cnt (required)
+    final DrillBuf buffer = ledger.newDrillBuf(0, size, bufferManager);
 
     // make sure that our allocation is equal to what we expected.
     Preconditions.checkArgument(buffer.capacity() == size,
@@ -238,6 +259,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       final String name,
       final long initReservation,
       final long maxAllocation) {
+    assertOpen();
+
     final ChildAllocator childAllocator = new ChildAllocator(this, name, initReservation, maxAllocation);
 
     if (DEBUG) {
@@ -269,6 +292,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     public boolean add(final int nBytes) {
+      assertOpen();
+
       Preconditions.checkArgument(nBytes >= 0, "nBytes(%d) < 0", nBytes);
       Preconditions.checkState(!closed, "Attempt to increase reservation after reservation has been closed");
       Preconditions.checkState(!used, "Attempt to increase reservation after reservation has been used");
@@ -288,6 +313,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     public DrillBuf allocateBuffer() {
+      assertOpen();
+
       Preconditions.checkState(!closed, "Attempt to allocate after closed");
       Preconditions.checkState(!used, "Attempt to allocate more than once");
 
@@ -310,6 +337,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
     @Override
     public void close() {
+      assertOpen();
+
       if (closed) {
         return;
       }
@@ -340,6 +369,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     public boolean reserve(int nBytes) {
+      assertOpen();
+
       final AllocationOutcome outcome = BaseAllocator.this.allocateBytes(nBytes);
 
       if (DEBUG) {
@@ -360,6 +391,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
      * @return the buffer, or null, if the request cannot be satisfied
      */
     private DrillBuf allocate(int nBytes) {
+      assertOpen();
+
       boolean success = false;
 
       /*
@@ -389,6 +422,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
      *          the size of the reservation
      */
     private void releaseReservation(int nBytes) {
+      assertOpen();
+
       releaseBytes(nBytes);
 
       if (DEBUG) {
@@ -400,6 +435,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public AllocationReservation newReservation() {
+    assertOpen();
+
     return new Reservation();
   }
 
@@ -413,6 +450,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     if (isClosed) {
       return;
     }
+
+    isClosed = true;
 
     if (DEBUG) {
       synchronized(DEBUG_LOCK) {
@@ -449,12 +488,12 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       }
     }
 
-      // Is there unaccounted-for outstanding allocation?
-      final long allocated = getAllocatedMemory();
-      if (allocated > 0) {
-        throw new IllegalStateException(
-          String.format("Unaccounted for outstanding allocation (%d)\n%s", allocated, toString()));
-      }
+    // Is there unaccounted-for outstanding allocation?
+    final long allocated = getAllocatedMemory();
+    if (allocated > 0) {
+      throw new IllegalStateException(
+          String.format("Memory was leaked by query. Memory leaked: (%d)\n%s", allocated, toString()));
+    }
 
     // we need to release our memory to our parent before we tell it we've closed.
     super.close();
@@ -470,8 +509,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
           "closed allocator[%s].",
           name));
     }
-
-    isClosed = true;
 
 
   }
@@ -650,6 +687,15 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         }
 
         logger.debug(sb.toString());
+
+        final long allocated2 = getAllocatedMemory();
+
+        if (allocated2 != allocated) {
+          throw new IllegalStateException(String.format(
+              "allocator[%s]: allocated t1 (%d) + allocated t2 (%d). Someone released memory while in verification.",
+              name, allocated, allocated2));
+
+        }
         throw new IllegalStateException(String.format(
             "allocator[%s]: buffer space (%d) + prealloc space (%d) + child space (%d) != allocated (%d)",
             name, bufferTotal, reservedTotal, childTotal, allocated));

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
@@ -146,4 +146,9 @@ public interface BufferAllocator extends AutoCloseable {
    */
   public String toVerboseString();
 
+  /**
+   * Asserts (using java assertions) that the provided allocator is currently open. If assertions are disabled, this is
+   * a no-op.
+   */
+  public void assertOpen();
 }


### PR DESCRIPTION
- Rename the internal DrillBuf field to udle to better express its purpose.
- Rename AllocatorManager to AllocationManager to better express its purpose.
- Address situation where dangling ledger could be transferred into while it was being released released by protecting association and release inside the AllocationManager.
- Add allocator assertions to ensure allocator operations are done while the allocator is open.
- Simplify AllocationManager locking model.
- Exclude HDFS reference to netty-all
- Improve debugging messages for allocators (and fix debug message bugs)

Tests pending but evaluation shows previously frequently failing flatten tests to consistently pass.