### PR TITLE
DRILL-4716: status.json doesn't work in drill ui

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -33,6 +33,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
 import org.apache.drill.exec.server.rest.DrillRestServer.UserAuthEnabled;
@@ -53,10 +55,17 @@ public class StatusResources {
   @Inject SecurityContext sc;
 
   @GET
+  @Path("/status.json")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Pair<String, String> getStatusJSON() {
+    return new ImmutablePair<>("status", "Running!");
+  }
+
+  @GET
   @Path("/status")
   @Produces(MediaType.TEXT_HTML)
   public Viewable getStatus() {
-    return ViewableWithPermissions.create(authEnabled.get(), "/rest/status.ftl", sc, "Running!");
+    return ViewableWithPermissions.create(authEnabled.get(), "/rest/status.ftl", sc, getStatusJSON());
   }
 
   @GET

--- a/exec/java-exec/src/main/resources/rest/status.ftl
+++ b/exec/java-exec/src/main/resources/rest/status.ftl
@@ -17,10 +17,9 @@
   <a href="/queries">back</a><br/>
   <div class="page-header">
     <div class="alert alert-success">
-      <strong>${model}</strong>
+      <strong>${model.getValue()}</strong>
     </div>
   </div>
-  <a href="/status/options"> System Options </a>
 </#macro>
 
 <@page_html/>


### PR DESCRIPTION
1. /status.json returns
{
  "status" : "Running!"
}
2. Removed link to System Options on /status as redundant.