### PR TITLE
DRILL-4256: Create HiveConf per HiveStoragePlugin and reuse it wherev…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/HivePartitionDescriptor.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/HivePartitionDescriptor.java
@@ -105,7 +105,7 @@ public class HivePartitionDescriptor extends AbstractPartitionDescriptor {
       }
     }
 
-    HiveReadEntry newReadEntry = new HiveReadEntry(origReadEntry.table, newPartitions, origReadEntry.hiveConfigOverride);
+    HiveReadEntry newReadEntry = new HiveReadEntry(origReadEntry.table, newPartitions);
 
     return hiveScan.clone(newReadEntry);
   }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.sql.logical;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -40,6 +41,7 @@ import org.apache.drill.exec.store.hive.HiveReadEntry;
 import org.apache.drill.exec.store.hive.HiveScan;
 import org.apache.drill.exec.store.hive.HiveTable.HivePartition;
 import org.apache.drill.exec.store.hive.HiveUtilities;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -86,17 +88,18 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
   @Override
   public boolean matches(RelOptRuleCall call) {
     final DrillScanRel scanRel = (DrillScanRel) call.rel(0);
-    final PlannerSettings settings = PrelUtil.getPlannerSettings(call.getPlanner());
 
     if (!(scanRel.getGroupScan() instanceof HiveScan) || ((HiveScan) scanRel.getGroupScan()).isNativeReader()) {
       return false;
     }
 
     final HiveScan hiveScan = (HiveScan) scanRel.getGroupScan();
+    final HiveConf hiveConf = hiveScan.getHiveConf();
     final Table hiveTable = hiveScan.hiveReadEntry.getTable();
 
     final Class<? extends InputFormat> tableInputFormat =
-        getInputFormatFromSD(MetaStoreUtils.getTableMetadata(hiveTable), hiveScan.hiveReadEntry, hiveTable.getSd());
+        getInputFormatFromSD(MetaStoreUtils.getTableMetadata(hiveTable), hiveScan.hiveReadEntry, hiveTable.getSd(),
+            hiveConf);
     if (tableInputFormat == null || !tableInputFormat.equals(MapredParquetInputFormat.class)) {
       return false;
     }
@@ -111,7 +114,8 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
     for (HivePartition partition : partitions) {
       final StorageDescriptor partitionSD = partition.getPartition().getSd();
       Class<? extends InputFormat> inputFormat = getInputFormatFromSD(
-          HiveUtilities.getPartitionMetadata(partition.getPartition(), hiveTable), hiveScan.hiveReadEntry, partitionSD);
+          HiveUtilities.getPartitionMetadata(partition.getPartition(), hiveTable), hiveScan.hiveReadEntry, partitionSD,
+          hiveConf);
       if (inputFormat == null || !inputFormat.equals(tableInputFormat)) {
         return false;
       }
@@ -139,11 +143,16 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
    * @return {@link InputFormat} class or null if a failure has occurred. Failure is logged as warning.
    */
   private Class<? extends InputFormat> getInputFormatFromSD(final Properties properties,
-      final HiveReadEntry hiveReadEntry, final StorageDescriptor sd) {
+      final HiveReadEntry hiveReadEntry, final StorageDescriptor sd, final HiveConf hiveConf) {
     final Table hiveTable = hiveReadEntry.getTable();
     try {
-      final JobConf job = new JobConf();
-      HiveUtilities.addConfToJob(job, properties, hiveReadEntry.hiveConfigOverride);
+      final String inputFormatName = sd.getInputFormat();
+      if (!Strings.isNullOrEmpty(inputFormatName)) {
+        return (Class<? extends InputFormat>) Class.forName(inputFormatName);
+      }
+
+      final JobConf job = new JobConf(hiveConf);
+      HiveUtilities.addConfToJob(job, properties);
       return HiveUtilities.getInputFormatClass(job, sd, hiveTable);
     } catch (final Exception e) {
       logger.warn("Failed to get InputFormat class from Hive table '{}.{}'. StorageDescriptor [{}]",

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetSubScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetSubScan.java
@@ -17,10 +17,13 @@
  */
 package org.apache.drill.exec.store.hive;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,17 +36,20 @@ public class HiveDrillNativeParquetSubScan extends HiveSubScan {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HiveDrillNativeParquetSubScan.class);
 
   @JsonCreator
-  public HiveDrillNativeParquetSubScan(@JsonProperty("userName") String userName,
+  public HiveDrillNativeParquetSubScan(@JacksonInject StoragePluginRegistry registry,
+                                       @JsonProperty("userName") String userName,
                                        @JsonProperty("splits") List<String> splits,
                                        @JsonProperty("hiveReadEntry") HiveReadEntry hiveReadEntry,
                                        @JsonProperty("splitClasses") List<String> splitClasses,
-                                       @JsonProperty("columns") List<SchemaPath> columns)
-      throws IOException, ReflectiveOperationException {
-    super(userName, splits, hiveReadEntry, splitClasses, columns);
+                                       @JsonProperty("columns") List<SchemaPath> columns,
+                                       @JsonProperty("storagePluginName") String pluginName)
+      throws IOException, ExecutionSetupException, ReflectiveOperationException {
+    super(registry, userName, splits, hiveReadEntry, splitClasses, columns, pluginName);
   }
 
-  public HiveDrillNativeParquetSubScan(final HiveSubScan subScan) throws IOException, ReflectiveOperationException {
-    this(subScan.getUserName(), subScan.getSplits(), subScan.getHiveReadEntry(), subScan.getSplitClasses(),
-        subScan.getColumns());
+  public HiveDrillNativeParquetSubScan(final HiveSubScan subScan)
+      throws IOException, ExecutionSetupException, ReflectiveOperationException {
+    super(subScan.getUserName(), subScan.getSplits(), subScan.getHiveReadEntry(), subScan.getSplitClasses(),
+        subScan.getColumns(), subScan.getStoragePlugin());
   }
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveReadEntry.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveReadEntry.java
@@ -17,15 +17,11 @@
  */
 package org.apache.drill.exec.store.hive;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.calcite.schema.Schema.TableType;
 
 import org.apache.drill.exec.store.hive.HiveTable.HivePartition;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 
@@ -40,16 +36,13 @@ public class HiveReadEntry {
   public HiveTable table;
   @JsonProperty("partitions")
   public List<HiveTable.HivePartition> partitions;
-  @JsonProperty("hiveConfigOverride")
-  public Map<String, String> hiveConfigOverride;
 
   @JsonIgnore
   private List<Partition> partitionsUnwrapped = Lists.newArrayList();
 
   @JsonCreator
   public HiveReadEntry(@JsonProperty("table") HiveTable table,
-                       @JsonProperty("partitions") List<HiveTable.HivePartition> partitions,
-                       @JsonProperty("hiveConfigOverride") Map<String, String> hiveConfigOverride) {
+                       @JsonProperty("partitions") List<HiveTable.HivePartition> partitions) {
     this.table = table;
     this.partitions = partitions;
     if (partitions != null) {
@@ -57,7 +50,6 @@ public class HiveReadEntry {
         partitionsUnwrapped.add(part.getPartition());
       }
     }
-    this.hiveConfigOverride = hiveConfigOverride;
   }
 
   @JsonIgnore

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveScan.java
@@ -96,7 +96,7 @@ public class HiveScan extends AbstractGroupScan {
     this.columns = columns;
     this.storagePlugin = storagePlugin;
     if (metadataProvider == null) {
-      this.metadataProvider = new HiveMetadataProvider(userName, hiveReadEntry);
+      this.metadataProvider = new HiveMetadataProvider(userName, hiveReadEntry, storagePlugin.getHiveConf());
     } else {
       this.metadataProvider = metadataProvider;
     }
@@ -166,8 +166,8 @@ public class HiveScan extends AbstractGroupScan {
         parts = null;
       }
 
-      final HiveReadEntry subEntry = new HiveReadEntry(hiveReadEntry.table, parts, hiveReadEntry.hiveConfigOverride);
-      return new HiveSubScan(getUserName(), encodedInputSplits, subEntry, splitTypes, columns);
+      final HiveReadEntry subEntry = new HiveReadEntry(hiveReadEntry.table, parts);
+      return new HiveSubScan(getUserName(), encodedInputSplits, subEntry, splitTypes, columns, storagePlugin);
     } catch (IOException | ReflectiveOperationException e) {
       throw new ExecutionSetupException(e);
     }
@@ -287,6 +287,11 @@ public class HiveScan extends AbstractGroupScan {
       return false;
     }
     return true;
+  }
+
+  @JsonIgnore
+  public HiveConf getHiveConf() {
+    return storagePlugin.getHiveConf();
   }
 
   @JsonIgnore

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePlugin.java
@@ -19,6 +19,8 @@ package org.apache.drill.exec.store.hive;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +43,8 @@ import org.apache.drill.exec.store.hive.schema.HiveSchemaFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 
 public class HiveStoragePlugin extends AbstractStoragePlugin {
 
@@ -50,12 +54,18 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
   private final HiveSchemaFactory schemaFactory;
   private final DrillbitContext context;
   private final String name;
+  private final HiveConf hiveConf;
 
   public HiveStoragePlugin(HiveStoragePluginConfig config, DrillbitContext context, String name) throws ExecutionSetupException {
     this.config = config;
     this.context = context;
-    this.schemaFactory = new HiveSchemaFactory(this, name, config.getHiveConfigOverride());
     this.name = name;
+    this.hiveConf = createHiveConf(config.getHiveConfigOverride());
+    this.schemaFactory = new HiveSchemaFactory(this, name, hiveConf);
+  }
+
+  public HiveConf getHiveConf() {
+    return hiveConf;
   }
 
   public HiveStoragePluginConfig getConfig() {
@@ -92,7 +102,7 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
 
   @Override
   public Set<StoragePluginOptimizerRule> getLogicalOptimizerRules(OptimizerRulesContext optimizerContext) {
-    final String defaultPartitionValue = HiveUtilities.getDefaultPartitionValue(config.getHiveConfigOverride());
+    final String defaultPartitionValue = hiveConf.get(ConfVars.DEFAULTPARTITIONNAME.varname);
 
     ImmutableSet.Builder<StoragePluginOptimizerRule> ruleBuilder = ImmutableSet.builder();
 
@@ -110,5 +120,16 @@ public class HiveStoragePlugin extends AbstractStoragePlugin {
     }
 
     return ImmutableSet.of();
+  }
+
+  private static HiveConf createHiveConf(final Map<String, String> hiveConfigOverride) {
+    final HiveConf hiveConf = new HiveConf();
+    for(Entry<String, String> config : hiveConfigOverride.entrySet()) {
+      final String key = config.getKey();
+      final String value = config.getValue();
+      hiveConf.set(key, value);
+      logger.trace("HiveConfig Override {}={}", key, value);
+    }
+    return hiveConf;
   }
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
@@ -355,18 +355,6 @@ public class HiveUtilities {
     return null;
   }
 
-  public static String getDefaultPartitionValue(final Map<String, String> hiveConfigOverride) {
-    // Check if the default partition config in given Hive config override in Hive storage pluging definition.
-    String defaultPartitionValue = hiveConfigOverride.get(ConfVars.DEFAULTPARTITIONNAME.varname);
-    if (!Strings.isNullOrEmpty(defaultPartitionValue)) {
-      return defaultPartitionValue;
-    }
-
-    // Create a HiveConf and get the configured value. If any hive-site.xml file on the classpath has the property
-    // defined, it will be returned. Otherwise default value is returned.
-    return new HiveConf().getVar(ConfVars.DEFAULTPARTITIONNAME);
-  }
-
   /**
    * Utility method which gets table or partition {@link InputFormat} class. First it
    * tries to get the class name from given StorageDescriptor object. If it doesn't contain it tries to get it from
@@ -397,18 +385,12 @@ public class HiveUtilities {
    *
    * @param job {@link JobConf} instance.
    * @param properties New config properties
-   * @param hiveConfigOverride HiveConfig override.
+   * @param hiveConf HiveConf of Hive storage plugin
    */
-  public static void addConfToJob(final JobConf job, final Properties properties,
-      final Map<String, String> hiveConfigOverride) {
-    final HiveConf hiveConf = new HiveConf();
+  public static void addConfToJob(final JobConf job, final Properties properties) {
     for (Object obj : properties.keySet()) {
-      hiveConf.set((String) obj, (String) properties.get(obj));
+      job.set((String) obj, (String) properties.get(obj));
     }
-    for(Map.Entry<String, String> entry : hiveConfigOverride.entrySet()) {
-      hiveConf.set(entry.getKey(), entry.getValue());
-    }
-    job.addResource(hiveConf);
   }
 
   /**


### PR DESCRIPTION
…er needed.

Creating new instances of HiveConf() are very costly, we should avoid creating new ones as much as possible.
Also get rid of hiveConfigOverride and use HiveConf in HiveStoregPlugin wherever we need the HiveConf.