### PR TITLE
DRILL-5098: Improving fault tolerance for connection between client a…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
@@ -50,6 +50,7 @@ import org.apache.drill.exec.rpc.ProtobufLengthDecoder;
 import org.apache.drill.exec.rpc.Response;
 import org.apache.drill.exec.rpc.RpcConnectionHandler;
 import org.apache.drill.exec.rpc.RpcException;
+import org.apache.drill.exec.rpc.InvalidConnectionInfoException;
 
 import com.google.protobuf.MessageLite;
 
@@ -158,7 +159,7 @@ public class UserClient extends BasicClientWithConnection<RpcType, UserToBitHand
       final String errMsg = String.format("Status: %s, Error Id: %s, Error message: %s",
           inbound.getStatus(), inbound.getErrorId(), inbound.getErrorMessage());
       logger.error(errMsg);
-      throw new RpcException(errMsg);
+      throw new InvalidConnectionInfoException(errMsg);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ZookeeperHelper;
+import org.apache.drill.exec.coord.ClusterCoordinator;
+import org.apache.drill.exec.exception.DrillbitStartupException;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.rpc.InvalidConnectionInfoException;
+import org.apache.drill.exec.rpc.RpcException;
+import org.apache.drill.exec.server.Drillbit;
+
+import org.apache.drill.exec.server.RemoteServiceSet;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class ConnectTriesPropertyTestClusterBits {
+
+  public static StringBuilder bitInfo;
+  public static final String fakeBitsInfo = "127.0.0.1:5000,127.0.0.1:5001";
+  public static List<Drillbit> drillbits;
+  public static final int drillBitCount = 1;
+  public static ZookeeperHelper zkHelper;
+  public static RemoteServiceSet remoteServiceSet;
+  public static DrillConfig drillConfig;
+
+  @BeforeClass
+  public static void testSetUp() throws Exception {
+    remoteServiceSet = RemoteServiceSet.getLocalServiceSet();
+    zkHelper = new ZookeeperHelper();
+    zkHelper.startZookeeper(1);
+
+    // Creating Drillbits
+    drillConfig = zkHelper.getConfig();
+    try {
+      int drillBitStarted = 0;
+      drillbits = new ArrayList<>();
+      while(drillBitStarted < drillBitCount){
+        drillbits.add(Drillbit.start(drillConfig, remoteServiceSet));
+        ++drillBitStarted;
+      }
+    } catch (DrillbitStartupException e) {
+      throw new RuntimeException("Failed to start drillbits.", e);
+    }
+    bitInfo = new StringBuilder();
+
+    for (int i = 0; i < drillBitCount; ++i) {
+      final DrillbitEndpoint currentEndPoint = drillbits.get(i).getContext().getEndpoint();
+      final String currentBitIp = currentEndPoint.getAddress();
+      final int currentBitPort = currentEndPoint.getUserPort();
+      bitInfo.append(",");
+      bitInfo.append(currentBitIp);
+      bitInfo.append(":");
+      bitInfo.append(currentBitPort);
+    }
+  }
+
+  @AfterClass
+  public static void testCleanUp() throws Exception {
+    AutoCloseables.close(drillbits);
+  }
+
+  @Test
+  public void testSuccessUsingDirectConnectionAndFakeDrillbitPresent() throws Exception {
+    final StringBuilder endpoints = new StringBuilder(fakeBitsInfo);
+    endpoints.append(bitInfo);
+
+    Properties props = new Properties();
+    props.setProperty("drillbit", endpoints.toString());
+    props.setProperty("connect_limit", "3");
+
+    // Test with direct connection
+    DrillClient client = new DrillClient(true);
+    client.connect(props);
+    client.close();
+  }
+
+  @Test
+  public void testSuccessDirectConnectionDefaultConnectTriesAndFakeDrillbits() throws Exception {
+    final StringBuilder endpoints = new StringBuilder(fakeBitsInfo);
+    endpoints.append(bitInfo);
+
+    Properties props = new Properties();
+    props.setProperty("drillbit", endpoints.toString());
+
+    // Test with direct connection
+    DrillClient client = new DrillClient(true);
+    client.connect(props);
+    client.close();
+  }
+
+  @Test
+  public void testFailureUsingDirectConnectionAllFakeBits() throws Exception {
+    final StringBuilder endpoints = new StringBuilder(fakeBitsInfo);
+
+    Properties props = new Properties();
+    props.setProperty("drillbit", endpoints.toString());
+    props.setProperty("tries", "2");
+
+    // Test with direct connection
+    DrillClient client = new DrillClient(true);
+
+    try{
+      client.connect(props);
+      fail();
+    }catch(RpcException ex){
+      assertTrue(ex.getCause() instanceof ExecutionException);
+      client.close();
+    }
+  }
+
+  @Test
+  public void testSuccessUsingZKWithNoFakeBits() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("tries", "2");
+
+    // Test with Cluster Coordinator connection
+    DrillClient client = new DrillClient(drillConfig, remoteServiceSet.getCoordinator());
+    client.connect(props);
+    client.close();
+  }
+
+  @Test
+  public void testSuccessUsingZKWithFakeBits() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("tries", "3");
+
+    // Test with Cluster Coordinator connection
+    DrillClient client = new DrillClient(drillConfig, remoteServiceSet.getCoordinator());
+    // Create couple of fake drillbit endpoints and register with cluster coordinator
+    DrillbitEndpoint fakeEndPoint1 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5000).build();
+    DrillbitEndpoint fakeEndPoint2 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5001).build();
+
+    ClusterCoordinator.RegistrationHandle fakeEndPoint1Handle = remoteServiceSet.getCoordinator()
+                                                                                .register(fakeEndPoint1);
+    ClusterCoordinator.RegistrationHandle fakeEndPoint2Handle = remoteServiceSet.getCoordinator()
+                                                                                .register(fakeEndPoint2);
+
+    client.connect(props);
+    client.close();
+
+    // Remove the fake drillbits so that other tests are not affected
+    remoteServiceSet.getCoordinator().unregister(fakeEndPoint1Handle);
+    remoteServiceSet.getCoordinator().unregister(fakeEndPoint2Handle);
+  }
+
+  @Test
+  public void testSuccessUsingZKWithDefaultConnectTriesFakeBits() throws Exception {
+    // Test with Cluster Coordinator connection
+    DrillClient client = new DrillClient(drillConfig, remoteServiceSet.getCoordinator());
+
+    // Create couple of fake drillbit endpoints and register with cluster coordinator
+    DrillbitEndpoint fakeEndPoint1 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5000).build();
+    DrillbitEndpoint fakeEndPoint2 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5001).build();
+
+    ClusterCoordinator.RegistrationHandle fakeEndPoint1Handle = remoteServiceSet.getCoordinator()
+                                                                                .register(fakeEndPoint1);
+    ClusterCoordinator.RegistrationHandle fakeEndPoint2Handle = remoteServiceSet.getCoordinator()
+                                                                                .register(fakeEndPoint2);
+
+    client.connect(null);
+    client.close();
+
+    // Remove the fake drillbits so that other tests are not affected
+    remoteServiceSet.getCoordinator().unregister(fakeEndPoint1Handle);
+    remoteServiceSet.getCoordinator().unregister(fakeEndPoint2Handle);
+  }
+
+  @Test
+  public void testInvalidConnectTriesValue() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("tries", "abc");
+
+    // Test with Cluster Cordinator connection
+    DrillClient client = new DrillClient(drillConfig, remoteServiceSet.getCoordinator());
+
+    try {
+      client.connect(props);
+      fail();
+    } catch (RpcException ex) {
+      assertTrue(ex instanceof InvalidConnectionInfoException);
+      client.close();
+    }
+  }
+
+  @Test
+  public void testConnectFailureUsingZKWithOnlyFakeBits() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("tries", "3");
+
+    // Test with Cluster Coordinator connection
+    RemoteServiceSet localServiceSet = RemoteServiceSet.getLocalServiceSet();
+    DrillClient client = new DrillClient(drillConfig, localServiceSet.getCoordinator());
+
+    // Create couple of fake drillbit endpoints and register with cluster coordinator
+    DrillbitEndpoint fakeEndPoint1 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5000).build();
+    DrillbitEndpoint fakeEndPoint2 = DrillbitEndpoint.newBuilder().setAddress("127.0.0.1").setUserPort(5001).build();
+
+    ClusterCoordinator.RegistrationHandle fakeEndPoint1Handle = localServiceSet.getCoordinator()
+                                                                               .register(fakeEndPoint1);
+    ClusterCoordinator.RegistrationHandle fakeEndPoint2Handle = localServiceSet.getCoordinator()
+                                                                               .register(fakeEndPoint2);
+
+    try {
+      client.connect(props);
+      fail();
+    } catch (RpcException ex) {
+      assertTrue(ex.getCause() instanceof ExecutionException);
+      client.close();
+    } finally {
+      // Remove the fake drillbits from local cluster cordinator
+      localServiceSet.getCoordinator().unregister(fakeEndPoint1Handle);
+      localServiceSet.getCoordinator().unregister(fakeEndPoint2Handle);
+    }
+  }
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcConnectTriesTestEmbeddedBits.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcConnectTriesTestEmbeddedBits.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.jdbc.test;
+
+import org.apache.drill.exec.rpc.InvalidConnectionInfoException;
+import org.apache.drill.exec.rpc.RpcException;
+import org.apache.drill.jdbc.Driver;
+import org.apache.drill.jdbc.JdbcTestBase;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Connection;
+
+import java.util.concurrent.ExecutionException;
+
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcConnectTriesTestEmbeddedBits extends JdbcTestBase {
+
+  public static Driver testDrillDriver;
+
+  @BeforeClass
+  public static void testSetUp() throws Exception {
+    testDrillDriver = new Driver();
+  }
+
+  @Test
+  public void testDirectConnectionConnectTriesEqualsDrillbitCount() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;" + "tries=2",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof RpcException);
+      assertTrue(ex.getCause().getCause() instanceof ExecutionException);
+    }
+  }
+
+  @Test
+  public void testDirectConnectionConnectTriesGreaterThanDrillbitCount() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;tries=5",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof RpcException);
+      assertTrue(ex.getCause().getCause() instanceof ExecutionException);
+    }
+  }
+
+  @Test
+  public void testDirectConnectionConnectTriesLessThanDrillbitCount() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;tries=1",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof RpcException);
+      assertTrue(ex.getCause().getCause() instanceof ExecutionException);
+    }
+  }
+
+  @Test
+  public void testDirectConnectionInvalidConnectTries() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;tries=abc",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof InvalidConnectionInfoException);
+    }
+  }
+
+  @Test
+  public void testDirectConnectionZeroConnectTries() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;tries=0",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof RpcException);
+      assertTrue(ex.getCause().getCause() instanceof ExecutionException);
+    }
+  }
+
+  @Test
+  public void testDirectConnectionNegativeConnectTries() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:drillbit=127.0.0.1:5000,127.0.0.1:5001;tries=-5",
+                                           JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof RpcException);
+      assertTrue(ex.getCause().getCause() instanceof ExecutionException);
+    }
+  }
+
+  @Test
+  public void testZKSuccessfulConnectionZeroConnectTries() throws SQLException {
+    Connection connection = testDrillDriver.connect("jdbc:drill:zk=local;tries=0", JdbcAssert.getDefaultProperties());
+    assertNotNull(connection);
+    connection.close();
+  }
+
+  @Test
+  public void testZKSuccessfulConnectionNegativeConnectTries() throws SQLException {
+    Connection connection = testDrillDriver.connect("jdbc:drill:zk=local;tries=-1", JdbcAssert.getDefaultProperties());
+    assertNotNull(connection);
+    connection.close();
+  }
+
+  @Test
+  public void testZKSuccessfulConnectionGreaterThanConnectTries() throws SQLException {
+    Connection connection = testDrillDriver.connect("jdbc:drill:zk=local;tries=7", JdbcAssert.getDefaultProperties());
+    assertNotNull(connection);
+    connection.close();
+  }
+
+  @Test
+  public void testZKConnectionInvalidConnectTries() throws SQLException {
+    Connection connection = null;
+    try {
+      connection = testDrillDriver.connect("jdbc:drill:zk=local;tries=abc", JdbcAssert.getDefaultProperties());
+      fail();
+    } catch (SQLException ex) {
+      assertNull(connection);
+      assertTrue(ex.getCause() instanceof InvalidConnectionInfoException);
+    }
+  }
+}

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BasicClient.java
@@ -150,9 +150,7 @@ public abstract class BasicClient<T extends EnumLite, R extends RemoteConnection
   public abstract ProtobufLengthDecoder getDecoder(BufferAllocator allocator);
 
   public boolean isActive() {
-    return connection != null
-        && connection.getChannel() != null
-        && connection.getChannel().isActive();
+    return (connection != null) && connection.isActive();
   }
 
   protected abstract void validateHandshake(HANDSHAKE_RESPONSE validateHandshake) throws RpcException;
@@ -302,14 +300,9 @@ public abstract class BasicClient<T extends EnumLite, R extends RemoteConnection
 
   public void close() {
     logger.debug("Closing client");
-    try {
-      connection.getChannel().close().get();
-    } catch (final InterruptedException | ExecutionException e) {
-      logger.warn("Failure while shutting {}", this.getClass().getName(), e);
 
-      // Preserve evidence that the interruption occurred so that code higher up on the call stack can learn of the
-      // interruption and respond to it if it wants to.
-      Thread.currentThread().interrupt();
+    if (connection != null) {
+      connection.close();
     }
   }
 


### PR DESCRIPTION
…nd foreman node.

         Note: Adding tries config option in connection string.
               Improving fault tolerance in Drill client when trying to make first connection with foreman.
               The client will try to connect to min(tries, num_drillbits) unique drillbits unless a successfull
               connection is established.