### PR TITLE
DRILL-4327: Fix rawtypes warnings emitted by compiler

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/planner/sql/logical/ConvertHiveParquetScanToDrillParquetScan.java
@@ -97,7 +97,7 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
     final HiveConf hiveConf = hiveScan.getHiveConf();
     final Table hiveTable = hiveScan.hiveReadEntry.getTable();
 
-    final Class<? extends InputFormat> tableInputFormat =
+    final Class<? extends InputFormat<?,?>> tableInputFormat =
         getInputFormatFromSD(MetaStoreUtils.getTableMetadata(hiveTable), hiveScan.hiveReadEntry, hiveTable.getSd(),
             hiveConf);
     if (tableInputFormat == null || !tableInputFormat.equals(MapredParquetInputFormat.class)) {
@@ -113,7 +113,7 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
     // Make sure all partitions have the same input format as the table input format
     for (HivePartition partition : partitions) {
       final StorageDescriptor partitionSD = partition.getPartition().getSd();
-      Class<? extends InputFormat> inputFormat = getInputFormatFromSD(
+      Class<? extends InputFormat<?, ?>> inputFormat = getInputFormatFromSD(
           HiveUtilities.getPartitionMetadata(partition.getPartition(), hiveTable), hiveScan.hiveReadEntry, partitionSD,
           hiveConf);
       if (inputFormat == null || !inputFormat.equals(tableInputFormat)) {
@@ -142,13 +142,13 @@ public class ConvertHiveParquetScanToDrillParquetScan extends StoragePluginOptim
    * @param sd
    * @return {@link InputFormat} class or null if a failure has occurred. Failure is logged as warning.
    */
-  private Class<? extends InputFormat> getInputFormatFromSD(final Properties properties,
+  private Class<? extends InputFormat<?, ?>> getInputFormatFromSD(final Properties properties,
       final HiveReadEntry hiveReadEntry, final StorageDescriptor sd, final HiveConf hiveConf) {
     final Table hiveTable = hiveReadEntry.getTable();
     try {
       final String inputFormatName = sd.getInputFormat();
       if (!Strings.isNullOrEmpty(inputFormatName)) {
-        return (Class<? extends InputFormat>) Class.forName(inputFormatName);
+        return (Class<? extends InputFormat<?, ?>>) Class.forName(inputFormatName);
       }
 
       final JobConf job = new JobConf(hiveConf);

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
@@ -154,7 +154,7 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       logger.warn("Hive metastore cache expire policy is set to {}", expireAfterWrite? "expireAfterWrite" : "expireAfterAccess");
     }
 
-    final CacheBuilder cacheBuilder = CacheBuilder
+    final CacheBuilder<Object, Object> cacheBuilder = CacheBuilder
         .newBuilder();
 
     if (expireAfterWrite) {

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveAuthorizationHelper.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveAuthorizationHelper.java
@@ -102,7 +102,7 @@ public class HiveAuthorizationHelper {
       return;
     }
 
-    authorize(HiveOperationType.SHOWDATABASES, Collections.EMPTY_LIST, Collections.EMPTY_LIST, "SHOW DATABASES");
+    authorize(HiveOperationType.SHOWDATABASES, Collections.<HivePrivilegeObject> emptyList(), Collections.<HivePrivilegeObject> emptyList(), "SHOW DATABASES");
   }
 
   /**
@@ -117,7 +117,7 @@ public class HiveAuthorizationHelper {
 
     final HivePrivilegeObject toRead = new HivePrivilegeObject(HivePrivilegeObjectType.DATABASE, dbName, null);
 
-    authorize(HiveOperationType.SHOWTABLES, ImmutableList.of(toRead), Collections.EMPTY_LIST, "SHOW TABLES");
+    authorize(HiveOperationType.SHOWTABLES, ImmutableList.of(toRead), Collections.<HivePrivilegeObject> emptyList(), "SHOW TABLES");
   }
 
   /**
@@ -132,7 +132,7 @@ public class HiveAuthorizationHelper {
     }
 
     HivePrivilegeObject toRead = new HivePrivilegeObject(HivePrivilegeObjectType.TABLE_OR_VIEW, dbName, tableName);
-    authorize(HiveOperationType.QUERY, ImmutableList.of(toRead), Collections.EMPTY_LIST, "READ TABLE");
+    authorize(HiveOperationType.QUERY, ImmutableList.of(toRead), Collections.<HivePrivilegeObject> emptyList(), "READ TABLE");
   }
 
   /* Helper method to check privileges */

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
@@ -249,7 +249,7 @@ public class HiveMetadataProvider {
 
           if (fs.exists(path)) {
             FileInputFormat.addInputPath(job, path);
-            final InputFormat format = job.getInputFormat();
+            final InputFormat<?, ?> format = job.getInputFormat();
             for (final InputSplit split : format.getSplits(job, 1)) {
               splits.add(new InputSplitWrapper(split, partition));
             }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveRecordReader.java
@@ -96,7 +96,7 @@ public class HiveRecordReader extends AbstractRecordReader {
   private Converter partTblObjectInspectorConverter;
 
   protected Object key, value;
-  protected org.apache.hadoop.mapred.RecordReader reader;
+  protected org.apache.hadoop.mapred.RecordReader<Object, Object> reader;
   protected List<ValueVector> vectors = Lists.newArrayList();
   protected List<ValueVector> pVectors = Lists.newArrayList();
   protected boolean empty;
@@ -215,7 +215,7 @@ public class HiveRecordReader extends AbstractRecordReader {
 
     if (!empty) {
       try {
-        reader = job.getInputFormat().getRecordReader(inputSplit, job, Reporter.NULL);
+        reader = (org.apache.hadoop.mapred.RecordReader<Object, Object>) job.getInputFormat().getRecordReader(inputSplit, job, Reporter.NULL);
       } catch (Exception e) {
         throw new ExecutionSetupException("Failed to get o.a.hadoop.mapred.RecordReader from Hive InputFormat", e);
       }
@@ -228,8 +228,8 @@ public class HiveRecordReader extends AbstractRecordReader {
    * Utility method which creates a SerDe object for given SerDe class name and properties.
    */
   private static SerDe createSerDe(final JobConf job, final String sLib, final Properties properties) throws Exception {
-    final Class<?> c = Class.forName(sLib);
-    final SerDe serde = (SerDe) c.getConstructor().newInstance();
+    final Class<? extends SerDe> c = Class.forName(sLib).asSubclass(SerDe.class);
+    final SerDe serde = c.getConstructor().newInstance();
     serde.initialize(job, properties);
 
     return serde;
@@ -244,7 +244,7 @@ public class HiveRecordReader extends AbstractRecordReader {
   }
 
   @Override
-  public void setup(@SuppressWarnings("unused") OperatorContext context, OutputMutator output)
+  public void setup(OperatorContext context, OutputMutator output)
       throws ExecutionSetupException {
     // initializes "reader"
     final Callable<Void> readerInitializer = new Callable<Void>() {
@@ -271,14 +271,14 @@ public class HiveRecordReader extends AbstractRecordReader {
       for (int i = 0; i < selectedColumnNames.size(); i++) {
         MajorType type = HiveUtilities.getMajorTypeFromHiveTypeInfo(selectedColumnTypes.get(i), options);
         MaterializedField field = MaterializedField.create(selectedColumnNames.get(i), type);
-        Class vvClass = TypeHelper.getValueVectorClass(type.getMinorType(), type.getMode());
+        Class<? extends ValueVector> vvClass = TypeHelper.getValueVectorClass(type.getMinorType(), type.getMode());
         vectors.add(output.addField(field, vvClass));
       }
 
       for (int i = 0; i < selectedPartitionNames.size(); i++) {
         MajorType type = HiveUtilities.getMajorTypeFromHiveTypeInfo(selectedPartitionTypes.get(i), options);
         MaterializedField field = MaterializedField.create(selectedPartitionNames.get(i), type);
-        Class vvClass = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getDataMode());
+        Class<? extends ValueVector> vvClass = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getDataMode());
         pVectors.add(output.addField(field, vvClass));
       }
     } catch(SchemaChangeException e) {

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveTable.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveTable.java
@@ -66,7 +66,7 @@ public class HiveTable {
   public String tableType;
 
   @JsonIgnore
-  public final Map<String, String> partitionNameTypeMap = new HashMap();
+  public final Map<String, String> partitionNameTypeMap = new HashMap<>();
 
   @JsonCreator
   public HiveTable(@JsonProperty("tableName") String tableName, @JsonProperty("dbName") String dbName, @JsonProperty("owner") String owner, @JsonProperty("createTime") int createTime,

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
@@ -364,7 +364,7 @@ public class HiveUtilities {
    * @param table Table object
    * @throws Exception
    */
-  public static Class<? extends InputFormat> getInputFormatClass(final JobConf job, final StorageDescriptor sd,
+  public static Class<? extends InputFormat<?, ?>> getInputFormatClass(final JobConf job, final StorageDescriptor sd,
       final Table table) throws Exception {
     final String inputFormatName = sd.getInputFormat();
     if (Strings.isNullOrEmpty(inputFormatName)) {
@@ -374,9 +374,9 @@ public class HiveUtilities {
             "InputFormat class explicitly specified nor StorageHandler class");
       }
       final HiveStorageHandler storageHandler = HiveUtils.getStorageHandler(job, storageHandlerClass);
-      return storageHandler.getInputFormatClass();
+      return (Class<? extends InputFormat<?, ?>>) storageHandler.getInputFormatClass();
     } else {
-      return (Class<? extends InputFormat>) Class.forName(inputFormatName);
+      return (Class<? extends InputFormat<?, ?>>) Class.forName(inputFormatName) ;
     }
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
@@ -265,7 +265,7 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
             u0_voter_all_755
         ));
 
-    showTablesHelper(db_u1g1_only, Collections.EMPTY_LIST);
+    showTablesHelper(db_u1g1_only, Collections.<String>emptyList());
   }
 
   @Test
@@ -289,7 +289,7 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
             u1g1_voter_u1_700
         ));
 
-    showTablesHelper(db_u0_only, Collections.EMPTY_LIST);
+    showTablesHelper(db_u0_only, Collections.<String>emptyList());
   }
 
   @Test
@@ -309,7 +309,7 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
             u1g1_voter_all_755
         ));
 
-    showTablesHelper(db_u0_only, Collections.EMPTY_LIST);
+    showTablesHelper(db_u0_only, Collections.<String>emptyList());
   }
 
   // Try to read the tables "user0" has access to read in db_general.

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduRecordReader.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduRecordReader.java
@@ -170,7 +170,6 @@ public class KuduRecordReader extends AbstractRecordReader {
     return rowCount;
   }
 
-  @SuppressWarnings("unchecked")
   private void initCols(Schema schema) throws SchemaChangeException {
     ImmutableList.Builder<ProjectedColumnInfo> pciBuilder = ImmutableList.builder();
 

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduSchemaFactory.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduSchemaFactory.java
@@ -96,7 +96,7 @@ public class KuduSchemaFactory implements SchemaFactory {
         return Sets.newHashSet(tablesList.getTablesList());
       } catch (Exception e) {
         logger.warn("Failure reading kudu tables.", e);
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/cache/DistributedCache.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/cache/DistributedCache.java
@@ -112,7 +112,7 @@ public interface DistributedCache extends AutoCloseable{
       if (getClass() != obj.getClass()) {
         return false;
       }
-      CacheConfig other = (CacheConfig) obj;
+      CacheConfig<?, ?> other = (CacheConfig<?, ?>) obj;
       if (keyClass == null) {
         if (other.keyClass != null) {
           return false;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
@@ -145,7 +145,7 @@ public class CodeGenerator<T> {
     if (getClass() != obj.getClass()){
       return false;
     }
-    CodeGenerator other = (CodeGenerator) obj;
+    CodeGenerator<?> other = (CodeGenerator<?>) obj;
     if (definition == null) {
       if (other.definition != null){
         return false;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import com.google.common.collect.Maps;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.CastExpression;
 import org.apache.drill.common.expression.ConvertExpression;
@@ -54,7 +53,6 @@ import org.apache.drill.common.expression.ValueExpressions.QuotedString;
 import org.apache.drill.common.expression.ValueExpressions.TimeExpression;
 import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
 import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
-import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -70,6 +68,7 @@ import org.apache.drill.exec.vector.ValueHolderHelper;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JConditional;
@@ -133,11 +132,11 @@ public class EvaluationVisitor {
 
   Map<ExpressionHolder,HoldingContainer> previousExpressions = Maps.newHashMap();
 
-  Stack<Map<ExpressionHolder,HoldingContainer>> mapStack = new Stack();
+  Stack<Map<ExpressionHolder,HoldingContainer>> mapStack = new Stack<>();
 
   void newScope() {
     mapStack.push(previousExpressions);
-    previousExpressions = new HashMap(previousExpressions);
+    previousExpressions = new HashMap<>(previousExpressions);
   }
 
   void leaveScope() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/interpreter/InterpreterEvaluator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/interpreter/InterpreterEvaluator.java
@@ -17,10 +17,10 @@
  */
 package org.apache.drill.exec.expr.fn.interpreter;
 
-import com.google.common.base.Preconditions;
-import io.netty.buffer.DrillBuf;
-
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.inject.Inject;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.BooleanOperator;
@@ -52,8 +52,9 @@ import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.vector.ValueHolderHelper;
 import org.apache.drill.exec.vector.ValueVector;
 
-import javax.inject.Inject;
-import java.lang.reflect.Method;
+import com.google.common.base.Preconditions;
+
+import io.netty.buffer.DrillBuf;
 
 public class InterpreterEvaluator {
 
@@ -111,7 +112,7 @@ public class InterpreterEvaluator {
         for (Field f : fields) {
           if ( f.getAnnotation(Inject.class) != null ) {
             f.setAccessible(true);
-            Class fieldType = f.getType();
+            Class<?> fieldType = f.getType();
             if (UdfUtilities.INJECTABLE_GETTER_METHODS.get(fieldType) != null) {
               Method method = udfUtilities.getClass().getMethod(UdfUtilities.INJECTABLE_GETTER_METHODS.get(fieldType));
               f.set(interpreter, method.invoke(udfUtilities));
@@ -427,7 +428,6 @@ public class InterpreterEvaluator {
     private ValueHolder visitBooleanAnd(BooleanOperator op, Integer inIndex) {
       ValueHolder [] args = new ValueHolder [op.args.size()];
       boolean hasNull = false;
-      ValueHolder out = null;
       for (int i = 0; i < op.args.size(); i++) {
         args[i] = op.args.get(i).accept(this, inIndex);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
@@ -17,9 +17,11 @@
  ******************************************************************************/
 package org.apache.drill.exec.ops;
 
-import com.google.common.collect.ImmutableMap;
-import io.netty.buffer.DrillBuf;
 import org.apache.drill.exec.store.PartitionExplorer;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.netty.buffer.DrillBuf;
 
 /**
  * Defines the query state and shared resources available to UDFs through
@@ -31,8 +33,8 @@ public interface UdfUtilities {
 
   // Map between injectable classes and their respective getter methods
   // used for code generation
-  public static final ImmutableMap<Class, String> INJECTABLE_GETTER_METHODS =
-      new ImmutableMap.Builder<Class, String>()
+  public static final ImmutableMap<Class<?>, String> INJECTABLE_GETTER_METHODS =
+      new ImmutableMap.Builder<Class<?>, String>()
           .put(DrillBuf.class, "getManagedBuffer")
           .put(PartitionExplorer.class, "getPartitionExplorer")
           .put(ContextInformation.class, "getContextInformation")

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
@@ -21,13 +21,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.planner.fragment.ParallelizationInfo;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 
 public abstract class AbstractExchange extends AbstractSingle implements Exchange {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractExchange.class);
@@ -93,7 +94,7 @@ public abstract class AbstractExchange extends AbstractSingle implements Exchang
       }
     }
 
-    return new ArrayList(affinityMap.values());
+    return new ArrayList<>(affinityMap.values());
   }
 
   protected void setupSenders(List<DrillbitEndpoint> senderLocations) throws PhysicalOperatorSetupException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
@@ -152,7 +152,7 @@ public class ImplCreator {
 
   /** Helper method to get OperatorCreator (RootCreator or BatchCreator) for given PhysicalOperator (root or non-root) */
   private Object getOpCreator(PhysicalOperator op, final FragmentContext context) throws ExecutionSetupException {
-    final Class opClass = op.getClass();
+    final Class<? extends PhysicalOperator> opClass = op.getClass();
     Object opCreator = context.getDrillbitContext().getOperatorCreatorRegistry().getOperatorCreator(opClass);
     if (opCreator == null) {
       throw new UnsupportedOperationException(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
@@ -1,5 +1,3 @@
-package org.apache.drill.exec.physical.impl.mergereceiver;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,8 +15,7 @@ package org.apache.drill.exec.physical.impl.mergereceiver;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import io.netty.buffer.ByteBuf;
+package org.apache.drill.exec.physical.impl.mergereceiver;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -82,6 +79,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JExpr;
+
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * The MergingRecordBatch merges pre-sorted record batches from remote senders.
@@ -312,6 +312,7 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
 
       // allocate the priority queue with the generated comparator
       this.pqueue = new PriorityQueue<>(fragProviders.length, new Comparator<Node>() {
+        @Override
         public int compare(final Node node1, final Node node2) {
           final int leftIndex = (node1.batchId << 16) + node1.valueIndex;
           final int rightIndex = (node2.batchId << 16) + node2.valueIndex;
@@ -663,7 +664,7 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
   GeneratorMapping COPIER_MAPPING = new GeneratorMapping("doSetup", "doCopy", null, null);
   public final MappingSet COPIER_MAPPING_SET = new MappingSet(COPIER_MAPPING, COPIER_MAPPING);
 
-  private void generateComparisons(final ClassGenerator g, final VectorAccessible batch) throws SchemaChangeException {
+  private void generateComparisons(final ClassGenerator<?> g, final VectorAccessible batch) throws SchemaChangeException {
     g.setMappingSet(MAIN_MAPPING);
 
     for (final Ordering od : popConfig.getOrderings()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
@@ -26,12 +26,12 @@ import java.util.concurrent.Future;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.OperatorStats;
 import org.apache.drill.exec.record.RecordBatch;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import org.apache.drill.exec.testing.ControlsInjector;
 import org.apache.drill.exec.testing.ControlsInjectorFactory;
 import org.apache.drill.exec.testing.CountDownLatchInjection;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 
 /**
  * Decorator class to hide multiple Partitioner existence from the caller
@@ -151,7 +151,7 @@ public class PartitionerDecorator {
     stats.startWait();
     final CountDownLatch latch = new CountDownLatch(partitioners.size());
     final List<CustomRunnable> runnables = Lists.newArrayList();
-    final List<Future> taskFutures = Lists.newArrayList();
+    final List<Future<?>> taskFutures = Lists.newArrayList();
     CountDownLatchInjection testCountDownLatch = null;
     try {
       // To simulate interruption of main fragment thread and interrupting the partition threads, create a
@@ -179,7 +179,7 @@ public class PartitionerDecorator {
           // If the fragment state says we shouldn't continue, cancel or interrupt partitioner threads
           if (!context.shouldContinue()) {
             logger.debug("Interrupting partioner threads. Fragment thread {}", tName);
-            for(Future f : taskFutures) {
+            for(Future<?> f : taskFutures) {
               f.cancel(true);
             }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/producer/ProducerConsumerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/producer/ProducerConsumerBatch.java
@@ -25,7 +25,6 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.expr.TypeHelper;
-import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.ProducerConsumer;
 import org.apache.drill.exec.physical.impl.sort.RecordBatchData;
@@ -39,7 +38,7 @@ import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.vector.ValueVector;
 
-public class ProducerConsumerBatch extends AbstractRecordBatch {
+public class ProducerConsumerBatch extends AbstractRecordBatch<ProducerConsumer> {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProducerConsumerBatch.class);
 
   private final RecordBatch incoming;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/RewriteAsBinaryOperators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/RewriteAsBinaryOperators.java
@@ -17,8 +17,9 @@
   */
 package org.apache.drill.exec.planner.logical.partition;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
@@ -35,8 +36,8 @@ import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * Rewrites an expression tree, replacing OR and AND operators with more than 2 operands with a chained operators
@@ -81,7 +82,7 @@ import java.util.List;
     RelDataType type = call.getType();
     if (kind == SqlKind.OR || kind == SqlKind.AND) {
       if (call.getOperands().size() > 2) {
-        List<RexNode> children = new ArrayList(call.getOperands());
+        List<RexNode> children = new ArrayList<>(call.getOperands());
         RexNode left = children.remove(0).accept(this);
         RexNode right = builder.makeCall(type, op, children).accept(this);
         return builder.makeCall(type, op, ImmutableList.of(left, right));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
@@ -224,7 +224,7 @@ public class PrelUtil {
   }
 
   // Simple visitor class to determine the last used reference in the expression
-  private static class LastUsedRefVisitor extends RexVisitorImpl {
+  private static class LastUsedRefVisitor extends RexVisitorImpl<Void> {
 
     int lastUsedRef = -1;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RewriteProjectToFlatten.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RewriteProjectToFlatten.java
@@ -17,14 +17,9 @@
  ******************************************************************************/
 package org.apache.drill.exec.planner.physical.visitor;
 
-import com.google.common.collect.Lists;
-import org.apache.calcite.tools.RelConversionException;
-import org.apache.drill.exec.planner.physical.FlattenPrel;
-import org.apache.drill.exec.planner.physical.Prel;
-import org.apache.drill.exec.planner.physical.ProjectPrel;
-import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
-import org.apache.drill.exec.planner.types.RelDataTypeHolder;
-import org.apache.drill.exec.planner.sql.DrillOperatorTable;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -32,9 +27,15 @@ import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.drill.exec.planner.physical.FlattenPrel;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.ProjectPrel;
+import org.apache.drill.exec.planner.sql.DrillOperatorTable;
+import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
+import org.apache.drill.exec.planner.types.RelDataTypeHolder;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.Lists;
 
 public class RewriteProjectToFlatten extends BasePrelVisitor<Prel, Object, RelConversionException> {
 
@@ -64,7 +65,7 @@ public class RewriteProjectToFlatten extends BasePrelVisitor<Prel, Object, RelCo
     List<RexNode> exprList = new ArrayList<>();
     boolean rewrite = false;
 
-    List<RelDataTypeField> relDataTypes = new ArrayList();
+    List<RelDataTypeField> relDataTypes = new ArrayList<>();
     int i = 0;
     RexNode flatttenExpr = null;
     for (RexNode rex : project.getChildExps()) {
@@ -72,7 +73,6 @@ public class RewriteProjectToFlatten extends BasePrelVisitor<Prel, Object, RelCo
       if (rex instanceof RexCall) {
         RexCall function = (RexCall) rex;
         String functionName = function.getOperator().getName();
-        int nArgs = function.getOperands().size();
 
         if (functionName.equalsIgnoreCase("flatten") ) {
           rewrite = true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RexVisitorComplexExprSplitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/RexVisitorComplexExprSplitter.java
@@ -17,10 +17,9 @@
  ******************************************************************************/
 package org.apache.drill.exec.planner.physical.visitor;
 
-import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.planner.physical.ProjectPrel;
-import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
-import org.apache.drill.exec.planner.types.RelDataTypeHolder;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
@@ -34,9 +33,10 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexRangeRef;
 import org.apache.calcite.rex.RexVisitorImpl;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.planner.physical.ProjectPrel;
+import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
+import org.apache.drill.exec.planner.types.RelDataTypeHolder;
 
 public class RexVisitorComplexExprSplitter extends RexVisitorImpl<RexNode> {
 
@@ -50,7 +50,7 @@ public class RexVisitorComplexExprSplitter extends RexVisitorImpl<RexNode> {
     super(true);
     this.factory = factory;
     this.funcReg = funcReg;
-    this.complexExprs = new ArrayList();
+    this.complexExprs = new ArrayList<>();
     this.lastUsedIndex = firstUnused;
   }
 
@@ -83,11 +83,12 @@ public class RexVisitorComplexExprSplitter extends RexVisitorImpl<RexNode> {
     return correlVariable;
   }
 
+  @Override
   public RexNode visitCall(RexCall call) {
 
     String functionName = call.getOperator().getName();
 
-    List<RexNode> newOps = new ArrayList();
+    List<RexNode> newOps = new ArrayList<>();
     for (RexNode operand : call.operands) {
       newOps.add(operand.accept(this));
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/SplitUpComplexExpressions.java
@@ -17,31 +17,30 @@
  ******************************************************************************/
 package org.apache.drill.exec.planner.physical.visitor;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.tools.RelConversionException;
-
-import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.planner.StarColumnHelper;
-import org.apache.drill.exec.planner.physical.Prel;
-import org.apache.drill.exec.planner.physical.PrelUtil;
-import org.apache.drill.exec.planner.physical.ProjectPrel;
-import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
-import org.apache.drill.exec.planner.types.RelDataTypeHolder;
-import org.apache.drill.exec.planner.sql.DrillOperatorTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.planner.StarColumnHelper;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.planner.physical.ProjectPrel;
+import org.apache.drill.exec.planner.sql.DrillOperatorTable;
+import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
+import org.apache.drill.exec.planner.types.RelDataTypeHolder;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, RelConversionException> {
 
@@ -76,8 +75,8 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
 
     List<RexNode> exprList = new ArrayList<>();
 
-    List<RelDataTypeField> relDataTypes = new ArrayList();
-    List<RelDataTypeField> origRelDataTypes = new ArrayList();
+    List<RelDataTypeField> relDataTypes = new ArrayList<>();
+    List<RelDataTypeField> origRelDataTypes = new ArrayList<>();
     int i = 0;
     final int lastColumnReferenced = PrelUtil.getLastUsedColumnReference(project.getProjects());
 
@@ -101,7 +100,7 @@ public class SplitUpComplexExpressions extends BasePrelVisitor<Prel, Object, Rel
 
     ProjectPrel childProject;
 
-    List<RexNode> allExprs = new ArrayList();
+    List<RexNode> allExprs = new ArrayList<>();
     int exprIndex = 0;
     List<String> fieldNames = originalInput.getRowType().getFieldNames();
     for (int index = 0; index < lastRexInput; index++) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
@@ -22,14 +22,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.calcite.config.Lex;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCostFactory;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.rules.ProjectToWindowRule;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.ValidationException;
-
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.PhysicalPlan;
@@ -47,22 +57,10 @@ import org.apache.drill.exec.planner.sql.parser.DrillSqlCall;
 import org.apache.drill.exec.planner.sql.parser.SqlCreateTable;
 import org.apache.drill.exec.planner.sql.parser.impl.DrillParserWithCompoundIdConverter;
 import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
-import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ControlsInjector;
 import org.apache.drill.exec.testing.ControlsInjectorFactory;
 import org.apache.drill.exec.util.Pointer;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
-import org.apache.calcite.rel.RelCollationTraitDef;
-import org.apache.calcite.rel.rules.ReduceExpressionsRule;
-import org.apache.calcite.plan.ConventionTraitDef;
-import org.apache.calcite.plan.RelOptCostFactory;
-import org.apache.calcite.plan.RelTraitDef;
-import org.apache.calcite.plan.hep.HepPlanner;
-import org.apache.calcite.plan.hep.HepProgramBuilder;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.sql.parser.SqlParser;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.drill.exec.work.foreman.SqlUnsupportedException;
 import org.apache.hadoop.security.AccessControlException;
 
@@ -80,7 +78,9 @@ public class DrillSqlWorker {
   private final QueryContext context;
 
   public DrillSqlWorker(QueryContext context) {
-    final List<RelTraitDef> traitDefs = new ArrayList<RelTraitDef>();
+    // Calcite is not fully generified
+    @SuppressWarnings("rawtypes")
+    final List<RelTraitDef> traitDefs = new ArrayList<>();
 
     traitDefs.add(ConventionTraitDef.INSTANCE);
     traitDefs.add(DrillDistributionTraitDef.INSTANCE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/DrillFixedRelDataTypeImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/DrillFixedRelDataTypeImpl.java
@@ -91,7 +91,7 @@ public class DrillFixedRelDataTypeImpl extends RelDataTypeImpl {
 
   @Override
   public RelDataTypePrecedenceList getPrecedenceList() {
-    return new SqlTypeExplicitPrecedenceList((List) Collections.emptyList());
+    return new SqlTypeExplicitPrecedenceList(Collections.<SqlTypeName>emptyList());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/RelDataTypeDrillImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/RelDataTypeDrillImpl.java
@@ -73,7 +73,7 @@ public class RelDataTypeDrillImpl extends RelDataTypeImpl {
 
     @Override
     public RelDataTypePrecedenceList getPrecedenceList() {
-      return new SqlTypeExplicitPrecedenceList((List<SqlTypeName>) (List) Collections.emptyList());
+      return new SqlTypeExplicitPrecedenceList(Collections.<SqlTypeName>emptyList());
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/ExpandableHyperContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/ExpandableHyperContainer.java
@@ -19,8 +19,6 @@ package org.apache.drill.exec.record;
 
 import org.apache.drill.exec.vector.ValueVector;
 
-import java.util.LinkedList;
-
 public class ExpandableHyperContainer extends VectorContainer {
 
   public ExpandableHyperContainer() {
@@ -30,12 +28,12 @@ public class ExpandableHyperContainer extends VectorContainer {
   public ExpandableHyperContainer(VectorAccessible batch) {
     super();
     if (batch.getSchema().getSelectionVectorMode() == BatchSchema.SelectionVectorMode.FOUR_BYTE) {
-      for (VectorWrapper w : batch) {
+      for (VectorWrapper<?> w : batch) {
         ValueVector[] hyperVector = w.getValueVectors();
         this.add(hyperVector, true);
       }
     } else {
-      for (VectorWrapper w : batch) {
+      for (VectorWrapper<?> w : batch) {
         ValueVector[] hyperVector = { w.getValueVector() };
         this.add(hyperVector, true);
       }
@@ -45,12 +43,12 @@ public class ExpandableHyperContainer extends VectorContainer {
   public void addBatch(VectorAccessible batch) {
     if (wrappers.size() == 0) {
       if (batch.getSchema().getSelectionVectorMode() == BatchSchema.SelectionVectorMode.FOUR_BYTE) {
-        for (VectorWrapper w : batch) {
+        for (VectorWrapper<?> w : batch) {
           ValueVector[] hyperVector = w.getValueVectors();
           this.add(hyperVector, true);
         }
       } else {
-        for (VectorWrapper w : batch) {
+        for (VectorWrapper<?> w : batch) {
           ValueVector[] hyperVector = { w.getValueVector() };
           this.add(hyperVector, true);
         }
@@ -59,14 +57,14 @@ public class ExpandableHyperContainer extends VectorContainer {
     }
     if (batch.getSchema().getSelectionVectorMode() == BatchSchema.SelectionVectorMode.FOUR_BYTE) {
       int i = 0;
-      for (VectorWrapper w : batch) {
-        HyperVectorWrapper hyperVectorWrapper = (HyperVectorWrapper) wrappers.get(i++);
+      for (VectorWrapper<?> w : batch) {
+        HyperVectorWrapper<?> hyperVectorWrapper = (HyperVectorWrapper<?>) wrappers.get(i++);
         hyperVectorWrapper.addVectors(w.getValueVectors());
       }
     } else {
       int i = 0;
-      for (VectorWrapper w : batch) {
-        HyperVectorWrapper hyperVectorWrapper = (HyperVectorWrapper) wrappers.get(i++);
+      for (VectorWrapper<?> w : batch) {
+        HyperVectorWrapper<?> hyperVectorWrapper = (HyperVectorWrapper<?>) wrappers.get(i++);
         hyperVectorWrapper.addVector(w.getValueVector());
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
@@ -17,16 +17,12 @@
  */
 package org.apache.drill.exec.record;
 
-import java.util.AbstractMap;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.exec.vector.complex.AbstractContainerVector;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
 import org.apache.drill.exec.vector.complex.FieldIdUtil;
-import org.apache.drill.exec.vector.complex.MapVector;
 
 import com.google.common.base.Preconditions;
 
@@ -147,12 +143,13 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
    * Both this and destination must be of same type and have same number of vectors.
    * @param destination destination HyperVectorWrapper.
    */
+  @Override
   public void transfer(VectorWrapper<?> destination) {
     Preconditions.checkArgument(destination instanceof HyperVectorWrapper);
     Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
-    Preconditions.checkArgument(vectors.length == ((HyperVectorWrapper)destination).vectors.length);
+    Preconditions.checkArgument(vectors.length == ((HyperVectorWrapper<?>)destination).vectors.length);
 
-    ValueVector[] destionationVectors = ((HyperVectorWrapper)destination).vectors;
+    ValueVector[] destionationVectors = ((HyperVectorWrapper<?>)destination).vectors;
     for (int i = 0; i < vectors.length; ++i) {
       vectors[i].makeTransferPair(destionationVectors[i]).transfer();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
@@ -17,25 +17,12 @@
  */
 package org.apache.drill.exec.record;
 
-import com.google.common.collect.Lists;
-import org.apache.drill.common.expression.PathSegment;
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.common.types.TypeProtos;
-import org.apache.drill.common.types.TypeProtos.DataMode;
-import org.apache.drill.common.types.TypeProtos.MajorType;
-import org.apache.drill.common.types.TypeProtos.MajorTypeOrBuilder;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.exec.vector.complex.AbstractContainerVector;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
 import org.apache.drill.exec.vector.complex.FieldIdUtil;
-import org.apache.drill.exec.vector.complex.ListVector;
-import org.apache.drill.exec.vector.complex.MapVector;
-import org.apache.drill.exec.vector.complex.UnionVector;
 
-import java.util.List;
 import com.google.common.base.Preconditions;
 
 public class SimpleVectorWrapper<T extends ValueVector> implements VectorWrapper<T>{
@@ -114,10 +101,11 @@ public class SimpleVectorWrapper<T extends ValueVector> implements VectorWrapper
     return FieldIdUtil.getFieldId(getValueVector(), id, expectedPath, false);
   }
 
+  @Override
   public void transfer(VectorWrapper<?> destination) {
     Preconditions.checkArgument(destination instanceof SimpleVectorWrapper);
     Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
-    vector.makeTransferPair(((SimpleVectorWrapper)destination).vector).transfer();
+    vector.makeTransferPair(((SimpleVectorWrapper<?>)destination).vector).transfer();
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/schema/DataRecord.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/schema/DataRecord.java
@@ -41,7 +41,7 @@ public class DataRecord {
             }
         } else {
             if(isList) {
-                ((List)dataMap.get(fieldId)).add(data);
+                ((List<Object>)dataMap.get(fieldId)).add(data);
             } else {
                 throw new IllegalStateException("Overriding field id existing data!");
             }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -42,8 +42,6 @@ import org.glassfish.jersey.server.mvc.Viewable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import static org.apache.drill.exec.server.rest.auth.DrillUserPrincipal.ADMIN_ROLE;
-
 @Path("/")
 @PermitAll
 public class StatusResources {
@@ -63,7 +61,7 @@ public class StatusResources {
   @Path("/options.json")
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.APPLICATION_JSON)
-  public List getSystemOptionsJSON() {
+  public List<OptionWrapper> getSystemOptionsJSON() {
     List<OptionWrapper> options = new LinkedList<>();
     for (OptionValue option : work.getContext().getOptionManager()) {
       options.add(new OptionWrapper(option.name, option.getValue(), option.type, option.kind));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockRecordReader.java
@@ -75,7 +75,7 @@ public class MockRecordReader extends AbstractRecordReader {
       for (int i = 0; i < config.getTypes().length; i++) {
         final MajorType type = config.getTypes()[i].getMajorType();
         final MaterializedField field = getVector(config.getTypes()[i].getName(), type, batchRecordCount);
-        final Class vvClass = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getDataMode());
+        final Class<? extends ValueVector> vvClass = TypeHelper.getValueVectorClass(field.getType().getMinorType(), field.getDataMode());
         valueVectors[i] = output.addField(field, vvClass);
       }
     } catch (SchemaChangeException e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
@@ -326,7 +326,7 @@ public class Metadata {
 
         boolean statsAvailable = (col.getStatistics() != null && !col.getStatistics().isEmpty());
 
-        Statistics stats = col.getStatistics();
+        Statistics<?> stats = col.getStatistics();
         String[] columnName = col.getPath().toArray();
         SchemaPath columnSchemaName = SchemaPath.getCompoundPath(columnName);
         ColumnTypeMetadata_v2 columnTypeMetadata =
@@ -1012,6 +1012,7 @@ public class Metadata {
       return nulls;
     }
 
+    @Override
     public boolean hasSingleValue() {
       return (mxValue != null);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
@@ -26,12 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
-import org.apache.calcite.util.Pair;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
@@ -87,21 +81,24 @@ import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.joda.time.DateTimeUtils;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.joda.time.DateTimeUtils;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-
-import org.apache.parquet.schema.OriginalType;
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 @JsonTypeName("parquet-scan")
 public class ParquetGroupScan extends AbstractFileGroupScan {
@@ -216,10 +213,10 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
     this.rowCount = that.rowCount;
     this.rowGroupInfos = that.rowGroupInfos == null ? null : Lists.newArrayList(that.rowGroupInfos);
     this.selectionRoot = that.selectionRoot;
-    this.columnValueCounts = that.columnValueCounts == null ? null : new HashMap(that.columnValueCounts);
-    this.columnTypeMap = that.columnTypeMap == null ? null : new HashMap(that.columnTypeMap);
-    this.partitionValueMap = that.partitionValueMap == null ? null : new HashMap(that.partitionValueMap);
-    this.fileSet = that.fileSet == null ? null : new HashSet(that.fileSet);
+    this.columnValueCounts = that.columnValueCounts == null ? null : new HashMap<>(that.columnValueCounts);
+    this.columnTypeMap = that.columnTypeMap == null ? null : new HashMap<>(that.columnTypeMap);
+    this.partitionValueMap = that.partitionValueMap == null ? null : new HashMap<>(that.partitionValueMap);
+    this.fileSet = that.fileSet == null ? null : new HashSet<>(that.fileSet);
     this.usedMetadataCache = that.usedMetadataCache;
     this.parquetTableMetadata = that.parquetTableMetadata;
   }
@@ -907,6 +904,6 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
 
   @Override
   public List<SchemaPath> getPartitionColumns() {
-    return new ArrayList(columnTypeMap.keySet());
+    return new ArrayList<>(columnTypeMap.keySet());
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BitReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BitReader.java
@@ -19,16 +19,14 @@ package org.apache.drill.exec.store.parquet.columnreaders;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.vector.BitVector;
-import org.apache.drill.exec.vector.ValueVector;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
-final class BitReader extends ColumnReader {
+final class BitReader extends ColumnReader<BitVector> {
 
   BitReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-            boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+            boolean fixedLength, BitVector v, SchemaElement schemaElement) throws ExecutionSetupException {
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
   }
 
@@ -53,7 +51,7 @@ final class BitReader extends ColumnReader {
     // benefit, for now this reader has been moved to use the higher level value
     // by value reader provided by the parquet library.
     for (int i = 0; i < recordsReadInThisIteration; i++){
-      ((BitVector)valueVec).getMutator().setSafe(i + valuesReadInCurrentPass,
+      valueVec.getMutator().setSafe(i + valuesReadInCurrentPass,
             pageReader.valueReader.readBoolean() ? 1 : 0 );
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedByteAlignedReader.java
@@ -17,14 +17,11 @@
  */
 package org.apache.drill.exec.store.parquet.columnreaders;
 
-import io.netty.buffer.DrillBuf;
-
 import java.math.BigDecimal;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.expr.holders.Decimal28SparseHolder;
 import org.apache.drill.exec.expr.holders.Decimal38SparseHolder;
-import org.apache.drill.exec.expr.holders.IntervalHolder;
 import org.apache.drill.exec.store.ParquetOutputRecordWriter;
 import org.apache.drill.exec.store.parquet.ParquetReaderUtility;
 import org.apache.drill.exec.util.DecimalUtility;
@@ -34,20 +31,20 @@ import org.apache.drill.exec.vector.Decimal38SparseVector;
 import org.apache.drill.exec.vector.IntervalVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VariableWidthVector;
-import org.joda.time.DateTimeUtils;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
-import org.apache.parquet.io.api.Binary;
+import org.joda.time.DateTimeUtils;
 
-class FixedByteAlignedReader extends ColumnReader {
+import io.netty.buffer.DrillBuf;
+
+class FixedByteAlignedReader<V extends ValueVector> extends ColumnReader<V> {
 
   protected DrillBuf bytebuf;
 
 
   FixedByteAlignedReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                         boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                         boolean fixedLength, V v, SchemaElement schemaElement) throws ExecutionSetupException {
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
   }
 
@@ -71,7 +68,7 @@ class FixedByteAlignedReader extends ColumnReader {
     vectorData.writeBytes(bytebuf, (int) readStartInBytes, (int) readLength);
   }
 
-  public static class FixedBinaryReader extends FixedByteAlignedReader {
+  public static class FixedBinaryReader extends FixedByteAlignedReader<VariableWidthVector> {
     // TODO - replace this with fixed binary type in drill
     VariableWidthVector castedVector;
 
@@ -95,12 +92,12 @@ class FixedByteAlignedReader extends ColumnReader {
 
   }
 
-  public static abstract class ConvertedReader extends FixedByteAlignedReader {
+  public static abstract class ConvertedReader<V extends ValueVector> extends FixedByteAlignedReader<V> {
 
     protected int dataTypeLengthInBytes;
 
     ConvertedReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                           boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                           boolean fixedLength, V v, SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
     }
 
@@ -120,14 +117,11 @@ class FixedByteAlignedReader extends ColumnReader {
     abstract void addNext(int start, int index);
   }
 
-  public static class DateReader extends ConvertedReader {
-
-    private final DateVector.Mutator mutator;
+  public static class DateReader extends ConvertedReader<DateVector> {
 
     DateReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                    boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                    boolean fixedLength, DateVector v, SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      mutator = ((DateVector) v).getMutator();
     }
 
     @Override
@@ -139,19 +133,16 @@ class FixedByteAlignedReader extends ColumnReader {
         intValue = readIntLittleEndian(bytebuf, start);
       }
 
-      mutator.set(index, DateTimeUtils.fromJulianDay(intValue - ParquetOutputRecordWriter.JULIAN_DAY_EPOC - 0.5));
+      valueVec.getMutator().set(index, DateTimeUtils.fromJulianDay(intValue - ParquetOutputRecordWriter.JULIAN_DAY_EPOC - 0.5));
     }
 
   }
 
-  public static class Decimal28Reader extends ConvertedReader {
-
-    Decimal28SparseVector decimal28Vector;
+  public static class Decimal28Reader extends ConvertedReader<Decimal28SparseVector> {
 
     Decimal28Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                    boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                    boolean fixedLength, Decimal28SparseVector v, SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      decimal28Vector = (Decimal28SparseVector) v;
     }
 
     @Override
@@ -159,19 +150,16 @@ class FixedByteAlignedReader extends ColumnReader {
       int width = Decimal28SparseHolder.WIDTH;
       BigDecimal intermediate = DecimalUtility.getBigDecimalFromDrillBuf(bytebuf, start, dataTypeLengthInBytes,
           schemaElement.getScale());
-      DecimalUtility.getSparseFromBigDecimal(intermediate, decimal28Vector.getBuffer(), index * width, schemaElement.getScale(),
+      DecimalUtility.getSparseFromBigDecimal(intermediate, valueVec.getBuffer(), index * width, schemaElement.getScale(),
               schemaElement.getPrecision(), Decimal28SparseHolder.nDecimalDigits);
     }
   }
 
-  public static class Decimal38Reader extends ConvertedReader {
-
-    Decimal38SparseVector decimal38Vector;
+  public static class Decimal38Reader extends ConvertedReader<Decimal38SparseVector> {
 
     Decimal38Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                    boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                    boolean fixedLength, Decimal38SparseVector v, SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      decimal38Vector = (Decimal38SparseVector) v;
     }
 
     @Override
@@ -179,30 +167,27 @@ class FixedByteAlignedReader extends ColumnReader {
       int width = Decimal38SparseHolder.WIDTH;
       BigDecimal intermediate = DecimalUtility.getBigDecimalFromDrillBuf(bytebuf, start, dataTypeLengthInBytes,
           schemaElement.getScale());
-      DecimalUtility.getSparseFromBigDecimal(intermediate, decimal38Vector.getBuffer(), index * width, schemaElement.getScale(),
+      DecimalUtility.getSparseFromBigDecimal(intermediate, valueVec.getBuffer(), index * width, schemaElement.getScale(),
               schemaElement.getPrecision(), Decimal38SparseHolder.nDecimalDigits);
     }
   }
 
-  public static class IntervalReader extends ConvertedReader {
-    IntervalVector intervalVector;
-
+  public static class IntervalReader extends ConvertedReader<IntervalVector> {
     IntervalReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                   boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                   boolean fixedLength, IntervalVector v, SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      intervalVector = (IntervalVector) v;
     }
 
     @Override
     void addNext(int start, int index) {
       if (usingDictionary) {
         byte[] input = pageReader.dictionaryValueReader.readBytes().getBytes();
-        intervalVector.getMutator().setSafe(index * 12,
+        valueVec.getMutator().setSafe(index * 12,
             ParquetReaderUtility.getIntFromLEBytes(input, 0),
             ParquetReaderUtility.getIntFromLEBytes(input, 4),
             ParquetReaderUtility.getIntFromLEBytes(input, 8));
       }
-      intervalVector.getMutator().setSafe(index, bytebuf.getInt(start), bytebuf.getInt(start + 4), bytebuf.getInt(start + 8));
+      valueVec.getMutator().setSafe(index, bytebuf.getInt(start), bytebuf.getInt(start + 4), bytebuf.getInt(start + 8));
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedWidthRepeatedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedWidthRepeatedReader.java
@@ -21,17 +21,15 @@ import java.io.IOException;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.vector.BaseDataValueVector;
-import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 import org.apache.drill.exec.vector.UInt4Vector;
-
+import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
-public class FixedWidthRepeatedReader extends VarLengthColumn {
+public class FixedWidthRepeatedReader extends VarLengthColumn<RepeatedValueVector> {
 
-  RepeatedValueVector castedRepeatedVector;
-  ColumnReader dataReader;
+  ColumnReader<?> dataReader;
   int dataTypeLengthInBytes;
   // we can do a vector copy of the data once we figure out how much we need to copy
   // this tracks the number of values to transfer (the dataReader will translate this to a number
@@ -48,9 +46,8 @@ public class FixedWidthRepeatedReader extends VarLengthColumn {
   boolean notFishedReadingList;
   byte[] leftOverBytes;
 
-  FixedWidthRepeatedReader(ParquetRecordReader parentReader, ColumnReader dataReader, int dataTypeLengthInBytes, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, RepeatedValueVector valueVector, SchemaElement schemaElement) throws ExecutionSetupException {
+  FixedWidthRepeatedReader(ParquetRecordReader parentReader, ColumnReader<?> dataReader, int dataTypeLengthInBytes, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, RepeatedValueVector valueVector, SchemaElement schemaElement) throws ExecutionSetupException {
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, valueVector, schemaElement);
-    this.castedRepeatedVector = valueVector;
     this.dataTypeLengthInBytes = dataTypeLengthInBytes;
     this.dataReader = dataReader;
     this.dataReader.pageReader.clear();
@@ -66,7 +63,7 @@ public class FixedWidthRepeatedReader extends VarLengthColumn {
     bytesReadInCurrentPass = 0;
     valuesReadInCurrentPass = 0;
     pageReader.valuesReadyToRead = 0;
-    dataReader.vectorData = BaseDataValueVector.class.cast(castedRepeatedVector.getDataVector()).getBuffer();
+    dataReader.vectorData = BaseDataValueVector.class.cast(valueVec.getDataVector()).getBuffer();
     dataReader.valuesReadInCurrentPass = 0;
     repeatedGroupsReadInCurrentPass = 0;
   }
@@ -145,12 +142,10 @@ public class FixedWidthRepeatedReader extends VarLengthColumn {
 
   @Override
   protected boolean readAndStoreValueSizeInformation() {
-    boolean readingValsAcrossPageBoundary = false;
     int numLeftoverVals = 0;
     if (notFishedReadingList) {
       numLeftoverVals = repeatedValuesInCurrentList;
       readRecords(numLeftoverVals);
-      readingValsAcrossPageBoundary = true;
       notFishedReadingList = false;
       pageReader.valuesReadyToRead = 0;
       try {
@@ -196,12 +191,8 @@ public class FixedWidthRepeatedReader extends VarLengthColumn {
     } else {
       repeatedValuesInCurrentList = 0;
     }
-    int currentValueListLength = repeatedValuesInCurrentList;
-    if (readingValsAcrossPageBoundary) {
-      currentValueListLength += numLeftoverVals;
-    }
     // this should not fail
-    final UInt4Vector offsets = castedRepeatedVector.getOffsetVector();
+    final UInt4Vector offsets = valueVec.getOffsetVector();
     offsets.getMutator().setSafe(repeatedGroupsReadInCurrentPass + 1, offsets.getAccessor().get(repeatedGroupsReadInCurrentPass));
     // This field is being referenced in the superclass determineSize method, so we need to set it here
     // again going to make this the length in BYTES to avoid repetitive multiplication/division
@@ -219,13 +210,13 @@ public class FixedWidthRepeatedReader extends VarLengthColumn {
     dataReader.valuesReadInCurrentPass = 0;
     dataReader.readValues(valuesToRead);
     valuesReadInCurrentPass += valuesToRead;
-    castedRepeatedVector.getMutator().setValueCount(repeatedGroupsReadInCurrentPass);
-    castedRepeatedVector.getDataVector().getMutator().setValueCount(valuesReadInCurrentPass);
+    valueVec.getMutator().setValueCount(repeatedGroupsReadInCurrentPass);
+    valueVec.getDataVector().getMutator().setValueCount(valuesReadInCurrentPass);
   }
 
   @Override
   public int capacity() {
-    return BaseDataValueVector.class.cast(castedRepeatedVector.getDataVector()).getBuffer().capacity();
+    return BaseDataValueVector.class.cast(valueVec.getDataVector()).getBuffer().capacity();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableBitReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableBitReader.java
@@ -19,8 +19,6 @@ package org.apache.drill.exec.store.parquet.columnreaders;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.vector.NullableBitVector;
-import org.apache.drill.exec.vector.ValueVector;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -33,10 +31,10 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
  * because page/batch boundaries that do not land on byte boundaries require shifting of all of the values
  * in the next batch.
  */
-final class NullableBitReader extends ColumnReader {
+final class NullableBitReader extends ColumnReader<NullableBitVector> {
 
   NullableBitReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
-                    boolean fixedLength, ValueVector v, SchemaElement schemaElement) throws ExecutionSetupException {
+                    boolean fixedLength, NullableBitVector v, SchemaElement schemaElement) throws ExecutionSetupException {
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
   }
 
@@ -50,7 +48,7 @@ final class NullableBitReader extends ColumnReader {
       defLevel = pageReader.definitionLevels.readInteger();
       // if the value is defined
       if (defLevel == columnDescriptor.getMaxDefinitionLevel()){
-        ((NullableBitVector)valueVec).getMutator().setSafe(i + valuesReadInCurrentPass,
+        valueVec.getMutator().setSafe(i + valuesReadInCurrentPass,
             pageReader.valueReader.readBoolean() ? 1 : 0 );
       }
       // otherwise the value is skipped, because the bit vector indicating nullability is zero filled

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
@@ -17,10 +17,7 @@
  */
 package org.apache.drill.exec.store.parquet.columnreaders;
 
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetStatistics;
 import static org.apache.parquet.column.Encoding.valueOf;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DrillBuf;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -35,13 +32,11 @@ import org.apache.drill.exec.store.parquet.ParquetReaderStats;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.ValuesType;
 import org.apache.parquet.column.page.DictionaryPage;
-import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesReader;
 import org.apache.parquet.format.PageHeader;
@@ -56,13 +51,16 @@ import org.apache.parquet.schema.PrimitiveType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DrillBuf;
+
 // class to keep track of the read position of variable length columns
 final class PageReader {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PageReader.class);
 
   public static final ParquetMetadataConverter METADATA_CONVERTER = ParquetFormatPlugin.parquetMetadataConverter;
 
-  private final ColumnReader parentColumnReader;
+  private final ColumnReader<?> parentColumnReader;
   private final ColumnDataReader dataReader;
 
   // buffer to store bytes of current page
@@ -242,9 +240,6 @@ final class PageReader {
 
     currentPageCount = pageHeader.data_page_header.num_values;
 
-    final int uncompressedPageSize = pageHeader.uncompressed_page_size;
-    final Statistics<?> stats = fromParquetStatistics(pageHeader.data_page_header.getStatistics(), parentColumnReader
-        .getColumnDescriptor().getType());
     final Encoding rlEncoding = METADATA_CONVERTER.getEncoding(pageHeader.data_page_header.repetition_level_encoding);
 
     final Encoding dlEncoding = METADATA_CONVERTER.getEncoding(pageHeader.data_page_header.definition_level_encoding);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetFixedWidthDictionaryReaders.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetFixedWidthDictionaryReaders.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.TimeStampVector;
 import org.apache.drill.exec.vector.TimeVector;
-
 import org.apache.drill.exec.vector.VarBinaryVector;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
@@ -35,15 +34,11 @@ import org.apache.parquet.io.api.Binary;
 
 public class ParquetFixedWidthDictionaryReaders {
 
-  static class DictionaryIntReader extends FixedByteAlignedReader {
-
-    IntVector castedVector;
-
+  static class DictionaryIntReader extends FixedByteAlignedReader<IntVector> {
     DictionaryIntReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                                 ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, IntVector v,
                                 SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -55,21 +50,17 @@ public class ParquetFixedWidthDictionaryReaders {
 
       if (usingDictionary) {
         for (int i = 0; i < recordsReadInThisIteration; i++){
-          castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
+          valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
         }
       }
     }
   }
 
-  static class DictionaryFixedBinaryReader extends FixedByteAlignedReader {
-
-    VarBinaryVector castedVector;
-
+  static class DictionaryFixedBinaryReader extends FixedByteAlignedReader<VarBinaryVector> {
     DictionaryFixedBinaryReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                         ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, VarBinaryVector v,
                         SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -82,7 +73,7 @@ public class ParquetFixedWidthDictionaryReaders {
       readLength = (int) Math.ceil(readLengthInBits / 8.0);
 
       if (usingDictionary) {
-        VarBinaryVector.Mutator mutator =  castedVector.getMutator();
+        VarBinaryVector.Mutator mutator =  valueVec.getMutator();
         Binary currDictValToWrite = null;
         for (int i = 0; i < recordsReadInThisIteration; i++){
           currDictValToWrite = pageReader.dictionaryValueReader.readBytes();
@@ -92,8 +83,8 @@ public class ParquetFixedWidthDictionaryReaders {
         // Set the write Index. The next page that gets read might be a page that does not use dictionary encoding
         // and we will go into the else condition below. The readField method of the parent class requires the
         // writer index to be set correctly.
-        int writerIndex = castedVector.getBuffer().writerIndex();
-        castedVector.getBuffer().setIndex(0, writerIndex + (int)readLength);
+        int writerIndex = valueVec.getBuffer().writerIndex();
+        valueVec.getBuffer().setIndex(0, writerIndex + (int)readLength);
       } else {
         super.readField(recordsToReadInThisPass);
       }
@@ -102,20 +93,16 @@ public class ParquetFixedWidthDictionaryReaders {
       // now we need to write the lengths of each value
       int byteLength = dataTypeLengthInBits / 8;
       for (int i = 0; i < recordsToReadInThisPass; i++) {
-        castedVector.getMutator().setValueLengthSafe(valuesReadInCurrentPass + i, byteLength);
+        valueVec.getMutator().setValueLengthSafe(valuesReadInCurrentPass + i, byteLength);
       }
     }
   }
 
-  static class DictionaryDecimal9Reader extends FixedByteAlignedReader {
-
-    Decimal9Vector castedVector;
-
+  static class DictionaryDecimal9Reader extends FixedByteAlignedReader<Decimal9Vector> {
     DictionaryDecimal9Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                         ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, Decimal9Vector v,
                         SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -127,21 +114,17 @@ public class ParquetFixedWidthDictionaryReaders {
 
       if (usingDictionary) {
         for (int i = 0; i < recordsReadInThisIteration; i++){
-          castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
+          valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
         }
       }
     }
   }
 
-  static class DictionaryTimeReader extends FixedByteAlignedReader {
-
-    TimeVector castedVector;
-
+  static class DictionaryTimeReader extends FixedByteAlignedReader<TimeVector> {
     DictionaryTimeReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                         ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, TimeVector v,
                         SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -153,21 +136,17 @@ public class ParquetFixedWidthDictionaryReaders {
 
       if (usingDictionary) {
         for (int i = 0; i < recordsReadInThisIteration; i++){
-          castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
+          valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readInteger());
         }
       }
     }
   }
 
-  static class DictionaryBigIntReader extends FixedByteAlignedReader {
-
-    BigIntVector castedVector;
-
+  static class DictionaryBigIntReader extends FixedByteAlignedReader<BigIntVector> {
     DictionaryBigIntReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                                    ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, BigIntVector v,
                                    SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -179,7 +158,7 @@ public class ParquetFixedWidthDictionaryReaders {
 
       for (int i = 0; i < recordsReadInThisIteration; i++){
         try {
-        castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
+        valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
         } catch ( Exception ex) {
           throw ex;
         }
@@ -187,15 +166,11 @@ public class ParquetFixedWidthDictionaryReaders {
     }
   }
 
-  static class DictionaryDecimal18Reader extends FixedByteAlignedReader {
-
-    Decimal18Vector castedVector;
-
+  static class DictionaryDecimal18Reader extends FixedByteAlignedReader<Decimal18Vector> {
     DictionaryDecimal18Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                            ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, Decimal18Vector v,
                            SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -207,7 +182,7 @@ public class ParquetFixedWidthDictionaryReaders {
 
       for (int i = 0; i < recordsReadInThisIteration; i++){
         try {
-          castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
+          valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
         } catch ( Exception ex) {
           throw ex;
         }
@@ -215,15 +190,11 @@ public class ParquetFixedWidthDictionaryReaders {
     }
   }
 
-  static class DictionaryTimeStampReader extends FixedByteAlignedReader {
-
-    TimeStampVector castedVector;
-
+  static class DictionaryTimeStampReader extends FixedByteAlignedReader<TimeStampVector> {
     DictionaryTimeStampReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                            ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, TimeStampVector v,
                            SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -235,7 +206,7 @@ public class ParquetFixedWidthDictionaryReaders {
 
       for (int i = 0; i < recordsReadInThisIteration; i++){
         try {
-          castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
+          valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readLong());
         } catch ( Exception ex) {
           throw ex;
         }
@@ -243,15 +214,11 @@ public class ParquetFixedWidthDictionaryReaders {
     }
   }
 
-  static class DictionaryFloat4Reader extends FixedByteAlignedReader {
-
-    Float4Vector castedVector;
-
+  static class DictionaryFloat4Reader extends FixedByteAlignedReader<Float4Vector> {
     DictionaryFloat4Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                                    ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, Float4Vector v,
                                    SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -261,20 +228,16 @@ public class ParquetFixedWidthDictionaryReaders {
           - pageReader.valuesRead, recordsToReadInThisPass - valuesReadInCurrentPass);
 
       for (int i = 0; i < recordsReadInThisIteration; i++){
-        castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readFloat());
+        valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readFloat());
       }
     }
   }
 
-  static class DictionaryFloat8Reader extends FixedByteAlignedReader {
-
-    Float8Vector castedVector;
-
+  static class DictionaryFloat8Reader extends FixedByteAlignedReader<Float8Vector> {
     DictionaryFloat8Reader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                                    ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, Float8Vector v,
                                    SchemaElement schemaElement) throws ExecutionSetupException {
       super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
-      castedVector = v;
     }
 
     // this method is called by its superclass during a read loop
@@ -284,7 +247,7 @@ public class ParquetFixedWidthDictionaryReaders {
           - pageReader.valuesRead, recordsToReadInThisPass - valuesReadInCurrentPass);
 
       for (int i = 0; i < recordsReadInThisIteration; i++){
-        castedVector.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readDouble());
+        valueVec.getMutator().setSafe(valuesReadInCurrentPass + i, pageReader.dictionaryValueReader.readDouble());
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLengthColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLengthColumn.java
@@ -21,14 +21,13 @@ import java.io.IOException;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.vector.ValueVector;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.Encoding;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.io.api.Binary;
 
-public abstract class VarLengthColumn<V extends ValueVector> extends ColumnReader {
+public abstract class VarLengthColumn<V extends ValueVector> extends ColumnReader<V> {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VarLengthColumn.class);
 
   Binary currDictVal;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
@@ -26,18 +26,18 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.server.DrillbitContext;
 
+import com.carrotsearch.hppc.cursors.ObjectLongCursor;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
-import org.apache.drill.exec.server.DrillbitContext;
+import com.google.common.collect.Maps;
 
 /**
  * The AssignmentCreator is responsible for assigning a set of work units to the available slices.
@@ -96,7 +96,7 @@ public class AssignmentCreator<T extends CompleteWork> {
     if (useOldAssignmentCode) {
       return OldAssignmentCreator.getMappings(incomingEndpoints, units);
     } else {
-      AssignmentCreator<T> creator = new AssignmentCreator(incomingEndpoints, units);
+      AssignmentCreator<T> creator = new AssignmentCreator<>(incomingEndpoints, units);
       return creator.getMappings();
     }
   }
@@ -185,20 +185,20 @@ public class AssignmentCreator<T extends CompleteWork> {
       for (ObjectLongCursor<DrillbitEndpoint> cursor : work.getByteMap()) {
         final DrillbitEndpoint ep = cursor.key;
         final Long val = cursor.value;
-        Map.Entry<DrillbitEndpoint,Long> entry = new Entry() {
+        Map.Entry<DrillbitEndpoint,Long> entry = new Entry<DrillbitEndpoint, Long>() {
 
           @Override
-          public Object getKey() {
+          public DrillbitEndpoint getKey() {
             return ep;
           }
 
           @Override
-          public Object getValue() {
+          public Long getValue() {
             return val;
           }
 
           @Override
-          public Object setValue(Object value) {
+          public Long setValue(Long value) {
             throw new UnsupportedOperationException();
           }
         };

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -98,7 +98,7 @@ public enum SystemTable {
     return distributed;
   }
 
-  public Class getPojoClass() {
+  public Class<?> getPojoClass() {
     return pojoClass;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/CopyUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/CopyUtil.java
@@ -28,7 +28,7 @@ import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JVar;
 
 public class CopyUtil {
-  public static void generateCopies(ClassGenerator g, VectorAccessible batch, boolean hyper){
+  public static void generateCopies(ClassGenerator<?> g, VectorAccessible batch, boolean hyper){
     // we have parallel ids for each value vector so we don't actually have to deal with managing the ids at all.
     int fieldId = 0;
 

--- a/exec/java-exec/src/main/java/org/apache/parquet/hadoop/ColumnChunkIncReadStore.java
+++ b/exec/java-exec/src/main/java/org/apache/parquet/hadoop/ColumnChunkIncReadStore.java
@@ -17,7 +17,7 @@
  */
 package org.apache.parquet.hadoop;
 
-import io.netty.buffer.ByteBuf;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetStatistics;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,13 +27,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.store.parquet.ColumnDataReader;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.DataPage;
@@ -50,7 +48,7 @@ import org.apache.parquet.hadoop.CodecFactory.BytesDecompressor;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.util.CompatibilityUtil;
 
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetStatistics;
+import io.netty.buffer.ByteBuf;
 
 
 public class ColumnChunkIncReadStore implements PageReadStore {
@@ -62,7 +60,7 @@ public class ColumnChunkIncReadStore implements PageReadStore {
   private FileSystem fs;
   private Path path;
   private long rowCount;
-  private List<FSDataInputStream> streams = new ArrayList();
+  private List<FSDataInputStream> streams = new ArrayList<>();
 
   public ColumnChunkIncReadStore(long rowCount, CodecFactory codecFactory, BufferAllocator allocator,
       FileSystem fs, Path path) {
@@ -239,7 +237,7 @@ public class ColumnChunkIncReadStore implements PageReadStore {
     }
   }
 
-  private Map<ColumnDescriptor, ColumnChunkIncPageReader> columns = new HashMap();
+  private Map<ColumnDescriptor, ColumnChunkIncPageReader> columns = new HashMap<>();
 
   public void addColumn(ColumnDescriptor descriptor, ColumnChunkMetaData metaData) throws IOException {
     FSDataInputStream in = fs.open(path);

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFrameworkTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFrameworkTest.java
@@ -24,12 +24,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos;
@@ -37,6 +36,8 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+
+import com.google.common.collect.Lists;
 
 // TODO - update framework to remove any dependency on the Drill engine for reading baseline result sets
 // currently using it with the assumption that the csv and json readers are well tested, and handling diverse
@@ -79,7 +80,7 @@ public class TestFrameworkTest extends BaseTestQuery{
     testBuilder()
         .sqlQuery(query)
         .schemaBaseLine(expectedSchema)
-        .baselineRecords(new ArrayList<Map>())
+        .baselineRecords(Collections.<Map<String, Object>>emptyList())
         .build()
         .run();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/HyperVectorValueIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/HyperVectorValueIterator.java
@@ -17,15 +17,15 @@
  ******************************************************************************/
 package org.apache.drill.exec;
 
+import java.util.Iterator;
+
 import org.apache.drill.exec.record.HyperVectorWrapper;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.ValueVector;
 
-import java.util.Iterator;
-
 public class HyperVectorValueIterator implements Iterator<Object> {
   private MaterializedField mf;
-  private HyperVectorWrapper hyperVector;
+  private HyperVectorWrapper<?> hyperVector;
   private int indexInVectorList;
   private int indexInCurrentVector;
   private ValueVector currVec;
@@ -34,7 +34,7 @@ public class HyperVectorValueIterator implements Iterator<Object> {
   // limit how many values will be read out of this iterator
   private long recordLimit;
 
-  public HyperVectorValueIterator(MaterializedField mf, HyperVectorWrapper hyperVector) {
+  public HyperVectorValueIterator(MaterializedField mf, HyperVectorWrapper<?> hyperVector) {
     this.mf = mf;
     this.hyperVector = hyperVector;
     this.totalValues = 0;
@@ -47,7 +47,7 @@ public class HyperVectorValueIterator implements Iterator<Object> {
     this.recordLimit = limit;
   }
 
-  public HyperVectorWrapper getHyperVector() {
+  public HyperVectorWrapper<?> getHyperVector() {
     return hyperVector;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
@@ -21,7 +21,8 @@ import static org.apache.drill.TestBuilder.listOf;
 import static org.apache.drill.TestBuilder.mapOf;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.Lists;
+import java.util.List;
+
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.TestBuilder;
 import org.apache.drill.common.util.FileUtils;
@@ -32,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.List;
+import com.google.common.collect.Lists;
 
 public class TestFlatten extends BaseTestQuery {
 
@@ -118,7 +119,7 @@ public class TestFlatten extends BaseTestQuery {
         mapOf("nested_list_col", 999,  "list_col", 9, "a", 1, "b",2)
     );
     int i = 0;
-    for (JsonStringHashMap record : result) {
+    for (JsonStringHashMap<String, Object> record : result) {
       assertEquals(record, expectedResult.get(i));
       i++;
     }
@@ -136,9 +137,9 @@ public class TestFlatten extends BaseTestQuery {
       String flattenedDataColName) {
     List<JsonStringHashMap<String,Object>> output = Lists.newArrayList();
     for (JsonStringHashMap<String, Object> incomingRecord : incomingRecords) {
-      List dataToFlatten = (List) incomingRecord.get(colToFlatten);
+      List<?> dataToFlatten = (List<?>) incomingRecord.get(colToFlatten);
       for (int i = 0; i < dataToFlatten.size(); i++) {
-        final JsonStringHashMap newRecord = new JsonStringHashMap();
+        final JsonStringHashMap<String, Object> newRecord = new JsonStringHashMap<>();
         newRecord.put(flattenedDataColName, dataToFlatten.get(i));
         for (String s : incomingRecord.keySet()) {
           if (s.equals(colToFlatten)) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
@@ -23,9 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import mockit.Injectable;
-import mockit.NonStrictExpectations;
-
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.scanner.ClassPathScanner;
 import org.apache.drill.common.util.FileUtils;
@@ -59,6 +56,9 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
+import mockit.Injectable;
+import mockit.NonStrictExpectations;
+
 
 public class TestMergeJoin extends PopUnitTestBase {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestMergeJoin.class);
@@ -91,7 +91,7 @@ public class TestMergeJoin extends PopUnitTestBase {
       }
       System.out.println("\n");
       for (int valueIdx = 0; valueIdx < exec.getRecordCount(); valueIdx++) {
-        final List<Object> row = new ArrayList();
+        final List<Object> row = new ArrayList<>();
         for (final ValueVector v : exec) {
            row.add(v.getAccessor().getObject(valueIdx));
         }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSort.java
@@ -29,8 +29,8 @@ import org.junit.Test;
  */
 public class TestSort extends BaseTestQuery {
 
-  private static final JsonStringHashMap x = new JsonStringHashMap();
-  private static final JsonStringArrayList<JsonStringHashMap> repeated_map = new JsonStringArrayList<>();
+  private static final JsonStringHashMap<String, Object> x = new JsonStringHashMap<>();
+  private static final JsonStringArrayList<JsonStringHashMap<String, Object>> repeated_map = new JsonStringArrayList<>();
 
   static {
     x.put("c", 1l);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestDirectoryExplorerUDFs.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestDirectoryExplorerUDFs.java
@@ -90,7 +90,7 @@ public class TestDirectoryExplorerUDFs extends PlanTestBase {
           excludedPatterns.toArray(excludedArray));
     }
 
-    JsonStringArrayList list = new JsonStringArrayList();
+    JsonStringArrayList<Text> list = new JsonStringArrayList<>();
 
     list.add(new Text("1"));
     list.add(new Text("2"));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.record.vector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import io.netty.buffer.DrillBuf;
 
 import java.nio.charset.Charset;
 
@@ -66,6 +65,8 @@ import org.junit.Test;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+
+import io.netty.buffer.DrillBuf;
 
 public class TestValueVector extends ExecTest {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestValueVector.class);
@@ -744,7 +745,7 @@ the interface to load has changed
     final VectorVerifier noChild = new ChildVerifier();
     final VectorVerifier offsetChild = new ChildVerifier(UInt4Holder.TYPE);
 
-    final ImmutableMap.Builder<Class, VectorVerifier> builder = ImmutableMap.builder();
+    final ImmutableMap.Builder<Class<? extends ValueVector>, VectorVerifier> builder = ImmutableMap.builder();
     builder.put(UInt4Vector.class, noChild);
     builder.put(BitVector.class, noChild);
     builder.put(VarCharVector.class, offsetChild);
@@ -752,14 +753,14 @@ the interface to load has changed
     builder.put(RepeatedListVector.class, new ChildVerifier(UInt4Holder.TYPE, Types.LATE_BIND_TYPE));
     builder.put(MapVector.class, noChild);
     builder.put(RepeatedMapVector.class, offsetChild);
-    final ImmutableMap<Class, VectorVerifier> children = builder.build();
+    final ImmutableMap<Class<? extends ValueVector>, VectorVerifier> children = builder.build();
 
     testVectors(new VectorVerifier() {
 
       @Override
       public void verify(ValueVector vector) throws Exception {
 
-        final Class klazz = vector.getClass();
+        final Class<?> klazz = vector.getClass();
         final VectorVerifier verifier = children.get(klazz);
         verifier.verify(vector);
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
@@ -79,7 +79,7 @@ public class TestAffinityCalculator extends ExecTest {
   }
 
   public LinkedList<CoordinationProtos.DrillbitEndpoint> buildEndpoints(int numberOfEndpoints) {
-    LinkedList<CoordinationProtos.DrillbitEndpoint> endPoints = new LinkedList();
+    LinkedList<CoordinationProtos.DrillbitEndpoint> endPoints = new LinkedList<>();
 
     for (int i = 0; i < numberOfEndpoints; i++) {
       endPoints.add(CoordinationProtos.DrillbitEndpoint.newBuilder().setAddress("host" + i).build());
@@ -155,7 +155,7 @@ public class TestAffinityCalculator extends ExecTest {
     }
     ImmutableRangeMap<Long,BlockLocation> map = blockMapBuilder.build();
     long tB = System.nanoTime();
-    System.out.println(String.format("Took %f ms to build range map", (float)(tB - tA) / 1e6));
+    System.out.println(String.format("Took %f ms to build range map", (tB - tA) / 1e6));
   }
   /*
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/Controls.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/Controls.java
@@ -17,10 +17,11 @@
  */
 package org.apache.drill.exec.testing;
 
-import com.google.common.collect.Lists;
+import java.util.List;
+
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 
-import java.util.List;
+import com.google.common.collect.Lists;
 
 public class Controls {
 
@@ -131,7 +132,7 @@ public class Controls {
      * @param nSkip     number of times to skip before firing
      * @return this builder
      */
-    public Builder addPause(final Class siteClass, final String desc, final int nSkip) {
+    public Builder addPause(final Class<?> siteClass, final String desc, final int nSkip) {
       injections.add(ControlsInjectionUtil.createPause(siteClass, desc, nSkip));
       return this;
     }
@@ -144,7 +145,7 @@ public class Controls {
      * @param desc      descriptor for the pause site in the site class
      * @return this builder
      */
-    public Builder addPause(final Class siteClass, final String desc) {
+    public Builder addPause(final Class<?> siteClass, final String desc) {
       return addPause(siteClass, desc, 0);
     }
 
@@ -156,7 +157,7 @@ public class Controls {
      * @param nSkip     number of times to skip before firing
      * @return this builder
      */
-    public Builder addPauseOnBit(final Class siteClass, final String desc,
+    public Builder addPauseOnBit(final Class<?> siteClass, final String desc,
                                  final DrillbitEndpoint endpoint, final int nSkip) {
       injections.add(ControlsInjectionUtil.createPauseOnBit(siteClass, desc, nSkip, endpoint));
       return this;
@@ -170,7 +171,7 @@ public class Controls {
      * @param desc      descriptor for the pause site in the site class
      * @return this builder
      */
-    public Builder addPauseOnBit(final Class siteClass, final String desc,
+    public Builder addPauseOnBit(final Class<?> siteClass, final String desc,
                                  final DrillbitEndpoint endpoint) {
       return addPauseOnBit(siteClass, desc, endpoint, 0);
     }
@@ -182,7 +183,7 @@ public class Controls {
      * @param desc      descriptor for the latch in the site class
      * @return this builder
      */
-    public Builder addLatch(final Class siteClass, final String desc) {
+    public Builder addLatch(final Class<?> siteClass, final String desc) {
       injections.add(ControlsInjectionUtil.createLatch(siteClass, desc));
       return this;
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
@@ -17,6 +17,12 @@
  */
 package org.apache.drill.exec.testing;
 
+import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROLS_VALIDATOR;
+import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROL_INJECTIONS;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.UserBitShared;
@@ -26,12 +32,6 @@ import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.rpc.user.UserSession.QueryCountIncrementer;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
-
-import java.util.List;
-
-import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROLS_VALIDATOR;
-import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROL_INJECTIONS;
-import static org.junit.Assert.fail;
 
 /**
  * Static methods for constructing exception and pause injections for testing purposes.
@@ -130,7 +130,7 @@ public class ControlsInjectionUtil {
    * Create a pause injection. Note this format is not directly accepted by the injection mechanism. Use the
    * {@link Controls} to build exceptions.
    */
-  public static String createPause(final Class siteClass, final String desc, final int nSkip) {
+  public static String createPause(final Class<?> siteClass, final String desc, final int nSkip) {
     return "{ \"type\" : \"pause\"," +
       "\"siteClass\" : \"" + siteClass.getName() + "\","
       + "\"desc\" : \"" + desc + "\","
@@ -141,7 +141,7 @@ public class ControlsInjectionUtil {
    * Create a pause injection on a specific bit. Note this format is not directly accepted by the injection
    * mechanism. Use the {@link Controls} to build exceptions.
    */
-  public static String createPauseOnBit(final Class siteClass, final String desc, final int nSkip,
+  public static String createPauseOnBit(final Class<?> siteClass, final String desc, final int nSkip,
                                         final DrillbitEndpoint endpoint) {
     return "{ \"type\" : \"pause\"," +
       "\"siteClass\" : \"" + siteClass.getName() + "\","
@@ -155,7 +155,7 @@ public class ControlsInjectionUtil {
    * Create a latch injection. Note this format is not directly accepted by the injection mechanism. Use the
    * {@link Controls} to build exceptions.
    */
-  public static String createLatch(final Class siteClass, final String desc) {
+  public static String createLatch(final Class<?> siteClass, final String desc) {
     return "{ \"type\":\"latch\"," +
       "\"siteClass\":\"" + siteClass.getName() + "\","
       + "\"desc\":\"" + desc + "\"}";

--- a/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
+++ b/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
@@ -108,7 +108,7 @@ public class ITTestShadedJar {
     try {
       Field f = ClassLoader.class.getDeclaredField("classes");
       f.setAccessible(true);
-      Vector<Class> classes = (Vector<Class>) f.get(classLoader);
+      Vector<Class<?>> classes = (Vector<Class<?>>) f.get(classLoader);
       return classes.size();
     } catch (Exception e) {
       System.out.println("Failure while loading class count.");
@@ -120,7 +120,7 @@ public class ITTestShadedJar {
     try {
       Field f = ClassLoader.class.getDeclaredField("classes");
       f.setAccessible(true);
-      Vector<Class> classes = (Vector<Class>) f.get(classLoader);
+      Vector<Class<?>> classes = (Vector<Class<?>>) f.get(classLoader);
       for (Class<?> c : classes) {
         System.out.println(prefix + ": " + c.getName());
       }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
@@ -102,7 +102,7 @@ public abstract class BasicClient<T extends EnumLite, R extends RemoteConnection
             }
 
             pipe.addLast("message-handler", new InboundHandler(connection));
-            pipe.addLast("exception-handler", new RpcExceptionHandler(connection));
+            pipe.addLast("exception-handler", new RpcExceptionHandler<R>(connection));
           }
         }); //
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
@@ -92,7 +92,7 @@ public abstract class BasicServer<T extends EnumLite, C extends RemoteConnection
             }
 
             pipe.addLast("message-handler", new InboundHandler(connection));
-            pipe.addLast("exception-handler", new RpcExceptionHandler(connection));
+            pipe.addLast("exception-handler", new RpcExceptionHandler<C>(connection));
 
             connect = true;
 //            logger.debug("Server connection initialization completed.");
@@ -104,7 +104,7 @@ public abstract class BasicServer<T extends EnumLite, C extends RemoteConnection
 //     }
   }
 
-  private class LogggingReadTimeoutHandler<C extends RemoteConnection> extends ReadTimeoutHandler {
+  private class LogggingReadTimeoutHandler extends ReadTimeoutHandler {
 
     private final C connection;
     private final int timeoutSeconds;

--- a/exec/vector/src/main/codegen/templates/BasicTypeHelper.java
+++ b/exec/vector/src/main/codegen/templates/BasicTypeHelper.java
@@ -73,7 +73,7 @@ public class BasicTypeHelper {
   }
   
   
-  public static Class<?> getValueVectorClass(MinorType type, DataMode mode){
+  public static Class<? extends ValueVector> getValueVectorClass(MinorType type, DataMode mode){
     switch (type) {
     case UNION:
       return UnionVector.class;

--- a/exec/vector/src/main/codegen/templates/UnionVector.java
+++ b/exec/vector/src/main/codegen/templates/UnionVector.java
@@ -236,7 +236,7 @@ public class UnionVector implements ValueVector {
     String name = v.getField().getType().getMinorType().name().toLowerCase();
     MajorType type = v.getField().getType();
     Preconditions.checkState(internalMap.getChild(name) == null, String.format("%s vector already exists", name));
-    final ValueVector newVector = internalMap.addOrGet(name, type, (Class<ValueVector>) BasicTypeHelper.getValueVectorClass(type.getMinorType(), type.getMode()));
+    final ValueVector newVector = internalMap.addOrGet(name, type, BasicTypeHelper.getValueVectorClass(type.getMinorType(), type.getMode()));
     v.makeTransferPair(newVector).transfer();
     internalMap.putChild(name, newVector);
     addSubType(v.getField().getType().getMinorType());

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringArrayList.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringArrayList.java
@@ -42,7 +42,7 @@ public class JsonStringArrayList<E> extends ArrayList<E> {
     if (!(obj instanceof List)) {
       return false;
     }
-    List other = (List) obj;
+    List<?> other = (List<?>) obj;
     return this.size() == other.size() && this.containsAll(other);
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/JsonStringHashMap.java
@@ -46,7 +46,7 @@ public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
     if (!(obj instanceof Map)) {
       return false;
     }
-    Map other = (Map) obj;
+    Map<?,?> other = (Map<?,?>) obj;
     if (this.size() != other.size()) {
       return false;
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -107,7 +107,7 @@ public class ZeroVector implements ValueVector {
   }
 
   @Override
-  public Iterator iterator() {
+  public Iterator<ValueVector> iterator() {
     return Iterators.emptyIterator();
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/PromotableWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/PromotableWriter.java
@@ -84,16 +84,16 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
     state = State.SINGLE;
     vector = v;
     type = v.getField().getType().getMinorType();
-    Class writerClass = BasicTypeHelper
+    Class<?> writerClass = BasicTypeHelper
         .getWriterImpl(v.getField().getType().getMinorType(), v.getField().getDataMode());
     if (writerClass.equals(SingleListWriter.class)) {
       writerClass = UnionListWriter.class;
     }
-    Class vectorClass = BasicTypeHelper.getValueVectorClass(v.getField().getType().getMinorType(), v.getField()
+    Class<? extends ValueVector> vectorClass = BasicTypeHelper.getValueVectorClass(v.getField().getType().getMinorType(), v.getField()
         .getDataMode());
     try {
-      Constructor constructor = null;
-      for (Constructor c : writerClass.getConstructors()) {
+      Constructor<?> constructor = null;
+      for (Constructor<?> c : writerClass.getConstructors()) {
         if (c.getParameterTypes().length == 3) {
           constructor = c;
         }

--- a/logical/src/main/java/org/apache/drill/common/logical/data/Limit.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/Limit.java
@@ -55,7 +55,7 @@ public class Limit extends SingleInputOperator {
   }
 
   @Override
-  public NodeBuilder nodeBuilder() {
+  public NodeBuilder<Limit> nodeBuilder() {
     return new LimitNodeBuilder();  //To change body of implemented methods use File | Settings | File Templates.
   }
 

--- a/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperator.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperator.java
@@ -48,7 +48,7 @@ public interface LogicalOperator extends GraphValue<LogicalOperator> {
 
   public void registerAsSubscriber(LogicalOperator operator);
 
-  NodeBuilder nodeBuilder();
+  NodeBuilder<?> nodeBuilder();
 
   public interface NodeBuilder<T extends LogicalOperator> {
     ObjectNode convert(ObjectMapper mapper, T operator, Integer inputId);

--- a/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperatorBase.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/LogicalOperatorBase.java
@@ -49,7 +49,7 @@ public abstract class LogicalOperatorBase implements LogicalOperator{
   }
 
   @Override
-  public NodeBuilder nodeBuilder() {
+  public NodeBuilder<?> nodeBuilder() {
     // FIXME: Implement this on all logical operators
     throw new UnsupportedOperationException("Not yet implemented.");
   }


### PR DESCRIPTION
Drill code base references lots of rawtypes, which generates lots of warning from the compiler.

As Drill is now compiled with Java 1.7, most of them can be replaced by generic types.
