### PR TITLE
DRILL-4854: Fix logic error in drill-config.sh

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -203,7 +203,7 @@ fi
 if [ -z "$DRILL_LOG_DIR" ]; then
   # Try the optional location
   DRILL_LOG_DIR=/var/log/drill
-  if [[ ! -d "$DRILL_LOG_DIR" && ! -w "$DRILL_LOG_DIR" ]]; then
+  if [[ ! -d "$DRILL_LOG_DIR" || ! -w "$DRILL_LOG_DIR" ]]; then
     # Default to the drill home folder. Create the directory
     # if not present.
 
@@ -215,7 +215,7 @@ fi
 # and be writable.
 
 mkdir -p "$DRILL_LOG_DIR"
-if [[ ! -d "$DRILL_LOG_DIR" && ! -w "$DRILL_LOG_DIR" ]]; then
+if [[ ! -d "$DRILL_LOG_DIR" || ! -w "$DRILL_LOG_DIR" ]]; then
   fatal_error "Log directory does not exist or is not writable: $DRILL_LOG_DIR"
 fi
 


### PR DESCRIPTION
This change should go into 1.8 as it fixes a minor regression introduced during 1.8.

The recent changes to the launch scripts introduced a subtle bug in the logic that verifies the log directory:

    if [[ ! -d "$DRILL_LOG_DIR" && ! -w "$DRILL_LOG_DIR" ]]; then
    ...
    if [[ ! -d "$DRILL_LOG_DIR" && ! -w "$DRILL_LOG_DIR" ]]; then

In both cases, the operator should be or ("||"). That is, if either the item is not a directory, or it is a directory but is not writable, then do the fall-back steps.