### PR TITLE
DRILL-4874: "No UserGroupInformation while generating ORC splits" - h…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1397,7 +1397,7 @@
       <properties>
         <alt-hadoop>mapr</alt-hadoop>
         <rat.excludeSubprojects>true</rat.excludeSubprojects>
-        <hive.version>1.2.0-mapr-1607</hive.version>
+        <hive.version>1.2.0-mapr-1608</hive.version>
         <hbase.version>1.1.1-mapr-1602-m7-5.1.0</hbase.version>
         <hadoop.version>2.7.0-mapr-1607</hadoop.version>
         <mapr.core.version>5.2.0-mapr</mapr.core.version>


### PR DESCRIPTION
…ive known issue in 1.2.0-mapr-1607 release

- drill is updated to 1.2.0-mapr-1608 hive version.