### PR TITLE
DRILL-3714: Query runs out of memory and remains in CANCELLATION_REQU…

### DIFF
--- a/common/src/main/java/org/apache/drill/common/DeferredException.java
+++ b/common/src/main/java/org/apache/drill/common/DeferredException.java
@@ -84,7 +84,7 @@ public class DeferredException implements AutoCloseable {
           }
           this.exception.addSuppressed(exception);
         }
-      } else {
+      } else if (this.exception != exception) { // make sure we don't try to suppress the root exception
         this.exception.addSuppressed(exception);
       }
     }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -167,7 +167,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
 
       logger.info(msg); // should we leave this at info level ?
 
-      queue.channelClosed(new ChannelClosedException(msg));
+      queue.channelClosed(new ChannelClosedException(msg), future.channel());
 
       clientConnection.close();
     }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -159,19 +159,15 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
       String msg;
-      if(local!=null) {
+      if(local != null) {
         msg = String.format("Channel closed %s <--> %s.", local, remote);
       }else{
         msg = String.format("Channel closed %s <--> %s.", future.channel().localAddress(), future.channel().remoteAddress());
       }
 
-      if (RpcBus.this.isClient()) {
-        if(local != null) {
-          logger.info(String.format(msg));
-        }
-      } else {
-        queue.channelClosed(new ChannelClosedException(msg));
-      }
+      logger.info(msg); // should we leave this at info level ?
+
+      queue.channelClosed(new ChannelClosedException(msg));
 
       clientConnection.close();
     }


### PR DESCRIPTION
…ESTED state until drillbit is restarted

RpcBus.ChannelClosedHandler calls CoordinationQueue.channelClosed() on both server and client side