### PR TITLE
DRILL-4353: Add HttpSessionListener to release resources of expired/invalidated sessions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.server.rest.auth;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.drill.exec.client.DrillClient;
-import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.eclipse.jetty.security.MappedLoginService.RolePrincipal;
 
 import java.security.Principal;
@@ -46,7 +45,7 @@ public class DrillUserPrincipal implements Principal, AutoCloseable {
 
   private final String userName;
   private final boolean isAdmin;
-  private final DrillClient drillClient;
+  private DrillClient drillClient;
 
   public DrillUserPrincipal(final String userName, final boolean isAdmin, final DrillClient drillClient) {
     this.userName = userName;
@@ -88,6 +87,7 @@ public class DrillUserPrincipal implements Principal, AutoCloseable {
   public void close() throws Exception {
     if (drillClient != null) {
       drillClient.close();
+      drillClient = null; // Reset it to null to avoid closing multiple times.
     }
   }
 }


### PR DESCRIPTION
Testing:

Send a curl request (5 secs apart) in a loop for about an hour and session timeout set to 30secs. Observed the openfiles in Drill. Openfile counts stabilizes after first few minutes (as the sessions expire for every 5 seconds after first 30secs and new session created every 5seconds)

@jaltekruse Could you please run the regression suites and review?