### PR TITLE
DRILL-4285: Bumps FMPP version to 0.9.15

### DIFF
--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -107,13 +107,6 @@
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.19</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>generate-fmpp-sources</id>

--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -137,13 +137,6 @@
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.19</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>generate-fmpp</id>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.19</version>
+      <version>${freemarker.version}</version>
     </dependency>
     <dependency>
       <groupId>net.hydromatic</groupId>
@@ -556,13 +556,6 @@
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.19</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>generate-fmpp</id>

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -113,13 +113,6 @@
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>2.3.19</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>generate-fmpp</id>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     -->
     <hive.version>1.2.1</hive.version>
     <hadoop.version>2.7.1</hadoop.version>
-    <fmpp.version>0.9.14</fmpp.version>
+    <fmpp.version>0.9.15</fmpp.version>
+    <freemarker.version>2.3.21</freemarker.version>
   </properties>
 
   <scm>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>fmpp</artifactId>
       <version>${fmpp.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>${freemarker.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
FMPP 0.9.14 pom.xml specifies a version range for FreeMarker dependency,
which should be okay except that latest SNAPSHOT version doesn't resolve
anymore.
FMPP 0.9.15 now uses a fixed stable version (2.3.21).