### PR TITLE
DRILL-4566: TDigest, median, and quantile functions

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -302,6 +302,11 @@
       <artifactId>vector</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+      <version>3.1</version>
+    </dependency>
     <!-- <dependency> -->
     <!-- <groupId>org.apache.drill.exec</groupId> -->
     <!-- <version>${project.version}</version> -->

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/TDigestFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/TDigestFunctions.java
@@ -1,0 +1,295 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.expr.DrillAggFunc;
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionCostCategory;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.BigIntHolder;
+import org.apache.drill.exec.expr.holders.Float8Holder;
+import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
+import org.apache.drill.exec.expr.holders.NullableVarBinaryHolder;
+import org.apache.drill.exec.expr.holders.ObjectHolder;
+import org.apache.drill.exec.expr.holders.VarBinaryHolder;
+
+import javax.inject.Inject;
+
+public class TDigestFunctions {
+
+  /**
+   * Computes the tdigest for a column of doubles
+   */
+  @FunctionTemplate(name = "tdigest", scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+  public static class TDigestDoubleRequired implements DrillAggFunc {
+
+    @Param
+    private Float8Holder in;
+    @Workspace
+    private ObjectHolder digest;
+    @Output
+    private NullableVarBinaryHolder out;
+    @Inject
+    private DrillBuf buffer;
+
+    public void setup() {
+      digest = new ObjectHolder();
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+    @Override
+    public void add() {
+      ((com.tdunning.math.stats.TDigest) digest.obj).add(in.value);
+    }
+
+    @Override
+    public void output() {
+      com.tdunning.math.stats.TDigest tdigest = ((com.tdunning.math.stats.TDigest) digest.obj);
+      int size = tdigest.smallByteSize();
+      buffer = buffer.reallocIfNeeded(size);
+      tdigest.asSmallBytes(buffer.nioBuffer(0, size));
+      out.isSet = 1;
+      out.start = 0;
+      out.buffer = buffer;
+      out.end = size;
+    }
+
+    @Override
+    public void reset() {
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+  }
+
+  /**
+   * Computes the tdigest for a column of doubles
+   */
+  @FunctionTemplate(name = "tdigest", scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+  public static class TDigestDouble implements DrillAggFunc {
+
+    @Param
+    private NullableFloat8Holder in;
+    @Workspace
+    private ObjectHolder digest;
+    @Output
+    private NullableVarBinaryHolder out;
+    @Inject
+    private DrillBuf buffer;
+
+    public void setup() {
+      digest = new ObjectHolder();
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+    @Override
+    public void add() {
+      if (in.isSet == 1) {
+        ((com.tdunning.math.stats.TDigest) digest.obj).add(in.value);
+      }
+    }
+
+    @Override
+    public void output() {
+      com.tdunning.math.stats.TDigest tdigest = ((com.tdunning.math.stats.TDigest) digest.obj);
+      int size = tdigest.smallByteSize();
+      buffer = buffer.reallocIfNeeded(size);
+      tdigest.asSmallBytes(buffer.nioBuffer(0, size));
+      out.isSet = 1;
+      out.start = 0;
+      out.buffer = buffer;
+      out.end = size;
+    }
+
+    @Override
+    public void reset() {
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+  }
+
+  /**
+   * Merges the tdigest produced by the tdigest functions to produce a new tdigest
+   */
+  @FunctionTemplate(name = "tdigest_merge", scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+  public static class TDigestMerge implements DrillAggFunc {
+
+    @Param
+    private NullableVarBinaryHolder in;
+    @Workspace
+    private ObjectHolder digest;
+    @Output
+    private NullableVarBinaryHolder out;
+    @Inject
+    private DrillBuf buffer;
+
+    public void setup() {
+      digest = new ObjectHolder();
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+    @Override
+    public void add() {
+      if (in.isSet == 1) {
+
+        com.tdunning.math.stats.TDigest tDigest = com.tdunning.math.stats.AVLTreeDigest.fromBytes(in.buffer.nioBuffer(in.start, in.end - in.start));
+        ((com.tdunning.math.stats.TDigest) digest.obj).add(tDigest);
+      }
+    }
+
+    @Override
+    public void output() {
+      com.tdunning.math.stats.TDigest tdigest = ((com.tdunning.math.stats.TDigest) digest.obj);
+      int size = tdigest.smallByteSize();
+      buffer = buffer.reallocIfNeeded(size);
+      tdigest.asSmallBytes(buffer.nioBuffer(0, size));
+      out.isSet = 1;
+      out.start = 0;
+      out.buffer = buffer;
+      out.end = size;
+    }
+
+    @Override
+    public void reset() {
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+  }
+
+  /**
+   * Computes the quantile q for input data in. This function should generally not be used in execution, as the DrillReduceAggregatesRule
+   * should reduce it to use quantile(q, tdigest(in))
+   */
+  @FunctionTemplate(name = "quantile", scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+  public static class QuantileConstant implements DrillAggFunc {
+
+    @Param private NullableFloat8Holder q;
+    @Param private NullableFloat8Holder in;
+    @Workspace private NullableFloat8Holder quantile;
+    @Workspace private ObjectHolder digest;
+    @Output private NullableFloat8Holder out;
+
+    public void setup() {
+      digest = new ObjectHolder();
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+      quantile = new NullableFloat8Holder();
+    }
+
+    @Override
+    public void add() {
+      if (in.isSet == 1) {
+        ((com.tdunning.math.stats.TDigest) digest.obj).add(in.value);
+      }
+      if (quantile.isSet == 0 && q.isSet == 1) {
+        quantile.value = q.value;
+        quantile.isSet = 1;
+      }
+    }
+
+    @Override
+    public void output() {
+      com.tdunning.math.stats.TDigest tdigest = ((com.tdunning.math.stats.TDigest) digest.obj);
+      out.value = tdigest.quantile(quantile.value);
+      out.isSet = 1;
+    }
+
+    @Override
+    public void reset() {
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+  }
+
+  /**
+   * Computes the approximate median from the tdigest
+   */
+  @FunctionTemplate(name = "tdigest_median", scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
+  public static class TDigestMedian implements DrillSimpleFunc {
+
+    @Param VarBinaryHolder in;
+    @Output Float8Holder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      com.tdunning.math.stats.TDigest tDigest = com.tdunning.math.stats.AVLTreeDigest.fromBytes(in.buffer.nioBuffer(in.start, in.end - in.start));
+      out.value = tDigest.quantile(0.5);
+    }
+  }
+
+  /**
+   * Computes the quantile from a tdigest
+   */
+  @FunctionTemplate(name = "tdigest_quantile", scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
+  public static class TDigestQuantile implements DrillSimpleFunc {
+
+    @Param Float8Holder quantile;
+    @Param VarBinaryHolder in;
+    @Output Float8Holder out;
+
+    public void setup() {
+    }
+
+    public void eval() {
+      com.tdunning.math.stats.TDigest tDigest = com.tdunning.math.stats.AVLTreeDigest.fromBytes(in.buffer.nioBuffer(in.start, in.end - in.start));
+      out.value = tDigest.quantile(quantile.value);
+    }
+  }
+
+  /**
+   * Computes the median of a column of data using the tdigest
+   */
+  @FunctionTemplate(name = "median", scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE, costCategory = FunctionCostCategory.COMPLEX)
+  public static class Median implements DrillAggFunc {
+
+    @Param private NullableFloat8Holder in;
+    @Workspace private ObjectHolder digest;
+    @Output private NullableFloat8Holder out;
+
+    public void setup() {
+      digest = new ObjectHolder();
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+    @Override
+    public void add() {
+      if (in.isSet == 1) {
+        ((com.tdunning.math.stats.TDigest) digest.obj).add(in.value);
+      }
+    }
+
+    @Override
+    public void output() {
+      com.tdunning.math.stats.TDigest tdigest = ((com.tdunning.math.stats.TDigest) digest.obj);
+      out.value = tdigest.quantile(0.5);
+      out.isSet = 1;
+    }
+
+    @Override
+    public void reset() {
+      digest.obj = com.tdunning.math.stats.TDigest.createAvlTreeDigest(100);
+    }
+
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -263,6 +263,7 @@ public enum PlannerPhase {
 
       AggregateExpandDistinctAggregatesRule.JOIN,
       DrillReduceAggregatesRule.INSTANCE,
+      DrillReduceAggregatesRule.INSTANCE_QUANTILE,
 
       /*
        Projection push-down related rules

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillAggregateRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillAggregateRel.java
@@ -93,7 +93,7 @@ public class DrillAggregateRel extends DrillAggregateRelBase implements DrillRel
       // to convert them to use sum and count. Here, we make the cost of the original functions high
       // enough such that the planner does not choose them and instead chooses the rewritten functions.
       if (name.equals("AVG") || name.equals("STDDEV_POP") || name.equals("STDDEV_SAMP")
-          || name.equals("VAR_POP") || name.equals("VAR_SAMP")) {
+          || name.equals("VAR_POP") || name.equals("VAR_SAMP") || name.equals("MEDIAN") || name.equals("QUANTILE")) {
         return ((DrillCostBase.DrillCostFactory)planner.getCostFactory()).makeHugeCost();
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
@@ -70,7 +70,7 @@ public abstract class AggPruleBase extends Prule {
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       String name = aggCall.getAggregation().getName();
       if ( ! (name.equals("SUM") || name.equals("MIN") || name.equals("MAX") || name.equals("COUNT")
-              || name.equals("$SUM0"))) {
+              || name.equals("$SUM0") || name.equals("TDIGEST"))) {
         return false;
       }
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestTDigestFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestTDigestFunctions.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.BaseTestQuery;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestTDigestFunctions extends BaseTestQuery {
+
+  private static final double MEDIAN = 34245.12;
+  private static final double Q90 = 66633.84;
+  private static final double Q99 = 86085.65;
+  private static final double MEDIAN_TAX = 0.04;
+  private static final double Q90_TAX = 0.08;
+  private static final double MEDIAN_N_O = 34329.33;
+  private static final double Q90_N_O = 66654.52;
+  private static final double MEDIAN_N_F = 33298.92;
+  private static final double Q90_N_F = 67175.52;
+  private static final double MEDIAN_A_F = 34129.44;
+  private static final double Q90_A_F = 66935.95;
+  private static final double MEDIAN_R_F = 34245.12;
+  private static final double Q90_R_F = 66172.05;
+
+  @Test
+  public void median() throws Exception {
+    String query = "select median(l_extendedprice) m from cp.`tpch/lineitem.parquet`";
+    Map<String,Float> tolerances = new HashMap<>();
+    tolerances.put("`m`", new Float(1e-3));
+    testBuilder()
+            .sqlQuery(query)
+            .unOrdered()
+            .baselineColumns("m")
+            .baselineValues(MEDIAN)
+            .baselineTolerances(tolerances)
+            .go();
+  }
+
+  @Test
+  public void q90() throws Exception {
+    String query = "select quantile(0.9, l_extendedprice) q90 from cp.`tpch/lineitem.parquet`";
+    Map<String,Float> tolerances = new HashMap<>();
+    tolerances.put("`q90`", new Float(1e-3));
+    testBuilder()
+            .sqlQuery(query)
+            .unOrdered()
+            .baselineColumns("q90")
+            .baselineValues(Q90)
+            .baselineTolerances(tolerances)
+            .go();
+  }
+
+  @Test
+  public void q99() throws Exception {
+    String query = "select quantile(0.99, l_extendedprice) q90 from cp.`tpch/lineitem.parquet`";
+    Map<String,Float> tolerances = new HashMap<>();
+    tolerances.put("`q90`", new Float(1e-3));
+    testBuilder()
+            .sqlQuery(query)
+            .unOrdered()
+            .baselineColumns("q90")
+            .baselineValues(Q99)
+            .baselineTolerances(tolerances)
+            .go();
+  }
+
+  @Test
+  public void multipleInputs() throws Exception {
+    String query = "select median(l_extendedprice) m, quantile(0.9, l_extendedprice) q90, median(l_tax) m_tax, quantile(0.9, l_tax) q90_tax from cp.`tpch/lineitem.parquet`";
+    Map<String,Float> tolerances = new HashMap<>();
+    tolerances.put("`m`", new Float(1e-3));
+    tolerances.put("`q90`", new Float(1e-3));
+    tolerances.put("`m_tax`", new Float(1e-3));
+    tolerances.put("`q90_tax`", new Float(1e-3));
+    testBuilder()
+            .sqlQuery(query)
+            .unOrdered()
+            .baselineColumns("m", "q90", "m_tax", "q90_tax")
+            .baselineValues(MEDIAN, Q90, MEDIAN_TAX, Q90_TAX)
+            .baselineTolerances(tolerances)
+            .go();
+  }
+
+  @Test
+  public void groupBy() throws Exception {
+    String query = "select median(l_extendedprice) m, quantile(0.9, l_extendedprice) q90 from cp.`tpch/lineitem.parquet` group by l_returnflag, l_linestatus";
+    test(query);
+    Map<String,Float> tolerances = new HashMap<>();
+    tolerances.put("`m`", new Float(1e-2));
+    tolerances.put("`q90`", new Float(1e-2));
+    testBuilder()
+            .sqlQuery(query)
+            .unOrdered()
+            .baselineColumns("m", "q90")
+            .baselineValues(MEDIAN_N_O, Q90_N_O)
+            .baselineValues(MEDIAN_N_F, Q90_N_F)
+            .baselineValues(MEDIAN_A_F, Q90_A_F)
+            .baselineValues(MEDIAN_R_F, Q90_R_F)
+            .baselineTolerances(tolerances)
+            .go();
+  }
+}


### PR DESCRIPTION
Adds tdigest, tdigest_merge, median, and quantile UDFS
Adds reduce aggregates rule to reduce:
  median(x) -> tdigest_median(tdigest(x))
  quantile(q, x) -> tdigest_quantile(q, tdigest(x))
Adds two-phase aggregate rule for tdigest

Also adds ability to specify tolerances in the TestBuilder