### PR TITLE
DRILL-4467: Fix ProjectPushInfo#desiredFields order when using PrelUtil#getColumns

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
@@ -256,7 +256,7 @@ public class PrelUtil {
     final Set<SchemaPath> columns = Sets.newLinkedHashSet();
     final private List<String> fieldNames;
     final private List<RelDataTypeField> fields;
-    final private Set<DesiredField> desiredFields = Sets.newHashSet();
+    final private Set<DesiredField> desiredFields = Sets.newLinkedHashSet();
 
     public RefFieldsVisitor(RelDataType rowType) {
       super(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -569,13 +569,11 @@ public class TestUnionAll extends BaseTestQuery{
         ".*UnionAll.*\n" +
             ".*Project.*\n" +
                 ".*HashJoin.*\n" +
-                    ".*Project.*\n" +
-                        ".*Scan.*columns=\\[`n_regionkey`, `n_nationkey`\\].*\n" +
+                    ".*Scan.*columns=\\[`n_regionkey`, `n_nationkey`\\].*\n" +
                     ".*Scan.*columns=\\[`r_regionkey`\\].*\n" +
             ".*Project.*\n" +
                 ".*HashJoin.*\n" +
-                    ".*Project.*\n" +
-                        ".*Scan.*columns=\\[`n_regionkey`, `n_nationkey`\\].*\n" +
+                    ".*Scan.*columns=\\[`n_regionkey`, `n_nationkey`\\].*\n" +
                     ".*Scan.*columns=\\[`r_regionkey`\\].*"};
     final String[] excludedPlan = {};
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/physical/TestPrelUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/physical/TestPrelUtil.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.rules.ProjectRemoveRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.exec.planner.physical.PrelUtil.ProjectPushInfo;
+import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Unit test for @{code PrelUtil}
+ */
+public class TestPrelUtil {
+  private static final RelDataType ANY_TYPE = new BasicSqlType(DrillRelDataTypeSystem.DRILL_REL_DATATYPE_SYSTEM, SqlTypeName.ANY);
+
+  @Test
+  public void testGetColumns() {
+    // Based on DRILL-4334 test failure. Field chosen to make it fail for both Java7 and Java8.
+    RelDataType rowType = new RelRecordType(Arrays.<RelDataTypeField> asList(
+        new RelDataTypeFieldImpl("*", 0, ANY_TYPE),
+        new RelDataTypeFieldImpl("rating", 1, ANY_TYPE),
+        new RelDataTypeFieldImpl("full_name", 2, ANY_TYPE),
+        new RelDataTypeFieldImpl("firstname", 3, ANY_TYPE)
+        ));
+
+    List<RexNode> projects = Arrays.<RexNode>asList(new RexInputRef(1, ANY_TYPE), new RexInputRef(3, ANY_TYPE), new RexInputRef(2, ANY_TYPE));
+    ProjectPushInfo info = PrelUtil.getColumns(rowType, projects);
+
+    // Making sure that fields are ordered the same as the projects
+    for(int index = 0; index < info.desiredFields.size(); index++) {
+      assertEquals(((RexInputRef) projects.get(index)).getIndex(), info.desiredFields.get(index).origIndex);
+    }
+
+    // Create a new projection, and check it's the identity.
+    RelDataType newRowType = info.createNewRowType(new JavaTypeFactoryImpl());
+    List<RexNode> newProjects = Lists.newArrayList();
+    for (RexNode n : projects) {
+      newProjects.add(n.accept(info.getInputRewriter()));
+    }
+
+    assertTrue("Projection should be identity", ProjectRemoveRule.isIdentity(newProjects, newRowType));
+  }
+
+}


### PR DESCRIPTION
Order of ProjectPushInfo#desiredFields elements is not the same as the list of
RexNode elements they are derived from. This might cause some optimization to
be skipped in DrillPushProjIntoScan as the ProjectRemoveRule.isTrivial(newProj)
check might fail simply because of the ordering mismatch.

The visitor created to visit the original RexNode elements now uses a
LinkedHashSet to guarantee that the ordering stays the same as the order
of the RexNode instances they are derived from.