### PR TITLE
DRILL-5091: JDBC unit test fail on Java 8

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -101,7 +101,7 @@ public class Drillbit implements AutoCloseable {
       storeProvider = new CachingPersistentStoreProvider(new LocalPersistentStoreProvider(config));
     } else {
       coord = new ZKClusterCoordinator(config);
-      storeProvider = new PersistentStoreRegistry(this.coord, config).newPStoreProvider();
+      storeProvider = new PersistentStoreRegistry<ClusterCoordinator>(this.coord, config).newPStoreProvider();
       isDistributedMode = true;
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -115,10 +115,12 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
         });
   }
 
+  @Override
   public PersistentStore<StoragePluginConfig> getStore() {
     return pluginSystemTable;
   }
 
+  @Override
   public void init() throws DrillbitStartupException {
     availablePlugins = findAvailablePlugins(classpathScan);
 
@@ -188,6 +190,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     plugins.put(name, plugin);
   }
 
+  @Override
   public void deletePlugin(String name) {
     StoragePlugin plugin = plugins.remove(name);
     closePlugin(plugin);
@@ -206,6 +209,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     }
   }
 
+  @Override
   public StoragePlugin createOrUpdate(String name, StoragePluginConfig config, boolean persist)
       throws ExecutionSetupException {
     for (;;) {
@@ -243,6 +247,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     }
   }
 
+  @Override
   public StoragePlugin getPlugin(String name) throws ExecutionSetupException {
     StoragePlugin plugin = plugins.get(name);
     if (name.equals(SYS_PLUGIN) || name.equals(INFORMATION_SCHEMA_PLUGIN)) {
@@ -267,6 +272,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
   }
 
 
+  @Override
   public StoragePlugin getPlugin(StoragePluginConfig config) throws ExecutionSetupException {
     if (config instanceof NamedStoragePluginConfig) {
       return getPlugin(((NamedStoragePluginConfig) config).name);
@@ -293,6 +299,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     }
   }
 
+  @Override
   public FormatPlugin getFormatPlugin(StoragePluginConfig storageConfig, FormatPluginConfig formatConfig)
       throws ExecutionSetupException {
     StoragePlugin p = getPlugin(storageConfig);
@@ -332,6 +339,7 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
     return plugins.iterator();
   }
 
+  @Override
   public SchemaFactory getSchemaFactory() {
     return schemaFactory;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
@@ -65,7 +65,7 @@ public class PersistentStoreConfig<V> {
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof PersistentStoreConfig) {
-      final PersistentStoreConfig other = PersistentStoreConfig.class.cast(obj);
+      final PersistentStoreConfig<?> other = PersistentStoreConfig.class.cast(obj);
       return Objects.equal(name, other.name)
           && Objects.equal(valueSerializer, other.valueSerializer)
           && Objects.equal(mode, other.mode);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -31,27 +31,25 @@ import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 import org.apache.drill.common.collections.ImmutableEntry;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
-import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreMode;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 public class LocalPersistentStore<V> extends BasePersistentStore<V> {
-  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStore.class);
+//  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStore.class);
 
   private final Path basePath;
   private final PersistentStoreConfig<V> config;
@@ -140,6 +138,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     return path;
   }
 
+  @Override
   public V get(String key) {
     try{
       Path path = makePath(key);
@@ -158,6 +157,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     }
   }
 
+  @Override
   public void put(String key, V value) {
     try (OutputStream os = fs.create(makePath(key))) {
       IOUtils.write(config.getSerializer().serialize(value), os);
@@ -181,6 +181,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     }
   }
 
+  @Override
   public void delete(String key) {
     try {
       fs.delete(makePath(key), false);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/CachingPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/CachingPersistentStoreProvider.java
@@ -29,7 +29,7 @@ import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 
 public class CachingPersistentStoreProvider extends BasePersistentStoreProvider {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CachingPersistentStoreProvider.class);
+//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CachingPersistentStoreProvider.class);
 
   private final ConcurrentMap<PersistentStoreConfig<?>, PersistentStore<?>> storeCache = Maps.newConcurrentMap();
   private final PersistentStoreProvider provider;
@@ -38,6 +38,7 @@ public class CachingPersistentStoreProvider extends BasePersistentStoreProvider 
     this.provider = provider;
   }
 
+  @Override
   @SuppressWarnings("unchecked")
   public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) throws StoreException {
     final PersistentStore<?> store = storeCache.get(config);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -23,20 +23,18 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.StoreException;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
-import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
+import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
 import org.apache.drill.exec.store.sys.store.LocalPersistentStore;
 import org.apache.drill.exec.testing.store.NoWriteLocalStore;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A really simple provider that stores data in the local file system, one value per file.
  */
 public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
-  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStoreProvider.class);
+//  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStoreProvider.class);
 
   private final Path path;
   private final DrillFileSystem fs;
@@ -44,7 +42,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
   // how to handle this flag.
   private final boolean enableWrite;
 
-  public LocalPersistentStoreProvider(final PersistentStoreRegistry registry) throws StoreException {
+  public LocalPersistentStoreProvider(final PersistentStoreRegistry<?> registry) throws StoreException {
     this(registry.getConfig());
   }
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
@@ -114,7 +114,8 @@ public class JdbcTestBase extends ExecTest {
 
   protected static void changeSchema(Connection conn, String schema) {
     final String query = String.format("use %s", schema);
-    try ( Statement s = conn.createStatement() ) {
+    try (Statement s = conn.createStatement()) {
+      @SuppressWarnings("unused")
       ResultSet r = s.executeQuery(query);
       // TODO:  Purge nextUntilEnd(...) and calls when remaining fragment
       // race conditions are fixed (not just DRILL-2245 fixes).
@@ -147,10 +148,10 @@ public class JdbcTestBase extends ExecTest {
    * (Note:  Not a guaranteed test--depends on order in which test methods are
    * run.)
    */
-  @Ignore( "Usually disabled; enable temporarily to check tests" )
+  @Ignore("Usually disabled; enable temporarily to check tests")
   @Test
   public void testJdbcTestConnectionResettingCompatibility() {
-    fail( "Intentional failure--did other test methods still run?" );
+    fail("Intentional failure--did other test methods still run?");
   }
 
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2489CallsAfterCloseThrowExceptionsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2489CallsAfterCloseThrowExceptionsTest.java
@@ -38,6 +38,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Struct;
 import java.util.ArrayList;
@@ -80,7 +81,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
   private static ResultSetMetaData resultSetMetaDataOfClosedResultSet;
   private static ResultSetMetaData resultSetMetaDataOfClosedStmt;
   private static DatabaseMetaData databaseMetaDataOfClosedConn;
-
 
   @BeforeClass
   public static void setUpClosedObjects() throws Exception {
@@ -135,15 +135,14 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     resultSetMetaDataOfClosedStmt = rsmdForClosedStmt;
     databaseMetaDataOfClosedConn = dbmd;
 
-
     // Self-check that member variables are set (and objects are in right open
     // or closed state):
-    assertTrue( "Test setup error", closedConn.isClosed());
+    assertTrue("Test setup error", closedConn.isClosed());
     assertFalse("Test setup error", openConn.isClosed());
-    assertTrue( "Test setup error", closedPlainStmtOfOpenConn.isClosed());
-    assertTrue( "Test setup error", closedPreparedStmtOfOpenConn.isClosed());
-    assertTrue( "Test setup error", closedResultSetOfClosedStmt.isClosed());
-    assertTrue( "Test setup error", closedResultSetOfOpenStmt.isClosed());
+    assertTrue("Test setup error", closedPlainStmtOfOpenConn.isClosed());
+    assertTrue("Test setup error", closedPreparedStmtOfOpenConn.isClosed());
+    assertTrue("Test setup error", closedResultSetOfClosedStmt.isClosed());
+    assertTrue("Test setup error", closedResultSetOfOpenStmt.isClosed());
     // (No ResultSetMetaData.isClosed() or DatabaseMetaData.isClosed():)
     assertNotNull("Test setup error", resultSetMetaDataOfClosedResultSet);
     assertNotNull("Test setup error", resultSetMetaDataOfClosedStmt);
@@ -154,7 +153,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
   public static void tearDownConnection() throws Exception {
     openConn.close();
   }
-
 
   ///////////////////////////////////////////////////////////////
   // 1.  Check that isClosed() and close() do not throw, and isClosed() returns
@@ -200,11 +198,9 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     assertThat(closedResultSetOfOpenStmt.isClosed(), equalTo(true));
   }
 
-
   ///////////////////////////////////////////////////////////////
   // 2.  Check that all methods throw or not appropriately (either as specified
   //     by JDBC or currently intended as partial Avatica workaround).
-
 
   /**
    * Reflection-based checker of throwing of "already closed" exception by JDBC
@@ -405,16 +401,13 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
           + ")";
       return report;
     }
-
   } // class ThrowsClosedChecker<INTF>
-
 
   private static class ClosedConnectionChecker
       extends ThrowsClosedBulkChecker<Connection> {
 
     private static final String STATEMENT_CLOSED_MESSAGE =
         "Connection is already closed.";
-
 
     ClosedConnectionChecker(Class<Connection> intf, Connection jdbcObject) {
       super(intf, jdbcObject, STATEMENT_CLOSED_MESSAGE);
@@ -449,7 +442,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       }
       return result;
     }
-
   } // class ClosedConnectionChecker
 
   @Test
@@ -465,7 +457,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     }
   }
 
-
   private static class ClosedPlainStatementChecker
       extends ThrowsClosedBulkChecker<Statement> {
 
@@ -477,9 +468,22 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     }
 
     @Override
+    protected boolean isOkayNonthrowingMethod(Method method) {
+      // TODO: Java 8 method
+      if ("getLargeUpdateCount".equals(method.getName())) {
+        return true; }
+      return super.isOkayNonthrowingMethod(method);
+    }
+
+    @Override
     protected boolean isOkaySpecialCaseException(Method method, Throwable cause) {
       final boolean result;
       if (super.isOkaySpecialCaseException(method, cause)) {
+        result = true;
+      }
+      else if (   method.getName().equals("executeLargeBatch")
+               || method.getName().equals("executeLargeUpdate")) {
+        // TODO: New Java 8 methods not implemented in Avatica.
         result = true;
       }
       else if (RuntimeException.class == cause.getClass()
@@ -489,6 +493,7 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
                    || method.getName().equals("getFetchDirection")
                    || method.getName().equals("getFetchSize")
                    || method.getName().equals("getMaxRows")
+                   || method.getName().equals("getLargeMaxRows") // TODO: Java 8
                    )) {
         // Special good-enough case--we had to use RuntimeException for now.
         result = true;
@@ -498,7 +503,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       }
       return result;
     }
-
   } // class ClosedPlainStatementChecker
 
   @Test
@@ -513,7 +517,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     }
   }
 
-
   private static class ClosedPreparedStatementChecker
       extends ThrowsClosedBulkChecker<PreparedStatement> {
 
@@ -523,6 +526,15 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
     ClosedPreparedStatementChecker(Class<PreparedStatement> intf,
                                    PreparedStatement jdbcObject) {
       super(intf, jdbcObject, PREPAREDSTATEMENT_CLOSED_MESSAGE);
+    }
+
+    @Override
+    protected boolean isOkayNonthrowingMethod(Method method) {
+      // TODO: Java 8 methods not yet supported by Avatica.
+      if (method.getName().equals("getLargeUpdateCount")) {
+        return true;
+      }
+      return super.isOkayNonthrowingMethod(method);
     }
 
     @Override
@@ -543,12 +555,19 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
         // Special good-enough case--we had to use RuntimeException for now.
         result = true;
       }
+      else if (  method.getName().equals("setObject")
+              || method.getName().equals("executeLargeUpdate")
+              || method.getName().equals("executeLargeBatch")
+              || method.getName().equals("getLargeMaxRows")
+              ) {
+        // TODO: Java 8 methods not yet supported by Avatica.
+        result = true;
+      }
       else {
         result = false;
       }
       return result;
     }
-
   } // class closedPreparedStmtOfOpenConnChecker
 
   @Test
@@ -563,7 +582,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       fail("Already-closed exception error(s): \n" + checker.getReport());
     }
   }
-
 
   private static class ClosedResultSetChecker
       extends ThrowsClosedBulkChecker<ResultSet> {
@@ -587,12 +605,16 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
         // Special good-enough case--we had to use RuntimeException for now.
         result = true;
       }
+      else if (SQLFeatureNotSupportedException.class == cause.getClass()
+               && (method.getName().equals("updateObject"))) {
+        // TODO: Java 8 methods not yet supported by Avatica.
+        result = true;
+      }
       else {
         result = false;
       }
       return result;
     }
-
   } // class ClosedResultSetChecker
 
   @Test
@@ -630,7 +652,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
                                    ResultSetMetaData jdbcObject) {
       super(intf, jdbcObject, RESULTSETMETADATA_CLOSED_MESSAGE);
     }
-
   } // class ClosedResultSetMetaDataChecker
 
   @Test
@@ -671,12 +692,16 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       super(intf, jdbcObject, DATABASEMETADATA_CLOSED_MESSAGE);
     }
 
+    @Override
     protected boolean isOkayNonthrowingMethod(Method method) {
       return
           super.isOkayNonthrowingMethod(method)
           || method.getName().equals("getDriverMajorVersion")
           || method.getName().equals("getDriverMinorVersion")
-          || method.getName().equals("getConnection");
+          || method.getName().equals("getConnection")
+          // TODO: New Java 8 methods not implemented in Avatica.
+          || method.getName().equals("getMaxLogicalLobSize")
+          || method.getName().equals("supportsRefCursors");
     }
 
     @Override
@@ -696,7 +721,6 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       }
       return result;
     }
-
   } // class ClosedDatabaseMetaDataChecker
 
 
@@ -712,5 +736,4 @@ public class Drill2489CallsAfterCloseThrowExceptionsTest extends JdbcTestBase {
       fail("Already-closed exception error(s): \n" + checker.getReport());
     }
   }
-
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
@@ -66,6 +66,11 @@ public class JdbcAssert {
   public static Properties getDefaultProperties() {
     final Properties properties = new Properties();
     properties.setProperty("drillJDBCUnitTests", "true");
+
+    // Must set this to false to ensure that the tests ignore any existing
+    // plugin configurations stored in /tmp/drill.
+
+    properties.setProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
     properties.setProperty(ExecConstants.HTTP_ENABLE, "false");
     return properties;
   }
@@ -246,7 +251,6 @@ public class JdbcAssert {
       }
     }
 
-
     /**
      * Checks that the current SQL statement returns the expected result lines. Lines are compared unordered; the test
      * succeeds if the query returns these lines in any order.
@@ -291,7 +295,6 @@ public class JdbcAssert {
           connection.close();
         }
       }
-
     }
 
     private SortedSet<String> unsortedList(List<String> strings) {
@@ -353,7 +356,6 @@ public class JdbcAssert {
   private static interface ConnectionFactoryAdapter {
     Connection createConnection() throws Exception;
   }
-
 }
 
 // End JdbcAssert.java


### PR DESCRIPTION
Two parts: hygiene and the bug fixes.

Hygiene just cleans up nuisance compiler warnings seen in Eclipse.

The second commit fixes the actual problems as detailed in DRILL-5091:

* Missing test config parameter
* Handle new Java 8 JDBC functions