### PR TITLE
DRILL-4623: Disable epoll transport by default

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -182,7 +182,7 @@ export DRILLBIT_MAX_PERM=${DRILLBIT_MAX_PERM:-"512M"}
 export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"1G"}
 
 export DRILLBIT_OPTS="-Xms$DRILL_HEAP -Xmx$DRILL_HEAP -XX:MaxDirectMemorySize=$DRILL_MAX_DIRECT_MEMORY"
-export DRILLBIT_OPTS="$DRILLBIT_OPTS -XX:ReservedCodeCacheSize=$DRILLBIT_CODE_CACHE_SIZE -Ddrill.exec.enable-epoll=true"
+export DRILLBIT_OPTS="$DRILLBIT_OPTS -XX:ReservedCodeCacheSize=$DRILLBIT_CODE_CACHE_SIZE -Ddrill.exec.enable-epoll=false"
 export DRILLBIT_OPTS="$DRILLBIT_OPTS -XX:MaxPermSize=$DRILLBIT_MAX_PERM"
 
 # Under YARN, the log directory is usually YARN-provided. Replace any

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/TransportCheck.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/TransportCheck.java
@@ -45,6 +45,8 @@ public class TransportCheck {
 
     String name = SystemPropertyUtil.get("os.name").toLowerCase(Locale.US).trim();
 
+    // Epoll is disabled by default (see distribution/src/resources/drill-env.sh) due to
+    // https://github.com/netty/netty/issues/3539
     if (name.startsWith("linux") && SystemPropertyUtil.getBoolean(USE_LINUX_EPOLL, false)) {
       SUPPORTS_EPOLL = true;
     } else {


### PR DESCRIPTION
@jacques-n can you please review?

Note: although this patch disables epoll as default transport, deployments that use another env file (e.g. `/etc/drill/conf/drill-env.sh`) would use epoll. Or disabling could be hard coded?