### PR TITLE
DRILL-4359: Adds equals/hashCode methods to EndpointAffinity

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/EndpointAffinity.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/EndpointAffinity.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.physical;
 
-import com.google.common.base.Preconditions;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.TextFormat;
 
 /**
@@ -93,6 +93,42 @@ public class EndpointAffinity {
    */
   public boolean isAssignmentRequired() {
     return Double.POSITIVE_INFINITY == affinity;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    long temp;
+    temp = Double.doubleToLongBits(affinity);
+    result = prime * result + (int) (temp ^ (temp >>> 32));
+    result = prime * result + ((endpoint == null) ? 0 : endpoint.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (!(obj instanceof EndpointAffinity)) {
+      return false;
+    }
+    EndpointAffinity other = (EndpointAffinity) obj;
+    if (Double.doubleToLongBits(affinity) != Double.doubleToLongBits(other.affinity)) {
+      return false;
+    }
+    if (endpoint == null) {
+      if (other.endpoint != null) {
+        return false;
+      }
+    } else if (!endpoint.equals(other.endpoint)) {
+      return false;
+    }
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Adds equals/hashCode methods to EndpointAffinity to allow for comparison in tests.