### PR TITLE
DRILL-4986: Allow customization of the Drill log file name

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -226,7 +226,8 @@ export DRILL_PID_DIR=${DRILL_PID_DIR:-$DRILL_HOME}
 
 # Prepare log file prefix and the main Drillbit log file.
 
-export DRILL_LOG_PREFIX="$DRILL_LOG_DIR/drillbit"
+export DRILL_LOG_NAME=${DRILL_LOG_NAME:-"drillbit"}
+export DRILL_LOG_PREFIX="$DRILL_LOG_DIR/$DRILL_LOG_NAME"
 export DRILLBIT_LOG_PATH="${DRILL_LOG_PREFIX}.log"
 
 # Class path construction.

--- a/distribution/src/resources/drill-env.sh
+++ b/distribution/src/resources/drill-env.sh
@@ -62,6 +62,10 @@
 
 #export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"1G"}
 
+# Base name for Drill log files. Files are named ${DRILL_LOG_NAME}.out, etc.
+
+# DRILL_LOG_NAME="drillbit"
+
 # Location to place Drill logs. Set to $DRILL_HOME/log by default.
 
 #export DRILL_LOG_DIR=${DRILL_LOG_DIR:-$DRILL_HOME/conf}


### PR DESCRIPTION
Adds a new user-settable environment variable to choose the log file base name.

Tested using automated script unit tests that validate both this new option and all the functionality of the scripts as updated in a prior PR.