### PR TITLE
DRILL-4974: NPE in FindPartitionConditions.analyzeCall() for 'holistic' expressions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/FindPartitionConditions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/FindPartitionConditions.java
@@ -312,12 +312,14 @@ public class FindPartitionConditions extends RexVisitorImpl<Void> {
 
     if (callPushDirFilter == PushDirFilter.NO_PUSH) {
       OpState currentOp = opStack.peek();
-      if (currentOp.sqlOperator.getKind() != SqlKind.AND) {
-        clearChildren();
-      } else {
-        // AND op, check if we pushed some children
-        if (currentOp.children.size() > 0) {
-          callPushDirFilter = PushDirFilter.PARTIAL_PUSH;
+      if (currentOp != null) {
+        if (currentOp.sqlOperator.getKind() != SqlKind.AND) {
+          clearChildren();
+        } else {
+          // AND op, check if we pushed some children
+          if (currentOp.children.size() > 0) {
+            callPushDirFilter = PushDirFilter.PARTIAL_PUSH;
+          }
         }
       }
     }


### PR DESCRIPTION
Changes: Added a missing null check in FindPartitionConditions.analyzeCall(), to ensure that opStack.peek() value is dereferenced only after a null-check. Without this check, if the expression is holistic, opStack can be null, so using the value of opStack.peek() without a check can cause an NPE.