### PR TITLE
DRILL-4964: Drill fails to connect to hive metastore after hive metas…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/DrillHiveMetaStoreClient.java
@@ -201,8 +201,12 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
     try {
       return mClient.getAllDatabases();
     } catch (MetaException e) {
-      throw e;
-    } catch (TException e) {
+      /*
+         HiveMetaStoreClient is encapsulating both the MetaException/TExceptions inside MetaException.
+         Since we don't have good way to differentiate, we will close older connection and retry once.
+         This is only applicable for getAllTables and getAllDatabases method since other methods are
+         properly throwing correct exceptions.
+      */
       logger.warn("Failure while attempting to get hive databases. Retries once.", e);
       try {
         mClient.close();
@@ -219,9 +223,13 @@ public abstract class DrillHiveMetaStoreClient extends HiveMetaStoreClient {
       throws TException {
     try {
       return mClient.getAllTables(dbName);
-    } catch (MetaException | UnknownDBException e) {
-      throw e;
-    } catch (TException e) {
+    } catch (MetaException e) {
+      /*
+         HiveMetaStoreClient is encapsulating both the MetaException/TExceptions inside MetaException.
+         Since we don't have good way to differentiate, we will close older connection and retry once.
+         This is only applicable for getAllTables and getAllDatabases method since other methods are
+         properly throwing correct exceptions.
+      */
       logger.warn("Failure while attempting to get hive tables. Retries once.", e);
       try {
         mClient.close();


### PR DESCRIPTION
…tore is restarted unless drillbits are restarted also

            Changes: For certain methods in DrillHiveMetaStoreClient like getAllDatabases and getAllTables the HiveMetaStoreClient
                     wraps the exception of type MetaException and TException both into MetaException. So in case of connection
                     failure which is thrown as TException it is difficult to categorize at DrillClient level. Hence the fix
                     is to close older connection and reconnect in case of these 2 api's. In all other cases proper set of exceptions
                     are thrown where we can handle each one individually.