### PR TITLE
DRILL-4727: [Addendum] Exclude netty from HBase Client's transitive d…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1597,6 +1597,10 @@
             <version>${mapr.core.version}</version>
             <exclusions>
               <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+              </exclusion>
+              <exclusion>
                 <artifactId>log4j</artifactId>
                 <groupId>log4j</groupId>
               </exclusion>


### PR DESCRIPTION
…ependencies

Excluded `netty-all` from the list of transitive dependencies pulled by `mapr-hbase` in `mapr` profile.