### PR TITLE
[maven-release-plugin] Hbase 1.1.2 Guava conflict

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-common</artifactId>

--- a/contrib/data/pom.xml
+++ b/contrib/data/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.data</groupId>

--- a/contrib/data/tpch-sample-data/pom.xml
+++ b/contrib/data/tpch-sample-data/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>drill-contrib-data-parent</artifactId>
     <groupId>org.apache.drill.contrib.data</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>tpch-sample-data</artifactId>

--- a/contrib/gis/pom.xml
+++ b/contrib/gis/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<artifactId>drill-contrib-parent</artifactId>
 		<groupId>org.apache.drill.contrib</groupId>
-		<version>1.8.0-SNAPSHOT</version>
+		<version>1.8.0</version>
 	</parent>
 
 	<artifactId>drill-gis</artifactId>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.contrib</groupId>

--- a/contrib/sqlline/pom.xml
+++ b/contrib/sqlline/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-sqlline</artifactId>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-storage-hbase</artifactId>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-storage-hive-core</artifactId>

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-hive-exec-shaded</artifactId>

--- a/contrib/storage-hive/pom.xml
+++ b/contrib/storage-hive/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.drill.contrib</groupId>
     <artifactId>drill-contrib-parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.storage-hive</groupId>

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-jdbc-storage</artifactId>

--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-kudu-storage</artifactId>

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-mongo-storage</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
   <artifactId>drill-java-exec</artifactId>
   <name>exec/Java Execution Engine</name>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-jdbc-all</artifactId>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
   <artifactId>drill-jdbc</artifactId>
   <name>exec/JDBC Driver using dependencies</name>

--- a/exec/memory/base/pom.xml
+++ b/exec/memory/base/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>memory-parent</artifactId>
     <groupId>org.apache.drill.memory</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
   <artifactId>drill-memory-base</artifactId>
   <name>exec/memory/base</name>

--- a/exec/memory/pom.xml
+++ b/exec/memory/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.memory</groupId>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.exec</groupId>

--- a/exec/rpc/pom.xml
+++ b/exec/rpc/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
   <artifactId>drill-rpc</artifactId>
   <name>exec/rpc</name>

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
   <artifactId>vector</artifactId>
   <name>exec/Vectors</name>

--- a/logical/pom.xml
+++ b/logical/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-logical</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.drill</groupId>
   <artifactId>drill-root</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
+  <version>1.8.0</version>
   <packaging>pom</packaging>
 
   <name>Apache Drill Root POM</name>
@@ -52,7 +52,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/drill.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/drill.git</developerConnection>
     <url>https://github.com/apache/drill</url>
-    <tag>HEAD</tag>
+    <tag>drill-1.8.0</tag>
   </scm>
 
   <mailingLists>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-protocol</artifactId>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>tools-parent</artifactId>
     <groupId>org.apache.drill.tools</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <artifactId>drill-fmpp-maven-plugin</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.0</version>
   </parent>
 
   <groupId>org.apache.drill.tools</groupId>


### PR DESCRIPTION
I use Apache Drill with Hbase1.1.2, when I tried to sumbit a SQL query I get the following message error : 

     [0: jdbc:drill:zk=local> select * from test; 
     Error: SYSTEM ERROR: IllegalAccessError: tried to access method     com.google.common.base.Stopwatch.<init>()V from class  org.apache.hadoop.hbase.zookeeper.MetaTableLocator


     [Error Id: d4408bbb-015a-4d93-80f7-0e64d3a72b8e on 192.168.0.17:31010] (state=,code=0)]

This error is caused by the conflict between guava library used in Drill (guava 18.0) and the version used in HBase (guava 12.0)