### PR TITLE
DRILL-3688: Drill should honor "skip.header.line.count" and "skip.foo…

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.hive;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.hadoop.fs.FileSystem;
@@ -29,8 +30,11 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 
 public class TestHiveStorage extends HiveTestBase {
   @BeforeClass
@@ -407,6 +411,93 @@ public class TestHiveStorage extends HiveTestBase {
     } finally {
       test(String.format("alter session set `%s` = false", ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS));
     }
+  }
+
+  @Test // DRILL-3688
+  public void readingFromSmallTableWithSkipHeaderAndFooter() throws Exception {
+   testBuilder()
+        .sqlQuery("select key, `value` from hive.skipper.kv_text_small order by key asc")
+        .ordered()
+        .baselineColumns("key", "value")
+        .baselineValues(1, "key_1")
+        .baselineValues(2, "key_2")
+        .baselineValues(3, "key_3")
+        .baselineValues(4, "key_4")
+        .baselineValues(5, "key_5")
+        .go();
+
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_small")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(5L)
+        .go();
+  }
+
+  @Test // DRILL-3688
+  public void readingFromLargeTableWithSkipHeaderAndFooter() throws Exception {
+    testBuilder()
+        .sqlQuery("select sum(key) as sum_keys from hive.skipper.kv_text_large")
+        .unOrdered()
+        .baselineColumns("sum_keys")
+        .baselineValues((long)(5000*(5000 + 1)/2))
+        .go();
+
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_large")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(5000L)
+        .go();
+  }
+
+  @Test // DRILL-3688
+  public void testIncorrectHeaderFooterProperty() throws Exception {
+    Map<String, String> testData = ImmutableMap.<String, String>builder()
+        .put("hive.skipper.kv_incorrect_skip_header","skip.header.line.count")
+        .put("hive.skipper.kv_incorrect_skip_footer", "skip.footer.line.count")
+        .build();
+
+    String query = "select * from %s";
+    String exceptionMessage = "Hive table property %s value 'A' is non-numeric";
+
+    for (Map.Entry<String, String> entry : testData.entrySet()) {
+      try {
+        test(String.format(query, entry.getKey()));
+      } catch (UserRemoteException e) {
+        assertThat(e.getMessage(), containsString(String.format(exceptionMessage, entry.getValue())));
+      }
+    }
+  }
+
+  @Test // DRILL-3688
+  public void testIgnoreSkipHeaderFooterForRcfile() throws Exception {
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_rcfile_large")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(5000L)
+        .go();
+  }
+
+  @Test // DRILL-3688
+  public void testIgnoreSkipHeaderFooterForParquet() throws Exception {
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_parquet_large")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(5000L)
+        .go();
+  }
+
+  @Test // DRILL-3688
+  public void testIgnoreSkipHeaderFooterForSequencefile() throws Exception {
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_sequencefile_large")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(5000L)
+        .go();
   }
 
   @AfterClass

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
@@ -51,6 +51,19 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineValues("hive.db1", "kv_db1")
         .baselineValues("hive.db1", "avro")
         .go();
+
+    testBuilder()
+        .sqlQuery("SHOW TABLES IN hive.skipper")
+        .unOrdered()
+        .baselineColumns("TABLE_SCHEMA", "TABLE_NAME")
+        .baselineValues("hive.skipper", "kv_text_small")
+        .baselineValues("hive.skipper", "kv_text_large")
+        .baselineValues("hive.skipper", "kv_incorrect_skip_header")
+        .baselineValues("hive.skipper", "kv_incorrect_skip_footer")
+        .baselineValues("hive.skipper", "kv_rcfile_large")
+        .baselineValues("hive.skipper", "kv_parquet_large")
+        .baselineValues("hive.skipper", "kv_sequencefile_large")
+        .go();
   }
 
   @Test
@@ -61,6 +74,7 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineColumns("SCHEMA_NAME")
         .baselineValues("hive.default")
         .baselineValues("hive.db1")
+        .baselineValues("hive.skipper")
         .baselineValues("dfs.default")
         .baselineValues("dfs.root")
         .baselineValues("dfs.tmp")


### PR DESCRIPTION
Drill should honor "skip.header.line.count" and "skip.footer.line.count" attribute of Hive table:
1. Functionality to skip header and footer lines while reading Hive data.
2. Unit tests.