### PR TITLE
DRILL-4664: ScanBatch.isNewSchema() returns wrong result for map datatype

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -533,9 +533,8 @@ public class TestAggregateFunctions extends BaseTestQuery {
     Map<String, String> objectsMap = Maps.newHashMap();
     objectsMap.put("COUNT_BIG_INT_REPEATED", "sia");
     objectsMap.put("COUNT_FLOAT_REPEATED", "sfa");
-    // TODO: can be uncommented after fixing DRILL-4664
-    // objectsMap.put("COUNT_MAP_REPEATED", "soa");
-    // objectsMap.put("COUNT_MAP_REQUIRED", "oooi");
+    objectsMap.put("COUNT_MAP_REPEATED", "soa");
+    objectsMap.put("COUNT_MAP_REQUIRED", "oooi");
     objectsMap.put("COUNT_LIST_REPEATED", "odd");
     objectsMap.put("COUNT_LIST_OPTIONAL", "sia");
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -38,6 +38,7 @@ import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.util.CallBack;
 import org.apache.drill.exec.util.JsonStringHashMap;
 import org.apache.drill.exec.vector.BaseValueVector;
+import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector.MapSingleCopier;
 import org.apache.drill.exec.vector.complex.impl.SingleMapReaderImpl;
@@ -161,7 +162,7 @@ public class MapVector extends AbstractMapVector {
     private final MapVector to;
 
     public MapTransferPair(MapVector from, String path, BufferAllocator allocator) {
-      this(from, new MapVector(MaterializedField.create(path, TYPE), allocator, from.callBack), false);
+      this(from, new MapVector(MaterializedField.create(path, TYPE), allocator, new SchemaChangeCallBack()), false);
     }
 
     public MapTransferPair(MapVector from, MapVector to) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
@@ -43,6 +43,7 @@ import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VectorDescriptor;
+import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.exec.vector.complex.impl.NullReader;
 import org.apache.drill.exec.vector.complex.impl.RepeatedMapReaderImpl;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
@@ -238,7 +239,7 @@ public class RepeatedMapVector extends AbstractMapVector
     private static final MajorType MAP_TYPE = Types.required(MinorType.MAP);
 
     public SingleMapTransferPair(RepeatedMapVector from, String path, BufferAllocator allocator) {
-      this(from, new MapVector(MaterializedField.create(path, MAP_TYPE), allocator, from.callBack), false);
+      this(from, new MapVector(MaterializedField.create(path, MAP_TYPE), allocator, new SchemaChangeCallBack()), false);
     }
 
     public SingleMapTransferPair(RepeatedMapVector from, MapVector to) {
@@ -303,7 +304,7 @@ public class RepeatedMapVector extends AbstractMapVector
     private final RepeatedMapVector from;
 
     public RepeatedMapTransferPair(RepeatedMapVector from, String path, BufferAllocator allocator) {
-      this(from, new RepeatedMapVector(MaterializedField.create(path, TYPE), allocator, from.callBack), false);
+      this(from, new RepeatedMapVector(MaterializedField.create(path, TYPE), allocator, new SchemaChangeCallBack()), false);
     }
 
     public RepeatedMapTransferPair(RepeatedMapVector from, RepeatedMapVector to) {


### PR DESCRIPTION
- creating a separate SchemaChangeCallBack for new MapVecor in MapTransferPair,
  RepeatedMapTransferPair and SingleMapTransferPair .