### PR TITLE
DRILL-4695: Log error thrown out of drillbit.run before close

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -283,6 +283,7 @@ public class Drillbit implements AutoCloseable {
     try {
       bit.run();
     } catch (final Exception e) {
+      logger.error("Failure during initial startup of Drillbit.", e);
       bit.close();
       throw new DrillbitStartupException("Failure during initial startup of Drillbit.", e);
     }


### PR DESCRIPTION
Seems reverting previous change closes the pull request, have to send a new one. Thanks Sudheesh for prompt code review at:
https://github.com/apache/drill/pull/535/