### PR TITLE
DRILL-5112: Unit tests derived from PopUnitTestBase fail in IDE due to config errors

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -64,7 +64,7 @@ public class Drillbit implements AutoCloseable {
     Environment.logEnv("Drillbit environment: ", logger);
   }
 
-  private final static String SYSTEM_OPTIONS_NAME = "org.apache.drill.exec.server.Drillbit.system_options";
+  public final static String SYSTEM_OPTIONS_NAME = "org.apache.drill.exec.server.Drillbit.system_options";
 
   private boolean isClosed = false;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.junit.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
 public class TestMergingReceiver extends PopUnitTestBase {
@@ -95,7 +94,7 @@ public class TestMergingReceiver extends PopUnitTestBase {
         final int batchRowCount = queryData.getRowCount();
         count += batchRowCount;
         batchLoader.load(queryData.getDef(), b.getData());
-        for (final VectorWrapper vw : batchLoader) {
+        for (final VectorWrapper<?> vw : batchLoader) {
           final ValueVector vv = vw.getValueVector();
           final ValueVector.Accessor va = vv.getAccessor();
           final MaterializedField materializedField = vv.getField();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
@@ -18,9 +18,12 @@
 package org.apache.drill.exec.pop;
 
 import java.io.IOException;
+import java.util.Properties;
 
+import org.apache.drill.QueryTestUtil;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.FileUtils;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.exception.FragmentSetupException;
 import org.apache.drill.exec.physical.PhysicalPlan;
@@ -29,6 +32,7 @@ import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.fragment.Fragment;
 import org.apache.drill.exec.planner.fragment.Fragment.ExchangeFragmentPair;
 import org.apache.drill.exec.planner.fragment.MakeFragmentsVisitor;
+import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.junit.BeforeClass;
 
@@ -42,7 +46,17 @@ public abstract class PopUnitTestBase  extends ExecTest{
 
   @BeforeClass
   public static void setup() {
-    CONFIG = DrillConfig.create();
+    Properties props = new Properties();
+
+    // Properties here mimic those in drill-root/pom.xml, Surefire plugin
+    // configuration. They allow tests to run successfully in Eclipse.
+
+    props.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+    props.put(ExecConstants.HTTP_ENABLE, "false");
+    props.put(Drillbit.SYSTEM_OPTIONS_NAME, "org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on");
+    props.put(QueryTestUtil.TEST_QUERY_PRINTING_SILENT, "true");
+    props.put("drill.catastrophic_to_standard_out", "true");
+    CONFIG = DrillConfig.create(props);
   }
 
 


### PR DESCRIPTION
Tests rely on command-line settings in the pom.xml file. Those settings
are not available when tests are run in Eclipse. Replicated required
settings into the base test class (as in BaseTestQuery).