### PR TITLE
DRILL-4576: Add PlannerCallback interface for additional planner initialization.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerCallback.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerCallback.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner;
+
+import java.util.Collection;
+
+import org.apache.calcite.plan.RelOptPlanner;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A callback that StoragePlugins can initialize to allow further configuration
+ * of the Planner at initialization time. Examples could be to allow adding lattices,
+ * materializations or additional traits to the planner that will be used in
+ * planning.
+ */
+public abstract class PlannerCallback {
+
+  /**
+   * Method that will be called before a planner is used to further configure the planner.
+   * @param planner The planner to be configured.
+   */
+  public abstract void onInitialization(RelOptPlanner planner);
+
+
+  public static PlannerCallback merge(Collection<PlannerCallback> callbacks) {
+    return new PlannerCallbackCollection(callbacks);
+  }
+
+  private static class PlannerCallbackCollection extends PlannerCallback {
+    private final Collection<PlannerCallback> callbacks;
+
+    private PlannerCallbackCollection(Collection<PlannerCallback> callbacks) {
+      this.callbacks = ImmutableList.copyOf(callbacks);
+    }
+
+    @Override
+    public void onInitialization(RelOptPlanner planner) {
+      for(PlannerCallback p : callbacks) {
+        p.onInitialization(planner);
+      }
+    }
+
+
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -64,6 +64,7 @@ import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.AbstractPhysicalVisitor;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.impl.join.JoinUtils;
+import org.apache.drill.exec.planner.PlannerCallback;
 import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.planner.PlannerType;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
@@ -358,6 +359,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       boolean log) {
     final Stopwatch watch = Stopwatch.createStarted();
     final RuleSet rules = config.getRules(phase);
+    final PlannerCallback callback = config.getPlannerCallback(phase);
     final RelTraitSet toTraits = targetTraits.simplify();
 
     final RelNode output;
@@ -373,6 +375,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       }
 
       final HepPlanner planner = new HepPlanner(hepPgmBldr.build(), context.getPlannerSettings());
+      callback.onInitialization(planner);
 
       final List<RelMetadataProvider> list = Lists.newArrayList();
       list.add(DrillDefaultRelMetadataProvider.INSTANCE);
@@ -394,6 +397,8 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       // as weird as it seems, the cluster's only planner is the volcano planner.
       final RelOptPlanner planner = input.getCluster().getPlanner();
       final Program program = Programs.of(rules);
+      callback.onInitialization(planner);
+
       Preconditions.checkArgument(planner instanceof VolcanoPlanner,
           "Cluster is expected to be constructed using VolcanoPlanner. Was actually of type %s.", planner.getClass()
               .getName());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -25,7 +25,9 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.planner.PlannerCallback;
 import org.apache.drill.exec.planner.PlannerPhase;
 
 import com.google.common.collect.ImmutableSet;
@@ -96,6 +98,18 @@ public abstract class AbstractStoragePlugin implements StoragePlugin{
       return ImmutableSet.of();
     }
 
+  }
+
+  /**
+   * Return a planner callback for this storage plugin (or null if one doesn't exist).
+   * @param queryContext The query context associated with the current planning process.
+   * @param phase The phase of query planning that this callback will be registered in.
+   * @return A callback or null if the plugin doesn't have any callbacks to include.
+   *
+   * Note: Move this method to {@link StoragePlugin} interface in next major version release.
+   */
+  public PlannerCallback getPlannerCallback(QueryContext queryContext, PlannerPhase phase) {
+    return null;
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestPlannerCallback.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestPlannerCallback.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.util.CancelFlag;
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.store.AbstractStoragePlugin;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestPlannerCallback extends BaseTestQuery {
+
+  @BeforeClass
+  public static void setupDefaultTestCluster() throws Exception {
+    BaseTestQuery.setupDefaultTestCluster();
+    bits[0].getContext().getStorage().addPlugin("fake", new FakeStoragePlugin());
+  }
+
+  @Test
+  public void ensureCallbackIsRegistered() {
+    try{
+      test("select * from cp.`employee.json`");
+      fail("Should have seen exception in planning due to planner initialization.");
+    } catch(Exception e) {
+      assertTrue(e.getMessage().contains("Statement preparation aborted"));
+    }
+  }
+
+  public static class FakeStoragePlugin extends AbstractStoragePlugin {
+
+    @Override
+    public StoragePluginConfig getConfig() {
+      return null;
+    }
+
+    @Override
+    public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+    }
+
+    @Override
+    public PlannerCallback getPlannerCallback(QueryContext optimizerContext, PlannerPhase phase) {
+      return new PlannerCallback() {
+        @Override
+        public void onInitialization(RelOptPlanner planner) {
+          CancelFlag f = new CancelFlag();
+          f.requestCancel();
+          planner.setCancelFlag(f);
+        }
+      };
+    }
+
+
+  }
+}


### PR DESCRIPTION
- Allow a storage plugin to be able to provide additional planner initialization.
- Fix issue in StoragePluginRegistryImpl which deletes manually added plugins from the registry since they don't exist in the PersistentStore.
- Add a simple test to ensure Callbacks are correctly registered and executed.
