### PR TITLE
DRILL-4441: Fix varchar data read out of Avro filtering incorrectly d…

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
@@ -28,7 +28,7 @@ public class TestInbuiltHiveUDFs extends HiveTestBase {
         .sqlQuery("SELECT concat_ws(string_field, string_part, '|') as rst from hive.readtest")
         .unOrdered()
         .baselineColumns("rst")
-        .baselineValues("stringstringfield|")
+        .baselineValues("stringstringfield|".getBytes())
         .baselineValues(new Object[] { null })
         .go();
   }
@@ -39,7 +39,7 @@ public class TestInbuiltHiveUDFs extends HiveTestBase {
         .sqlQuery("SELECT encode(varchar_field, 'UTF-8') as rst from hive.readtest")
         .unOrdered()
         .baselineColumns("rst")
-        .baselineValues("varcharfield")
+        .baselineValues("varcharfield".getBytes())
         .baselineValues(new Object[] { null })
         .go();
   }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -134,7 +134,7 @@ public class TestHiveStorage extends HiveTestBase {
             "timestamp_part",
             "date_part")
         .baselineValues(
-            "binaryfield",
+            "binaryfield".getBytes(),
             false,
             34,
             new BigDecimal("66"),
@@ -244,7 +244,7 @@ public class TestHiveStorage extends HiveTestBase {
               "timestamp_part",
               "date_part")
           .baselineValues(
-              "binaryfield",
+              "binaryfield".getBytes(),
               false,
               34,
               new BigDecimal("66"),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -295,6 +295,7 @@ public class DrillOptiq {
         case "INTERVAL_YEAR_MONTH": castType = Types.required(MinorType.INTERVALYEAR); break;
         case "INTERVAL_DAY_TIME": castType = Types.required(MinorType.INTERVALDAY); break;
         case "BOOLEAN": castType = Types.required(MinorType.BIT); break;
+        case "BINARY": castType = Types.required(MinorType.VARBINARY).toBuilder().setWidth(call.getType().getPrecision()).build(); break;
         case "ANY": return arg; // Type will be same as argument.
         default: castType = Types.required(MinorType.valueOf(call.getType().getSqlTypeName().getName()));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroDrillTable.java
@@ -82,7 +82,7 @@ public class AvroDrillTable extends DrillTable {
       relDataType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
       break;
     case BYTES:
-      relDataType = typeFactory.createSqlType(SqlTypeName.BINARY);
+      relDataType = typeFactory.createSqlType(SqlTypeName.BINARY, 65000);
       break;
     case DOUBLE:
       relDataType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
@@ -101,7 +101,7 @@ public class AvroDrillTable extends DrillTable {
       break;
     case MAP:
       RelDataType valueType = getNullableRelDataTypeFromAvroType(typeFactory, fieldSchema.getValueType());
-      RelDataType keyType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+      RelDataType keyType = typeFactory.createSqlType(SqlTypeName.VARCHAR, 65000);
       relDataType = typeFactory.createMapType(keyType, valueType);
       break;
     case NULL:
@@ -118,13 +118,13 @@ public class AvroDrillTable extends DrillTable {
 
       //TODO This has to be mapped to struct type but because of calcite issue,
       //for now mapping it to map type.
-      keyType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+      keyType = typeFactory.createSqlType(SqlTypeName.VARCHAR, 65000);
       valueType = typeFactory.createSqlType(SqlTypeName.ANY);
       relDataType = typeFactory.createMapType(keyType, valueType);
       break;
     case ENUM:
     case STRING:
-      relDataType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+      relDataType = typeFactory.createSqlType(SqlTypeName.VARCHAR, 65000);
       break;
     case UNION:
       RelDataType optinalType = getNullableRelDataTypeFromAvroType(typeFactory, fieldSchema.getTypes().get(1));

--- a/exec/java-exec/src/test/java/org/apache/drill/DrillTestWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/DrillTestWrapper.java
@@ -516,9 +516,6 @@ public class DrillTestWrapper {
             if (obj instanceof Text) {
               obj = obj.toString();
             }
-            else if (obj instanceof byte[]) {
-              obj = new String((byte[]) obj, "UTF-8");
-            }
             record.put(SchemaPath.getSimplePath(w.getField().getPath()).toExpr(), obj);
           }
           record.put(SchemaPath.getSimplePath(w.getField().getPath()).toExpr(), obj);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
@@ -94,7 +94,7 @@ public class AvroTestUtil {
         byte[] drillVal = new byte[((ByteBuffer)value).remaining()];
         bb.get(drillVal);
         bb.position(0);
-        value = new String(drillVal, Charsets.UTF_8);
+        value = drillVal;
       }
       currentExpectedRecord.put("`" + key + "`", value);
     }
@@ -143,10 +143,11 @@ public class AvroTestUtil {
 
     final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      ByteBuffer bb = ByteBuffer.allocate(1);
+      ByteBuffer bb = ByteBuffer.allocate(2);
       bb.put(0, (byte) 'a');
 
       for (int i = 0; i < numRecords; i++) {
+        bb.put(1, (byte) ('0' + (i % 10)));
         bb.position(0);
         record.startRecord();
         record.put("a_string", "a_" + i);


### PR DESCRIPTION
…ue to metadata bug

The precision of the Varchar datatype was not being set causing inconsistent
truncation of values to the default length of 1.