### PR TITLE
updated ZooKeeper to CamelCase

### DIFF
--- a/_docs/architecture/010-architecture-introduction.md
+++ b/_docs/architecture/010-architecture-introduction.md
@@ -27,7 +27,7 @@ query execution without moving data over the network or between nodes. Drill
 uses ZooKeeper to maintain cluster membership and health-check information.
 
 Though Drill works in a Hadoop cluster environment, Drill is not tied to
-Hadoop and can run in any distributed cluster environment. The only pre-requisite for Drill is Zookeeper.
+Hadoop and can run in any distributed cluster environment. The only pre-requisite for Drill is ZooKeeper.
 
 See [Drill Query Execution]({{ site.baseurl }}/docs/drill-query-execution/).
 


### PR DESCRIPTION
Minor copy editing change. Apache ZooKeeper uses camel case (https://zookeeper.apache.org/).
