### PR TITLE
DRILL-4822: Add $DRILL_SITE to distrib-env.sh search path

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -166,10 +166,17 @@ fi
 # Source distrib-env.sh for any distribution-specific settings.
 # distrib-env.sh is optional; it is created by some distribution installers
 # that need distribution-specific settings.
+# Because installers write site-specific values into the file, the file
+# should be moved into the site directory, if the user employs one.
 
-distribEnv="$DRILL_HOME/conf/distrib-env.sh"
+distribEnv="$DRILL_CONF_DIR/distrib-env.sh"
 if [ -r "$distribEnv" ]; then
   . "$distribEnv"
+else
+  distribEnv="$DRILL_HOME/conf/distrib-env.sh"
+  if [ -r "$distribEnv" ]; then
+    . "$distribEnv"
+  fi
 fi
 
 # Default memory settings if none provided by the environment or


### PR DESCRIPTION
DRILL-4581 provided revisions to the Drill launch scripts. As part of that fix, we introduced a new distrib-env.sh file to hold settings created by custom Drill installers (that is, by custom distributions.) The original version of this feature looks for distrib-env.sh only in $DRILL_HOME/env.

Experience suggests that installers will write site-specific values to distrib-env.sh and so the file must then be copied to $DRILL_SITE when running under YARN. Add $DRILL_SITE to the search path in drill-config.sh for distrib-env.sh.