### PR TITLE
DRILL-3623: For limit 0 queries, use a shorter path when result column types are known

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
@@ -58,7 +58,7 @@ public class TestInbuiltHiveUDFs extends HiveTestBase {
 
     final TypeProtos.MajorType majorType = TypeProtos.MajorType.newBuilder()
         .setMinorType(TypeProtos.MinorType.FLOAT8)
-        .setMode(TypeProtos.DataMode.REQUIRED)
+        .setMode(TypeProtos.DataMode.OPTIONAL)
         .build();
 
     final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -202,6 +202,9 @@ public interface ExecConstants {
   String AFFINITY_FACTOR_KEY = "planner.affinity_factor";
   OptionValidator AFFINITY_FACTOR = new DoubleValidator(AFFINITY_FACTOR_KEY, 1.2d);
 
+  String EARLY_LIMIT0_OPT_KEY = "planner.enable_limit0_optimization";
+  BooleanValidator EARLY_LIMIT0_OPT = new BooleanValidator(EARLY_LIMIT0_OPT_KEY, false);
+
   String ENABLE_MEMORY_ESTIMATION_KEY = "planner.memory.enable_memory_estimation";
   OptionValidator ENABLE_MEMORY_ESTIMATION = new BooleanValidator(ENABLE_MEMORY_ESTIMATION_KEY, false);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.physical.base;
 
-
 public class ScanStats {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ScanStats.class);
-
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ScanStats.class);
 
   public static final ScanStats TRIVIAL_TABLE = new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, 20, 1, 1);
+
+  public static final ScanStats ZERO_RECORD_TABLE = new ScanStats(GroupScanProperty.EXACT_ROW_COUNT, 0, 1, 1);
 
   private final long recordCount;
   private final float cpuCost;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -65,6 +65,7 @@ import org.apache.drill.exec.planner.logical.DrillWindowRule;
 import org.apache.drill.exec.planner.logical.partition.ParquetPruneScanRule;
 import org.apache.drill.exec.planner.logical.partition.PruneScanRule;
 import org.apache.drill.exec.planner.physical.ConvertCountToDirectScan;
+import org.apache.drill.exec.planner.physical.DirectScanPrule;
 import org.apache.drill.exec.planner.physical.FilterPrule;
 import org.apache.drill.exec.planner.physical.HashAggPrule;
 import org.apache.drill.exec.planner.physical.HashJoinPrule;
@@ -391,6 +392,7 @@ public enum PlannerPhase {
     ruleList.add(LimitUnionExchangeTransposeRule.INSTANCE);
     ruleList.add(UnionAllPrule.INSTANCE);
     ruleList.add(ValuesPrule.INSTANCE);
+    ruleList.add(DirectScanPrule.INSTANCE);
 
     if (ps.isHashAggEnabled()) {
       ruleList.add(HashAggPrule.INSTANCE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillDirectScanRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillDirectScanRel.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.drill.common.logical.data.LogicalOperator;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.store.direct.DirectGroupScan;
+
+/**
+ * Logical RelNode representing a {@link DirectGroupScan}. This is not backed by a {@link DrillTable},
+ * unlike {@link DrillScanRel}.
+ */
+public class DrillDirectScanRel extends AbstractRelNode implements DrillRel {
+
+  private final DirectGroupScan groupScan;
+  private final RelDataType rowType;
+
+  public DrillDirectScanRel(RelOptCluster cluster, RelTraitSet traitSet, DirectGroupScan directGroupScan,
+                            RelDataType rowType) {
+    super(cluster, traitSet);
+    this.groupScan = directGroupScan;
+    this.rowType = rowType;
+  }
+
+  @Override
+  public LogicalOperator implement(DrillImplementor implementor) {
+    return null;
+  }
+
+  @Override
+  public RelDataType deriveRowType() {
+    return this.rowType;
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw).item("directscan", groupScan.getDigest());
+  }
+
+  @Override
+  public double getRows() {
+    final PlannerSettings settings = PrelUtil.getPlannerSettings(getCluster());
+    return groupScan.getScanStats(settings).getRecordCount();
+  }
+
+  public DirectGroupScan getGroupScan() {
+    return groupScan;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DirectScanPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DirectScanPrule.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.drill.exec.planner.logical.DrillDirectScanRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+
+public class DirectScanPrule extends Prule {
+
+  public static final RelOptRule INSTANCE = new DirectScanPrule();
+
+  public DirectScanPrule() {
+    super(RelOptHelper.any(DrillDirectScanRel.class), "Prel.DirectScanPrule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final DrillDirectScanRel scan = call.rel(0);
+    final RelTraitSet traits = scan.getTraitSet().plus(Prel.DRILL_PHYSICAL);
+
+    final ScanPrel newScan = new ScanPrel(scan.getCluster(), traits, scan.getGroupScan(), scan.getRowType()) {
+      // direct scan (no execution) => no accidental column shuffling => no reordering
+      @Override
+      public boolean needsFinalColumnReordering() {
+        return false;
+      }
+    };
+
+    call.transformTo(newScan);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -116,6 +116,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       ExecConstants.SMALL_QUEUE_SIZE,
       ExecConstants.MIN_HASH_TABLE_SIZE,
       ExecConstants.MAX_HASH_TABLE_SIZE,
+      ExecConstants.EARLY_LIMIT0_OPT,
       ExecConstants.ENABLE_MEMORY_ESTIMATION,
       ExecConstants.MAX_QUERY_MEMORY_PER_NODE,
       ExecConstants.NON_BLOCKING_OPERATORS_MEMORY,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/DirectGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/DirectGroupScan.java
@@ -17,12 +17,9 @@
  */
 package org.apache.drill.exec.store.direct;
 
-import java.util.Collections;
-import java.util.List;
-
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.GroupScan;
@@ -32,14 +29,23 @@ import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.store.RecordReader;
 
-public class DirectGroupScan extends AbstractGroupScan{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DirectGroupScan.class);
+import java.util.List;
+
+@JsonTypeName("direct-scan")
+public class DirectGroupScan extends AbstractGroupScan {
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DirectGroupScan.class);
 
   private final RecordReader reader;
+  private final ScanStats stats;
 
   public DirectGroupScan(RecordReader reader) {
-    super((String)null);
+    this(reader, ScanStats.TRIVIAL_TABLE);
+  }
+
+  public DirectGroupScan(RecordReader reader, ScanStats stats) {
+    super((String) null);
     this.reader = reader;
+    this.stats = stats;
   }
 
   @Override
@@ -58,14 +64,15 @@ public class DirectGroupScan extends AbstractGroupScan{
     return 1;
   }
 
-  public ScanStats getScanStats(){
-    return ScanStats.TRIVIAL_TABLE;
+  @Override
+  public ScanStats getScanStats() {
+    return stats;
   }
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) throws ExecutionSetupException {
     assert children == null || children.isEmpty();
-    return new DirectGroupScan(reader);
+    return new DirectGroupScan(reader, stats);
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
@@ -291,6 +291,7 @@ public class PlanTestBase extends BaseTestQuery {
     final List<QueryDataBatch> results = testSqlWithResults(sql);
     final RecordBatchLoader loader = new RecordBatchLoader(getDrillbitContext().getAllocator());
     final StringBuilder builder = new StringBuilder();
+    final boolean silent = config != null && config.getBoolean(QueryTestUtil.TEST_QUERY_PRINTING_SILENT);
 
     for (final QueryDataBatch b : results) {
       if (!b.hasData()) {
@@ -308,12 +309,16 @@ public class PlanTestBase extends BaseTestQuery {
         throw new Exception("Looks like you did not provide an explain plan query, please add EXPLAIN PLAN FOR to the beginning of your query.");
       }
 
-      System.out.println(vw.getValueVector().getField().getPath());
+      if (!silent) {
+        System.out.println(vw.getValueVector().getField().getPath());
+      }
       final ValueVector vv = vw.getValueVector();
       for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
         final Object o = vv.getAccessor().getObject(i);
         builder.append(o);
-        System.out.println(vv.getAccessor().getObject(i));
+        if (!silent) {
+          System.out.println(o);
+        }
       }
       loader.clear();
       b.release();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestEarlyLimit0Optimization.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestEarlyLimit0Optimization.java
@@ -1,0 +1,663 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.limit;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.PlanTestBase;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.ExecConstants;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.util.List;
+
+public class TestEarlyLimit0Optimization extends BaseTestQuery {
+
+  private static final String viewName = "limitZeroEmployeeView";
+
+  private static String wrapLimit0(final String query) {
+    return "SELECT * FROM (" + query + ") LZT LIMIT 0";
+  }
+
+  @BeforeClass
+  public static void createView() throws Exception {
+    test("USE dfs_test.tmp");
+    test(String.format("CREATE OR REPLACE VIEW %s AS SELECT " +
+        "CAST(employee_id AS INT) AS employee_id, " +
+        "CAST(full_name AS VARCHAR(25)) AS full_name, " +
+        "CAST(position_id AS INTEGER) AS position_id, " +
+        "CAST(department_id AS BIGINT) AS department_id," +
+        "CAST(birth_date AS DATE) AS birth_date, " +
+        "CAST(hire_date AS TIMESTAMP) AS hire_date, " +
+        "CAST(salary AS DOUBLE) AS salary, " +
+        "CAST(salary AS FLOAT) AS fsalary, " +
+        "CAST((CASE WHEN marital_status = 'S' THEN true ELSE false END) AS BOOLEAN) AS single, " +
+        "CAST(education_level AS VARCHAR(60)) AS education_level," +
+        "CAST(gender AS CHAR) AS gender " +
+        "FROM cp.`employee.json` " +
+        "ORDER BY employee_id " +
+        "LIMIT 1;", viewName));
+    // { "employee_id":1,"full_name":"Sheri Nowmer","first_name":"Sheri","last_name":"Nowmer","position_id":1,
+    // "position_title":"President","store_id":0,"department_id":1,"birth_date":"1961-08-26",
+    // "hire_date":"1994-12-01 00:00:00.0","end_date":null,"salary":80000.0000,"supervisor_id":0,
+    // "education_level":"Graduate Degree","marital_status":"S","gender":"F","management_role":"Senior Management" }
+  }
+
+  @AfterClass
+  public static void tearDownView() throws Exception {
+    test("DROP VIEW " + viewName + ";");
+  }
+
+  @Before
+  public void setOption() throws Exception {
+    test("SET `%s` = true;", ExecConstants.EARLY_LIMIT0_OPT_KEY);
+  }
+
+  @After
+  public void resetOption() throws Exception {
+    test("RESET `%s`;", ExecConstants.EARLY_LIMIT0_OPT_KEY);
+  }
+
+  // -------------------- SIMPLE QUERIES --------------------
+
+  @Test
+  public void infoSchema() throws Exception {
+    testBuilder()
+        .sqlQuery(String.format("DESCRIBE %s", viewName))
+        .unOrdered()
+        .baselineColumns("COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE")
+        .baselineValues("employee_id", "INTEGER", "YES")
+        .baselineValues("full_name", "CHARACTER VARYING", "YES")
+        .baselineValues("position_id", "INTEGER", "YES")
+        .baselineValues("department_id", "BIGINT", "YES")
+        .baselineValues("birth_date", "DATE", "YES")
+        .baselineValues("hire_date", "TIMESTAMP", "YES")
+        .baselineValues("salary", "DOUBLE", "YES")
+        .baselineValues("fsalary", "FLOAT", "YES")
+        .baselineValues("single", "BOOLEAN", "NO")
+        .baselineValues("education_level", "CHARACTER VARYING", "YES")
+        .baselineValues("gender", "CHARACTER", "YES")
+        .go();
+  }
+
+  @Test
+  public void simpleSelect() throws Exception {
+    testBuilder()
+        .sqlQuery(String.format("SELECT * FROM %s", viewName))
+        .ordered()
+        .baselineColumns("employee_id", "full_name", "position_id", "department_id", "birth_date", "hire_date",
+            "salary", "fsalary", "single", "education_level", "gender")
+        .baselineValues(1, "Sheri Nowmer", 1, 1L, new DateTime(Date.valueOf("1961-08-26").getTime()),
+            new DateTime(Date.valueOf("1994-12-01").getTime()), 80000.0D, 80000.0F, true, "Graduate Degree", "F")
+        .go();
+  }
+
+  @Test
+  public void simpleSelectLimit0() throws Exception {
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("employee_id"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("full_name"), Types.optional(TypeProtos.MinorType.VARCHAR)),
+        Pair.of(SchemaPath.getSimplePath("position_id"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("department_id"), Types.optional(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("birth_date"), Types.optional(TypeProtos.MinorType.DATE)),
+        Pair.of(SchemaPath.getSimplePath("hire_date"), Types.optional(TypeProtos.MinorType.TIMESTAMP)),
+        Pair.of(SchemaPath.getSimplePath("salary"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("fsalary"), Types.optional(TypeProtos.MinorType.FLOAT4)),
+        Pair.of(SchemaPath.getSimplePath("single"), Types.required(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("education_level"), Types.optional(TypeProtos.MinorType.VARCHAR)),
+        Pair.of(SchemaPath.getSimplePath("gender"), Types.optional(TypeProtos.MinorType.VARCHAR)));
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(String.format("SELECT * FROM %s", viewName)))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized("SELECT * FROM " + viewName);
+  }
+
+  private static void checkThatQueryPlanIsOptimized(final String query) throws Exception {
+    PlanTestBase.testPlanMatchingPatterns(
+        wrapLimit0(query),
+        new String[]{
+            ".*Project.*\n" +
+                ".*Scan.*RelDataTypeReader.*"
+        },
+        new String[]{});
+  }
+
+  // -------------------- AGGREGATE FUNC. QUERIES --------------------
+
+  private static String getAggQuery(final String functionName) {
+    return "SELECT " +
+        functionName + "(employee_id) AS e, " +
+        functionName + "(position_id) AS p, " +
+        functionName + "(department_id) AS d, " +
+        functionName + "(salary) AS s, " +
+        functionName + "(fsalary) AS f " +
+        "FROM " + viewName;
+  }
+
+  @Test
+  public void sums() throws Exception {
+    final String query = getAggQuery("SUM");
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("d"), Types.optional(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("f"), Types.optional(TypeProtos.MinorType.FLOAT8)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("e", "p", "d", "s", "f")
+        .baselineValues(1L, 1L, 1L, 80000D, 80000D)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void counts() throws Exception {
+    final String query = getAggQuery("COUNT");
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("e"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("d"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("s"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("f"), Types.required(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("e", "p", "d", "s", "f")
+        .ordered()
+        .baselineValues(1L, 1L, 1L, 1L, 1L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  private void minAndMaxTest(final String functionName) throws Exception {
+    final String query = getAggQuery(functionName);
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("d"), Types.optional(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("f"), Types.optional(TypeProtos.MinorType.FLOAT4)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("e", "p", "d", "s", "f")
+        .ordered()
+        .baselineValues(1, 1, 1L, 80_000D, 80_000F)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void mins() throws Exception {
+    minAndMaxTest("MIN");
+  }
+
+  @Test
+  public void maxs() throws Exception {
+    minAndMaxTest("MAX");
+  }
+
+  @Test
+  public void avgs() throws Exception {
+    final String query = getAggQuery("AVG");
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("d"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("f"), Types.optional(TypeProtos.MinorType.FLOAT8)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("e", "p", "d", "s", "f")
+        .baselineValues(1D, 1D, 1D, 80_000D, 80_000D)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void measures() throws Exception {
+    final String query = "SELECT " +
+        "STDDEV_SAMP(employee_id) AS s, " +
+        "STDDEV_POP(position_id) AS p, " +
+        "AVG(position_id) AS a, " +
+        "COUNT(position_id) AS c " +
+        "FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("a"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("c"), Types.required(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("s", "p", "a", "c")
+        .baselineValues(null, 0.0D, 1.0D, 1L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void nullableCount() throws Exception {
+    final String query = "SELECT " +
+        "COUNT(CASE WHEN position_id = 1 THEN NULL ELSE position_id END) AS c FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("c"), Types.required(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("c")
+        .baselineValues(0L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void nullableSumAndCount() throws Exception {
+    final String query = "SELECT " +
+        "COUNT(position_id) AS c, " +
+        "SUM(CAST((CASE WHEN position_id = 1 THEN NULL ELSE position_id END) AS INT)) AS p " +
+        "FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("c"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("c", "p")
+        .baselineValues(1L, null)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void castSum() throws Exception {
+    final String query = "SELECT CAST(SUM(position_id) AS INT) AS s FROM cp.`employee.json`";
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.INT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("s")
+        .baselineValues(18422)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void sumCast() throws Exception {
+    final String query = "SELECT SUM(CAST(position_id AS INT)) AS s FROM cp.`employee.json`";
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("s")
+        .baselineValues(18422L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void sumsAndCounts1() throws Exception {
+    final String query = "SELECT " +
+        "COUNT(*) as cs, " +
+        "COUNT(1) as c1, " +
+        "COUNT(employee_id) as cc, " +
+        "SUM(1) as s1," +
+        "department_id " +
+        " FROM " + viewName + " GROUP BY department_id";
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("cs"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("c1"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("cc"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("s1"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("department_id"), Types.optional(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("cs", "c1", "cc", "s1", "department_id")
+        .baselineValues(1L, 1L, 1L, 1L, 1L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void sumsAndCounts2() throws Exception {
+    final String query = "SELECT " +
+        "SUM(1) as s1, " +
+        "COUNT(1) as c1, " +
+        "COUNT(*) as cs, " +
+        "COUNT(CAST(n_regionkey AS INT)) as cc " +
+        "FROM cp.`tpch/nation.parquet` " +
+        "GROUP BY CAST(n_regionkey AS INT)";
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("s1"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("c1"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("cs"), Types.required(TypeProtos.MinorType.BIGINT)),
+        Pair.of(SchemaPath.getSimplePath("cc"), Types.required(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("s1", "c1", "cs", "cc")
+        .baselineValues(5L, 5L, 5L, 5L)
+        .baselineValues(5L, 5L, 5L, 5L)
+        .baselineValues(5L, 5L, 5L, 5L)
+        .baselineValues(5L, 5L, 5L, 5L)
+        .baselineValues(5L, 5L, 5L, 5L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+
+  }
+
+  @Test
+  public void rank() throws Exception {
+    final String query = "SELECT RANK() OVER(PARTITION BY employee_id ORDER BY employee_id) AS r FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("r"), Types.required(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("r")
+        .baselineValues(1L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  // -------------------- SCALAR FUNC. QUERIES --------------------
+
+  @Test
+  public void cast() throws Exception {
+    final String query = "SELECT CAST(fsalary AS DOUBLE) AS d," +
+        "CAST(employee_id AS BIGINT) AS e FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("d"), Types.optional(TypeProtos.MinorType.FLOAT8)),
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("d", "e")
+        .ordered()
+        .baselineValues(80_000D, 1L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  public void concatTest(final String query) throws Exception {
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("c"), Types.optional(TypeProtos.MinorType.VARCHAR)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("c")
+        .ordered()
+        .baselineValues("Sheri NowmerGraduate Degree")
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void concat() throws Exception {
+    concatTest("SELECT CONCAT(full_name, education_level) AS c FROM " + viewName);
+  }
+
+  @Test
+  public void concatOp() throws Exception {
+    concatTest("SELECT full_name || education_level AS c FROM " + viewName);
+  }
+
+  @Test
+  public void extract() throws Exception {
+    final String query = "SELECT EXTRACT(YEAR FROM hire_date) AS e FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.BIGINT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("e")
+        .ordered()
+        .baselineValues(1994L)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void binary() throws Exception {
+    final String query = "SELECT " +
+        "single AND true AS b, " +
+        "full_name || education_level AS c, " +
+        "position_id / position_id AS d, " +
+        "position_id = position_id AS e, " +
+        "position_id > position_id AS g, " +
+        "position_id >= position_id AS ge, " +
+        "position_id IN (0, 1) AS i, +" +
+        "position_id < position_id AS l, " +
+        "position_id <= position_id AS le, " +
+        "position_id - position_id AS m, " +
+        "position_id * position_id AS mu, " +
+        "position_id <> position_id AS n, " +
+        "single OR false AS o, " +
+        "position_id + position_id AS p FROM " + viewName;
+
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("b"), Types.required(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("c"), Types.optional(TypeProtos.MinorType.VARCHAR)),
+        Pair.of(SchemaPath.getSimplePath("d"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("e"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("g"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("ge"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("i"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("l"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("le"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("m"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("mu"), Types.optional(TypeProtos.MinorType.INT)),
+        Pair.of(SchemaPath.getSimplePath("n"), Types.optional(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("o"), Types.required(TypeProtos.MinorType.BIT)),
+        Pair.of(SchemaPath.getSimplePath("p"), Types.optional(TypeProtos.MinorType.INT)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("b", "c", "d", "e", "g", "ge", "i", "l", "le", "m", "mu", "n", "o", "p")
+        .ordered()
+        .baselineValues(true, "Sheri NowmerGraduate Degree", 1, true, false, true, true, false, true,
+            0, 1, false, true, 2)
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  public void substringTest(final String query) throws Exception {
+    @SuppressWarnings("unchecked")
+    final List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Lists.newArrayList(
+        Pair.of(SchemaPath.getSimplePath("s"), Types.optional(TypeProtos.MinorType.VARCHAR)));
+
+    testBuilder()
+        .sqlQuery(query)
+        .baselineColumns("s")
+        .ordered()
+        .baselineValues("Sheri")
+        .go();
+
+    testBuilder()
+        .sqlQuery(wrapLimit0(query))
+        .schemaBaseLine(expectedSchema)
+        .go();
+
+    checkThatQueryPlanIsOptimized(query);
+  }
+
+  @Test
+  public void substring() throws Exception {
+    substringTest("SELECT SUBSTRING(full_name, 1, 5) AS s FROM " + viewName);
+  }
+
+  @Test
+  public void substr() throws Exception {
+    substringTest("SELECT SUBSTR(full_name, 1, 5) AS s FROM " + viewName);
+  }
+}


### PR DESCRIPTION
Moving from #193 to here.

+ There is a pull request open for first commit (DRILL-4372: #397).
+ Second commit has a "nice to have" check: ensuring planning and execution types patch.
+ My changes are in the third commit (e4cfdfa). Please review this.