### PR TITLE
DRILL-3714: Avoid cascading disconnection when a single connection is broken

### DIFF
--- a/exec/memory/base/pom.xml
+++ b/exec/memory/base/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
-      <version>0.5.2</version>
+      <version>0.7.1</version>
     </dependency>
   </dependencies>
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
@@ -41,6 +41,7 @@ import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.GeneralRPCProtos.RpcMode;
 import org.apache.drill.exec.rpc.RpcConnectionHandler.FailureType;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.Internal.EnumLite;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
@@ -95,7 +96,7 @@ public abstract class BasicClient<T extends EnumLite, R extends RemoteConnection
             pipe.addLast("protocol-decoder", getDecoder(connection.getAllocator()));
             pipe.addLast("message-decoder", new RpcDecoder("c-" + rpcConfig.getName()));
             pipe.addLast("protocol-encoder", new RpcEncoder("c-" + rpcConfig.getName()));
-            pipe.addLast("handshake-handler", new ClientHandshakeHandler());
+            pipe.addLast("handshake-handler", new ClientHandshakeHandler(connection));
 
             if(pingHandler != null){
               pipe.addLast("idle-state-handler", pingHandler);
@@ -282,15 +283,19 @@ public abstract class BasicClient<T extends EnumLite, R extends RemoteConnection
 
   private class ClientHandshakeHandler extends AbstractHandshakeHandler<HANDSHAKE_RESPONSE> {
 
-    public ClientHandshakeHandler() {
+    private final R connection;
+
+    public ClientHandshakeHandler(R connection) {
       super(BasicClient.this.handshakeType, BasicClient.this.handshakeParser);
+      Preconditions.checkNotNull(connection);
+      this.connection = connection;
     }
 
     @Override
     protected final void consumeHandshake(ChannelHandlerContext ctx, HANDSHAKE_RESPONSE msg) throws Exception {
       // remove the handshake information from the queue so it doesn't sit there forever.
-      RpcOutcome<HANDSHAKE_RESPONSE> response = queue.getFuture(handshakeType.getNumber(), coordinationId,
-          responseClass);
+      final RpcOutcome<HANDSHAKE_RESPONSE> response =
+          connection.getAndRemoveRpcOutcome(handshakeType.getNumber(), coordinationId, responseClass);
       response.set(msg, null);
     }
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RemoteConnection.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RemoteConnection.java
@@ -21,21 +21,21 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
-
 import java.util.concurrent.ExecutionException;
 
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 
 public abstract class RemoteConnection implements ConnectionThrottle, AutoCloseable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RemoteConnection.class);
   private final Channel channel;
   private final WriteManager writeManager;
-  private String name;
+  private final RequestIdMap requestIdMap = new RequestIdMap();
   private final String clientName;
 
-  public boolean inEventLoop(){
+  private String name;
+
+  public boolean inEventLoop() {
     return channel.eventLoop().inEventLoop();
   }
 
@@ -45,19 +45,10 @@ public abstract class RemoteConnection implements ConnectionThrottle, AutoClosea
     this.clientName = name;
     this.writeManager = new WriteManager();
     channel.pipeline().addLast(new BackPressureHandler());
-    channel.closeFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
-      public void operationComplete(Future<? super Void> future) throws Exception {
-        // this could possibly overrelease but it doesn't matter since we're only going to do this to ensure that we
-        // fail out any pending messages
-        writeManager.disable();
-        writeManager.setWritable(true);
-      }
-    });
-
   }
 
   public String getName() {
-    if(name == null){
+    if (name == null) {
       name = String.format("%s <--> %s (%s)", channel.localAddress(), channel.remoteAddress(), clientName);
     }
     return name;
@@ -69,14 +60,15 @@ public abstract class RemoteConnection implements ConnectionThrottle, AutoClosea
     return channel;
   }
 
-  public boolean blockOnNotWritable(RpcOutcomeListener<?> listener){
-    try{
+  public boolean blockOnNotWritable(RpcOutcomeListener<?> listener) {
+    try {
       writeManager.waitForWritable();
       return true;
-    }catch(final InterruptedException e){
+    } catch (final InterruptedException e) {
       listener.interrupted(e);
 
-      // Preserve evidence that the interruption occurred so that code higher up on the call stack can learn of the
+      // Preserve evidence that the interruption occurred so that code higher up
+      // on the call stack can learn of the
       // interruption and respond to it if it wants to.
       Thread.currentThread().interrupt();
 
@@ -84,31 +76,33 @@ public abstract class RemoteConnection implements ConnectionThrottle, AutoClosea
     }
   }
 
-  public void setAutoRead(boolean enableAutoRead){
+  public void setAutoRead(boolean enableAutoRead) {
     channel.config().setAutoRead(enableAutoRead);
   }
 
-  public boolean isActive(){
+  public boolean isActive() {
     return channel.isActive();
   }
 
   /**
-   * The write manager is responsible for controlling whether or not a write can be sent.  It controls whether or not to block a sender if we have tcp backpressure on the receive side.
+   * The write manager is responsible for controlling whether or not a write can
+   * be sent. It controls whether or not to block a sender if we have tcp
+   * backpressure on the receive side.
    */
-  private static class WriteManager{
+  private static class WriteManager {
     private final ResettableBarrier barrier = new ResettableBarrier();
     private volatile boolean disabled = false;
 
-    public WriteManager(){
+    public WriteManager() {
       barrier.openBarrier();
     }
 
-    public void waitForWritable() throws InterruptedException{
+    public void waitForWritable() throws InterruptedException {
       barrier.await();
     }
 
-    public void setWritable(boolean isWritable){
-      if(isWritable){
+    public void setWritable(boolean isWritable) {
+      if (isWritable) {
         barrier.openBarrier();
       } else if (!disabled) {
         barrier.closeBarrier();
@@ -121,17 +115,72 @@ public abstract class RemoteConnection implements ConnectionThrottle, AutoClosea
     }
   }
 
-  private class BackPressureHandler extends ChannelInboundHandlerAdapter{
+  private class BackPressureHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-//      logger.debug("Channel writability changed.", ctx.channel().isWritable());
       writeManager.setWritable(ctx.channel().isWritable());
       ctx.fireChannelWritabilityChanged();
     }
 
   }
 
+  /**
+   * For incoming messages, remove the outcome listener and return it. Can only be done once per coordinationId.
+   * @param rpcType The rpc type associated with the coordination.
+   * @param coordinationId The coordination id that was returned with the listener was created.
+   * @param clazz The class that is expected in response.
+   * @return
+   */
+  <V> RpcOutcome<V> getAndRemoveRpcOutcome(int rpcType, int coordinationId, Class<V> clazz) {
+    return requestIdMap.getAndRemoveRpcOutcome(rpcType, coordinationId, clazz);
+  }
+
+  /**
+   * Create a new rpc listener that will be notified when the response is returned.
+   * @param handler The outcome handler to be notified when the response arrives.
+   * @param clazz The Class associated with the response object.
+   * @return The new listener. Also carries the coordination id for use in the rpc message.
+   */
+  <V> ChannelListenerWithCoordinationId createNewRpcListener(RpcOutcomeListener<V> handler, Class<V> clazz) {
+    return requestIdMap.createNewRpcListener(handler, clazz, this);
+  }
+
+  /**
+   * Inform the local outcome listener that the remote operation could not be handled.
+   * @param coordinationId The id that failed.
+   * @param failure The failure that occurred.
+   */
+  void recordRemoteFailure(int coordinationId, DrillPBError failure) {
+    requestIdMap.recordRemoteFailure(coordinationId, failure);
+  }
+
+  /**
+   * Called from the RpcBus's channel close handler to close all remaining
+   * resources associated with this connection. Ensures that any pending
+   * back-pressure items are also unblocked so they can be thrown away.
+   *
+   * @param ex
+   *          The exception that caused the channel to close.
+   */
+  void channelClosed(RpcException ex) {
+    // this could possibly overrelease but it doesn't matter since we're only
+    // going to do this to ensure that we
+    // fail out any pending messages
+    writeManager.disable();
+    writeManager.setWritable(true);
+
+    // ensure outstanding requests are cleaned up.
+    requestIdMap.channelClosed(ex);
+  }
+
+  /**
+   * Connection consumer wants to close connection. Initiate connection close
+   * and complete. This is a blocking call that ensures that the connection is
+   * closed before returning. As part of this call, the channel close handler
+   * will be triggered which will call channelClosed() above. The latter will
+   * happen in a separate thread while this method is blocking.
+   */
   @Override
   public void close() {
     try {
@@ -141,7 +190,8 @@ public abstract class RemoteConnection implements ConnectionThrottle, AutoClosea
     } catch (final InterruptedException | ExecutionException e) {
       logger.warn("Caught exception while closing channel.", e);
 
-      // Preserve evidence that the interruption occurred so that code higher up on the call stack can learn of the
+      // Preserve evidence that the interruption occurred so that code higher up
+      // on the call stack can learn of the
       // interruption and respond to it if it wants to.
       Thread.currentThread().interrupt();
     }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -59,8 +59,6 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
   private static final OutboundRpcMessage PONG = new OutboundRpcMessage(RpcMode.PONG, 0, 0, Acks.OK);
   private static final boolean ENABLE_SEPARATE_THREADS = "true".equals(System.getProperty("drill.enable_rpc_offload"));
 
-  protected final CoordinationQueue queue = new CoordinationQueue(16, 16);
-
   protected abstract MessageLite getResponseDefaultInstance(int rpcType) throws RpcException;
 
   protected void handle(C connection, int rpcType, ByteBuf pBody, ByteBuf dBody, ResponseSender sender) throws RpcException{
@@ -120,7 +118,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
       assert rpcConfig.checkSend(rpcType, protobufBody.getClass(), clazz);
 
       Preconditions.checkNotNull(protobufBody);
-      ChannelListenerWithCoordinationId futureListener = queue.get(listener, clazz, connection);
+      ChannelListenerWithCoordinationId futureListener = connection.createNewRpcListener(listener, clazz);
       OutboundRpcMessage m = new OutboundRpcMessage(RpcMode.REQUEST, rpcType, futureListener.getCoordinationId(), protobufBody, dataBodies);
       ChannelFuture channelFuture = connection.getChannel().writeAndFlush(m);
       channelFuture.addListener(futureListener);
@@ -129,6 +127,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
     } catch (Exception | AssertionError e) {
       listener.failed(new RpcException("Failure sending message.", e));
     } finally {
+
       if (!completed) {
         if (pBuffer != null) {
           pBuffer.release();
@@ -158,22 +157,16 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
 
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
-      String msg;
+      final String msg;
+
       if(local!=null) {
         msg = String.format("Channel closed %s <--> %s.", local, remote);
       }else{
         msg = String.format("Channel closed %s <--> %s.", future.channel().localAddress(), future.channel().remoteAddress());
       }
 
-      if (RpcBus.this.isClient()) {
-        if(local != null) {
-          logger.info(String.format(msg));
-        }
-      } else {
-        queue.channelClosed(new ChannelClosedException(msg));
-      }
-
-      clientConnection.close();
+      final ChannelClosedException ex = future.cause() != null ? new ChannelClosedException(msg, future.cause()) : new ChannelClosedException(msg);
+      clientConnection.channelClosed(ex);
     }
 
   }
@@ -182,9 +175,6 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
     return new ChannelClosedHandler(clientConnection, channel);
   }
 
-  private interface Recyclable {
-    public void recycle();
-  }
 
   private class ResponseSenderImpl implements ResponseSender {
 
@@ -261,6 +251,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
 
     public InboundHandler(C connection) {
       super();
+      Preconditions.checkNotNull(connection);
       this.connection = connection;
       final Executor underlyingExecutor = ENABLE_SEPARATE_THREADS ? rpcConfig.getExecutor() : new SameExecutor();
       this.exec = new RpcEventHandler(underlyingExecutor);
@@ -286,13 +277,13 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
           break;
 
         case RESPONSE:
-          ResponseEvent respEvent = new ResponseEvent(msg.rpcType, msg.coordinationId, msg.pBody, msg.dBody);
+          ResponseEvent respEvent = new ResponseEvent(connection, msg.rpcType, msg.coordinationId, msg.pBody, msg.dBody);
           exec.execute(respEvent);
           break;
 
         case RESPONSE_FAILURE:
           DrillPBError failure = DrillPBError.parseFrom(new ByteBufInputStream(msg.pBody, msg.pBody.readableBytes()));
-          queue.updateFailedFuture(msg.coordinationId, failure);
+          connection.recordRemoteFailure(msg.coordinationId, failure);
           if (RpcConstants.EXTRA_DEBUGGING) {
             logger.debug("Updated rpc future with coordinationId {} with failure ", msg.coordinationId, failure);
           }
@@ -398,12 +389,14 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
     private final int coordinationId;
     private final ByteBuf pBody;
     private final ByteBuf dBody;
+    private final C connection;
 
-    public ResponseEvent(int rpcType, int coordinationId, ByteBuf pBody, ByteBuf dBody) {
+    public ResponseEvent(C connection, int rpcType, int coordinationId, ByteBuf pBody, ByteBuf dBody) {
       this.rpcType = rpcType;
       this.coordinationId = coordinationId;
       this.pBody = pBody;
       this.dBody = dBody;
+      this.connection = connection;
 
       if(pBody != null){
         pBody.retain();
@@ -418,7 +411,7 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
       try {
         MessageLite m = getResponseDefaultInstance(rpcType);
         assert rpcConfig.checkReceive(rpcType, m.getClass());
-        RpcOutcome<?> rpcFuture = queue.getFuture(rpcType, coordinationId, m.getClass());
+        RpcOutcome<?> rpcFuture = connection.getAndRemoveRpcOutcome(rpcType, coordinationId, m.getClass());
         Parser<?> parser = m.getParserForType();
         Object value = parser.parseFrom(new ByteBufInputStream(pBody, pBody.readableBytes()));
         rpcFuture.set(value, dBody);


### PR DESCRIPTION
DRILL-3714: Avoid cascading disconnection when a single connection is broken

- Move the coordination id management to be connection level instead of RpcBus level
- Rename CoordinationQueue to a more appropriate name: RequestIdMap
- Simplify locking and memory overhead of RequestIdMap. It used to be that this would accessed by a large number of threads concurrently. We modified the behavior so that it is only accessed by two threads at most. Rather than have memory overhead of ConcurrentHashMap, switch to simple locking approach since contention should be low.
- Update all methods associated with coordination to improve names as well as add javadocs. Move these methods to the RemoteConnection.
- Consolidate the two different close handlers into a single, ordered close handler managed inside the connection.
- Add better javadoc around the close method of RemoteConnection
- Add some preconditions checks.
- Update the HPPC version in the base memory module since it conflicts with the one in the java-exec module.