### PR TITLE
DRILL-4411: hash join should limit batch based on size and number of records

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -46,6 +46,7 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
   private int recordCount = -1;
   private OperatorContext oContext;
   private boolean schemaChanged = true; // Schema has changed since last built. Must rebuild schema
+  private BufferAllocator allocator;
 
   public VectorContainer() {
     this.oContext = null;
@@ -53,6 +54,11 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
 
   public VectorContainer( OperatorContext oContext) {
     this.oContext = oContext;
+    allocator = this.oContext.getAllocator();
+  }
+
+  public void setAllocator(BufferAllocator allocator) {
+    this.allocator = allocator;
   }
 
   @Override
@@ -122,13 +128,13 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
     if (id != null) {
       vector = getValueAccessorById(id.getFieldIds()).getValueVector();
       if (id.getFieldIds().length == 1 && clazz != null && !clazz.isAssignableFrom(vector.getClass())) {
-        final ValueVector newVector = TypeHelper.getNewVector(field, this.oContext.getAllocator(), callBack);
+        final ValueVector newVector = TypeHelper.getNewVector(field, this.allocator, callBack);
         replace(vector, newVector);
         return (T) newVector;
       }
     } else {
 
-      vector = TypeHelper.getNewVector(field, this.oContext.getAllocator(), callBack);
+      vector = TypeHelper.getNewVector(field, this.allocator, callBack);
       add(vector);
     }
     return (T) vector;
@@ -199,7 +205,7 @@ public class VectorContainer implements Iterable<VectorWrapper<?>>, VectorAccess
   }
 
   private void cloneAndTransfer(VectorWrapper<?> wrapper) {
-    wrappers.add(wrapper.cloneAndTransfer(oContext.getAllocator()));
+    wrappers.add(wrapper.cloneAndTransfer(allocator));
   }
 
   public void addCollection(Iterable<ValueVector> vectors) {


### PR DESCRIPTION
Right now, hash joins can run out of memory if records are large since the batch is limited only by size (of 4000).  This patch implements a simple heuristic.  If the allocator for the outputs become larger than 10 MB before outputing 4000 records (say 2000), then set the batch size limit to 2000 for the future batches.
