### PR TITLE
DRILL-4390: Uses Resource where Drill favicon is located for static assets

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -108,6 +108,9 @@ public class WebServer implements AutoCloseable {
     }
   }
 
+  private static final String BASE_STATIC_PATH = "/rest/static/";
+  private static final String DRILL_ICON_RESOURCE_RELATIVE_PATH = "img/drill.ico";
+
   /**
    * Start the web server including setup.
    * @throws Exception
@@ -144,7 +147,12 @@ public class WebServer implements AutoCloseable {
     servletContextHandler.addServlet(new ServletHolder(new ThreadDumpServlet()), "/status/threads");
 
     final ServletHolder staticHolder = new ServletHolder("static", DefaultServlet.class);
-    staticHolder.setInitParameter("resourceBase", Resource.newClassPathResource("/rest/static").toString());
+    // Get resource URL for Drill static assets, based on where Drill icon is located
+    String drillIconResourcePath =
+        Resource.newClassPathResource(BASE_STATIC_PATH + DRILL_ICON_RESOURCE_RELATIVE_PATH).getURL().toString();
+    staticHolder.setInitParameter(
+        "resourceBase",
+        drillIconResourcePath.substring(0,  drillIconResourcePath.length() - DRILL_ICON_RESOURCE_RELATIVE_PATH.length()));
     staticHolder.setInitParameter("dirAllowed", "false");
     staticHolder.setInitParameter("pathInfoOnly", "true");
     servletContextHandler.addServlet(staticHolder, "/static/*");


### PR DESCRIPTION
Drill Webserver uses the first jar containing a rest/static directory to
find its static assets. In case of another jar containing this directory, it
might cause the webserver to return 404 errors.

This configures the server to use the resource containing the Drill favicon
as the place to look for all static resources.