### PR TITLE
DRILL-4331: Fix TestFlattenPlanning.testFlattenPlanningAvoidUnnecessaryProject for Java8

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlattenPlanning.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlattenPlanning.java
@@ -24,8 +24,11 @@ public class TestFlattenPlanning extends PlanTestBase {
 
   @Test
   public void testFlattenPlanningAvoidUnnecessaryProject() throws Exception {
-    testPlanSubstrPatterns("select flatten(complex), rownum from cp.`/store/json/test_flatten_mappify2.json`",
-        new String[]{"Project(EXPR$0=[$1], rownum=[$0])"}, new String[]{"Project(EXPR$0=[$0], EXPR$1=[$1], EXPR$3=[$1])"});
+    // Because of Java7 vs Java8 map ordering differences, we check for both cases
+    // See DRILL-4331 for details
+    testPlanMatchingPatterns("select flatten(complex), rownum from cp.`/store/json/test_flatten_mappify2.json`",
+        new String[]{"\\QProject(EXPR$0=[$1], rownum=[$0])\\E|\\QProject(EXPR$0=[$0], rownum=[$1])\\E"},
+        new String[]{"\\QProject(EXPR$0=[$0], EXPR$1=[$1], EXPR$3=[$1])\\E|\\QProject(EXPR$0=[$1], EXPR$1=[$0], EXPR$3=[$0])\\E"});
   }
 
   @Test // DRILL-4121 : push partial filter past projects.


### PR DESCRIPTION
Test TestFlattenPlanning.testFlattenPlanningAvoidUnnecessaryProject fails with Java8
because of Map order differences between Java7 and Java8. Test now checks for both
options.