### PR TITLE
[DRILL-2330] Add support for nested aggregates in Drill

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1287,7 +1287,7 @@
           <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.4.0-drill-r12</version>
+            <version>1.4.0-drill-r13</version>
             <exclusions>
               <exclusion>
                 <groupId>org.jgrapht</groupId>


### PR DESCRIPTION
This is the second part of the commit which adds nested aggregate tests in Drill using Drill Calcite r12. The first part of the commit added support for nested aggregates in Drill's forked version of Calcite. Please take a look.