### PR TITLE
DRILL-3581: Upgrade Guava, HPPC and Jackson

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -74,12 +74,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     
     <dependency>

--- a/common/src/main/java/org/apache/drill/common/CatastrophicFailure.java
+++ b/common/src/main/java/org/apache/drill/common/CatastrophicFailure.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common;
+
+import java.io.PrintStream;
+
+
+public class CatastrophicFailure {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CatastrophicFailure.class);
+
+  private CatastrophicFailure() {
+  }
+
+  /**
+   * Exit the VM as we hit a catastrophic failure.
+   * @param e
+   *          The Throwable that occurred
+   * @param name
+   *          A descriptive message
+   * @param code
+   *          An error code to exit the VM with.
+   */
+  public static void exit(Throwable e, String message, int code) {
+    logger.error("Catastrophic Failure Occurred, exiting. Information message: {}", message, e);
+
+    final PrintStream out = ("true".equals(System.getProperty("drill.catastrpohic_to_standard_out", "true"))) ? System.out
+        : System.err;
+    out.println("Catastrophic failure occurred. Exiting. Information follows: " + message);
+    e.printStackTrace(out);
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e2) {
+    }
+    System.exit(code);
+  }
+}

--- a/common/src/main/java/org/apache/drill/common/config/DrillConfig.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillConfig.java
@@ -177,7 +177,7 @@ public class DrillConfig extends NestedConfig {
                                     final Properties overriderProps,
                                     final boolean enableServerConfigs) {
     final StringBuilder logString = new StringBuilder();
-    final Stopwatch watch = new Stopwatch().start();
+    final Stopwatch watch = Stopwatch.createStarted();
     overrideFileResourcePathname =
         overrideFileResourcePathname == null
             ? CommonConstants.CONFIG_OVERRIDE_RESOURCE_PATHNAME

--- a/common/src/main/java/org/apache/drill/common/scanner/ClassPathScanner.java
+++ b/common/src/main/java/org/apache/drill/common/scanner/ClassPathScanner.java
@@ -383,7 +383,7 @@ public final class ClassPathScanner {
    * @return the merged scan
    */
   static ScanResult scan(Collection<URL> pathsToScan, Collection<String> packagePrefixes, Collection<String> scannedClasses, Collection<String> scannedAnnotations, ScanResult parentResult) {
-    Stopwatch watch = new Stopwatch().start();
+    Stopwatch watch = Stopwatch.createStarted();
     try {
       AnnotationScanner annotationScanner = new AnnotationScanner(scannedAnnotations);
       SubTypesScanner subTypesScanner = new SubTypesScanner(parentResult.getImplementations());

--- a/common/src/main/java/org/apache/drill/common/scanner/persistence/ScanResult.java
+++ b/common/src/main/java/org/apache/drill/common/scanner/persistence/ScanResult.java
@@ -132,7 +132,7 @@ public final class ScanResult {
    */
   public <T> Set<Class<? extends T>> getImplementations(Class<T> c) {
     ParentClassDescriptor p = getImplementations(c.getName());
-    Stopwatch watch = new Stopwatch().start();
+    Stopwatch watch = Stopwatch.createStarted();
     Set<Class<? extends T>> result = new HashSet<>();
     try {
       if (p != null) {

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -34,6 +34,14 @@
 
   <dependencies>
     <dependency>
+      <!-- used to update stopwatch -->
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.20.0-GA</version>
+      <scope>test</scope>
+    </dependency>
+  
+    <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-java-exec</artifactId>
       <version>${project.version}</version>
@@ -146,12 +154,24 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-testing-util</artifactId>
           <classifier>tests</classifier>
+          <exclusions>
+            <exclusion>
+              <artifactId>log4j</artifactId>
+              <groupId>log4j</groupId>
+            </exclusion>
+          </exclusions>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-hdfs</artifactId>
           <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <artifactId>log4j</artifactId>
+              <groupId>log4j</groupId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
@@ -85,7 +85,7 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
 
   private HBaseStoragePlugin storagePlugin;
 
-  private Stopwatch watch = new Stopwatch();
+  private Stopwatch watch = Stopwatch.createUnstarted();
 
   private Map<Integer, List<HBaseSubScanSpec>> endpointFragmentMapping;
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
@@ -178,8 +178,7 @@ public class HBaseRecordReader extends AbstractRecordReader implements DrillHBas
 
   @Override
   public int next() {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     if (rowKeyVector != null) {
       rowKeyVector.clear();
       rowKeyVector.allocateNew();

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -46,8 +46,11 @@ public class BaseHBaseTest extends BaseTestQuery {
 
   protected static HBaseStoragePluginConfig storagePluginConfig;
 
+
   @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
+  public static void setupDefaultTestCluster() throws Exception {
+    GauavaPatcher.patch();
+
     /*
      * Change the following to HBaseTestsSuite.configure(false, true)
      * if you want to test against an externally running HBase cluster.
@@ -55,12 +58,15 @@ public class BaseHBaseTest extends BaseTestQuery {
     HBaseTestsSuite.configure(true, true);
     HBaseTestsSuite.initCluster();
 
+    BaseTestQuery.setupDefaultTestCluster();
+
     final StoragePluginRegistry pluginRegistry = getDrillbitContext().getStorage();
     storagePlugin = (HBaseStoragePlugin) pluginRegistry.getPlugin(HBASE_STORAGE_PLUGIN_NAME);
     storagePluginConfig = storagePlugin.getConfig();
     storagePluginConfig.setEnabled(true);
     storagePluginConfig.setZookeeperPort(HBaseTestsSuite.getZookeeperPort());
     pluginRegistry.createOrUpdate(HBASE_STORAGE_PLUGIN_NAME, storagePluginConfig, true);
+
   }
 
   @AfterClass
@@ -101,5 +107,7 @@ public class BaseHBaseTest extends BaseTestQuery {
   protected String canonizeHBaseSQL(String sql) {
     return sql.replace("[TABLE_NAME]", HBaseTestsSuite.TEST_TABLE_1);
   }
+
+
 
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/GauavaPatcher.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/GauavaPatcher.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.hbase;
+
+import java.lang.reflect.Modifier;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtConstructor;
+import javassist.CtMethod;
+import javassist.CtNewMethod;
+
+import org.apache.drill.common.CatastrophicFailure;
+
+public class GauavaPatcher {
+
+  private static boolean patched;
+
+  public static synchronized void patch() {
+    if (!patched) {
+      try {
+        patchStopwatch();
+        patchCloseables();
+        patched = true;
+      } catch (Exception e) {
+        CatastrophicFailure.exit(e, "Unable to patch Guava classes.", -100);
+      }
+    }
+  }
+
+  /**
+   * Makes Guava stopwatch look like the old version for compatibility with hbase-server (for test purposes).
+   */
+  private static void patchStopwatch() throws Exception {
+
+    ClassPool cp = ClassPool.getDefault();
+    CtClass cc = cp.get("com.google.common.base.Stopwatch");
+
+    // Expose the constructor for Stopwatch for old libraries who use the pattern new Stopwatch().start().
+    for (CtConstructor c : cc.getConstructors()) {
+      if (!Modifier.isStatic(c.getModifiers())) {
+        c.setModifiers(Modifier.PUBLIC);
+      }
+    }
+
+    // Add back the Stopwatch.elapsedMillis() method for old consumers.
+    CtMethod newmethod = CtNewMethod.make(
+        "public long elapsedMillis() { return elapsed(java.util.concurrent.TimeUnit.MILLISECONDS); }", cc);
+    cc.addMethod(newmethod);
+
+    // Load the modified class instead of the original.
+    cc.toClass();
+
+    System.out.println("Google's Stopwatch patched for old HBase Guava version.");
+  }
+
+  private static void patchCloseables() throws Exception {
+
+    ClassPool cp = ClassPool.getDefault();
+    CtClass cc = cp.get("com.google.common.io.Closeables");
+
+    // Expose the constructor for Stopwatch for old libraries who use the pattern new Stopwatch().start().
+    for (CtConstructor c : cc.getConstructors()) {
+      if (!Modifier.isStatic(c.getModifiers())) {
+        c.setModifiers(Modifier.PUBLIC);
+      }
+    }
+
+    // Add back the Stopwatch.elapsedMillis() method for old consumers.
+    CtMethod newmethod = CtNewMethod.make(
+        "public static void closeQuietly(java.io.Closeable closeable) { try{closeable.close();}catch(Exception e){} }",
+        cc);
+    cc.addMethod(newmethod);
+
+    // Load the modified class instead of the original.
+    cc.toClass();
+
+    System.out.println("Google's Closeables patched for old HBase Guava version.");
+  }
+
+}

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
@@ -81,6 +81,8 @@ public class HBaseTestsSuite {
 
   @BeforeClass
   public static void initCluster() throws Exception {
+    GauavaPatcher.patch();
+
     if (initCount.get() == 0) {
       synchronized (HBaseTestsSuite.class) {
         if (initCount.get() == 0) {

--- a/contrib/storage-hbase/src/test/resources/logback.xml
+++ b/contrib/storage-hbase/src/test/resources/logback.xml
@@ -53,12 +53,14 @@
 
   <logger name="org.apache.hadoop" additivity="false">
     <level value="info" />
-    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="SOCKET" />
   </logger>
 
   <root>
     <level value="error" />
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="SOCKET" />
   </root>
 
 </configuration>

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
@@ -62,7 +62,7 @@ public class HiveMetadataProvider {
   private final HiveConf hiveConf;
   private List<InputSplitWrapper> tableInputSplits;
 
-  private final Stopwatch watch = new Stopwatch();
+  private final Stopwatch watch = Stopwatch.createUnstarted();
 
   public HiveMetadataProvider(final String userName, final HiveReadEntry hiveReadEntry, final HiveConf hiveConf) {
     this.hiveReadEntry = hiveReadEntry;
@@ -81,7 +81,7 @@ public class HiveMetadataProvider {
    * @throws IOException
    */
   public HiveStats getStats(final HiveReadEntry hiveReadEntry) throws IOException {
-    final Stopwatch timeGetStats = new Stopwatch().start();
+    final Stopwatch timeGetStats = Stopwatch.createStarted();
 
     final Table table = hiveReadEntry.getTable();
     try {
@@ -154,7 +154,7 @@ public class HiveMetadataProvider {
    * @return
    */
   public List<InputSplitWrapper> getInputSplits(final HiveReadEntry hiveReadEntry) {
-    final Stopwatch timeGetSplits = new Stopwatch().start();
+    final Stopwatch timeGetSplits = Stopwatch.createStarted();
     try {
       if (!isPartitionedTable) {
         return getTableInputSplits();

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -35,6 +35,12 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -108,7 +108,7 @@ public class MongoGroupScan extends AbstractGroupScan implements
 
   private Map<String, List<ChunkInfo>> chunksInverseMapping;
 
-  private Stopwatch watch = new Stopwatch();
+  private Stopwatch watch = Stopwatch.createUnstarted();
 
   private boolean filterPushedDown = false;
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -176,8 +176,7 @@ public class MongoRecordReader extends AbstractRecordReader {
     writer.reset();
 
     int docCount = 0;
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
 
     try {
       while (docCount < BaseValueVector.INITIAL_VALUE_ALLOCATION && cursor.hasNext()) {

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-afterburner</artifactId>
-      <version>2.4.0</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -342,7 +342,7 @@
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
-      <version>0.4.2</version>
+      <version>0.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -27,6 +27,7 @@
       <version>1.3</version>
       <scope>test</scope>
     </dependency>
+    
     <!-- <dependency> -->
     <!-- <groupId>org.ow2.asm</groupId> -->
     <!-- <artifactId>asm-util</artifactId> -->

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/PrintingResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/PrintingResultsListener.java
@@ -44,7 +44,7 @@ public class PrintingResultsListener implements UserResultsListener {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PrintingResultsListener.class);
 
   private final AtomicInteger count = new AtomicInteger();
-  private final Stopwatch w = new Stopwatch();
+  private final Stopwatch w = Stopwatch.createUnstarted();
   private final RecordBatchLoader loader;
   private final Format format;
   private final int columnWidth;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
@@ -186,7 +186,7 @@ public class QuerySubmitter {
         System.out.println("Invalid format type: " + format);
         return -1;
     }
-    Stopwatch watch = new Stopwatch();
+    Stopwatch watch = Stopwatch.createUnstarted();
     for (String query : queries) {
       AwaitableUserResultsListener listener =
           new AwaitableUserResultsListener(new PrintingResultsListener(client.getConfig(), outputFormat, width));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/InstructionModifier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/InstructionModifier.java
@@ -28,8 +28,8 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.analysis.BasicValue;
 import org.objectweb.asm.tree.analysis.Frame;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
+import com.carrotsearch.hppc.IntIntHashMap;
+import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.cursors.IntIntCursor;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.google.common.base.Preconditions;
@@ -38,9 +38,9 @@ public class InstructionModifier extends MethodVisitor {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InstructionModifier.class);
 
   /* Map from old (reference) local variable index to new local variable information. */
-  private final IntObjectOpenHashMap<ValueHolderIden.ValueHolderSub> oldToNew = new IntObjectOpenHashMap<>();
+  private final IntObjectHashMap<ValueHolderIden.ValueHolderSub> oldToNew = new IntObjectHashMap<>();
 
-  private final IntIntOpenHashMap oldLocalToFirst = new IntIntOpenHashMap();
+  private final IntIntHashMap oldLocalToFirst = new IntIntHashMap();
 
   private final DirectSorter adder;
   private int lastLineNumber = 0; // the last line number seen
@@ -313,7 +313,7 @@ public class InstructionModifier extends MethodVisitor {
 
       // if local var is not set, then check map to see if existing holders are mapped to local var.
       if (oldLocalToFirst.containsKey(var)) {
-        final ValueHolderSub sub = oldToNew.get(oldLocalToFirst.lget());
+        final ValueHolderSub sub = oldToNew.get(oldLocalToFirst.get(var));
         if (sub.iden() == from.iden()) {
           // if they are, then transfer to that.
           from.transfer(this, sub.first());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/ValueHolderIden.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/bytecode/ValueHolderIden.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
-import com.carrotsearch.hppc.ObjectIntOpenHashMap;
+import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.cursors.ObjectIntCursor;
 import com.google.common.collect.Lists;
 
@@ -32,7 +32,7 @@ class ValueHolderIden {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ValueHolderIden.class);
 
   // the index of a field is the number in which it appears within the holder
-  private final ObjectIntOpenHashMap<String> fieldMap; // field name -> index
+  private final ObjectIntHashMap<String> fieldMap; // field name -> index
   private final Type[] types; // the type of each field in the holder, by index
   private final String[] names; // the name of each field in the holder, by index
   private final int[] offsets; // the offset of each field in the holder, by index
@@ -54,7 +54,7 @@ class ValueHolderIden {
     this.types = new Type[fldList.size()];
     this.names = new String[fldList.size()];
     this.offsets = new int[fldList.size()];
-    fieldMap = new ObjectIntOpenHashMap<String>(fldList.size(), 1.0f);
+    fieldMap = new ObjectIntHashMap<String>(fldList.size());
     int i = 0; // index of the next holder member variable
     int offset = 0; // offset of the next holder member variable
     for (Field f : fldList) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -51,7 +51,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext {
   }
 
   public FunctionImplementationRegistry(DrillConfig config, ScanResult classpathScan){
-    Stopwatch w = new Stopwatch().start();
+    Stopwatch w = Stopwatch.createStarted();
 
     logger.debug("Generating function registry.");
     drillFuncRegistry = new DrillFunctionRegistry(classpathScan);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
@@ -33,7 +33,6 @@ import org.codehaus.janino.Scanner;
 import org.mortbay.util.IO;
 
 import com.google.common.collect.Maps;
-import com.google.common.io.InputSupplier;
 import com.google.common.io.Resources;
 
 /**
@@ -125,8 +124,7 @@ public class FunctionInitializer {
     }
 
     URL u = Resources.getResource(c, path);
-    InputSupplier<InputStream> supplier = Resources.newInputStreamSupplier(u);
-    try (InputStream is = supplier.getInput()) {
+    try (InputStream is = Resources.asByteSource(u).openStream()) {
       if (is == null) {
         throw new IOException(String.format(
             "Failure trying to located source code for Class %s, tried to read on classpath location %s", c.getName(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BufferManagerImpl.java
@@ -21,10 +21,10 @@ import io.netty.buffer.DrillBuf;
 
 import org.apache.drill.exec.memory.BufferAllocator;
 
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 
 public class BufferManagerImpl implements BufferManager {
-  private LongObjectOpenHashMap<DrillBuf> managedBuffers = new LongObjectOpenHashMap<>();
+  private LongObjectHashMap<DrillBuf> managedBuffers = new LongObjectHashMap<>();
   private final BufferAllocator allocator;
 
   public BufferManagerImpl(BufferAllocator allocator) {
@@ -33,10 +33,11 @@ public class BufferManagerImpl implements BufferManager {
 
   @Override
   public void close() {
-    final Object[] mbuffers = ((LongObjectOpenHashMap<Object>) (Object) managedBuffers).values;
+    final Object[] mbuffers = ((LongObjectHashMap<Object>) (Object) managedBuffers).values;
     for (int i = 0; i < mbuffers.length; i++) {
-      if (managedBuffers.allocated[i]) {
-        ((DrillBuf) mbuffers[i]).release(1);
+      final DrillBuf buf = (DrillBuf) mbuffers[i];
+      if (buf != null) {
+        buf.release();
       }
     }
     managedBuffers.clear();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
@@ -24,8 +24,8 @@ import org.apache.drill.exec.proto.UserBitShared.MetricValue;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
 import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
 
-import com.carrotsearch.hppc.IntDoubleOpenHashMap;
-import com.carrotsearch.hppc.IntLongOpenHashMap;
+import com.carrotsearch.hppc.IntDoubleHashMap;
+import com.carrotsearch.hppc.IntLongHashMap;
 import com.carrotsearch.hppc.cursors.IntDoubleCursor;
 import com.carrotsearch.hppc.cursors.IntLongCursor;
 
@@ -36,8 +36,8 @@ public class OperatorStats {
   protected final int operatorType;
   private final BufferAllocator allocator;
 
-  private IntLongOpenHashMap longMetrics = new IntLongOpenHashMap();
-  private IntDoubleOpenHashMap doubleMetrics = new IntDoubleOpenHashMap();
+  private IntLongHashMap longMetrics = new IntLongHashMap();
+  private IntDoubleHashMap doubleMetrics = new IntDoubleHashMap();
 
   public long[] recordsReceivedByInput;
   public long[] batchesReceivedByInput;
@@ -107,7 +107,7 @@ public class OperatorStats {
    * @return OperatorStats - for convenience so one can merge multiple stats in one go
    */
   public OperatorStats mergeMetrics(OperatorStats from) {
-    final IntLongOpenHashMap fromMetrics = from.longMetrics;
+    final IntLongHashMap fromMetrics = from.longMetrics;
 
     final Iterator<IntLongCursor> iter = fromMetrics.iterator();
     while (iter.hasNext()) {
@@ -115,7 +115,7 @@ public class OperatorStats {
       longMetrics.putOrAdd(next.key, next.value, next.value);
     }
 
-    final IntDoubleOpenHashMap fromDMetrics = from.doubleMetrics;
+    final IntDoubleHashMap fromDMetrics = from.doubleMetrics;
     final Iterator<IntDoubleCursor> iterD = fromDMetrics.iterator();
 
     while (iterD.hasNext()) {
@@ -217,16 +217,16 @@ public class OperatorStats {
   }
 
   public void addLongMetrics(OperatorProfile.Builder builder) {
-    for(int i =0; i < longMetrics.allocated.length; i++){
-      if(longMetrics.allocated[i]){
+    for (int i = 0; i < longMetrics.keys.length; i++) {
+      if (longMetrics.keys[i] != 0) {
         builder.addMetric(MetricValue.newBuilder().setMetricId(longMetrics.keys[i]).setLongValue(longMetrics.values[i]));
       }
     }
   }
 
   public void addDoubleMetrics(OperatorProfile.Builder builder) {
-    for(int i =0; i < doubleMetrics.allocated.length; i++){
-      if(doubleMetrics.allocated[i]){
+    for (int i = 0; i < longMetrics.keys.length; i++) {
+      if (doubleMetrics.keys[i] != 0) {
         builder.addMetric(MetricValue.newBuilder().setMetricId(doubleMetrics.keys[i]).setDoubleValue(doubleMetrics.values[i]));
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ViewExpansionContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ViewExpansionContext.java
@@ -17,14 +17,15 @@
  */
 package org.apache.drill.exec.ops;
 
-import com.carrotsearch.hppc.ObjectIntOpenHashMap;
-import com.google.common.base.Preconditions;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.drill.common.exceptions.UserException;
+import static org.apache.drill.exec.ExecConstants.IMPERSONATION_MAX_CHAINED_USER_HOPS;
+
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptTable.ToRelContext;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.exceptions.UserException;
 
-import static org.apache.drill.exec.ExecConstants.IMPERSONATION_MAX_CHAINED_USER_HOPS;
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.google.common.base.Preconditions;
 
 /**
  * Contains context information about view expansion(s) in a query. Part of {@link org.apache.drill.exec.ops
@@ -72,7 +73,7 @@ public class ViewExpansionContext {
   private final QueryContext queryContext;
   private final int maxChainedUserHops;
   private final String queryUser;
-  private final ObjectIntOpenHashMap<String> userTokens = new ObjectIntOpenHashMap<>();
+  private final ObjectIntHashMap<String> userTokens = new ObjectIntHashMap<>();
 
   public ViewExpansionContext(QueryContext queryContext) {
     this.queryContext = queryContext;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
@@ -72,8 +72,7 @@ public class ImplCreator {
       root = IteratorValidatorInjector.rewritePlanWithIteratorValidator(context, root);
     }
     final ImplCreator creator = new ImplCreator();
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
 
     try {
       final RootExec rootExec = creator.getRootExec(root, context);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/PriorityQueueTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/PriorityQueueTemplate.java
@@ -88,8 +88,7 @@ public abstract class PriorityQueueTemplate implements PriorityQueue {
 
   @Override
   public void add(FragmentContext context, RecordBatchData batch) throws SchemaChangeException{
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     if (hyperBatch == null) {
       hyperBatch = new ExpandableHyperContainer(batch.getContainer());
     } else {
@@ -124,8 +123,7 @@ public abstract class PriorityQueueTemplate implements PriorityQueue {
 
   @Override
   public void generate() throws SchemaChangeException {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     final DrillBuf drillBuf = allocator.buffer(4 * queueSize);
     finalSv4 = new SelectionVector4(drillBuf, queueSize, 4000);
     for (int i = queueSize - 1; i >= 0; i--) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
@@ -180,8 +180,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
 
     try{
       outer: while (true) {
-        Stopwatch watch = new Stopwatch();
-        watch.start();
+        Stopwatch watch = Stopwatch.createStarted();
         IterOutcome upstream;
         if (first) {
           upstream = IterOutcome.OK_NEW_SCHEMA;
@@ -284,8 +283,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   }
 
   private void purge() throws SchemaChangeException {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     VectorContainer c = priorityQueue.getHyperBatch();
     VectorContainer newContainer = new VectorContainer(oContext);
     SelectionVector4 selectionVector4 = priorityQueue.getHeapSv4();
@@ -380,8 +378,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
    * @throws SchemaChangeException
    */
   public void purgeAndResetPriorityQueue() throws SchemaChangeException, ClassTransformationException, IOException {
-    final Stopwatch watch = new Stopwatch();
-    watch.start();
+    final Stopwatch watch = Stopwatch.createStarted();
     final VectorContainer c = priorityQueue.getHyperBatch();
     final VectorContainer newContainer = new VectorContainer(oContext);
     final SelectionVector4 selectionVector4 = priorityQueue.getHeapSv4();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
@@ -20,8 +20,6 @@ package org.apache.drill.exec.physical.impl.flatten;
 import java.io.IOException;
 import java.util.List;
 
-import com.carrotsearch.hppc.IntOpenHashSet;
-
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
@@ -49,11 +47,12 @@ import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.record.TypedFieldId;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
-import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector;
+import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
+import com.carrotsearch.hppc.IntHashSet;
 import com.google.common.collect.Lists;
 import com.sun.codemodel.JExpr;
 
@@ -285,7 +284,7 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
     final List<TransferPair> transfers = Lists.newArrayList();
 
     final ClassGenerator<Flattener> cg = CodeGenerator.getRoot(Flattener.TEMPLATE_DEFINITION, context.getFunctionRegistry());
-    final IntOpenHashSet transferFieldIds = new IntOpenHashSet();
+    final IntHashSet transferFieldIds = new IntHashSet();
 
     final NamedExpression flattenExpr = new NamedExpression(popConfig.getColumn(), new FieldReference(popConfig.getColumn()));
     final ValueVectorReadExpression vectorRead = (ValueVectorReadExpression)ExpressionTreeMaterializer.materialize(flattenExpr.getExpr(), incoming, collector, context.getFunctionRegistry(), true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -26,7 +26,6 @@ import org.apache.drill.common.expression.ConvertExpression;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.ExpressionPosition;
-import org.apache.drill.common.expression.ExpressionStringBuilder;
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.FunctionCallFactory;
@@ -38,7 +37,6 @@ import org.apache.drill.common.expression.fn.CastFunctions;
 import org.apache.drill.common.logical.data.NamedExpression;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.exception.SchemaChangeException;
@@ -47,7 +45,6 @@ import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.expr.DrillFuncHolderExpr;
 import org.apache.drill.exec.expr.ExpressionTreeMaterializer;
-import org.apache.drill.exec.expr.HashVisitor;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.expr.ValueVectorReadExpression;
 import org.apache.drill.exec.expr.ValueVectorWriteExpression;
@@ -68,7 +65,7 @@ import org.apache.drill.exec.vector.FixedWidthVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 
-import com.carrotsearch.hppc.IntOpenHashSet;
+import com.carrotsearch.hppc.IntHashSet;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -299,7 +296,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
     final ClassGenerator<Projector> cg = CodeGenerator.getRoot(Projector.TEMPLATE_DEFINITION, context.getFunctionRegistry());
 
-    final IntOpenHashSet transferFieldIds = new IntOpenHashSet();
+    final IntHashSet transferFieldIds = new IntHashSet();
 
     final boolean isAnyWildcard = isAnyWildcard(exprs);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortTemplate.java
@@ -47,8 +47,7 @@ public abstract class SortTemplate implements Sorter, IndexedSortable{
 
   @Override
   public void sort(SelectionVector4 vector4, VectorContainer container){
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     QuickSort qs = new QuickSort();
     qs.sort(this, 0, vector4.getTotalCount());
     logger.debug("Took {} us to sort {} records", watch.elapsed(TimeUnit.MICROSECONDS), vector4.getTotalCount());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/BatchGroup.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/BatchGroup.java
@@ -92,8 +92,7 @@ public class BatchGroup implements VectorAccessible, AutoCloseable {
     int recordCount = newContainer.getRecordCount();
     WritableBatch batch = WritableBatch.getBatchNoHVWrap(recordCount, newContainer, false);
     VectorAccessibleSerializable outputBatch = new VectorAccessibleSerializable(batch, allocator);
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     outputBatch.writeToStream(outputStream);
     newContainer.zeroVectors();
     logger.debug("Took {} us to spill {} records", watch.elapsed(TimeUnit.MICROSECONDS), recordCount);
@@ -107,8 +106,7 @@ public class BatchGroup implements VectorAccessible, AutoCloseable {
       inputStream = fs.open(path);
     }
     VectorAccessibleSerializable vas = new VectorAccessibleSerializable(allocator);
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     vas.readFromStream(inputStream);
     VectorContainer c =  vas.get();
     if (schema != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
@@ -267,8 +267,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       if (spillCount == 0) {
         return (getSelectionVector4().next()) ? IterOutcome.OK : IterOutcome.NONE;
       } else {
-        Stopwatch w = new Stopwatch();
-        w.start();
+        Stopwatch w = Stopwatch.createStarted();
         int count = copier.next(targetRecordCount);
         if (count > 0) {
           long t = w.elapsed(TimeUnit.MICROSECONDS);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
@@ -124,8 +124,7 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
 
   @Override
   public void sort(final VectorContainer container) {
-    final Stopwatch watch = new Stopwatch();
-    watch.start();
+    final Stopwatch watch = Stopwatch.createStarted();
     while (runStarts.size() > 1) {
 
       // check if we're cancelled/failed frequently

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorterTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorterTemplate.java
@@ -50,8 +50,7 @@ public abstract class SingleBatchSorterTemplate implements SingleBatchSorter, In
   @Override
   public void sort(SelectionVector2 vector2){
     QuickSort qs = new QuickSort();
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     if (vector2.getCount() > 0) {
       qs.sort(this, 0, vector2.getCount());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
@@ -154,9 +154,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
   protected void doOnMatch(RelOptRuleCall call, Filter filterRel, Project projectRel, TableScan scanRel) {
     final String pruningClassName = getClass().getName();
     logger.info("Beginning partition pruning, pruning class: {}", pruningClassName);
-    Stopwatch totalPruningTime = new Stopwatch();
-    totalPruningTime.start();
-
+    Stopwatch totalPruningTime = Stopwatch.createStarted();
 
     final PlannerSettings settings = PrelUtil.getPlannerSettings(call.getPlanner());
     PartitionDescriptor descriptor = getPartitionDescriptor(settings, scanRel);
@@ -196,7 +194,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
     }
 
     // stop watch to track how long we spend in different phases of pruning
-    Stopwatch miscTimer = new Stopwatch();
+    Stopwatch miscTimer = Stopwatch.createUnstarted();
 
     // track how long we spend building the filter tree
     miscTimer.start();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
@@ -17,31 +17,18 @@
  */
 package org.apache.drill.exec.planner.physical;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.drill.common.expression.ExpressionPosition;
-import org.apache.drill.common.expression.FieldReference;
-import org.apache.drill.common.expression.FunctionCall;
-import org.apache.drill.common.expression.LogicalExpression;
-import org.apache.drill.common.expression.PathSegment;
-import org.apache.drill.common.expression.PathSegment.ArraySegment;
-import org.apache.drill.common.expression.PathSegment.NameSegment;
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.common.logical.data.Order.Ordering;
-import org.apache.drill.exec.planner.physical.DrillDistributionTrait.DistributionField;
-import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
-
+import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -52,8 +39,16 @@ import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.PathSegment;
+import org.apache.drill.common.expression.PathSegment.ArraySegment;
+import org.apache.drill.common.expression.PathSegment.NameSegment;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.Order.Ordering;
+import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.IntIntHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -198,7 +193,7 @@ public class PrelUtil {
 
       this.fieldNames = Lists.newArrayListWithCapacity(desiredFields.size());
       this.types = Lists.newArrayListWithCapacity(desiredFields.size());
-      IntIntOpenHashMap oldToNewIds = new IntIntOpenHashMap();
+      IntIntHashMap oldToNewIds = new IntIntHashMap();
 
       int i =0;
       for (DesiredField f : desiredFields) {
@@ -352,9 +347,9 @@ public class PrelUtil {
 
   public static class InputRewriter extends RexShuttle {
 
-    final IntIntOpenHashMap map;
+    final IntIntHashMap map;
 
-    public InputRewriter(IntIntOpenHashMap map) {
+    public InputRewriter(IntIntHashMap map) {
       super();
       this.map = map;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControlConnection.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.rpc.RemoteConnection;
 import org.apache.drill.exec.rpc.RpcBus;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 
-import com.google.common.io.Closeables;
 import com.google.protobuf.MessageLite;
 
 public class ControlConnection extends RemoteConnection {
@@ -106,12 +105,6 @@ public class ControlConnection extends RemoteConnection {
       return false;
     }
     return true;
-  }
-
-  public void shutdownIfClient() {
-    if (bus.isClient()) {
-      Closeables.closeQuietly(bus);
-    }
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/Controller.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/Controller.java
@@ -20,8 +20,6 @@ package org.apache.drill.exec.rpc.control;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DrillBuf;
 
-import java.io.Closeable;
-
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.rpc.UserRpcException;
@@ -35,7 +33,7 @@ import com.google.protobuf.Parser;
  * making a connection. TODO: Controller should automatically straight route local BitCommunication rather than connecting to its
  * self.
  */
-public interface Controller extends Closeable {
+public interface Controller extends AutoCloseable {
 
   /**
    * Get a Bit to Bit communication tunnel. If the BitCom doesn't have a tunnel attached to the node already, it will

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.rpc.control;
 
+import java.util.List;
+
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -24,7 +27,7 @@ import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.work.batch.ControlMessageHandler;
 
-import com.google.common.io.Closeables;
+import com.google.common.collect.Lists;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
 
@@ -74,11 +77,15 @@ public class ControllerImpl implements Controller {
     handlerRegistry.registerCustomHandler(messageTypeId, handler, parser);
   }
 
-  public void close() {
-    Closeables.closeQuietly(server);
+  public void close() throws Exception {
+    List<AutoCloseable> closeables = Lists.newArrayList();
+    closeables.add(server);
+
     for (ControlConnectionManager bt : connectionRegistry) {
-      bt.close();
+      closeables.add(bt);
     }
+
+    AutoCloseables.close(closeables);
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/CustomHandlerRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/CustomHandlerRegistry.java
@@ -33,7 +33,7 @@ import org.apache.drill.exec.rpc.UserRpcException;
 import org.apache.drill.exec.rpc.control.Controller.CustomMessageHandler;
 import org.apache.drill.exec.rpc.control.Controller.CustomResponse;
 
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
+import com.carrotsearch.hppc.IntObjectHashMap;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -46,7 +46,7 @@ public class CustomHandlerRegistry {
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private final AutoCloseableLock read = new AutoCloseableLock(readWriteLock.readLock());
   private final AutoCloseableLock write = new AutoCloseableLock(readWriteLock.writeLock());
-  private final IntObjectOpenHashMap<ParsingHandler<?>> handlers = new IntObjectOpenHashMap<>();
+  private final IntObjectHashMap<ParsingHandler<?>> handlers = new IntObjectHashMap<>();
   private volatile DrillbitEndpoint endpoint;
 
   public CustomHandlerRegistry() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClientConnection.java
@@ -27,7 +27,6 @@ import org.apache.drill.exec.proto.BitData.RpcType;
 import org.apache.drill.exec.rpc.RemoteConnection;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 
-import com.google.common.io.Closeables;
 import com.google.protobuf.MessageLite;
 
 public class DataClientConnection extends RemoteConnection{
@@ -84,8 +83,5 @@ public class DataClientConnection extends RemoteConnection{
     return true;
   }
 
-  public void shutdownIfClient() {
-    Closeables.closeQuietly(client);
-  }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataConnectionCreator.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.rpc.data;
 
-import java.io.Closeable;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
@@ -28,12 +28,11 @@ import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.work.WorkManager.WorkerBee;
 
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 
 /**
  * Manages a connection for each endpoint.
  */
-public class DataConnectionCreator implements Closeable {
+public class DataConnectionCreator implements AutoCloseable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DataConnectionCreator.class);
 
   private volatile DataServer server;
@@ -75,9 +74,8 @@ public class DataConnectionCreator implements Closeable {
   }
 
   @Override
-  public void close() {
-    Closeables.closeQuietly(server);
-    dataAllocator.close();
+  public void close() throws Exception {
+    AutoCloseables.close(server, dataAllocator);
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -57,7 +57,6 @@ import org.apache.drill.exec.rpc.user.security.UserAuthenticator;
 import org.apache.drill.exec.rpc.user.security.UserAuthenticatorFactory;
 import org.apache.drill.exec.work.user.UserWorker;
 
-import com.google.common.io.Closeables;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 
@@ -284,7 +283,11 @@ public class UserServer extends BasicServer<RpcType, UserServer.UserClientConnec
 
   @Override
   public void close() throws IOException {
-    Closeables.closeQuietly(authenticator);
+    try {
+      authenticator.close();
+    } catch (Exception e) {
+      logger.warn("Failure closing authenticator.", e);
+    }
     super.close();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -81,7 +81,7 @@ public class Drillbit implements AutoCloseable {
       final DrillConfig config,
       final RemoteServiceSet serviceSet,
       final ScanResult classpathScan) throws Exception {
-    final Stopwatch w = new Stopwatch().start();
+    final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Construction started.");
     final boolean allowPortHunting = serviceSet != null;
     context = new BootStrapContext(config, classpathScan);
@@ -102,7 +102,7 @@ public class Drillbit implements AutoCloseable {
   }
 
   public void run() throws Exception {
-    final Stopwatch w = new Stopwatch().start();
+    final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Startup begun.");
     coord.start(10000);
     storeProvider.start();
@@ -126,7 +126,7 @@ public class Drillbit implements AutoCloseable {
     if (isClosed) {
       return;
     }
-    final Stopwatch w = new Stopwatch().start();
+    final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Shutdown begun.");
 
     // wait for anything that is running to complete

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -379,8 +379,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
 
     @Override
     public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
-      Stopwatch watch = new Stopwatch();
-      watch.start();
+      Stopwatch watch = Stopwatch.createStarted();
 
       try {
         Set<String> currentPluginNames = Sets.newHashSet(plugins.names());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/TimedRunnable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/TimedRunnable.java
@@ -115,7 +115,7 @@ public abstract class TimedRunnable<V> implements Runnable {
    * @throws IOException All exceptions are coerced to IOException since this was build for storage system tasks initially.
    */
   public static <V> List<V> run(final String activity, final Logger logger, final List<TimedRunnable<V>> runnables, int parallelism) throws IOException {
-    Stopwatch watch = new Stopwatch().start();
+    Stopwatch watch = Stopwatch.createStarted();
     long timedRunnableStart=System.nanoTime();
     if(runnables.size() == 1){
       parallelism = 1;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
@@ -130,7 +130,7 @@ public class AvroRecordReader extends AbstractRecordReader {
 
   @Override
   public int next() {
-    final Stopwatch watch = new Stopwatch().start();
+    final Stopwatch watch = Stopwatch.createStarted();
 
     if (reader == null) {
       throw new IllegalStateException("Avro reader is not open.");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileRecordReader.java
@@ -124,8 +124,7 @@ public class SequenceFileRecordReader extends AbstractRecordReader {
 
   @Override
   public int next() {
-    final Stopwatch watch = new Stopwatch();
-    watch.start();
+    final Stopwatch watch = Stopwatch.createStarted();
     if (keyVector != null) {
       keyVector.clear();
       keyVector.allocateNew();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
@@ -198,8 +198,7 @@ public class Metadata {
   private ParquetTableMetadata_v2 getParquetTableMetadata(String path) throws IOException {
     Path p = new Path(path);
     FileStatus fileStatus = fs.getFileStatus(p);
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    final Stopwatch watch = Stopwatch.createStarted();
     List<FileStatus> fileStatuses = getFileStatuses(fileStatus);
     logger.info("Took {} ms to get file statuses", watch.elapsed(TimeUnit.MILLISECONDS));
     watch.reset();
@@ -425,8 +424,7 @@ public class Metadata {
    * @throws IOException
    */
   private ParquetTableMetadataBase readBlockMeta(String path) throws IOException {
-    Stopwatch timer = new Stopwatch();
-    timer.start();
+    Stopwatch timer = Stopwatch.createStarted();
     Path p = new Path(path);
     ObjectMapper mapper = new ObjectMapper();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
@@ -17,6 +17,36 @@
  */
 package org.apache.drill.exec.store.parquet;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.store.TimedRunnable;
+import org.apache.drill.exec.store.dfs.DrillPathFilter;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -33,41 +63,11 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.store.TimedRunnable;
-import org.apache.drill.exec.store.dfs.DrillPathFilter;
-import org.apache.hadoop.fs.BlockLocation;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
-import org.apache.parquet.schema.Type;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
-import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class Metadata {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Metadata.class);
@@ -429,9 +429,15 @@ public class Metadata {
     timer.start();
     Path p = new Path(path);
     ObjectMapper mapper = new ObjectMapper();
+
+    final SimpleModule serialModule = new SimpleModule();
+    serialModule.addDeserializer(SchemaPath.class, new SchemaPath.De());
+    serialModule.addKeyDeserializer(ColumnTypeMetadata_v2.Key.class, new ColumnTypeMetadata_v2.Key.DeSerializer());
+
     AfterburnerModule module = new AfterburnerModule();
-    module.addDeserializer(SchemaPath.class, new SchemaPath.De());
-    module.addKeyDeserializer(ColumnTypeMetadata_v2.Key.class, new ColumnTypeMetadata_v2.Key.DeSerializer());
+    module.setUseOptimizedBeanDeserializer(true);
+
+    mapper.registerModule(serialModule);
     mapper.registerModule(module);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     FSDataInputStream is = fs.open(p);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
@@ -108,7 +108,7 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
 
 
   private final List<ReadEntryWithPath> entries;
-  private final Stopwatch watch = new Stopwatch();
+  private final Stopwatch watch = Stopwatch.createUnstarted();
   private final ParquetFormatPlugin formatPlugin;
   private final ParquetFormatConfig formatConfig;
   private final DrillFileSystem fs;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetScanBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetScanBatchCreator.java
@@ -120,7 +120,7 @@ public class ParquetScanBatchCreator implements BatchCreator<ParquetRowGroupScan
       These fields will be added to the constructor below
       */
       try {
-        Stopwatch timer = new Stopwatch();
+        Stopwatch timer = Stopwatch.createUnstarted();
         if ( ! footers.containsKey(e.getPath())){
           timer.start();
           ParquetMetadata footer = ParquetFileReader.readFooter(conf, new Path(e.getPath()));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
@@ -131,7 +131,7 @@ final class PageReader {
 
   private void loadDictionaryIfExists(final ColumnReader<?> parentStatus,
       final ColumnChunkMetaData columnChunkMetaData, final FSDataInputStream f) throws IOException {
-    Stopwatch timer = new Stopwatch();
+    Stopwatch timer = Stopwatch.createUnstarted();
     if (columnChunkMetaData.getDictionaryPageOffset() > 0) {
       f.seek(columnChunkMetaData.getDictionaryPageOffset());
       long start=f.getPos();
@@ -163,7 +163,7 @@ final class PageReader {
   }
 
   public void readPage(PageHeader pageHeader, int compressedSize, int uncompressedSize, DrillBuf dest) throws IOException {
-    Stopwatch timer = new Stopwatch();
+    Stopwatch timer = Stopwatch.createUnstarted();
     long timeToRead;
     long start=inputStream.getPos();
     if (parentColumnReader.columnChunkMetaData.getCodec() == CompressionCodecName.UNCOMPRESSED) {
@@ -203,7 +203,7 @@ final class PageReader {
    * @throws java.io.IOException
    */
   public boolean next() throws IOException {
-    Stopwatch timer = new Stopwatch();
+    Stopwatch timer = Stopwatch.createUnstarted();
     currentPageCount = -1;
     valuesRead = 0;
     valuesReadyToRead = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AffinityCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AffinityCreator.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 
-import com.carrotsearch.hppc.ObjectFloatOpenHashMap;
+import com.carrotsearch.hppc.ObjectFloatHashMap;
 import com.carrotsearch.hppc.cursors.ObjectFloatCursor;
 import com.carrotsearch.hppc.cursors.ObjectLongCursor;
 import com.google.common.base.Stopwatch;
@@ -40,7 +40,7 @@ public class AffinityCreator {
       totalBytes += entry.getTotalBytes();
     }
 
-    ObjectFloatOpenHashMap<DrillbitEndpoint> affinities = new ObjectFloatOpenHashMap<DrillbitEndpoint>();
+    ObjectFloatHashMap<DrillbitEndpoint> affinities = new ObjectFloatHashMap<DrillbitEndpoint>();
     for (CompleteWork entry : work) {
       for (ObjectLongCursor<DrillbitEndpoint> cursor : entry.getByteMap()) {
         long bytes = cursor.value;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AffinityCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AffinityCreator.java
@@ -33,7 +33,7 @@ public class AffinityCreator {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AffinityCreator.class);
 
   public static <T extends CompleteWork> List<EndpointAffinity> getAffinityMap(List<T> work){
-    Stopwatch watch = new Stopwatch();
+    Stopwatch watch = Stopwatch.createStarted();
 
     long totalBytes = 0;
     for (CompleteWork entry : work) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
@@ -106,8 +106,7 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @return the minor fragment id to work units mapping
    */
   private ListMultimap<Integer, T> getMappings() {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     maxWork = (int) Math.ceil(units.size() / ((float) incomingEndpoints.size()));
     LinkedList<WorkEndpointListPair<T>> workList = getWorkList();
     LinkedList<WorkEndpointListPair<T>> unassignedWorkList;
@@ -179,8 +178,7 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @return the list of WorkEndpointListPairs
    */
   private LinkedList<WorkEndpointListPair<T>> getWorkList() {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     LinkedList<WorkEndpointListPair<T>> workList = Lists.newLinkedList();
     for (T work : units) {
       List<Map.Entry<DrillbitEndpoint,Long>> entries = Lists.newArrayList();
@@ -236,8 +234,7 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @return
    */
   private Map<DrillbitEndpoint,FragIteratorWrapper> getEndpointIterators() {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     Map<DrillbitEndpoint,FragIteratorWrapper> map = Maps.newLinkedHashMap();
     Map<DrillbitEndpoint,List<Integer>> mmap = Maps.newLinkedHashMap();
     for (int i = 0; i < incomingEndpoints.size(); i++) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/BlockMapBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/BlockMapBuilder.java
@@ -216,8 +216,7 @@ public class BlockMapBuilder {
    * @throws IOException
    */
   public EndpointByteMap getEndpointByteMap(FileWork work) throws IOException {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     Path fileName = new Path(work.getPath());
 
 
@@ -267,8 +266,7 @@ public class BlockMapBuilder {
    * Builds a mapping of Drillbit endpoints to hostnames
    */
   private static ImmutableMap<String, DrillbitEndpoint> buildEndpointMap(Collection<DrillbitEndpoint> endpoints) {
-    Stopwatch watch = new Stopwatch();
-    watch.start();
+    Stopwatch watch = Stopwatch.createStarted();
     HashMap<String, DrillbitEndpoint> endpointMap = Maps.newHashMap();
     for (DrillbitEndpoint d : endpoints) {
       String hostName = d.getAddress();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/EndpointByteMapImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/EndpointByteMapImpl.java
@@ -21,13 +21,13 @@ import java.util.Iterator;
 
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 
-import com.carrotsearch.hppc.ObjectLongOpenHashMap;
+import com.carrotsearch.hppc.ObjectLongHashMap;
 import com.carrotsearch.hppc.cursors.ObjectLongCursor;
 
 public class EndpointByteMapImpl implements EndpointByteMap{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(EndpointByteMapImpl.class);
 
-  private final ObjectLongOpenHashMap<DrillbitEndpoint> map = new ObjectLongOpenHashMap<>();
+  private final ObjectLongHashMap<DrillbitEndpoint> map = new ObjectLongHashMap<>();
 
   private long maxBytes;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/OldAssignmentCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/OldAssignmentCreator.java
@@ -63,7 +63,7 @@ public class OldAssignmentCreator<T extends CompleteWork> {
 
    OldAssignmentCreator(List<DrillbitEndpoint> incomingEndpoints, List<T> units) {
     logger.debug("Assigning {} units to {} endpoints", units.size(), incomingEndpoints.size());
-    Stopwatch watch = new Stopwatch();
+    Stopwatch watch = Stopwatch.createUnstarted();
 
     Preconditions.checkArgument(incomingEndpoints.size() <= units.size(), String.format("Incoming endpoints %d "
         + "is greater than number of row groups %d", incomingEndpoints.size(), units.size()));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/VersionIterator.java
@@ -46,7 +46,7 @@ public class VersionIterator implements Iterator<Object>{
         URL u = Resources.getResource("git.properties");
         if(u != null){
           Properties p = new Properties();
-          p.load(Resources.newInputStreamSupplier(u).getInput());
+          p.load(Resources.asByteSource(u).openStream());
           commit_id = p.getProperty("git.commit.id");
           build_email = p.getProperty("git.build.user.email");
           commit_time = p.getProperty("git.commit.time");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/SpoolingRawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/SpoolingRawBatchBuffer.java
@@ -374,8 +374,7 @@ public class SpoolingRawBatchBuffer extends BaseRawBatchBuffer<SpoolingRawBatchB
     }
 
     public void writeToStream(FSDataOutputStream stream) throws IOException {
-      Stopwatch watch = new Stopwatch();
-      watch.start();
+      Stopwatch watch = Stopwatch.createStarted();
       available = false;
       check = ThreadLocalRandom.current().nextLong();
       start = stream.getPos();
@@ -421,8 +420,7 @@ public class SpoolingRawBatchBuffer extends BaseRawBatchBuffer<SpoolingRawBatchB
           final long check = stream.readLong();
           pos = stream.getPos();
           assert check == this.check : String.format("Check values don't match: %d %d, Position %d", this.check, check, currentPos);
-          Stopwatch watch = new Stopwatch();
-          watch.start();
+          Stopwatch watch = Stopwatch.createStarted();
           BitData.FragmentRecordBatch header = BitData.FragmentRecordBatch.parseDelimitedFrom(stream);
           pos = stream.getPos();
           assert header != null : "header null after parsing from stream";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.drill.common.CatastrophicFailure;
 import org.apache.drill.common.EventProcessor;
 import org.apache.drill.common.concurrent.ExtendedLatch;
 import org.apache.drill.common.config.DrillConfig;
@@ -272,10 +273,7 @@ public class Foreman implements Runnable {
          * die here, they should get notified about that, and cancel themselves; we don't have to attempt to notify
          * them, which might not work under these conditions.
          */
-        System.out.println("Node ran out of Heap memory, exiting.");
-        e.printStackTrace();
-        System.out.flush();
-        System.exit(-1);
+        CatastrophicFailure.exit(e, "Unable to handle out of memory condition in Foreman.", -1);
       }
 
     } finally {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -51,7 +51,7 @@ import org.apache.drill.exec.store.sys.PStoreProvider;
 import org.apache.drill.exec.work.EndpointListener;
 import org.apache.drill.exec.work.foreman.Foreman.StateListener;
 
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
+import com.carrotsearch.hppc.IntObjectHashMap;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -86,8 +86,8 @@ public class QueryManager {
    * Doesn't need to be thread safe as fragmentDataMap is generated in a single thread and then
    * accessed by multiple threads for reads only.
    */
-  private final IntObjectOpenHashMap<IntObjectOpenHashMap<FragmentData>> fragmentDataMap =
-      new IntObjectOpenHashMap<>();
+  private final IntObjectHashMap<IntObjectHashMap<FragmentData>> fragmentDataMap =
+      new IntObjectHashMap<>();
   private final List<FragmentData> fragmentDataSet = Lists.newArrayList();
 
   private final PStore<QueryProfile> profilePStore;
@@ -163,9 +163,9 @@ public class QueryManager {
     final int majorFragmentId = fragmentHandle.getMajorFragmentId();
     final int minorFragmentId = fragmentHandle.getMinorFragmentId();
 
-    IntObjectOpenHashMap<FragmentData> minorMap = fragmentDataMap.get(majorFragmentId);
+    IntObjectHashMap<FragmentData> minorMap = fragmentDataMap.get(majorFragmentId);
     if (minorMap == null) {
-      minorMap = new IntObjectOpenHashMap<>();
+      minorMap = new IntObjectHashMap<>();
       fragmentDataMap.put(majorFragmentId, minorMap);
     }
     minorMap.put(minorFragmentId, fragmentData);
@@ -351,15 +351,15 @@ public class QueryManager {
       profileBuilder.setPlan(planText);
     }
 
-    for (int i = 0; i < fragmentDataMap.allocated.length; i++) {
-      if (fragmentDataMap.allocated[i]) {
+    for (int i = 0; i < fragmentDataMap.keys.length; i++) {
+      if (fragmentDataMap.keys[i] != 0) {
         final int majorFragmentId = fragmentDataMap.keys[i];
-        final IntObjectOpenHashMap<FragmentData> minorMap =
-            (IntObjectOpenHashMap<FragmentData>) ((Object[]) fragmentDataMap.values)[i];
+        final IntObjectHashMap<FragmentData> minorMap =
+            (IntObjectHashMap<FragmentData>) ((Object[]) fragmentDataMap.values)[i];
         final MajorFragmentProfile.Builder fb = MajorFragmentProfile.newBuilder()
             .setMajorFragmentId(majorFragmentId);
-        for (int v = 0; v < minorMap.allocated.length; v++) {
-          if (minorMap.allocated[v]) {
+        for (int v = 0; v < minorMap.keys.length; v++) {
+          if (minorMap.keys[v] != 0) {
             final FragmentData data = (FragmentData) ((Object[]) minorMap.values)[v];
             fb.addMinorFragmentProfile(data.getProfile());
           }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.drill.common.CatastrophicFailure;
 import org.apache.drill.common.DeferredException;
 import org.apache.drill.common.SerializedExecutor;
 import org.apache.drill.common.concurrent.ExtendedLatch;
@@ -266,11 +267,7 @@ public class FragmentExecutor implements Runnable {
         fail(UserException.memoryError(e).build(logger));
       } else {
         // we have a heap out of memory error. The JVM in unstable, exit.
-        System.err.println("Node ran out of Heap memory, exiting.");
-        e.printStackTrace(System.err);
-        System.err.flush();
-        System.exit(-2);
-
+        CatastrophicFailure.exit(e, "Unable to handle out of memory condition in FragmentExecutor.", -2);
       }
     } catch (AssertionError | Exception e) {
       fail(e);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
@@ -55,7 +55,7 @@ public class RunRootExec {
     FragmentContext context = new FragmentContext(bitContext, PlanFragment.getDefaultInstance(), null, registry);
     SimpleRootExec exec;
     for (int i = 0; i < iterations; i ++) {
-      Stopwatch w= new Stopwatch().start();
+      Stopwatch w = Stopwatch.createStarted();
       System.out.println("STARTITER:" + i);
       exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestBitRpc.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestBitRpc.java
@@ -151,7 +151,7 @@ public class TestBitRpc extends ExecTest {
 
   private class TimingOutcome implements RpcOutcomeListener<Ack> {
     private AtomicLong max;
-    private Stopwatch watch = new Stopwatch().start();
+    private Stopwatch watch = Stopwatch.createStarted();
 
     public TimingOutcome(AtomicLong max) {
       super();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -291,7 +291,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     TestFileGenerator.populateFieldInfoMap(props);
     final ParquetResultListener resultListener =
         new ParquetResultListener(getAllocator(), props, numberOfTimesRead, testValues);
-    final Stopwatch watch = new Stopwatch().start();
+    final Stopwatch watch = Stopwatch.createStarted();
     testWithListener(type, planText, resultListener);
     resultListener.getResults();
     // batchLoader.clear();
@@ -642,8 +642,7 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
           f.getParquetMetadata(), columns);
       final TestOutputMutator mutator = new TestOutputMutator(allocator);
       rr.setup(null, mutator);
-      final Stopwatch watch = new Stopwatch();
-      watch.start();
+      final Stopwatch watch = Stopwatch.createStarted();
 
       int rowCount = 0;
       while ((rowCount = rr.next()) > 0) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
@@ -127,8 +127,7 @@ public class TestParquetPhysicalPlan extends ExecTest {
     try(DrillClient client = new DrillClient(config);) {
       client.connect();
       ParquetResultsListener listener = new ParquetResultsListener();
-      Stopwatch watch = new Stopwatch();
-      watch.start();
+      Stopwatch watch = Stopwatch.createStarted();
       client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(Resources.getResource(fileName),Charsets.UTF_8), listener);
       System.out.println(String.format("Got %d total records in %d seconds", listener.await(), watch.elapsed(TimeUnit.SECONDS)));
       client.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/FileTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/FileTest.java
@@ -58,8 +58,7 @@ public class FileTest {
     out = fs.create(new Path("/tmp/file"));
     for (int i = 0; i < 100; i++) {
       bytes = new byte[256*1024];
-      Stopwatch watch = new Stopwatch();
-      watch.start();
+      Stopwatch watch = Stopwatch.createStarted();
       out.write(bytes);
       out.sync();
       long t = watch.elapsed(TimeUnit.MILLISECONDS);

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -57,6 +57,10 @@
           <artifactId>log4j</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase</artifactId>
         </exclusion>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -58,12 +58,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>    
     <dependency>
       <groupId>net.hydromatic</groupId>

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestActionBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestActionBase.java
@@ -71,7 +71,7 @@ public class JdbcTestActionBase extends JdbcTestBase {
 
   protected void testAction(JdbcAction action, long rowcount) throws Exception {
     int rows = 0;
-    Stopwatch watch = new Stopwatch().start();
+    Stopwatch watch = Stopwatch.createStarted();
     ResultSet r = action.getResult(connection);
     boolean first = true;
     while (r.next()) {

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestQueryBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestQueryBase.java
@@ -49,7 +49,7 @@ public class JdbcTestQueryBase extends JdbcTestBase {
     boolean success = false;
     try (Connection conn = connect("jdbc:drill:zk=local")) {
       for (int x = 0; x < 1; x++) {
-        Stopwatch watch = new Stopwatch().start();
+        Stopwatch watch = Stopwatch.createStarted();
         Statement s = conn.createStatement();
         ResultSet r = s.executeQuery(sql);
         System.out.println(String.format("QueryId: %s", r.unwrap(DrillResultSet.class).getQueryId()));

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcDistQuery.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcDistQuery.java
@@ -199,7 +199,7 @@ public class TestJdbcDistQuery extends JdbcTestBase {
       // (e.g., for debugging) then define a constant field or local variable
       // for the number of iterations.)
       for (int x = 0; x < 1; x++) {
-        Stopwatch watch = new Stopwatch().start();
+        Stopwatch watch = Stopwatch.createStarted();
         Statement s = c.createStatement();
         ResultSet r = s.executeQuery(sql);
         boolean first = true;
@@ -222,7 +222,7 @@ public class TestJdbcDistQuery extends JdbcTestBase {
           System.out.println();
         }
 
-        System.out.println(String.format("Query completed in %d millis.", watch.elapsedMillis()));
+        System.out.println(String.format("Query completed in %d millis.", watch.elapsed(TimeUnit.MILLISECONDS)));
       }
 
       System.out.println("\n\n\n");

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicServer.java
@@ -217,7 +217,7 @@ public abstract class BasicServer<T extends EnumLite, C extends RemoteConnection
   @Override
   public void close() throws IOException {
     try {
-      Stopwatch watch = new Stopwatch().start();
+      Stopwatch watch = Stopwatch.createStarted();
       // this takes 1s to complete
       // known issue: https://github.com/netty/netty/issues/2545
       eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).get();

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -275,7 +275,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
         logger.debug("Received message {}", msg);
       }
       final Channel channel = connection.getChannel();
-      final Stopwatch watch = new Stopwatch().start();
+      final Stopwatch watch = Stopwatch.createStarted();
 
       try{
 

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
-      <version>0.4.2</version>
+      <version>0.7.1</version>
     </dependency>
 
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/expr/fn/impl/DateUtility.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/expr/fn/impl/DateUtility.java
@@ -24,7 +24,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
 
-import com.carrotsearch.hppc.ObjectIntOpenHashMap;
+import com.carrotsearch.hppc.ObjectIntHashMap;
 
 // Utility class for Date, DateTime, TimeStamp, Interval data types
 public class DateUtility {
@@ -35,7 +35,7 @@ public class DateUtility {
      * reconstruct the timestamp, we use this index to index through the array timezoneList
      * and get the corresponding timezone and pass it to joda-time
      */
-    public static ObjectIntOpenHashMap<String> timezoneMap = new ObjectIntOpenHashMap<String>();
+  public static ObjectIntHashMap<String> timezoneMap = new ObjectIntHashMap<String>();
 
     public static String[] timezoneList =  {"Africa/Abidjan",
                                             "Africa/Accra",

--- a/logical/pom.xml
+++ b/logical/pom.xml
@@ -87,12 +87,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.3</version>
+      <version>${jackson.version}</version>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <forkCount>2</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>
+    <jackson.version>2.7.1</jackson.version>
 
     <!--
       Currently Hive storage plugin only supports Apache Hive 1.2 or vendor specific variants of the

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <proto.cas.path>${project.basedir}/src/main/protobuf/</proto.cas.path>
     <dep.junit.version>4.11</dep.junit.version>
     <dep.slf4j.version>1.7.6</dep.slf4j.version>
+    <dep.guava.version>18.0</dep.guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>
@@ -328,6 +329,7 @@
                     <exclude>javax.servlet:servlet-api</exclude>
                     <exclude>org.mortbay.jetty:servlet-api</exclude>
                     <exclude>org.mortbay.jetty:servlet-api-2.5</exclude>
+                    <exclude>log4j:log4j</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>
@@ -408,7 +410,10 @@
               -Ddrill.exec.sys.store.provider.local.write=false
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true
+              -Ddrill.catastrpohic_to_standard_out=true
               -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=3072M
+              -Djava.net.preferIPv4Stack=true
+              -Djava.awt.headless=true
               -XX:+CMSClassUnloadingEnabled -ea</argLine>
             <forkCount>${forkCount}</forkCount>
             <reuseForks>true</reuseForks>
@@ -526,7 +531,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${dep.guava.version}</version>
     </dependency>
 
     <dependency>

--- a/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
+++ b/tools/fmpp/src/main/java/org/apache/drill/fmpp/mojo/FMPPMojo.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -114,7 +113,7 @@ public class FMPPMojo extends AbstractMojo {
         throw new MojoFailureException("scope must be compile or test");
     }
 
-    final Stopwatch sw = new Stopwatch().start();
+    final Stopwatch sw = Stopwatch.createStarted();
     try {
       getLog().info(format("Freemarker generation:\n scope: %s,\n config: %s,\n templates: %s",
           scope, config.getAbsolutePath(), templatesPath));


### PR DESCRIPTION
- Replace Stopwatch constructors with .createStarted() or .createUnstarted()
- Stop using InputSupplier and Closeables.closeQuietly
- Clean up quiet closes to log or (preferably) propagate.
- Add log4j to enforcer exclusions.
- Update HBaseTestSuite to add patching of Closeables.closeQuietly() and Stopwatch legacy methods. Only needed when running HBaseMiniCluster.
- Remove log4j from HBase's pom to provide exception logging.
- Remove log4j from Hive's shaded pom.
- Update Catastrophic failures to use the same pattern to ensure reporting.
- Update test framework to avoid trying IPv6 resolution. (This removes 90s pause from HBase startup in my tests)