### PR TITLE
DRILL-4544: Improve error messages for REFRESH TABLE METADATA command

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
@@ -30,6 +30,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.sql.DirectPlan;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.parser.SqlRefreshMetadata;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
@@ -52,7 +53,7 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
   }
 
   private PhysicalPlan notSupported(String tbl){
-    return direct(false, "Table %s does not support metadata refresh.  Support is currently limited to single-directory-based Parquet tables.", tbl);
+    return direct(false, "Table %s does not support metadata refresh. Support is currently limited to directory-based Parquet tables.", tbl);
   }
 
   @Override
@@ -63,6 +64,11 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
 
       final SchemaPlus schema = findSchema(config.getConverter().getDefaultSchema(),
           refreshTable.getSchemaPath());
+
+      if (schema == null) {
+        return direct(false, "Storage plugin or workspace does not exist [%s]",
+            SchemaUtilites.SCHEMA_PATH_JOINER.join(refreshTable.getSchemaPath()));
+      }
 
       final String tableName = refreshTable.getName();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
@@ -177,6 +177,34 @@ public class TestParquetMetadataCache extends PlanTestBase {
       .go();
   }
 
+  @Test
+  public void testAbsentPluginOrWorkspaceError() throws Exception {
+    testBuilder()
+        .sqlQuery("refresh table metadata dfs_test.incorrect.table_name")
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(false, "Storage plugin or workspace does not exist [dfs_test.incorrect]")
+        .go();
+
+    testBuilder()
+        .sqlQuery("refresh table metadata incorrect.table_name")
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(false, "Storage plugin or workspace does not exist [incorrect]")
+        .go();
+  }
+
+  @Test
+  public void testNoSupportedError() throws Exception {
+    testBuilder()
+        .sqlQuery("refresh table metadata cp.`tpch/nation.parquet`")
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(false, "Table tpch/nation.parquet does not support metadata refresh. " +
+            "Support is currently limited to directory-based Parquet tables.")
+        .go();
+  }
+
   private void checkForMetadataFile(String table) throws Exception {
     String tmpDir = getDfsTestTmpSchemaLocation();
     String metaFile = Joiner.on("/").join(tmpDir, table, Metadata.METADATA_FILENAME);


### PR DESCRIPTION
1. Added error message when storage plugin or workspace does not exist
2. Updated error message when refresh metadata is not supported
3. Unit tests