### PR TITLE
DRILL-4139: Add missing BIT support for Parquet partition pruning

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
@@ -61,6 +61,7 @@ import org.apache.drill.exec.store.schedule.CompleteWork;
 import org.apache.drill.exec.store.schedule.EndpointByteMap;
 import org.apache.drill.exec.store.schedule.EndpointByteMapImpl;
 import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.exec.vector.NullableBitVector;
 import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.apache.drill.exec.vector.NullableDateVector;
 import org.apache.drill.exec.vector.NullableDecimal18Vector;
@@ -386,6 +387,12 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
     String f = Path.getPathWithoutSchemeAndAuthority(new Path(file)).toString();
     MinorType type = getTypeForColumn(column).getMinorType();
     switch (type) {
+      case BIT: {
+        NullableBitVector bitVector = (NullableBitVector) v;
+        Boolean value = (Boolean) partitionValueMap.get(f).get(column);
+        bitVector.getMutator().setSafe(index, value ? 1 : 0);
+        return;
+      }
       case INT: {
         NullableIntVector intVector = (NullableIntVector) v;
         Integer value = (Integer) partitionValueMap.get(f).get(column);


### PR DESCRIPTION
This is really trivial fix for the issue. 

Couldn't find a way to enforce pruning of the query when working on a test - if anyone has an idea I will be happy to add unit test for the case.
