### PR TITLE
DRILL-4607: Add a split function that allows to separate string by a …

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -17,10 +17,13 @@
  */
 package org.apache.drill.exec.expr.fn.impl;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.drill.BaseTestQuery;
+import org.apache.drill.exec.util.Text;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import com.google.common.collect.ImmutableList;
 
 public class TestStringFunctions extends BaseTestQuery {
 
@@ -232,4 +235,16 @@ public class TestStringFunctions extends BaseTestQuery {
         .build()
         .run();
   }
+
+  @Test
+  public void testSplit() throws Exception {
+    testBuilder()
+        .sqlQuery("select split(n_name, ' ') words from cp.`tpch/nation.parquet` where n_nationkey = 24")
+        .unOrdered()
+        .baselineColumns("words")
+        .baselineValues(ImmutableList.of(new Text("UNITED"), new Text("STATES")))
+        .build()
+        .run();
+  }
+
 }


### PR DESCRIPTION
…delimiter

This patch allows to apply a split function by providing a string and a delimiter.