### PR TITLE
DRILL-4237: Implement murmur3 for HashHelper

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/DrillStringUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillStringUtils.java
@@ -163,10 +163,10 @@ public class DrillStringUtils {
   public static int parseBinaryString(ByteBuf str, int strStart, int strEnd) {
     int length = (strEnd - strStart);
     int dstEnd = strStart;
-    for (int i = strStart; i < length ; i++) {
+    for (int i = strStart; i < strStart+length ; i++) {
       byte b = str.getByte(i);
       if (b == '\\'
-          && length > i+3
+          && strEnd > i+3
           && (str.getByte(i+1) == 'x' || str.getByte(i+1) == 'X')) {
         // ok, take next 2 hex digits.
         byte hd1 = str.getByte(i+2);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/DrillHash.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/DrillHash.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.expr.fn.impl;
+
+import io.netty.buffer.DrillBuf;
+import io.netty.util.internal.PlatformDependent;
+
+/**
+ * The base class of hash classes used in Drill.
+ */
+public class DrillHash {
+
+    public static final long getLongLittleEndian(long offset) {
+        //return PlatformDependent.getLong(offset);
+        return     ((long) PlatformDependent.getByte(offset+7)    << 56)
+                | ((PlatformDependent.getByte(offset+6) & 0xffL) << 48)
+                | ((PlatformDependent.getByte(offset+5) & 0xffL) << 40)
+                | ((PlatformDependent.getByte(offset+4) & 0xffL) << 32)
+                | ((PlatformDependent.getByte(offset+3) & 0xffL) << 24)
+                | ((PlatformDependent.getByte(offset+2) & 0xffL) << 16)
+                | ((PlatformDependent.getByte(offset+1) & 0xffL) << 8)
+                | ((PlatformDependent.getByte(offset) & 0xffL));
+    }
+
+    public static final long getIntLittleEndian(long offset) {
+        long retl = 0;
+        retl = ((PlatformDependent.getByte(offset+3) &0xffL) << 24)
+                | ((PlatformDependent.getByte(offset+2) & 0xffL) << 16)
+                | ((PlatformDependent.getByte(offset+1) & 0xffL) << 8)
+                | ((PlatformDependent.getByte(offset) & 0xffL));
+        return retl;
+    }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32AsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32AsDouble.java
@@ -45,6 +45,7 @@ import org.apache.drill.exec.expr.holders.NullableIntHolder;
  */
 public class Hash32AsDouble {
   @FunctionTemplate(name = "hash32AsDouble", scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+
   public static class NullableFloatHash implements DrillSimpleFunc {
 
     @Param
@@ -59,7 +60,7 @@ public class Hash32AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -76,7 +77,7 @@ public class Hash32AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -95,7 +96,7 @@ public class Hash32AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -112,7 +113,7 @@ public class Hash32AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -131,7 +132,7 @@ public class Hash32AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((long) in.value, 0);
       }
     }
   }
@@ -150,7 +151,7 @@ public class Hash32AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -167,7 +168,7 @@ public class Hash32AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((long)in.value, 0);
     }
   }
 
@@ -182,7 +183,7 @@ public class Hash32AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -198,7 +199,7 @@ public class Hash32AsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
     }
   }
 
@@ -217,7 +218,7 @@ public class Hash32AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
       }
     }
   }
@@ -234,7 +235,7 @@ public class Hash32AsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
     }
   }
 
@@ -253,7 +254,7 @@ public class Hash32AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
       }
     }
   }
@@ -271,7 +272,7 @@ public class Hash32AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
     }
   }
 
@@ -291,7 +292,7 @@ public class Hash32AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
       }
     }
   }
@@ -309,7 +310,7 @@ public class Hash32AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
     }
   }
 
@@ -329,7 +330,7 @@ public class Hash32AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), 0);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
@@ -68,7 +68,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -83,7 +83,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -100,7 +100,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -115,7 +115,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -132,7 +132,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -150,7 +150,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -168,7 +168,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -187,7 +187,7 @@ public class Hash32Functions {
         out.value = 0;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -205,7 +205,7 @@ public class Hash32Functions {
         out.value = 0;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -220,7 +220,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -234,7 +234,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -248,7 +248,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -262,7 +262,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -275,7 +275,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
   @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
@@ -287,7 +287,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -303,7 +303,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -317,7 +317,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -333,7 +333,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -347,7 +347,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -363,7 +363,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -377,7 +377,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -393,7 +393,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -407,7 +407,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 
@@ -423,7 +423,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -442,7 +442,7 @@ public class Hash32Functions {
       for (int i = 0; i < in.nDecimalDigits; i++) {
         xor = xor ^ Decimal28SparseHolder.getInteger(i, in.start, in.buffer);
       }
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(xor, 0);
     }
   }
 
@@ -462,7 +462,7 @@ public class Hash32Functions {
         for (int i = 0; i < in.nDecimalDigits; i++) {
           xor = xor ^ NullableDecimal28SparseHolder.getInteger(i, in.start, in.buffer);
         }
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(xor, 0);
       }
     }
   }
@@ -481,7 +481,7 @@ public class Hash32Functions {
       for (int i = 0; i < in.nDecimalDigits; i++) {
         xor = xor ^ Decimal38SparseHolder.getInteger(i, in.start, in.buffer);
       }
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(xor, 0);
     }
   }
 
@@ -501,7 +501,7 @@ public class Hash32Functions {
         for (int i = 0; i < in.nDecimalDigits; i++) {
           xor = xor ^ NullableDecimal38SparseHolder.getInteger(i, in.start, in.buffer);
         }
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(xor, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(xor, 0);
       }
     }
   }
@@ -519,7 +519,7 @@ public class Hash32Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
       }
     }
   }
@@ -534,7 +534,7 @@ public class Hash32Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, 0);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32FunctionsWithSeed.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32FunctionsWithSeed.java
@@ -72,7 +72,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -89,7 +89,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -108,7 +108,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -125,7 +125,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -144,7 +144,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -164,7 +164,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -184,7 +184,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -205,7 +205,7 @@ public class Hash32FunctionsWithSeed {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -225,7 +225,7 @@ public class Hash32FunctionsWithSeed {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -242,7 +242,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -258,7 +258,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -274,7 +274,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -290,7 +290,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -306,7 +306,7 @@ public class Hash32FunctionsWithSeed {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
   @FunctionTemplate(names = {"hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
@@ -320,7 +320,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -338,7 +338,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -354,7 +354,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -372,7 +372,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -388,7 +388,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -406,7 +406,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -422,7 +422,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -440,7 +440,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -456,7 +456,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -474,7 +474,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -490,7 +490,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + Decimal28SparseHolder.WIDTH, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.start + Decimal28SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
@@ -508,7 +508,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + NullableDecimal28SparseHolder.WIDTH, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.start + NullableDecimal28SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
@@ -524,7 +524,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + Decimal38SparseHolder.WIDTH, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.start + Decimal38SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
@@ -542,7 +542,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.start, in.start + NullableDecimal38SparseHolder.WIDTH, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.start, in.start + NullableDecimal38SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
@@ -562,7 +562,7 @@ public class Hash32FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -579,6 +579,7 @@ public class Hash32FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
-  }}
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32WithSeedAsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32WithSeedAsDouble.java
@@ -59,7 +59,7 @@ public class Hash32WithSeedAsDouble {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
       }
     }
   }
@@ -76,7 +76,7 @@ public class Hash32WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
     }
   }
 
@@ -95,7 +95,7 @@ public class Hash32WithSeedAsDouble {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
       }
     }
   }
@@ -112,7 +112,7 @@ public class Hash32WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(in.value, seed.value);
     }
   }
 
@@ -132,7 +132,7 @@ public class Hash32WithSeedAsDouble {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
       }
     }
   }
@@ -152,7 +152,7 @@ public class Hash32WithSeedAsDouble {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
       }
     }
   }
@@ -169,7 +169,7 @@ public class Hash32WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
     }
   }
 
@@ -185,7 +185,7 @@ public class Hash32WithSeedAsDouble {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32((double) in.value, seed.value);
     }
   }
 
@@ -201,7 +201,7 @@ public class Hash32WithSeedAsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
     }
   }
 
@@ -220,7 +220,7 @@ public class Hash32WithSeedAsDouble {
         out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
       }
     }
   }
@@ -237,7 +237,7 @@ public class Hash32WithSeedAsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
     }
   }
 
@@ -256,7 +256,7 @@ public class Hash32WithSeedAsDouble {
         out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
       }
     }
   }
@@ -274,7 +274,7 @@ public class Hash32WithSeedAsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
     }
   }
 
@@ -294,7 +294,7 @@ public class Hash32WithSeedAsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
       }
     }
   }
@@ -312,7 +312,7 @@ public class Hash32WithSeedAsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
     }
   }
 
@@ -332,7 +332,7 @@ public class Hash32WithSeedAsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash32(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash32(input.doubleValue(), seed.value);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64AsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64AsDouble.java
@@ -63,7 +63,7 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
       }
     }
   }
@@ -80,7 +80,7 @@ public class Hash64AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
     }
   }
 
@@ -99,7 +99,7 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
       }
     }
   }
@@ -116,7 +116,7 @@ public class Hash64AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -135,7 +135,7 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
       }
     }
   }
@@ -154,7 +154,7 @@ public class Hash64AsDouble {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
       }
     }
   }
@@ -171,7 +171,7 @@ public class Hash64AsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
     }
   }
 
@@ -187,7 +187,7 @@ public class Hash64AsDouble {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, 0);
     }
   }
 
@@ -203,7 +203,7 @@ public class Hash64AsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
     }
   }
 
@@ -222,7 +222,7 @@ public class Hash64AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
       }
     }
   }
@@ -239,7 +239,7 @@ public class Hash64AsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
     }
   }
 
@@ -258,7 +258,7 @@ public class Hash64AsDouble {
         out.value = 0;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
       }
     }
   }
@@ -276,7 +276,7 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
     }
   }
 
@@ -296,7 +296,7 @@ public class Hash64AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
       }
     }
   }
@@ -314,7 +314,7 @@ public class Hash64AsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
     }
   }
 
@@ -334,7 +334,7 @@ public class Hash64AsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), 0);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64Functions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64Functions.java
@@ -72,7 +72,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -89,7 +89,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -108,7 +108,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -125,7 +125,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -144,7 +144,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -164,7 +164,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -184,7 +184,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
       }
     }
   }
@@ -204,7 +204,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -223,7 +223,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -240,7 +240,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -256,7 +256,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -272,7 +272,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, 0);
     }
   }
 
@@ -288,7 +288,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -304,7 +304,7 @@ public class Hash64Functions {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -319,7 +319,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -337,7 +337,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -353,7 +353,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -371,7 +371,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -387,7 +387,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -405,7 +405,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -421,7 +421,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -439,7 +439,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -455,7 +455,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 
@@ -473,7 +473,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -489,7 +489,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + Decimal28SparseHolder.WIDTH,
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + Decimal28SparseHolder.WIDTH,
           in.buffer, 0);
     }
   }
@@ -508,7 +508,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start
             + NullableDecimal28SparseHolder.WIDTH, in.buffer, 0);
       }
     }
@@ -525,7 +525,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + Decimal38SparseHolder.WIDTH,
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + Decimal38SparseHolder.WIDTH,
           in.buffer, 0);
     }
   }
@@ -544,7 +544,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start
             + NullableDecimal38SparseHolder.WIDTH, in.buffer, 0);
       }
     }
@@ -565,7 +565,7 @@ public class Hash64Functions {
       if (in.isSet == 0) {
         out.value = 0;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
       }
     }
   }
@@ -582,7 +582,7 @@ public class Hash64Functions {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, 0);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64FunctionsWithSeed.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64FunctionsWithSeed.java
@@ -72,7 +72,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -89,7 +89,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -108,7 +108,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -125,7 +125,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -144,7 +144,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -164,7 +164,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -184,7 +184,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
       }
     }
   }
@@ -205,7 +205,7 @@ public class Hash64FunctionsWithSeed {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -225,7 +225,7 @@ public class Hash64FunctionsWithSeed {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -242,7 +242,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -258,7 +258,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -274,7 +274,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.end, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.end, in.buffer, seed.value);
     }
   }
 
@@ -290,7 +290,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -306,7 +306,7 @@ public class Hash64FunctionsWithSeed {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
   @FunctionTemplate(names = {"hash64", "hash64AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
@@ -320,7 +320,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -338,7 +338,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -354,7 +354,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -372,7 +372,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -388,7 +388,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -406,7 +406,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -422,7 +422,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -440,7 +440,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -456,7 +456,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -474,7 +474,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -490,7 +490,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + Decimal28SparseHolder.WIDTH, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + Decimal28SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
@@ -508,7 +508,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + NullableDecimal28SparseHolder.WIDTH, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + NullableDecimal28SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
@@ -524,7 +524,7 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + Decimal38SparseHolder.WIDTH, in.buffer, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + Decimal38SparseHolder.WIDTH, in.buffer, seed.value);
     }
   }
 
@@ -542,7 +542,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.start, in.start + NullableDecimal38SparseHolder.WIDTH, in.buffer, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.start, in.start + NullableDecimal38SparseHolder.WIDTH, in.buffer, seed.value);
       }
     }
   }
@@ -562,7 +562,7 @@ public class Hash64FunctionsWithSeed {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -579,6 +579,6 @@ public class Hash64FunctionsWithSeed {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64WithSeedAsDouble.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash64WithSeedAsDouble.java
@@ -63,7 +63,7 @@ public class Hash64WithSeedAsDouble {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
       }
     }
   }
@@ -80,7 +80,7 @@ public class Hash64WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
     }
   }
 
@@ -99,7 +99,7 @@ public class Hash64WithSeedAsDouble {
       if (in.isSet == 0) {
         out.value = seed.value;
       } else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
       }
     }
   }
@@ -116,7 +116,7 @@ public class Hash64WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(in.value, seed.value);
     }
   }
 
@@ -136,7 +136,7 @@ public class Hash64WithSeedAsDouble {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
       }
     }
   }
@@ -156,7 +156,7 @@ public class Hash64WithSeedAsDouble {
         out.value = seed.value;
       }
       else {
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
       }
     }
   }
@@ -173,7 +173,7 @@ public class Hash64WithSeedAsDouble {
     }
 
     public void eval() {
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
     }
   }
 
@@ -189,7 +189,7 @@ public class Hash64WithSeedAsDouble {
 
     public void eval() {
       // TODO: implement hash function for other types
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64((double) in.value, seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64((double) in.value, seed.value);
     }
   }
 
@@ -205,7 +205,7 @@ public class Hash64WithSeedAsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
     }
   }
 
@@ -224,7 +224,7 @@ public class Hash64WithSeedAsDouble {
         out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
       }
     }
   }
@@ -241,7 +241,7 @@ public class Hash64WithSeedAsDouble {
 
     public void eval() {
       java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), seed.value);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
     }
   }
 
@@ -260,7 +260,7 @@ public class Hash64WithSeedAsDouble {
         out.value = seed.value;
       } else {
         java.math.BigDecimal input = new java.math.BigDecimal(java.math.BigInteger.valueOf(in.value), in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), seed.value);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
       }
     }
   }
@@ -278,7 +278,7 @@ public class Hash64WithSeedAsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
     }
   }
 
@@ -298,7 +298,7 @@ public class Hash64WithSeedAsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
       }
     }
   }
@@ -316,7 +316,7 @@ public class Hash64WithSeedAsDouble {
     public void eval() {
       java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
           in.start, in.nDecimalDigits, in.scale);
-      out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+      out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
     }
   }
 
@@ -336,7 +336,7 @@ public class Hash64WithSeedAsDouble {
       } else {
         java.math.BigDecimal input = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromSparse(in.buffer,
             in.start, in.nDecimalDigits, in.scale);
-        out.value = org.apache.drill.exec.expr.fn.impl.XXHash.hash64(input.doubleValue(), 0);
+        out.value = org.apache.drill.exec.expr.fn.impl.HashHelper.hash64(input.doubleValue(), seed.value);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/HashHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/HashHelper.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.expr.fn.impl;
 
+import io.netty.buffer.DrillBuf;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 public class HashHelper {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashHelper.class);
-
 
   /** taken from mahout **/
   public static int hash(ByteBuffer buf, int seed) {
@@ -60,4 +60,45 @@ public class HashHelper {
     return h;
   }
 
+  public static int hash32(int val, long seed) {
+    double converted = val;
+    return hash32(converted, seed);
+  }
+  public static int hash32(long val, long seed) {
+    double converted = val;
+    return hash32(converted, seed);
+  }
+  public static int hash32(float val, long seed){
+    double converted = val;
+    return hash32(converted, seed);
+  }
+
+
+  public static long hash64(float val, long seed){
+    double converted = val;
+    return hash64(converted, seed);
+  }
+  public static long hash64(long val, long seed){
+    double converted = val;
+    return hash64(converted, seed);
+  }
+
+  public static long hash64(double val, long seed){
+    return MurmurHash3.hash64(val, (int)seed);
+  }
+
+  public static long hash64(long start, long end, DrillBuf buffer, long seed){
+    return MurmurHash3.hash64(start, end, buffer, (int)seed);
+  }
+
+  public static int hash32(double val, long seed) {
+    //return com.google.common.hash.Hashing.murmur3_128().hashLong(Double.doubleToLongBits(val)).asInt();
+    return MurmurHash3.hash32(val, (int)seed);
+  }
+
+  public static int hash32(int start, int end, DrillBuf buffer, int seed){
+    return MurmurHash3.hash32(start, end, buffer, seed);
+  }
+
 }
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MurmurHash3.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MurmurHash3.java
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package org.apache.drill.exec.expr.fn.impl;
+
+import io.netty.buffer.DrillBuf;
+import io.netty.util.internal.PlatformDependent;
+
+
+/**
+ *
+ * MurmurHash3 was written by Austin Appleby, and is placed in the public
+ * domain.
+ * See http://smhasher.googlecode.com/svn/trunk/MurmurHash3.cpp
+ * MurmurHash3_x64_128
+ * MurmurHash3_x86_32
+ */
+public final class MurmurHash3 extends DrillHash{
+
+   public static final long fmix64(long k) {
+    k ^= k >>> 33;
+    k *= 0xff51afd7ed558ccdL;
+    k ^= k >>> 33;
+    k *= 0xc4ceb9fe1a85ec53L;
+    k ^= k >>> 33;
+    return k;
+  }
+
+  /*
+  Take 64 bit of murmur3_128's output
+   */
+  public static long murmur3_64(long bStart, long bEnd, DrillBuf buffer, int seed) {
+
+    long h1 = seed & 0x00000000FFFFFFFFL;
+    long h2 = seed & 0x00000000FFFFFFFFL;
+
+    final long c1 = 0x87c37b91114253d5L;
+    final long c2 = 0x4cf5ad432745937fL;
+    long start = buffer.memoryAddress() + bStart;
+    long end = buffer.memoryAddress() + bEnd;
+    long length = bEnd - bStart;
+    long roundedEnd = start + ( length & 0xFFFFFFF0);  // round down to 16 byte block
+    for (long i=start; i<roundedEnd; i+=16) {
+      long k1 = getLongLittleEndian(i);
+      long k2 = getLongLittleEndian(i+8);
+      k1 *= c1;
+      k1  = Long.rotateLeft(k1,31);
+      k1 *= c2;
+      h1 ^= k1;
+      h1 = Long.rotateLeft(h1,27);
+      h1 += h2;
+      h1 = h1*5+0x52dce729;
+      k2 *= c2;
+      k2  = Long.rotateLeft(k2,33);
+      k2 *= c1;
+      h2 ^= k2;
+      h2 = Long.rotateLeft(h2,31);
+      h2 += h1;
+      h2 = h2*5+0x38495ab5;
+    }
+
+    long k1 = 0;
+    long k2 = 0;
+
+    // tail
+    switch ((int)length & 15) {
+      case 15: k2  = (PlatformDependent.getByte(roundedEnd+14) & 0xffL) << 48;
+      case 14: k2 ^= (PlatformDependent.getByte(roundedEnd+13) & 0xffL) << 40;
+      case 13: k2 ^= (PlatformDependent.getByte(roundedEnd+12) & 0xffL) << 32;
+      case 12: k2 ^= (PlatformDependent.getByte(roundedEnd+11) & 0xffL) << 24;
+      case 11: k2 ^= (PlatformDependent.getByte(roundedEnd+10) & 0xffL) << 16;
+      case 10: k2 ^= (PlatformDependent.getByte(roundedEnd+ 9) & 0xffL) << 8;
+      case  9: k2 ^= (PlatformDependent.getByte(roundedEnd+ 8) & 0xffL);
+        k2 *= c2;
+        k2  = Long.rotateLeft(k2, 33);
+        k2 *= c1;
+        h2 ^= k2;
+      case  8: k1  = (long)PlatformDependent.getByte(roundedEnd+7) << 56;
+      case  7: k1 ^= (PlatformDependent.getByte(roundedEnd+6) & 0xffL) << 48;
+      case  6: k1 ^= (PlatformDependent.getByte(roundedEnd+5) & 0xffL) << 40;
+      case  5: k1 ^= (PlatformDependent.getByte(roundedEnd+4) & 0xffL) << 32;
+      case  4: k1 ^= (PlatformDependent.getByte(roundedEnd+3) & 0xffL) << 24;
+      case  3: k1 ^= (PlatformDependent.getByte(roundedEnd+2) & 0xffL) << 16;
+      case  2: k1 ^= (PlatformDependent.getByte(roundedEnd+1) & 0xffL) << 8;
+      case  1: k1 ^= (PlatformDependent.getByte(roundedEnd ) & 0xffL);
+        k1 *= c1;
+        k1  = Long.rotateLeft(k1,31);
+        k1 *= c2;
+        h1 ^= k1;
+    }
+
+    h1 ^= length;
+    h2 ^= length;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+    h2 += h1;
+    // murmur3_128 should return 128 bit (h1,h2), now we return only 64bits,
+    return h1;
+  }
+
+  public static long murmur3_64(long val, int seed) {
+
+    long h1 = seed & 0x00000000FFFFFFFFL;
+    long h2 = seed & 0x00000000FFFFFFFFL;
+
+    final long c1 = 0x87c37b91114253d5L;
+    final long c2 = 0x4cf5ad432745937fL;
+
+    int length = 8;
+    long k1 = 0;
+
+    k1 = val;
+    k1 *= c1;
+    k1  = Long.rotateLeft(k1,31);
+    k1 *= c2;
+    h1 ^= k1;
+
+    h1 ^= length;
+    h2 ^= length;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+
+    //h2 += h1;
+    // murmur3_128 should return 128 bit (h1,h2), now we return only 64bits,
+    return h1;
+
+  }
+
+  public static int murmur3_32(int bStart, int bEnd, DrillBuf buffer, int seed) {
+
+    final long c1 = 0xcc9e2d51L;
+    final long c2 = 0x1b873593L;
+    long start = buffer.memoryAddress() + bStart;
+    long length = bEnd - bStart;
+    long UINT_MASK=0xffffffffL;
+    long lh1 = seed;
+    long roundedEnd = start + (length & 0xfffffffc);  // round down to 4 byte block
+
+    for (long i=start; i<roundedEnd; i+=4) {
+      // little endian load order
+      long lk1 = (PlatformDependent.getByte(i) & 0xff) | ((PlatformDependent.getByte(i+1) & 0xff) << 8) |
+              ((PlatformDependent.getByte(i+2) & 0xff) << 16) | (PlatformDependent.getByte(i+3) << 24);
+
+      //k1 *= c1;
+      lk1 *= c1;
+      lk1 &= UINT_MASK;
+
+      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+      lk1 *= c2;
+      lk1 = lk1 & UINT_MASK;
+      lh1 ^= lk1;
+      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
+
+      lh1 = lh1*5+0xe6546b64L;
+      lh1 = UINT_MASK & lh1;
+    }
+
+    // tail
+    long lk1 = 0;
+
+    switch((byte)length & 0x03) {
+      case 3:
+        lk1 = (PlatformDependent.getByte(roundedEnd + 2) & 0xff) << 16;
+      case 2:
+        lk1 |= (PlatformDependent.getByte(roundedEnd + 1) & 0xff) << 8;
+      case 1:
+        lk1 |= (PlatformDependent.getByte(roundedEnd) & 0xff);
+        lk1 *= c1;
+        lk1 = UINT_MASK & lk1;
+        lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+        lk1 *= c2;
+        lk1 = lk1 & UINT_MASK;
+
+        lh1 ^= lk1;
+    }
+
+    // finalization
+    lh1 ^= length;
+
+    lh1 ^= lh1 >>> 16;
+    lh1 *= 0x85ebca6b;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 13;
+
+    lh1 *= 0xc2b2ae35;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 16;
+
+    return (int)(lh1 & UINT_MASK);
+  }
+
+  public static int murmur3_32(long val, int seed) {
+    final long c1 = 0xcc9e2d51L;
+    final long c2 = 0x1b873593;
+    long length = 8;
+    long UINT_MASK=0xffffffffL;
+    long lh1 = seed & UINT_MASK;
+    for (int i=0; i<2; i++) {
+      //int ik1 = (int)((val >> i*32) & UINT_MASK);
+      long lk1 = ((val >> i*32) & UINT_MASK);
+
+      //k1 *= c1;
+      lk1 *= c1;
+      lk1 &= UINT_MASK;
+
+      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+      lk1 *= c2;
+      lk1 &= UINT_MASK;
+
+      lh1 ^= lk1;
+      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
+
+      lh1 = lh1*5+0xe6546b64L;
+      lh1 = UINT_MASK & lh1;
+    }
+    // finalization
+    lh1 ^= length;
+
+    lh1 ^= lh1 >>> 16;
+    lh1 *= 0x85ebca6bL;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 13;
+    lh1 *= 0xc2b2ae35L;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 16;
+
+    return (int)lh1;
+  }
+
+  public static long hash64(double val, long seed){
+    return murmur3_64(Double.doubleToLongBits(val), (int)seed);
+  }
+
+  public static long hash64(long start, long end, DrillBuf buffer, long seed){
+    return murmur3_64(start, end, buffer, (int)seed);
+  }
+
+  public static int hash32(double val, long seed) {
+    //return com.google.common.hash.Hashing.murmur3_128().hashLong(Double.doubleToLongBits(val)).asInt();
+    return (int)murmur3_64(Double.doubleToLongBits(val), (int)seed);
+  }
+
+  public static int hash32(int start, int end, DrillBuf buffer, int seed){
+    return (int)murmur3_64(start, end, buffer, seed);
+  }
+
+}
+

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
@@ -584,22 +584,6 @@ public class TestFunctionsQuery extends BaseTestQuery {
   }
 
   @Test
-  public void testHashFunctions() throws Exception {
-    String query = "select " +
-        "hash(cast(hire_date as date)) hash_date, " +
-        "hash(cast(employee_id as decimal(9, 2))) as hash_dec9, " +
-        "hash(cast(employee_id as decimal(38, 11))) as hash_dec38 " +
-        "from cp.`employee.json` where employee_id = 1 limit 1";
-
-    testBuilder()
-        .sqlQuery(query)
-        .unOrdered()
-        .baselineColumns("hash_date", "hash_dec9", "hash_dec38")
-        .baselineValues(312993367, 292570647, 337328302)
-        .go();
-  }
-
-  @Test
   public void testDecimalAddConstant() throws Exception {
     String query = "select (cast('-1' as decimal(37, 3)) + cast (employee_id as decimal(37, 3))) as CNT " +
         "from cp.`employee.json` where employee_id <= 4";
@@ -795,6 +779,7 @@ public class TestFunctionsQuery extends BaseTestQuery {
         .go();
   }
 
+
   /*
    * We may apply implicit casts in Hash Join while dealing with different numeric data types
    * For this to work we need to distribute the data based on a common key, below method
@@ -810,7 +795,7 @@ public class TestFunctionsQuery extends BaseTestQuery {
         "hash64AsDouble(cast(employee_id as decimal(9, 0))) = hash64AsDouble(cast(employee_id as decimal(18, 0))) col5, " +
         "hash64AsDouble(cast(employee_id as decimal(18, 0))) = hash64AsDouble(cast(employee_id as decimal(28, 0))) col6, " +
         "hash64AsDouble(cast(employee_id as decimal(28, 0))) = hash64AsDouble(cast(employee_id as decimal(38, 0))) col7 " +
-        "from cp.`employee.json` where employee_id = 1";
+        "from cp.`employee.json`  where employee_id = 1";
 
     testBuilder()
         .sqlQuery(query)
@@ -818,11 +803,32 @@ public class TestFunctionsQuery extends BaseTestQuery {
         .baselineColumns("col1", "col2", "col3", "col4", "col5", "col6", "col7")
         .baselineValues(true, true, true, true, true, true, true)
         .go();
+
+    java.util.Random seedGen = new java.util.Random();
+    seedGen.setSeed(System.currentTimeMillis());
+    int seed = seedGen.nextInt();
+
+    String querytemplate = "select " +
+            "hash64AsDouble(cast(employee_id as int), #RAND_SEED#) = hash64AsDouble(cast(employee_id as bigint), #RAND_SEED#) col1, " +
+            "hash64AsDouble(cast(employee_id as bigint), #RAND_SEED#) = hash64AsDouble(cast(employee_id as float), #RAND_SEED#) col2, " +
+            "hash64AsDouble(cast(employee_id as float), #RAND_SEED#) = hash64AsDouble(cast(employee_id as double), #RAND_SEED#) col3, " +
+            "hash64AsDouble(cast(employee_id as double), #RAND_SEED#) = hash64AsDouble(cast(employee_id as decimal(9, 0)), #RAND_SEED#) col4, " +
+            "hash64AsDouble(cast(employee_id as decimal(9, 0)), #RAND_SEED#) = hash64AsDouble(cast(employee_id as decimal(18, 0)), #RAND_SEED#) col5, " +
+            "hash64AsDouble(cast(employee_id as decimal(18, 0)), #RAND_SEED#) = hash64AsDouble(cast(employee_id as decimal(28, 0)), #RAND_SEED#) col6, " +
+            "hash64AsDouble(cast(employee_id as decimal(28, 0)), #RAND_SEED#) = hash64AsDouble(cast(employee_id as decimal(38, 0)), #RAND_SEED#) col7 " +
+            "from cp.`employee.json` where employee_id = 1";
+
+    String queryWithSeed = querytemplate.replaceAll("#RAND_SEED#", String.format("%d",seed));
+    testBuilder()
+            .sqlQuery(queryWithSeed)
+            .unOrdered()
+            .baselineColumns("col1", "col2", "col3", "col4", "col5", "col6", "col7")
+            .baselineValues(true, true, true, true, true, true, true)
+            .go();
+
   }
 
-  /*
-   * hash32 version of the above test
-   */
+
   @Test
   public void testHash32() throws Exception {
     String query = "select " +
@@ -841,6 +847,29 @@ public class TestFunctionsQuery extends BaseTestQuery {
         .baselineColumns("col1", "col2", "col3", "col4", "col5", "col6", "col7")
         .baselineValues(true, true, true, true, true, true, true)
         .go();
+
+    java.util.Random seedGen = new java.util.Random();
+    seedGen.setSeed(System.currentTimeMillis());
+    int seed = seedGen.nextInt();
+
+    String querytemplate = "select " +
+            "hash32AsDouble(cast(employee_id as int), #RAND_SEED#) = hash32AsDouble(cast(employee_id as bigint), #RAND_SEED#) col1, " +
+            "hash32AsDouble(cast(employee_id as bigint), #RAND_SEED#) = hash32AsDouble(cast(employee_id as float), #RAND_SEED#) col2, " +
+            "hash32AsDouble(cast(employee_id as float),  #RAND_SEED#) = hash32AsDouble(cast(employee_id as double), #RAND_SEED#) col3, " +
+            "hash32AsDouble(cast(employee_id as double), #RAND_SEED#) = hash32AsDouble(cast(employee_id as decimal(9, 0)), #RAND_SEED#) col4, " +
+            "hash32AsDouble(cast(employee_id as decimal(9, 0)), #RAND_SEED#) = hash32AsDouble(cast(employee_id as decimal(18, 0)), #RAND_SEED#) col5, " +
+            "hash32AsDouble(cast(employee_id as decimal(18, 0)), #RAND_SEED#) = hash32AsDouble(cast(employee_id as decimal(28, 0)), #RAND_SEED#) col6, " +
+            "hash32AsDouble(cast(employee_id as decimal(28, 0)), #RAND_SEED#) = hash32AsDouble(cast(employee_id as decimal(38, 0)), #RAND_SEED#) col7 " +
+            "from cp.`employee.json` where employee_id = 1";
+
+    String queryWithSeed = querytemplate.replaceAll("#RAND_SEED#", String.format("%d",seed));
+    testBuilder()
+            .sqlQuery(queryWithSeed)
+            .unOrdered()
+            .baselineColumns("col1", "col2", "col3", "col4", "col5", "col6", "col7")
+            .baselineValues(true, true, true, true, true, true, true)
+            .go();
+
   }
 
   @Test


### PR DESCRIPTION
Unit Test was removed from this commit. Test codes and the the test vector generator program will be included in functional tests in a separate checkin.

While implementing hash function instead of inventing a hash function, one thing need to emphasize is, in these well tested and widely accepted algorithms, all parameters and steps to shuffle are carefully designed and tested by the inventors and the community(e.g. smhasher). It is not just generating 'random' result from 'random' input. So each implementations of the algorithm should prove their complete correctness by testing with the same standard as I am doing here: cover all code paths(in murmurhash and xxhash cases, it is all possible input lengths that may go through different code paths, and sign/unsign cases).

