### PR TITLE
DRILL-4882 - Support for MongoDB Direct Connection to a node in a Replica Set.

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -164,7 +164,7 @@ public class MongoGroupScan extends AbstractGroupScan implements
 
   private boolean isShardedCluster(MongoClient client) {
     MongoDatabase db = client.getDatabase(scanSpec.getDbName());
-    String msg = db.runCommand(new Document("isMaster", 1)).getString("msg");
+    String msg = db.runCommand(new Document("isMaster", 1), ReadPreference.nearest()).getString("msg");
     return msg == null ? false : msg.equals("isdbgrid");
   }
 

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
@@ -59,6 +59,7 @@ public class MongoStoragePlugin extends AbstractStoragePlugin {
   private final MongoSchemaFactory schemaFactory;
   private final Cache<MongoCnxnKey, MongoClient> addressClientMap;
   private final MongoClientURI clientURI;
+  private final boolean directConnection;
 
   public MongoStoragePlugin(MongoStoragePluginConfig mongoConfig,
       DrillbitContext context, String name) throws IOException,
@@ -70,6 +71,7 @@ public class MongoStoragePlugin extends AbstractStoragePlugin {
         .expireAfterAccess(24, TimeUnit.HOURS)
         .removalListener(new AddressCloser()).build();
     this.schemaFactory = new MongoSchemaFactory(this, name);
+    directConnection = mongoConfig.isDirectConnection();
   }
 
   public DrillbitContext getContext() {
@@ -136,15 +138,38 @@ public class MongoStoragePlugin extends AbstractStoragePlugin {
     if (client == null) {
       if (credential != null) {
         List<MongoCredential> credentialList = Arrays.asList(credential);
-        client = new MongoClient(addresses, credentialList, clientURI.getOptions());
+        if (!isDirectConnection()) {
+          client = new MongoClient(addresses, credentialList, clientURI.getOptions());
+        } else {
+          client = new MongoClient(serverAddress, credentialList );
+        }
       } else {
-        client = new MongoClient(addresses, clientURI.getOptions());
+        if (!isDirectConnection()) {
+          client = new MongoClient(addresses, clientURI.getOptions());
+        } else {
+          // direct connection must use a single address/node
+          client = new MongoClient(serverAddress);
+        }
       }
+
+      if (isDirectConnection()) {
+        if (addresses.size() > 1) {
+          logger.warn(
+                  "Invalid Configuration: \"direct-connection\" set to true with multiple addresses. {} will be used",
+                  serverAddress.toString() );
+        }
+      }
+
+
       addressClientMap.put(key, client);
       logger.debug("Created connection to {}.", key.toString());
       logger.debug("Number of open connections {}.", addressClientMap.size());
     }
     return client;
+  }
+
+  public boolean isDirectConnection() {
+    return directConnection;
   }
 
   @Override

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
@@ -38,12 +38,15 @@ public class MongoStoragePluginConfig extends StoragePluginConfig {
 
   private String connection;
 
+  private boolean directConnection;
+
   @JsonIgnore
   private MongoClientURI clientURI;
 
   @JsonCreator
-  public MongoStoragePluginConfig(@JsonProperty("connection") String connection) {
+  public MongoStoragePluginConfig(@JsonProperty("connection") String connection, @JsonProperty("direct-connection")boolean directConnection) {
     this.connection = connection;
+    this.directConnection = directConnection;
     this.clientURI = new MongoClientURI(connection);
   }
 
@@ -81,5 +84,19 @@ public class MongoStoragePluginConfig extends StoragePluginConfig {
 
   public String getConnection() {
     return connection;
+  }
+
+  /**
+   * The direct connection is used to force Drill to only connect to the node listed in the connection string
+   * This is mandatory when Drill has to access specific nodes of a cluster/replica-set without having access to other.
+   * It is a common pattern for MongoDB when used for analytics, see: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#terms
+   *
+   * The default value is false, meaning that the default behavior of the plugin is to connect to the full cluster.
+   *
+   * @return true if the plugin is configured to use direct connection to MongoDB nodes
+   */
+  @JsonProperty("direct-connection")
+  public boolean isDirectConnection() {
+    return directConnection;
   }
 }

--- a/contrib/storage-mongo/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-mongo/src/main/resources/bootstrap-storage-plugins.json
@@ -3,7 +3,8 @@
     mongo : {
       type:"mongo",
       enabled: false,
-      connection:"mongodb://localhost:27017/"
+      connection:"mongodb://localhost:27017/",
+      "direct-connection" : false
     }
   }
 }

--- a/contrib/storage-mongo/src/main/resources/drill-module.conf
+++ b/contrib/storage-mongo/src/main/resources/drill-module.conf
@@ -23,7 +23,8 @@ drill.exec: {
 
   sys.store.provider: {
     mongo : {
-      "connection": "mongodb://localhost:27017/?connectTimeoutMS=60000&maxPoolSize=1000&safe=true"
+      "connection": "mongodb://localhost:27017/?connectTimeoutMS=60000&maxPoolSize=1000&safe=true",
+      "direct-connection" : false
     }
   }
 


### PR DESCRIPTION
See issue DRILL-4882

In some case, for analytics the applicatio, Drill, has to connect to node directly without access the replica set or shard globally.

The new configuration option `direct-connection` true|false allows drillbit to be directly connected to a node.

References:
* [Connection String](http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/connecting/connection-settings/)
* [Direct Connection term](https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#terms)
