### PR TITLE
DRILL-4727: Exclude netty from HBase Client's transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-    </repository>    
+    </repository>
 
     <repository>
       <id>mapr-drill-thirdparty</id>
@@ -574,8 +574,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Mockito needs to be on the class path after JUnit (or Hamcrest) as 
-           long as Mockito _contains_ older Hamcrest classes.  See DRILL-2130. --> 
+      <!-- Mockito needs to be on the class path after JUnit (or Hamcrest) as
+           long as Mockito _contains_ older Hamcrest classes.  See DRILL-2130. -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>
@@ -1041,7 +1041,7 @@
               <exclusion>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-              </exclusion>              
+              </exclusion>
               <exclusion>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
@@ -1129,6 +1129,10 @@
             <artifactId>hbase-client</artifactId>
             <version>1.1.3</version>
             <exclusions>
+              <exclusion>
+                <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+              </exclusion>
               <exclusion>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>servlet-api-2.5</artifactId>
@@ -1500,7 +1504,7 @@
               <exclusion>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-              </exclusion>              
+              </exclusion>
               <exclusion>
                 <artifactId>commons-logging</artifactId>
                 <groupId>commons-logging</groupId>
@@ -1719,6 +1723,10 @@
             <artifactId>hbase-client</artifactId>
             <version>${hbase.version}</version>
             <exclusions>
+              <exclusion>
+                <artifactId>netty-all</artifactId>
+                <groupId>io.netty</groupId>
+              </exclusion>
               <exclusion>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>


### PR DESCRIPTION
Excluded `netty-all` from the list of transitive dependencies pulled by `hbase-client`.