### PR TITLE
fix the wrong content

### DIFF
--- a/_docs/configure-drill/076-configuring-user-impersonation-with-hive-authorization.md
+++ b/_docs/configure-drill/076-configuring-user-impersonation-with-hive-authorization.md
@@ -152,7 +152,7 @@ Add the following required authorization parameters in hive-site.xml to configur
 **Value:** org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory  
 
 **hive.server2.enable.doAs**  
-**Description:** Tells HiveServer2 to execute Hive operations as the user submitting the query. Must be set to false for the storage based model. 
+**Description:** Tells HiveServer2 to execute Hive operations as the user submitting the query. Must be set to false for the SQL standard based model. 
 **Value:** false
 
 **hive.users.in.admin.role**  


### PR DESCRIPTION
modify the content "Tells HiveServer2 to execute Hive operations as the user submitting the query. Must be set to false for the Storage  based model" to "Tells HiveServer2 to execute Hive operations as the user submitting the query. Must be set to false for the SQL standard based model" in the section SQL Standard Based Authorization
