### PR TITLE
DRILL-3510: Add ANSI_QUOTES option so that Drill's SQL Parser will recognize ANSI_SQL identifiers

### DIFF
--- a/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
@@ -63,6 +63,8 @@ public final class DrillProperties extends Properties {
   // Subject's credentials set
   public static final String KERBEROS_FROM_SUBJECT = "from_subject";
 
+  public static final String QUOTING_IDENTIFIERS = "quoting_identifiers";
+
   // Although all properties from the application are sent to the server (from the client), the following
   // sets of properties are used by the client and server respectively. These are reserved words.
 
@@ -77,7 +79,8 @@ public final class DrillProperties extends Properties {
   public static final ImmutableSet<String> ACCEPTED_BY_SERVER = ImmutableSet.of(
       USER /** deprecated */, PASSWORD /** deprecated */,
       SCHEMA,
-      IMPERSONATION_TARGET
+      IMPERSONATION_TARGET,
+      QUOTING_IDENTIFIERS
   );
 
   private DrillProperties() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -527,7 +527,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
   /**
    * Returns the list of methods supported by the server based on its advertised information.
    *
-   * @return a immutable set of capabilities
+   * @return an immutable set of capabilities
    */
   public Set<ServerMethod> getSupportedMethods() {
     return client != null ? ServerMethod.getSupportedMethods(client.getSupportedMethods(), client.getServerInfos()) : null;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,13 +17,14 @@
  */
 package org.apache.drill.exec.planner.physical;
 
+import org.apache.calcite.avatica.util.Quoting;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValidator;
-import org.apache.drill.exec.server.options.TypeValidators;
 import org.apache.drill.exec.server.options.TypeValidators.BooleanValidator;
+import org.apache.drill.exec.server.options.TypeValidators.EnumeratedStringValidator;
 import org.apache.drill.exec.server.options.TypeValidators.LongValidator;
 import org.apache.drill.exec.server.options.TypeValidators.DoubleValidator;
 import org.apache.drill.exec.server.options.TypeValidators.PositiveLongValidator;
@@ -105,6 +106,9 @@ public class PlannerSettings implements Context{
   public static final PositiveLongValidator PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD = new PositiveLongValidator(PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD_KEY,
       Long.MAX_VALUE, 10000);
 
+  public static final String QUOTING_IDENTIFIERS_KEY = "planner.parser.quoting_identifiers";
+  public static final EnumeratedStringValidator QUOTING_IDENTIFIERS = new EnumeratedStringValidator(
+      QUOTING_IDENTIFIERS_KEY, Quoting.BACK_TICK.string, Quoting.DOUBLE_QUOTE.string, Quoting.BRACKET.string);
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
@@ -260,6 +264,22 @@ public class PlannerSettings implements Context{
 
   public long getParquetRowGroupFilterPushDownThreshold() {
     return options.getOption(PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD);
+  }
+
+  /**
+   * @return Quoting enum for current quoting identifiers character
+   */
+  public Quoting getQuotingIdentifiers() {
+    String quotingIdentifiersCharacter = options.getOption(QUOTING_IDENTIFIERS);
+    for (Quoting value : Quoting.values()) {
+      if (value.string.equals(quotingIdentifiersCharacter)) {
+        return value;
+      }
+    }
+    // this is never reached
+    throw UserException.validationError()
+        .message("Unknown quoting identifier character '%s'", quotingIdentifiersCharacter)
+        .build(logger);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillParserConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillParserConfig.java
@@ -27,9 +27,11 @@ import org.apache.drill.exec.planner.sql.parser.impl.DrillParserWithCompoundIdCo
 public class DrillParserConfig implements SqlParser.Config {
 
   private final long identifierMaxLength;
+  private final Quoting quotingIdentifiers;
 
   public DrillParserConfig(PlannerSettings settings) {
     identifierMaxLength = settings.getIdentifierMaxLength();
+    quotingIdentifiers = settings.getQuotingIdentifiers();
   }
 
   @Override
@@ -49,7 +51,7 @@ public class DrillParserConfig implements SqlParser.Config {
 
   @Override
   public Quoting quoting() {
-    return Quoting.BACK_TICK;
+    return quotingIdentifiers;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -14,10 +14,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.apache.drill.exec.server.options;
 
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.server.options.OptionValue.Kind;
 
 /**
  * Validates the values provided to Drill options.
@@ -97,5 +98,12 @@ public abstract class OptionValidator {
    * @throws UserException message to describe error with value, including range or list of expected values
    */
   public abstract void validate(OptionValue value, OptionManager manager);
+
+  /**
+   * Gets the kind of this option value for this validator.
+   *
+   * @return kind of this option value
+   */
+  public abstract Kind getKind();
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValue.java
@@ -200,6 +200,6 @@ public class OptionValue implements Comparable<OptionValue> {
 
   @Override
   public String toString() {
-    return "OptionValue [type=" + type + ", name=" + name + ", value=" + getValue() + "]";
+    return "OptionValue [ type=" + type + ", name=" + name + ", value=" + getValue() + " ]";
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -91,6 +91,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       PlannerSettings.UNIONALL_DISTRIBUTE,
       PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING,
       PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD,
+      PlannerSettings.QUOTING_IDENTIFIERS,
       ExecConstants.CAST_TO_NULLABLE_NUMERIC_OPTION,
       ExecConstants.OUTPUT_FORMAT_VALIDATOR,
       ExecConstants.PARQUET_BLOCK_SIZE_VALIDATOR,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.server.options;
 
-import java.util.HashSet;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
 import org.apache.drill.exec.server.options.OptionValue.OptionType;
@@ -204,10 +204,11 @@ public class TypeValidators {
    * Validator that checks if the given value is included in a list of acceptable values. Case insensitive.
    */
   public static class EnumeratedStringValidator extends StringValidator {
-    private final Set<String> valuesSet = new HashSet<>();
+    private final Set<String> valuesSet = Sets.newLinkedHashSet();
 
     public EnumeratedStringValidator(String name, String def, String... values) {
       super(name, def);
+      valuesSet.add(def.toLowerCase());
       for (String value : values) {
         valuesSet.add(value.toLowerCase());
       }
@@ -257,6 +258,11 @@ public class TypeValidators {
             .message("Admin related settings can only be set at SYSTEM level scope. Given scope '%s'.", v.type)
             .build(logger);
       }
+    }
+
+    @Override
+    public Kind getKind() {
+      return kind;
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.drill.DrillTestWrapper.TestServices;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.scanner.ClassPathScanner;
 import org.apache.drill.common.scanner.persistence.ScanResult;
@@ -51,7 +52,6 @@ import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.user.AwaitableUserResultsListener;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.rpc.user.UserResultsListener;
-import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.RemoteServiceSet;
@@ -237,9 +237,9 @@ public class BaseTestQuery extends ExecTest {
    */
   public static void updateClient(final String user, final String password) throws Exception {
     final Properties props = new Properties();
-    props.setProperty(UserSession.USER, user);
+    props.setProperty(DrillProperties.USER, user);
     if (password != null) {
-      props.setProperty(UserSession.PASSWORD, password);
+      props.setProperty(DrillProperties.PASSWORD, password);
     }
     updateClient(props);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -25,7 +25,6 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.dotdrill.DotDrillType;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.rpc.RpcException;
-import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
 import org.apache.drill.exec.store.dfs.WorkspaceConfig;
 import org.apache.drill.test.UserExceptionMatcher;
@@ -128,9 +127,9 @@ public class TestInboundImpersonation extends BaseTestImpersonation {
     // Connect as PROXY_NAME and query for IMPERSONATION_TARGET
     // data belongs to OWNER, however a view is shared with IMPERSONATION_TARGET
     final Properties connectionProps = new Properties();
-    connectionProps.setProperty(UserSession.USER, PROXY_NAME);
-    connectionProps.setProperty(UserSession.PASSWORD, PROXY_PASSWORD);
-    connectionProps.setProperty(UserSession.IMPERSONATION_TARGET, TARGET_NAME);
+    connectionProps.setProperty(DrillProperties.USER, PROXY_NAME);
+    connectionProps.setProperty(DrillProperties.PASSWORD, PROXY_PASSWORD);
+    connectionProps.setProperty(DrillProperties.IMPERSONATION_TARGET, TARGET_NAME);
     updateClient(connectionProps);
 
     testBuilder()
@@ -146,9 +145,9 @@ public class TestInboundImpersonation extends BaseTestImpersonation {
   public void unauthorizedTarget() throws Exception {
     final String unauthorizedTarget = org2Users[0];
     final Properties connectionProps = new Properties();
-    connectionProps.setProperty(UserSession.USER, PROXY_NAME);
-    connectionProps.setProperty(UserSession.PASSWORD, PROXY_PASSWORD);
-    connectionProps.setProperty(UserSession.IMPERSONATION_TARGET, unauthorizedTarget);
+    connectionProps.setProperty(DrillProperties.USER, PROXY_NAME);
+    connectionProps.setProperty(DrillProperties.PASSWORD, PROXY_PASSWORD);
+    connectionProps.setProperty(DrillProperties.IMPERSONATION_TARGET, unauthorizedTarget);
     updateClient(connectionProps); // throws up
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,10 +19,13 @@ package org.apache.drill.exec.planner.sql;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.junit.Test;
 
-public class TestDrillSQLWorker {
+public class TestDrillSQLWorker extends BaseTestQuery {
 
   private void validateFormattedIs(String sql, SqlParserPos pos, String expected) {
     String formatted = SqlConverter.formatSQLParsingError(sql, pos);
@@ -47,5 +50,43 @@ public class TestDrillSQLWorker {
     validateFormattedIs(sql, new SqlParserPos(-11, -10), sql);
     validateFormattedIs(sql, new SqlParserPos(0, 10), sql);
     validateFormattedIs(sql, new SqlParserPos(100, 10), sql);
+  }
+
+  @Test
+  public void testDoubleQuotesForQuotingIdentifiers() throws Exception {
+    try {
+      test("ALTER SESSION SET `%s` = '%s'", PlannerSettings.QUOTING_IDENTIFIERS_KEY,
+          Quoting.DOUBLE_QUOTE.string);
+      testBuilder()
+          .sqlQuery("select \"employee_id\", \"full_name\" from cp.\"employee.json\" limit 1")
+          .ordered()
+          .baselineColumns("employee_id", "full_name")
+          .baselineValues(1L, "Sheri Nowmer")
+          .go();
+
+      // Other quoting characters are not acceptable while particular one is chosen,
+      // since calcite doesn't support parsing sql statements with several quoting identifiers characters
+      errorMsgTestHelper("select `employee_id`, `full_name` from cp.`employee.json` limit 1", "Encountered: \"`\"");
+      // Mix of different quotes in the one SQL statement is not acceptable
+      errorMsgTestHelper("select \"employee_id\", \"full_name\" from cp.`employee.json` limit 1", "Encountered: \"`\"");
+    } finally {
+      test("ALTER SESSION RESET %s", PlannerSettings.QUOTING_IDENTIFIERS_KEY);
+    }
+  }
+
+  @Test
+  public void testBracketsForQuotingIdentifiers() throws Exception {
+    try {
+      test("ALTER SESSION SET `%s` = '%s'", PlannerSettings.QUOTING_IDENTIFIERS_KEY,
+          Quoting.BRACKET.string);
+      testBuilder()
+          .sqlQuery("select [employee_id], [full_name] from cp.[employee.json] limit 1")
+          .ordered()
+          .baselineColumns("employee_id", "full_name")
+          .baselineValues(1L, "Sheri Nowmer")
+          .go();
+    } finally {
+      test("ALTER SESSION RESET %s", PlannerSettings.QUOTING_IDENTIFIERS_KEY);
+    }
   }
 }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -279,7 +279,6 @@
               <exclude>com.googlecode.json-simple:*</exclude>
               <exclude>dom4j:*</exclude>
               <exclude>org.hibernate:*</exclude>
-              <exclude>javax.validation:*</exclude>
               <exclude>antlr:*</exclude>
               <exclude>org.ow2.asm:*</exclude>
               <exclude>com.univocity:*</exclude>
@@ -391,7 +390,13 @@
                <exclude>**/*.SF</exclude>
                <exclude>**/*.RSA</exclude>
                <exclude>**/*.DSA</exclude>
-               <exclude>javax/**</exclude>
+               <exclude>javax/*</exclude>
+               <exclude>javax/activation/**</exclude>
+               <exclude>javax/annotation-api/**</exclude>
+               <exclude>javax/inject/**</exclude>
+               <exclude>javax/servlet-api/**</exclude>
+               <exclude>javax/json/**</exclude>
+               <exclude>javax/ws/**</exclude>
                <exclude>rest/**</exclude>
                <exclude>*.tokens</exclude>
                <exclude>codegen/**</exclude>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -95,6 +95,11 @@
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillDatabaseMetaData.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillDatabaseMetaData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF); under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -19,6 +19,7 @@ package org.apache.drill.jdbc;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.apache.calcite.avatica.util.Quoting;
 
 
 /**
@@ -80,13 +81,16 @@ public interface DrillDatabaseMetaData extends DatabaseMetaData {
   //  storesLowerCaseQuotedIdentifiers()
   //  storesMixedCaseQuotedIdentifiers()
 
-
-  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
   /**
    * <strong>Drill</strong>:
-   * Reports that the SQL identifier quoting character is the back-quote
-   * character ("{@code `}"; Unicode U+0060; "GRAVE ACCENT").
-   * @return "{@code `}"
+   * Reports current SQL identifier quoting character.
+   *  <li>{@link Quoting#BACK_TICK} - default back-quote character ("{@code `}"; Unicode U+0060; "GRAVE ACCENT") </li>
+   *  <li>{@link Quoting#DOUBLE_QUOTE} - double quote character ("{@code "}"; Unicode U+0022; 'QUOTATION MARK')</li>
+   *  <li>{@link Quoting#BRACKET} - brackets characters ("{@code [}"; Unicode U+005B; 'LEFT SQUARE BRACKET' and
+   *  "{@code ]}"; Unicode U+005D; 'RIGHT SQUARE BRACKET')</li>
+   *
+   * @return current SQL identifier quoting character. Note: 'LEFT SQUARE BRACKET' is returned,
+   *         when {@link Quoting#BRACKET} is set.
    */
   @Override
   String getIdentifierQuoteString() throws SQLException;

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.calcite.avatica.AvaticaDatabaseMetaData;
+import org.apache.calcite.avatica.util.Quoting;
 import org.apache.drill.common.Version;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -397,12 +398,11 @@ class DrillDatabaseMetaDataImpl extends AvaticaDatabaseMetaData
     return getServerMeta().getQuotedIdentifierCasing() == IdentifierCasing.IC_STORES_MIXED;
   }
 
-  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
   @Override
   public String getIdentifierQuoteString() throws SQLException {
     throwIfClosed();
     if (!getServerMetaSupported()) {
-      return "`";
+      return Quoting.BACK_TICK.string;
     }
     return getServerMeta().getIdentifierQuoteString();
   }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionFactory.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionFactory.java
@@ -18,6 +18,7 @@
 package org.apache.drill.jdbc;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * A factory used to get open {@link Connection} instances.
@@ -31,5 +32,5 @@ public interface ConnectionFactory {
    * @param info the connection parameters
    * @throws Exception if factory fails to get a connection.
    */
-  Connection getConnection(ConnectionInfo info) throws Exception;
+  Connection getConnection(ConnectionInfo info) throws SQLException;
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionInfoTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionInfoTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.jdbc;
+
+import org.apache.calcite.avatica.util.Quoting;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for Drill's Properties in the JDBC URL connection string
+ */
+public class ConnectionInfoTest extends JdbcTestBase {
+  private static Connection connection;
+  private static DatabaseMetaData dbmd;
+
+  @Test
+  public void testQuotingIdentifiersProperty() throws SQLException {
+    try {
+      // Test DoubleQuotes for the DrillProperty#QUOTING_IDENTIFIERS in connection URL
+      connection = connect("jdbc:drill:zk=local;quoting_identifiers='\"'");
+      dbmd = connection.getMetaData();
+      assertThat(dbmd.getIdentifierQuoteString(), equalTo(Quoting.DOUBLE_QUOTE.string));
+      reset();
+
+      // Test Brackets for the DrillProperty#QUOTING_IDENTIFIERS in connection URL
+      connection = connect("jdbc:drill:zk=local;quoting_identifiers=[");
+      dbmd = connection.getMetaData();
+      assertThat(dbmd.getIdentifierQuoteString(), equalTo(Quoting.BRACKET.string));
+    } finally {
+      reset();
+    }
+  }
+
+  @Test(expected = SQLException.class)
+  public void testIncorrectCharacterForQuotingIdentifiers() throws SQLException {
+    try {
+      connection = connect("jdbc:drill:zk=local;quoting_identifiers=&");
+    }
+    catch (SQLException e) {
+      // Check exception text message
+      assertThat(e.getMessage(), containsString("Option planner.parser.quoting_identifiers " +
+          "must be one of: [`, \", []"));
+      throw e;
+    } finally {
+      reset();
+    }
+  }
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.calcite.avatica.util.Quoting;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -103,10 +104,12 @@ public class DatabaseMetaDataTest {
   //  storesMixedCaseQuotedIdentifiers()
 
 
-  // TODO(DRILL-3510):  Update when Drill accepts standard SQL's double quote.
+  // TODO(DRILL-5402): Update when server meta information will be updated during one session.
   @Test
-  public void testGetIdentifierQuoteStringSaysBackquote() throws SQLException {
-    assertThat( dbmd.getIdentifierQuoteString(), equalTo( "`" ) );
+  public void testGetIdentifierQuoteString() throws SQLException {
+    // If connection string hasn't "quoting_identifiers" property, this method will return current system
+    // "planner.parser.quoting_identifiers" option (back tick by default)
+    assertThat(dbmd.getIdentifierQuoteString(), equalTo(Quoting.BACK_TICK.string));
   }
 
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -60,8 +60,7 @@ public class JdbcTestBase extends ExecTest {
   public static void setUpTestCase() {
     factory = new SingleConnectionCachingFactory(new ConnectionFactory() {
       @Override
-      public Connection getConnection(ConnectionInfo info) throws Exception {
-        Class.forName("org.apache.drill.jdbc.Driver");
+      public Connection getConnection(ConnectionInfo info) throws SQLException {
         return DriverManager.getConnection(info.getUrl(), info.getParamsAsProperties());
       }
     });
@@ -73,7 +72,7 @@ public class JdbcTestBase extends ExecTest {
    * @param url connection URL
    * @throws Exception if connection fails
    */
-  protected static Connection connect(String url) throws Exception {
+  protected static Connection connect(String url) throws SQLException {
     return connect(url, JdbcAssert.getDefaultProperties());
   }
 
@@ -84,7 +83,7 @@ public class JdbcTestBase extends ExecTest {
    * @param info connection info
    * @throws Exception if connection fails
    */
-  protected static Connection connect(String url, Properties info) throws Exception {
+  protected static Connection connect(String url, Properties info) throws SQLException {
     final Connection conn = factory.getConnection(new ConnectionInfo(url, info));
     changeSchemaIfSupplied(conn, info);
     return conn;

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/MultiConnectionCachingFactory.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/MultiConnectionCachingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -45,7 +45,7 @@ public class MultiConnectionCachingFactory implements CachingConnectionFactory {
    * {@link java.sql.Connection#close()}. Consumer must call {#close} to close the cached connections.
    */
   @Override
-  public Connection getConnection(ConnectionInfo info) throws Exception {
+  public Connection getConnection(ConnectionInfo info) throws SQLException {
     Connection conn = cache.get(info);
     if (conn == null) {
       conn = delegate.getConnection(info);

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/SingleConnectionCachingFactory.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/SingleConnectionCachingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -45,7 +45,7 @@ public class SingleConnectionCachingFactory implements CachingConnectionFactory 
    * </p>
    */
   @Override
-  public Connection getConnection(ConnectionInfo info) throws Exception {
+  public Connection getConnection(ConnectionInfo info) throws SQLException {
     if (connection == null) {
       connection = delegate.getConnection(info);
     } else {

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -167,7 +167,7 @@ public class JdbcAssert {
       this.info = info;
       this.adapter = new ConnectionFactoryAdapter() {
         @Override
-        public Connection createConnection() throws Exception {
+        public Connection createConnection() throws SQLException {
           return factory.getConnection(new ConnectionInfo("jdbc:drill:zk=local", ModelAndSchema.this.info));
         }
       };


### PR DESCRIPTION
- added calcite's Lex.MYSQL_ANSI (double quote) supporting for SQL identifiers;
- replaced drill's SqlParser.Config with calcite's one;
- added unit test TestSqlConverter - testAnsiQuotes();
- upgraded getIdentifierQuoteString() for drill's database metadata;
- upgraded unit test testGetIdentifierQuoteString();
