### PR TITLE
DRILL-4925: Add tableType filter to GetTables metadata query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -17,12 +17,10 @@
  */
 package org.apache.drill.exec.client;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.drill.exec.proto.UserProtos.QueryResultsMode.STREAM_FULL;
 import static org.apache.drill.exec.proto.UserProtos.RunQuery.newBuilder;
-import io.netty.buffer.DrillBuf;
-import io.netty.channel.EventLoopGroup;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -55,8 +53,8 @@ import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.proto.UserProtos;
 import org.apache.drill.exec.proto.UserProtos.CreatePreparedStatementReq;
 import org.apache.drill.exec.proto.UserProtos.CreatePreparedStatementResp;
-import org.apache.drill.exec.proto.UserProtos.GetCatalogsResp;
 import org.apache.drill.exec.proto.UserProtos.GetCatalogsReq;
+import org.apache.drill.exec.proto.UserProtos.GetCatalogsResp;
 import org.apache.drill.exec.proto.UserProtos.GetColumnsReq;
 import org.apache.drill.exec.proto.UserProtos.GetColumnsResp;
 import org.apache.drill.exec.proto.UserProtos.GetQueryPlanFragments;
@@ -91,6 +89,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractCheckedFuture;
 import com.google.common.util.concurrent.SettableFuture;
+
+import io.netty.buffer.DrillBuf;
+import io.netty.channel.EventLoopGroup;
 
 /**
  * Thin wrapper around a UserClient that handles connect/close and transforms
@@ -463,7 +464,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
     }
 
     if (schemaNameFilter != null) {
-      reqBuilder.setSchameNameFilter(schemaNameFilter);
+      reqBuilder.setSchemaNameFilter(schemaNameFilter);
     }
 
     return client.send(RpcType.GET_SCHEMAS, reqBuilder.build(), GetSchemasResp.class);
@@ -475,21 +476,26 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    * @param catalogNameFilter Filter on <code>catalog name</code>. Pass null to apply no filter.
    * @param schemaNameFilter Filter on <code>schema name</code>. Pass null to apply no filter.
    * @param tableNameFilter Filter in <code>table name</code>. Pass null to apply no filter.
+   * @param tableTypeFilter Filter in <code>table type</code>. Pass null to apply no filter
    * @return
    */
   public DrillRpcFuture<GetTablesResp> getTables(LikeFilter catalogNameFilter, LikeFilter schemaNameFilter,
-      LikeFilter tableNameFilter) {
+      LikeFilter tableNameFilter, List<String> tableTypeFilter) {
     final GetTablesReq.Builder reqBuilder = GetTablesReq.newBuilder();
     if (catalogNameFilter != null) {
       reqBuilder.setCatalogNameFilter(catalogNameFilter);
     }
 
     if (schemaNameFilter != null) {
-      reqBuilder.setSchameNameFilter(schemaNameFilter);
+      reqBuilder.setSchemaNameFilter(schemaNameFilter);
     }
 
     if (tableNameFilter != null) {
       reqBuilder.setTableNameFilter(tableNameFilter);
+    }
+
+    if (tableTypeFilter != null) {
+      reqBuilder.addAllTableTypeFilter(tableTypeFilter);
     }
 
     return client.send(RpcType.GET_TABLES, reqBuilder.build(), GetTablesResp.class);
@@ -512,7 +518,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
     }
 
     if (schemaNameFilter != null) {
-      reqBuilder.setSchameNameFilter(schemaNameFilter);
+      reqBuilder.setSchemaNameFilter(schemaNameFilter);
     }
 
     if (tableNameFilter != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -19,6 +19,8 @@ package org.apache.drill.exec.planner.logical;
 
 import java.io.IOException;
 
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
@@ -27,30 +29,42 @@ import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.store.StoragePlugin;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.plan.RelOptTable;
 import org.apache.drill.exec.util.ImpersonationUtil;
 
 public abstract class DrillTable implements Table {
 
   private final String storageEngineName;
   private final StoragePluginConfig storageEngineConfig;
+  private final TableType tableType;
   private final Object selection;
   private final StoragePlugin plugin;
   private final String userName;
-
   private GroupScan scan;
 
   /**
-   * Creates a DrillTable instance.
+   * Creates a DrillTable instance for a @{code TableType#Table} table.
    * @param storageEngineName StorageEngine name.
    * @param plugin Reference to StoragePlugin.
    * @param userName Whom to impersonate while reading the contents of the table.
    * @param selection Table contents (type and contents depend on type of StoragePlugin).
    */
   public DrillTable(String storageEngineName, StoragePlugin plugin, String userName, Object selection) {
+    this(storageEngineName, plugin, TableType.TABLE, userName, selection);
+  }
+
+  /**
+   * Creates a DrillTable instance.
+   * @param storageEngineName StorageEngine name.
+   * @param plugin Reference to StoragePlugin.
+   * @param tableType the JDBC table type
+   * @param userName Whom to impersonate while reading the contents of the table.
+   * @param selection Table contents (type and contents depend on type of StoragePlugin).
+   */
+  public DrillTable(String storageEngineName, StoragePlugin plugin, TableType tableType, String userName, Object selection) {
     this.selection = selection;
     this.plugin = plugin;
+
+    this.tableType = tableType;
 
     this.storageEngineConfig = plugin.getConfig();
     this.storageEngineName = storageEngineName;
@@ -106,7 +120,7 @@ public abstract class DrillTable implements Table {
 
   @Override
   public TableType getJdbcTableType() {
-    return TableType.TABLE;
+    return tableType;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaDrillTable.java
@@ -17,18 +17,20 @@
  */
 package org.apache.drill.exec.store.ischema;
 
-import org.apache.drill.common.logical.StoragePluginConfig;
-import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema.TableType;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.util.ImpersonationUtil;
 
-public class InfoSchemaDrillTable extends DrillTable{
+public class InfoSchemaDrillTable extends DrillTable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InfoSchemaDrillTable.class);
 
   private final InfoSchemaTableType table;
 
   public InfoSchemaDrillTable(InfoSchemaStoragePlugin plugin, String storageEngineName, InfoSchemaTableType selection, StoragePluginConfig storageEngineConfig) {
-    super(storageEngineName, plugin, selection);
+    super(storageEngineName, plugin, TableType.SYSTEM_TABLE, ImpersonationUtil.getProcessUserName(), selection);
     this.table = selection;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -19,17 +19,17 @@ package org.apache.drill.exec.store.ischema;
 
 import static org.apache.drill.exec.expr.fn.impl.RegexpUtil.sqlToRegexLike;
 
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode.Type;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Joiner;
-import org.apache.drill.exec.expr.fn.impl.RegexpUtil;
-import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode.Type;
-
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 
 @JsonTypeName("info-schema-filter")
 public class InfoSchemaFilter {
@@ -210,6 +210,22 @@ public class InfoSchemaFilter {
         }
 
         return Result.TRUE;
+      }
+
+      case "in": {
+        FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
+        List<ExprNode> args = exprNode.args.subList(1, exprNode.args.size());
+        final String fieldValue = recordValues.get(col.field.toString());
+        if (fieldValue != null) {
+          for(ExprNode arg: args) {
+            if (fieldValue.equals(((ConstantExprNode) arg).value)) {
+              return Result.TRUE;
+            }
+          }
+          return Result.FALSE;
+        }
+
+        return Result.INCONCLUSIVE;
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTable.java
@@ -17,25 +17,56 @@
  */
 package org.apache.drill.exec.store.ischema;
 
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_CONNECT;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_DESCRIPTION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_CHARACTER_MAXIMUM_LENGTH;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_CHARACTER_OCTET_LENGTH;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_COLUMN_DEFAULT;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_COLUMN_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_DATA_TYPE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_DATETIME_PRECISION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_INTERVAL_PRECISION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_INTERVAL_TYPE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_IS_NULLABLE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_NUMERIC_PRECISION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_NUMERIC_PRECISION_RADIX;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_NUMERIC_SCALE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_ORDINAL_POSITION;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_CATALOG_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_IS_MUTABLE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_SCHEMA_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_SCHEMA_OWNER;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_TYPE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_CATALOG;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_SCHEMA;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TAB_CATALOGS;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TAB_COLUMNS;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TAB_SCHEMATA;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TAB_TABLES;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TAB_VIEWS;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TBLS_COL_TABLE_TYPE;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.VIEWS_COL_VIEW_DEFINITION;
+
 import java.util.List;
 
-import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.*;
-import org.apache.drill.common.types.TypeProtos.MajorType;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.common.types.Types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.server.options.OptionManager;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.apache.drill.exec.server.options.OptionManager;
 
 /**
  * Base class for tables in INFORMATION_SCHEMA.  Defines the table (fields and
  * types).
  */
-public abstract class InfoSchemaTable {
+public abstract class InfoSchemaTable<S> {
 
   public static class Field {
     public String name;
@@ -86,10 +117,10 @@ public abstract class InfoSchemaTable {
     return typeFactory.createStructType(relTypes, fieldNames);
   }
 
-  public abstract InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager);
+  public abstract InfoSchemaRecordGenerator<S> getRecordGenerator(OptionManager optionManager);
 
   /** Layout for the CATALOGS table. */
-  static public class Catalogs extends InfoSchemaTable {
+  static public class Catalogs extends InfoSchemaTable<Records.Catalog> {
     // NOTE:  Nothing seems to verify that the types here (apparently used
     // by SQL validation) match the types of the fields in Records.Catalogs).
     private static final List<Field> fields = ImmutableList.of(
@@ -102,13 +133,13 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+    public InfoSchemaRecordGenerator<Records.Catalog> getRecordGenerator(OptionManager optionManager) {
       return new InfoSchemaRecordGenerator.Catalogs(optionManager);
     }
   }
 
   /** Layout for the SCHEMATA table. */
-  public static class Schemata extends InfoSchemaTable {
+  public static class Schemata extends InfoSchemaTable<Records.Schema> {
     // NOTE:  Nothing seems to verify that the types here (apparently used
     // by SQL validation) match the types of the fields in Records.Schemata).
     private static final List<Field> fields = ImmutableList.of(
@@ -123,13 +154,13 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+    public InfoSchemaRecordGenerator<Records.Schema> getRecordGenerator(OptionManager optionManager) {
       return new InfoSchemaRecordGenerator.Schemata(optionManager);
     }
   }
 
   /** Layout for the TABLES table. */
-  public static class Tables extends InfoSchemaTable {
+  public static class Tables extends InfoSchemaTable<Records.Table> {
     // NOTE:  Nothing seems to verify that the types here (apparently used
     // by SQL validation) match the types of the fields in Records.Tables).
     private static final List<Field> fields = ImmutableList.of(
@@ -143,13 +174,13 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+    public InfoSchemaRecordGenerator<Records.Table> getRecordGenerator(OptionManager optionManager) {
       return new InfoSchemaRecordGenerator.Tables(optionManager);
     }
   }
 
   /** Layout for the VIEWS table. */
-  static public class Views extends InfoSchemaTable {
+  static public class Views extends InfoSchemaTable<Records.View> {
     // NOTE:  Nothing seems to verify that the types here (apparently used
     // by SQL validation) match the types of the fields in Records.Views).
     private static final List<Field> fields = ImmutableList.of(
@@ -163,13 +194,13 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+    public InfoSchemaRecordGenerator<Records.View> getRecordGenerator(OptionManager optionManager) {
       return new InfoSchemaRecordGenerator.Views(optionManager);
     }
   }
 
   /** Layout for the COLUMNS table. */
-  public static class Columns extends InfoSchemaTable {
+  public static class Columns extends InfoSchemaTable<Records.Column> {
     // COLUMNS columns, from SQL standard:
     // 1. TABLE_CATALOG
     // 2. TABLE_SCHEMA
@@ -215,7 +246,7 @@ public abstract class InfoSchemaTable {
     }
 
     @Override
-    public InfoSchemaRecordGenerator getRecordGenerator(OptionManager optionManager) {
+    public InfoSchemaRecordGenerator<Records.Column> getRecordGenerator(OptionManager optionManager) {
       return new InfoSchemaRecordGenerator.Columns(optionManager);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTableType.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaTableType.java
@@ -17,17 +17,15 @@
  */
 package org.apache.drill.exec.store.ischema;
 
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.SchemaPlus;
-
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Catalogs;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Columns;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Schemata;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Tables;
 import org.apache.drill.exec.store.ischema.InfoSchemaTable.Views;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.drill.exec.store.pojo.PojoRecordReader;
 
 /**
@@ -43,18 +41,19 @@ public enum InfoSchemaTableType {
   COLUMNS(new Columns()),
   TABLES(new Tables());
 
-  private final InfoSchemaTable tableDef;
+  private final InfoSchemaTable<?> tableDef;
 
   /**
    * ...
    * @param  tableDef  the definition (columns and data generator) of the table
    */
-  InfoSchemaTableType(InfoSchemaTable tableDef) {
+  InfoSchemaTableType(InfoSchemaTable<?> tableDef) {
     this.tableDef = tableDef;
   }
 
-  public PojoRecordReader<?> getRecordReader(SchemaPlus rootSchema, InfoSchemaFilter filter, OptionManager optionManager) {
-    InfoSchemaRecordGenerator recordGenerator = tableDef.getRecordGenerator(optionManager);
+  public <S> PojoRecordReader<S> getRecordReader(SchemaPlus rootSchema, InfoSchemaFilter filter, OptionManager optionManager) {
+    @SuppressWarnings("unchecked")
+    InfoSchemaRecordGenerator<S> recordGenerator = (InfoSchemaRecordGenerator<S>) tableDef.getRecordGenerator(optionManager);
     recordGenerator.setInfoSchemaFilter(filter);
     recordGenerator.scanSchema(rootSchema);
     return recordGenerator.getRecordReader();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/StaticDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/StaticDrillTable.java
@@ -19,9 +19,11 @@ package org.apache.drill.exec.store.sys;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema.TableType;
 import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.store.RecordDataType;
 import org.apache.drill.exec.store.StoragePlugin;
+import org.apache.drill.exec.util.ImpersonationUtil;
 
 /**
  * A {@link org.apache.drill.exec.planner.logical.DrillTable} with a defined schema
@@ -32,8 +34,8 @@ public class StaticDrillTable extends DrillTable {
 
   private final RecordDataType dataType;
 
-  public StaticDrillTable(String storageEngineName, StoragePlugin plugin, Object selection, RecordDataType dataType) {
-    super(storageEngineName, plugin, selection);
+  public StaticDrillTable(String storageEngineName, StoragePlugin plugin, TableType tableType, Object selection, RecordDataType dataType) {
+    super(storageEngineName, plugin, tableType, ImpersonationUtil.getProcessUserName(), selection);
     this.dataType = dataType;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTablePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTablePlugin.java
@@ -21,10 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.JSONOptions;
 import org.apache.drill.common.expression.SchemaPath;
@@ -36,6 +32,11 @@ import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.pojo.PojoDataType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 /**
  * A "storage" plugin for system tables.
@@ -103,8 +104,8 @@ public class SystemTablePlugin extends AbstractStoragePlugin {
     public DrillTable getTable(String name) {
       for (SystemTable table : SystemTable.values()) {
         if (table.getTableName().equalsIgnoreCase(name)) {
-          return new StaticDrillTable(SystemTablePlugin.this.name, SystemTablePlugin.this, table,
-            new PojoDataType(table.getPojoClass()));
+          return new StaticDrillTable(SystemTablePlugin.this.name, SystemTablePlugin.this, TableType.SYSTEM_TABLE,
+            table, new PojoDataType(table.getPojoClass()));
         }
       }
       return null;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -18,14 +18,17 @@
 package org.apache.drill.exec.work.metadata;
 
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_NAME;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_COLUMN_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SCHS_COL_SCHEMA_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_SCHEMA;
+import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.TBLS_COL_TABLE_TYPE;
 import static org.apache.drill.exec.store.ischema.InfoSchemaTableType.CATALOGS;
 import static org.apache.drill.exec.store.ischema.InfoSchemaTableType.COLUMNS;
 import static org.apache.drill.exec.store.ischema.InfoSchemaTableType.SCHEMATA;
 import static org.apache.drill.exec.store.ischema.InfoSchemaTableType.TABLES;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.calcite.schema.SchemaPlus;
@@ -35,8 +38,8 @@ import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
 import org.apache.drill.exec.proto.UserProtos.CatalogMetadata;
 import org.apache.drill.exec.proto.UserProtos.ColumnMetadata;
-import org.apache.drill.exec.proto.UserProtos.GetCatalogsResp;
 import org.apache.drill.exec.proto.UserProtos.GetCatalogsReq;
+import org.apache.drill.exec.proto.UserProtos.GetCatalogsResp;
 import org.apache.drill.exec.proto.UserProtos.GetColumnsReq;
 import org.apache.drill.exec.proto.UserProtos.GetColumnsResp;
 import org.apache.drill.exec.proto.UserProtos.GetSchemasReq;
@@ -55,7 +58,6 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.store.SchemaConfig.SchemaConfigInfoProvider;
 import org.apache.drill.exec.store.SchemaTreeProvider;
-import org.apache.drill.exec.store.ischema.InfoSchemaConstants;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ConstantExprNode;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode;
@@ -77,6 +79,7 @@ import com.google.common.collect.ImmutableList;
 public class MetadataProvider {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MetadataProvider.class);
 
+  private static final String IN_FUNCTION = "in";
   private static final String LIKE_FUNCTION = "like";
   private static final String AND_FUNCTION = "booleanand";
   private static final String OR_FUNCTION = "booleanor";
@@ -160,11 +163,11 @@ public class MetadataProvider {
       final GetCatalogsResp.Builder respBuilder = GetCatalogsResp.newBuilder();
 
       final InfoSchemaFilter filter = createInfoSchemaFilter(
-          req.hasCatalogNameFilter() ? req.getCatalogNameFilter() : null, null, null, null);
+          req.hasCatalogNameFilter() ? req.getCatalogNameFilter() : null, null, null, null, null);
 
       try {
         final PojoRecordReader<Catalog> records =
-            (PojoRecordReader<Catalog>) getPojoRecordReader(CATALOGS, filter, schemaProvider, session);
+            getPojoRecordReader(CATALOGS, filter, schemaProvider, session);
 
         for(Catalog c : records) {
           final CatalogMetadata.Builder catBuilder = CatalogMetadata.newBuilder();
@@ -179,9 +182,9 @@ public class MetadataProvider {
       } catch (Throwable e) {
         respBuilder.setStatus(RequestStatus.FAILED);
         respBuilder.setError(createPBError("get catalogs", e));
-      } finally {
-        return new Response(RpcType.CATALOGS, respBuilder.build());
       }
+
+      return new Response(RpcType.CATALOGS, respBuilder.build());
     }
   }
 
@@ -200,11 +203,11 @@ public class MetadataProvider {
 
       final InfoSchemaFilter filter = createInfoSchemaFilter(
           req.hasCatalogNameFilter() ? req.getCatalogNameFilter() : null,
-          req.hasSchameNameFilter() ? req.getSchameNameFilter() : null,
-          null, null);
+          req.hasSchemaNameFilter() ? req.getSchemaNameFilter() : null,
+          null, null, null);
 
       try {
-        final PojoRecordReader<Schema> records = (PojoRecordReader<Schema>)
+        final PojoRecordReader<Schema> records =
             getPojoRecordReader(SCHEMATA, filter, schemaProvider, session);
 
         for(Schema s : records) {
@@ -222,9 +225,9 @@ public class MetadataProvider {
       } catch (Throwable e) {
         respBuilder.setStatus(RequestStatus.FAILED);
         respBuilder.setError(createPBError("get schemas", e));
-      } finally {
-        return new Response(RpcType.SCHEMAS, respBuilder.build());
       }
+
+      return new Response(RpcType.SCHEMAS, respBuilder.build());
     }
   }
 
@@ -243,13 +246,14 @@ public class MetadataProvider {
 
       final InfoSchemaFilter filter = createInfoSchemaFilter(
           req.hasCatalogNameFilter() ? req.getCatalogNameFilter() : null,
-          req.hasSchameNameFilter() ? req.getSchameNameFilter() : null,
+          req.hasSchemaNameFilter() ? req.getSchemaNameFilter() : null,
           req.hasTableNameFilter() ? req.getTableNameFilter() : null,
+          req.getTableTypeFilterCount() != 0 ? req.getTableTypeFilterList() : null,
           null);
 
       try {
         final PojoRecordReader<Table> records =
-            (PojoRecordReader<Table>)getPojoRecordReader(TABLES, filter, schemaProvider, session);
+            getPojoRecordReader(TABLES, filter, schemaProvider, session);
 
         for(Table t : records) {
           final TableMetadata.Builder tableBuilder = TableMetadata.newBuilder();
@@ -265,9 +269,9 @@ public class MetadataProvider {
       } catch (Throwable e) {
         respBuilder.setStatus(RequestStatus.FAILED);
         respBuilder.setError(createPBError("get tables", e));
-      } finally {
-        return new Response(RpcType.TABLES, respBuilder.build());
       }
+
+      return new Response(RpcType.TABLES, respBuilder.build());
     }
   }
 
@@ -286,14 +290,14 @@ public class MetadataProvider {
 
       final InfoSchemaFilter filter = createInfoSchemaFilter(
           req.hasCatalogNameFilter() ? req.getCatalogNameFilter() : null,
-          req.hasSchameNameFilter() ? req.getSchameNameFilter() : null,
+          req.hasSchemaNameFilter() ? req.getSchemaNameFilter() : null,
           req.hasTableNameFilter() ? req.getTableNameFilter() : null,
-          req.hasColumnNameFilter() ? req.getColumnNameFilter() : null
+          null, req.hasColumnNameFilter() ? req.getColumnNameFilter() : null
       );
 
       try {
         final PojoRecordReader<Column> records =
-            (PojoRecordReader<Column>)getPojoRecordReader(COLUMNS, filter, schemaProvider, session);
+            getPojoRecordReader(COLUMNS, filter, schemaProvider, session);
 
         for(Column c : records) {
           final ColumnMetadata.Builder columnBuilder = ColumnMetadata.newBuilder();
@@ -347,9 +351,9 @@ public class MetadataProvider {
       } catch (Exception e) {
         respBuilder.setStatus(RequestStatus.FAILED);
         respBuilder.setError(createPBError("get columns", e));
-      } finally {
-        return new Response(RpcType.COLUMNS, respBuilder.build());
       }
+
+      return new Response(RpcType.COLUMNS, respBuilder.build());
     }
   }
 
@@ -358,11 +362,12 @@ public class MetadataProvider {
    * @param catalogNameFilter Optional filter on <code>catalog name</code>
    * @param schemaNameFilter Optional filter on <code>schema name</code>
    * @param tableNameFilter Optional filter on <code>table name</code>
+   * @param tableTypeFilter Optional filter on <code>table type</code>
    * @param columnNameFilter Optional filter on <code>column name</code>
    * @return
    */
   private static InfoSchemaFilter createInfoSchemaFilter(final LikeFilter catalogNameFilter,
-      final LikeFilter schemaNameFilter, final LikeFilter tableNameFilter, final LikeFilter columnNameFilter) {
+      final LikeFilter schemaNameFilter, final LikeFilter tableNameFilter, List<String> tableTypeFilter, final LikeFilter columnNameFilter) {
 
     FunctionExprNode exprNode = createLikeFunctionExprNode(CATS_COL_CATALOG_NAME,  catalogNameFilter);
 
@@ -381,7 +386,12 @@ public class MetadataProvider {
 
     exprNode = combineFunctions(AND_FUNCTION,
         exprNode,
-        createLikeFunctionExprNode(InfoSchemaConstants.COLS_COL_COLUMN_NAME, columnNameFilter)
+        createInFunctionExprNode(TBLS_COL_TABLE_TYPE, tableTypeFilter)
+        );
+
+    exprNode = combineFunctions(AND_FUNCTION,
+        exprNode,
+        createLikeFunctionExprNode(COLS_COL_COLUMN_NAME, columnNameFilter)
     );
 
     return exprNode != null ? new InfoSchemaFilter(exprNode) : null;
@@ -402,12 +412,32 @@ public class MetadataProvider {
         likeFilter.hasEscape() ?
             ImmutableList.of(
                 new FieldExprNode(fieldName),
-                new ConstantExprNode(likeFilter.getRegex()),
+                new ConstantExprNode(likeFilter.getPattern()),
                 new ConstantExprNode(likeFilter.getEscape())) :
             ImmutableList.of(
                 new FieldExprNode(fieldName),
-                new ConstantExprNode(likeFilter.getRegex()))
+                new ConstantExprNode(likeFilter.getPattern()))
     );
+  }
+
+  /**
+   * Helper method to create {@link FunctionExprNode} from {@code List<String>}.
+   * @param fieldName Name of the filed on which the like expression is applied.
+   * @param valuesFilter a list of values
+   * @return {@link FunctionExprNode} for given arguments. Null if the <code>valuesFilter</code> is null.
+   */
+  private static FunctionExprNode createInFunctionExprNode(String fieldName, List<String> valuesFilter) {
+    if (valuesFilter == null) {
+      return null;
+    }
+
+    ImmutableList.Builder<ExprNode> nodes = ImmutableList.builder();
+    nodes.add(new FieldExprNode(fieldName));
+    for(String type: valuesFilter) {
+      nodes.add(new ConstantExprNode(type));
+    }
+
+    return new FunctionExprNode(IN_FUNCTION, nodes.build());
   }
 
   /**
@@ -435,7 +465,7 @@ public class MetadataProvider {
    * @param userSession
    * @return
    */
-  private static PojoRecordReader getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter,
+  private static <S> PojoRecordReader<S> getPojoRecordReader(final InfoSchemaTableType tableType, final InfoSchemaFilter filter,
       final SchemaTreeProvider provider, final UserSession userSession) {
     final SchemaPlus rootSchema =
         provider.createRootSchema(userSession.getCredentials().getUserName(), newSchemaConfigInfoProvider(userSession));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -21,8 +21,10 @@ import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.IS_CATALOG
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.IS_CATALOG_DESCR;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.IS_CATALOG_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.drill.BaseTestQuery;
@@ -36,7 +38,6 @@ import org.apache.drill.exec.proto.UserProtos.LikeFilter;
 import org.apache.drill.exec.proto.UserProtos.RequestStatus;
 import org.apache.drill.exec.proto.UserProtos.SchemaMetadata;
 import org.apache.drill.exec.proto.UserProtos.TableMetadata;
-
 import org.junit.Test;
 
 /**
@@ -65,7 +66,7 @@ public class TestMetadataProvider extends BaseTestQuery {
     // test("SELECT * FROM INFORMATION_SCHEMA.CATALOGS " +
     //    "WHERE CATALOG_NAME LIKE '%DRI%' ESCAPE '\\'"); // SQL equivalent
     GetCatalogsResp resp =
-        client.getCatalogs(LikeFilter.newBuilder().setRegex("%DRI%").setEscape("\\").build()).get();
+        client.getCatalogs(LikeFilter.newBuilder().setPattern("%DRI%").setEscape("\\").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<CatalogMetadata> catalogs = resp.getCatalogsList();
@@ -83,7 +84,7 @@ public class TestMetadataProvider extends BaseTestQuery {
     //     WHERE CATALOG_NAME LIKE '%DRIj\\\\hgjh%' ESCAPE '\\'"); // SQL equivalent
 
     GetCatalogsResp resp =
-        client.getCatalogs(LikeFilter.newBuilder().setRegex("%DRIj\\%hgjh%").setEscape("\\").build()).get();
+        client.getCatalogs(LikeFilter.newBuilder().setPattern("%DRIj\\%hgjh%").setEscape("\\").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<CatalogMetadata> catalogs = resp.getCatalogsList();
@@ -115,7 +116,7 @@ public class TestMetadataProvider extends BaseTestQuery {
   public void schemasWithSchemaNameFilter() throws Exception {
     // test("SELECT * FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE '%y%'"); // SQL equivalent
 
-    GetSchemasResp resp = client.getSchemas(null, LikeFilter.newBuilder().setRegex("%y%").build()).get();
+    GetSchemasResp resp = client.getSchemas(null, LikeFilter.newBuilder().setPattern("%y%").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<SchemaMetadata> schemas = resp.getSchemasList();
@@ -131,8 +132,8 @@ public class TestMetadataProvider extends BaseTestQuery {
     //    "WHERE CATALOG_NAME LIKE '%RI%' AND SCHEMA_NAME LIKE '%y%'"); // SQL equivalent
 
     GetSchemasResp resp = client.getSchemas(
-        LikeFilter.newBuilder().setRegex("%RI%").build(),
-        LikeFilter.newBuilder().setRegex("%dfs_test%").build()).get();
+        LikeFilter.newBuilder().setPattern("%RI%").build(),
+        LikeFilter.newBuilder().setPattern("%dfs_test%").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<SchemaMetadata> schemas = resp.getSchemasList();
@@ -147,7 +148,41 @@ public class TestMetadataProvider extends BaseTestQuery {
   public void tables() throws Exception {
     // test("SELECT * FROM INFORMATION_SCHEMA.`TABLES`"); // SQL equivalent
 
-    GetTablesResp resp = client.getTables(null, null, null).get();
+    GetTablesResp resp = client.getTables(null, null, null, null).get();
+
+    assertEquals(RequestStatus.OK, resp.getStatus());
+    List<TableMetadata> tables = resp.getTablesList();
+    assertEquals(11, tables.size());
+
+    verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
+    verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
+    verifyTable("INFORMATION_SCHEMA", "SCHEMATA", tables);
+    verifyTable("INFORMATION_SCHEMA", "TABLES", tables);
+    verifyTable("INFORMATION_SCHEMA", "VIEWS", tables);
+    verifyTable("sys", "boot", tables);
+    verifyTable("sys", "drillbits", tables);
+    verifyTable("sys", "memory", tables);
+    verifyTable("sys", "options", tables);
+    verifyTable("sys", "threads", tables);
+    verifyTable("sys", "version", tables);
+  }
+
+  @Test
+  public void tablesWithTableFilter() throws Exception {
+    // test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_TYPE IN ('TABLE')"); // SQL equivalent
+
+    GetTablesResp resp = client.getTables(null, null, null, Arrays.asList("TABLE")).get();
+
+    assertEquals(RequestStatus.OK, resp.getStatus());
+    List<TableMetadata> tables = resp.getTablesList();
+    assertTrue(tables.isEmpty());
+  }
+
+  @Test
+  public void tablesWithSystemTableFilter() throws Exception {
+    // test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_TYPE IN ('SYSTEM_TABLE')"); // SQL equivalent
+
+    GetTablesResp resp = client.getTables(null, null, null, Arrays.asList("SYSTEM_TABLE")).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
@@ -171,7 +206,8 @@ public class TestMetadataProvider extends BaseTestQuery {
     // test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_NAME LIKE '%o%'"); // SQL equivalent
 
     GetTablesResp resp = client.getTables(null, null,
-        LikeFilter.newBuilder().setRegex("%o%").build()).get();
+        LikeFilter.newBuilder().setPattern("%o%").build(),
+        null).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
@@ -189,8 +225,9 @@ public class TestMetadataProvider extends BaseTestQuery {
     //    "WHERE TABLE_SCHEMA LIKE '%N\\_S%' ESCAPE '\\' AND TABLE_NAME LIKE '%o%'"); // SQL equivalent
 
     GetTablesResp resp = client.getTables(null,
-        LikeFilter.newBuilder().setRegex("%N\\_S%").setEscape("\\").build(),
-        LikeFilter.newBuilder().setRegex("%o%").build()).get();
+        LikeFilter.newBuilder().setPattern("%N\\_S%").setEscape("\\").build(),
+        LikeFilter.newBuilder().setPattern("%o%").build(),
+        null).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
@@ -214,7 +251,7 @@ public class TestMetadataProvider extends BaseTestQuery {
     // test("SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME LIKE '%\\_p%' ESCAPE '\\'"); // SQL equivalent
 
     GetColumnsResp resp = client.getColumns(null, null, null,
-        LikeFilter.newBuilder().setRegex("%\\_p%").setEscape("\\").build()).get();
+        LikeFilter.newBuilder().setPattern("%\\_p%").setEscape("\\").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
@@ -233,8 +270,8 @@ public class TestMetadataProvider extends BaseTestQuery {
     //     WHERE TABLE_NAME LIKE '%bits' AND COLUMN_NAME LIKE '%\\_p%' ESCAPE '\\'"); // SQL equivalent
 
     GetColumnsResp resp = client.getColumns(null, null,
-        LikeFilter.newBuilder().setRegex("%bits").build(),
-        LikeFilter.newBuilder().setRegex("%\\_p%").setEscape("\\").build()).get();
+        LikeFilter.newBuilder().setPattern("%bits").build(),
+        LikeFilter.newBuilder().setPattern("%\\_p%").setEscape("\\").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
@@ -252,10 +289,10 @@ public class TestMetadataProvider extends BaseTestQuery {
     //    "TABLE_NAME LIKE '%bits' AND COLUMN_NAME LIKE '%\\_p%' ESCAPE '\\'"); // SQL equivalent
 
     GetColumnsResp resp = client.getColumns(
-        LikeFilter.newBuilder().setRegex("%ILL").build(),
-        LikeFilter.newBuilder().setRegex("sys").build(),
-        LikeFilter.newBuilder().setRegex("%bits").build(),
-        LikeFilter.newBuilder().setRegex("%\\_p%").setEscape("\\").build()).get();
+        LikeFilter.newBuilder().setPattern("%ILL").build(),
+        LikeFilter.newBuilder().setPattern("sys").build(),
+        LikeFilter.newBuilder().setPattern("%bits").build(),
+        LikeFilter.newBuilder().setPattern("%\\_p%").setEscape("\\").build()).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserProtos.java
@@ -938,8 +938,8 @@ public final class SchemaUserProtos
         {
             public void writeTo(com.dyuproject.protostuff.Output output, org.apache.drill.exec.proto.UserProtos.LikeFilter message) throws java.io.IOException
             {
-                if(message.hasRegex())
-                    output.writeString(1, message.getRegex(), false);
+                if(message.hasPattern())
+                    output.writeString(1, message.getPattern(), false);
                 if(message.hasEscape())
                     output.writeString(2, message.getEscape(), false);
             }
@@ -982,7 +982,7 @@ public final class SchemaUserProtos
                         case 0:
                             return;
                         case 1:
-                            builder.setRegex(input.readString());
+                            builder.setPattern(input.readString());
                             break;
                         case 2:
                             builder.setEscape(input.readString());
@@ -1027,7 +1027,7 @@ public final class SchemaUserProtos
         {
             switch(number)
             {
-                case 1: return "regex";
+                case 1: return "pattern";
                 case 2: return "escape";
                 default: return null;
             }
@@ -1040,7 +1040,7 @@ public final class SchemaUserProtos
         private static final java.util.HashMap<java.lang.String,java.lang.Integer> fieldMap = new java.util.HashMap<java.lang.String,java.lang.Integer>();
         static
         {
-            fieldMap.put("regex", 1);
+            fieldMap.put("pattern", 1);
             fieldMap.put("escape", 2);
         }
     }
@@ -1426,8 +1426,8 @@ public final class SchemaUserProtos
                 if(message.hasCatalogNameFilter())
                     output.writeObject(1, message.getCatalogNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
-                if(message.hasSchameNameFilter())
-                    output.writeObject(2, message.getSchameNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
+                if(message.hasSchemaNameFilter())
+                    output.writeObject(2, message.getSchemaNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserProtos.GetSchemasReq message)
@@ -1473,7 +1473,7 @@ public final class SchemaUserProtos
 
                             break;
                         case 2:
-                            builder.setSchameNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
+                            builder.setSchemaNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
 
                             break;
                         default:
@@ -1517,7 +1517,7 @@ public final class SchemaUserProtos
             switch(number)
             {
                 case 1: return "catalogNameFilter";
-                case 2: return "schameNameFilter";
+                case 2: return "schemaNameFilter";
                 default: return null;
             }
         }
@@ -1530,7 +1530,7 @@ public final class SchemaUserProtos
         static
         {
             fieldMap.put("catalogNameFilter", 1);
-            fieldMap.put("schameNameFilter", 2);
+            fieldMap.put("schemaNameFilter", 2);
         }
     }
 
@@ -1816,12 +1816,14 @@ public final class SchemaUserProtos
                 if(message.hasCatalogNameFilter())
                     output.writeObject(1, message.getCatalogNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
-                if(message.hasSchameNameFilter())
-                    output.writeObject(2, message.getSchameNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
+                if(message.hasSchemaNameFilter())
+                    output.writeObject(2, message.getSchemaNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
                 if(message.hasTableNameFilter())
                     output.writeObject(3, message.getTableNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
+                for(String tableTypeFilter : message.getTableTypeFilterList())
+                    output.writeString(4, tableTypeFilter, true);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserProtos.GetTablesReq message)
             {
@@ -1866,12 +1868,15 @@ public final class SchemaUserProtos
 
                             break;
                         case 2:
-                            builder.setSchameNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
+                            builder.setSchemaNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
 
                             break;
                         case 3:
                             builder.setTableNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
 
+                            break;
+                        case 4:
+                            builder.addTableTypeFilter(input.readString());
                             break;
                         default:
                             input.handleUnknownField(number, this);
@@ -1914,8 +1919,9 @@ public final class SchemaUserProtos
             switch(number)
             {
                 case 1: return "catalogNameFilter";
-                case 2: return "schameNameFilter";
+                case 2: return "schemaNameFilter";
                 case 3: return "tableNameFilter";
+                case 4: return "tableTypeFilter";
                 default: return null;
             }
         }
@@ -1928,8 +1934,9 @@ public final class SchemaUserProtos
         static
         {
             fieldMap.put("catalogNameFilter", 1);
-            fieldMap.put("schameNameFilter", 2);
+            fieldMap.put("schemaNameFilter", 2);
             fieldMap.put("tableNameFilter", 3);
+            fieldMap.put("tableTypeFilter", 4);
         }
     }
 
@@ -2208,8 +2215,8 @@ public final class SchemaUserProtos
                 if(message.hasCatalogNameFilter())
                     output.writeObject(1, message.getCatalogNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
-                if(message.hasSchameNameFilter())
-                    output.writeObject(2, message.getSchameNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
+                if(message.hasSchemaNameFilter())
+                    output.writeObject(2, message.getSchemaNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
 
                 if(message.hasTableNameFilter())
                     output.writeObject(3, message.getTableNameFilter(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.WRITE, false);
@@ -2261,7 +2268,7 @@ public final class SchemaUserProtos
 
                             break;
                         case 2:
-                            builder.setSchameNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
+                            builder.setSchemaNameFilter(input.mergeObject(org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.LikeFilter.MERGE));
 
                             break;
                         case 3:
@@ -2313,7 +2320,7 @@ public final class SchemaUserProtos
             switch(number)
             {
                 case 1: return "catalogNameFilter";
-                case 2: return "schameNameFilter";
+                case 2: return "schemaNameFilter";
                 case 3: return "tableNameFilter";
                 case 4: return "columnNameFilter";
                 default: return null;
@@ -2328,7 +2335,7 @@ public final class SchemaUserProtos
         static
         {
             fieldMap.put("catalogNameFilter", 1);
-            fieldMap.put("schameNameFilter", 2);
+            fieldMap.put("schemaNameFilter", 2);
             fieldMap.put("tableNameFilter", 3);
             fieldMap.put("columnNameFilter", 4);
         }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserProtos.java
@@ -6667,32 +6667,32 @@ public final class UserProtos {
   public interface LikeFilterOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
-    // optional string regex = 1;
+    // optional string pattern = 1;
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
-    boolean hasRegex();
+    boolean hasPattern();
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
-    java.lang.String getRegex();
+    java.lang.String getPattern();
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
     com.google.protobuf.ByteString
-        getRegexBytes();
+        getPatternBytes();
 
     // optional string escape = 2;
     /**
@@ -6779,7 +6779,7 @@ public final class UserProtos {
             }
             case 10: {
               bitField0_ |= 0x00000001;
-              regex_ = input.readBytes();
+              pattern_ = input.readBytes();
               break;
             }
             case 18: {
@@ -6827,28 +6827,28 @@ public final class UserProtos {
     }
 
     private int bitField0_;
-    // optional string regex = 1;
-    public static final int REGEX_FIELD_NUMBER = 1;
-    private java.lang.Object regex_;
+    // optional string pattern = 1;
+    public static final int PATTERN_FIELD_NUMBER = 1;
+    private java.lang.Object pattern_;
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
-    public boolean hasRegex() {
+    public boolean hasPattern() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
-    public java.lang.String getRegex() {
-      java.lang.Object ref = regex_;
+    public java.lang.String getPattern() {
+      java.lang.Object ref = pattern_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
@@ -6856,26 +6856,26 @@ public final class UserProtos {
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
-          regex_ = s;
+          pattern_ = s;
         }
         return s;
       }
     }
     /**
-     * <code>optional string regex = 1;</code>
+     * <code>optional string pattern = 1;</code>
      *
      * <pre>
      * pattern to match
      * </pre>
      */
     public com.google.protobuf.ByteString
-        getRegexBytes() {
-      java.lang.Object ref = regex_;
+        getPatternBytes() {
+      java.lang.Object ref = pattern_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        regex_ = b;
+        pattern_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -6938,7 +6938,7 @@ public final class UserProtos {
     }
 
     private void initFields() {
-      regex_ = "";
+      pattern_ = "";
       escape_ = "";
     }
     private byte memoizedIsInitialized = -1;
@@ -6954,7 +6954,7 @@ public final class UserProtos {
                         throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getRegexBytes());
+        output.writeBytes(1, getPatternBytes());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, getEscapeBytes());
@@ -6970,7 +6970,7 @@ public final class UserProtos {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getRegexBytes());
+          .computeBytesSize(1, getPatternBytes());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -7097,7 +7097,7 @@ public final class UserProtos {
 
       public Builder clear() {
         super.clear();
-        regex_ = "";
+        pattern_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         escape_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -7132,7 +7132,7 @@ public final class UserProtos {
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
           to_bitField0_ |= 0x00000001;
         }
-        result.regex_ = regex_;
+        result.pattern_ = pattern_;
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
@@ -7153,9 +7153,9 @@ public final class UserProtos {
 
       public Builder mergeFrom(org.apache.drill.exec.proto.UserProtos.LikeFilter other) {
         if (other == org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) return this;
-        if (other.hasRegex()) {
+        if (other.hasPattern()) {
           bitField0_ |= 0x00000001;
-          regex_ = other.regex_;
+          pattern_ = other.pattern_;
           onChanged();
         }
         if (other.hasEscape()) {
@@ -7190,100 +7190,100 @@ public final class UserProtos {
       }
       private int bitField0_;
 
-      // optional string regex = 1;
-      private java.lang.Object regex_ = "";
+      // optional string pattern = 1;
+      private java.lang.Object pattern_ = "";
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
-      public boolean hasRegex() {
+      public boolean hasPattern() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
-      public java.lang.String getRegex() {
-        java.lang.Object ref = regex_;
+      public java.lang.String getPattern() {
+        java.lang.Object ref = pattern_;
         if (!(ref instanceof java.lang.String)) {
           java.lang.String s = ((com.google.protobuf.ByteString) ref)
               .toStringUtf8();
-          regex_ = s;
+          pattern_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
         }
       }
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
       public com.google.protobuf.ByteString
-          getRegexBytes() {
-        java.lang.Object ref = regex_;
+          getPatternBytes() {
+        java.lang.Object ref = pattern_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          regex_ = b;
+          pattern_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
         }
       }
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
-      public Builder setRegex(
+      public Builder setPattern(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   bitField0_ |= 0x00000001;
-        regex_ = value;
+        pattern_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
-      public Builder clearRegex() {
+      public Builder clearPattern() {
         bitField0_ = (bitField0_ & ~0x00000001);
-        regex_ = getDefaultInstance().getRegex();
+        pattern_ = getDefaultInstance().getPattern();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string regex = 1;</code>
+       * <code>optional string pattern = 1;</code>
        *
        * <pre>
        * pattern to match
        * </pre>
        */
-      public Builder setRegexBytes(
+      public Builder setPatternBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   bitField0_ |= 0x00000001;
-        regex_ = value;
+        pattern_ = value;
         onChanged();
         return this;
       }
@@ -9693,19 +9693,19 @@ public final class UserProtos {
      */
     org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getCatalogNameFilterOrBuilder();
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    boolean hasSchameNameFilter();
+    boolean hasSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter();
+    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder();
+    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder();
   }
   /**
    * Protobuf type {@code exec.user.GetSchemasReq}
@@ -9779,12 +9779,12 @@ public final class UserProtos {
             case 18: {
               org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = schameNameFilter_.toBuilder();
+                subBuilder = schemaNameFilter_.toBuilder();
               }
-              schameNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
+              schemaNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(schameNameFilter_);
-                schameNameFilter_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(schemaNameFilter_);
+                schemaNameFilter_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
               break;
@@ -9851,31 +9851,31 @@ public final class UserProtos {
       return catalogNameFilter_;
     }
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
-    public static final int SCHAME_NAME_FILTER_FIELD_NUMBER = 2;
-    private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
+    public static final int SCHEMA_NAME_FILTER_FIELD_NUMBER = 2;
+    private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public boolean hasSchameNameFilter() {
+    public boolean hasSchemaNameFilter() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+      return schemaNameFilter_;
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+      return schemaNameFilter_;
     }
 
     private void initFields() {
       catalogNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
-      schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -9893,7 +9893,7 @@ public final class UserProtos {
         output.writeMessage(1, catalogNameFilter_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, schameNameFilter_);
+        output.writeMessage(2, schemaNameFilter_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -9910,7 +9910,7 @@ public final class UserProtos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, schameNameFilter_);
+          .computeMessageSize(2, schemaNameFilter_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -10026,7 +10026,7 @@ public final class UserProtos {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getCatalogNameFilterFieldBuilder();
-          getSchameNameFilterFieldBuilder();
+          getSchemaNameFilterFieldBuilder();
         }
       }
       private static Builder create() {
@@ -10041,10 +10041,10 @@ public final class UserProtos {
           catalogNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
@@ -10086,10 +10086,10 @@ public final class UserProtos {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        if (schameNameFilterBuilder_ == null) {
-          result.schameNameFilter_ = schameNameFilter_;
+        if (schemaNameFilterBuilder_ == null) {
+          result.schemaNameFilter_ = schemaNameFilter_;
         } else {
-          result.schameNameFilter_ = schameNameFilterBuilder_.build();
+          result.schemaNameFilter_ = schemaNameFilterBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -10110,8 +10110,8 @@ public final class UserProtos {
         if (other.hasCatalogNameFilter()) {
           mergeCatalogNameFilter(other.getCatalogNameFilter());
         }
-        if (other.hasSchameNameFilter()) {
-          mergeSchameNameFilter(other.getSchameNameFilter());
+        if (other.hasSchemaNameFilter()) {
+          mergeSchemaNameFilter(other.getSchemaNameFilter());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -10257,121 +10257,121 @@ public final class UserProtos {
         return catalogNameFilterBuilder_;
       }
 
-      // optional .exec.user.LikeFilter schame_name_filter = 2;
-      private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      // optional .exec.user.LikeFilter schema_name_filter = 2;
+      private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schameNameFilterBuilder_;
+          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schemaNameFilterBuilder_;
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public boolean hasSchameNameFilter() {
+      public boolean hasSchemaNameFilter() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          return schameNameFilter_;
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          return schemaNameFilter_;
         } else {
-          return schameNameFilterBuilder_.getMessage();
+          return schemaNameFilterBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder setSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          schameNameFilter_ = value;
+          schemaNameFilter_ = value;
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(value);
+          schemaNameFilterBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(
+      public Builder setSchemaNameFilter(
           org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder builderForValue) {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = builderForValue.build();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = builderForValue.build();
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(builderForValue.build());
+          schemaNameFilterBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder mergeSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder mergeSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              schameNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
-            schameNameFilter_ =
-              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schameNameFilter_).mergeFrom(value).buildPartial();
+              schemaNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
+            schemaNameFilter_ =
+              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schemaNameFilter_).mergeFrom(value).buildPartial();
           } else {
-            schameNameFilter_ = value;
+            schemaNameFilter_ = value;
           }
           onChanged();
         } else {
-          schameNameFilterBuilder_.mergeFrom(value);
+          schemaNameFilterBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder clearSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      public Builder clearSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
           onChanged();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchameNameFilterBuilder() {
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchemaNameFilterBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
-        return getSchameNameFilterFieldBuilder().getBuilder();
+        return getSchemaNameFilterFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-        if (schameNameFilterBuilder_ != null) {
-          return schameNameFilterBuilder_.getMessageOrBuilder();
+      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+        if (schemaNameFilterBuilder_ != null) {
+          return schemaNameFilterBuilder_.getMessageOrBuilder();
         } else {
-          return schameNameFilter_;
+          return schemaNameFilter_;
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> 
-          getSchameNameFilterFieldBuilder() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          getSchemaNameFilterFieldBuilder() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder>(
-                  schameNameFilter_,
+                  schemaNameFilter_,
                   getParentForChildren(),
                   isClean());
-          schameNameFilter_ = null;
+          schemaNameFilter_ = null;
         }
-        return schameNameFilterBuilder_;
+        return schemaNameFilterBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:exec.user.GetSchemasReq)
@@ -12524,19 +12524,19 @@ public final class UserProtos {
      */
     org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getCatalogNameFilterOrBuilder();
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    boolean hasSchameNameFilter();
+    boolean hasSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter();
+    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder();
+    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder();
 
     // optional .exec.user.LikeFilter table_name_filter = 3;
     /**
@@ -12551,6 +12551,26 @@ public final class UserProtos {
      * <code>optional .exec.user.LikeFilter table_name_filter = 3;</code>
      */
     org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getTableNameFilterOrBuilder();
+
+    // repeated string table_type_filter = 4;
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    java.util.List<java.lang.String>
+    getTableTypeFilterList();
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    int getTableTypeFilterCount();
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    java.lang.String getTableTypeFilter(int index);
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getTableTypeFilterBytes(int index);
   }
   /**
    * Protobuf type {@code exec.user.GetTablesReq}
@@ -12624,12 +12644,12 @@ public final class UserProtos {
             case 18: {
               org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = schameNameFilter_.toBuilder();
+                subBuilder = schemaNameFilter_.toBuilder();
               }
-              schameNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
+              schemaNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(schameNameFilter_);
-                schameNameFilter_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(schemaNameFilter_);
+                schemaNameFilter_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
               break;
@@ -12647,6 +12667,14 @@ public final class UserProtos {
               bitField0_ |= 0x00000004;
               break;
             }
+            case 34: {
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                tableTypeFilter_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              tableTypeFilter_.add(input.readBytes());
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -12655,6 +12683,9 @@ public final class UserProtos {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+          tableTypeFilter_ = new com.google.protobuf.UnmodifiableLazyStringList(tableTypeFilter_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -12709,26 +12740,26 @@ public final class UserProtos {
       return catalogNameFilter_;
     }
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
-    public static final int SCHAME_NAME_FILTER_FIELD_NUMBER = 2;
-    private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
+    public static final int SCHEMA_NAME_FILTER_FIELD_NUMBER = 2;
+    private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public boolean hasSchameNameFilter() {
+    public boolean hasSchemaNameFilter() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+      return schemaNameFilter_;
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+      return schemaNameFilter_;
     }
 
     // optional .exec.user.LikeFilter table_name_filter = 3;
@@ -12753,10 +12784,41 @@ public final class UserProtos {
       return tableNameFilter_;
     }
 
+    // repeated string table_type_filter = 4;
+    public static final int TABLE_TYPE_FILTER_FIELD_NUMBER = 4;
+    private com.google.protobuf.LazyStringList tableTypeFilter_;
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    public java.util.List<java.lang.String>
+        getTableTypeFilterList() {
+      return tableTypeFilter_;
+    }
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    public int getTableTypeFilterCount() {
+      return tableTypeFilter_.size();
+    }
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    public java.lang.String getTableTypeFilter(int index) {
+      return tableTypeFilter_.get(index);
+    }
+    /**
+     * <code>repeated string table_type_filter = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getTableTypeFilterBytes(int index) {
+      return tableTypeFilter_.getByteString(index);
+    }
+
     private void initFields() {
       catalogNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
-      schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       tableNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      tableTypeFilter_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -12774,10 +12836,13 @@ public final class UserProtos {
         output.writeMessage(1, catalogNameFilter_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, schameNameFilter_);
+        output.writeMessage(2, schemaNameFilter_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeMessage(3, tableNameFilter_);
+      }
+      for (int i = 0; i < tableTypeFilter_.size(); i++) {
+        output.writeBytes(4, tableTypeFilter_.getByteString(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -12794,11 +12859,20 @@ public final class UserProtos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, schameNameFilter_);
+          .computeMessageSize(2, schemaNameFilter_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, tableNameFilter_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < tableTypeFilter_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(tableTypeFilter_.getByteString(i));
+        }
+        size += dataSize;
+        size += 1 * getTableTypeFilterList().size();
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -12914,7 +12988,7 @@ public final class UserProtos {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getCatalogNameFilterFieldBuilder();
-          getSchameNameFilterFieldBuilder();
+          getSchemaNameFilterFieldBuilder();
           getTableNameFilterFieldBuilder();
         }
       }
@@ -12930,10 +13004,10 @@ public final class UserProtos {
           catalogNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         if (tableNameFilterBuilder_ == null) {
@@ -12942,6 +13016,8 @@ public final class UserProtos {
           tableNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000004);
+        tableTypeFilter_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -12981,10 +13057,10 @@ public final class UserProtos {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        if (schameNameFilterBuilder_ == null) {
-          result.schameNameFilter_ = schameNameFilter_;
+        if (schemaNameFilterBuilder_ == null) {
+          result.schemaNameFilter_ = schemaNameFilter_;
         } else {
-          result.schameNameFilter_ = schameNameFilterBuilder_.build();
+          result.schemaNameFilter_ = schemaNameFilterBuilder_.build();
         }
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
@@ -12994,6 +13070,12 @@ public final class UserProtos {
         } else {
           result.tableNameFilter_ = tableNameFilterBuilder_.build();
         }
+        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          tableTypeFilter_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              tableTypeFilter_);
+          bitField0_ = (bitField0_ & ~0x00000008);
+        }
+        result.tableTypeFilter_ = tableTypeFilter_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -13013,11 +13095,21 @@ public final class UserProtos {
         if (other.hasCatalogNameFilter()) {
           mergeCatalogNameFilter(other.getCatalogNameFilter());
         }
-        if (other.hasSchameNameFilter()) {
-          mergeSchameNameFilter(other.getSchameNameFilter());
+        if (other.hasSchemaNameFilter()) {
+          mergeSchemaNameFilter(other.getSchemaNameFilter());
         }
         if (other.hasTableNameFilter()) {
           mergeTableNameFilter(other.getTableNameFilter());
+        }
+        if (!other.tableTypeFilter_.isEmpty()) {
+          if (tableTypeFilter_.isEmpty()) {
+            tableTypeFilter_ = other.tableTypeFilter_;
+            bitField0_ = (bitField0_ & ~0x00000008);
+          } else {
+            ensureTableTypeFilterIsMutable();
+            tableTypeFilter_.addAll(other.tableTypeFilter_);
+          }
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -13163,121 +13255,121 @@ public final class UserProtos {
         return catalogNameFilterBuilder_;
       }
 
-      // optional .exec.user.LikeFilter schame_name_filter = 2;
-      private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      // optional .exec.user.LikeFilter schema_name_filter = 2;
+      private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schameNameFilterBuilder_;
+          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schemaNameFilterBuilder_;
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public boolean hasSchameNameFilter() {
+      public boolean hasSchemaNameFilter() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          return schameNameFilter_;
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          return schemaNameFilter_;
         } else {
-          return schameNameFilterBuilder_.getMessage();
+          return schemaNameFilterBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder setSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          schameNameFilter_ = value;
+          schemaNameFilter_ = value;
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(value);
+          schemaNameFilterBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(
+      public Builder setSchemaNameFilter(
           org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder builderForValue) {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = builderForValue.build();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = builderForValue.build();
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(builderForValue.build());
+          schemaNameFilterBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder mergeSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder mergeSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              schameNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
-            schameNameFilter_ =
-              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schameNameFilter_).mergeFrom(value).buildPartial();
+              schemaNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
+            schemaNameFilter_ =
+              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schemaNameFilter_).mergeFrom(value).buildPartial();
           } else {
-            schameNameFilter_ = value;
+            schemaNameFilter_ = value;
           }
           onChanged();
         } else {
-          schameNameFilterBuilder_.mergeFrom(value);
+          schemaNameFilterBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder clearSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      public Builder clearSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
           onChanged();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchameNameFilterBuilder() {
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchemaNameFilterBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
-        return getSchameNameFilterFieldBuilder().getBuilder();
+        return getSchemaNameFilterFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-        if (schameNameFilterBuilder_ != null) {
-          return schameNameFilterBuilder_.getMessageOrBuilder();
+      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+        if (schemaNameFilterBuilder_ != null) {
+          return schemaNameFilterBuilder_.getMessageOrBuilder();
         } else {
-          return schameNameFilter_;
+          return schemaNameFilter_;
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> 
-          getSchameNameFilterFieldBuilder() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          getSchemaNameFilterFieldBuilder() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder>(
-                  schameNameFilter_,
+                  schemaNameFilter_,
                   getParentForChildren(),
                   isClean());
-          schameNameFilter_ = null;
+          schemaNameFilter_ = null;
         }
-        return schameNameFilterBuilder_;
+        return schemaNameFilterBuilder_;
       }
 
       // optional .exec.user.LikeFilter table_name_filter = 3;
@@ -13395,6 +13487,99 @@ public final class UserProtos {
           tableNameFilter_ = null;
         }
         return tableNameFilterBuilder_;
+      }
+
+      // repeated string table_type_filter = 4;
+      private com.google.protobuf.LazyStringList tableTypeFilter_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureTableTypeFilterIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          tableTypeFilter_ = new com.google.protobuf.LazyStringArrayList(tableTypeFilter_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public java.util.List<java.lang.String>
+          getTableTypeFilterList() {
+        return java.util.Collections.unmodifiableList(tableTypeFilter_);
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public int getTableTypeFilterCount() {
+        return tableTypeFilter_.size();
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public java.lang.String getTableTypeFilter(int index) {
+        return tableTypeFilter_.get(index);
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTableTypeFilterBytes(int index) {
+        return tableTypeFilter_.getByteString(index);
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public Builder setTableTypeFilter(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTableTypeFilterIsMutable();
+        tableTypeFilter_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public Builder addTableTypeFilter(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTableTypeFilterIsMutable();
+        tableTypeFilter_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public Builder addAllTableTypeFilter(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureTableTypeFilterIsMutable();
+        super.addAll(values, tableTypeFilter_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public Builder clearTableTypeFilter() {
+        tableTypeFilter_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string table_type_filter = 4;</code>
+       */
+      public Builder addTableTypeFilterBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTableTypeFilterIsMutable();
+        tableTypeFilter_.add(value);
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:exec.user.GetTablesReq)
@@ -15391,19 +15576,19 @@ public final class UserProtos {
      */
     org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getCatalogNameFilterOrBuilder();
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    boolean hasSchameNameFilter();
+    boolean hasSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter();
+    org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter();
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder();
+    org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder();
 
     // optional .exec.user.LikeFilter table_name_filter = 3;
     /**
@@ -15505,12 +15690,12 @@ public final class UserProtos {
             case 18: {
               org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = schameNameFilter_.toBuilder();
+                subBuilder = schemaNameFilter_.toBuilder();
               }
-              schameNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
+              schemaNameFilter_ = input.readMessage(org.apache.drill.exec.proto.UserProtos.LikeFilter.PARSER, extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(schameNameFilter_);
-                schameNameFilter_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(schemaNameFilter_);
+                schemaNameFilter_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
               break;
@@ -15603,26 +15788,26 @@ public final class UserProtos {
       return catalogNameFilter_;
     }
 
-    // optional .exec.user.LikeFilter schame_name_filter = 2;
-    public static final int SCHAME_NAME_FILTER_FIELD_NUMBER = 2;
-    private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_;
+    // optional .exec.user.LikeFilter schema_name_filter = 2;
+    public static final int SCHEMA_NAME_FILTER_FIELD_NUMBER = 2;
+    private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_;
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public boolean hasSchameNameFilter() {
+    public boolean hasSchemaNameFilter() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+      return schemaNameFilter_;
     }
     /**
-     * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+     * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
      */
-    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-      return schameNameFilter_;
+    public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+      return schemaNameFilter_;
     }
 
     // optional .exec.user.LikeFilter table_name_filter = 3;
@@ -15671,7 +15856,7 @@ public final class UserProtos {
 
     private void initFields() {
       catalogNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
-      schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       tableNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       columnNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
     }
@@ -15691,7 +15876,7 @@ public final class UserProtos {
         output.writeMessage(1, catalogNameFilter_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, schameNameFilter_);
+        output.writeMessage(2, schemaNameFilter_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeMessage(3, tableNameFilter_);
@@ -15714,7 +15899,7 @@ public final class UserProtos {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, schameNameFilter_);
+          .computeMessageSize(2, schemaNameFilter_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
@@ -15838,7 +16023,7 @@ public final class UserProtos {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getCatalogNameFilterFieldBuilder();
-          getSchameNameFilterFieldBuilder();
+          getSchemaNameFilterFieldBuilder();
           getTableNameFilterFieldBuilder();
           getColumnNameFilterFieldBuilder();
         }
@@ -15855,10 +16040,10 @@ public final class UserProtos {
           catalogNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         if (tableNameFilterBuilder_ == null) {
@@ -15912,10 +16097,10 @@ public final class UserProtos {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        if (schameNameFilterBuilder_ == null) {
-          result.schameNameFilter_ = schameNameFilter_;
+        if (schemaNameFilterBuilder_ == null) {
+          result.schemaNameFilter_ = schemaNameFilter_;
         } else {
-          result.schameNameFilter_ = schameNameFilterBuilder_.build();
+          result.schemaNameFilter_ = schemaNameFilterBuilder_.build();
         }
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
@@ -15952,8 +16137,8 @@ public final class UserProtos {
         if (other.hasCatalogNameFilter()) {
           mergeCatalogNameFilter(other.getCatalogNameFilter());
         }
-        if (other.hasSchameNameFilter()) {
-          mergeSchameNameFilter(other.getSchameNameFilter());
+        if (other.hasSchemaNameFilter()) {
+          mergeSchemaNameFilter(other.getSchemaNameFilter());
         }
         if (other.hasTableNameFilter()) {
           mergeTableNameFilter(other.getTableNameFilter());
@@ -16105,121 +16290,121 @@ public final class UserProtos {
         return catalogNameFilterBuilder_;
       }
 
-      // optional .exec.user.LikeFilter schame_name_filter = 2;
-      private org.apache.drill.exec.proto.UserProtos.LikeFilter schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      // optional .exec.user.LikeFilter schema_name_filter = 2;
+      private org.apache.drill.exec.proto.UserProtos.LikeFilter schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schameNameFilterBuilder_;
+          org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> schemaNameFilterBuilder_;
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public boolean hasSchameNameFilter() {
+      public boolean hasSchemaNameFilter() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          return schameNameFilter_;
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter getSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          return schemaNameFilter_;
         } else {
-          return schameNameFilterBuilder_.getMessage();
+          return schemaNameFilterBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder setSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          schameNameFilter_ = value;
+          schemaNameFilter_ = value;
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(value);
+          schemaNameFilterBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder setSchameNameFilter(
+      public Builder setSchemaNameFilter(
           org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder builderForValue) {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = builderForValue.build();
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = builderForValue.build();
           onChanged();
         } else {
-          schameNameFilterBuilder_.setMessage(builderForValue.build());
+          schemaNameFilterBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder mergeSchameNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
-        if (schameNameFilterBuilder_ == null) {
+      public Builder mergeSchemaNameFilter(org.apache.drill.exec.proto.UserProtos.LikeFilter value) {
+        if (schemaNameFilterBuilder_ == null) {
           if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              schameNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
-            schameNameFilter_ =
-              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schameNameFilter_).mergeFrom(value).buildPartial();
+              schemaNameFilter_ != org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance()) {
+            schemaNameFilter_ =
+              org.apache.drill.exec.proto.UserProtos.LikeFilter.newBuilder(schemaNameFilter_).mergeFrom(value).buildPartial();
           } else {
-            schameNameFilter_ = value;
+            schemaNameFilter_ = value;
           }
           onChanged();
         } else {
-          schameNameFilterBuilder_.mergeFrom(value);
+          schemaNameFilterBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public Builder clearSchameNameFilter() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
+      public Builder clearSchemaNameFilter() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilter_ = org.apache.drill.exec.proto.UserProtos.LikeFilter.getDefaultInstance();
           onChanged();
         } else {
-          schameNameFilterBuilder_.clear();
+          schemaNameFilterBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchameNameFilterBuilder() {
+      public org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder getSchemaNameFilterBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
-        return getSchameNameFilterFieldBuilder().getBuilder();
+        return getSchemaNameFilterFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
-      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchameNameFilterOrBuilder() {
-        if (schameNameFilterBuilder_ != null) {
-          return schameNameFilterBuilder_.getMessageOrBuilder();
+      public org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder getSchemaNameFilterOrBuilder() {
+        if (schemaNameFilterBuilder_ != null) {
+          return schemaNameFilterBuilder_.getMessageOrBuilder();
         } else {
-          return schameNameFilter_;
+          return schemaNameFilter_;
         }
       }
       /**
-       * <code>optional .exec.user.LikeFilter schame_name_filter = 2;</code>
+       * <code>optional .exec.user.LikeFilter schema_name_filter = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder> 
-          getSchameNameFilterFieldBuilder() {
-        if (schameNameFilterBuilder_ == null) {
-          schameNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          getSchemaNameFilterFieldBuilder() {
+        if (schemaNameFilterBuilder_ == null) {
+          schemaNameFilterBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.drill.exec.proto.UserProtos.LikeFilter, org.apache.drill.exec.proto.UserProtos.LikeFilter.Builder, org.apache.drill.exec.proto.UserProtos.LikeFilterOrBuilder>(
-                  schameNameFilter_,
+                  schemaNameFilter_,
                   getParentForChildren(),
                   isClean());
-          schameNameFilter_ = null;
+          schemaNameFilter_ = null;
         }
-        return schameNameFilterBuilder_;
+        return schemaNameFilterBuilder_;
       }
 
       // optional .exec.user.LikeFilter table_name_filter = 3;
@@ -27286,104 +27471,105 @@ public final class UserProtos {
       "ec.shared.DrillPBError\"|\n\022BitToUserHands" +
       "hake\022\023\n\013rpc_version\030\002 \001(\005\022*\n\006status\030\003 \001(" +
       "\0162\032.exec.user.HandshakeStatus\022\017\n\007errorId" +
-      "\030\004 \001(\t\022\024\n\014errorMessage\030\005 \001(\t\"+\n\nLikeFilt" +
-      "er\022\r\n\005regex\030\001 \001(\t\022\016\n\006escape\030\002 \001(\t\"D\n\016Get" +
-      "CatalogsReq\0222\n\023catalog_name_filter\030\001 \001(\013" +
-      "2\025.exec.user.LikeFilter\"M\n\017CatalogMetada" +
-      "ta\022\024\n\014catalog_name\030\001 \001(\t\022\023\n\013description\030",
-      "\002 \001(\t\022\017\n\007connect\030\003 \001(\t\"\223\001\n\017GetCatalogsRe" +
-      "sp\022(\n\006status\030\001 \001(\0162\030.exec.user.RequestSt" +
-      "atus\022,\n\010catalogs\030\002 \003(\0132\032.exec.user.Catal" +
-      "ogMetadata\022(\n\005error\030\003 \001(\0132\031.exec.shared." +
-      "DrillPBError\"v\n\rGetSchemasReq\0222\n\023catalog" +
-      "_name_filter\030\001 \001(\0132\025.exec.user.LikeFilte" +
-      "r\0221\n\022schame_name_filter\030\002 \001(\0132\025.exec.use" +
-      "r.LikeFilter\"i\n\016SchemaMetadata\022\024\n\014catalo" +
-      "g_name\030\001 \001(\t\022\023\n\013schema_name\030\002 \001(\t\022\r\n\005own" +
-      "er\030\003 \001(\t\022\014\n\004type\030\004 \001(\t\022\017\n\007mutable\030\005 \001(\t\"",
-      "\220\001\n\016GetSchemasResp\022(\n\006status\030\001 \001(\0162\030.exe" +
-      "c.user.RequestStatus\022*\n\007schemas\030\002 \003(\0132\031." +
-      "exec.user.SchemaMetadata\022(\n\005error\030\003 \001(\0132" +
-      "\031.exec.shared.DrillPBError\"\247\001\n\014GetTables" +
-      "Req\0222\n\023catalog_name_filter\030\001 \001(\0132\025.exec." +
-      "user.LikeFilter\0221\n\022schame_name_filter\030\002 " +
-      "\001(\0132\025.exec.user.LikeFilter\0220\n\021table_name" +
-      "_filter\030\003 \001(\0132\025.exec.user.LikeFilter\"\\\n\r" +
-      "TableMetadata\022\024\n\014catalog_name\030\001 \001(\t\022\023\n\013s" +
-      "chema_name\030\002 \001(\t\022\022\n\ntable_name\030\003 \001(\t\022\014\n\004",
-      "type\030\004 \001(\t\"\215\001\n\rGetTablesResp\022(\n\006status\030\001" +
-      " \001(\0162\030.exec.user.RequestStatus\022(\n\006tables" +
-      "\030\002 \003(\0132\030.exec.user.TableMetadata\022(\n\005erro" +
-      "r\030\003 \001(\0132\031.exec.shared.DrillPBError\"\333\001\n\rG" +
-      "etColumnsReq\0222\n\023catalog_name_filter\030\001 \001(" +
-      "\0132\025.exec.user.LikeFilter\0221\n\022schame_name_" +
-      "filter\030\002 \001(\0132\025.exec.user.LikeFilter\0220\n\021t" +
-      "able_name_filter\030\003 \001(\0132\025.exec.user.LikeF" +
-      "ilter\0221\n\022column_name_filter\030\004 \001(\0132\025.exec" +
-      ".user.LikeFilter\"\224\003\n\016ColumnMetadata\022\024\n\014c",
-      "atalog_name\030\001 \001(\t\022\023\n\013schema_name\030\002 \001(\t\022\022" +
-      "\n\ntable_name\030\003 \001(\t\022\023\n\013column_name\030\004 \001(\t\022" +
-      "\030\n\020ordinal_position\030\005 \001(\005\022\025\n\rdefault_val" +
-      "ue\030\006 \001(\t\022\023\n\013is_nullable\030\007 \001(\010\022\021\n\tdata_ty" +
-      "pe\030\010 \001(\t\022\027\n\017char_max_length\030\t \001(\005\022\031\n\021cha" +
-      "r_octet_length\030\n \001(\005\022\031\n\021numeric_precisio" +
-      "n\030\013 \001(\005\022\037\n\027numeric_precision_radix\030\014 \001(\005" +
-      "\022\025\n\rnumeric_scale\030\r \001(\005\022\033\n\023date_time_pre" +
-      "cision\030\016 \001(\005\022\025\n\rinterval_type\030\017 \001(\t\022\032\n\022i" +
-      "nterval_precision\030\020 \001(\005\"\220\001\n\016GetColumnsRe",
-      "sp\022(\n\006status\030\001 \001(\0162\030.exec.user.RequestSt" +
-      "atus\022*\n\007columns\030\002 \003(\0132\031.exec.user.Column" +
-      "Metadata\022(\n\005error\030\003 \001(\0132\031.exec.shared.Dr" +
-      "illPBError\"/\n\032CreatePreparedStatementReq" +
-      "\022\021\n\tsql_query\030\001 \001(\t\"\326\003\n\024ResultColumnMeta" +
-      "data\022\024\n\014catalog_name\030\001 \001(\t\022\023\n\013schema_nam" +
-      "e\030\002 \001(\t\022\022\n\ntable_name\030\003 \001(\t\022\023\n\013column_na" +
-      "me\030\004 \001(\t\022\r\n\005label\030\005 \001(\t\022\021\n\tdata_type\030\006 \001" +
-      "(\t\022\023\n\013is_nullable\030\007 \001(\010\022\021\n\tprecision\030\010 \001" +
-      "(\005\022\r\n\005scale\030\t \001(\005\022\016\n\006signed\030\n \001(\010\022\024\n\014dis",
-      "play_size\030\013 \001(\005\022\022\n\nis_aliased\030\014 \001(\010\0225\n\rs" +
-      "earchability\030\r \001(\0162\036.exec.user.ColumnSea" +
-      "rchability\0223\n\014updatability\030\016 \001(\0162\035.exec." +
-      "user.ColumnUpdatability\022\026\n\016auto_incremen" +
-      "t\030\017 \001(\010\022\030\n\020case_sensitivity\030\020 \001(\010\022\020\n\010sor" +
-      "table\030\021 \001(\010\022\022\n\nclass_name\030\022 \001(\t\022\023\n\013is_cu" +
-      "rrency\030\024 \001(\010\".\n\027PreparedStatementHandle\022" +
-      "\023\n\013server_info\030\001 \001(\014\"\200\001\n\021PreparedStateme" +
-      "nt\0220\n\007columns\030\001 \003(\0132\037.exec.user.ResultCo" +
-      "lumnMetadata\0229\n\rserver_handle\030\002 \001(\0132\".ex",
-      "ec.user.PreparedStatementHandle\"\253\001\n\033Crea" +
-      "tePreparedStatementResp\022(\n\006status\030\001 \001(\0162" +
-      "\030.exec.user.RequestStatus\0228\n\022prepared_st" +
-      "atement\030\002 \001(\0132\034.exec.user.PreparedStatem" +
-      "ent\022(\n\005error\030\003 \001(\0132\031.exec.shared.DrillPB" +
-      "Error\"\353\001\n\010RunQuery\0221\n\014results_mode\030\001 \001(\016" +
-      "2\033.exec.user.QueryResultsMode\022$\n\004type\030\002 " +
-      "\001(\0162\026.exec.shared.QueryType\022\014\n\004plan\030\003 \001(" +
-      "\t\0221\n\tfragments\030\004 \003(\0132\036.exec.bit.control." +
-      "PlanFragment\022E\n\031prepared_statement_handl",
-      "e\030\005 \001(\0132\".exec.user.PreparedStatementHan" +
-      "dle*\310\003\n\007RpcType\022\r\n\tHANDSHAKE\020\000\022\007\n\003ACK\020\001\022" +
-      "\013\n\007GOODBYE\020\002\022\r\n\tRUN_QUERY\020\003\022\020\n\014CANCEL_QU" +
-      "ERY\020\004\022\023\n\017REQUEST_RESULTS\020\005\022\027\n\023RESUME_PAU" +
-      "SED_QUERY\020\013\022\034\n\030GET_QUERY_PLAN_FRAGMENTS\020" +
-      "\014\022\020\n\014GET_CATALOGS\020\016\022\017\n\013GET_SCHEMAS\020\017\022\016\n\n" +
-      "GET_TABLES\020\020\022\017\n\013GET_COLUMNS\020\021\022\035\n\031CREATE_" +
-      "PREPARED_STATEMENT\020\026\022\016\n\nQUERY_DATA\020\006\022\020\n\014" +
-      "QUERY_HANDLE\020\007\022\030\n\024QUERY_PLAN_FRAGMENTS\020\r" +
-      "\022\014\n\010CATALOGS\020\022\022\013\n\007SCHEMAS\020\023\022\n\n\006TABLES\020\024\022",
-      "\013\n\007COLUMNS\020\025\022\026\n\022PREPARED_STATEMENT\020\027\022\026\n\022" +
-      "REQ_META_FUNCTIONS\020\010\022\026\n\022RESP_FUNCTION_LI" +
-      "ST\020\t\022\020\n\014QUERY_RESULT\020\n*#\n\020QueryResultsMo" +
-      "de\022\017\n\013STREAM_FULL\020\001*^\n\017HandshakeStatus\022\013" +
-      "\n\007SUCCESS\020\001\022\030\n\024RPC_VERSION_MISMATCH\020\002\022\017\n" +
-      "\013AUTH_FAILED\020\003\022\023\n\017UNKNOWN_FAILURE\020\004*D\n\rR" +
-      "equestStatus\022\022\n\016UNKNOWN_STATUS\020\000\022\006\n\002OK\020\001" +
-      "\022\n\n\006FAILED\020\002\022\013\n\007TIMEOUT\020\003*Y\n\023ColumnSearc" +
-      "hability\022\031\n\025UNKNOWN_SEARCHABILITY\020\000\022\010\n\004N" +
-      "ONE\020\001\022\010\n\004CHAR\020\002\022\n\n\006NUMBER\020\003\022\007\n\003ALL\020\004*K\n\022",
-      "ColumnUpdatability\022\030\n\024UNKNOWN_UPDATABILI" +
-      "TY\020\000\022\r\n\tREAD_ONLY\020\001\022\014\n\010WRITABLE\020\002B+\n\033org" +
-      ".apache.drill.exec.protoB\nUserProtosH\001"
+      "\030\004 \001(\t\022\024\n\014errorMessage\030\005 \001(\t\"-\n\nLikeFilt" +
+      "er\022\017\n\007pattern\030\001 \001(\t\022\016\n\006escape\030\002 \001(\t\"D\n\016G" +
+      "etCatalogsReq\0222\n\023catalog_name_filter\030\001 \001" +
+      "(\0132\025.exec.user.LikeFilter\"M\n\017CatalogMeta" +
+      "data\022\024\n\014catalog_name\030\001 \001(\t\022\023\n\013descriptio",
+      "n\030\002 \001(\t\022\017\n\007connect\030\003 \001(\t\"\223\001\n\017GetCatalogs" +
+      "Resp\022(\n\006status\030\001 \001(\0162\030.exec.user.Request" +
+      "Status\022,\n\010catalogs\030\002 \003(\0132\032.exec.user.Cat" +
+      "alogMetadata\022(\n\005error\030\003 \001(\0132\031.exec.share" +
+      "d.DrillPBError\"v\n\rGetSchemasReq\0222\n\023catal" +
+      "og_name_filter\030\001 \001(\0132\025.exec.user.LikeFil" +
+      "ter\0221\n\022schema_name_filter\030\002 \001(\0132\025.exec.u" +
+      "ser.LikeFilter\"i\n\016SchemaMetadata\022\024\n\014cata" +
+      "log_name\030\001 \001(\t\022\023\n\013schema_name\030\002 \001(\t\022\r\n\005o" +
+      "wner\030\003 \001(\t\022\014\n\004type\030\004 \001(\t\022\017\n\007mutable\030\005 \001(",
+      "\t\"\220\001\n\016GetSchemasResp\022(\n\006status\030\001 \001(\0162\030.e" +
+      "xec.user.RequestStatus\022*\n\007schemas\030\002 \003(\0132" +
+      "\031.exec.user.SchemaMetadata\022(\n\005error\030\003 \001(" +
+      "\0132\031.exec.shared.DrillPBError\"\302\001\n\014GetTabl" +
+      "esReq\0222\n\023catalog_name_filter\030\001 \001(\0132\025.exe" +
+      "c.user.LikeFilter\0221\n\022schema_name_filter\030" +
+      "\002 \001(\0132\025.exec.user.LikeFilter\0220\n\021table_na" +
+      "me_filter\030\003 \001(\0132\025.exec.user.LikeFilter\022\031" +
+      "\n\021table_type_filter\030\004 \003(\t\"\\\n\rTableMetada" +
+      "ta\022\024\n\014catalog_name\030\001 \001(\t\022\023\n\013schema_name\030",
+      "\002 \001(\t\022\022\n\ntable_name\030\003 \001(\t\022\014\n\004type\030\004 \001(\t\"" +
+      "\215\001\n\rGetTablesResp\022(\n\006status\030\001 \001(\0162\030.exec" +
+      ".user.RequestStatus\022(\n\006tables\030\002 \003(\0132\030.ex" +
+      "ec.user.TableMetadata\022(\n\005error\030\003 \001(\0132\031.e" +
+      "xec.shared.DrillPBError\"\333\001\n\rGetColumnsRe" +
+      "q\0222\n\023catalog_name_filter\030\001 \001(\0132\025.exec.us" +
+      "er.LikeFilter\0221\n\022schema_name_filter\030\002 \001(" +
+      "\0132\025.exec.user.LikeFilter\0220\n\021table_name_f" +
+      "ilter\030\003 \001(\0132\025.exec.user.LikeFilter\0221\n\022co" +
+      "lumn_name_filter\030\004 \001(\0132\025.exec.user.LikeF",
+      "ilter\"\224\003\n\016ColumnMetadata\022\024\n\014catalog_name" +
+      "\030\001 \001(\t\022\023\n\013schema_name\030\002 \001(\t\022\022\n\ntable_nam" +
+      "e\030\003 \001(\t\022\023\n\013column_name\030\004 \001(\t\022\030\n\020ordinal_" +
+      "position\030\005 \001(\005\022\025\n\rdefault_value\030\006 \001(\t\022\023\n" +
+      "\013is_nullable\030\007 \001(\010\022\021\n\tdata_type\030\010 \001(\t\022\027\n" +
+      "\017char_max_length\030\t \001(\005\022\031\n\021char_octet_len" +
+      "gth\030\n \001(\005\022\031\n\021numeric_precision\030\013 \001(\005\022\037\n\027" +
+      "numeric_precision_radix\030\014 \001(\005\022\025\n\rnumeric" +
+      "_scale\030\r \001(\005\022\033\n\023date_time_precision\030\016 \001(" +
+      "\005\022\025\n\rinterval_type\030\017 \001(\t\022\032\n\022interval_pre",
+      "cision\030\020 \001(\005\"\220\001\n\016GetColumnsResp\022(\n\006statu" +
+      "s\030\001 \001(\0162\030.exec.user.RequestStatus\022*\n\007col" +
+      "umns\030\002 \003(\0132\031.exec.user.ColumnMetadata\022(\n" +
+      "\005error\030\003 \001(\0132\031.exec.shared.DrillPBError\"" +
+      "/\n\032CreatePreparedStatementReq\022\021\n\tsql_que" +
+      "ry\030\001 \001(\t\"\326\003\n\024ResultColumnMetadata\022\024\n\014cat" +
+      "alog_name\030\001 \001(\t\022\023\n\013schema_name\030\002 \001(\t\022\022\n\n" +
+      "table_name\030\003 \001(\t\022\023\n\013column_name\030\004 \001(\t\022\r\n" +
+      "\005label\030\005 \001(\t\022\021\n\tdata_type\030\006 \001(\t\022\023\n\013is_nu" +
+      "llable\030\007 \001(\010\022\021\n\tprecision\030\010 \001(\005\022\r\n\005scale",
+      "\030\t \001(\005\022\016\n\006signed\030\n \001(\010\022\024\n\014display_size\030\013" +
+      " \001(\005\022\022\n\nis_aliased\030\014 \001(\010\0225\n\rsearchabilit" +
+      "y\030\r \001(\0162\036.exec.user.ColumnSearchability\022" +
+      "3\n\014updatability\030\016 \001(\0162\035.exec.user.Column" +
+      "Updatability\022\026\n\016auto_increment\030\017 \001(\010\022\030\n\020" +
+      "case_sensitivity\030\020 \001(\010\022\020\n\010sortable\030\021 \001(\010" +
+      "\022\022\n\nclass_name\030\022 \001(\t\022\023\n\013is_currency\030\024 \001(" +
+      "\010\".\n\027PreparedStatementHandle\022\023\n\013server_i" +
+      "nfo\030\001 \001(\014\"\200\001\n\021PreparedStatement\0220\n\007colum" +
+      "ns\030\001 \003(\0132\037.exec.user.ResultColumnMetadat",
+      "a\0229\n\rserver_handle\030\002 \001(\0132\".exec.user.Pre" +
+      "paredStatementHandle\"\253\001\n\033CreatePreparedS" +
+      "tatementResp\022(\n\006status\030\001 \001(\0162\030.exec.user" +
+      ".RequestStatus\0228\n\022prepared_statement\030\002 \001" +
+      "(\0132\034.exec.user.PreparedStatement\022(\n\005erro" +
+      "r\030\003 \001(\0132\031.exec.shared.DrillPBError\"\353\001\n\010R" +
+      "unQuery\0221\n\014results_mode\030\001 \001(\0162\033.exec.use" +
+      "r.QueryResultsMode\022$\n\004type\030\002 \001(\0162\026.exec." +
+      "shared.QueryType\022\014\n\004plan\030\003 \001(\t\0221\n\tfragme" +
+      "nts\030\004 \003(\0132\036.exec.bit.control.PlanFragmen",
+      "t\022E\n\031prepared_statement_handle\030\005 \001(\0132\".e" +
+      "xec.user.PreparedStatementHandle*\310\003\n\007Rpc" +
+      "Type\022\r\n\tHANDSHAKE\020\000\022\007\n\003ACK\020\001\022\013\n\007GOODBYE\020" +
+      "\002\022\r\n\tRUN_QUERY\020\003\022\020\n\014CANCEL_QUERY\020\004\022\023\n\017RE" +
+      "QUEST_RESULTS\020\005\022\027\n\023RESUME_PAUSED_QUERY\020\013" +
+      "\022\034\n\030GET_QUERY_PLAN_FRAGMENTS\020\014\022\020\n\014GET_CA" +
+      "TALOGS\020\016\022\017\n\013GET_SCHEMAS\020\017\022\016\n\nGET_TABLES\020" +
+      "\020\022\017\n\013GET_COLUMNS\020\021\022\035\n\031CREATE_PREPARED_ST" +
+      "ATEMENT\020\026\022\016\n\nQUERY_DATA\020\006\022\020\n\014QUERY_HANDL" +
+      "E\020\007\022\030\n\024QUERY_PLAN_FRAGMENTS\020\r\022\014\n\010CATALOG",
+      "S\020\022\022\013\n\007SCHEMAS\020\023\022\n\n\006TABLES\020\024\022\013\n\007COLUMNS\020" +
+      "\025\022\026\n\022PREPARED_STATEMENT\020\027\022\026\n\022REQ_META_FU" +
+      "NCTIONS\020\010\022\026\n\022RESP_FUNCTION_LIST\020\t\022\020\n\014QUE" +
+      "RY_RESULT\020\n*#\n\020QueryResultsMode\022\017\n\013STREA" +
+      "M_FULL\020\001*^\n\017HandshakeStatus\022\013\n\007SUCCESS\020\001" +
+      "\022\030\n\024RPC_VERSION_MISMATCH\020\002\022\017\n\013AUTH_FAILE" +
+      "D\020\003\022\023\n\017UNKNOWN_FAILURE\020\004*D\n\rRequestStatu" +
+      "s\022\022\n\016UNKNOWN_STATUS\020\000\022\006\n\002OK\020\001\022\n\n\006FAILED\020" +
+      "\002\022\013\n\007TIMEOUT\020\003*Y\n\023ColumnSearchability\022\031\n" +
+      "\025UNKNOWN_SEARCHABILITY\020\000\022\010\n\004NONE\020\001\022\010\n\004CH",
+      "AR\020\002\022\n\n\006NUMBER\020\003\022\007\n\003ALL\020\004*K\n\022ColumnUpdat" +
+      "ability\022\030\n\024UNKNOWN_UPDATABILITY\020\000\022\r\n\tREA" +
+      "D_ONLY\020\001\022\014\n\010WRITABLE\020\002B+\n\033org.apache.dri" +
+      "ll.exec.protoB\nUserProtosH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -27437,7 +27623,7 @@ public final class UserProtos {
           internal_static_exec_user_LikeFilter_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_user_LikeFilter_descriptor,
-              new java.lang.String[] { "Regex", "Escape", });
+              new java.lang.String[] { "Pattern", "Escape", });
           internal_static_exec_user_GetCatalogsReq_descriptor =
             getDescriptor().getMessageTypes().get(8);
           internal_static_exec_user_GetCatalogsReq_fieldAccessorTable = new
@@ -27461,7 +27647,7 @@ public final class UserProtos {
           internal_static_exec_user_GetSchemasReq_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_user_GetSchemasReq_descriptor,
-              new java.lang.String[] { "CatalogNameFilter", "SchameNameFilter", });
+              new java.lang.String[] { "CatalogNameFilter", "SchemaNameFilter", });
           internal_static_exec_user_SchemaMetadata_descriptor =
             getDescriptor().getMessageTypes().get(12);
           internal_static_exec_user_SchemaMetadata_fieldAccessorTable = new
@@ -27479,7 +27665,7 @@ public final class UserProtos {
           internal_static_exec_user_GetTablesReq_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_user_GetTablesReq_descriptor,
-              new java.lang.String[] { "CatalogNameFilter", "SchameNameFilter", "TableNameFilter", });
+              new java.lang.String[] { "CatalogNameFilter", "SchemaNameFilter", "TableNameFilter", "TableTypeFilter", });
           internal_static_exec_user_TableMetadata_descriptor =
             getDescriptor().getMessageTypes().get(15);
           internal_static_exec_user_TableMetadata_fieldAccessorTable = new
@@ -27497,7 +27683,7 @@ public final class UserProtos {
           internal_static_exec_user_GetColumnsReq_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_user_GetColumnsReq_descriptor,
-              new java.lang.String[] { "CatalogNameFilter", "SchameNameFilter", "TableNameFilter", "ColumnNameFilter", });
+              new java.lang.String[] { "CatalogNameFilter", "SchemaNameFilter", "TableNameFilter", "ColumnNameFilter", });
           internal_static_exec_user_ColumnMetadata_descriptor =
             getDescriptor().getMessageTypes().get(18);
           internal_static_exec_user_ColumnMetadata_fieldAccessorTable = new

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetColumnsReq.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetColumnsReq.java
@@ -48,7 +48,7 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
 
     
     private LikeFilter catalogNameFilter;
-    private LikeFilter schameNameFilter;
+    private LikeFilter schemaNameFilter;
     private LikeFilter tableNameFilter;
     private LikeFilter columnNameFilter;
 
@@ -72,16 +72,16 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
         return this;
     }
 
-    // schameNameFilter
+    // schemaNameFilter
 
-    public LikeFilter getSchameNameFilter()
+    public LikeFilter getSchemaNameFilter()
     {
-        return schameNameFilter;
+        return schemaNameFilter;
     }
 
-    public GetColumnsReq setSchameNameFilter(LikeFilter schameNameFilter)
+    public GetColumnsReq setSchemaNameFilter(LikeFilter schemaNameFilter)
     {
-        this.schameNameFilter = schameNameFilter;
+        this.schemaNameFilter = schemaNameFilter;
         return this;
     }
 
@@ -170,7 +170,7 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
                     break;
 
                 case 2:
-                    message.schameNameFilter = input.mergeObject(message.schameNameFilter, LikeFilter.getSchema());
+                    message.schemaNameFilter = input.mergeObject(message.schemaNameFilter, LikeFilter.getSchema());
                     break;
 
                 case 3:
@@ -194,8 +194,8 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
              output.writeObject(1, message.catalogNameFilter, LikeFilter.getSchema(), false);
 
 
-        if(message.schameNameFilter != null)
-             output.writeObject(2, message.schameNameFilter, LikeFilter.getSchema(), false);
+        if(message.schemaNameFilter != null)
+             output.writeObject(2, message.schemaNameFilter, LikeFilter.getSchema(), false);
 
 
         if(message.tableNameFilter != null)
@@ -212,7 +212,7 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
         switch(number)
         {
             case 1: return "catalogNameFilter";
-            case 2: return "schameNameFilter";
+            case 2: return "schemaNameFilter";
             case 3: return "tableNameFilter";
             case 4: return "columnNameFilter";
             default: return null;
@@ -229,7 +229,7 @@ public final class GetColumnsReq implements Externalizable, Message<GetColumnsRe
     static
     {
         __fieldMap.put("catalogNameFilter", 1);
-        __fieldMap.put("schameNameFilter", 2);
+        __fieldMap.put("schemaNameFilter", 2);
         __fieldMap.put("tableNameFilter", 3);
         __fieldMap.put("columnNameFilter", 4);
     }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetSchemasReq.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetSchemasReq.java
@@ -48,7 +48,7 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
 
     
     private LikeFilter catalogNameFilter;
-    private LikeFilter schameNameFilter;
+    private LikeFilter schemaNameFilter;
 
     public GetSchemasReq()
     {
@@ -70,16 +70,16 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
         return this;
     }
 
-    // schameNameFilter
+    // schemaNameFilter
 
-    public LikeFilter getSchameNameFilter()
+    public LikeFilter getSchemaNameFilter()
     {
-        return schameNameFilter;
+        return schemaNameFilter;
     }
 
-    public GetSchemasReq setSchameNameFilter(LikeFilter schameNameFilter)
+    public GetSchemasReq setSchemaNameFilter(LikeFilter schemaNameFilter)
     {
-        this.schameNameFilter = schameNameFilter;
+        this.schemaNameFilter = schemaNameFilter;
         return this;
     }
 
@@ -142,7 +142,7 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
                     break;
 
                 case 2:
-                    message.schameNameFilter = input.mergeObject(message.schameNameFilter, LikeFilter.getSchema());
+                    message.schemaNameFilter = input.mergeObject(message.schemaNameFilter, LikeFilter.getSchema());
                     break;
 
                 default:
@@ -158,8 +158,8 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
              output.writeObject(1, message.catalogNameFilter, LikeFilter.getSchema(), false);
 
 
-        if(message.schameNameFilter != null)
-             output.writeObject(2, message.schameNameFilter, LikeFilter.getSchema(), false);
+        if(message.schemaNameFilter != null)
+             output.writeObject(2, message.schemaNameFilter, LikeFilter.getSchema(), false);
 
     }
 
@@ -168,7 +168,7 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
         switch(number)
         {
             case 1: return "catalogNameFilter";
-            case 2: return "schameNameFilter";
+            case 2: return "schemaNameFilter";
             default: return null;
         }
     }
@@ -183,7 +183,7 @@ public final class GetSchemasReq implements Externalizable, Message<GetSchemasRe
     static
     {
         __fieldMap.put("catalogNameFilter", 1);
-        __fieldMap.put("schameNameFilter", 2);
+        __fieldMap.put("schemaNameFilter", 2);
     }
     
 }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetTablesReq.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/GetTablesReq.java
@@ -24,6 +24,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.dyuproject.protostuff.GraphIOUtil;
 import com.dyuproject.protostuff.Input;
@@ -48,8 +50,9 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
 
     
     private LikeFilter catalogNameFilter;
-    private LikeFilter schameNameFilter;
+    private LikeFilter schemaNameFilter;
     private LikeFilter tableNameFilter;
+    private List<String> tableTypeFilter;
 
     public GetTablesReq()
     {
@@ -71,16 +74,16 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
         return this;
     }
 
-    // schameNameFilter
+    // schemaNameFilter
 
-    public LikeFilter getSchameNameFilter()
+    public LikeFilter getSchemaNameFilter()
     {
-        return schameNameFilter;
+        return schemaNameFilter;
     }
 
-    public GetTablesReq setSchameNameFilter(LikeFilter schameNameFilter)
+    public GetTablesReq setSchemaNameFilter(LikeFilter schemaNameFilter)
     {
-        this.schameNameFilter = schameNameFilter;
+        this.schemaNameFilter = schemaNameFilter;
         return this;
     }
 
@@ -94,6 +97,19 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
     public GetTablesReq setTableNameFilter(LikeFilter tableNameFilter)
     {
         this.tableNameFilter = tableNameFilter;
+        return this;
+    }
+
+    // tableTypeFilter
+
+    public List<String> getTableTypeFilterList()
+    {
+        return tableTypeFilter;
+    }
+
+    public GetTablesReq setTableTypeFilterList(List<String> tableTypeFilter)
+    {
+        this.tableTypeFilter = tableTypeFilter;
         return this;
     }
 
@@ -156,13 +172,18 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
                     break;
 
                 case 2:
-                    message.schameNameFilter = input.mergeObject(message.schameNameFilter, LikeFilter.getSchema());
+                    message.schemaNameFilter = input.mergeObject(message.schemaNameFilter, LikeFilter.getSchema());
                     break;
 
                 case 3:
                     message.tableNameFilter = input.mergeObject(message.tableNameFilter, LikeFilter.getSchema());
                     break;
 
+                case 4:
+                    if(message.tableTypeFilter == null)
+                        message.tableTypeFilter = new ArrayList<String>();
+                    message.tableTypeFilter.add(input.readString());
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -176,13 +197,22 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
              output.writeObject(1, message.catalogNameFilter, LikeFilter.getSchema(), false);
 
 
-        if(message.schameNameFilter != null)
-             output.writeObject(2, message.schameNameFilter, LikeFilter.getSchema(), false);
+        if(message.schemaNameFilter != null)
+             output.writeObject(2, message.schemaNameFilter, LikeFilter.getSchema(), false);
 
 
         if(message.tableNameFilter != null)
              output.writeObject(3, message.tableNameFilter, LikeFilter.getSchema(), false);
 
+
+        if(message.tableTypeFilter != null)
+        {
+            for(String tableTypeFilter : message.tableTypeFilter)
+            {
+                if(tableTypeFilter != null)
+                    output.writeString(4, tableTypeFilter, true);
+            }
+        }
     }
 
     public String getFieldName(int number)
@@ -190,8 +220,9 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
         switch(number)
         {
             case 1: return "catalogNameFilter";
-            case 2: return "schameNameFilter";
+            case 2: return "schemaNameFilter";
             case 3: return "tableNameFilter";
+            case 4: return "tableTypeFilter";
             default: return null;
         }
     }
@@ -206,8 +237,9 @@ public final class GetTablesReq implements Externalizable, Message<GetTablesReq>
     static
     {
         __fieldMap.put("catalogNameFilter", 1);
-        __fieldMap.put("schameNameFilter", 2);
+        __fieldMap.put("schemaNameFilter", 2);
         __fieldMap.put("tableNameFilter", 3);
+        __fieldMap.put("tableTypeFilter", 4);
     }
     
 }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/LikeFilter.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/LikeFilter.java
@@ -47,7 +47,7 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
     static final LikeFilter DEFAULT_INSTANCE = new LikeFilter();
 
     
-    private String regex;
+    private String pattern;
     private String escape;
 
     public LikeFilter()
@@ -57,16 +57,16 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
 
     // getters and setters
 
-    // regex
+    // pattern
 
-    public String getRegex()
+    public String getPattern()
     {
-        return regex;
+        return pattern;
     }
 
-    public LikeFilter setRegex(String regex)
+    public LikeFilter setPattern(String pattern)
     {
-        this.regex = regex;
+        this.pattern = pattern;
         return this;
     }
 
@@ -138,7 +138,7 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
                 case 0:
                     return;
                 case 1:
-                    message.regex = input.readString();
+                    message.pattern = input.readString();
                     break;
                 case 2:
                     message.escape = input.readString();
@@ -152,8 +152,8 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
 
     public void writeTo(Output output, LikeFilter message) throws IOException
     {
-        if(message.regex != null)
-            output.writeString(1, message.regex, false);
+        if(message.pattern != null)
+            output.writeString(1, message.pattern, false);
 
         if(message.escape != null)
             output.writeString(2, message.escape, false);
@@ -163,7 +163,7 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
     {
         switch(number)
         {
-            case 1: return "regex";
+            case 1: return "pattern";
             case 2: return "escape";
             default: return null;
         }
@@ -178,7 +178,7 @@ public final class LikeFilter implements Externalizable, Message<LikeFilter>, Sc
     private static final java.util.HashMap<String,Integer> __fieldMap = new java.util.HashMap<String,Integer>();
     static
     {
-        __fieldMap.put("regex", 1);
+        __fieldMap.put("pattern", 1);
         __fieldMap.put("escape", 2);
     }
     

--- a/protocol/src/main/protobuf/User.proto
+++ b/protocol/src/main/protobuf/User.proto
@@ -120,7 +120,7 @@ enum RequestStatus {
  * Simple filter which encapsulates the SQL LIKE ... ESCAPE function
  */
 message LikeFilter {
-  optional string regex = 1; // pattern to match
+  optional string pattern = 1; // pattern to match
   optional string escape = 2; // escape character (if any) present in the pattern
 }
 
@@ -154,7 +154,7 @@ message GetCatalogsResp {
  */
 message GetSchemasReq {
   optional LikeFilter catalog_name_filter = 1;
-  optional LikeFilter schame_name_filter = 2;
+  optional LikeFilter schema_name_filter = 2;
 }
 
 /*
@@ -182,8 +182,9 @@ message GetSchemasResp {
  */
 message GetTablesReq {
   optional LikeFilter catalog_name_filter = 1;
-  optional LikeFilter schame_name_filter = 2;
+  optional LikeFilter schema_name_filter = 2;
   optional LikeFilter table_name_filter = 3;
+  repeated string table_type_filter = 4;
 }
 
 /*
@@ -210,7 +211,7 @@ message GetTablesResp {
  */
 message GetColumnsReq {
   optional LikeFilter catalog_name_filter = 1;
-  optional LikeFilter schame_name_filter = 2;
+  optional LikeFilter schema_name_filter = 2;
   optional LikeFilter table_name_filter = 3;
   optional LikeFilter column_name_filter = 4;
 }


### PR DESCRIPTION
- Adding tableType filter to GetTablesReq query (needed for JDBC and ODBC
drivers).
- Fix table type returned by sys and INFORMATION_SCHEMA tables
- Also fixes some protobuf typos to related classes.