### PR TITLE
DRILL-5113: Upgrade Maven RAT plugin to avoid annoying XML errors

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-  license agreements. See the NOTICE file distributed with this work for additional 
-  information regarding copyright ownership. The ASF licenses this file to 
-  You under the Apache License, Version 2.0 (the "License"); you may not use 
-  this file except in compliance with the License. You may obtain a copy of 
-  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-  by applicable law or agreed to in writing, software distributed under the 
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-  OF ANY KIND, either express or implied. See the License for the specific 
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
   language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -26,7 +26,7 @@
       <version>1.3</version>
       <scope>test</scope>
     </dependency>
-    
+
     <!-- <dependency> -->
     <!-- <groupId>org.ow2.asm</groupId> -->
     <!-- <artifactId>asm-util</artifactId> -->
@@ -54,13 +54,13 @@
       <artifactId>commons-pool2</artifactId>
       <version>2.1</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.univocity</groupId>
       <artifactId>univocity-parsers</artifactId>
       <version>1.3.0</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math</artifactId>
@@ -71,7 +71,7 @@
       <artifactId>paranamer</artifactId>
       <version>2.5.6</version>
       <exclusions>
-        <!-- Exclude Paranamer's dependency on mockito-all, which has a Jar 
+        <!-- Exclude Paranamer's dependency on mockito-all, which has a Jar
              file that contains old Hamcrest 1.1 classes (rather than declaring
              a dependency on Hamcrest).  (See DRILL-2130.) -->
         <exclusion>
@@ -321,7 +321,7 @@
       <groupId>org.apache.drill</groupId>
       <artifactId>drill-logical</artifactId>
       <version>${project.version}</version>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-rpc</artifactId>
@@ -518,7 +518,7 @@
   </profiles>
 
   <build>
-  
+
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
@@ -542,9 +542,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
-        <!-- Extract parser grammar template from calcite-core.jar and put 
+        <!-- Extract parser grammar template from calcite-core.jar and put
           it under ${project.build.directory}/codegen/templates where all freemarker templates are. -->
           <execution>
             <id>unpack-parser-template</id>
@@ -565,8 +564,8 @@
               </artifactItems>
             </configuration>
           </execution>
-          
-        <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put 
+
+        <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put
           it under ${project.build.directory}/codegen/data where all freemarker data files are. -->
           <execution>
             <id>unpack-vector-types</id>
@@ -586,7 +585,7 @@
                 </artifactItem>
               </artifactItems>
             </configuration>
-          </execution>          
+          </execution>
         </executions>
       </plugin>
 
@@ -702,8 +701,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
           <execution>
-            <!-- we override the default test execution to exclude tests 
-              that would take unusually long time to run (> 1 minute) and run such tests 
+            <!-- we override the default test execution to exclude tests
+              that would take unusually long time to run (> 1 minute) and run such tests
               in a different profile -->
             <id>default-test</id>
             <phase>test</phase>
@@ -719,7 +718,7 @@
     </plugins>
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings 
+        <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
+        <version>0.12</version>
         <executions>
           <execution>
             <id>rat-checks</id>


### PR DESCRIPTION
Upgrade to eliminate XML compiler warnings that appear for each sub-project in the Drill build.

Also fixes a Maven warning about a duplicated version error for the dependency plugin (version is inherited from root pom.xml). And removes some trailing spaces.