### PR TITLE
DRILL-5050: C++ client library has symbol resolution issues

### DIFF
--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -88,19 +88,28 @@ if(MSVC)
     set(Boost_USE_STATIC_LIBS ON)
     set(Boost_USE_MULTITHREADED ON)
     set(Boost_USE_STATIC_RUNTIME OFF)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+    #    To build a production version, the macos build must use a shaded version
+    #    of boost. Arbirtarily, we choose the new namspace to be drill_boost.
+    #    See the instructions in the readme for the mac and rebuild boost. Then
+    #    uncomment the line below to build
+    #    set(Boost_NAMESPACE drill_boost)
 else()
     set(Boost_USE_STATIC_LIBS OFF)
     set(Boost_USE_MULTITHREADED ON)
-    set(Boost_USE_STATIC_RUNTIME OFF)
 endif()
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS regex system date_time chrono thread random)
 include_directories(${Boost_INCLUDE_DIRS})
 
+
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_EXE_LINKER_FLAGS "-lrt -lpthread")
     set(CMAKE_CXX_FLAGS "-fPIC")
 endif()
+
 if(MSVC)
     set(CMAKE_CXX_FLAGS "/EHsc")
 endif()

--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -84,24 +84,14 @@ add_definitions("-DGIT_COMMIT_PROP=${GIT_COMMIT_PROP}")
 
 
 # Find Boost
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_MULTITHREADED ON)
 if(MSVC)
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_MULTITHREADED ON)
     set(Boost_USE_STATIC_RUNTIME OFF)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_MULTITHREADED ON)
-    #    To build a production version, the macos build must use a shaded version
-    #    of boost. Arbirtarily, we choose the new namspace to be drill_boost.
-    #    See the instructions in the readme for the mac and rebuild boost. Then
-    #    uncomment the line below to build
-    #    set(Boost_NAMESPACE drill_boost)
 else()
-    set(Boost_USE_STATIC_LIBS OFF)
-    set(Boost_USE_MULTITHREADED ON)
-    #    To build a production version, the macos build must use a shaded version
+    #    To build a production version, the linux/macos build must use a shaded version
     #    of boost. Arbirtarily, we choose the new namspace to be drill_boost.
-    #    See the instructions in the readme for  linux and rebuild boost. Then
+    #    See the instructions in the readme for linux/macos and rebuild boost. Then
     #    uncomment the line below to build
     #    set(Boost_NAMESPACE drill_boost)
 endif()

--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -99,6 +99,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 else()
     set(Boost_USE_STATIC_LIBS OFF)
     set(Boost_USE_MULTITHREADED ON)
+    #    To build a production version, the macos build must use a shaded version
+    #    of boost. Arbirtarily, we choose the new namspace to be drill_boost.
+    #    See the instructions in the readme for  linux and rebuild boost. Then
+    #    uncomment the line below to build
+    #    set(Boost_NAMESPACE drill_boost)
 endif()
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS regex system date_time chrono thread random)

--- a/contrib/native/client/readme.boost
+++ b/contrib/native/client/readme.boost
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Building Boost for Dill on MacOs
+--------------------------------
+
+These instreuctions are using Boost version 1.60.0 which is recommended
+
+Assuming there a BOOST_BUILD_DIR 
+
+$ cd $BOOST_BUILD_DIR
+$ tar zxf boost_1_60_0.tar.gz
+$ cd $BOOST_BUILD_DIR/boost_1_60_0
+$ ./bootstrap.sh --prefix=$BOOST_BUILD_DIR/boost_1_60_0/
+$ ./b2 tools/bcp
+$ cd $BOOST_BUILD_DIR/drill_boost_1_60_0
+
+# Use boost bcp to rename the boost namespace to drill_boost
+# the following builds a subset of boost without icu. You may need to add more modules to include icu. 
+# bcp documentation can be found here: http://www.boost.org/doc/libs/1_60_0/tools/bcp/doc/html/index.html
+
+$ $BOOST_BUILD_DIR/boost_1_60_0/dist/bin/bcp --namespace=drill_boost --namespace-alias --boost=$BOOST_BUILD_DIR/boost_1_60_0/ shared_ptr random context chrono date_time regex system timer thread asio smart_ptr bind config build regex config assign $BOOST_BUILD_DIR/drill_boost_1_60_0 
+
+$ cd $BOOST_BUILD_DIR/drill_boost_1_60_0
+$ ./bootstrap.sh --prefix=$BOOST_BUILD_DIR/drill_boost_1_60_0/
+
+# change the variant to debug for a debug build
+$ ./b2 --build-dir=$BOOST_BUILD_DIR/drill_boost_1_60_0/build variant=release link=static threading=multi
+
+
+# To build the Drill client library , export the following to make sure boost is picked up correctly
+$ export BOOST_INCLUDEDIR=$BOOST_BUILD_DIR/drill_boost_1_60_0
+$ export BOOST_LIBRARYDIR=$BOOST_BUILD_DIR/drill_boost_1_60_0/stage/lib
+$ export Boost_NO_SYSTEM_PATHS=ON
+
+# Then follow the usual CMake build steps.
+
+

--- a/contrib/native/client/readme.boost
+++ b/contrib/native/client/readme.boost
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-Building Boost for Dill on MacOs
+Building Boost for Drill on MacOs/Linux
 --------------------------------
 
-These instreuctions are using Boost version 1.60.0 which is recommended
+These instructions are using Boost version 1.60.0 which is recommended
 
-Assuming there a BOOST_BUILD_DIR 
+Assuming there is a BOOST_BUILD_DIR 
 
 $ cd $BOOST_BUILD_DIR
 $ tar zxf boost_1_60_0.tar.gz

--- a/contrib/native/client/readme.boost
+++ b/contrib/native/client/readme.boost
@@ -19,7 +19,7 @@
 Building Boost for Drill on MacOs/Linux
 --------------------------------
 
-These instructions are using Boost version 1.60.0 which is recommended
+These instructions are using Boost version 1.60.0
 
 Assuming there is a BOOST_BUILD_DIR 
 
@@ -34,13 +34,16 @@ $ cd $BOOST_BUILD_DIR/drill_boost_1_60_0
 # the following builds a subset of boost without icu. You may need to add more modules to include icu. 
 # bcp documentation can be found here: http://www.boost.org/doc/libs/1_60_0/tools/bcp/doc/html/index.html
 
-$ $BOOST_BUILD_DIR/boost_1_60_0/dist/bin/bcp --namespace=drill_boost --namespace-alias --boost=$BOOST_BUILD_DIR/boost_1_60_0/ shared_ptr random context chrono date_time regex system timer thread asio smart_ptr bind config build regex config assign $BOOST_BUILD_DIR/drill_boost_1_60_0 
+$ $BOOST_BUILD_DIR/boost_1_60_0/dist/bin/bcp --namespace=drill_boost --namespace-alias --boost=$BOOST_BUILD_DIR/boost_1_60_0/ shared_ptr random context chrono date_time regex system timer thread asio smart_ptr bind config build regex config assign functional multiprecision $BOOST_BUILD_DIR/drill_boost_1_60_0 
 
 $ cd $BOOST_BUILD_DIR/drill_boost_1_60_0
 $ ./bootstrap.sh --prefix=$BOOST_BUILD_DIR/drill_boost_1_60_0/
 
 # change the variant to debug for a debug build
-$ ./b2 --build-dir=$BOOST_BUILD_DIR/drill_boost_1_60_0/build variant=release link=static threading=multi
+  # For linux 
+  $ ./b2 --build-dir=$BOOST_BUILD_DIR/drill_boost_1_60_0/build variant=release link=static threading=multi cxxflags="-fPIC"
+  # For MacOS
+  $ ./b2 --build-dir=$BOOST_BUILD_DIR/drill_boost_1_60_0/build variant=release link=static threading=multi 
 
 
 # To build the Drill client library , export the following to make sure boost is picked up correctly

--- a/contrib/native/client/readme.macos
+++ b/contrib/native/client/readme.macos
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+MacOS build (tested on OS X El Capitan)
+
+Install Prerequisites
+---------------------
+
+0.1) Install XCode 
+  Download an istall from here: https://developer.apple.com/xcode/downloads/
+  In Terminal, install the command line tools 
+    $> xcode-select --install
+
+0.2) Install brew following the instructions here: http://brew.sh/
+
+1) CMAKE 2.8 or above
+  Download and install Cmake : https://cmake.org/download/
+
+2.1) Install protobuf
+  $> brew install protobuf
+
+2.2) Install zookeeper
+  $> brew install zookeeper
+
+2.3) Install boost
+  $> brew install boost
+
+2.3.1) For production builds, see the readme.boost file  
+  
+  
+(Optional) Refresh protobuf source files
+----------------------------------------
+When changes have been introduced to the protocol module, you might need to refresh the protobuf C++ source files too.
+  $> cd DRILL_DIR/contrib/native/client
+  $> mkdir build
+  $> cd build && cmake3 -G "XCode" -D CMAKE_BUILD_TYPE=Debug ..
+  $> xcodebuild -project drillclient.xcodeproj -configuration ${BUILDTYPE} -target fixProtobufs
+  $> xcodebuild -project drillclient.xcodeproj -configuration ${BUILDTYPE} -target cpProtobufs
+
+Open a pull request with the changes to DRILL_DIR/contrib/native/client/src/protobuf
+
+Build drill client
+-------------------
+  $> cd DRILL_DIR/contrib/native/client
+  $> mkdir build
+  $> cd build && cmake3 -G "XCode" -D CMAKE_BUILD_TYPE=Debug ..
+  $> xcodebuild -project drillclient.xcodeproj -configuration ${BUILDTYPE} -target ALL_BUILD
+
+
+XCode IDE
+---------
+  You can open the drillclient.xcodeproj file in the XCode ide and run/debug as with any other command line app
+
+Test
+----
+Run query submitter from the command line
+  $> querySubmitter query='select * from dfs.`/Users/pchandra/work/data/tpc-h/customer.parquet`' type=sql connectStr=local=10.250.0.146:31010 api=async logLevel=trace user=yourUserName password=yourPassWord
+
+Valgrind
+--------
+  If you can get valgrind to build and run on macos, please update the instuctions here
+
+

--- a/contrib/native/client/readme.macos
+++ b/contrib/native/client/readme.macos
@@ -23,16 +23,20 @@ Install Prerequisites
 ---------------------
 
 0.1) Install XCode 
-  Download an istall from here: https://developer.apple.com/xcode/downloads/
+  Download and install from here: https://developer.apple.com/xcode/downloads/
+  or from the App store https://itunes.apple.com/us/app/xcode/id497799835?mt=12
   In Terminal, install the command line tools 
     $> xcode-select --install
 
 0.2) Install brew following the instructions here: http://brew.sh/
 
-1) CMAKE 2.8 or above
+1) CMAKE 3.0 or above
   Download and install Cmake : https://cmake.org/download/
+  or use brew to install 
+  $> brew install cmake
 
-2.1) Install protobuf
+
+2.1) Install protobuf 2.5.0 (or higher)
   $> brew install protobuf
 
 2.2) Install zookeeper
@@ -43,7 +47,8 @@ Install Prerequisites
 
 2.3.1) For production builds, see the readme.boost file  
   
-  
+2.3.1.1 Build using XCODE
+=========================  
 (Optional) Refresh protobuf source files
 ----------------------------------------
 When changes have been introduced to the protocol module, you might need to refresh the protobuf C++ source files too.
@@ -67,13 +72,37 @@ XCode IDE
 ---------
   You can open the drillclient.xcodeproj file in the XCode ide and run/debug as with any other command line app
 
-Test
-----
+2.3.1.2 Build using MAKE
+========================
+(Optional) Refresh protobuf source files
+----------------------------------------
+When changes have been introduced to the protocol module, you might need to refresh the protobuf C++ source files too.
+    $> cd DRILL_DIR/contrib/native/client
+    $> mkdir build
+    $> cd build && cmake3 -G "Unix Makefiles" ..
+    $> make cpProtobufs
+
+Open a pull request with the changes to DRILL_DIR/contrib/native/client/src/protobuf
+
+Build drill client
+-------------------
+    $> cd DRILL_DIR/contrib/native/client
+    $> mkdir build
+    $> cd build && cmake3 -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Debug ..
+    $> make
+
+
+2.4 Test
+--------
 Run query submitter from the command line
   $> querySubmitter query='select * from dfs.`/Users/pchandra/work/data/tpc-h/customer.parquet`' type=sql connectStr=local=10.250.0.146:31010 api=async logLevel=trace user=yourUserName password=yourPassWord
 
-Valgrind
---------
-  If you can get valgrind to build and run on macos, please update the instuctions here
+2.5 Valgrind
+------------
+  Valgrind is available only for MacOs 10.11 or earlier. Install valgrind using brew
+  $> brew install valgrind
+  $> valgrind --leak-check=yes querySubmitter query='select LINEITEM from dfs.`/Users/pchandra/work/data/tpc-h/customer.parquet`' type=sql connectStr=local=10.250.0.146:31010 api=async logLevel=trace
+
+
 
 

--- a/contrib/native/client/readme.macos
+++ b/contrib/native/client/readme.macos
@@ -99,7 +99,7 @@ Run query submitter from the command line
 
 2.5 Valgrind
 ------------
-  Valgrind is available only for MacOs 10.11 or earlier. Install valgrind using brew
+  Install valgrind using brew
   $> brew install valgrind
   $> valgrind --leak-check=yes querySubmitter query='select LINEITEM from dfs.`/Users/pchandra/work/data/tpc-h/customer.parquet`' type=sql connectStr=local=10.250.0.146:31010 api=async logLevel=trace
 


### PR DESCRIPTION
when loaded by a process that already uses boost::asio

Build with Boost static libs and drill_boost namespace on mac. Added
readme with instructions