### PR TITLE
DRILL-4768: Fix leaking hive meta store connection in Drill's hive me…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/HiveSchemaFactory.java
@@ -73,7 +73,7 @@ public class HiveSchemaFactory implements SchemaFactory {
 
     try {
       processUserMetastoreClient =
-          DrillHiveMetaStoreClient.createNonCloseableClientWithCaching(hiveConf);
+          DrillHiveMetaStoreClient.createCloseableClientWithCaching(hiveConf);
     } catch (MetaException e) {
       throw new ExecutionSetupException("Failure setting up Hive metastore client.", e);
     }


### PR DESCRIPTION
…tastore client call.

do not call reconnect if the connection is still alive and the error is caused by either UnknownTableException or access error.