### PR TITLE
DRILL-4258: Add threads, fragments, and queries system tables

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ThreadStatCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ThreadStatCollector.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import com.carrotsearch.hppc.LongObjectHashMap;
+import com.carrotsearch.hppc.procedures.LongObjectProcedure;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+public class ThreadStatCollector implements Runnable {
+  private static final long ONE_BILLION = 1000000000;
+  private static final long RETAIN_INTERVAL = 5 * ONE_BILLION;
+  private static final int COLLECTION_INTERVAL = 1;
+
+  private ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
+  private ThreadStat cpuStat = new ThreadStat();
+  private ThreadStat userStat = new ThreadStat();
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        Thread.sleep(COLLECTION_INTERVAL * 1000);
+        addCpuTime();
+        addUserTime();
+      } catch (InterruptedException e) {
+        return;
+      }
+    }
+  }
+
+  public Integer getCpuTrailingAverage(long id, int seconds) {
+    return cpuStat.getTrailingAverage(id, seconds);
+  }
+
+  public Integer getUserTrailingAverage(long id, int seconds) {
+    return userStat.getTrailingAverage(id, seconds);
+  }
+
+  private void addCpuTime() {
+    for (long id : mxBean.getAllThreadIds()) {
+      cpuStat.add(id, System.nanoTime(), mxBean.getThreadCpuTime(id));
+    }
+  }
+
+  private void addUserTime() {
+    for (long id : mxBean.getAllThreadIds()) {
+      userStat.add(id, System.nanoTime(), mxBean.getThreadUserTime(id));
+    }
+  }
+
+  private static class ThreadStat {
+    volatile LongObjectHashMap<Deque<Entry<Long,Long>>> data = new LongObjectHashMap<>();
+
+    public void add(long id, long ts, long value) {
+      Entry<Long,Long> entry = new SimpleEntry<>(ts, value);
+      Deque<Entry<Long,Long>> list = data.get(id);
+      if (list == null) {
+        list = new ConcurrentLinkedDeque<>();
+      }
+      list.add(entry);
+      while (ts - list.peekFirst().getKey() > RETAIN_INTERVAL) {
+        list.removeFirst();
+      }
+      data.put(id, list);
+    }
+
+    public Integer getTrailingAverage(long id, int seconds) {
+      Deque<Entry<Long,Long>> list = data.get(id);
+      if (list == null) {
+        return null;
+      }
+      return getTrailingAverage(list, seconds);
+    }
+
+    private Integer getTrailingAverage(Deque<Entry<Long, Long>> list, int seconds) {
+      Entry<Long,Long> latest = list.peekLast();
+      Entry<Long,Long> old = list.peekFirst();
+      Iterator<Entry<Long,Long>> iter = list.descendingIterator();
+      while (iter.hasNext()) {
+        Entry<Long,Long> e = iter.next();
+        if (e.getKey() - latest.getKey() > seconds * ONE_BILLION) {
+          old = e;
+          break;
+        }
+      }
+      try {
+        return (int) (100 * (old.getValue() - latest.getValue()) / (old.getKey() - latest.getKey()));
+      } catch (Exception e) {
+        return null;
+      }
+    }
+
+    public void print(final int window) {
+      data.forEach(new LongObjectProcedure<Deque<Entry<Long,Long>>>() {
+        @Override
+        public void apply(long l, Deque<Entry<Long,Long>> entries) {
+          System.out.println(String.format("%d %d", l, getTrailingAverage(entries, window)));
+        }
+      });
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -31,6 +31,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.metrics.DrillMetrics;
+import org.apache.drill.exec.ops.ThreadStatCollector;
 import org.apache.drill.exec.rpc.NamedThreadFactory;
 import org.apache.drill.exec.rpc.TransportCheck;
 
@@ -46,6 +47,8 @@ public class BootStrapContext implements AutoCloseable {
   private final BufferAllocator allocator;
   private final ScanResult classpathScan;
   private final ExecutorService executor;
+
+  private final ThreadStatCollector threadStatCollector;
 
   public BootStrapContext(DrillConfig config, ScanResult classpathScan) {
     this.config = config;
@@ -65,6 +68,7 @@ public class BootStrapContext implements AutoCloseable {
         super.afterExecute(r, t);
       }
     };
+    this.threadStatCollector = new ThreadStatCollector();
   }
 
   public ExecutorService getExecutor() {
@@ -93,6 +97,10 @@ public class BootStrapContext implements AutoCloseable {
 
   public ScanResult getClasspathScan() {
     return classpathScan;
+  }
+
+  public ThreadStatCollector getThreadStatCollector() {
+    return threadStatCollector;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -118,6 +118,7 @@ public class Drillbit implements AutoCloseable {
     javaPropertiesToSystemOptions();
     registrationHandle = coord.register(md);
     webServer.start();
+    context.getExecutor().submit(context.getThreadStatCollector());
 
     Runtime.getRuntime().addShutdownHook(new ShutdownThread(this, new StackTrace()));
     logger.info("Startup completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.ops.ThreadStatCollector;
 import org.apache.drill.exec.physical.impl.OperatorCreatorRegistry;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
@@ -42,6 +43,7 @@ import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 
 import com.codahale.metrics.MetricRegistry;
+import org.apache.drill.exec.work.WorkManager;
 
 public class DrillbitContext implements AutoCloseable {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillbitContext.class);
@@ -61,6 +63,7 @@ public class DrillbitContext implements AutoCloseable {
   private final CodeCompiler compiler;
   private final ScanResult classpathScan;
   private final LogicalPlanPersistence lpPersistence;
+  private final WorkManager workManager;
 
 
   public DrillbitContext(
@@ -70,7 +73,8 @@ public class DrillbitContext implements AutoCloseable {
       Controller controller,
       DataConnectionCreator connectionsPool,
       WorkEventBus workBus,
-      PersistentStoreProvider provider) {
+      PersistentStoreProvider provider,
+      WorkManager workManager) {
     this.classpathScan = context.getClasspathScan();
     this.workBus = workBus;
     this.controller = checkNotNull(controller);
@@ -79,6 +83,7 @@ public class DrillbitContext implements AutoCloseable {
     this.connectionsPool = checkNotNull(connectionsPool);
     this.endpoint = checkNotNull(endpoint);
     this.provider = provider;
+    this.workManager = workManager;
     this.lpPersistence = new LogicalPlanPersistence(context.getConfig(), classpathScan);
 
     // TODO remove escaping "this".
@@ -172,12 +177,20 @@ public class DrillbitContext implements AutoCloseable {
     return context.getExecutor();
   }
 
+  public ThreadStatCollector getThreadStatCollector() {
+    return context.getThreadStatCollector();
+  }
+
   public LogicalPlanPersistence getLpPersistence() {
     return lpPersistence;
   }
 
   public ScanResult getClasspathScan() {
     return classpathScan;
+  }
+
+  public WorkManager getWorkManager() {
+    return workManager;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FragmentIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FragmentIterator.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.proto.CoordinationProtos;
+import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
+import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
+import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.work.WorkManager;
+import org.apache.drill.exec.work.fragment.FragmentExecutor;
+
+import java.sql.Timestamp;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Iterator which returns {@link FragmentInfo} for every fragment running in this drillbit.
+ */
+public class FragmentIterator implements Iterator<Object> {
+  private final WorkManager workManager;
+  private final Iterator<FragmentExecutor> iter;
+
+  public FragmentIterator(FragmentContext c) {
+    this.workManager = c.getDrillbitContext().getWorkManager();
+    iter = ImmutableList.copyOf(workManager.getRunningFragments()).iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iter.hasNext();
+  }
+
+  @Override
+  public Object next() {
+    FragmentExecutor fragmentExecutor = iter.next();
+    MinorFragmentProfile profile = fragmentExecutor.getStatus().getProfile();
+    FragmentInfo fragmentInfo = new FragmentInfo();
+    fragmentInfo.hostname = workManager.getContext().getEndpoint().getAddress();
+    fragmentInfo.queryId = QueryIdHelper.getQueryId(fragmentExecutor.getContext().getHandle().getQueryId());
+    fragmentInfo.majorFragmentId = fragmentExecutor.getContext().getHandle().getMajorFragmentId();
+    fragmentInfo.minorFragmentId = fragmentExecutor.getContext().getHandle().getMinorFragmentId();
+    fragmentInfo.rowsProcessed = getRowsProcessed(profile);
+    fragmentInfo.memoryUsage = profile.getMemoryUsed();
+    fragmentInfo.startTime = new Timestamp(profile.getStartTime());
+    return fragmentInfo;
+  }
+
+  private long getRowsProcessed(MinorFragmentProfile profile) {
+    long maxRecords = 0;
+    for (OperatorProfile operatorProfile : profile.getOperatorProfileList()) {
+      long records = 0;
+      for (StreamProfile inputProfile :operatorProfile.getInputProfileList()) {
+        if (inputProfile.hasRecords()) {
+          records += inputProfile.getRecords();
+        }
+      }
+      maxRecords = Math.max(maxRecords, records);
+    }
+    return maxRecords;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class FragmentInfo {
+    public String hostname;
+    public String queryId;
+    public int majorFragmentId;
+    public int minorFragmentId;
+    public Long memoryUsage;
+    /**
+     * The maximum number of input records across all Operators in fragment
+     */
+    public Long rowsProcessed;
+    public Timestamp startTime;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/QueryIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/QueryIterator.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.work.WorkManager;
+
+import java.sql.Timestamp;
+import java.util.Iterator;
+
+/**
+ * Iterator which returns {@link QueryInfo} for each query foreman running in this drillbit
+ */
+public class QueryIterator implements Iterator<Object> {
+  private final WorkManager workManager;
+  private final Iterator<QueryProfile> iter;
+
+  public QueryIterator(FragmentContext c) {
+    this.workManager = c.getDrillbitContext().getWorkManager();
+    iter = ImmutableList.copyOf(workManager.getQueries()).iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iter.hasNext();
+  }
+
+  @Override
+  public Object next() {
+    QueryProfile profile = iter.next();
+    QueryInfo queryInfo = new QueryInfo();
+    queryInfo.foreman = profile.getForeman().getAddress();
+    queryInfo.user = profile.getUser();
+    queryInfo.queryId = QueryIdHelper.getQueryId(profile.getId());
+    queryInfo.query = profile.getQuery();
+    queryInfo.startTime = new Timestamp(profile.getStart());
+    return queryInfo;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class QueryInfo {
+    /**
+     * The host where foreman is running
+     */
+    public String foreman;
+    /**
+     * User who submitted query
+     */
+    public String user;
+    public String queryId;
+    /**
+     * Query sql string
+     */
+    public String query;
+    public Timestamp startTime;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -53,12 +53,25 @@ public enum SystemTable {
     }
   },
 
+  // TODO - should be possibly make this a distributed table so that we can figure out if
+  // users have inconsistent versions installed across their cluster?
   VERSION("version", false, VersionIterator.VersionInfo.class) {
     @Override
     public Iterator<Object> getIterator(final FragmentContext context) {
       return new VersionIterator();
     }
   },
+
+  /*
+
+   TODO - DRILL-4258: fill in these system tables
+    cpu: Drillbit, # Cores, CPU consumption (with different windows?)
+    queries: Foreman, QueryId, User, SQL, Start Time, rows processed, query plan, # nodes involved, number of running fragments, memory consumed
+    fragments: Drillbit, queryid, major fragmentid, minorfragmentid, coordinate, memory usage, rows processed, start time
+    threads: name, priority, state, id, thread-level cpu stats
+    threadtraces: threads, stack trace
+    connections: client, server, type, establishedDate, messagesSent, bytesSent
+   */
 
   MEMORY("memory", true, MemoryIterator.MemoryInfo.class) {
     @Override
@@ -67,10 +80,24 @@ public enum SystemTable {
     }
   },
 
-  THREADS("threads", true, ThreadsIterator.ThreadsInfo.class) {
+  THREADS("threads", true, ThreadsIterator.ThreadSummary.class) {
     @Override
-  public Iterator<Object> getIterator(final FragmentContext context) {
+    public Iterator<Object> getIterator(final FragmentContext context) {
       return new ThreadsIterator(context);
+    }
+  },
+
+  QUERIES("queries", true, QueryIterator.QueryInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new QueryIterator(context);
+    }
+  },
+
+  FRAGMENTS("fragments", true, FragmentIterator.FragmentInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new FragmentIterator(context);
     }
   };
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.work;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,6 +33,8 @@ import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
+import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.DrillRpcFuture;
 import org.apache.drill.exec.rpc.RpcException;
@@ -102,7 +106,7 @@ public class WorkManager implements AutoCloseable {
       final DataConnectionCreator data,
       final ClusterCoordinator coord,
       final PersistentStoreProvider provider) {
-    dContext = new DrillbitContext(endpoint, bContext, coord, controller, data, workBus, provider);
+    dContext = new DrillbitContext(endpoint, bContext, coord, controller, data, workBus, provider, this);
     statusThread.start();
 
     // TODO remove try block once metrics moved from singleton, For now catch to avoid unit test failures
@@ -138,6 +142,22 @@ public class WorkManager implements AutoCloseable {
 
   public WorkerBee getBee() {
     return bee;
+  }
+
+  public Collection<FragmentExecutor> getRunningFragments() {
+    return runningFragments.values();
+  }
+
+  public Collection<QueryProfile> getQueries() {
+    List<QueryProfile> profiles = new ArrayList<>();
+    for (Foreman foreman : queries.values()) {
+      QueryState state = foreman.getState();
+      if (state == QueryState.RUNNING ||
+              state == QueryState.STARTING) {
+        profiles.add(foreman.getQueryManager().getQueryProfile());
+      }
+    }
+    return profiles;
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestOptiqPlans.java
@@ -58,6 +58,7 @@ import org.apache.drill.exec.store.StoragePluginRegistryImpl;
 import org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarBinaryVector;
+import org.apache.drill.exec.work.WorkManager;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -74,26 +75,26 @@ public class TestOptiqPlans extends ExecTest {
   @Test
   public void orderBy(@Injectable final BootStrapContext ctxt, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
-      @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_order.json", coord, com, controller, workBus);
+      @Injectable Controller controller, @Injectable WorkEventBus workBus, @Injectable WorkManager workManager) throws Throwable {
+    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_order.json", coord, com, controller, workBus, workManager);
   }
 
   @Test
   public void stringFilter(@Injectable final BootStrapContext ctxt, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
-      @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_string_filter.json", coord, com, controller, workBus);
+      @Injectable Controller controller, @Injectable WorkEventBus workBus, @Injectable WorkManager workManager) throws Throwable {
+    final SimpleRootExec exec = doLogicalTest(ctxt, connection, "/logical_string_filter.json", coord, com, controller, workBus, workManager);
   }
 
   @Test
   public void groupBy(@Injectable final BootStrapContext bitContext, @Injectable UserClientConnection connection,
       @Injectable ClusterCoordinator coord, @Injectable DataConnectionCreator com,
-      @Injectable Controller controller, @Injectable WorkEventBus workBus) throws Throwable {
-    final SimpleRootExec exec = doLogicalTest(bitContext, connection, "/logical_group.json", coord, com, controller, workBus);
+      @Injectable Controller controller, @Injectable WorkEventBus workBus, @Injectable WorkManager workManager) throws Throwable {
+    final SimpleRootExec exec = doLogicalTest(bitContext, connection, "/logical_group.json", coord, com, controller, workBus, workManager);
   }
 
   private SimpleRootExec doLogicalTest(final BootStrapContext context, UserClientConnection connection, String file,
-      ClusterCoordinator coord, DataConnectionCreator com, Controller controller, WorkEventBus workBus) throws Exception {
+      ClusterCoordinator coord, DataConnectionCreator com, Controller controller, WorkEventBus workBus, WorkManager workManager) throws Exception {
     new NonStrictExpectations() {
       {
         context.getMetrics();
@@ -112,7 +113,8 @@ public class TestOptiqPlans extends ExecTest {
         controller,
         com,
         workBus,
-        new LocalPersistentStoreProvider(config));
+        new LocalPersistentStoreProvider(config),
+        workManager);
     final QueryContext qc = new QueryContext(UserSession.Builder.newBuilder().setSupportComplexTypes(true).build(),
         bitContext, QueryId.getDefaultInstance());
     final PhysicalPlanReader reader = bitContext.getPlanReader();


### PR DESCRIPTION
Here are the pojos that represent the data for the new system tables:

```java
  public static class FragmentInfo {
    public String hostname;
    public String queryId;
    public int majorFragmentId;
    public int minorFragmentId;
    public Long memoryUsage;
    /**
     * The maximum number of input records across all Operators in fragment
     */
    public Long rowsProcessed;
    public Timestamp startTime;
  }
```

```java
  public static class ThreadSummary {
    /**
     * The Drillbit hostname
     */
    public String hostname;

    /**
     * The Drillbit user port
     */
    public long user_port;
    public String threadName;
    public long threadId;
    public boolean inNative;
    public boolean suspended;
    public String threadState;
    /**
     * Thread cpu time during last second. Between 0 and 100
     */
    public Integer cpuTime;
    /**
     * Thread user cpu time during last second. Between 0 and 100
     */
    public Integer userTime;
    public String stackTrace;
  }
```

```java
  public static class QueryInfo {
    /**
     * The host where foreman is running
     */
    public String foreman;
    /**
     * User who submitted query
     */
    public String user;
    public String queryId;
    /**
     * Query sql string
     */
    public String query;
    public Timestamp startTime;
  }
```

I did not include data in the query table which can be obtained from the fragments table and doing a join on the queryId.