### PR TITLE
DRILL-4199: Add Support for HBase 1.X

### DIFF
--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -77,6 +77,14 @@
       <version>2.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <!-- Needed by HBase test cluster, set to provided
+           scope to avoid dependency propagation -->
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -126,6 +134,28 @@
                   <filtering>true</filtering>
                 </resource>
               </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>avoid_bad_dependencies</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration combine.self="override">
+              <rules>
+                <bannedDependencies>
+                  <includes>
+                    <!-- Needed by HBase test cluster -->
+                    <include>commons-logging:commons-logging:*:jar:provided</include>
+                  </includes>
+                </bannedDependencies>
+              </rules>
             </configuration>
           </execution>
         </executions>

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertFrom.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertFrom.java
@@ -40,7 +40,7 @@ public class OrderedBytesBigIntConvertFrom implements DrillSimpleFunc {
   @Override
   public void setup() {
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesBigIntConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(9);
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntDescConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesBigIntDescConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesBigIntDescConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(9);
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertFrom.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertFrom.java
@@ -40,7 +40,7 @@ public class OrderedBytesDoubleConvertFrom implements DrillSimpleFunc {
   @Override
   public void setup() {
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesDoubleConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(9);
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleDescConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesDoubleDescConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesDoubleDescConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(9);
     bytes = new byte[9];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatConvertFrom.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatConvertFrom.java
@@ -40,7 +40,7 @@ public class OrderedBytesFloatConvertFrom implements DrillSimpleFunc {
   @Override
   public void setup() {
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesFloatConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(5);
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatDescConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesFloatDescConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesFloatDescConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(5);
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntConvertFrom.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntConvertFrom.java
@@ -40,7 +40,7 @@ public class OrderedBytesIntConvertFrom implements DrillSimpleFunc {
   @Override
   public void setup() {
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesIntConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(5);
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntDescConvertTo.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/OrderedBytesIntDescConvertTo.java
@@ -45,7 +45,7 @@ public class OrderedBytesIntDescConvertTo implements DrillSimpleFunc {
   public void setup() {
     buffer = buffer.reallocIfNeeded(5);
     bytes = new byte[5];
-    br = new org.apache.hadoop.hbase.util.SimplePositionedByteRange();
+    br = new org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange();
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/CompareFunctionsProcessor.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/CompareFunctionsProcessor.java
@@ -40,7 +40,7 @@ import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
 import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
 import org.apache.hadoop.hbase.util.Order;
 import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedByteRange;
+import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.filter.Filter;
@@ -254,7 +254,7 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
         case "DOUBLE_OBD":
           if (valueArg instanceof DoubleExpression) {
             bb = newByteBuf(9, true);
-            PositionedByteRange br = new SimplePositionedByteRange(bb.array(), 0, 9);
+            PositionedByteRange br = new SimplePositionedMutableByteRange(bb.array(), 0, 9);
             if (encodingType.endsWith("_OBD")) {
               org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat64(br,
                   ((DoubleExpression)valueArg).getDouble(), Order.DESCENDING);
@@ -269,7 +269,7 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
         case "FLOAT_OBD":
           if (valueArg instanceof FloatExpression) {
             bb = newByteBuf(5, true);
-            PositionedByteRange br = new SimplePositionedByteRange(bb.array(), 0, 5);
+            PositionedByteRange br = new SimplePositionedMutableByteRange(bb.array(), 0, 5);
             if (encodingType.endsWith("_OBD")) {
               org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat32(br,
                   ((FloatExpression)valueArg).getFloat(), Order.DESCENDING);
@@ -284,7 +284,7 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
         case "BIGINT_OBD":
           if (valueArg instanceof LongExpression) {
             bb = newByteBuf(9, true);
-            PositionedByteRange br = new SimplePositionedByteRange(bb.array(), 0, 9);
+            PositionedByteRange br = new SimplePositionedMutableByteRange(bb.array(), 0, 9);
             if (encodingType.endsWith("_OBD")) {
               org.apache.hadoop.hbase.util.OrderedBytes.encodeInt64(br,
                         ((LongExpression)valueArg).getLong(), Order.DESCENDING);
@@ -299,7 +299,7 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
         case "INT_OBD":
           if (valueArg instanceof IntExpression) {
             bb = newByteBuf(5, true);
-            PositionedByteRange br = new SimplePositionedByteRange(bb.array(), 0, 5);
+            PositionedByteRange br = new SimplePositionedMutableByteRange(bb.array(), 0, 5);
             if (encodingType.endsWith("_OBD")) {
               org.apache.hadoop.hbase.util.OrderedBytes.encodeInt32(br,
                   ((IntExpression)valueArg).getInt(), Order.DESCENDING);

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/DrillHBaseTable.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/DrillHBaseTable.java
@@ -21,24 +21,25 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
 
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.planner.logical.DrillTable;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.util.Bytes;
 
 public class DrillHBaseTable extends DrillTable implements DrillHBaseConstants {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillHBaseTable.class);
 
-  private HTableDescriptor table;
+  private HTableDescriptor tableDesc;
 
   public DrillHBaseTable(String storageEngineName, HBaseStoragePlugin plugin, HBaseScanSpec scanSpec) {
     super(storageEngineName, plugin, scanSpec);
-    try(HBaseAdmin admin = new HBaseAdmin(plugin.getConfig().getHBaseConf())) {
-      table = admin.getTableDescriptor(HBaseUtils.getBytes(scanSpec.getTableName()));
+    try(Admin admin = plugin.getConnection().getAdmin()) {
+      tableDesc = admin.getTableDescriptor(TableName.valueOf(scanSpec.getTableName()));
     } catch (IOException e) {
       throw UserException.dataReadError()
           .message("Failure while loading table %s in database %s.", scanSpec.getTableName(), storageEngineName)
@@ -55,7 +56,7 @@ public class DrillHBaseTable extends DrillTable implements DrillHBaseConstants {
     fieldNameList.add(ROW_KEY);
     typeList.add(typeFactory.createSqlType(SqlTypeName.ANY));
 
-    Set<byte[]> families = table.getFamiliesKeys();
+    Set<byte[]> families = tableDesc.getFamiliesKeys();
     for (byte[] family : families) {
       fieldNameList.add(Bytes.toString(family));
       typeList.add(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), typeFactory.createSqlType(SqlTypeName.ANY)));

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseConnectionManager.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseConnectionManager.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hbase;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.store.hbase.HBaseStoragePlugin.HBaseConnectionKey;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+/**
+ * <p>A singleton class which manages the lifecycle of HBase connections.</p>
+ * <p>One connection per storage plugin instance is maintained.</p>
+ */
+public final class HBaseConnectionManager
+    extends CacheLoader<HBaseConnectionKey, Connection> implements RemovalListener<HBaseConnectionKey, Connection> {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HBaseConnectionManager.class);
+
+  public static final HBaseConnectionManager INSTANCE = new HBaseConnectionManager();
+
+  private final LoadingCache<HBaseConnectionKey, Connection> connectionCache;
+
+  private HBaseConnectionManager() {
+    this.connectionCache = CacheBuilder.newBuilder()
+        .expireAfterAccess(1, TimeUnit.HOURS) // Connections will be closed after 1 hour of inactivity
+        .removalListener(this)
+        .build(this);
+  }
+
+  private boolean isValid(Connection conn) {
+    return conn != null
+        && !conn.isAborted()
+        && !conn.isClosed();
+  }
+
+  @Override
+  public Connection load(HBaseConnectionKey key) throws Exception {
+    Connection connection = ConnectionFactory.createConnection(key.getHBaseConf());
+    logger.info("HBase connection '{}' created.", connection);
+    return connection;
+  }
+
+  @Override
+  public void onRemoval(RemovalNotification<HBaseConnectionKey, Connection> notification) {
+    try {
+      Connection conn = notification.getValue();
+      if (isValid(conn)) {
+        conn.close();
+      }
+      logger.info("HBase connection '{}' closed.", conn);
+    } catch (Throwable t) {
+      logger.warn("Error while closing HBase connection.", t);
+    }
+  }
+
+  public Connection getConnection(HBaseConnectionKey key) {
+    checkNotNull(key);
+    try {
+      Connection conn = connectionCache.get(key);
+      if (!isValid(conn)) {
+        key.lock(); // invalidate the connection with a per storage plugin lock
+        try {
+          conn = connectionCache.get(key);
+          if (!isValid(conn)) {
+            connectionCache.invalidate(key);
+            conn = connectionCache.get(key);
+          }
+        } finally {
+          key.unlock();
+        }
+      }
+      return conn;
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      throw UserException.dataReadError(e.getCause()).build(logger);
+    }
+  }
+
+  public void closeConnection(HBaseConnectionKey key) {
+    checkNotNull(key);
+    connectionCache.invalidate(key);
+  }
+
+}

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hbase.filter.ByteArrayComparable;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.NullComparator;
-import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
@@ -332,20 +331,19 @@ public class HBaseFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void,
     return null;
   }
 
-private HBaseScanSpec createRowKeyPrefixScanSpec(FunctionCall call,
-    CompareFunctionsProcessor processor) {
+  private HBaseScanSpec createRowKeyPrefixScanSpec(FunctionCall call, CompareFunctionsProcessor processor) {
     byte[] startRow = processor.getRowKeyPrefixStartRow();
     byte[] stopRow  = processor.getRowKeyPrefixStopRow();
     Filter filter   = processor.getRowKeyPrefixFilter();
 
     if (startRow != HConstants.EMPTY_START_ROW ||
-      stopRow != HConstants.EMPTY_END_ROW ||
-      filter != null) {
+        stopRow != HConstants.EMPTY_END_ROW ||
+        filter != null) {
       return new HBaseScanSpec(groupScan.getTableName(), startRow, stopRow, filter);
     }
 
     // else
     return null;
-}
+  }
 
 }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
@@ -18,21 +18,20 @@
 
 package org.apache.drill.exec.store.hbase;
 
+import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.exec.planner.logical.DrillOptiq;
 import org.apache.drill.exec.planner.logical.DrillParseContext;
 import org.apache.drill.exec.planner.logical.RelOptHelper;
 import org.apache.drill.exec.planner.physical.FilterPrel;
-import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.planner.physical.PrelUtil;
 import org.apache.drill.exec.planner.physical.ProjectPrel;
 import org.apache.drill.exec.planner.physical.ScanPrel;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.rex.RexNode;
 
 import com.google.common.collect.ImmutableList;
 
@@ -95,7 +94,7 @@ public abstract class HBasePushFilterIntoScan extends StoragePluginOptimizerRule
       }
 
       // convert the filter to one that references the child of the project
-      final RexNode condition =  RelOptUtil.pushFilterPastProject(filter.getCondition(), project);
+      final RexNode condition =  RelOptUtil.pushPastProject(filter.getCondition(), project);
 
       doPushFilterToScan(call, filter, project, scan, groupScan, condition);
     }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseScanBatchCreator.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseScanBatchCreator.java
@@ -45,7 +45,7 @@ public class HBaseScanBatchCreator implements BatchCreator<HBaseSubScan>{
         if ((columns = subScan.getColumns())==null) {
           columns = GroupScan.ALL_COLUMNS;
         }
-        readers.add(new HBaseRecordReader(subScan.getStorageConfig().getHBaseConf(), scanSpec, columns, context));
+        readers.add(new HBaseRecordReader(subScan.getStorageEngine().getConnection(), scanSpec, columns, context));
       } catch (Exception e1) {
         throw new ExecutionSetupException(e1);
       }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
@@ -21,15 +21,13 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
-import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
-
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.SchemaFactory;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Admin;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -79,11 +77,11 @@ public class HBaseSchemaFactory implements SchemaFactory {
 
     @Override
     public Set<String> getTableNames() {
-      try(HBaseAdmin admin = new HBaseAdmin(plugin.getConfig().getHBaseConf())) {
+      try(Admin admin = plugin.getConnection().getAdmin()) {
         HTableDescriptor[] tables = admin.listTables();
         Set<String> tableNames = Sets.newHashSet();
         for (HTableDescriptor table : tables) {
-          tableNames.add(new String(table.getName()));
+          tableNames.add(new String(table.getTableName().getNameAsString()));
         }
         return tableNames;
       } catch (Exception e) {

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.hbase;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,7 +40,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 
 // Class containing information for reading a single HBase region
 @JsonTypeName("hbase-region-scan")
@@ -111,7 +111,7 @@ public class HBaseSubScan extends AbstractBase implements SubScan {
 
   @Override
   public Iterator<PhysicalOperator> iterator() {
-    return Iterators.emptyIterator();
+    return Collections.emptyIterator();
   }
 
   public static class HBaseSubScanSpec {

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.hbase.HBaseStoragePlugin;
 import org.apache.drill.exec.store.hbase.HBaseStoragePluginConfig;
+import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.AfterClass;
@@ -38,6 +39,10 @@ import com.google.common.io.Files;
 
 public class BaseHBaseTest extends BaseTestQuery {
 
+  static {
+    GuavaPatcher.patch();
+  }
+
   private static final String HBASE_STORAGE_PLUGIN_NAME = "hbase";
 
   protected static Configuration conf = HBaseConfiguration.create();
@@ -46,16 +51,13 @@ public class BaseHBaseTest extends BaseTestQuery {
 
   protected static HBaseStoragePluginConfig storagePluginConfig;
 
-
   @BeforeClass
   public static void setupDefaultTestCluster() throws Exception {
-    GuavaPatcher.patch();
-
     /*
      * Change the following to HBaseTestsSuite.configure(false, true)
      * if you want to test against an externally running HBase cluster.
      */
-    HBaseTestsSuite.configure(true, true);
+    HBaseTestsSuite.configure(true /*manageHBaseCluster*/, true /*createTables*/);
     HBaseTestsSuite.initCluster();
 
     BaseTestQuery.setupDefaultTestCluster();
@@ -66,7 +68,6 @@ public class BaseHBaseTest extends BaseTestQuery {
     storagePluginConfig.setEnabled(true);
     storagePluginConfig.setZookeeperPort(HBaseTestsSuite.getZookeeperPort());
     pluginRegistry.createOrUpdate(HBASE_STORAGE_PLUGIN_NAME, storagePluginConfig, true);
-
   }
 
   @AfterClass
@@ -105,9 +106,7 @@ public class BaseHBaseTest extends BaseTestQuery {
   }
 
   protected String canonizeHBaseSQL(String sql) {
-    return sql.replace("[TABLE_NAME]", HBaseTestsSuite.TEST_TABLE_1);
+    return sql.replace("[TABLE_NAME]", HBaseTestsSuite.TEST_TABLE_1.getNameAsString());
   }
-
-
 
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseRecordReaderTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseRecordReaderTest.java
@@ -24,19 +24,19 @@ public class HBaseRecordReaderTest extends BaseHBaseTest {
   @Test
   public void testLocalDistributed() throws Exception {
     String planName = "/hbase/hbase_scan_screen_physical.json";
-    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1, 8);
+    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1.getNameAsString(), 8);
   }
 
   @Test
   public void testLocalDistributedColumnSelect() throws Exception {
     String planName = "/hbase/hbase_scan_screen_physical_column_select.json";
-    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1, 3);
+    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1.getNameAsString(), 3);
   }
 
   @Test
   public void testLocalDistributedFamilySelect() throws Exception {
     String planName = "/hbase/hbase_scan_screen_physical_family_select.json";
-    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1, 4);
+    runHBasePhysicalVerifyCount(planName, HBaseTestsSuite.TEST_TABLE_1.getNameAsString(), 4);
   }
 
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseConnectionManager.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseConnectionManager.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.hbase;
+
+import org.junit.Test;
+
+public class TestHBaseConnectionManager extends BaseHBaseTest {
+
+  @Test
+  public void testHBaseConnectionManager() throws Exception{
+    setColumnWidth(8);
+    runHBaseSQLVerifyCount("SELECT\n"
+        + "row_key\n"
+        + "FROM\n"
+        + "  hbase.`[TABLE_NAME]` tableName"
+        , 8);
+
+    /*
+     * Simulate HBase connection close and ensure that the connection
+     * will be reestablished automatically.
+     */
+    storagePlugin.getConnection().close();
+    runHBaseSQLVerifyCount("SELECT\n"
+        + "row_key\n"
+        + "FROM\n"
+        + "  hbase.`[TABLE_NAME]` tableName"
+        , 8);
+
+    /*
+     * Simulate HBase cluster restart and ensure that running query against
+     * HBase does not require Drill cluster restart.
+     */
+    HBaseTestsSuite.getHBaseTestingUtility().shutdownMiniHBaseCluster();
+    HBaseTestsSuite.getHBaseTestingUtility().restartHBaseCluster(1);
+    runHBaseSQLVerifyCount("SELECT\n"
+        + "row_key\n"
+        + "FROM\n"
+        + "  hbase.`[TABLE_NAME]` tableName"
+        , 8);
+
+  }
+
+}

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseFilterPushDown.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseFilterPushDown.java
@@ -18,7 +18,6 @@
 package org.apache.drill.hbase;
 
 import org.apache.drill.PlanTestBase;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestHBaseFilterPushDown extends BaseHBaseTest {

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestOrderedBytesConvertFunctions.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestOrderedBytesConvertFunctions.java
@@ -17,42 +17,20 @@
  */
 package org.apache.drill.hbase;
 
-import static org.apache.drill.TestBuilder.listOf;
-import static org.apache.drill.TestBuilder.mapOf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import io.netty.buffer.DrillBuf;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import mockit.Injectable;
-
 import org.apache.drill.BaseTestQuery;
-import org.apache.drill.TestBuilder;
-import org.apache.drill.exec.compile.ClassTransformer;
-import org.apache.drill.exec.compile.ClassTransformer.ScalarReplacementOption;
-import org.apache.drill.exec.expr.fn.impl.DateUtility;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.record.RecordBatchLoader;
-import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
-import org.apache.drill.exec.rpc.user.UserServer;
-import org.apache.drill.exec.server.Drillbit;
-import org.apache.drill.exec.server.DrillbitContext;
-import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
-import org.apache.drill.exec.util.ByteBufUtil.HadoopWritables;
-import org.apache.drill.exec.util.VectorUtil;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
-import org.joda.time.DateTime;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.base.Charsets;

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestTableGenerator.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestTableGenerator.java
@@ -24,9 +24,15 @@ import java.util.Random;
 
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Order;
+import org.apache.hadoop.hbase.util.OrderedBytes;
+import org.apache.hadoop.hbase.util.PositionedByteRange;
+import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 
 public class TestTableGenerator {
 
@@ -39,7 +45,7 @@ public class TestTableGenerator {
   static final byte[] FAMILY_F = {'f'};
   static final byte[] COLUMN_C = {'c'};
 
-  public static void generateHBaseDataset1(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDataset1(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -54,81 +60,80 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     Put p = new Put("a1".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f".getBytes(), "c2".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "3".getBytes());
-    p.add("f".getBytes(), "c4".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "5".getBytes());
-    p.add("f".getBytes(), "c6".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f".getBytes(), "c2".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "3".getBytes());
+    p.addColumn("f".getBytes(), "c4".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "5".getBytes());
+    p.addColumn("f".getBytes(), "c6".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("a2".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f".getBytes(), "c2".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "3".getBytes());
-    p.add("f".getBytes(), "c4".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "5".getBytes());
-    p.add("f".getBytes(), "c6".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f".getBytes(), "c2".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "3".getBytes());
+    p.addColumn("f".getBytes(), "c4".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "5".getBytes());
+    p.addColumn("f".getBytes(), "c6".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("a3".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "3".getBytes());
-    p.add("f".getBytes(), "c7".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c8".getBytes(), "5".getBytes());
-    p.add("f".getBytes(), "c9".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "3".getBytes());
+    p.addColumn("f".getBytes(), "c7".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c8".getBytes(), "5".getBytes());
+    p.addColumn("f".getBytes(), "c9".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put(new byte[]{'b', '4', 0});
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f2".getBytes(), "c2".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "3".getBytes());
-    p.add("f2".getBytes(), "c4".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "5".getBytes());
-    p.add("f2".getBytes(), "c6".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f2".getBytes(), "c2".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "3".getBytes());
+    p.addColumn("f2".getBytes(), "c4".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "5".getBytes());
+    p.addColumn("f2".getBytes(), "c6".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("b4".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f2".getBytes(), "c2".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "3".getBytes());
-    p.add("f2".getBytes(), "c4".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "5".getBytes());
-    p.add("f2".getBytes(), "c6".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f2".getBytes(), "c2".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "3".getBytes());
+    p.addColumn("f2".getBytes(), "c4".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "5".getBytes());
+    p.addColumn("f2".getBytes(), "c6".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("b5".getBytes());
-    p.add("f2".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f".getBytes(), "c2".getBytes(), "2".getBytes());
-    p.add("f2".getBytes(), "c3".getBytes(), "3".getBytes());
-    p.add("f".getBytes(), "c4".getBytes(), "4".getBytes());
-    p.add("f2".getBytes(), "c5".getBytes(), "5".getBytes());
-    p.add("f".getBytes(), "c6".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f2".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f".getBytes(), "c2".getBytes(), "2".getBytes());
+    p.addColumn("f2".getBytes(), "c3".getBytes(), "3".getBytes());
+    p.addColumn("f".getBytes(), "c4".getBytes(), "4".getBytes());
+    p.addColumn("f2".getBytes(), "c5".getBytes(), "5".getBytes());
+    p.addColumn("f".getBytes(), "c6".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("b6".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f2".getBytes(), "c3".getBytes(), "2".getBytes());
-    p.add("f".getBytes(), "c5".getBytes(), "3".getBytes());
-    p.add("f2".getBytes(), "c7".getBytes(), "4".getBytes());
-    p.add("f".getBytes(), "c8".getBytes(), "5".getBytes());
-    p.add("f2".getBytes(), "c9".getBytes(), "6".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f2".getBytes(), "c3".getBytes(), "2".getBytes());
+    p.addColumn("f".getBytes(), "c5".getBytes(), "3".getBytes());
+    p.addColumn("f2".getBytes(), "c7".getBytes(), "4".getBytes());
+    p.addColumn("f".getBytes(), "c8".getBytes(), "5".getBytes());
+    p.addColumn("f2".getBytes(), "c9".getBytes(), "6".getBytes());
+    table.mutate(p);
 
     p = new Put("b7".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "1".getBytes());
-    p.add("f".getBytes(), "c2".getBytes(), "2".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "1".getBytes());
+    p.addColumn("f".getBytes(), "c2".getBytes(), "2".getBytes());
+    table.mutate(p);
 
-    table.flushCommits();
     table.close();
   }
 
-  public static void generateHBaseDataset2(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDataset2(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -143,7 +148,7 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     int rowCount = 0;
     byte[] bytes = null;
@@ -156,9 +161,9 @@ public class TestTableGenerator {
         Put p = new Put((""+rowKeyChar+iteration).getBytes());
         for (int j = 1; j <= numColumns; j++) {
           bytes = new byte[5000]; random.nextBytes(bytes);
-          p.add("f".getBytes(), ("c"+j).getBytes(), bytes);
+          p.addColumn("f".getBytes(), ("c"+j).getBytes(), bytes);
         }
-        table.put(p);
+        table.mutate(p);
 
         ++rowKeyChar;
         ++rowCount;
@@ -166,13 +171,12 @@ public class TestTableGenerator {
       ++iteration;
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDataset3(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDataset3(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -187,34 +191,33 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (int i = 0; i <= 100; ++i) {
       Put p = new Put((String.format("%03d", i)).getBytes());
-      p.add(FAMILY_F, COLUMN_C, String.format("value %03d", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %03d", i).getBytes());
+      table.mutate(p);
     }
     for (int i = 0; i <= 1000; ++i) {
       Put p = new Put((String.format("%04d", i)).getBytes());
-      p.add(FAMILY_F, COLUMN_C, String.format("value %04d", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %04d", i).getBytes());
+      table.mutate(p);
     }
 
     Put p = new Put("%_AS_PREFIX_ROW1".getBytes());
-    p.add(FAMILY_F, COLUMN_C, "dummy".getBytes());
-    table.put(p);
+    p.addColumn(FAMILY_F, COLUMN_C, "dummy".getBytes());
+    table.mutate(p);
 
     p = new Put("%_AS_PREFIX_ROW2".getBytes());
-    p.add(FAMILY_F, COLUMN_C, "dummy".getBytes());
-    table.put(p);
+    p.addColumn(FAMILY_F, COLUMN_C, "dummy".getBytes());
+    table.mutate(p);
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetCompositeKeyDate(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetCompositeKeyDate(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -229,7 +232,7 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     Date startDate = new Date(1408924800000L);
     long startTime  = startDate.getTime();
@@ -246,15 +249,14 @@ public class TestTableGenerator {
       }
 
       Put p = new Put(rowKey);
-      p.add(FAMILY_F, COLUMN_C, "dummy".getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, "dummy".getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
   }
 
-  public static void generateHBaseDatasetCompositeKeyTime(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetCompositeKeyTime(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -269,7 +271,7 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     long startTime  = 0;
     long MILLISECONDS_IN_A_SEC  = (long)1000;
@@ -287,8 +289,8 @@ public class TestTableGenerator {
       }
 
       Put p = new Put(rowKey);
-      p.add(FAMILY_F, COLUMN_C, "dummy".getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, "dummy".getBytes());
+      table.mutate(p);
 
       if (interval == smallInterval) {
         interval = largeInterval;
@@ -297,11 +299,10 @@ public class TestTableGenerator {
       }
     }
 
-    table.flushCommits();
     table.close();
   }
 
-  public static void generateHBaseDatasetCompositeKeyInt(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetCompositeKeyInt(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -316,7 +317,7 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     int startVal = 0;
     int stopVal = 1000;
@@ -330,15 +331,14 @@ public class TestTableGenerator {
       }
 
       Put p = new Put(rowKey);
-      p.add(FAMILY_F, COLUMN_C, "dummy".getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, "dummy".getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
   }
 
-  public static void generateHBaseDatasetDoubleOB(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetDoubleOB(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -353,26 +353,23 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (double i = 0.5; i <= 100.00; i += 0.75) {
-        byte[] bytes = new byte[9];
-        org.apache.hadoop.hbase.util.PositionedByteRange br =
-                new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 9);
-        org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat64(br, i,
-                org.apache.hadoop.hbase.util.Order.ASCENDING);
+      byte[] bytes = new byte[9];
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
+      OrderedBytes.encodeFloat64(br, i, Order.ASCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetFloatOB(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetFloatOB(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -387,60 +384,23 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (float i = (float)0.5; i <= 100.00; i += 0.75) {
       byte[] bytes = new byte[5];
-      org.apache.hadoop.hbase.util.PositionedByteRange br =
-              new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 5);
-      org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat32(br, i,
-              org.apache.hadoop.hbase.util.Order.ASCENDING);
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
+      OrderedBytes.encodeFloat32(br, i,Order.ASCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetBigIntOB(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
-    if (admin.tableExists(tableName)) {
-      admin.disableTable(tableName);
-      admin.deleteTable(tableName);
-    }
-
-   HTableDescriptor desc = new HTableDescriptor(tableName);
-  desc.addFamily(new HColumnDescriptor(FAMILY_F));
-
-  if (numberRegions > 1) {
-    admin.createTable(desc, Arrays.copyOfRange(SPLIT_KEYS, 0, numberRegions-1));
-  } else {
-    admin.createTable(desc);
-  }
-
-  HTable table = new HTable(admin.getConfiguration(), tableName);
-  long startTime = (long)1438034423 * 1000;
-  for (long i = startTime; i <= startTime + 100; i ++) {
-    byte[] bytes = new byte[9];
-    org.apache.hadoop.hbase.util.PositionedByteRange br =
-            new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 9);
-    org.apache.hadoop.hbase.util.OrderedBytes.encodeInt64(br, i,
-            org.apache.hadoop.hbase.util.Order.ASCENDING);
-    Put p = new Put(bytes);
-    p.add(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
-    table.put(p);
-  }
-
-  table.flushCommits();
-  table.close();
-
-  admin.flush(tableName);
-  }
-
-  public static void generateHBaseDatasetIntOB(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetBigIntOB(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -455,26 +415,54 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
+    long startTime = (long)1438034423 * 1000;
+    for (long i = startTime; i <= startTime + 100; i ++) {
+      byte[] bytes = new byte[9];
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
+      OrderedBytes.encodeInt64(br, i, Order.ASCENDING);
+      Put p = new Put(bytes);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
+      table.mutate(p);
+    }
+
+    table.close();
+
+    admin.flush(tableName);
+  }
+
+  public static void generateHBaseDatasetIntOB(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+    }
+
+    HTableDescriptor desc = new HTableDescriptor(tableName);
+    desc.addFamily(new HColumnDescriptor(FAMILY_F));
+
+    if (numberRegions > 1) {
+      admin.createTable(desc, Arrays.copyOfRange(SPLIT_KEYS, 0, numberRegions-1));
+    } else {
+      admin.createTable(desc);
+    }
+
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (int i = -49; i <= 100; i ++) {
       byte[] bytes = new byte[5];
-      org.apache.hadoop.hbase.util.PositionedByteRange br =
-              new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 5);
-      org.apache.hadoop.hbase.util.OrderedBytes.encodeInt32(br, i,
-              org.apache.hadoop.hbase.util.Order.ASCENDING);
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
+      OrderedBytes.encodeInt32(br, i, Order.ASCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetDoubleOBDesc(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetDoubleOBDesc(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -489,26 +477,23 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (double i = 0.5; i <= 100.00; i += 0.75) {
-        byte[] bytes = new byte[9];
-        org.apache.hadoop.hbase.util.PositionedByteRange br =
-                new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 9);
-        org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat64(br, i,
-                org.apache.hadoop.hbase.util.Order.DESCENDING);
+      byte[] bytes = new byte[9];
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
+      OrderedBytes.encodeFloat64(br, i, Order.DESCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetFloatOBDesc(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetFloatOBDesc(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -523,61 +508,23 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     for (float i = (float)0.5; i <= 100.00; i += 0.75) {
       byte[] bytes = new byte[5];
-      org.apache.hadoop.hbase.util.PositionedByteRange br =
-              new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 5);
-      org.apache.hadoop.hbase.util.OrderedBytes.encodeFloat32(br, i,
-              org.apache.hadoop.hbase.util.Order.DESCENDING);
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
+      OrderedBytes.encodeFloat32(br, i, Order.DESCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %03f", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetBigIntOBDesc(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
-    if (admin.tableExists(tableName)) {
-      admin.disableTable(tableName);
-      admin.deleteTable(tableName);
-    }
-
-   HTableDescriptor desc = new HTableDescriptor(tableName);
-  desc.addFamily(new HColumnDescriptor(FAMILY_F));
-
-  if (numberRegions > 1) {
-    admin.createTable(desc, Arrays.copyOfRange(SPLIT_KEYS, 0, numberRegions-1));
-  } else {
-    admin.createTable(desc);
-  }
-
-  HTable table = new HTable(admin.getConfiguration(), tableName);
-  long startTime = (long)1438034423 * 1000;
-  for (long i = startTime; i <= startTime + 100; i ++) {
-    byte[] bytes = new byte[9];
-    org.apache.hadoop.hbase.util.PositionedByteRange br =
-            new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 9);
-    org.apache.hadoop.hbase.util.OrderedBytes.encodeInt64(br, i,
-            org.apache.hadoop.hbase.util.Order.DESCENDING);
-    Put p = new Put(bytes);
-    p.add(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
-    table.put(p);
-  }
-
-  table.flushCommits();
-  table.close();
-
-  admin.flush(tableName);
-  }
-
-
-  public static void generateHBaseDatasetIntOBDesc(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+  public static void generateHBaseDatasetBigIntOBDesc(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -592,26 +539,55 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
-
-    for (int i = -49; i <= 100; i ++) {
-      byte[] bytes = new byte[5];
-      org.apache.hadoop.hbase.util.PositionedByteRange br =
-              new org.apache.hadoop.hbase.util.SimplePositionedByteRange(bytes, 0, 5);
-      org.apache.hadoop.hbase.util.OrderedBytes.encodeInt32(br, i,
-              org.apache.hadoop.hbase.util.Order.DESCENDING);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
+    long startTime = (long)1438034423 * 1000;
+    for (long i = startTime; i <= startTime + 100; i ++) {
+      byte[] bytes = new byte[9];
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
+      OrderedBytes.encodeInt64(br, i, Order.DESCENDING);
       Put p = new Put(bytes);
-      p.add(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
-      table.put(p);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
+      table.mutate(p);
     }
 
-    table.flushCommits();
     table.close();
 
     admin.flush(tableName);
   }
 
-  public static void generateHBaseDatasetNullStr(HBaseAdmin admin, String tableName, int numberRegions) throws Exception {
+
+  public static void generateHBaseDatasetIntOBDesc(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+    }
+
+    HTableDescriptor desc = new HTableDescriptor(tableName);
+    desc.addFamily(new HColumnDescriptor(FAMILY_F));
+
+    if (numberRegions > 1) {
+      admin.createTable(desc, Arrays.copyOfRange(SPLIT_KEYS, 0, numberRegions-1));
+    } else {
+      admin.createTable(desc);
+    }
+
+    BufferedMutator table = conn.getBufferedMutator(tableName);
+
+    for (int i = -49; i <= 100; i ++) {
+      byte[] bytes = new byte[5];
+      PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
+      OrderedBytes.encodeInt32(br, i, Order.DESCENDING);
+      Put p = new Put(bytes);
+      p.addColumn(FAMILY_F, COLUMN_C, String.format("value %d", i).getBytes());
+      table.mutate(p);
+    }
+
+    table.close();
+
+    admin.flush(tableName);
+  }
+
+  public static void generateHBaseDatasetNullStr(Connection conn, Admin admin, TableName tableName, int numberRegions) throws Exception {
     if (admin.tableExists(tableName)) {
       admin.disableTable(tableName);
       admin.deleteTable(tableName);
@@ -625,16 +601,16 @@ public class TestTableGenerator {
       admin.createTable(desc);
     }
 
-    HTable table = new HTable(admin.getConfiguration(), tableName);
+    BufferedMutator table = conn.getBufferedMutator(tableName);
 
     Put p = new Put("a1".getBytes());
-    p.add("f".getBytes(), "c1".getBytes(), "".getBytes());
-    p.add("f".getBytes(), "c2".getBytes(), "".getBytes());
-    p.add("f".getBytes(), "c3".getBytes(), "5".getBytes());
-    p.add("f".getBytes(), "c4".getBytes(), "".getBytes());
-    table.put(p);
+    p.addColumn("f".getBytes(), "c1".getBytes(), "".getBytes());
+    p.addColumn("f".getBytes(), "c2".getBytes(), "".getBytes());
+    p.addColumn("f".getBytes(), "c3".getBytes(), "5".getBytes());
+    p.addColumn("f".getBytes(), "c4".getBytes(), "".getBytes());
+    table.mutate(p);
 
-    table.flushCommits();
     table.close();
   }
+
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/test/Drill2130StorageHBaseHamcrestConfigurationTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/test/Drill2130StorageHBaseHamcrestConfigurationTest.java
@@ -17,13 +17,15 @@
  */
 package org.apache.drill.hbase.test;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.junit.Test;
 
 
 public class Drill2130StorageHBaseHamcrestConfigurationTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130StorageHBaseHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")
   private org.hamcrest.MatcherAssert forCompileTimeCheckForNewEnoughHamcrest;
@@ -38,7 +40,7 @@ public class Drill2130StorageHBaseHamcrestConfigurationTest {
              + "  Got NoSuchMethodError;  e: " + e );
     }
     catch ( AssertionError e ) {
-      System.out.println( "Class path seems fine re new JUnit vs. old Hamcrest."
+      logger.info("Class path seems fine re new JUnit vs. old Hamcrest."
                           + " (Got AssertionError, not NoSuchMethodError.)" );
     }
   }

--- a/contrib/storage-hbase/src/test/resources/logback.xml
+++ b/contrib/storage-hbase/src/test/resources/logback.xml
@@ -52,9 +52,17 @@
   </logger>
 
   <logger name="org.apache.hadoop" additivity="false">
-    <level value="info" />
+    <level value="warn" />
     <appender-ref ref="STDOUT" />
     <appender-ref ref="SOCKET" />
+    <appender-ref ref="FILE" />
+  </logger>
+
+  <logger name="org.apache.hadoop.hbase.client.ConnectionManager" additivity="false">
+    <level value="error" />
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="SOCKET" />
+    <appender-ref ref="FILE" />
   </logger>
 
   <root>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -41,6 +41,7 @@ import org.apache.drill.exec.store.sys.store.provider.CachingPersistentStoreProv
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
 import org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider;
+import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.exec.work.WorkManager;
 import org.apache.zookeeper.Environment;
 
@@ -54,6 +55,12 @@ public class Drillbit implements AutoCloseable {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drillbit.class);
 
   static {
+    /*
+     * HBase client uses older version of Guava's Stopwatch API,
+     * while Drill ships with 18.x which has changes the scope of
+     * these API to 'package', this code make them accessible.
+     */
+    GuavaPatcher.patch();
     Environment.logEnv("Drillbit environment: ", logger);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/GuavaPatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/GuavaPatcher.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.hbase;
+package org.apache.drill.exec.util;
 
 import java.lang.reflect.Modifier;
 
@@ -25,9 +25,8 @@ import javassist.CtConstructor;
 import javassist.CtMethod;
 import javassist.CtNewMethod;
 
-import org.apache.drill.common.CatastrophicFailure;
-
 public class GuavaPatcher {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(GuavaPatcher.class);
 
   private static boolean patched;
 
@@ -37,8 +36,8 @@ public class GuavaPatcher {
         patchStopwatch();
         patchCloseables();
         patched = true;
-      } catch (Exception e) {
-        CatastrophicFailure.exit(e, "Unable to patch Guava classes.", -100);
+      } catch (Throwable e) {
+        logger.warn("Unable to patch Guava classes.", e);
       }
     }
   }
@@ -66,7 +65,7 @@ public class GuavaPatcher {
     // Load the modified class instead of the original.
     cc.toClass();
 
-    System.out.println("Google's Stopwatch patched for old HBase Guava version.");
+    logger.info("Google's Stopwatch patched for old HBase Guava version.");
   }
 
   private static void patchCloseables() throws Exception {
@@ -84,7 +83,7 @@ public class GuavaPatcher {
     // Load the modified class instead of the original.
     cc.toClass();
 
-    System.out.println("Google's Closeables patched for old HBase Guava version.");
+    logger.info("Google's Closeables patched for old HBase Guava version.");
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1127,7 +1127,7 @@
           <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>0.98.7-hadoop2</version>
+            <version>1.1.3</version>
             <exclusions>
               <exclusion>
                 <groupId>org.mortbay.jetty</groupId>
@@ -1239,9 +1239,13 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-testing-util</artifactId>
             <classifier>tests</classifier>
-            <version>0.98.7-hadoop2</version>
+            <version>1.1.3</version>
             <scope>test</scope>
             <exclusions>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
               <exclusion>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>servlet-api-2.5</artifactId>
@@ -1390,7 +1394,7 @@
         <alt-hadoop>mapr</alt-hadoop>
         <rat.excludeSubprojects>true</rat.excludeSubprojects>
         <hive.version>1.2.0-mapr-1601</hive.version>
-        <hbase.version>0.98.12-mapr-1602-m7-5.1.0</hbase.version>
+        <hbase.version>1.1.1-mapr-1602-m7-5.1.0</hbase.version>
         <hadoop.version>2.7.0-mapr-1602</hadoop.version>
         <mapr.core.version>5.1.0-mapr</mapr.core.version>
       </properties>


### PR DESCRIPTION
Highlights of the changes:

* Updated HBase dependencies version to 1.1.3 and 1.1.1-mapr-1602-m7-5.1.0 for default and mapr profiles respectively.
* Replaced the old HBase APIs (HBaseAdmin/HTable) with the new HBase 1.1 APIs (Connection/Admin/Table).
* Added `commons-logging` dependency in the `provided` scope to allow HBase test cluster to come up for Unit tests.
* Relaxed banned dependency rule for `commons-logging` library for `storage-hbase` module alone, in provided scope only.
* Removed the use of many deprecated APIs throughout the modules code.
* Added some missing test to HBase storage plugin's test suit.

All unit tests are green.