### PR TITLE
DRILL-5108: Reduce output from Maven git-commit-id-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
 
         <configuration>
           <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-          <verbose>true</verbose>
+          <verbose>false</verbose>
           <skipPoms>false</skipPoms>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>


### PR DESCRIPTION
The git-commit-id-plugin grabs information from Git to display during a
build. It prints many e-mail addresses and other generic project
information. As part of the effort to trim down unit test output, we
propose to turn off the verbose output from this plugin by default.