### PR TITLE
DRILL-4416: quote path separator for cross platform compatibility

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/FileUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/FileUtils.java
@@ -21,16 +21,18 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class FileUtils {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FileUtils.class);
-
-  public static final char separatorChar = '/';
-
-  public static final String separator = "" + separatorChar;
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FileUtils.class);
+  public static final String UNIX_FILE_SEPARATOR = "/";
+  public static final String FILE_SEPARATOR = File.separator;
+  // pattern string for path separator to use with string splitting etc. it is important to use quoted string for
+  // cross platform functionality ie mind shitty windows!
+  public static final String PATH_SEPARATOR_QUOTED = Pattern.quote(FILE_SEPARATOR);
 
   public static File getResourceAsFile(String fileName) throws IOException {
     URL u = FileUtils.class.getResource(fileName);

--- a/common/src/main/java/org/apache/drill/common/util/TestTools.java
+++ b/common/src/main/java/org/apache/drill/common/util/TestTools.java
@@ -49,7 +49,6 @@ public class TestTools {
     return WORKING_PATH;
   }
 
-  private static final String PATH_SEPARATOR = System.getProperty("file.separator");
   private static final String[] STRUCTURE = {"drill", "exec", "java-exec", "src", "test", "resources"};
 
   /**
@@ -61,7 +60,7 @@ public class TestTools {
     for (int i=0; i< STRUCTURE.length; i++) {
       if (WORKING_PATH.endsWith(STRUCTURE[i])) {
         for (int j=i+1; j< STRUCTURE.length; j++) {
-          builder.append(PATH_SEPARATOR).append(STRUCTURE[j]);
+          builder.append(FileUtils.FILE_SEPARATOR).append(STRUCTURE[j]);
         }
         return builder.toString();
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
@@ -159,8 +159,8 @@ public class ClassTransformer {
 
     public ClassNames(String className) {
       dot = className;
-      slash = className.replace('.', FileUtils.separatorChar);
-      clazz = FileUtils.separatorChar + slash + ".class";
+      slash = className.replace(".", FileUtils.UNIX_FILE_SEPARATOR);
+      clazz = FileUtils.UNIX_FILE_SEPARATOR + slash + ".class";
     }
 
     @Override
@@ -286,7 +286,7 @@ public class ClassTransformer {
         }
 
         for (String s : result.innerClasses) {
-          s = s.replace(FileUtils.separatorChar, '.');
+          s = s.replace(FileUtils.UNIX_FILE_SEPARATOR, ".");
           names.add(nextSet.getChild(s));
         }
         classLoader.injectByteCode(nextGenerated.dot, result.bytes);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionInitializer.java
@@ -116,7 +116,9 @@ public class FunctionInitializer {
   private CompilationUnit get(Class<?> c) throws IOException {
     String path = c.getName();
     path = path.replaceFirst("\\$.*", "");
-    path = path.replace(".", FileUtils.separator);
+    // classpath file system relies on unix like file separator regardless the underlying platform. make sure to use
+    // unix file separator.
+    path = path.replace(".", FileUtils.UNIX_FILE_SEPARATOR);
     path = "/" + path + ".java";
     CompilationUnit cu = functionUnits.get(path);
     if (cu != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.store.dfs;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +32,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.common.util.FileUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
@@ -41,7 +41,6 @@ import org.apache.hadoop.fs.Path;
  */
 public class FileSelection {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FileSelection.class);
-  private static final String PATH_SEPARATOR = System.getProperty("file.separator");
   private static final String WILD_CARD = "*";
 
   private List<FileStatus> statuses;
@@ -194,7 +193,7 @@ public class FileSelection {
     int shortest = Integer.MAX_VALUE;
     for (int i = 0; i < total; i++) {
       final Path path = new Path(files.get(i));
-      folders[i] = Path.getPathWithoutSchemeAndAuthority(path).toString().split(PATH_SEPARATOR);
+      folders[i] = Path.getPathWithoutSchemeAndAuthority(path).toString().split(FileUtils.PATH_SEPARATOR_QUOTED);
       shortest = Math.min(shortest, folders[i].length);
     }
 
@@ -217,7 +216,7 @@ public class FileSelection {
   private static String buildPath(final String[] path, final int folderIndex) {
     final StringBuilder builder = new StringBuilder();
     for (int i=0; i<folderIndex; i++) {
-      builder.append(path[i]).append(PATH_SEPARATOR);
+      builder.append(path[i]).append(FileUtils.FILE_SEPARATOR);
     }
     builder.deleteCharAt(builder.length()-1);
     return builder.toString();


### PR DESCRIPTION
Windows uses backslash as its path separator. We need to do string manipulation using the separator during which the separator must be quoted. This issue handles (i) creating a global static path separator variable in common and (ii) removing all others and (iii) using quoted separator where need be.
