### PR TITLE
DRILL-5056: UserException does not write full message to log

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
  * @see org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType
  */
 public class UserException extends DrillRuntimeException {
+  private static final long serialVersionUID = -6720929331624621840L;
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UserException.class);
 
   public static final String MEMORY_ERROR_MSG = "One or more nodes ran out of memory while executing the query.";
@@ -549,7 +550,15 @@ public class UserException extends DrillRuntimeException {
       if (isSystemError) {
         logger.error(newException.getMessage(), newException);
       } else {
-        logger.info("User Error Occurred", newException);
+        StringBuilder buf = new StringBuilder();
+        buf.append("User Error Occurred");
+        if (message != null) {
+          buf.append(": ").append(message);
+        }
+        if (cause != null) {
+          buf.append(" (").append(cause.getMessage()).append(")");
+        }
+        logger.info(buf.toString(), newException);
       }
 
       return newException;


### PR DESCRIPTION
A case occurred in which the External Sort failed during spilling. All
that was written to the log was:

2016-11-18 ... INFO  o.a.d.e.p.i.xsort.ExternalSortBatch - User Error
Occurred

Modified the logging code to provide more information to aid tracking
down problems that occur in the field.

Also cleaned up some warnings found while tracking down this issue.

The test case for this is {{TestSortSpillWithException}}, then look at the log output.