### PR TITLE
DRILL-4725: Improvements to InfoSchema RecordGenerator needed for DRILL-4714

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaConstants.java
@@ -25,6 +25,12 @@ public final class InfoSchemaConstants {
   /** Name of catalog containing information schema. */
   public static final String IS_CATALOG_NAME = "DRILL";
 
+  /** Catalog description */
+  public static final String IS_CATALOG_DESCR = "The internal metadata used by Drill";
+
+  /** Catalog connect string. Currently empty */
+  public static final String IS_CATALOG_CONNECT = "";
+
   /** Name of information schema. */
   public static final String IS_SCHEMA_NAME = "INFORMATION_SCHEMA";
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaDrillTable.java
@@ -25,9 +25,9 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 public class InfoSchemaDrillTable extends DrillTable{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InfoSchemaDrillTable.class);
 
-  private final SelectedTable table;
+  private final InfoSchemaTableType table;
 
-  public InfoSchemaDrillTable(InfoSchemaStoragePlugin plugin, String storageEngineName, SelectedTable selection, StoragePluginConfig storageEngineConfig) {
+  public InfoSchemaDrillTable(InfoSchemaStoragePlugin plugin, String storageEngineName, InfoSchemaTableType selection, StoragePluginConfig storageEngineConfig) {
     super(storageEngineName, plugin, selection);
     this.table = selection;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.store.ischema;
 
+import static org.apache.drill.exec.expr.fn.impl.RegexpUtil.sqlToRegexLike;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -144,11 +146,18 @@ public class InfoSchemaFilter {
   private Result evaluateHelperFunction(Map<String, String> recordValues, FunctionExprNode exprNode) {
     switch(exprNode.function) {
       case "like": {
-        FieldExprNode arg0 = (FieldExprNode) exprNode.args.get(0);
-        ConstantExprNode arg1 = (ConstantExprNode) exprNode.args.get(1);
-        if (recordValues.get(arg0.field.toString()) != null) {
-          return Pattern.matches(RegexpUtil.sqlToRegexLike(arg1.value), recordValues.get(arg0.field.toString())) ?
-              Result.TRUE : Result.FALSE;
+        FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
+        ConstantExprNode pattern = (ConstantExprNode) exprNode.args.get(1);
+        ConstantExprNode escape = exprNode.args.size() > 2 ? (ConstantExprNode) exprNode.args.get(2) : null;
+        final String fieldValue = recordValues.get(col.field.toString());
+        if (fieldValue != null) {
+          if (escape == null) {
+            return Pattern.matches(sqlToRegexLike(pattern.value), fieldValue) ?
+                Result.TRUE : Result.FALSE;
+          } else {
+            return Pattern.matches(sqlToRegexLike(pattern.value, escape.value), fieldValue) ?
+                Result.TRUE : Result.FALSE;
+          }
         }
 
         return Result.INCONCLUSIVE;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 /**
  * Builds a InfoSchemaFilter out of the Filter condition. Currently we look only for certain conditions. Mainly
- * conditions involving columns "TABLE_NAME", "SCHEMA_NAME" and "TABLE_SCHEMA" and
+ * conditions involving columns "CATALOG_NAME, "TABLE_NAME", "SCHEMA_NAME", "TABLE_SCHEMA" and "COLUMN_NAME", and
  * functions EQUAL, NOT EQUAL, LIKE, OR and AND.
  */
 public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void, RuntimeException> {
@@ -69,13 +69,25 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
       case "equal":
       case "not equal":
       case "notequal":
-      case "not_equal":
-      case "like": {
-        ExprNode arg0 = call.args.get(0).accept(this, value);
-        ExprNode arg1 = call.args.get(1).accept(this, value);
+      case "not_equal": {
+        final ExprNode col = call.args.get(0).accept(this, value);
+        final ExprNode constant = call.args.get(1).accept(this, value);
 
-        if (arg0 != null && arg0 instanceof FieldExprNode && arg1 != null && arg1 instanceof ConstantExprNode) {
-          return new FunctionExprNode(funcName, ImmutableList.of(arg0, arg1));
+        if (col instanceof FieldExprNode && constant instanceof ConstantExprNode) {
+          return new FunctionExprNode(funcName, ImmutableList.of(col, constant));
+        }
+        break;
+      }
+
+      case "like": {
+        final ExprNode col = call.args.get(0).accept(this, value);
+        final ExprNode pattern = call.args.get(1).accept(this, value);
+        final ExprNode escape = call.args.size() > 2 ? call.args.get(2).accept(this, value) : null;
+
+        if (col instanceof FieldExprNode && pattern instanceof ConstantExprNode &&
+            (escape == null || escape instanceof ConstantExprNode)) {
+          return new FunctionExprNode(funcName,
+              escape == null ? ImmutableList.of(col, pattern) : ImmutableList.of(col, pattern, escape));
         }
         break;
       }
@@ -127,9 +139,11 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
     if (e.getInput() instanceof FieldReference) {
       FieldReference fieldRef = (FieldReference) e.getInput();
       String field = fieldRef.getAsUnescapedPath().toUpperCase();
-      if (field.equals(SCHS_COL_SCHEMA_NAME)
+      if (field.equals(CATS_COL_CATALOG_NAME)
+          || field.equals(SCHS_COL_SCHEMA_NAME)
           || field.equals(SHRD_COL_TABLE_NAME)
-          || field.equals(SHRD_COL_TABLE_SCHEMA)) {
+          || field.equals(SHRD_COL_TABLE_SCHEMA)
+          || field.equals(COLS_COL_COLUMN_NAME)) {
         return new FieldExprNode(field);
       }
     }
@@ -145,9 +159,11 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
   @Override
   public ExprNode visitSchemaPath(SchemaPath path, Void value) throws RuntimeException {
     String field = path.getAsUnescapedPath().toUpperCase();
-    if (field.equals(SCHS_COL_SCHEMA_NAME)
+    if (field.equals(CATS_COL_CATALOG_NAME)
+        || field.equals(SCHS_COL_SCHEMA_NAME)
         || field.equals(SHRD_COL_TABLE_NAME)
-        || field.equals(SHRD_COL_TABLE_SCHEMA)) {
+        || field.equals(SHRD_COL_TABLE_SCHEMA)
+        || field.equals(COLS_COL_COLUMN_NAME)) {
       return new FieldExprNode(field);
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaGroupScan.java
@@ -17,13 +17,11 @@
  */
 package org.apache.drill.exec.store.ischema;
 
-import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.GroupScan;
@@ -42,17 +40,17 @@ import com.google.common.base.Preconditions;
 public class InfoSchemaGroupScan extends AbstractGroupScan{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InfoSchemaGroupScan.class);
 
-  private final SelectedTable table;
+  private final InfoSchemaTableType table;
   private final InfoSchemaFilter filter;
 
   private boolean isFilterPushedDown = false;
 
-  public InfoSchemaGroupScan(SelectedTable table) {
+  public InfoSchemaGroupScan(InfoSchemaTableType table) {
     this(table, null);
   }
 
   @JsonCreator
-  public InfoSchemaGroupScan(@JsonProperty("table") SelectedTable table,
+  public InfoSchemaGroupScan(@JsonProperty("table") InfoSchemaTableType table,
                              @JsonProperty("filter") InfoSchemaFilter filter) {
     super((String)null);
     this.table = table;
@@ -67,7 +65,7 @@ public class InfoSchemaGroupScan extends AbstractGroupScan{
   }
 
   @JsonProperty("table")
-  public SelectedTable getTable() {
+  public InfoSchemaTableType getTable() {
     return table;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaStoragePlugin.java
@@ -62,7 +62,7 @@ public class InfoSchemaStoragePlugin extends AbstractStoragePlugin {
   @Override
   public InfoSchemaGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns)
       throws IOException {
-    SelectedTable table = selection.getWith(context.getLpPersistence(),  SelectedTable.class);
+    InfoSchemaTableType table = selection.getWith(context.getLpPersistence(),  InfoSchemaTableType.class);
     return new InfoSchemaGroupScan(table);
   }
 
@@ -85,7 +85,7 @@ public class InfoSchemaStoragePlugin extends AbstractStoragePlugin {
     public ISchema(SchemaPlus parent, InfoSchemaStoragePlugin plugin){
       super(ImmutableList.<String>of(), IS_SCHEMA_NAME);
       Map<String, InfoSchemaDrillTable> tbls = Maps.newHashMap();
-      for(SelectedTable tbl : SelectedTable.values()){
+      for(InfoSchemaTableType tbl : InfoSchemaTableType.values()){
         tbls.put(tbl.name(), new InfoSchemaDrillTable(plugin, IS_SCHEMA_NAME, tbl, config));
       }
       this.tables = ImmutableMap.copyOf(tbls);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaSubScan.java
@@ -26,11 +26,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class InfoSchemaSubScan extends AbstractSubScan{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InfoSchemaSubScan.class);
 
-  private final SelectedTable table;
+  private final InfoSchemaTableType table;
   private final InfoSchemaFilter filter;
 
   @JsonCreator
-  public InfoSchemaSubScan(@JsonProperty("table") SelectedTable table,
+  public InfoSchemaSubScan(@JsonProperty("table") InfoSchemaTableType table,
                            @JsonProperty("filter") InfoSchemaFilter filter) {
     super(null);
     this.table = table;
@@ -38,7 +38,7 @@ public class InfoSchemaSubScan extends AbstractSubScan{
   }
 
   @JsonProperty("table")
-  public SelectedTable getTable() {
+  public InfoSchemaTableType getTable() {
     return table;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTable.java
@@ -86,7 +86,7 @@ public abstract class InfoSchemaTable {
     return typeFactory.createStructType(relTypes, fieldNames);
   }
 
-  public abstract RecordGenerator getRecordGenerator(OptionManager optionManager);
+  public abstract InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager);
 
   /** Layout for the CATALOGS table. */
   static public class Catalogs extends InfoSchemaTable {
@@ -102,8 +102,8 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public RecordGenerator getRecordGenerator(OptionManager optionManager) {
-      return new RecordGenerator.Catalogs(optionManager);
+    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+      return new InfoSchemaRecordGenerator.Catalogs(optionManager);
     }
   }
 
@@ -123,8 +123,8 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public RecordGenerator getRecordGenerator(OptionManager optionManager) {
-      return new RecordGenerator.Schemata(optionManager);
+    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+      return new InfoSchemaRecordGenerator.Schemata(optionManager);
     }
   }
 
@@ -143,8 +143,8 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public RecordGenerator getRecordGenerator(OptionManager optionManager) {
-      return new RecordGenerator.Tables(optionManager);
+    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+      return new InfoSchemaRecordGenerator.Tables(optionManager);
     }
   }
 
@@ -163,8 +163,8 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public RecordGenerator getRecordGenerator(OptionManager optionManager) {
-      return new RecordGenerator.Views(optionManager);
+    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+      return new InfoSchemaRecordGenerator.Views(optionManager);
     }
   }
 
@@ -215,8 +215,8 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public RecordGenerator getRecordGenerator(OptionManager optionManager) {
-      return new RecordGenerator.Columns(optionManager);
+    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+      return new InfoSchemaRecordGenerator.Columns(optionManager);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTableType.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTableType.java
@@ -28,11 +28,12 @@ import org.apache.drill.exec.store.ischema.InfoSchemaTable.Tables;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Views;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.drill.exec.store.pojo.PojoRecordReader;
 
 /**
  * The set of tables/views in INFORMATION_SCHEMA.
  */
-public enum SelectedTable{
+public enum InfoSchemaTableType {
   // TODO:  Resolve how to not have two different place defining table names:
   // NOTE: These identifiers have to match the string values in
   // InfoSchemaConstants.
@@ -48,12 +49,12 @@ public enum SelectedTable{
    * ...
    * @param  tableDef  the definition (columns and data generator) of the table
    */
-  private SelectedTable(InfoSchemaTable tableDef) {
+  InfoSchemaTableType(InfoSchemaTable tableDef) {
     this.tableDef = tableDef;
   }
 
-  public RecordReader getRecordReader(SchemaPlus rootSchema, InfoSchemaFilter filter, OptionManager optionManager) {
-    RecordGenerator recordGenerator = tableDef.getRecordGenerator(optionManager);
+  public PojoRecordReader<?> getRecordReader(SchemaPlus rootSchema, InfoSchemaFilter filter, OptionManager optionManager) {
+    InfoSchemaRecordGenerator recordGenerator = tableDef.getRecordGenerator(optionManager);
     recordGenerator.setInfoSchemaFilter(filter);
     recordGenerator.scanSchema(rootSchema);
     return recordGenerator.getRecordReader();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.sql;
 
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_CONNECT;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_DESCRIPTION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_NAME;
+
 import com.google.common.collect.ImmutableList;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.TestBuilder;
@@ -39,6 +43,16 @@ public class TestInfoSchema extends BaseTestQuery {
     test("select * from INFORMATION_SCHEMA.VIEWS");
     test("select * from INFORMATION_SCHEMA.`TABLES`");
     test("select * from INFORMATION_SCHEMA.COLUMNS");
+  }
+
+  @Test
+  public void catalogs() throws Exception {
+    testBuilder()
+        .sqlQuery("SELECT * FROM INFORMATION_SCHEMA.CATALOGS")
+        .unOrdered()
+        .baselineColumns(CATS_COL_CATALOG_NAME, CATS_COL_CATALOG_DESCRIPTION, CATS_COL_CATALOG_CONNECT)
+        .baselineValues("DRILL", "The internal metadata used by Drill", "")
+        .go();
   }
 
   @Test


### PR DESCRIPTION
1. Add support for pushing the filter on following fields into InfoSchemaRecordGenerator:
   - CATALOG_NAME
   - COLUMN_NAME

2. Pushdown LIKE with ESCAPE. Add test TestInfoSchemaFilterPushDown#testFilterPushdown_LikeWithEscape

3. Add a method visitCatalog() to InfoSchemaRecordGenerator to decide whether to explore the catalog or not

4. Refactor CATALOG_DESCRIPTION and CATALOG_CONNECT as constant strings in InfoSchemaConstants.java

5. Update TestInfoSchemaFilterPushDown#testPartialFilterPushDownWithProject as
   we are now pushing the filter on COLUMN_NAME field

6. Cleanup:
   Rename RecordGenerator -> InfoSchemaRecordGenerator
   Add comments in RecordGenerator
   Rename SelectedTable -> InfoSchemaTableType

@parthchandra Can you please review this change?