### PR TITLE
DRILL-4870 drill-config.sh sets JAVA_HOME incorrectly for the Mac

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -392,5 +392,7 @@ export DRILL_HOME
 export DRILL_CONF_DIR
 export DRILL_LOG_DIR
 export CP
-export JAVA_HOME
+# DRILL-4870: Don't export JAVA_HOME. Java can find it just fine from the java
+# command. If we attempt to work out out, we do so incorrectly for the Mac.
+#export JAVA_HOME
 export JAVA

--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -393,6 +393,6 @@ export DRILL_CONF_DIR
 export DRILL_LOG_DIR
 export CP
 # DRILL-4870: Don't export JAVA_HOME. Java can find it just fine from the java
-# command. If we attempt to work out out, we do so incorrectly for the Mac.
+# command. If we attempt to work it out, we do so incorrectly for the Mac.
 #export JAVA_HOME
 export JAVA

--- a/distribution/src/resources/drillbit.sh
+++ b/distribution/src/resources/drillbit.sh
@@ -102,7 +102,7 @@ waitForProcessEnd()
   # process still there : kill -9
   if kill -0 $pidKilled > /dev/null 2>&1; then
     echo "$commandName did not complete after $origcnt seconds, killing with kill -9 $pidKilled"
-    $JAVA_HOME/bin/jstack -l $pidKilled > "$logout" 2>&1
+    `dirname $JAVA`/jstack -l $pidKilled > "$logout" 2>&1
     kill -9 $pidKilled > /dev/null 2>&1
   fi
 }


### PR DESCRIPTION
Recent script revisions uncommented a line to export the Drill-computed JAVA_HOME. Turns out, we should not do this; we should allow Java to figure it out as the location differs depending on platform. This change comments out that export line to restore the pre-1.8 functionality.