### PR TITLE
DRILL-5051: Fix incorrect result returned in nest query with offset specified

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
@@ -139,18 +139,13 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
       skipBatch = true;
     } else {
       outgoingSv.allocateNew(recordCount);
-      if(incomingSv != null) {
-       limitWithSV(recordCount);
-      } else {
-       limitWithNoSV(recordCount);
-      }
+      limit(recordCount);
     }
 
     return IterOutcome.OK;
   }
 
-  // These two functions are identical except for the computation of the index; merge
-  private void limitWithNoSV(int recordCount) {
+  private void limit(int recordCount) {
     final int offset = Math.max(0, Math.min(recordCount - 1, recordsToSkip));
     recordsToSkip -= offset;
     int fetch;
@@ -164,27 +159,11 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
 
     int svIndex = 0;
     for(int i = offset; i < fetch; svIndex++, i++) {
-      outgoingSv.setIndex(svIndex, (char) i);
-    }
-    outgoingSv.setRecordCount(svIndex);
-  }
-
-  private void limitWithSV(int recordCount) {
-    final int offset = Math.max(0, Math.min(recordCount - 1, recordsToSkip));
-    recordsToSkip -= offset;
-    int fetch;
-
-    if(noEndLimit) {
-      fetch = recordCount;
-    } else {
-      fetch = Math.min(recordCount, recordsLeft);
-      recordsLeft -= Math.max(0, fetch - offset);
-    }
-
-    int svIndex = 0;
-    for(int i = offset; i < fetch; svIndex++, i++) {
-      final char index = incomingSv.getIndex(i);
-      outgoingSv.setIndex(svIndex, index);
+      if (incomingSv != null) {
+        outgoingSv.setIndex(svIndex, incomingSv.getIndex(i));
+      } else {
+        outgoingSv.setIndex(svIndex, (char) i);
+      }
     }
     outgoingSv.setRecordCount(svIndex);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
@@ -221,4 +221,14 @@ public class TestBugFixes extends BaseTestQuery {
             .baselineRecords(baseline)
             .go();
   }
+
+  @Test
+  public void testDRILL5051() throws Exception {
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from (select l_orderkey from (select l_orderkey from cp.`tpch/lineitem.parquet` limit 2) limit 1 offset 1)")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(1L)
+        .go();
+  }
 }


### PR DESCRIPTION
1. Fix this problem.
2. Merge two limit methods, most of code is the same.