### PR TITLE
Added -P to CD handle symbolic links in PWD

### DIFF
--- a/distribution/src/resources/drill-conf
+++ b/distribution/src/resources/drill-conf
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 # Start sqlline session using connection settings from configuration file
 exec ${bin}/sqlline -u "jdbc:drill:" "$@"

--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -66,7 +66,7 @@ done
 # convert relative path to absolute path
 bin=`dirname "$this"`
 script=`basename "$this"`
-home=`cd "$bin/..">/dev/null; pwd`
+home=`cd -P "$bin/..">/dev/null; pwd`
 this="$home/bin/$script"
 
 # the root of the drill installation

--- a/distribution/src/resources/drill-embedded
+++ b/distribution/src/resources/drill-embedded
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 # Start a sqlline session with an embedded Drillbit
 export DRILL_EMBEDDED=1

--- a/distribution/src/resources/drill-localhost
+++ b/distribution/src/resources/drill-localhost
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 # Start sqlline session by connection to locally running Drillbit
 exec ${bin}/sqlline -u "jdbc:drill:drillbit=localhost" "$@"

--- a/distribution/src/resources/drillbit.sh
+++ b/distribution/src/resources/drillbit.sh
@@ -59,7 +59,7 @@ usage="Usage: drillbit.sh [--config|--site <site-dir>]\
  (start|stop|status|restart|run) [args]"
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 base=`basename "${BASH_SOURCE-$0}"`
 command=${base/.*/}

--- a/distribution/src/resources/dumpcat
+++ b/distribution/src/resources/dumpcat
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 . "$bin"/drill-config.sh
 

--- a/distribution/src/resources/submit_plan
+++ b/distribution/src/resources/submit_plan
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin">/dev/null; pwd`
+bin=`cd -P "$bin">/dev/null; pwd`
 
 . "$bin"/drill-config.sh
 


### PR DESCRIPTION
The use of plain "cd" with a symbolic link to a directory maintains the logical name (i.e., includes the link's name), hence in a script, when a path is set using "pwd", that path includes the link instead of the full physical path.  This is a problem when the path is used (e.g in "cd .." -- which ends in the wrong place !!)
   Adding the "-P" option makes "cd" follow the physical name. For example:

[mapr@mfs91 ~]$ ls -l ~/drill/bin
lrwxrwxrwx 1 mapr mapr 79 Oct 18 16:55 /home/mapr/drill/bin -> distribution/target/apache-drill-1.9.0-SNAPSHOT/apache-drill-1.9.0-SNAPSHOT/bin
[mapr@mfs91 ~]$ cd ~/drill/bin ; pwd
/home/mapr/drill/bin
[mapr@mfs91 bin]$ cd -P ~/drill/bin ; pwd
/home/mapr/drill/distribution/target/apache-drill-1.9.0-SNAPSHOT/apache-drill-1.9.0-SNAPSHOT/bin

@paul-rogers please review 
