### PR TITLE
DRILL-4812: Fix for detecting wildcards in paths when running on windows

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
@@ -369,7 +369,7 @@ public class FileSelection {
   private static Path handleWildCard(final String root) {
     if (root.contains(WILD_CARD)) {
       int idx = root.indexOf(WILD_CARD); // first wild card in the path
-      idx = root.lastIndexOf(PATH_SEPARATOR, idx); // file separator right before the first wild card
+      idx = root.lastIndexOf('/', idx); // file separator right before the first wild card
       final String newRoot = root.substring(0, idx);
       return new Path(newRoot);
     } else {


### PR DESCRIPTION
By the time the path makes it to the `handleWildCard` method the separators have all been normalized to the forward slash.  This method, like `removeLeadingSlash` are safe, and must only check directly for the `/` separator.
