### PR TITLE
DRILL-5058: External sort does not handle its own UserExceptions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
@@ -511,7 +511,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       context.fail(UserException.unsupportedError(ex)
         .message("Sort doesn't currently support sorts with changing schemas").build(logger));
       return IterOutcome.STOP;
-    } catch(ClassTransformationException | IOException ex) {
+    } catch(ClassTransformationException | IOException | UserException ex) {
       kill(false);
       context.fail(ex);
       return IterOutcome.STOP;


### PR DESCRIPTION
Solution is to catch the exception, clean up, and fail the operator.

Test case is the existing {{TestSortSpillWithException}} test case.