### PR TITLE
DRILL-4969: Basic implementation of display size for column metadata

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -275,6 +275,84 @@ public class Types {
     return isSigned;
   }
 
+  public static int getJdbcDisplaySize(MajorType type) {
+    if (type.getMode() == DataMode.REPEATED || type.getMinorType() == MinorType.LIST) {
+      return 0;
+    }
+
+    final int precision = getPrecision(type);
+
+    switch(type.getMinorType()) {
+    case BIT:             return 1; // 1 digit
+
+    case TINYINT:         return 4; // sign + 3 digit
+    case SMALLINT:        return 6; // sign + 5 digits
+    case INT:             return 11; // sign + 10 digits
+    case BIGINT:          return 20; // sign + 19 digits
+
+    case UINT1:          return 3; // 3 digits
+    case UINT2:          return 5; // 5 digits
+    case UINT4:          return 10; // 10 digits
+    case UINT8:          return 19; // 19 digits
+
+    case FLOAT4:          return 14; // sign + 7 digits + decimal point + E + 2 digits
+    case FLOAT8:          return 24; // sign + 15 digits + decimal point + E + 3 digits
+
+    case DECIMAL9:
+    case DECIMAL18:
+    case DECIMAL28DENSE:
+    case DECIMAL28SPARSE:
+    case DECIMAL38DENSE:
+    case DECIMAL38SPARSE:
+    case MONEY:           return 2 + precision; // precision of the column plus a sign and a decimal point
+
+    case VARCHAR:
+    case FIXEDCHAR:
+    case VAR16CHAR:
+    case FIXED16CHAR:     return precision; // number of characters
+
+    case VARBINARY:
+    case FIXEDBINARY:     return 2 * precision; // each binary byte is represented as a 2digit hex number
+
+    case DATE:            return 10; // yyyy-mm-dd
+    case TIME:
+      return precision > 0
+        ? 9 + precision // hh-mm-ss.SSS
+        : 8; // hh-mm-ss
+    case TIMETZ:
+      return precision > 0
+        ? 15 + precision // hh-mm-ss.SSS-zz:zz
+        : 14; // hh-mm-ss-zz:zz
+    case TIMESTAMP:
+      return precision > 0
+         ? 20 + precision // yyyy-mm-ddThh:mm:ss.SSS
+         : 19; // yyyy-mm-ddThh:mm:ss
+    case TIMESTAMPTZ:
+      return precision > 0
+        ? 26 + precision // yyyy-mm-ddThh:mm:ss.SSS:ZZ-ZZ
+        : 25; // yyyy-mm-ddThh:mm:ss-ZZ:ZZ
+
+    case INTERVALYEAR:
+      return precision > 0
+          ? 5 + precision // P..Y12M
+          : 0; // if precision is not set, return 0 because there's not enough info
+
+    case INTERVALDAY:
+      return precision > 0
+          ? 12 + precision // P..DT12H60M60S assuming fractional seconds precision is not supported
+          : 0; // if precision is not set, return 0 because there's not enough info
+
+    case INTERVAL:
+    case MAP:
+    case LATE:
+    case NULL:
+    case UNION:           return 0;
+
+    default:
+      throw new UnsupportedOperationException(
+          "Unexpected/unhandled MinorType value " + type.getMinorType() );
+    }
+  }
   public static boolean usesHolderForGet(final MajorType type) {
     if (type.getMode() == REPEATED) {
       return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
@@ -22,6 +22,18 @@ import static org.apache.drill.exec.proto.UserProtos.RequestStatus.FAILED;
 import static org.apache.drill.exec.proto.UserProtos.RequestStatus.OK;
 import static org.apache.drill.exec.proto.UserProtos.RequestStatus.TIMEOUT;
 
+import java.math.BigDecimal;
+import java.net.SocketAddress;
+import java.sql.Date;
+import java.sql.ResultSetMetaData;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.drill.common.exceptions.ErrorHelper;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
@@ -61,17 +73,6 @@ import com.google.common.collect.ImmutableMap;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
-import java.math.BigDecimal;
-import java.net.SocketAddress;
-import java.sql.Date;
-import java.sql.ResultSetMetaData;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Contains worker {@link Runnable} for creating a prepared statement and helper methods.
@@ -371,9 +372,9 @@ public class PreparedStatementProvider {
     builder.setSigned(Types.isNumericType(majorType));
 
     /**
-     * Maximum number of characters required to display data from the column. Initial implementation hard coded to 10.
+     * Maximum number of characters required to display data from the column.
      */
-    builder.setDisplaySize(10);
+    builder.setDisplaySize(Types.getJdbcDisplaySize(majorType));
 
     /**
      * Is the column an aliased column. Initial implementation defaults to true as we derive schema from LIMIT 0 query and

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillColumnMetaDataList.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillColumnMetaDataList.java
@@ -144,10 +144,9 @@ public class DrillColumnMetaDataList extends BasicList<ColumnMetaData>{
       //   getColumns()'s COLUMN_SIZE)
       // - scale for getScale(...), and
       // - and displaySize for getColumnDisplaySize(...).
-      final int precision =
-          rpcDataType.hasPrecision() ? rpcDataType.getPrecision() : 0;
-      final int scale = rpcDataType.hasScale() ? rpcDataType.getScale() : 0;
-      final int displaySize = 10;
+      final int precision = Types.getPrecision(rpcDataType);
+      final int scale = Types.getScale(rpcDataType);
+      final int displaySize = Types.getJdbcDisplaySize(rpcDataType);
 
       ColumnMetaData col = new ColumnMetaData(
           colOffset,    // (zero-based ordinal (for Java arrays/lists).)

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
@@ -24,20 +24,13 @@ import static java.sql.Types.DECIMAL;
 import static java.sql.Types.INTEGER;
 import static java.sql.Types.TIMESTAMP;
 import static java.sql.Types.VARCHAR;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.hamcrest.CoreMatchers.*;
-
-import org.apache.drill.exec.planner.physical.PlannerSettings;
-import org.apache.drill.exec.store.ischema.InfoSchemaConstants;
-import org.hamcrest.Matcher;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
 import java.sql.Clob;
@@ -52,6 +45,15 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.List;
+
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.store.ischema.InfoSchemaConstants;
+import org.hamcrest.Matcher;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -119,12 +121,12 @@ public class PreparedStatementTest extends JdbcTestBase {
             " FROM sys.version")) {
 
       List<ExpectedColumnResult> exp = ImmutableList.of(
-          new ExpectedColumnResult("int_field", INTEGER, columnNoNulls, 0, 0, true, Integer.class.getName()),
-          new ExpectedColumnResult("bigint_field", BIGINT, columnNoNulls, 0, 0, true, Long.class.getName()),
-          new ExpectedColumnResult("varchar_field", VARCHAR, columnNoNulls, 65536, 0, false, String.class.getName()),
-          new ExpectedColumnResult("ts_field", TIMESTAMP, columnNoNulls, 0, 0, false, Timestamp.class.getName()),
-          new ExpectedColumnResult("date_field", DATE, columnNoNulls, 0, 0, false, Date.class.getName()),
-          new ExpectedColumnResult("decimal_field", DECIMAL, columnNoNulls, 18, 5, true, BigDecimal.class.getName())
+          new ExpectedColumnResult("int_field", INTEGER, columnNoNulls, 11, 0, 0, true, Integer.class.getName()),
+          new ExpectedColumnResult("bigint_field", BIGINT, columnNoNulls, 20, 0, 0, true, Long.class.getName()),
+          new ExpectedColumnResult("varchar_field", VARCHAR, columnNoNulls, 65536, 65536, 0, false, String.class.getName()),
+          new ExpectedColumnResult("ts_field", TIMESTAMP, columnNoNulls, 19, 0, 0, false, Timestamp.class.getName()),
+          new ExpectedColumnResult("date_field", DATE, columnNoNulls, 10, 0, 0, false, Date.class.getName()),
+          new ExpectedColumnResult("decimal_field", DECIMAL, columnNoNulls, 20, 18, 5, true, BigDecimal.class.getName())
       );
 
       ResultSetMetaData prepareMetadata = stmt.getMetaData();
@@ -148,32 +150,41 @@ public class PreparedStatementTest extends JdbcTestBase {
 
   private static void verifyMetadata(ResultSetMetaData act, List<ExpectedColumnResult> exp) throws SQLException {
     assertEquals(exp.size(), act.getColumnCount());
+    int i = 0;
     for(ExpectedColumnResult e : exp) {
-      boolean found = false;
-      for(int i=1; i<=act.getColumnCount(); i++) {
-        found = e.isEqualsTo(act, i);
-        if (found) {
-          break;
-        }
-      }
-      assertTrue("Failed to find the expected column metadata: " + e, found);
+      ++i;
+      assertTrue("Failed to find the expected column metadata. Expected " + e + ". Was: " + toString(act, i), e.isEqualsTo(act, i));
     }
   }
 
+  private static String toString(ResultSetMetaData metadata, int colNum) throws SQLException {
+    return "ResultSetMetaData(" + colNum + ")[" +
+        "columnName='" + metadata.getColumnName(colNum) + '\'' +
+        ", type='" + metadata.getColumnType(colNum) + '\'' +
+        ", nullable=" + metadata.isNullable(colNum) +
+        ", displaySize=" + metadata.getColumnDisplaySize(colNum) +
+        ", precision=" + metadata.getPrecision(colNum) +
+        ", scale=" + metadata.getScale(colNum) +
+        ", signed=" + metadata.isSigned(colNum) +
+        ", className='" + metadata.getColumnClassName(colNum) + '\'' +
+        ']';
+  }
   private static class ExpectedColumnResult {
     final String columnName;
     final int type;
     final int nullable;
+    final int displaySize;
     final int precision;
     final int scale;
     final boolean signed;
     final String className;
 
-    ExpectedColumnResult(String columnName, int type, int nullable, int precision, int scale, boolean signed,
-        String className) {
+    ExpectedColumnResult(String columnName, int type, int nullable, int displaySize, int precision,
+        int scale, boolean signed, String className) {
       this.columnName = columnName;
       this.type = type;
       this.nullable = nullable;
+      this.displaySize = displaySize;
       this.precision = precision;
       this.scale = scale;
       this.signed = signed;
@@ -193,7 +204,7 @@ public class PreparedStatementTest extends JdbcTestBase {
           //metadata.getPrecision(colNum) == precision &&
           metadata.getScale(colNum) == scale &&
           metadata.isSigned(colNum) == signed &&
-          metadata.getColumnDisplaySize(colNum) == 10 &&
+          metadata.getColumnDisplaySize(colNum) == displaySize &&
           metadata.getColumnClassName(colNum).equals(className) &&
           metadata.isSearchable(colNum) &&
           metadata.isAutoIncrement(colNum) == false &&
@@ -210,6 +221,7 @@ public class PreparedStatementTest extends JdbcTestBase {
           "columnName='" + columnName + '\'' +
           ", type='" + type + '\'' +
           ", nullable=" + nullable +
+          ", displaySize=" + displaySize +
           ", precision=" + precision +
           ", scale=" + scale +
           ", signed=" + signed +

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/ResultSetMetaDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/ResultSetMetaDataTest.java
@@ -17,28 +17,27 @@
  */
 package org.apache.drill.jdbc;
 
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.hamcrest.CoreMatchers.*;
-
-import org.apache.drill.jdbc.Driver;
-import org.apache.drill.jdbc.test.JdbcAssert;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.sql.SQLException;
 import java.sql.Types;
+
+import org.apache.drill.jdbc.test.JdbcAssert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 
 
 /**
@@ -386,11 +385,10 @@ public class ResultSetMetaDataTest extends JdbcTestBase {
   //       designated column"
   // (What exactly is the "normal maximum" number of characters?)
 
-  @Ignore( "TODO(DRILL-3355): unignore when getColumnDisplaySize(...) implemented" )
   @Test
   public void test_getColumnDisplaySize_forBOOLEAN() throws SQLException {
     assertThat( rowMetadata.getColumnDisplaySize( ordOptBOOLEAN ),
-                equalTo( 5 ) );
+                equalTo( 1 ) );
   }
 
   // TODO(DRILL-3355):  Do more types when metadata is available.


### PR DESCRIPTION
Add a simple implementation of display size, based on the ODBC table
available at: https://msdn.microsoft.com/en-us/library/ms713974(v=vs.85).aspx
