### PR TITLE
DRILL-4322: Add underlying exception message when IOException causes …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
@@ -728,13 +728,13 @@ public class WorkspaceSchemaFactory {
         fs.delete(new Path(defaultLocation, tableRename), true);
       } catch (AccessControlException e) {
         throw UserException
-            .permissionError()
-            .message("Unauthorized to drop table", e)
+            .permissionError(e)
+            .message("Unauthorized to drop table")
             .build(logger);
       } catch (IOException e) {
         throw UserException
-            .dataWriteError()
-            .message("Failed to drop table", e)
+            .dataWriteError(e)
+            .message("Failed to drop table: " + e.getMessage())
             .build(logger);
       }
     }


### PR DESCRIPTION
…DROP TABLE failure