### PR TITLE
DRILL-4482: Avro subselection broken by 4382

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
@@ -39,7 +39,7 @@ public class TestInbuiltHiveUDFs extends HiveTestBase {
         .sqlQuery("SELECT encode(varchar_field, 'UTF-8') as rst from hive.readtest")
         .unOrdered()
         .baselineColumns("rst")
-        .baselineValues("varcharfield")
+        .baselineValues("varcharfield".getBytes())
         .baselineValues(new Object[] { null })
         .go();
   }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -134,7 +134,7 @@ public class TestHiveStorage extends HiveTestBase {
             "timestamp_part",
             "date_part")
         .baselineValues(
-            "binaryfield",
+            "binaryfield".getBytes(),
             false,
             34,
             new BigDecimal("66"),
@@ -244,7 +244,7 @@ public class TestHiveStorage extends HiveTestBase {
               "timestamp_part",
               "date_part")
           .baselineValues(
-              "binaryfield",
+              "binaryfield".getBytes(),
               false,
               34,
               new BigDecimal("66"),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -295,6 +295,7 @@ public class DrillOptiq {
         case "INTERVAL_YEAR_MONTH": castType = Types.required(MinorType.INTERVALYEAR); break;
         case "INTERVAL_DAY_TIME": castType = Types.required(MinorType.INTERVALDAY); break;
         case "BOOLEAN": castType = Types.required(MinorType.BIT); break;
+        case "BINARY": castType = Types.required(MinorType.VARBINARY).toBuilder().setWidth(call.getType().getPrecision()).build(); break;
         case "ANY": return arg; // Type will be same as argument.
         default: castType = Types.required(MinorType.valueOf(call.getType().getSqlTypeName().getName()));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
@@ -218,7 +218,7 @@ public class AvroRecordReader extends AbstractRecordReader {
         if (schema.getTypes().get(0).getType() != Schema.Type.NULL) {
           throw new UnsupportedOperationException("Avro union type must be of the format : [\"null\", \"some-type\"]");
         }
-        process(value, schema.getTypes().get(1), fieldName, writer, fieldSelection.getChild(fieldName));
+        process(value, schema.getTypes().get(1), fieldName, writer, fieldSelection);
         break;
       case MAP:
         @SuppressWarnings("unchecked")

--- a/exec/java-exec/src/test/java/org/apache/drill/DrillTestWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/DrillTestWrapper.java
@@ -516,9 +516,6 @@ public class DrillTestWrapper {
             if (obj instanceof Text) {
               obj = obj.toString();
             }
-            else if (obj instanceof byte[]) {
-              obj = new String((byte[]) obj, "UTF-8");
-            }
             record.put(SchemaPath.getSimplePath(w.getField().getPath()).toExpr(), obj);
           }
           record.put(SchemaPath.getSimplePath(w.getField().getPath()).toExpr(), obj);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
@@ -36,23 +37,17 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 
 import com.google.common.base.Charsets;
+import org.apache.drill.exec.util.JsonStringArrayList;
+import org.apache.drill.exec.util.JsonStringHashMap;
+import org.apache.drill.exec.util.Text;
 
 /**
  * Utilities for generating Avro test data.
  */
 public class AvroTestUtil {
 
-  public static final int RECORD_COUNT = 10;
-
-  public static class AvroTestSetup {
-    private String filePath;
-    private List<Map<String, ?>> expectedRecords;
-
-    public AvroTestSetup(String filePath, List<Map<String, ?>> expectedRecords) {
-      this.filePath = filePath;
-      this.expectedRecords = expectedRecords;
-    }
-  }
+  public static final int RECORD_COUNT = 10_000;
+  public static int ARRAY_SIZE = 20;
 
   /**
    * Class to write records to an Avro file while simultaneously
@@ -62,7 +57,7 @@ public class AvroTestUtil {
   public static class AvroTestRecordWriter implements Closeable {
     private final List<Map<String, Object>> expectedRecords;
     GenericData.Record currentAvroRecord;
-    Map<String, Object> currentExpectedRecord;
+    TreeMap<String, Object> currentExpectedRecord;
     private Schema schema;
     private final DataFileWriter<GenericData.Record> writer;
     private final String filePath;
@@ -75,28 +70,53 @@ public class AvroTestUtil {
         throw new RuntimeException("Error creating file in Avro test setup.", e);
       }
       this.schema = schema;
-      currentExpectedRecord = new HashMap<>();
+      currentExpectedRecord = new TreeMap<>();
       expectedRecords = new ArrayList<>();
       filePath = file.getAbsolutePath();
     }
 
     public void startRecord() {
       currentAvroRecord = new GenericData.Record(schema);
-      currentExpectedRecord = new HashMap<>();
+      currentExpectedRecord = new TreeMap<>();
     }
 
     public void put(String key, Object value) {
       currentAvroRecord.put(key, value);
       // convert binary values into byte[], the format they will be given
       // in the Drill result set in the test framework
+      currentExpectedRecord.put("`" + key + "`", convertAvroValToDrill(value, true));
+    }
+
+    // TODO - fix this the test wrapper to prevent the need for this hack
+    // to make the root behave differently than nested fields for String vs. Text
+    private Object convertAvroValToDrill(Object value, boolean root) {
       if (value instanceof ByteBuffer) {
         ByteBuffer bb = ((ByteBuffer)value);
         byte[] drillVal = new byte[((ByteBuffer)value).remaining()];
         bb.get(drillVal);
         bb.position(0);
         value = drillVal;
+      } else if (!root && value instanceof CharSequence) {
+        value = new Text(value.toString());
+      } else if (value instanceof GenericData.Array) {
+        GenericData.Array array = ((GenericData.Array) value);
+        final JsonStringArrayList<Object> drillList = new JsonStringArrayList<>();
+        for (Object o : array) {
+          drillList.add(convertAvroValToDrill(o, false));
+        }
+        value = drillList;
+      } else if (value instanceof GenericData.EnumSymbol) {
+        value = value.toString();
+      } else if (value instanceof GenericData.Record) {
+        GenericData.Record rec = ((GenericData.Record) value);
+        final JsonStringHashMap<String, Object> newRecord = new JsonStringHashMap<>();
+        for (Schema.Field field : rec.getSchema().getFields()) {
+          Object val = rec.get(field.name());
+          newRecord.put(field.name(), convertAvroValToDrill(val, false));
+        }
+        value = newRecord;
       }
-      currentExpectedRecord.put("`" + key + "`", value);
+      return value;
     }
 
     public void endRecord() throws IOException {
@@ -167,7 +187,7 @@ public class AvroTestUtil {
     return record;
   }
 
-  public static String generateUnionSchema_WithNullValues() throws Exception {
+  public static AvroTestRecordWriter generateUnionSchema_WithNullValues() throws Exception {
 
     final Schema schema = SchemaBuilder.record("AvroRecordReaderTest")
             .namespace("org.apache.drill.exec.store.avro")
@@ -186,15 +206,14 @@ public class AvroTestUtil {
     final File file = File.createTempFile("avro-primitive-test", ".avro");
     file.deleteOnExit();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      writer.create(schema, file);
 
       ByteBuffer bb = ByteBuffer.allocate(1);
       bb.put(0, (byte) 1);
 
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
         record.put("c_long", (long) i);
@@ -204,16 +223,16 @@ public class AvroTestUtil {
         record.put("g_null", null);
         record.put("h_boolean", (i % 2 == 0));
         record.put("i_union", (i % 2 == 0 ? (double) i : null));
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateUnionSchema_WithNonNullValues() throws Exception {
+  public static AvroTestRecordWriter generateUnionSchema_WithNonNullValues() throws Exception {
 
     final Schema schema = SchemaBuilder.record("AvroRecordReaderTest")
             .namespace("org.apache.drill.exec.store.avro")
@@ -232,15 +251,14 @@ public class AvroTestUtil {
     final File file = File.createTempFile("avro-primitive-test", ".avro");
     file.deleteOnExit();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      writer.create(schema, file);
 
       ByteBuffer bb = ByteBuffer.allocate(1);
       bb.put(0, (byte) 1);
 
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
         record.put("c_long", (long) i);
@@ -250,16 +268,16 @@ public class AvroTestUtil {
         record.put("g_null", null);
         record.put("h_boolean", (i % 2 == 0));
         record.put("i_union", (i % 2 == 0 ? (double) i : (long) i));
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateSimpleEnumSchema_NoNullValues() throws Exception {
+  public static AvroTestRecordWriter generateSimpleEnumSchema_NoNullValues() throws Exception {
 
     final String[] symbols = { "E_SYM_A", "E_SYM_B", "E_SYM_C", "E_SYM_D" };
 
@@ -275,27 +293,25 @@ public class AvroTestUtil {
 
     final Schema enumSchema = schema.getField("b_enum").schema();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      writer.create(schema, file);
 
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         final GenericData.EnumSymbol symbol =
                 new GenericData.EnumSymbol(enumSchema, symbols[(i + symbols.length) % symbols.length]);
         record.put("b_enum", symbol);
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateSimpleArraySchema_NoNullValues() throws Exception {
+  public static AvroTestRecordWriter generateSimpleArraySchema_NoNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-array-test", ".avro");
     file.deleteOnExit();
@@ -310,46 +326,43 @@ public class AvroTestUtil {
             .name("e_float_array").type().array().items().floatType().noDefault()
             .endRecord();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      writer.create(schema, file);
-
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
         {
-          GenericArray<String> array = new GenericData.Array<>(RECORD_COUNT, schema.getField("c_string_array").schema());
-          for (int j = 0; j < RECORD_COUNT; j++) {
+          GenericArray<String> array = new GenericData.Array<>(ARRAY_SIZE, schema.getField("c_string_array").schema());
+          for (int j = 0; j < ARRAY_SIZE; j++) {
             array.add(j, "c_string_array_" + i + "_" + j);
           }
           record.put("c_string_array", array);
         }
         {
-          GenericArray<Integer> array = new GenericData.Array<>(RECORD_COUNT, schema.getField("d_int_array").schema());
-          for (int j = 0; j < RECORD_COUNT; j++) {
+          GenericArray<Integer> array = new GenericData.Array<>(ARRAY_SIZE, schema.getField("d_int_array").schema());
+          for (int j = 0; j < ARRAY_SIZE; j++) {
             array.add(j, i * j);
           }
           record.put("d_int_array", array);
         }
         {
-          GenericArray<Float> array = new GenericData.Array<>(RECORD_COUNT, schema.getField("e_float_array").schema());
-          for (int j = 0; j < RECORD_COUNT; j++) {
+          GenericArray<Float> array = new GenericData.Array<>(ARRAY_SIZE, schema.getField("e_float_array").schema());
+          for (int j = 0; j < ARRAY_SIZE; j++) {
             array.add(j, (float) (i * j));
           }
           record.put("e_float_array", array);
         }
-
-        writer.append(record);
+        record.endRecord();
       }
 
     } finally {
-      writer.close();
+      record.close();
     }
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateSimpleNestedSchema_NoNullValues() throws Exception {
+  public static AvroTestRecordWriter generateSimpleNestedSchema_NoNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-nested-test", ".avro");
     file.deleteOnExit();
@@ -370,12 +383,10 @@ public class AvroTestUtil {
 
     final Schema nestedSchema = schema.getField("c_record").schema();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -384,16 +395,16 @@ public class AvroTestUtil {
         nestedRecord.put("nested_1_int", i * i);
 
         record.put("c_record", nestedRecord);
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateUnionNestedArraySchema_withNullValues() throws Exception {
+  public static AvroTestRecordWriter generateUnionNestedArraySchema_withNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-nested-test", ".avro");
     file.deleteOnExit();
@@ -414,12 +425,10 @@ public class AvroTestUtil {
     final Schema arraySchema = nestedSchema.getTypes().get(1);
     final Schema itemSchema = arraySchema.getElementType();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -431,16 +440,16 @@ public class AvroTestUtil {
           array.add(nestedRecord);
           record.put("c_array", array);
         }
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateMapSchema_withNullValues() throws Exception {
+  public static AvroTestRecordWriter generateMapSchema_withNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-nested-test", ".avro");
     file.deleteOnExit();
@@ -453,12 +462,10 @@ public class AvroTestUtil {
             .name("c_map").type().optional().map().values(Schema.create(Type.STRING))
             .endRecord();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -468,16 +475,16 @@ public class AvroTestUtil {
           strMap.put("key2", "nested_1_string_" +  (i + 1 ));
           record.put("c_map", strMap);
         }
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateMapSchemaComplex_withNullValues() throws Exception {
+  public static AvroTestRecordWriter generateMapSchemaComplex_withNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-nested-test", ".avro");
     file.deleteOnExit();
@@ -494,12 +501,10 @@ public class AvroTestUtil {
     final Schema arrayMapSchema = schema.getField("d_map").schema();
     final Schema arrayItemSchema = arrayMapSchema.getTypes().get(1).getValueType();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -510,8 +515,8 @@ public class AvroTestUtil {
           record.put("c_map", c_map);
         } else {
           Map<String, GenericArray<Double>> d_map = new HashMap<>();
-          GenericArray<Double> array = new GenericData.Array<>(RECORD_COUNT, arrayItemSchema);
-          for (int j = 0; j < RECORD_COUNT; j++) {
+          GenericArray<Double> array = new GenericData.Array<>(ARRAY_SIZE, arrayItemSchema);
+          for (int j = 0; j < ARRAY_SIZE; j++) {
             array.add((double)j);
           }
           d_map.put("key1", array);
@@ -519,16 +524,16 @@ public class AvroTestUtil {
 
           record.put("d_map", d_map);
         }
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateUnionNestedSchema_withNullValues() throws Exception {
+  public static AvroTestRecordWriter generateUnionNestedSchema_withNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-nested-test", ".avro");
     file.deleteOnExit();
@@ -548,12 +553,10 @@ public class AvroTestUtil {
     final Schema nestedSchema = schema.getField("c_record").schema();
     final Schema optionalSchema = nestedSchema.getTypes().get(1);
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -563,16 +566,16 @@ public class AvroTestUtil {
           nestedRecord.put("nested_1_int", i * i);
           record.put("c_record", nestedRecord);
         }
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
-  public static String generateDoubleNestedSchema_NoNullValues() throws Exception {
+  public static AvroTestRecordWriter generateDoubleNestedSchema_NoNullValues() throws Exception {
 
     final File file = File.createTempFile("avro-double-nested-test", ".avro");
     file.deleteOnExit();
@@ -601,12 +604,10 @@ public class AvroTestUtil {
     final Schema nestedSchema = schema.getField("c_record").schema();
     final Schema doubleNestedSchema = nestedSchema.getField("nested_1_record").schema();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
-    writer.create(schema, file);
-
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_int", i);
 
@@ -621,13 +622,13 @@ public class AvroTestUtil {
         nestedRecord.put("nested_1_record", doubleNestedRecord);
         record.put("c_record", nestedRecord);
 
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 
   public static String generateLinkedList() throws Exception {
@@ -665,7 +666,7 @@ public class AvroTestUtil {
     return file.getAbsolutePath();
   }
 
-  public static String generateStringAndUtf8Data() throws Exception {
+  public static AvroTestRecordWriter generateStringAndUtf8Data() throws Exception {
 
     final Schema schema = SchemaBuilder.record("AvroRecordReaderTest")
             .namespace("org.apache.drill.exec.store.avro")
@@ -677,23 +678,22 @@ public class AvroTestUtil {
     final File file = File.createTempFile("avro-primitive-test", ".avro");
     file.deleteOnExit();
 
-    final DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
+    final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      writer.create(schema, file);
 
       ByteBuffer bb = ByteBuffer.allocate(1);
       bb.put(0, (byte) 1);
 
       for (int i = 0; i < RECORD_COUNT; i++) {
-        final GenericRecord record = new GenericData.Record(schema);
+        record.startRecord();
         record.put("a_string", "a_" + i);
         record.put("b_utf8", "b_" + i);
-        writer.append(record);
+        record.endRecord();
       }
     } finally {
-      writer.close();
+      record.close();
     }
 
-    return file.getAbsolutePath();
+    return record;
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroTestUtil.java
@@ -94,7 +94,7 @@ public class AvroTestUtil {
         byte[] drillVal = new byte[((ByteBuffer)value).remaining()];
         bb.get(drillVal);
         bb.position(0);
-        value = new String(drillVal, Charsets.UTF_8);
+        value = drillVal;
       }
       currentExpectedRecord.put("`" + key + "`", value);
     }
@@ -143,10 +143,11 @@ public class AvroTestUtil {
 
     final AvroTestRecordWriter record = new AvroTestRecordWriter(schema, file);
     try {
-      ByteBuffer bb = ByteBuffer.allocate(1);
+      ByteBuffer bb = ByteBuffer.allocate(2);
       bb.put(0, (byte) 'a');
 
       for (int i = 0; i < numRecords; i++) {
+        bb.put(1, (byte) ('0' + (i % 10)));
         bb.position(0);
         record.startRecord();
         record.put("a_string", "a_" + i);


### PR DESCRIPTION
This fix includes a number of test updates to ensure Avro files are being read correctly.

The branch includes 4441, which is on a different PR, but touched some of the same code, so I just based this fix on that branch.

The actual regression fix is in the AvroRecordReader, in the case of a Union, we should not be created a child of the fieldSelection, which was properly done in the case with maps and records.