### PR TITLE
DRILL-4143: Fix inconsistency in writing metadata with different user's permission.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/Metadata.java
@@ -27,7 +27,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.store.TimedRunnable;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.dfs.DrillPathFilter;
+import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -131,7 +133,7 @@ public class Metadata {
   }
 
   private Metadata(FileSystem fs) {
-    this.fs = fs;
+    this.fs = ImpersonationUtil.createFileSystem(ImpersonationUtil.getProcessUserName(), fs.getConf());
   }
 
   /**


### PR DESCRIPTION
 When accessing readBlockMeta, use an impersonated special Filesystem object which is of drillbituser. So we are making sure we always write metadata with drillbit-user's permission.