### PR TITLE
Improve JDBC Metadata support

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.ops;
 
-import io.netty.buffer.DrillBuf;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -50,6 +48,8 @@ import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.util.Utilities;
 
 import com.google.common.collect.Lists;
+
+import io.netty.buffer.DrillBuf;
 
 // TODO - consider re-name to PlanningContext, as the query execution context actually appears
 // in fragment contexts
@@ -142,6 +142,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    * @param userName User who owns the schema tree.
    * @return Root of the schema tree.
    */
+  @Override
   public SchemaPlus getRootSchema(final String userName) {
     return schemaTreeProvider.createRootSchema(userName, this);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ViewExpansionContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ViewExpansionContext.java
@@ -22,7 +22,10 @@ import static org.apache.drill.exec.ExecConstants.IMPERSONATION_MAX_CHAINED_USER
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptTable.ToRelContext;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.store.SchemaConfig.SchemaConfigInfoProvider;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.google.common.base.Preconditions;
@@ -70,20 +73,25 @@ import com.google.common.base.Preconditions;
 public class ViewExpansionContext {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ViewExpansionContext.class);
 
-  private final QueryContext queryContext;
+  private SchemaConfigInfoProvider schemaConfigInfoProvider;
   private final int maxChainedUserHops;
   private final String queryUser;
   private final ObjectIntHashMap<String> userTokens = new ObjectIntHashMap<>();
+  private final boolean impersonationEnabled;
 
   public ViewExpansionContext(QueryContext queryContext) {
-    this.queryContext = queryContext;
-    this.maxChainedUserHops =
-        queryContext.getConfig().getInt(IMPERSONATION_MAX_CHAINED_USER_HOPS);
-    this.queryUser = queryContext.getQueryUserName();
+    this(queryContext.getConfig(), queryContext);
+  }
+
+  public ViewExpansionContext(DrillConfig config, SchemaConfigInfoProvider schemaConfigInfoProvider) {
+    this.schemaConfigInfoProvider = schemaConfigInfoProvider;
+    this.maxChainedUserHops = config.getInt(IMPERSONATION_MAX_CHAINED_USER_HOPS);
+    this.queryUser = schemaConfigInfoProvider.getQueryUserName();
+    this.impersonationEnabled = config.getBoolean(ExecConstants.IMPERSONATION_ENABLED);
   }
 
   public boolean isImpersonationEnabled() {
-    return queryContext.isImpersonationEnabled();
+    return impersonationEnabled;
   }
 
   /**
@@ -160,7 +168,7 @@ public class ViewExpansionContext {
      */
     public SchemaPlus getSchemaTree() {
       Preconditions.checkState(!released, "Trying to use released token.");
-      return queryContext.getRootSchema(viewOwner);
+      return schemaConfigInfoProvider.getRootSchema(viewOwner);
     }
 
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/SchemaConfig.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.store;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.drill.exec.server.options.OptionValue;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 /**
  * Contains information needed by {@link org.apache.drill.exec.store.AbstractSchema} implementations.
@@ -99,6 +99,10 @@ public class SchemaConfig {
    */
   public interface SchemaConfigInfoProvider {
     ViewExpansionContext getViewExpansionContext();
+
+    SchemaPlus getRootSchema(String userName);
+
+    String getQueryUserName();
 
     OptionValue getOption(String optionKey);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.ErrorHelper;
 import org.apache.drill.exec.ops.ViewExpansionContext;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
@@ -148,6 +149,10 @@ public class MetadataProvider {
      * @return A {@link Response} message. Response must be returned in any case.
      */
     protected abstract Response runInternal(UserSession session, SchemaTreeProvider schemaProvider);
+
+    public DrillConfig getConfig() {
+      return dContext.getConfig();
+    }
   }
 
   /**
@@ -177,7 +182,7 @@ public class MetadataProvider {
 
       try {
         final PojoRecordReader<Catalog> records =
-            getPojoRecordReader(CATALOGS, filter, schemaProvider, session);
+            getPojoRecordReader(CATALOGS, filter, getConfig(), schemaProvider, session);
 
         List<CatalogMetadata> metadata = new ArrayList<>();
         for(Catalog c : records) {
@@ -233,7 +238,7 @@ public class MetadataProvider {
 
       try {
         final PojoRecordReader<Schema> records =
-            getPojoRecordReader(SCHEMATA, filter, schemaProvider, session);
+            getPojoRecordReader(SCHEMATA, filter, getConfig(), schemaProvider, session);
 
         List<SchemaMetadata> metadata = new ArrayList<>();
         for(Schema s : records) {
@@ -293,7 +298,7 @@ public class MetadataProvider {
 
       try {
         final PojoRecordReader<Table> records =
-            getPojoRecordReader(TABLES, filter, schemaProvider, session);
+            getPojoRecordReader(TABLES, filter, getConfig(), schemaProvider, session);
 
         List<TableMetadata> metadata = new ArrayList<>();
         for(Table t : records) {
@@ -354,7 +359,7 @@ public class MetadataProvider {
 
       try {
         final PojoRecordReader<Column> records =
-            getPojoRecordReader(COLUMNS, filter, schemaProvider, session);
+            getPojoRecordReader(COLUMNS, filter, getConfig(), schemaProvider, session);
 
         List<ColumnMetadata> metadata = new ArrayList<>();
         for(Column c : records) {
@@ -380,6 +385,10 @@ public class MetadataProvider {
 
           if (c.CHARACTER_OCTET_LENGTH != null) {
             columnBuilder.setCharOctetLength(c.CHARACTER_OCTET_LENGTH);
+          }
+
+          if (c.NUMERIC_SCALE != null) {
+            columnBuilder.setNumericScale(c.NUMERIC_SCALE);
           }
 
           if (c.NUMERIC_PRECISION != null) {
@@ -527,29 +536,41 @@ public class MetadataProvider {
    * @param userSession
    * @return
    */
-  private static <S> PojoRecordReader<S> getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter,
+  private static <S> PojoRecordReader<S> getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter, final DrillConfig config,
       final SchemaTreeProvider provider, final UserSession userSession) {
     final SchemaPlus rootSchema =
-        provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(userSession));
+        provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(config, userSession, provider));
     return tableType.getRecordReader(rootSchema, filter, userSession.getOptions());
   }
 
   /**
    * Helper method to create a {@link SchemaConfigInfoProvider} instance for metadata purposes.
    * @param session
+   * @param schemaTreeProvider
    * @return
    */
-  private static SchemaConfigInfoProvider newSchemaConfigInfoProvider(final UserSession session) {
+  private static SchemaConfigInfoProvider newSchemaConfigInfoProvider(final DrillConfig config, final UserSession session, final SchemaTreeProvider schemaTreeProvider) {
     return new SchemaConfigInfoProvider() {
+      private final ViewExpansionContext viewExpansionContext = new ViewExpansionContext(config, this);
+
       @Override
       public ViewExpansionContext getViewExpansionContext() {
-        // Metadata APIs don't expect to expand the views.
-        throw new UnsupportedOperationException("View expansion context is not supported");
+        return viewExpansionContext;
+      }
+
+      @Override
+      public SchemaPlus getRootSchema(String userName) {
+        return schemaTreeProvider.createRootSchema(userName, this);
       }
 
       @Override
       public OptionValue getOption(String optionKey) {
         return session.getOptions().getOption(optionKey);
+      }
+
+      @Override
+      public String getQueryUserName() {
+        return session.getCredentials().getUserName();
       }
     };
   }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/AvaticaDrillSqlAccessor.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/AvaticaDrillSqlAccessor.java
@@ -64,11 +64,11 @@ class AvaticaDrillSqlAccessor implements Accessor {
     // so in that case row can be left at -1, so isBeforeFirst() returns true
     // even though we're not longer before the empty set of rows--and it's all
     // private, so we can't get to it to override any of several candidates.
-    if ( cursor.getResultSet().isAfterLast() ) {
+    if ( cursor.isAfterLast() ) {
       throw new InvalidCursorStateSqlException(
           "Result set cursor is already positioned past all rows." );
     }
-    else if ( cursor.getResultSet().isBeforeFirst() ) {
+    else if ( cursor.isBeforeFirst() ) {
       throw new InvalidCursorStateSqlException(
           "Result set cursor is positioned before all rows.  Call next() first." );
     }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillConnectionImpl.java
@@ -25,6 +25,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -43,6 +44,7 @@ import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaFactory;
 import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta.ExecuteResult;
+import org.apache.calcite.avatica.Meta.MetaResultSet;
 import org.apache.calcite.avatica.UnregisteredDriver;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
@@ -157,6 +159,12 @@ class DrillConnectionImpl extends AvaticaConnection
       // toString() since getMessage() text doesn't always mention error:)
       throw new SQLException("Failure in connecting to Drill: " + e, e);
     }
+  }
+
+
+  @Override
+  protected ResultSet createResultSet(MetaResultSet metaResultSet) throws SQLException {
+    return super.createResultSet(metaResultSet);
   }
 
   @Override

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
@@ -24,33 +24,260 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.calcite.avatica.AvaticaResultSet;
+import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.avatica.Meta.Signature;
 import org.apache.calcite.avatica.util.ArrayImpl.Factory;
 import org.apache.calcite.avatica.util.Cursor;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
+import org.apache.drill.exec.proto.UserBitShared.QueryType;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.RecordBatchLoader;
+import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
+import org.apache.drill.exec.rpc.user.UserResultsListener;
 import org.apache.drill.exec.store.ischema.InfoSchemaConstants;
+import org.apache.drill.jdbc.SchemaChangeListener;
 import org.slf4j.Logger;
+
+import com.google.common.collect.Queues;
 
 
 class DrillCursor implements Cursor {
+
+  ////////////////////////////////////////
+  // ResultsListener:
+  static class ResultsListener implements UserResultsListener {
+    private static final org.slf4j.Logger logger =
+        org.slf4j.LoggerFactory.getLogger(ResultsListener.class);
+
+    private static volatile int nextInstanceId = 1;
+
+    /** (Just for logging.) */
+    private final int instanceId;
+
+    private final int batchQueueThrottlingThreshold;
+
+    /** (Just for logging.) */
+    private volatile QueryId queryId;
+
+    /** (Just for logging.) */
+    private int lastReceivedBatchNumber;
+    /** (Just for logging.) */
+    private int lastDequeuedBatchNumber;
+
+    private volatile UserException executionFailureException;
+
+    // TODO:  Revisit "completed".  Determine and document exactly what it
+    // means.  Some uses imply that it means that incoming messages indicate
+    // that the _query_ has _terminated_ (not necessarily _completing_
+    // normally), while some uses imply that it's some other state of the
+    // ResultListener.  Some uses seem redundant.)
+    volatile boolean completed = false;
+
+    /** Whether throttling of incoming data is active. */
+    private final AtomicBoolean throttled = new AtomicBoolean( false );
+    private volatile ConnectionThrottle throttle;
+
+    private volatile boolean closed = false;
+
+    private final CountDownLatch firstMessageReceived = new CountDownLatch(1);
+
+    final LinkedBlockingDeque<QueryDataBatch> batchQueue =
+        Queues.newLinkedBlockingDeque();
+
+
+    /**
+     * ...
+     * @param  batchQueueThrottlingThreshold
+     *         queue size threshold for throttling server
+     */
+    ResultsListener( int batchQueueThrottlingThreshold ) {
+      instanceId = nextInstanceId++;
+      this.batchQueueThrottlingThreshold = batchQueueThrottlingThreshold;
+      logger.debug( "[#{}] Query listener created.", instanceId );
+    }
+
+    /**
+     * Starts throttling if not currently throttling.
+     * @param  throttle  the "throttlable" object to throttle
+     * @return  true if actually started (wasn't throttling already)
+     */
+    private boolean startThrottlingIfNot( ConnectionThrottle throttle ) {
+      final boolean started = throttled.compareAndSet( false, true );
+      if ( started ) {
+        this.throttle = throttle;
+        throttle.setAutoRead(false);
+      }
+      return started;
+    }
+
+    /**
+     * Stops throttling if currently throttling.
+     * @return  true if actually stopped (was throttling)
+     */
+    private boolean stopThrottlingIfSo() {
+      final boolean stopped = throttled.compareAndSet( true, false );
+      if ( stopped ) {
+        throttle.setAutoRead(true);
+        throttle = null;
+      }
+      return stopped;
+    }
+
+    public void awaitFirstMessage() throws InterruptedException {
+      firstMessageReceived.await();
+    }
+
+    private void releaseIfFirst() {
+      firstMessageReceived.countDown();
+    }
+
+    @Override
+    public void queryIdArrived(QueryId queryId) {
+      logger.debug( "[#{}] Received query ID: {}.",
+                    instanceId, QueryIdHelper.getQueryId( queryId ) );
+      this.queryId = queryId;
+    }
+
+    @Override
+    public void submissionFailed(UserException ex) {
+      logger.debug( "Received query failure:", instanceId, ex );
+      this.executionFailureException = ex;
+      completed = true;
+      close();
+      logger.info( "[#{}] Query failed: ", instanceId, ex );
+    }
+
+    @Override
+    public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
+      lastReceivedBatchNumber++;
+      logger.debug( "[#{}] Received query data batch #{}: {}.",
+                    instanceId, lastReceivedBatchNumber, result );
+
+      // If we're in a closed state, just release the message.
+      if (closed) {
+        result.release();
+        // TODO:  Revisit member completed:  Is ResultListener really completed
+        // after only one data batch after being closed?
+        completed = true;
+        return;
+      }
+
+      // We're active; let's add to the queue.
+      batchQueue.add(result);
+
+      // Throttle server if queue size has exceed threshold.
+      if (batchQueue.size() > batchQueueThrottlingThreshold ) {
+        if ( startThrottlingIfNot( throttle ) ) {
+          logger.debug( "[#{}] Throttling started at queue size {}.",
+                        instanceId, batchQueue.size() );
+        }
+      }
+
+      releaseIfFirst();
+    }
+
+    @Override
+    public void queryCompleted(QueryState state) {
+      logger.debug( "[#{}] Received query completion: {}.", instanceId, state );
+      releaseIfFirst();
+      completed = true;
+    }
+
+    QueryId getQueryId() {
+      return queryId;
+    }
+
+
+    /**
+     * Gets the next batch of query results from the queue.
+     * @return  the next batch, or {@code null} after last batch has been returned
+     * @throws UserException
+     *         if the query failed
+     * @throws InterruptedException
+     *         if waiting on the queue was interrupted
+     */
+    QueryDataBatch getNext() throws UserException, InterruptedException {
+      while (true) {
+        if (executionFailureException != null) {
+          logger.debug( "[#{}] Dequeued query failure exception: {}.",
+                        instanceId, executionFailureException );
+          throw executionFailureException;
+        }
+        if (completed && batchQueue.isEmpty()) {
+          return null;
+        } else {
+          QueryDataBatch qdb = batchQueue.poll(50, TimeUnit.MILLISECONDS);
+          if (qdb != null) {
+            lastDequeuedBatchNumber++;
+            logger.debug( "[#{}] Dequeued query data batch #{}: {}.",
+                          instanceId, lastDequeuedBatchNumber, qdb );
+
+            // Unthrottle server if queue size has dropped enough below threshold:
+            if ( batchQueue.size() < batchQueueThrottlingThreshold / 2
+                 || batchQueue.size() == 0  // (in case threshold < 2)
+                 ) {
+              if ( stopThrottlingIfSo() ) {
+                logger.debug( "[#{}] Throttling stopped at queue size {}.",
+                              instanceId, batchQueue.size() );
+              }
+            }
+            return qdb;
+          }
+        }
+      }
+    }
+
+    void close() {
+      logger.debug( "[#{}] Query listener closing.", instanceId );
+      closed = true;
+      if ( stopThrottlingIfSo() ) {
+        logger.debug( "[#{}] Throttling stopped at close() (at queue size {}).",
+                      instanceId, batchQueue.size() );
+      }
+      while (!batchQueue.isEmpty()) {
+        QueryDataBatch qdb = batchQueue.poll();
+        if (qdb != null && qdb.getData() != null) {
+          qdb.getData().release();
+        }
+      }
+      // Close may be called before the first result is received and therefore
+      // when the main thread is blocked waiting for the result.  In that case
+      // we want to unblock the main thread.
+      firstMessageReceived.countDown(); // TODO:  Why not call releaseIfFirst as used elsewhere?
+      completed = true;
+    }
+
+  }
+
   private static final Logger logger = getLogger( DrillCursor.class );
 
   /** JDBC-specified string for unknown catalog, schema, and table names. */
   private static final String UNKNOWN_NAME_STRING = "";
 
-  /** The associated {@link java.sql.ResultSet} implementation. */
-  private final DrillResultSetImpl resultSet;
+  private final DrillConnectionImpl connection;
+  private final AvaticaStatement statement;
+  private final Meta.Signature signature;
 
   /** Holds current batch of records (none before first load). */
   private final RecordBatchLoader currentBatchHolder;
 
-  private final DrillResultSetImpl.ResultsListener resultsListener;
+  private final ResultsListener resultsListener;
+  private SchemaChangeListener changeListener;
 
   private final DrillAccessorList accessors = new DrillAccessorList();
 
@@ -85,6 +312,7 @@ class DrillCursor implements Cursor {
   /** Whether cursor is after the end of the sequence of records/rows. */
   private boolean afterLastRow = false;
 
+  private int currentRowNumber = -1;
   /** Zero-based offset of current record in record batch.
    * (Not <i>row</i> number.) */
   private int currentRecordNumber = -1;
@@ -92,20 +320,40 @@ class DrillCursor implements Cursor {
 
   /**
    *
-   * @param  resultSet  the associated ResultSet implementation
+   * @param statement
+   * @param signature
    */
-  DrillCursor(final DrillResultSetImpl resultSet) {
-    this.resultSet = resultSet;
-    currentBatchHolder = resultSet.batchLoader;
-    resultsListener = resultSet.resultsListener;
-  }
+  DrillCursor(DrillConnectionImpl connection, AvaticaStatement statement, Signature signature) {
+    this.connection = connection;
+    this.statement = statement;
+    this.signature = signature;
 
-  DrillResultSetImpl getResultSet() {
-    return resultSet;
+    DrillClient client = connection.getClient();
+    final int batchQueueThrottlingThreshold =
+        client.getConfig().getInt(
+            ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
+    resultsListener = new ResultsListener(batchQueueThrottlingThreshold);
+    currentBatchHolder = new RecordBatchLoader(client.getAllocator());
   }
 
   protected int getCurrentRecordNumber() {
     return currentRecordNumber;
+  }
+
+  public String getQueryId() {
+    if (resultsListener.getQueryId() != null) {
+      return QueryIdHelper.getQueryId(resultsListener.getQueryId());
+    } else {
+      return null;
+    }
+  }
+
+  public boolean isBeforeFirst() {
+    return currentRowNumber < 0;
+  }
+
+  public boolean isAfterLast() {
+    return afterLastRow;
   }
 
   // (Overly restrictive Avatica uses List<Accessor> instead of List<? extends
@@ -117,6 +365,14 @@ class DrillCursor implements Cursor {
                                         Calendar localCalendar, Factory factory) {
     columnMetaDataList = (DrillColumnMetaDataList) types;
     return accessors;
+  }
+
+  synchronized void cleanup() {
+    if (resultsListener.getQueryId() != null && ! resultsListener.completed) {
+      connection.getClient().cancelQuery(resultsListener.getQueryId());
+    }
+    resultsListener.close();
+    currentBatchHolder.clear();
   }
 
   /**
@@ -144,8 +400,8 @@ class DrillCursor implements Cursor {
         schema,
         getObjectClasses );
 
-    if (getResultSet().changeListener != null) {
-      getResultSet().changeListener.schemaChanged(schema);
+    if (changeListener != null) {
+      changeListener.schemaChanged(schema);
     }
   }
 
@@ -274,6 +530,7 @@ class DrillCursor implements Cursor {
       throw new IllegalStateException(
           "loadInitialSchema() called a second time" );
     }
+
     assert ! afterLastRow : "afterLastRow already true in loadInitialSchema()";
     assert ! afterFirstBatch : "afterLastRow already true in loadInitialSchema()";
     assert -1 == currentRecordNumber
@@ -282,6 +539,26 @@ class DrillCursor implements Cursor {
     assert 0 == currentBatchHolder.getRecordCount()
         : "currentBatchHolder.getRecordCount() not 0 (is "
           + currentBatchHolder.getRecordCount() + " in loadInitialSchema()";
+
+    if (statement instanceof DrillPreparedStatementImpl) {
+      DrillPreparedStatementImpl drillPreparedStatement = (DrillPreparedStatementImpl) statement;
+      connection.getClient().executePreparedStatement(drillPreparedStatement.getPreparedStatementHandle().getServerHandle(), resultsListener);
+    } else {
+      connection.getClient().runQuery(QueryType.SQL, signature.sql, resultsListener);
+    }
+
+    try {
+      resultsListener.awaitFirstMessage();
+    } catch ( InterruptedException e ) {
+      // Preserve evidence that the interruption occurred so that code higher up
+      // on the call stack can learn of the interruption and respond to it if it
+      // wants to.
+      Thread.currentThread().interrupt();
+
+      // Not normally expected--Drill doesn't interrupt in this area (right?)--
+      // but JDBC client certainly could.
+      throw new SQLException("Interrupted", e );
+    }
 
     returnTrueForNextCallToNext = true;
 
@@ -310,26 +587,28 @@ class DrillCursor implements Cursor {
       return false;
     }
     else if ( returnTrueForNextCallToNext ) {
+      ++currentRowNumber;
       // We have a deferred "not after end" to report--reset and report that.
       returnTrueForNextCallToNext = false;
       return true;
     }
     else {
       accessors.clearLastColumnIndexedInRow();
-      return nextRowInternally();
+      boolean res = nextRowInternally();
+      if (res) { ++ currentRowNumber; }
+
+      return res;
     }
+  }
+
+  public void cancel() {
+    close();
   }
 
   @Override
   public void close() {
-    // currentBatchHolder is owned by resultSet and cleaned up by
-    // DrillResultSet.cleanup()
-
-    // listener is owned by resultSet and cleaned up by
-    // DrillResultSet.cleanup()
-
     // Clean up result set (to deallocate any buffers).
-    getResultSet().cleanup();
+    cleanup();
     // TODO:  CHECK:  Something might need to set statement.openResultSet to
     // null.  Also, AvaticaResultSet.close() doesn't check whether already
     // closed and skip calls to cursor.close(), statement.onResultSetClose()

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillMetaImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillMetaImpl.java
@@ -17,17 +17,47 @@
  */
 package org.apache.drill.jdbc.impl;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import javax.validation.constraints.NotNull;
 
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.AvaticaStatement;
+import org.apache.calcite.avatica.AvaticaUtils;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.avatica.ColumnMetaData.StructType;
+import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.MetaImpl;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.common.util.DrillStringUtils;
+import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
+import org.apache.drill.exec.proto.UserProtos.CatalogMetadata;
+import org.apache.drill.exec.proto.UserProtos.ColumnMetadata;
+import org.apache.drill.exec.proto.UserProtos.GetCatalogsResp;
+import org.apache.drill.exec.proto.UserProtos.GetColumnsResp;
+import org.apache.drill.exec.proto.UserProtos.GetSchemasResp;
+import org.apache.drill.exec.proto.UserProtos.GetTablesResp;
+import org.apache.drill.exec.proto.UserProtos.LikeFilter;
+import org.apache.drill.exec.proto.UserProtos.RequestStatus;
+import org.apache.drill.exec.proto.UserProtos.SchemaMetadata;
+import org.apache.drill.exec.proto.UserProtos.TableMetadata;
+import org.apache.drill.exec.rpc.DrillRpcFuture;
+
+import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
 
 
 class DrillMetaImpl extends MetaImpl {
@@ -61,77 +91,271 @@ class DrillMetaImpl extends MetaImpl {
         sql,
         Collections.<AvaticaParameter> emptyList(),
         Collections.<String, Object>emptyMap(),
-        CursorFactory.OBJECT);
+        null // CursorFactory set to null, as SQL requests use DrillCursor
+        );
   }
 
-  private MetaResultSet s(String s) {
-    try {
-      logger.debug("Running {}", s);
 
-      AvaticaStatement statement = connection.createStatement();
-      return MetaResultSet.create(connection.id, statement.getId(), true,
-          newSignature(s), null);
-    } catch (Exception e) {
-      // Wrap in RuntimeException because Avatica's abstract method declarations
-      // didn't allow for SQLException!
-      throw new DrillRuntimeException("Failure while attempting to get DatabaseMetadata.", e);
+  /** Information about type mapping. */
+  private static class TypeInfo {
+    private static Map<Class<?>, TypeInfo> MAPPING = ImmutableMap.<Class<?>, TypeInfo> builder()
+        .put(boolean.class, of(Types.BOOLEAN, "BOOLEAN"))
+        .put(Boolean.class, of(Types.BOOLEAN, "BOOLEAN"))
+        .put(Byte.TYPE, of(Types.TINYINT, "TINYINT"))
+        .put(Byte.class, of(Types.TINYINT, "TINYINT"))
+        .put(Short.TYPE, of(Types.SMALLINT, "SMALLINT"))
+        .put(Short.class, of(Types.SMALLINT, "SMALLINT"))
+        .put(Integer.TYPE, of(Types.INTEGER, "INTEGER"))
+        .put(Integer.class, of(Types.INTEGER, "INTEGER"))
+        .put(Long.TYPE,  of(Types.BIGINT, "BIGINT"))
+        .put(Long.class, of(Types.BIGINT, "BIGINT"))
+        .put(Float.TYPE, of(Types.FLOAT, "FLOAT"))
+        .put(Float.class,  of(Types.FLOAT, "FLOAT"))
+        .put(Double.TYPE,  of(Types.DOUBLE, "DOUBLE"))
+        .put(Double.class, of(Types.DOUBLE, "DOUBLE"))
+        .put(String.class, of(Types.VARCHAR, "CHARACTER VARYING"))
+        .put(java.sql.Date.class, of(Types.DATE, "DATE"))
+        .put(Time.class, of(Types.TIME, "TIME"))
+        .put(Timestamp.class, of(Types.TIMESTAMP, "TIMESTAMP"))
+        .build();
+
+    private final int sqlType;
+    private final String sqlTypeName;
+
+    public TypeInfo(int sqlType, String sqlTypeName) {
+      this.sqlType = sqlType;
+      this.sqlTypeName = sqlTypeName;
+    }
+
+    private static TypeInfo of(int sqlType, String sqlTypeName) {
+      return new TypeInfo(sqlType, sqlTypeName);
+    }
+
+    public static TypeInfo get(Class<?> clazz) {
+      return MAPPING.get(clazz);
     }
   }
 
+  /** Metadata describing a column.
+   * Copied from Avatica with several fixes
+   * */
+  public static class MetaColumn implements Named {
+    public final String tableCat;
+    public final String tableSchem;
+    public final String tableName;
+    public final String columnName;
+    public final int dataType;
+    public final String typeName;
+    public final Integer columnSize;
+    public final Integer bufferLength = null;
+    public final Integer decimalDigits;
+    public final Integer numPrecRadix;
+    public final int nullable;
+    public final String remarks = null;
+    public final String columnDef = null;
+    public final Integer sqlDataType = null;
+    public final Integer sqlDatetimeSub = null;
+    public final Integer charOctetLength;
+    public final int ordinalPosition;
+    @NotNull
+    public final String isNullable;
+    public final String scopeCatalog = null;
+    public final String scopeSchema = null;
+    public final String scopeTable = null;
+    public final Short sourceDataType = null;
+    @NotNull
+    public final String isAutoincrement = "";
+    @NotNull
+    public final String isGeneratedcolumn = "";
+
+    public MetaColumn(
+        String tableCat,
+        String tableSchem,
+        String tableName,
+        String columnName,
+        int dataType,
+        String typeName,
+        Integer columnSize,
+        Integer decimalDigits,
+        Integer numPrecRadix,
+        int nullable,
+        Integer charOctetLength,
+        int ordinalPosition,
+        String isNullable) {
+      this.tableCat = tableCat;
+      this.tableSchem = tableSchem;
+      this.tableName = tableName;
+      this.columnName = columnName;
+      this.dataType = dataType;
+      this.typeName = typeName;
+      this.columnSize = columnSize;
+      this.decimalDigits = decimalDigits;
+      this.numPrecRadix = numPrecRadix;
+      this.nullable = nullable;
+      this.charOctetLength = charOctetLength;
+      this.ordinalPosition = ordinalPosition;
+      this.isNullable = isNullable;
+    }
+
+    @Override
+    public String getName() {
+      return columnName;
+    }
+  }
+
+  private static LikeFilter newLikeFilter(final Pat pattern) {
+    if (pattern == null || pattern.s == null) {
+      return null;
+    }
+
+    return LikeFilter.newBuilder().setPattern(pattern.s).build();
+  }
+
+  /**
+   * Quote the provided string as a LIKE pattern
+   *
+   * @param v the value to quote
+   * @return a LIKE pattern matching exactly v, or {@code null} if v is {@code null}
+   */
+  private static Pat quote(String v) {
+    if (v == null) {
+      return null;
+    }
+
+    StringBuilder sb = new StringBuilder(v.length());
+    for(int index = 0; index<v.length(); index++) {
+      char c = v.charAt(index);
+      switch(c) {
+      case '%':
+      case '_':
+      case '\\':
+        sb.append('\\').append(c);
+        break;
+
+      default:
+        sb.append(c);
+      }
+    }
+
+    return Pat.of(sb.toString());
+  }
+
+  // Overriding fieldMetaData as Calcite version create ColumnMetaData with invalid offset
+  protected static ColumnMetaData.StructType drillFieldMetaData(Class<?> clazz) {
+    final List<ColumnMetaData> list = new ArrayList<>();
+    for (Field field : clazz.getFields()) {
+      if (Modifier.isPublic(field.getModifiers())
+          && !Modifier.isStatic(field.getModifiers())) {
+        NotNull notNull = field.getAnnotation(NotNull.class);
+        boolean notNullable = (notNull != null || field.getType().isPrimitive());
+        list.add(
+            drillColumnMetaData(
+                AvaticaUtils.camelToUpper(field.getName()),
+                list.size(), field.getType(), notNullable));
+      }
+    }
+    return ColumnMetaData.struct(list);
+  }
 
 
-  @Override
-  protected <E> MetaResultSet createEmptyResultSet(Class<E> clazz) {
-    return s(
-        "SELECT '' AS `Interim zero-row result set` "  // dummy row type
-        + "FROM INFORMATION_SCHEMA.CATALOGS "          // any table
-        + "LIMIT 0"                                    // zero rows
-        );
+  protected static ColumnMetaData drillColumnMetaData(String name, int index,
+      Class<?> type, boolean notNullable) {
+    TypeInfo pair = TypeInfo.get(type);
+    ColumnMetaData.Rep rep =
+        ColumnMetaData.Rep.VALUE_MAP.get(type);
+    ColumnMetaData.AvaticaType scalarType =
+        ColumnMetaData.scalar(pair.sqlType, pair.sqlTypeName, rep);
+    return new ColumnMetaData(
+        index, false, true, false, false,
+        notNullable
+            ? DatabaseMetaData.columnNoNulls
+            : DatabaseMetaData.columnNullable,
+        true, -1, name, name, null,
+        0, 0, null, null, scalarType, true, false, false,
+        scalarType.columnClassName());
+  }
+
+  abstract private class MetadataAdapter<CalciteMetaType, Response, ResponseValue> {
+    private final Class<? extends CalciteMetaType> clazz;
+
+    public MetadataAdapter(Class<? extends CalciteMetaType> clazz) {
+      this.clazz = clazz;
+    }
+
+    MetaResultSet getMeta(DrillRpcFuture<Response> future) {
+      final Response response;
+      try {
+        response = future.get();
+      } catch (InterruptedException e) {
+        throw Throwables.propagate(e);
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause();
+        if (cause != null) {
+          throw Throwables.propagate(cause);
+        }
+        throw Throwables.propagate(e);
+      }
+
+      try {
+        List<Object> tables = Lists.transform(getResult(response), new Function<ResponseValue, Object>() {
+          @Override
+          public Object apply(ResponseValue input) {
+            return adapt(input);
+          }
+        });
+
+        Meta.Frame frame = Meta.Frame.create(0, true, tables);
+        StructType fieldMetaData = drillFieldMetaData(clazz);
+        Meta.Signature signature = Meta.Signature.create(
+            fieldMetaData.columns, "",
+            Collections.<AvaticaParameter>emptyList(), CursorFactory.record(clazz));
+
+        AvaticaStatement statement = connection.createStatement();
+        return MetaResultSet.create(connection.id, statement.getId(), true,
+            signature, frame);
+      } catch (Exception e) {
+        // Wrap in RuntimeException because Avatica's abstract method declarations
+        // didn't allow for SQLException!
+        throw new DrillRuntimeException("Failure while attempting to get DatabaseMetadata.", e);
+      }
+    }
+
+    abstract protected RequestStatus getStatus(Response response);
+    abstract protected DrillPBError getError(Response response);
+    abstract protected List<ResponseValue> getResult(Response response);
+    abstract protected CalciteMetaType adapt(ResponseValue protoValue);
   }
 
   @Override
   public MetaResultSet getTables(String catalog, final Pat schemaPattern, final Pat tableNamePattern,
       final List<String> typeList) {
-    StringBuilder sb = new StringBuilder();
-    sb.append("select "
-        + "TABLE_CATALOG as TABLE_CAT, "
-        + "TABLE_SCHEMA as TABLE_SCHEM, "
-        + "TABLE_NAME, "
-        + "TABLE_TYPE, "
-        + "'' as REMARKS, "
-        + "'' as TYPE_CAT, "
-        + "'' as TYPE_SCHEM, "
-        + "'' as TYPE_NAME, "
-        + "'' as SELF_REFERENCING_COL_NAME, "
-        + "'' as REF_GENERATION "
-        + "FROM INFORMATION_SCHEMA.`TABLES` WHERE 1=1 ");
+    // Catalog is not a pattern
+    final LikeFilter catalogNameFilter = newLikeFilter(quote(catalog));
+    final LikeFilter schemaNameFilter = newLikeFilter(schemaPattern);
+    final LikeFilter tableNameFilter = newLikeFilter(tableNamePattern);
 
-    if (catalog != null) {
-      sb.append(" AND TABLE_CATALOG = '" + DrillStringUtils.escapeSql(catalog) + "' ");
-    }
+    return new MetadataAdapter<MetaImpl.MetaTable, GetTablesResp, TableMetadata>(MetaTable.class) {
 
-    if (schemaPattern.s != null) {
-      sb.append(" AND TABLE_SCHEMA like '" + DrillStringUtils.escapeSql(schemaPattern.s) + "'");
-    }
+      @Override
+      protected RequestStatus getStatus(GetTablesResp response) {
+        return response.getStatus();
+      };
 
-    if (tableNamePattern.s != null) {
-      sb.append(" AND TABLE_NAME like '" + DrillStringUtils.escapeSql(tableNamePattern.s) + "'");
-    }
+      @Override
+      protected DrillPBError getError(GetTablesResp response) {
+        return response.getError();
+      };
 
-    if (typeList != null && typeList.size() > 0) {
-      sb.append("AND (");
-      for (int t = 0; t < typeList.size(); t++) {
-        if (t != 0) {
-          sb.append(" OR ");
-        }
-        sb.append(" TABLE_TYPE LIKE '" + DrillStringUtils.escapeSql(typeList.get(t)) + "' ");
+      @Override
+      protected List<TableMetadata> getResult(GetTablesResp response) {
+        return response.getTablesList();
       }
-      sb.append(")");
-    }
 
-    sb.append(" ORDER BY TABLE_TYPE, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME");
-
-    return s(sb.toString());
+      @Override
+      protected MetaImpl.MetaTable adapt(TableMetadata protoValue) {
+        return new MetaImpl.MetaTable(protoValue.getCatalogName(), protoValue.getSchemaName(), protoValue.getTableName(), protoValue.getType());
+      };
+    }.getMeta(connection.getClient().getTables(catalogNameFilter, schemaNameFilter, tableNameFilter, typeList));
   }
 
   /**
@@ -140,109 +364,30 @@ class DrillMetaImpl extends MetaImpl {
   @Override
   public MetaResultSet getColumns(String catalog, Pat schemaPattern,
                               Pat tableNamePattern, Pat columnNamePattern) {
-    StringBuilder sb = new StringBuilder();
-    // TODO:  Resolve the various questions noted below.
-    sb.append(
-        "SELECT "
-        // getColumns   INFORMATION_SCHEMA.COLUMNS        getColumns()
-        // column       source column or                  column name
-        // number       expression
-        // -------      ------------------------          -------------
-        + /*  1 */ "\n  TABLE_CATALOG                 as  TABLE_CAT, "
-        + /*  2 */ "\n  TABLE_SCHEMA                  as  TABLE_SCHEM, "
-        + /*  3 */ "\n  TABLE_NAME                    as  TABLE_NAME, "
-        + /*  4 */ "\n  COLUMN_NAME                   as  COLUMN_NAME, "
+    final LikeFilter catalogNameFilter = newLikeFilter(quote(catalog));
+    final LikeFilter schemaNameFilter = newLikeFilter(schemaPattern);
+    final LikeFilter tableNameFilter = newLikeFilter(tableNamePattern);
+    final LikeFilter columnNameFilter = newLikeFilter(columnNamePattern);
 
-        /*    5                                           DATA_TYPE */
-        // TODO:  Resolve the various questions noted below for DATA_TYPE.
-        + "\n  CASE DATA_TYPE "
-        // (All values in JDBC 4.0/Java 7 java.sql.Types except for types.NULL:)
+    return new MetadataAdapter<MetaColumn, GetColumnsResp, ColumnMetadata>(MetaColumn.class) {
+      @Override
+      protected RequestStatus getStatus(GetColumnsResp response) {
+        return response.getStatus();
+      }
 
-        + "\n    WHEN 'ARRAY'                       THEN " + Types.ARRAY
+      @Override
+      protected DrillPBError getError(GetColumnsResp response) {
+        return response.getError();
+      }
 
-        + "\n    WHEN 'BIGINT'                      THEN " + Types.BIGINT
-        + "\n    WHEN 'BINARY'                      THEN " + Types.BINARY
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'BINARY LARGE OBJECT'         THEN " + Types.BLOB
-        + "\n    WHEN 'BINARY VARYING'              THEN " + Types.VARBINARY
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'BIT'                         THEN " + Types.BIT
-        + "\n    WHEN 'BOOLEAN'                     THEN " + Types.BOOLEAN
+      @Override
+      protected List<ColumnMetadata> getResult(GetColumnsResp response) {
+        return response.getColumnsList();
+      };
 
-        + "\n    WHEN 'CHARACTER'                   THEN " + Types.CHAR
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'CHARACTER LARGE OBJECT'      THEN " + Types.CLOB
-        + "\n    WHEN 'CHARACTER VARYING'           THEN " + Types.VARCHAR
-
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'DATALINK'                    THEN " + Types.DATALINK
-        + "\n    WHEN 'DATE'                        THEN " + Types.DATE
-        + "\n    WHEN 'DECIMAL'                     THEN " + Types.DECIMAL
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'DISTINCT'                    THEN " + Types.DISTINCT
-        + "\n    WHEN 'DOUBLE', 'DOUBLE PRECISION'  THEN " + Types.DOUBLE
-
-        + "\n    WHEN 'FLOAT'                       THEN " + Types.FLOAT
-
-        + "\n    WHEN 'INTEGER'                     THEN " + Types.INTEGER
-        + "\n    WHEN 'INTERVAL'                    THEN " + Types.OTHER
-
-        // Resolve:  Not seen in Drill yet.  Can it ever appear?:
-        + "\n    WHEN 'JAVA_OBJECT'                 THEN " + Types.JAVA_OBJECT
-
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'LONGNVARCHAR'                THEN " + Types.LONGNVARCHAR
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'LONGVARBINARY'               THEN " + Types.LONGVARBINARY
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'LONGVARCHAR'                 THEN " + Types.LONGVARCHAR
-
-        + "\n    WHEN 'MAP'                         THEN " + Types.OTHER
-
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'NATIONAL CHARACTER'          THEN " + Types.NCHAR
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'NATIONAL CHARACTER LARGE OBJECT' "
-        + "\n                                       THEN " + Types.NCLOB
-        // TODO:  Resolve following about NULL (and then update comment and code):
-        // It is not clear whether Types.NULL can represent a type (perhaps the
-        // type of the literal NULL when no further type information is known?) or
-        // whether 'NULL' can appear in INFORMATION_SCHEMA.COLUMNS.DATA_TYPE.
-        // For now, since it shouldn't hurt, include 'NULL'/Types.NULL in mapping.
-        + "\n    WHEN 'NULL'                        THEN " + Types.NULL
-        // (No NUMERIC--Drill seems to map any to DECIMAL currently.)
-        + "\n    WHEN 'NUMERIC'                     THEN " + Types.NUMERIC
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'NATIONAL CHARACTER'          THEN " + Types.NCHAR
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'NATIONAL CHARACTER VARYING'  THEN " + Types.NVARCHAR
-
-        // Resolve:  Unexpectedly, has appeared in Drill.  Should it?
-        + "\n    WHEN 'OTHER'                       THEN " + Types.OTHER
-
-        + "\n    WHEN 'REAL'                        THEN " + Types.REAL
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'REF'                         THEN " + Types.REF
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'ROWID'                       THEN " + Types.ROWID
-
-        + "\n    WHEN 'SMALLINT'                    THEN " + Types.SMALLINT
-        // Resolve:  Not seen in Drill yet.  Can it appear?:
-        + "\n    WHEN 'SQLXML'                      THEN " + Types.SQLXML
-        + "\n    WHEN 'STRUCT'                      THEN " + Types.STRUCT
-
-        + "\n    WHEN 'TIME'                        THEN " + Types.TIME
-        + "\n    WHEN 'TIMESTAMP'                   THEN " + Types.TIMESTAMP
-        + "\n    WHEN 'TINYINT'                     THEN " + Types.TINYINT
-
-        + "\n    ELSE                                    " + Types.OTHER
-        + "\n  END                                    as  DATA_TYPE, "
-
-        + /*  6 */ "\n  DATA_TYPE                     as  TYPE_NAME, "
-
-        /*    7                                           COLUMN_SIZE */
+      private Integer getColumnSize(ColumnMetadata value) {
         /* "... COLUMN_SIZE ....
-         * For numeric data, this is the maximum precision.
+         * For numeric data, this is the maximum precision (in base 10).
          * For character data, this is the length in characters.
          * For datetime datatypes, this is the length in characters of the String
          *   representation (assuming the maximum allowed precision of the
@@ -256,189 +401,384 @@ class DrillMetaImpl extends MetaImpl {
          * that can be counted on, and not the maximum number of (decimal)
          * characters needed to display a value).
          */
-        + "\n  CASE DATA_TYPE "
+        switch(value.getDataType()) {
+        // 1. For numeric data, the maximum precision in base 10:
+        case "TINYINT":
+        case "SMALLINT":
+        case "INTEGER":
+        case "BIGINT":
+        case "DECIMAL":
+        case "NUMERIC":
+        case "REAL":
+        case "FLOAT":
+        case "DOUBLE":
+        case "DOUBLE PRECISION":
+          return value.getNumericPrecision();
 
-        // 1. "For numeric data, ... the maximum precision":
-        + "\n    WHEN 'TINYINT', 'SMALLINT', 'INTEGER', 'BIGINT', "
-        + "\n         'DECIMAL', 'NUMERIC', "
-        + "\n         'REAL', 'FLOAT', 'DOUBLE' "
-        + "\n                         THEN NUMERIC_PRECISION "
+        // 2. For character data, the length in characters
+        case "CHARACTER":
+        case "CHARACTER VARYING":
+          return value.getCharMaxLength();
 
-        // 2. "For character data, ... the length in characters":
-        + "\n    WHEN 'CHARACTER', 'CHARACTER VARYING' "
-        + "\n                         THEN CHARACTER_MAXIMUM_LENGTH "
-
-        // 3. "For datetime datatypes ... length ... String representation
-        //    (assuming the maximum ... precision of ... fractional seconds ...)":
+        // 3. For datetime datatypes ... length ... String representation
+        //    (assuming the maximum ... precision of ... fractional seconds ...)
         // SQL datetime types:
-        + "\n    WHEN 'DATE'          THEN 10 "            // YYYY-MM-DD
-        + "\n    WHEN 'TIME'          THEN "
-        + "\n      CASE "
-        + "\n        WHEN DATETIME_PRECISION > 0 "         // HH:MM:SS.sss
-        + "\n                         THEN          8 + 1 + DATETIME_PRECISION"
-        + "\n        ELSE                           8"     // HH:MM:SS
-        + "\n      END "
-        + "\n    WHEN 'TIMESTAMP'     THEN "
-        + "\n      CASE "                                  // date + "T" + time
-        + "\n        WHEN DATETIME_PRECISION > 0 "
-        + "                           THEN 10 + 1 + 8 + 1 + DATETIME_PRECISION"
-        + "\n        ELSE                  10 + 1 + 8"
-        + "\n      END "
+        case "DATE":
+          return 10; // YYYY-MM-DD
+        case "TIME":
+          if (value.getDateTimePrecision() > 0) {
+            return 8 + 1 + value.getDateTimePrecision(); // HH:MM:SS.sss
+          } else {
+            return 8; // HH:MM:SS
+          }
+
+        case "TIMESTAMP":
+          if (value.getDateTimePrecision() > 0) {
+            return 10 + 1 + 8 + 1 + value.getDateTimePrecision(); // date + "T" + time
+          } else {
+            return 10 + 1 + 8;
+          }
         // SQL interval types:
         // Note:  Not addressed by JDBC 4.1; providing length of current string
         // representation (not length of, say, interval literal).
-        + "\n    WHEN 'INTERVAL'      THEN "
-        + "\n      INTERVAL_PRECISION "
-        + "\n      + "
-        + "\n      CASE INTERVAL_TYPE "
-        // a. Single field, not SECOND:
-        + "\n        WHEN 'YEAR', 'MONTH', 'DAY' THEN 2 "  // like P...Y
-        + "\n        WHEN 'HOUR', 'MINUTE'       THEN 3 "  // like PT...M
-        // b. Two adjacent fields, no SECOND:
-        + "\n        WHEN 'YEAR TO MONTH'        THEN 5 "  // P...Y12M
-        + "\n        WHEN 'DAY TO HOUR'          THEN 6 "  // P...DT12H
-        + "\n        WHEN 'HOUR TO MINUTE'       THEN 6 "  // PT...H12M
-        // c. Three contiguous fields, no SECOND:
-        + "\n        WHEN 'DAY TO MINUTE'        THEN 9 "  // P...DT12H12M
-        // d. With SECOND field:
-        + "\n        ELSE "
-        + "\n          CASE INTERVAL_TYPE "
-        + "\n            WHEN 'DAY TO SECOND'    THEN 12 " // P...DT12H12M12...S
-        + "\n            WHEN 'HOUR TO SECOND'   THEN  9 " // PT...H12M12...S
-        + "\n            WHEN 'MINUTE TO SECOND' THEN  6 " // PT...M12...S
-        + "\n            WHEN 'SECOND'           THEN  3 " // PT......S
-        + "\n            ELSE "                  // Make net result be -1:
-        // WORKAROUND:  This "0" is to work around Drill's failure to support
-        // unary minus syntax (negation):
-        + "\n                                    0-INTERVAL_PRECISION - 1 "
-        + "\n          END "
-        + "\n          + "
-        + "\n          DATETIME_PRECISION"
-        + "\n          + "
-        + "\n          CASE " // If frac. digits, also add 1 for decimal point.
-        + "\n            WHEN DATETIME_PRECISION > 0 THEN 1"
-        + "\n            ELSE                             0 "
-        + "\n          END"
-        // - For INTERVAL ... TO SECOND(0): "P...DT12H12M12S"
-        + "\n      END "
+        case "INTERVAL":
+          int intervalPrecision = value.getIntervalPrecision();
+          int extraSecondIntervalSize = value.getDateTimePrecision();
+          if (extraSecondIntervalSize > 0) {
+            // If frac. digits, also add 1 for decimal point.
+            extraSecondIntervalSize++;
+          }
+
+          switch(value.getIntervalType()) {
+          // a. Single field, not SECOND:
+          case "YEAR":
+          case "MONTH":
+          case "DAY":
+            return intervalPrecision + 2; // P...Y
+          case "HOUR":
+          case "MINUTE":
+            return intervalPrecision + 3; // PT...M
+
+          // b. Two adjacent fields, no SECOND:
+          case "YEAR TO MONTH":
+            return intervalPrecision + 5; // P..Y12M
+          case "DAY TO HOUR":
+            return intervalPrecision + 6; // P...DT12H
+          case "HOUR TO MINUTE":
+            return intervalPrecision + 6; // PT..H12M
+          // c. Three contiguous fields, no SECOND:
+          case "DAY TO MINUTE":
+            return intervalPrecision + 9; // P...DT12H12M
+
+          // d. With SECOND field:
+          // - For INTERVAL ... TO SECOND(0): "P...DT12H12M12S"
+          case "DAY TO SECOND":
+            return intervalPrecision + extraSecondIntervalSize + 12; // P...DT12H12M12...S
+          case "HOUR TO SECOND":
+            return intervalPrecision + extraSecondIntervalSize + 9; // PT...H12M12...S
+          case "MINUTE TO SECOND":
+            return intervalPrecision + extraSecondIntervalSize + 6; // PT...M12...S
+          case "SECOND":
+            return intervalPrecision + extraSecondIntervalSize + 3; // PT......S
+          default:
+            return -1; // Make net result be -1:
+          }
 
         // 4. "For binary data, ... the length in bytes":
-        + "\n    WHEN 'BINARY', 'BINARY VARYING' "
-        + "\n                         THEN CHARACTER_MAXIMUM_LENGTH "
+        case "BINARY":
+        case "BINARY VARYING":
+          return value.getCharMaxLength();
 
         // 5. "For ... ROWID datatype...": Not in Drill?
+        // 6. "unknown ... for data types [for which] ... not applicable.":
+        default:
+          return null;
+        }
+      }
 
-        // 6. "Null ... for data types [for which] ... not applicable.":
-        + "\n    ELSE                      NULL "
-        + "\n  END                                    as  COLUMN_SIZE, "
+      private int getDataType(ColumnMetadata value) {
+        switch (value.getDataType()) {
+        case "ARRAY":
+          return Types.ARRAY;
 
-        + /*  8 */ "\n  CHARACTER_MAXIMUM_LENGTH      as  BUFFER_LENGTH, "
+        case "BIGINT":
+          return Types.BIGINT;
+        case "BINARY":
+          return Types.BINARY;
+        case "BINARY LARGE OBJECT":
+          return Types.BLOB;
+        case "BINARY VARYING":
+          return Types.VARBINARY;
+        case "BIT":
+          return Types.BIT;
+        case "BOOLEAN":
+          return Types.BOOLEAN;
+        case "CHARACTER":
+          return Types.CHAR;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "CHARACTER LARGE OBJECT":
+          return Types.CLOB;
+        case "CHARACTER VARYING":
+          return Types.VARCHAR;
 
-        /*    9                                           DECIMAL_DIGITS */
-        + "\n  CASE  DATA_TYPE"
-        + "\n    WHEN 'TINYINT', 'SMALLINT', 'INTEGER', 'BIGINT', "
-        + "\n         'DECIMAL', 'NUMERIC'        THEN NUMERIC_SCALE "
-        + "\n    WHEN 'REAL'                      THEN " + DECIMAL_DIGITS_REAL
-        + "\n    WHEN 'FLOAT'                     THEN " + DECIMAL_DIGITS_FLOAT
-        + "\n    WHEN 'DOUBLE'                    THEN " + DECIMAL_DIGITS_DOUBLE
-        + "\n    WHEN 'DATE', 'TIME', 'TIMESTAMP' THEN DATETIME_PRECISION "
-        + "\n    WHEN 'INTERVAL'                  THEN DATETIME_PRECISION "
-        + "\n  END                                    as  DECIMAL_DIGITS, "
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "DATALINK":
+          return Types.DATALINK;
+        case "DATE":
+          return Types.DATE;
+        case "DECIMAL":
+          return Types.DECIMAL;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "DISTINCT":
+          return Types.DISTINCT;
+        case "DOUBLE":
+        case "DOUBLE PRECISION":
+          return Types.DOUBLE;
 
-        /*   10                                           NUM_PREC_RADIX */
-        + "\n  CASE DATA_TYPE "
-        + "\n    WHEN 'TINYINT', 'SMALLINT', 'INTEGER', 'BIGINT', "
-        + "\n         'DECIMAL', 'NUMERIC', "
-        + "\n         'REAL', 'FLOAT', 'DOUBLE'   THEN NUMERIC_PRECISION_RADIX "
-        // (NUMERIC_PRECISION_RADIX is NULL for these:)
-        + "\n    WHEN 'INTERVAL'                  THEN " + RADIX_INTERVAL
-        + "\n    WHEN 'DATE', 'TIME', 'TIMESTAMP' THEN " + RADIX_DATETIME
-        + "\n    ELSE                                  NULL"
-        + "\n  END                                    as  NUM_PREC_RADIX, "
+        case "FLOAT":
+          return Types.FLOAT;
 
-        /*   11                                           NULLABLE */
-        + "\n  CASE IS_NULLABLE "
-        + "\n    WHEN 'YES'      THEN " + DatabaseMetaData.columnNullable
-        + "\n    WHEN 'NO'       THEN " + DatabaseMetaData.columnNoNulls
-        + "\n    WHEN ''         THEN " + DatabaseMetaData.columnNullableUnknown
-        + "\n    ELSE                 -1"
-        + "\n  END                                    as  NULLABLE, "
+        case "INTEGER":
+          return Types.INTEGER;
+        case "INTERVAL":
+          return Types.OTHER;
 
-        + /* 12 */ "\n  CAST( NULL as VARCHAR )       as  REMARKS, "
-        + /* 13 */ "\n  COLUMN_DEFAULT                as  COLUMN_DEF, "
-        + /* 14 */ "\n  0                             as  SQL_DATA_TYPE, "
-        + /* 15 */ "\n  0                             as  SQL_DATETIME_SUB, "
+        // Resolve: Not seen in Drill yet. Can it ever appear?:
+        case "JAVA_OBJECT":
+          return Types.JAVA_OBJECT;
 
-        /*   16                                           CHAR_OCTET_LENGTH */
-        + "\n  CASE DATA_TYPE"
-        + "\n    WHEN 'CHARACTER', "
-        + "\n         'CHARACTER VARYING', "
-        + "\n         'NATIONAL CHARACTER', "
-        + "\n         'NATIONAL CHARACTER VARYING' "
-        + "\n                                 THEN CHARACTER_OCTET_LENGTH "
-        + "\n    ELSE                              NULL "
-        + "\n  END                                    as  CHAR_OCTET_LENGTH, "
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "LONGNVARCHAR":
+          return Types.LONGNVARCHAR;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "LONGVARBINARY":
+          return Types.LONGVARBINARY;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "LONGVARCHAR":
+          return Types.LONGVARCHAR;
 
-        + /* 17 */ "\n  ORDINAL_POSITION              as  ORDINAL_POSITION, "
-        + /* 18 */ "\n  IS_NULLABLE                   as  IS_NULLABLE, "
-        + /* 19 */ "\n  CAST( NULL as VARCHAR )       as  SCOPE_CATALOG, "
-        + /* 20 */ "\n  CAST( NULL as VARCHAR )       as  SCOPE_SCHEMA, "
-        + /* 21 */ "\n  CAST( NULL as VARCHAR )       as  SCOPE_TABLE, "
-        // TODO:  Change to SMALLINT when it's implemented (DRILL-2470):
-        + /* 22 */ "\n  CAST( NULL as INTEGER )       as  SOURCE_DATA_TYPE, "
-        + /* 23 */ "\n  ''                            as  IS_AUTOINCREMENT, "
-        + /* 24 */ "\n  ''                            as  IS_GENERATEDCOLUMN "
+        case "MAP":
+          return Types.OTHER;
 
-        + "\n  FROM INFORMATION_SCHEMA.COLUMNS "
-        + "\n  WHERE 1=1 ");
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "NATIONAL CHARACTER":
+          return Types.NCHAR;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "NATIONAL CHARACTER LARGE OBJECT":
+          return Types.NCLOB;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "NATIONAL CHARACTER VARYING":
+          return Types.NVARCHAR;
 
-    if (catalog != null) {
-      sb.append("\n  AND TABLE_CATALOG = '" + DrillStringUtils.escapeSql(catalog) + "'");
-    }
-    if (schemaPattern.s != null) {
-      sb.append("\n  AND TABLE_SCHEMA like '" + DrillStringUtils.escapeSql(schemaPattern.s) + "'");
-    }
-    if (tableNamePattern.s != null) {
-      sb.append("\n  AND TABLE_NAME like '" + DrillStringUtils.escapeSql(tableNamePattern.s) + "'");
-    }
-    if (columnNamePattern.s != null) {
-      sb.append("\n  AND COLUMN_NAME like '" + DrillStringUtils.escapeSql(columnNamePattern.s) + "'");
-    }
+        // TODO: Resolve following about NULL (and then update comment and
+        // code):
+        // It is not clear whether Types.NULL can represent a type (perhaps the
+        // type of the literal NULL when no further type information is known?)
+        // or
+        // whether 'NULL' can appear in INFORMATION_SCHEMA.COLUMNS.DATA_TYPE.
+        // For now, since it shouldn't hurt, include 'NULL'/Types.NULL in
+        // mapping.
+        case "NULL":
+          return Types.NULL;
+        // (No NUMERIC--Drill seems to map any to DECIMAL currently.)
+        case "NUMERIC":
+          return Types.NUMERIC;
 
-    sb.append("\n ORDER BY TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME");
+        // Resolve: Unexpectedly, has appeared in Drill. Should it?
+        case "OTHER":
+          return Types.OTHER;
 
-    return s(sb.toString());
+        case "REAL":
+          return Types.REAL;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "REF":
+          return Types.REF;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "ROWID":
+          return Types.ROWID;
+
+        case "SMALLINT":
+          return Types.SMALLINT;
+        // Resolve: Not seen in Drill yet. Can it appear?:
+        case "SQLXML":
+          return Types.SQLXML;
+        case "STRUCT":
+          return Types.STRUCT;
+
+        case "TIME":
+          return Types.TIME;
+        case "TIMESTAMP":
+          return Types.TIMESTAMP;
+        case "TINYINT":
+          return Types.TINYINT;
+
+        default:
+          return Types.OTHER;
+        }
+      }
+
+      Integer getDecimalDigits(ColumnMetadata value) {
+        switch(value.getDataType()) {
+        case "TINYINT":
+        case "SMALLINT":
+        case "INTEGER":
+        case "BIGINT":
+        case "DECIMAL":
+        case "NUMERIC":
+          return value.hasNumericScale() ? value.getNumericScale() : null;
+
+        case "REAL":
+          return DECIMAL_DIGITS_REAL;
+
+        case "FLOAT":
+          return DECIMAL_DIGITS_FLOAT;
+
+        case "DOUBLE":
+          return DECIMAL_DIGITS_DOUBLE;
+
+        case "DATE":
+        case "TIME":
+        case "TIMESTAMP":
+        case "INTERVAL":
+          return value.getDateTimePrecision();
+
+        default:
+          return null;
+        }
+      }
+
+      private Integer getNumPrecRadix(ColumnMetadata value) {
+        switch(value.getDataType()) {
+        case "TINYINT":
+        case "SMALLINT":
+        case "INTEGER":
+        case "BIGINT":
+        case "DECIMAL":
+        case "NUMERIC":
+        case "REAL":
+        case "FLOAT":
+        case "DOUBLE":
+          return value.getNumericPrecisionRadix();
+
+        case "INTERVAL":
+          return RADIX_INTERVAL;
+
+        case "DATE":
+        case "TIME":
+        case "TIMESTAMP":
+          return RADIX_DATETIME;
+
+        default:
+          return null;
+        }
+      }
+
+      private int getNullable(ColumnMetadata value) {
+        if (!value.hasIsNullable()) {
+          return DatabaseMetaData.columnNullableUnknown;
+        }
+        return  value.getIsNullable() ? DatabaseMetaData.columnNullable : DatabaseMetaData.columnNoNulls;
+      }
+
+      private String getIsNullable(ColumnMetadata value) {
+        if (!value.hasIsNullable()) {
+          return "";
+        }
+        return  value.getIsNullable() ? "YES" : "NO";
+      }
+
+      private Integer getCharOctetLength(ColumnMetadata value) {
+        if (!value.hasCharMaxLength()) {
+          return null;
+        }
+
+        switch(value.getDataType()) {
+        case "CHARACTER":
+        case "CHARACTER LARGE OBJECT":
+        case "CHARACTER VARYING":
+        case "LONGVARCHAR":
+        case "LONGNVARCHAR":
+        case "NATIONAL CHARACTER":
+        case "NATIONAL CHARACTER LARGE OBJECT":
+        case "NATIONAL CHARACTER VARYING":
+          return value.getCharOctetLength();
+
+        default:
+          return null;
+        }
+      }
+
+      @Override
+      protected MetaColumn adapt(ColumnMetadata value) {
+        return new MetaColumn(
+            value.getCatalogName(),
+            value.getSchemaName(),
+            value.getTableName(),
+            value.getColumnName(),
+            getDataType(value), // It might require the full SQL type
+            value.getDataType(),
+            getColumnSize(value),
+            getDecimalDigits(value),
+            getNumPrecRadix(value),
+            getNullable(value),
+            getCharOctetLength(value),
+            value.getOrdinalPosition(),
+            getIsNullable(value));
+      }
+    }.getMeta(connection.getClient().getColumns(catalogNameFilter, schemaNameFilter, tableNameFilter, columnNameFilter));
   }
 
   @Override
   public MetaResultSet getSchemas(String catalog, Pat schemaPattern) {
-    StringBuilder sb = new StringBuilder();
-    sb.append("select "
-        + "SCHEMA_NAME as TABLE_SCHEM, "
-        + "CATALOG_NAME as TABLE_CAT "
-        + " FROM INFORMATION_SCHEMA.SCHEMATA WHERE 1=1 ");
+    final LikeFilter catalogNameFilter = newLikeFilter(quote(catalog));
+    final LikeFilter schemaNameFilter = newLikeFilter(schemaPattern);
 
-    if (catalog != null) {
-      sb.append(" AND CATALOG_NAME = '" + DrillStringUtils.escapeSql(catalog) + "' ");
-    }
-    if (schemaPattern.s != null) {
-      sb.append(" AND SCHEMA_NAME like '" + DrillStringUtils.escapeSql(schemaPattern.s) + "'");
-    }
-    sb.append(" ORDER BY CATALOG_NAME, SCHEMA_NAME");
+    return new MetadataAdapter<MetaImpl.MetaSchema, GetSchemasResp, SchemaMetadata>(MetaImpl.MetaSchema.class) {
+      @Override
+      protected RequestStatus getStatus(GetSchemasResp response) {
+        return response.getStatus();
+      }
 
-    return s(sb.toString());
+      @Override
+      protected List<SchemaMetadata> getResult(GetSchemasResp response) {
+        return response.getSchemasList();
+      }
+
+      @Override
+      protected DrillPBError getError(GetSchemasResp response) {
+        return response.getError();
+      }
+
+      @Override
+      protected MetaSchema adapt(SchemaMetadata value) {
+        return new MetaImpl.MetaSchema(value.getCatalogName(), value.getSchemaName());
+      }
+    }.getMeta(connection.getClient().getSchemas(catalogNameFilter, schemaNameFilter));
   }
 
   @Override
   public MetaResultSet getCatalogs() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("select "
-        + "CATALOG_NAME as TABLE_CAT "
-        + " FROM INFORMATION_SCHEMA.CATALOGS ");
+    return new MetadataAdapter<MetaImpl.MetaCatalog, GetCatalogsResp, CatalogMetadata>(MetaImpl.MetaCatalog.class) {
+      @Override
+      protected RequestStatus getStatus(GetCatalogsResp response) {
+        return response.getStatus();
+      }
 
-    sb.append(" ORDER BY CATALOG_NAME");
+      @Override
+      protected List<CatalogMetadata> getResult(GetCatalogsResp response) {
+        return response.getCatalogsList();
+      }
 
-    return s(sb.toString());
+      @Override
+      protected DrillPBError getError(GetCatalogsResp response) {
+        return response.getError();
+      }
+
+      @Override
+      protected MetaImpl.MetaCatalog adapt(CatalogMetadata protoValue) {
+        return new MetaImpl.MetaCatalog(protoValue.getCatalogName());
+      }
+    }.getMeta(connection.getClient().getCatalogs(null));
   }
 
 

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillResultSetImpl.java
@@ -37,13 +37,11 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.calcite.avatica.AvaticaResultSet;
 import org.apache.calcite.avatica.AvaticaSite;
@@ -51,23 +49,10 @@ import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.util.Cursor;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.client.DrillClient;
-import org.apache.drill.exec.proto.UserBitShared.QueryId;
-import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
-import org.apache.drill.exec.proto.UserBitShared.QueryType;
-import org.apache.drill.exec.proto.helper.QueryIdHelper;
-import org.apache.drill.exec.record.RecordBatchLoader;
-import org.apache.drill.exec.rpc.ConnectionThrottle;
-import org.apache.drill.exec.rpc.user.QueryDataBatch;
-import org.apache.drill.exec.rpc.user.UserResultsListener;
+import org.apache.calcite.avatica.util.Cursor.Accessor;
 import org.apache.drill.jdbc.AlreadyClosedSqlException;
 import org.apache.drill.jdbc.DrillResultSet;
 import org.apache.drill.jdbc.ExecutionCanceledSqlException;
-import org.apache.drill.jdbc.SchemaChangeListener;
-
-import com.google.common.collect.Queues;
 
 
 /**
@@ -79,29 +64,13 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
       org.slf4j.LoggerFactory.getLogger(DrillResultSetImpl.class);
 
   private final DrillConnectionImpl connection;
-
-  SchemaChangeListener changeListener;
-  final ResultsListener resultsListener;
-  private final DrillClient client;
-  // TODO:  Resolve:  Since is barely manipulated here in DrillResultSetImpl,
-  //  move down into DrillCursor and have this.clean() have cursor clean it.
-  final RecordBatchLoader batchLoader;
-  final DrillCursor cursor;
-  boolean hasPendingCancelationNotification;
-
+  private volatile boolean hasPendingCancelationNotification = false;
 
   DrillResultSetImpl(AvaticaStatement statement, Meta.Signature signature,
                      ResultSetMetaData resultSetMetaData, TimeZone timeZone,
                      Meta.Frame firstFrame) {
     super(statement, signature, resultSetMetaData, timeZone, firstFrame);
     connection = (DrillConnectionImpl) statement.getConnection();
-    client = connection.getClient();
-    final int batchQueueThrottlingThreshold =
-        client.getConfig().getInt(
-            ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
-    resultsListener = new ResultsListener(batchQueueThrottlingThreshold);
-    batchLoader = new RecordBatchLoader(client.getAllocator());
-    cursor = new DrillCursor(this);
   }
 
   /**
@@ -118,7 +87,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
                                       ExecutionCanceledSqlException,
                                       SQLException {
     if ( isClosed() ) {
-      if ( hasPendingCancelationNotification ) {
+      if (cursor instanceof DrillCursor && hasPendingCancelationNotification) {
         hasPendingCancelationNotification = false;
         throw new ExecutionCanceledSqlException(
             "SQL statement execution canceled; ResultSet now closed." );
@@ -139,17 +108,12 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
 
   @Override
   protected void cancel() {
-    hasPendingCancelationNotification = true;
-    cleanup();
-    close();
-  }
-
-  synchronized void cleanup() {
-    if (resultsListener.getQueryId() != null && ! resultsListener.completed) {
-      client.cancelQuery(resultsListener.getQueryId());
+    if (cursor instanceof DrillCursor) {
+      hasPendingCancelationNotification = true;
+      ((DrillCursor) cursor).cancel();
+    } else {
+      super.cancel();
     }
-    resultsListener.close();
-    batchLoader.clear();
   }
 
   ////////////////////////////////////////
@@ -172,7 +136,7 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
     // cancellation) which in turn sets the cursor to null.  So we must check
     // before we call next.
     // TODO: handle next() after close is called in the Avatica code.
-    if (super.cursor != null) {
+    if (cursor != null) {
       return super.next();
     } else {
       return false;
@@ -1900,11 +1864,10 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
   @Override
   public String getQueryId() throws SQLException {
     throwIfClosed();
-    if (resultsListener.getQueryId() != null) {
-      return QueryIdHelper.getQueryId(resultsListener.getQueryId());
-    } else {
-      return null;
+    if (cursor instanceof DrillCursor) {
+      return ((DrillCursor) cursor).getQueryId();
     }
+    return null;
   }
 
 
@@ -1912,249 +1875,26 @@ class DrillResultSetImpl extends AvaticaResultSet implements DrillResultSet {
 
   @Override
   protected DrillResultSetImpl execute() throws SQLException{
-    if (statement instanceof DrillPreparedStatementImpl) {
-      DrillPreparedStatementImpl drillPreparedStatement = (DrillPreparedStatementImpl) statement;
-      client.executePreparedStatement(drillPreparedStatement.getPreparedStatementHandle().getServerHandle(), resultsListener);
-    } else {
-      client.runQuery(QueryType.SQL, this.signature.sql, resultsListener);
-    }
     connection.getDriver().handler.onStatementExecute(statement, null);
 
-    super.execute2(cursor, this.signature.columns);
-
-    // don't return with metadata until we've achieved at least one return message.
-    try {
-      // TODO:  Revisit:  Why reaching directly into ResultsListener rather than
-      // calling some wait method?
-      resultsListener.latch.await();
-    } catch ( InterruptedException e ) {
-      // Preserve evidence that the interruption occurred so that code higher up
-      // on the call stack can learn of the interruption and respond to it if it
-      // wants to.
-      Thread.currentThread().interrupt();
-
-      // Not normally expected--Drill doesn't interrupt in this area (right?)--
-      // but JDBC client certainly could.
-      throw new SQLException( "Interrupted", e );
+    if (signature.cursorFactory != null) {
+      // Avatica accessors have to be wrapped to match Drill behaviour regarding exception thrown
+      super.execute();
+      List<Accessor> wrappedAccessorList = new ArrayList<>(accessorList.size());
+      for(Accessor accessor: accessorList) {
+        wrappedAccessorList.add(new WrappedAccessor(accessor));
+      }
+      this.accessorList = wrappedAccessorList;
     }
+    else {
+      DrillCursor drillCursor = new DrillCursor(connection, statement, signature);
+      super.execute2(drillCursor, this.signature.columns);
 
-    // Read first (schema-only) batch to initialize result-set metadata from
-    // (initial) schema before Statement.execute...(...) returns result set:
-    cursor.loadInitialSchema();
+      // Read first (schema-only) batch to initialize result-set metadata from
+      // (initial) schema before Statement.execute...(...) returns result set:
+      drillCursor.loadInitialSchema();
+    }
 
     return this;
   }
-
-
-  ////////////////////////////////////////
-  // ResultsListener:
-
-  static class ResultsListener implements UserResultsListener {
-    private static final org.slf4j.Logger logger =
-        org.slf4j.LoggerFactory.getLogger(ResultsListener.class);
-
-    private static volatile int nextInstanceId = 1;
-
-    /** (Just for logging.) */
-    private final int instanceId;
-
-    private final int batchQueueThrottlingThreshold;
-
-    /** (Just for logging.) */
-    private volatile QueryId queryId;
-
-    /** (Just for logging.) */
-    private int lastReceivedBatchNumber;
-    /** (Just for logging.) */
-    private int lastDequeuedBatchNumber;
-
-    private volatile UserException executionFailureException;
-
-    // TODO:  Revisit "completed".  Determine and document exactly what it
-    // means.  Some uses imply that it means that incoming messages indicate
-    // that the _query_ has _terminated_ (not necessarily _completing_
-    // normally), while some uses imply that it's some other state of the
-    // ResultListener.  Some uses seem redundant.)
-    volatile boolean completed = false;
-
-    /** Whether throttling of incoming data is active. */
-    private final AtomicBoolean throttled = new AtomicBoolean( false );
-    private volatile ConnectionThrottle throttle;
-
-    private volatile boolean closed = false;
-    // TODO:  Rename.  It's obvious it's a latch--but what condition or action
-    // does it represent or control?
-    private CountDownLatch latch = new CountDownLatch(1);
-    private AtomicBoolean receivedMessage = new AtomicBoolean(false);
-
-    final LinkedBlockingDeque<QueryDataBatch> batchQueue =
-        Queues.newLinkedBlockingDeque();
-
-
-    /**
-     * ...
-     * @param  batchQueueThrottlingThreshold
-     *         queue size threshold for throttling server
-     */
-    ResultsListener( int batchQueueThrottlingThreshold ) {
-      instanceId = nextInstanceId++;
-      this.batchQueueThrottlingThreshold = batchQueueThrottlingThreshold;
-      logger.debug( "[#{}] Query listener created.", instanceId );
-    }
-
-    /**
-     * Starts throttling if not currently throttling.
-     * @param  throttle  the "throttlable" object to throttle
-     * @return  true if actually started (wasn't throttling already)
-     */
-    private boolean startThrottlingIfNot( ConnectionThrottle throttle ) {
-      final boolean started = throttled.compareAndSet( false, true );
-      if ( started ) {
-        this.throttle = throttle;
-        throttle.setAutoRead(false);
-      }
-      return started;
-    }
-
-    /**
-     * Stops throttling if currently throttling.
-     * @return  true if actually stopped (was throttling)
-     */
-    private boolean stopThrottlingIfSo() {
-      final boolean stopped = throttled.compareAndSet( true, false );
-      if ( stopped ) {
-        throttle.setAutoRead(true);
-        throttle = null;
-      }
-      return stopped;
-    }
-
-    // TODO:  Doc.:  Release what if what is first relative to what?
-    private boolean releaseIfFirst() {
-      if (receivedMessage.compareAndSet(false, true)) {
-        latch.countDown();
-        return true;
-      }
-
-      return false;
-    }
-
-    @Override
-    public void queryIdArrived(QueryId queryId) {
-      logger.debug( "[#{}] Received query ID: {}.",
-                    instanceId, QueryIdHelper.getQueryId( queryId ) );
-      this.queryId = queryId;
-    }
-
-    @Override
-    public void submissionFailed(UserException ex) {
-      logger.debug( "Received query failure:", instanceId, ex );
-      this.executionFailureException = ex;
-      completed = true;
-      close();
-      logger.info( "[#{}] Query failed: ", instanceId, ex );
-    }
-
-    @Override
-    public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
-      lastReceivedBatchNumber++;
-      logger.debug( "[#{}] Received query data batch #{}: {}.",
-                    instanceId, lastReceivedBatchNumber, result );
-
-      // If we're in a closed state, just release the message.
-      if (closed) {
-        result.release();
-        // TODO:  Revisit member completed:  Is ResultListener really completed
-        // after only one data batch after being closed?
-        completed = true;
-        return;
-      }
-
-      // We're active; let's add to the queue.
-      batchQueue.add(result);
-
-      // Throttle server if queue size has exceed threshold.
-      if (batchQueue.size() > batchQueueThrottlingThreshold ) {
-        if ( startThrottlingIfNot( throttle ) ) {
-          logger.debug( "[#{}] Throttling started at queue size {}.",
-                        instanceId, batchQueue.size() );
-        }
-      }
-
-      releaseIfFirst();
-    }
-
-    @Override
-    public void queryCompleted(QueryState state) {
-      logger.debug( "[#{}] Received query completion: {}.", instanceId, state );
-      releaseIfFirst();
-      completed = true;
-    }
-
-    QueryId getQueryId() {
-      return queryId;
-    }
-
-
-    /**
-     * Gets the next batch of query results from the queue.
-     * @return  the next batch, or {@code null} after last batch has been returned
-     * @throws UserException
-     *         if the query failed
-     * @throws InterruptedException
-     *         if waiting on the queue was interrupted
-     */
-    QueryDataBatch getNext() throws UserException, InterruptedException {
-      while (true) {
-        if (executionFailureException != null) {
-          logger.debug( "[#{}] Dequeued query failure exception: {}.",
-                        instanceId, executionFailureException );
-          throw executionFailureException;
-        }
-        if (completed && batchQueue.isEmpty()) {
-          return null;
-        } else {
-          QueryDataBatch qdb = batchQueue.poll(50, TimeUnit.MILLISECONDS);
-          if (qdb != null) {
-            lastDequeuedBatchNumber++;
-            logger.debug( "[#{}] Dequeued query data batch #{}: {}.",
-                          instanceId, lastDequeuedBatchNumber, qdb );
-
-            // Unthrottle server if queue size has dropped enough below threshold:
-            if ( batchQueue.size() < batchQueueThrottlingThreshold / 2
-                 || batchQueue.size() == 0  // (in case threshold < 2)
-                 ) {
-              if ( stopThrottlingIfSo() ) {
-                logger.debug( "[#{}] Throttling stopped at queue size {}.",
-                              instanceId, batchQueue.size() );
-              }
-            }
-            return qdb;
-          }
-        }
-      }
-    }
-
-    void close() {
-      logger.debug( "[#{}] Query listener closing.", instanceId );
-      closed = true;
-      if ( stopThrottlingIfSo() ) {
-        logger.debug( "[#{}] Throttling stopped at close() (at queue size {}).",
-                      instanceId, batchQueue.size() );
-      }
-      while (!batchQueue.isEmpty()) {
-        QueryDataBatch qdb = batchQueue.poll();
-        if (qdb != null && qdb.getData() != null) {
-          qdb.getData().release();
-        }
-      }
-      // Close may be called before the first result is received and therefore
-      // when the main thread is blocked waiting for the result.  In that case
-      // we want to unblock the main thread.
-      latch.countDown(); // TODO:  Why not call releaseIfFirst as used elsewhere?
-      completed = true;
-    }
-
-  }
-
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/WrappedAccessor.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/WrappedAccessor.java
@@ -1,0 +1,448 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.apache.drill.jdbc.impl;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Map;
+
+import org.apache.calcite.avatica.util.Cursor.Accessor;
+
+/**
+ * Wraps Avatica {@code Accessor} instances to catch convertion exception
+ * which are thrown as {@code RuntimeException} and throws {@code SQLException}
+ * instead
+ *
+ */
+class WrappedAccessor implements Accessor {
+  private final Accessor delegate;
+
+  public WrappedAccessor(Accessor delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean wasNull() throws SQLException {
+    return delegate.wasNull();
+  }
+
+  @Override
+  public String getString() throws SQLException {
+    try {
+      return delegate.getString();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean getBoolean() throws SQLException {
+    try {
+      return delegate.getBoolean();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public byte getByte() throws SQLException {
+    try {
+      return delegate.getByte();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public short getShort() throws SQLException {
+    try {
+      return delegate.getShort();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public int getInt() throws SQLException {
+    try {
+      return delegate.getInt();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public long getLong() throws SQLException {
+    try {
+      return delegate.getLong();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public float getFloat() throws SQLException {
+    try {
+      return delegate.getFloat();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public double getDouble() throws SQLException {
+    try {
+      return delegate.getDouble();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public BigDecimal getBigDecimal() throws SQLException {
+    try {
+      return delegate.getBigDecimal();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int scale) throws SQLException {
+    try {
+      return delegate.getBigDecimal(scale);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public byte[] getBytes() throws SQLException {
+    try {
+      return delegate.getBytes();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public InputStream getAsciiStream() throws SQLException {
+    try {
+      return delegate.getAsciiStream();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public InputStream getUnicodeStream() throws SQLException {
+    try {
+      return delegate.getUnicodeStream();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public InputStream getBinaryStream() throws SQLException {
+    try {
+      return delegate.getBinaryStream();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Object getObject() throws SQLException {
+    try {
+      return delegate.getObject();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Reader getCharacterStream() throws SQLException {
+    try {
+      return delegate.getCharacterStream();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Object getObject(Map<String, Class<?>> map) throws SQLException {
+    try {
+      return delegate.getObject(map);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Ref getRef() throws SQLException {
+    try {
+      return delegate.getRef();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Blob getBlob() throws SQLException {
+    try {
+      return delegate.getBlob();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Clob getClob() throws SQLException {
+    try {
+      return delegate.getClob();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Array getArray() throws SQLException {
+    try {
+      return delegate.getArray();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Date getDate(Calendar calendar) throws SQLException {
+    try {
+      return delegate.getDate(calendar);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Time getTime(Calendar calendar) throws SQLException {
+    try {
+      return delegate.getTime(calendar);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Timestamp getTimestamp(Calendar calendar) throws SQLException {
+    try {
+      return delegate.getTimestamp(calendar);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public URL getURL() throws SQLException {
+    try {
+      return delegate.getURL();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public NClob getNClob() throws SQLException {
+    try {
+      return delegate.getNClob();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public SQLXML getSQLXML() throws SQLException {
+    try {
+      return delegate.getSQLXML();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public String getNString() throws SQLException {
+    try {
+      return delegate.getNString();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public Reader getNCharacterStream() throws SQLException {
+    try {
+      return delegate.getNCharacterStream();
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public <T> T getObject(Class<T> type) throws SQLException {
+    try {
+      return delegate.getObject(type);
+    } catch(RuntimeException e) {
+      String message = e.getMessage();
+      if (message != null && message.startsWith("cannot convert to")) {
+        throw new SQLException(e.getMessage(), e);
+      }
+      throw e;
+    }
+  }
+
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataGetColumnsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataGetColumnsTest.java
@@ -2702,7 +2702,7 @@ public class DatabaseMetaDataGetColumnsTest extends JdbcTestBase {
 
   @Test
   public void test_SOURCE_DATA_TYPE_hasRightValue_mdrOptBOOLEAN() throws SQLException {
-    assertThat( getIntOrNull( mdrOptBOOLEAN, "SOURCE_DATA_TYPE" ), nullValue() );
+    assertThat( mdrOptBOOLEAN.getString( "SOURCE_DATA_TYPE" ), nullValue() );
   }
 
   @Test
@@ -2712,22 +2712,18 @@ public class DatabaseMetaDataGetColumnsTest extends JdbcTestBase {
 
   @Test
   public void test_SOURCE_DATA_TYPE_hasRightTypeString() throws SQLException {
-    // TODO(DRILL-2135):  Resolve workaround:
-    //assertThat( rsMetadata.getColumnTypeName( 22 ), equalTo( "SMALLINT" ) );
-    assertThat( rowsMetadata.getColumnTypeName( 22 ), equalTo( "INTEGER" ) );
+    assertThat( rowsMetadata.getColumnTypeName( 22 ), equalTo( "SMALLINT" ) );
   }
 
   @Test
   public void test_SOURCE_DATA_TYPE_hasRightTypeCode() throws SQLException {
-    // TODO(DRILL-2135):  Resolve workaround:
-    //assertThat( rsMetadata.getColumnType( 22 ), equalTo( Types.SMALLINT ) );
-    assertThat( rowsMetadata.getColumnType( 22 ), equalTo( Types.INTEGER ) );
+    assertThat( rowsMetadata.getColumnType( 22 ), equalTo( Types.SMALLINT ) );
   }
 
   @Test
   public void test_SOURCE_DATA_TYPE_hasRightClass() throws SQLException {
     assertThat( rowsMetadata.getColumnClassName( 22 ),
-                equalTo( Integer.class.getName() ) );
+                equalTo( Short.class.getName() ) );
   }
 
   @Test

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcMetadata.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcMetadata.java
@@ -37,6 +37,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void catalogs() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getCatalogs();
       }
@@ -46,6 +47,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void allSchemas() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getSchemas();
       }
@@ -55,6 +57,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void schemasWithConditions() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getSchemas("DRILL", "%fs%");
       }
@@ -64,6 +67,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void allTables() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getTables(null, null, null, null);
       }
@@ -73,6 +77,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void tablesWithConditions() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getTables("DRILL", "sys", "opt%", new String[]{"SYSTEM_TABLE", "SYSTEM_VIEW"});
       }
@@ -82,6 +87,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void allColumns() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getColumns(null, null, null, null);
       }
@@ -91,6 +97,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
   @Test
   public void columnsWithConditions() throws Exception{
     this.testAction(new JdbcAction(){
+      @Override
       public ResultSet getResult(Connection c) throws SQLException {
         return c.getMetaData().getColumns("DRILL", "sys", "opt%", "%ame");
       }


### PR DESCRIPTION
Improve Drill JDBC metadata support by upgrading Avatica version, adding types filter to getTable Metadata API, and letting the JDBC driver using new Metadata API instead of SQL queries.