### PR TITLE
DRILL-4410: ListVector should initialize bits in allocateNew

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -26,7 +26,7 @@ import java.nio.charset.Charset;
 
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.MinorType;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ExecTest;
@@ -48,6 +48,7 @@ import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.vector.BaseValueVector;
 import org.apache.drill.exec.vector.BitVector;
 import org.apache.drill.exec.vector.NullableFloat4Vector;
@@ -57,6 +58,7 @@ import org.apache.drill.exec.vector.RepeatedIntVector;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
+import org.apache.drill.exec.vector.complex.ListVector;
 import org.apache.drill.exec.vector.complex.MapVector;
 import org.apache.drill.exec.vector.complex.RepeatedListVector;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector;
@@ -788,4 +790,23 @@ the interface to load has changed
       }
     });
   }
+
+  @Test
+  public void testListVectorShouldNotThrowOversizedAllocationException() throws Exception {
+    final MaterializedField field = MaterializedField.create(EMPTY_SCHEMA_PATH,
+            Types.optional(TypeProtos.MinorType.LIST));
+    ListVector vector = new ListVector(field, allocator, null);
+    ListVector vectorFrom = new ListVector(field, allocator, null);
+    vectorFrom.allocateNew();
+
+    for (int i = 0; i < 10000; i++) {
+      vector.allocateNew();
+      vector.copyFromSafe(0, 0, vectorFrom);
+      vector.clear();
+    }
+
+    vectorFrom.clear();
+    vector.clear();
+  }
+
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestComplexTypeReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestComplexTypeReader.java
@@ -241,4 +241,10 @@ public class TestComplexTypeReader extends BaseTestQuery{
             .go();
   }
 
+  @Test  // DRILL-4410
+  // ListVector allocation
+  public void test_array() throws Exception{
+    test("select * from cp.`jsoninput/arrays1.json` `arrays1` INNER JOIN cp.`jsoninput/arrays2.json` `arrays2` ON "
+      + "(`arrays1`.id = `arrays2`.id)");
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestComplexTypeReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestComplexTypeReader.java
@@ -257,8 +257,10 @@ public class TestComplexTypeReader extends BaseTestQuery{
   public void test_array() throws Exception{
 
     long numRecords = 100000;
-    String file1 = "/tmp/" + TestComplexTypeReader.class.getName() + "arrays1.json";
-    String file2 = "/tmp/" + TestComplexTypeReader.class.getName() + "arrays2.json";
+
+    String tempDir = BaseTestQuery.getTempDir("ComplexTypeWriter");
+    String file1 = tempDir + TestComplexTypeReader.class.getName() + "arrays1.json";
+    String file2 = tempDir + TestComplexTypeReader.class.getName() + "arrays2.json";
     Path path1 = Paths.get(file1);
     Path path2 = Paths.get(file2);
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -70,6 +70,7 @@ public class ListVector extends BaseRepeatedValueVector {
   @Override
   public void allocateNew() throws OutOfMemoryException {
     super.allocateNewSafe();
+    bits.allocateNewSafe();
   }
 
   public void transferTo(ListVector target) {


### PR DESCRIPTION
ListVector does not initialize bits, but various ValueVectors depend on bits being initialized.  ONe of the side effects of not having bits set is that for each batch, the ValueVector will reAlloc() with 2x the previous buffer size (regardless of whether it needs it or not).  If there are enough batches, this results in reAlloc() request of size > Integer.MAX, which triggers out-of-memory/max-buffer exception.