### PR TITLE
DRILL-4131: Move RPC allocators under Drill's root allocator & accounting

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ConnectionManagerRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ConnectionManagerRegistry.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.rpc.control;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.work.batch.ControlMessageHandler;
@@ -34,18 +35,20 @@ public class ConnectionManagerRegistry implements Iterable<ControlConnectionMana
   private final ControlMessageHandler handler;
   private final BootStrapContext context;
   private volatile DrillbitEndpoint localEndpoint;
+  private final BufferAllocator allocator;
 
-  public ConnectionManagerRegistry(ControlMessageHandler handler, BootStrapContext context) {
+  public ConnectionManagerRegistry(BufferAllocator allocator, ControlMessageHandler handler, BootStrapContext context) {
     super();
     this.handler = handler;
     this.context = context;
+    this.allocator = allocator;
   }
 
   public ControlConnectionManager getConnectionManager(DrillbitEndpoint endpoint) {
     assert localEndpoint != null : "DrillbitEndpoint must be set before a connection manager can be retrieved";
     ControlConnectionManager m = registry.get(endpoint);
     if (m == null) {
-      m = new ControlConnectionManager(endpoint, localEndpoint, handler, context);
+      m = new ControlConnectionManager(allocator, endpoint, localEndpoint, handler, context);
       ControlConnectionManager m2 = registry.putIfAbsent(endpoint, m);
       if (m2 != null) {
         m = m2;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlClient.java
@@ -49,10 +49,11 @@ public class ControlClient extends BasicClient<RpcType, ControlConnection, BitCo
   private final DrillbitEndpoint localIdentity;
   private final BufferAllocator allocator;
 
-  public ControlClient(DrillbitEndpoint remoteEndpoint, DrillbitEndpoint localEndpoint, ControlMessageHandler handler,
+  public ControlClient(BufferAllocator allocator, DrillbitEndpoint remoteEndpoint, DrillbitEndpoint localEndpoint,
+      ControlMessageHandler handler,
       BootStrapContext context, ControlConnectionManager.CloseHandlerCreator closeHandlerFactory) {
     super(ControlRpcConfig.getMapping(context.getConfig(), context.getExecutor()),
-        context.getAllocator().getAsByteBufAllocator(),
+        allocator.getAsByteBufAllocator(),
         context.getBitLoopGroup(),
         RpcType.HANDSHAKE,
         BitControlHandshake.class,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlConnectionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlConnectionManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.rpc.control;
 
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.BitControl.BitControlHandshake;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.rpc.BasicClient;
@@ -34,13 +35,16 @@ public class ControlConnectionManager extends ReconnectingConnection<ControlConn
   private final ControlMessageHandler handler;
   private final BootStrapContext context;
   private final DrillbitEndpoint localIdentity;
+  private final BufferAllocator allocator;
 
-  public ControlConnectionManager(DrillbitEndpoint remoteEndpoint, DrillbitEndpoint localIdentity, ControlMessageHandler handler, BootStrapContext context) {
+  public ControlConnectionManager(BufferAllocator allocator, DrillbitEndpoint remoteEndpoint,
+      DrillbitEndpoint localIdentity, ControlMessageHandler handler, BootStrapContext context) {
     super(BitControlHandshake.newBuilder().setRpcVersion(ControlRpcConfig.RPC_VERSION).setEndpoint(localIdentity).build(), remoteEndpoint.getAddress(), remoteEndpoint.getControlPort());
     assert remoteEndpoint != null : "Endpoint cannot be null.";
     assert remoteEndpoint.getAddress() != null && !remoteEndpoint.getAddress().isEmpty(): "Endpoint address cannot be null.";
     assert remoteEndpoint.getControlPort() > 0 : String.format("Bit Port must be set to a port between 1 and 65k.  Was set to %d.", remoteEndpoint.getControlPort());
 
+    this.allocator = allocator;
     this.endpoint = remoteEndpoint;
     this.localIdentity = localIdentity;
     this.handler = handler;
@@ -49,7 +53,7 @@ public class ControlConnectionManager extends ReconnectingConnection<ControlConn
 
   @Override
   protected BasicClient<?, ControlConnection, BitControlHandshake, ?> getNewClient() {
-    return new ControlClient(endpoint, localIdentity, handler, context, new CloseHandlerCreator());
+    return new ControlClient(allocator, endpoint, localIdentity, handler, context, new CloseHandlerCreator());
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.rpc.control;
 
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.work.batch.ControlMessageHandler;
@@ -40,11 +41,12 @@ public class ControllerImpl implements Controller {
   private final boolean allowPortHunting;
   private final CustomHandlerRegistry handlerRegistry;
 
-  public ControllerImpl(BootStrapContext context, ControlMessageHandler handler, boolean allowPortHunting) {
+  public ControllerImpl(BootStrapContext context, ControlMessageHandler handler, BufferAllocator allocator,
+      boolean allowPortHunting) {
     super();
     this.handler = handler;
     this.context = context;
-    this.connectionRegistry = new ConnectionManagerRegistry(handler, context);
+    this.connectionRegistry = new ConnectionManagerRegistry(allocator, handler, context);
     this.allowPortHunting = allowPortHunting;
     this.handlerRegistry = handler.getHandlerRegistry();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
@@ -44,14 +44,18 @@ public class DataConnectionCreator implements Closeable {
   private ConcurrentMap<DrillbitEndpoint, DataConnectionManager> connectionManager = Maps.newConcurrentMap();
   private final BufferAllocator dataAllocator;
 
-  public DataConnectionCreator(BootStrapContext context, WorkEventBus workBus, WorkerBee bee, boolean allowPortHunting) {
+  public DataConnectionCreator(
+      BootStrapContext context,
+      BufferAllocator allocator,
+      WorkEventBus workBus,
+      WorkerBee bee,
+      boolean allowPortHunting) {
     super();
     this.context = context;
     this.workBus = workBus;
     this.bee = bee;
     this.allowPortHunting = allowPortHunting;
-    this.dataAllocator = context.getAllocator()
-        .newChildAllocator("rpc-data", 0, Long.MAX_VALUE);
+    this.dataAllocator = allocator;
   }
 
   public DrillbitEndpoint start(DrillbitEndpoint partialEndpoint) throws DrillbitStartupException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
@@ -18,10 +18,10 @@
 package org.apache.drill.exec.service;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import io.netty.buffer.PooledByteBufAllocatorL;
 import io.netty.channel.EventLoopGroup;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.Executor;
@@ -29,9 +29,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.rpc.TransportCheck;
 import org.apache.drill.exec.rpc.control.Controller;
@@ -44,10 +46,12 @@ import org.apache.drill.exec.work.WorkManager.WorkerBee;
 import org.apache.drill.exec.work.batch.ControlMessageHandler;
 import org.apache.drill.exec.work.user.UserWorker;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Closeables;
 
-public class ServiceEngine implements Closeable{
+public class ServiceEngine implements AutoCloseable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ServiceEngine.class);
 
   private final UserServer userServer;
@@ -56,22 +60,83 @@ public class ServiceEngine implements Closeable{
   private final DrillConfig config;
   boolean useIP = false;
   private final boolean allowPortHunting;
+  private final BufferAllocator userAllocator;
+  private final BufferAllocator controlAllocator;
+  private final BufferAllocator dataAllocator;
+
 
   public ServiceEngine(ControlMessageHandler controlMessageHandler, UserWorker userWorker, BootStrapContext context,
       WorkEventBus workBus, WorkerBee bee, boolean allowPortHunting) throws DrillbitStartupException {
+    userAllocator = newAllocator(context, "rpc:user", "drill.exec.rpc.user.server.memory.reservation",
+        "drill.exec.rpc.user.server.memory.maximum");
+    controlAllocator = newAllocator(context, "rpc:bit-control",
+        "drill.exec.rpc.bit.server.memory.control.reservation", "drill.exec.rpc.bit.server.memory.control.maximum");
+    dataAllocator = newAllocator(context, "rpc:bit-control",
+        "drill.exec.rpc.bit.server.memory.data.reservation", "drill.exec.rpc.bit.server.memory.data.maximum");
     final EventLoopGroup eventLoopGroup = TransportCheck.createEventLoopGroup(
         context.getConfig().getInt(ExecConstants.USER_SERVER_RPC_THREADS), "UserServer-");
     this.userServer = new UserServer(
         context.getConfig(),
         context.getClasspathScan(),
-        context.getAllocator(),
+        userAllocator,
         eventLoopGroup,
         userWorker,
         context.getExecutor());
-    this.controller = new ControllerImpl(context, controlMessageHandler, allowPortHunting);
-    this.dataPool = new DataConnectionCreator(context, workBus, bee, allowPortHunting);
+    this.controller = new ControllerImpl(context, controlMessageHandler, controlAllocator, allowPortHunting);
+    this.dataPool = new DataConnectionCreator(context, dataAllocator, workBus, bee, allowPortHunting);
     this.config = context.getConfig();
     this.allowPortHunting = allowPortHunting;
+    registerMetrics(context.getMetrics());
+
+  }
+
+  private final void registerMetrics(final MetricRegistry registry) {
+    final String prefix = PooledByteBufAllocatorL.METRIC_PREFIX + "rpc.";
+    registry.register(prefix + "user.current", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return userAllocator.getAllocatedMemory();
+      }
+    });
+    registry.register(prefix + "user.peak", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return userAllocator.getPeakMemoryAllocation();
+      }
+    });
+    registry.register(prefix + "bit.control.current", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return controlAllocator.getAllocatedMemory();
+      }
+    });
+    registry.register(prefix + "bit.control.peak", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return controlAllocator.getPeakMemoryAllocation();
+      }
+    });
+
+    registry.register(prefix + "bit.data.current", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return dataAllocator.getAllocatedMemory();
+      }
+    });
+    registry.register(prefix + "bit.data.peak", new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return dataAllocator.getPeakMemoryAllocation();
+      }
+    });
+
+  }
+
+
+  private static BufferAllocator newAllocator(
+      BootStrapContext context, String name, String initReservation, String maxAllocation) {
+    return context.getAllocator().newChildAllocator(
+        name, context.getConfig().getLong(initReservation), context.getConfig().getLong(maxAllocation));
   }
 
   public DrillbitEndpoint start() throws DrillbitStartupException, UnknownHostException{
@@ -110,7 +175,7 @@ public class ServiceEngine implements Closeable{
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() throws Exception {
     // this takes time so close them in parallel
     // Ideally though we fix this netty bug: https://github.com/netty/netty/issues/2545
     ExecutorService p = Executors.newFixedThreadPool(2);
@@ -123,5 +188,7 @@ public class ServiceEngine implements Closeable{
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
+    AutoCloseables.close(userAllocator, controlAllocator, dataAllocator);
+
   }
 }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -52,7 +52,11 @@ drill.exec: {
       timeout: 30,
       server: {
         port: 31010
-        threads: 1
+        threads: 1,
+        memory: {
+          reservation: 0,
+          maximum: 9223372036854775807
+        }
       }
       client: {
         threads: 1
@@ -67,6 +71,16 @@ drill.exec: {
           delay: 500
         },
         threads: 10
+        memory: {
+          control: {
+            reservation: 0,
+            maximum: 9223372036854775807
+          },
+          data: {
+            reservation: 0,
+            maximum: 9223372036854775807
+          }
+        }
       }
     },
     use.ip : false

--- a/exec/memory/base/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -40,7 +40,7 @@ public class PooledByteBufAllocatorL {
   private static final int MEMORY_LOGGER_FREQUENCY_SECONDS = 60;
 
 
-  private static final String METRIC_PREFIX = "drill.allocator.";
+  public static final String METRIC_PREFIX = "drill.allocator.";
 
   private final MetricRegistry registry;
   private final AtomicLong hugeBufferSize = new AtomicLong(0);
@@ -48,7 +48,7 @@ public class PooledByteBufAllocatorL {
   private final AtomicLong normalBufferSize = new AtomicLong(0);
   private final AtomicLong normalBufferCount = new AtomicLong(0);
 
-  public final InnerAllocator allocator;
+  private final InnerAllocator allocator;
   public final UnsafeDirectLittleEndian empty;
 
   public PooledByteBufAllocatorL(MetricRegistry registry) {
@@ -59,7 +59,7 @@ public class PooledByteBufAllocatorL {
 
   public UnsafeDirectLittleEndian allocate(int size) {
     try {
-      return allocator.directBuffer(size, size);
+      return allocator.directBuffer(size, Integer.MAX_VALUE);
     } catch (OutOfMemoryError e) {
       throw new OutOfMemoryException("Failure allocating buffer.", e);
     }

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -84,9 +84,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     this.parentAllocator = parentAllocator;
     this.name = name;
 
-    // TODO: DRILL-4131
-    // this.thisAsByteBufAllocator = new DrillByteBufAllocator(this);
-    this.thisAsByteBufAllocator = AllocatorManager.INNER_ALLOCATOR.allocator;
+    this.thisAsByteBufAllocator = new DrillByteBufAllocator(this);
 
     if (DEBUG) {
       childAllocators = new IdentityHashMap<>();


### PR DESCRIPTION
- Allow settings to be set to ensure RPC reservation and maximums (currently unset by default). Defaults set in drill-module.conf
- Add new metrics to report RPC layer memory consumption.
- Check for memory leaks from RPC layer at shutdown.