### PR TITLE
DRILL-4363: Row count based pruning for parquet table used in Limit n…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -128,4 +128,25 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
   public List<SchemaPath> getPartitionColumns() {
     return Lists.newArrayList();
   }
+
+  /**
+   * Default is not to support limit pushdown.
+   * @return
+   */
+  @Override
+  @JsonIgnore
+  public boolean supportsLimitPushdown() {
+    return false;
+  }
+
+  /**
+   * By default, return null to indicate rowcount based prune is not supported.
+   * Each groupscan subclass should override, if it supports rowcount based prune.
+   */
+  @Override
+  @JsonIgnore
+  public GroupScan applyLimit(long maxRecords) {
+    return null;
+  }
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
@@ -98,4 +98,16 @@ public interface GroupScan extends Scan, HasAffinity{
   @JsonIgnore
   public List<SchemaPath> getPartitionColumns();
 
+  /**
+   * Whether or not this GroupScan supports limit pushdown
+   */
+  public boolean supportsLimitPushdown();
+
+  /**
+   * Apply rowcount based prune for "LIMIT n" query.
+   * @param maxRecords : the number of rows requested from group scan.
+   * @return  a new instance of group scan if the prune is successful.
+   *          null when either if row-based prune is not supported, or if prune is not successful.
+   */
+  public GroupScan applyLimit(long maxRecords);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushLimitToScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushLimitToScanRule.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.planner.logical;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.planner.logical.partition.PruneScanRule;
+import org.apache.drill.exec.store.parquet.ParquetGroupScan;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class DrillPushLimitToScanRule extends RelOptRule {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillPushLimitToScanRule.class);
+
+  private DrillPushLimitToScanRule(RelOptRuleOperand operand, String description) {
+    super(operand, description);
+  }
+
+  public static DrillPushLimitToScanRule LIMIT_ON_SCAN = new DrillPushLimitToScanRule(
+      RelOptHelper.some(DrillLimitRel.class, RelOptHelper.any(DrillScanRel.class)), "DrillPushLimitToScanRule_LimitOnScan") {
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      DrillScanRel scanRel = call.rel(1);
+      return scanRel.getGroupScan().supportsLimitPushdown(); // For now only applies to Parquet.
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        DrillLimitRel limitRel = call.rel(0);
+        DrillScanRel scanRel = call.rel(1);
+        doOnMatch(call, limitRel, scanRel, null);
+    }
+  };
+
+  public static DrillPushLimitToScanRule LIMIT_ON_PROJECT = new DrillPushLimitToScanRule(
+      RelOptHelper.some(DrillLimitRel.class, RelOptHelper.some(DrillProjectRel.class, RelOptHelper.any(DrillScanRel.class))), "DrillPushLimitToScanRule_LimitOnProject") {
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      DrillScanRel scanRel = call.rel(2);
+      return scanRel.getGroupScan().supportsLimitPushdown(); // For now only applies to Parquet.
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      DrillLimitRel limitRel = call.rel(0);
+      DrillProjectRel projectRel = call.rel(1);
+      DrillScanRel scanRel = call.rel(2);
+      doOnMatch(call, limitRel, scanRel, projectRel);
+    }
+  };
+
+
+  protected void doOnMatch(RelOptRuleCall call, DrillLimitRel limitRel, DrillScanRel scanRel, DrillProjectRel projectRel){
+    try {
+      final int rowCountRequested = (int) limitRel.getRows();
+
+      final GroupScan newGroupScan = scanRel.getGroupScan().applyLimit(rowCountRequested);
+
+      if (newGroupScan == null ) {
+        return;
+      }
+
+      DrillScanRel newScanRel = new DrillScanRel(scanRel.getCluster(),
+          scanRel.getTraitSet(),
+          scanRel.getTable(),
+          newGroupScan,
+          scanRel.getRowType(),
+          scanRel.getColumns(),
+          scanRel.partitionFilterPushdown());
+
+      final RelNode newLimit;
+      if (projectRel != null) {
+        final RelNode newProject = projectRel.copy(projectRel.getTraitSet(), ImmutableList.of((RelNode)newScanRel));
+        newLimit = limitRel.copy(limitRel.getTraitSet(), ImmutableList.of((RelNode)newProject));
+      } else {
+        newLimit = limitRel.copy(limitRel.getTraitSet(), ImmutableList.of((RelNode)newScanRel));
+      }
+
+      call.transformTo(newLimit);
+      logger.debug("Converted to a new DrillScanRel" + newScanRel.getGroupScan());
+    }  catch (Exception e) {
+      logger.warn("Exception while using the pruned partitions.", e);
+    }
+
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillRuleSets.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillRuleSets.java
@@ -207,7 +207,9 @@ public class DrillRuleSets {
             PruneScanRule.getDirFilterOnProject(optimizerRulesContext),
             PruneScanRule.getDirFilterOnScan(optimizerRulesContext),
             ParquetPruneScanRule.getFilterOnProjectParquet(optimizerRulesContext),
-            ParquetPruneScanRule.getFilterOnScanParquet(optimizerRulesContext)
+            ParquetPruneScanRule.getFilterOnScanParquet(optimizerRulesContext),
+            DrillPushLimitToScanRule.LIMIT_ON_SCAN,
+            DrillPushLimitToScanRule.LIMIT_ON_PROJECT
         )
         .build();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
@@ -257,7 +257,8 @@ public class TestPartitionFilter extends PlanTestBase {
   public void testMainQueryFalseCondition() throws Exception {
     String root = FileUtils.getResourceAsFile("/multilevel/parquet").toURI().toString();
     String query = String.format("select * from (select dir0, o_custkey from dfs_test.`%s` where dir0='1994') t where 1 = 0", root);
-    testExcludeFilter(query, 4, "Filter", 0);
+    // the 1 = 0 becomes limit 0, which will require to read only one parquet file, in stead of 4 for year '1994'.
+    testExcludeFilter(query, 1, "Filter", 0);
   }
 
   @Test // see DRILL-2712

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
@@ -72,7 +72,9 @@ public class TestAffinityCalculator extends ExecTest {
     rowGroups.clear();
 
     for (int i = 0; i < numberOfRowGroups; i++) {
-      rowGroups.add(new ParquetGroupScan.RowGroupInfo(path, (long)i*rowGroupSize, (long)rowGroupSize, i));
+      // buildRowGroups method seems not be used at all.  Pass -1 as rowCount.
+      // Maybe remove this method completely ?
+      rowGroups.add(new ParquetGroupScan.RowGroupInfo(path, (long)i*rowGroupSize, (long)rowGroupSize, i, -1));
     }
   }
 


### PR DESCRIPTION
… query.

Modify two existint unit testcase:
1) TestPartitionFilter.testMainQueryFalseCondition(): rowCount pruning applied after false condition is transformed into LIMIT 0
2) TestLimitWithExchanges.testPushLimitPastUnionExchange(): modify the testcase to use Json source, so that it does not mix with PushLimitIntoScanRule.