### PR TITLE
DRILL-4880: Support JDBC driver registration using ServiceLoader

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -387,7 +387,16 @@
                <exclude>**/logback.xml</exclude>
                <exclude>**/LICENSE.txt</exclude>
                <exclude>**/*.java</exclude>
-               <exclude>**/META-INF/**</exclude>
+               <exclude>META-INF/ASL2.0</exclude>
+               <exclude>META-INF/NOTICE.txt</exclude>
+               <exclude>META-INF/drill-module-scan/**</exclude>
+               <exclude>META-INF/jboss-beans.xml</exclude>
+               <exclude>META-INF/license/**</exclude>
+               <exclude>META-INF/maven/**</exclude>
+               <exclude>META-INF/native/**</exclude>
+               <exclude>META-INF/services/com.fasterxml.*</exclude>
+               <exclude>META-INF/services/javax.ws.*</exclude>
+               <exclude>META-INF/**/*.properties</exclude>
                <exclude>**/org.codehaus.commons.compiler.properties</exclude>
                <exclude>**/*.SF</exclude>
                <exclude>**/*.RSA</exclude>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -112,6 +112,7 @@
             <exclude>**/donuts-output-data.txt</exclude>
             <exclude>**/*.tbl</exclude>
             <exclude>**/derby.log</exclude>
+            <exclude>src/main/resources/META-INF/services/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/exec/jdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/exec/jdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+org.apache.drill.jdbc.Driver


### PR DESCRIPTION
Support loading Drill driver using ServiceLoader. From the user perspective,
it means being able to use the driver without registering it first, like by using
Class.forName("org.apache.drill.jdbc.Driver") for example.