### PR TITLE
DRILL-4375: Fix the maven release profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ CMakeFiles
 Makefile
 cmake_install.cmake
 install_manifest.txt
+# TODO - DRILL-4336
+exec/jdbc-all/dependency-reduced-pom.xml

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -263,7 +263,13 @@
         <configuration>
           <shadedArtifactAttached>false</shadedArtifactAttached>
           <createDependencyReducedPom>true</createDependencyReducedPom>
-          <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+          <!-- TODO DRILL-4336: try to move the dependencyReducedPom out of the default location (the module root).
+               Putting it here caused the target directory to be run as a submodule (oddly
+               only when trying to run the maven release goal) -->
+          <!--dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
+          <!-- TODO DRILL-4336: an attempt to fix the issue by moving the file elsewhere, had issues executing
+               but may be able to be modified to to fix the issue-->
+          <!--dependencyReducedPomLocation>${project.build.directory}/generated/shade/dependency-reduced-pom.xml</dependencyReducedPomLocation-->
           <minimizeJar>false</minimizeJar>
 
           <artifactSet>

--- a/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
+++ b/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
@@ -63,7 +63,7 @@ public class ITTestShadedJar {
     try {
       Driver driver = (Driver) clazz.newInstance();
       try (Connection c = driver.connect("jdbc:drill:drillbit=localhost:31010", null)) {
-        String path = Paths.get("").toAbsolutePath().toString() + "/../src/test/resources/types.json";
+        String path = Paths.get("").toAbsolutePath().toString() + "/src/test/resources/types.json";
         printQuery(c, "select * from dfs.`" + path + "`");
       }
     } catch (Exception ex) {

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,8 @@
             <exclude>**/*.linux</exclude>
             <exclude>**/client/build/**</exclude>
             <exclude>**/*.tbl</exclude>
+            <!-- TODO DRILL-4336: try to avoid the need to add this -->
+            <exclude>dependency-reduced-pom.xml</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
This generated pom file was being discovered and maven was trying to
run the target directory in jdbc-all as a submodule.

This change reverts to the default output location (the module root)
and adds corresponding .gitignore and RAT exclude entries. NOTE:
this is considered bad practice as generated files should appear in
the target directory and be removed upon a maven clean. This default
location is considered to be a known shortcoming of the shade plugin.

Also updated integration test for the jdbc-all jar with small
path change, as changing the location of the dependency-reduced-pom.xml
actually changed the directory the test was being executed from.