### PR TITLE
DRILL-4989: Fix TestParquetWriter.testImpalaParquetBinaryAsTimeStamp_DictChange

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -773,7 +773,7 @@ public class TestParquetWriter extends BaseTestQuery {
     final String TEST_RES_PATH = WORKING_PATH + "/src/test/resources";
     try {
       testBuilder()
-          .sqlQuery("select int96_ts from dfs_test.`%s/parquet/int96_dict_change`", TEST_RES_PATH)
+          .sqlQuery("select int96_ts from dfs_test.`%s/parquet/int96_dict_change` order by int96_ts", TEST_RES_PATH)
           .optionSettingQueriesForTestQuery(
               "alter session set `%s` = true", ExecConstants.PARQUET_READER_INT96_AS_TIMESTAMP)
           .ordered()


### PR DESCRIPTION
Test `TestParquetWriter.testImpalaParquetBinaryAsTimeStamp_DictChange` expects sorted output but query does not include order by clause. 