### PR TITLE
DRILL-3944: Drill MAXDIR Unknown variable or type "FILE_SEPARATOR"

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/DirectoryExplorers.java
+++ b/exec/java-exec/src/main/codegen/templates/DirectoryExplorers.java
@@ -38,7 +38,6 @@ import javax.inject.Inject;
  */
 public class DirectoryExplorers {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DirectoryExplorers.class);
-  private static final String FILE_SEPARATOR = "/";
 
   <#list [ { "name" : "\"maxdir\"", "functionClassName" : "MaxDir", "comparison" : "compareTo(curr) < 0", "goal" : "maximum", "comparisonType" : "case-sensitive"},
            { "name" : "\"imaxdir\"", "functionClassName" : "IMaxDir", "comparison" : "compareToIgnoreCase(curr) < 0", "goal" : "maximum", "comparisonType" : "case-insensitive"},
@@ -94,7 +93,7 @@ public class DirectoryExplorers {
           subPartitionStr = curr;
         }
       }
-      String[] subPartitionParts = subPartitionStr.split(FILE_SEPARATOR);
+      String[] subPartitionParts = subPartitionStr.split("/");
       subPartitionStr = subPartitionParts[subPartitionParts.length - 1];
       byte[] result = subPartitionStr.getBytes();
       out.buffer = buffer = buffer.reallocIfNeeded(result.length);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/UnsupportedOperatorsVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/UnsupportedOperatorsVisitor.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.UnsupportedOperatorCollector;
 import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.work.foreman.SqlUnsupportedException;
 
 import org.apache.calcite.sql.SqlSelectKeyword;
@@ -48,12 +49,17 @@ public class UnsupportedOperatorsVisitor extends SqlShuttle {
   private QueryContext context;
   private static List<String> disabledType = Lists.newArrayList();
   private static List<String> disabledOperators = Lists.newArrayList();
+  private static List<String> dirExplorers = Lists.newArrayList();
 
   static {
     disabledType.add(SqlTypeName.TINYINT.name());
     disabledType.add(SqlTypeName.SMALLINT.name());
     disabledType.add(SqlTypeName.REAL.name());
     disabledOperators.add("CARDINALITY");
+    dirExplorers.add("MAXDIR");
+    dirExplorers.add("IMAXDIR");
+    dirExplorers.add("MINDIR");
+    dirExplorers.add("IMINDIR");
   }
 
   private UnsupportedOperatorCollector unsupportedOperatorCollector;
@@ -269,15 +275,40 @@ public class UnsupportedOperatorsVisitor extends SqlShuttle {
       }
     }
 
-    // Disable complex functions being present in any place other than Select-Clause
+    // Disable complex functions incorrect placement
     if(sqlCall instanceof SqlSelect) {
       SqlSelect sqlSelect = (SqlSelect) sqlCall;
+
+      for (SqlNode nodeInSelectList : sqlSelect.getSelectList()) {
+        if (checkDirExplorers(nodeInSelectList)) {
+          unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
+              "Directory explorers " + dirExplorers + " functions are not supported in Select List\n" +
+                  "See Apache Drill JIRA: DRILL-3944");
+          throw new UnsupportedOperationException();
+        }
+      }
+
+      if (sqlSelect.hasWhere()) {
+        if (checkDirExplorers(sqlSelect.getWhere()) && !context.getPlannerSettings().isConstantFoldingEnabled()) {
+          unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
+              "Directory explorers " + dirExplorers + " functions can not be used " +
+                  "when " + PlannerSettings.CONSTANT_FOLDING.getOptionName() + " option is set to false\n" +
+                  "See Apache Drill JIRA: DRILL-3944");
+          throw new UnsupportedOperationException();
+        }
+      }
+
       if(sqlSelect.hasOrderBy()) {
         for (SqlNode sqlNode : sqlSelect.getOrderList()) {
           if(containsFlatten(sqlNode)) {
             unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
                 "Flatten function is not supported in Order By\n" +
                 "See Apache Drill JIRA: DRILL-2181");
+            throw new UnsupportedOperationException();
+          } else if (checkDirExplorers(sqlNode)) {
+            unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
+                "Directory explorers " + dirExplorers + " functions are not supported in Order By\n" +
+                "See Apache Drill JIRA: DRILL-3944");
             throw new UnsupportedOperationException();
           }
         }
@@ -289,6 +320,11 @@ public class UnsupportedOperatorsVisitor extends SqlShuttle {
             unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
                 "Flatten function is not supported in Group By\n" +
                 "See Apache Drill JIRA: DRILL-2181");
+            throw new UnsupportedOperationException();
+          } else if (checkDirExplorers(sqlNode)) {
+                unsupportedOperatorCollector.setException(SqlUnsupportedException.ExceptionType.FUNCTION,
+                "Directory explorers " + dirExplorers + " functions are not supported in Group By\n" +
+                "See Apache Drill JIRA: DRILL-3944");
             throw new UnsupportedOperationException();
           }
         }
@@ -351,6 +387,12 @@ public class UnsupportedOperatorsVisitor extends SqlShuttle {
     }
   }
 
+  private boolean checkDirExplorers(SqlNode sqlNode) {
+    final ExprFinder dirExplorersFinder = new ExprFinder(DirExplorersCondition);
+    sqlNode.accept(dirExplorersFinder);
+    return dirExplorersFinder.find();
+  }
+
   /**
    * A function that replies true or false for a given expression.
    *
@@ -400,6 +442,35 @@ public class UnsupportedOperatorsVisitor extends SqlShuttle {
       }
       return false;
     }
+  };
+
+  /**
+   * A condition that returns true if SqlNode has Directory Explorers.
+   */
+  private final SqlNodeCondition DirExplorersCondition = new SqlNodeCondition() {
+    @Override
+    public boolean test(SqlNode sqlNode) {
+      return sqlNode instanceof SqlCall && checkOperator((SqlCall) sqlNode, dirExplorers, true);
+    }
+
+    /**
+     * Checks recursively if operator and its operands are present in provided list of operators
+     */
+    private boolean checkOperator(SqlCall sqlCall, List<String> operators, boolean checkOperator) {
+      if (checkOperator) {
+        return operators.contains(sqlCall.getOperator().getName().toUpperCase()) || checkOperator(sqlCall, operators, false);
+      }
+      for (SqlNode sqlNode : sqlCall.getOperandList()) {
+        if (!(sqlNode instanceof SqlCall)) {
+          continue;
+        }
+        if (checkOperator((SqlCall) sqlNode, operators, true)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
   };
 
   /**


### PR DESCRIPTION
1. Fixed issue with unknown variable or type "FILE_SEPARATOR".
2. Fixed error when directory functions are used outside of where clause.
3. Fixed error when directory functions are used with `planner.enable_constant_folding` = false;
4. Added appropriate unit tests.