### PR TITLE
DRILL-5070: Code gen: create methods in fixed order to allow test verification	

### DIFF
--- a/common/src/test/java/org/apache/drill/test/FileMatcher.java
+++ b/common/src/test/java/org/apache/drill/test/FileMatcher.java
@@ -1,0 +1,352 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+
+import com.google.common.io.Closeables;
+
+/**
+ * Compares two files (or file-like sources) to check if they are identical.
+ * Used when comparing actual output to a "golden" copy. Provides a line-by-line
+ * filter to filter out details that might change from one run to the next
+ * (such as user name, the numeric suffix added to generated classes, etc.)
+ * <p>
+ * Golden files can have internal comments, starting with the '#' character.
+ * Use the comments to identify the test that uses the file and other information.
+ * <p>
+ * Comparing is done line-by-line. Leading and trailing white space is ignored
+ * as are blank lines. The resulting non-blank lines are expected to match
+ * those in the expected file. (The expected file can also contain white space
+ * and blank lines which are also ignored.)
+ */
+
+public class FileMatcher {
+
+  public interface Filter {
+    String filter(String line);
+  }
+
+  /**
+   * Generic mechanism for opening a variety of input sources.
+   */
+  static interface Source {
+    Reader reader() throws IOException;
+  }
+
+  static class FileSource implements Source {
+    File file;
+
+    public FileSource(File file) {
+      this.file = file;
+    }
+
+    @Override
+    public Reader reader() throws IOException {
+      return new FileReader(file);
+    }
+  }
+
+  static class StringSource implements Source {
+
+    String string;
+
+    public StringSource(String string) {
+      this.string = string;
+    }
+
+    @Override
+    public Reader reader() {
+      return new StringReader(string);
+    }
+  }
+
+  static class ReaderSource implements Source {
+
+    Reader reader;
+
+    public ReaderSource(Reader reader) {
+      this.reader = reader;
+    }
+
+    @Override
+    public Reader reader() {
+      return reader;
+    }
+  }
+
+  static class ResourceSource implements Source {
+
+    String resource;
+
+    public ResourceSource(String resource) {
+      this.resource = resource;
+    }
+
+    @Override
+    public Reader reader() {
+      try {
+        InputStream stream = getClass().getResourceAsStream(resource);
+        if (stream == null) {
+          throw new IllegalStateException("Resource not found: " + resource);
+        }
+        return new InputStreamReader(stream, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  /**
+   * Creates a FileMatcher given a pair of inputs and other options.
+   * One input is the "expected" (or "golden") file that has been pre-filtered.
+   * The other is the "actual" value produced by the test. The actual
+   * value can be filtered during comparison.
+   * <p>
+   * The matcher can operate in two modes. Start off with the
+   * {@link #capture()} mode to filter the actual input and display it
+   * to stdout. When the actual output is correct, copy in into a test
+   * resource and remove the call to <tt>capture()</tt>. After that, the
+   * matcher will ensure that future actual output matches the expected
+   * output.
+   */
+
+  public static class Builder {
+    private boolean ignoreWhitespace = true;
+    private Filter filter;
+    private Source expected;
+    private Source actual;
+    private boolean capture;
+    public boolean allowComments = true;
+
+    public Builder expectedFile(File file) {
+      expected = new FileSource(file);
+      return this;
+    }
+
+    public Builder expectedString(String text) {
+      expected = new StringSource(text);
+      return this;
+    }
+
+    public Builder expectedReader(Reader in) {
+      expected = new ReaderSource(in);
+      return this;
+    }
+
+    public Builder expectedResource(String resource) {
+      expected = new ResourceSource(resource);
+      return this;
+    }
+
+    public Builder actualFile(File file) {
+      actual = new FileSource(file);
+      return this;
+    }
+
+    public Builder actualString(String text) {
+      actual = new StringSource(text);
+      return this;
+    }
+
+    public Builder actualReader(Reader in) {
+      actual = new ReaderSource(in);
+      return this;
+    }
+
+    public Builder actualResource(String resource) {
+      actual = new ResourceSource(resource);
+      return this;
+    }
+
+    /**
+     * Preserve leading and trailing whitespace. By default,
+     * the matcher ignores such spaces.
+     *
+     * @return
+     */
+
+    public Builder preserveWhitespace() {
+      ignoreWhitespace = false;
+      return this;
+    }
+
+    /**
+     * By default the matcher ignores comment lines. Call this
+     * method to treat comment lines as regular lines.
+     * @return
+     */
+
+    public Builder disallowComments() {
+      allowComments = false;
+      return this;
+    }
+
+    /**
+     * Attach a filter applied to actual lines before comparing the
+     * lines with the expected values (or displaying them during
+     * capture.)
+     *
+     * @param filter
+     * @return
+     */
+    public Builder withFilter(Filter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /**
+     * Call this method to "capture" the expected output (after filtering).
+     * Use this when first creating the test to get the text to be used
+     * to create the golden file.
+     *
+     * @return
+     */
+
+    public Builder capture() {
+      this.capture = true;
+      return this;
+    }
+
+    /**
+     * Performs the matching (or capture) operation.
+     */
+
+    public boolean matches() throws IOException {
+      FileMatcher matcher = new FileMatcher(this);
+      if (capture) {
+        matcher.capture();
+        return true;
+      } else {
+        return matcher.match();
+      }
+    }
+  }
+
+  private Builder builder;
+  private LineNumberReader expected;
+  private LineNumberReader actual;
+
+  private FileMatcher(Builder builder) {
+    this.builder = builder;
+  }
+
+  public void capture() throws IOException {
+    try (LineNumberReader actual = new LineNumberReader(builder.actual.reader())) {
+      System.out.println("----- Captured Results -----");
+      String line;
+      while ((line = actual.readLine()) != null) {
+        if (builder.filter != null) {
+          line = builder.filter.filter(line);
+          if (line == null) {
+            continue; }
+        }
+        System.out.println(line);
+      }
+      System.out.println("----- End Results -----");
+    }
+  }
+
+  public boolean match() throws IOException {
+    try {
+      open();
+      return compare();
+    }
+    finally {
+      close();
+    }
+  }
+
+  private void open() throws IOException {
+    expected = new LineNumberReader(builder.expected.reader());
+    actual = new LineNumberReader(builder.actual.reader());
+  }
+
+  private boolean compare() throws IOException {
+    for (; ;) {
+      String expectedLine;
+
+      // Find a non-blank expected line.
+
+      for (;;) {
+        expectedLine = expected.readLine();
+        if (expectedLine == null) {
+          break; }
+        if (builder.ignoreWhitespace) {
+          expectedLine = expectedLine.trim();
+          if (expectedLine.isEmpty()) {
+            continue; }
+        }
+        if (builder.allowComments && expectedLine.charAt(0) == '#') {
+          continue; }
+        break;
+      }
+
+      // Find a non-blank actual line (after filtering).
+
+      String actualLine;
+      for (; ;) {
+        actualLine = actual.readLine();
+        if (actualLine == null) {
+          break; }
+        if (builder.filter != null) {
+          actualLine = builder.filter.filter(actualLine);
+          if (actualLine == null) {
+            continue; }
+        }
+        if (builder.ignoreWhitespace) {
+          actualLine = actualLine.trim();
+          if (actualLine.isEmpty()) {
+            continue; }
+        }
+        break;
+      }
+
+      // Do the line-by-line comparison.
+
+      if (expectedLine == null  &&  actualLine == null) {
+        return true; }
+      if (expectedLine == null) {
+        System.err.println("Missing lines at line " + expected.getLineNumber());
+        return false;
+      }
+      if (actualLine == null) {
+        System.err.println("Unexpected lines at line " + expected.getLineNumber());
+        return false;
+      }
+      if (! actualLine.equals(expectedLine)) {
+        System.err.println("Lines differ. Expected: " + expected.getLineNumber() +
+                            ", Actual: " + actual.getLineNumber());
+        return false;
+      }
+    }
+  }
+
+  private void close() {
+    Closeables.closeQuietly(expected);
+    Closeables.closeQuietly(actual);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/SignatureHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/SignatureHolder.java
@@ -20,6 +20,8 @@ package org.apache.drill.exec.compile.sig;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,14 @@ public class SignatureHolder implements Iterable<CodeGeneratorMethod> {
       }
       methodHolders.add(new CodeGeneratorMethod(m));
     }
+
+    // Alphabetize methods to ensure generated code is comparable.
+
+    Collections.sort( methodHolders, new Comparator<CodeGeneratorMethod>( ) {
+      @Override
+      public int compare(CodeGeneratorMethod o1, CodeGeneratorMethod o2) {
+        return o1.getMethodName().compareTo( o2.getMethodName() );
+      } } );
 
     methods = new CodeGeneratorMethod[methodHolders.size()+1];
     for (int i =0; i < methodHolders.size(); i++) {

--- a/exec/java-exec/src/test/resources/code/expr/basicExpr.txt
+++ b/exec/java-exec/src/test/resources/code/expr/basicExpr.txt
@@ -1,0 +1,58 @@
+# Expected output for org.apache.drill.exec.expr.ExpressionTest.testBasicExpression
+# Generated from: if(true) then 1 else 0 end
+
+package org.apache.drill.exec.test.generated;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.holders.BitHolder;
+import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.vector.IntVector;
+
+public class ProjectorGen {
+
+    IntHolder constant4;
+    IntVector vv5;
+
+    public void doEval(int inIndex, int outIndex)
+        throws SchemaChangeException
+    {
+        {
+            vv5 .getMutator().set((outIndex), constant4 .value);
+        }
+    }
+
+    public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing)
+        throws SchemaChangeException
+    {
+        {
+            IntHolder out0 = new IntHolder();
+            BitHolder out1 = new BitHolder();
+            out1 .value = 1;
+            if (out1 .value == 1) {
+                IntHolder out2 = new IntHolder();
+                out2 .value = 1;
+                out0 = out2;
+            } else {
+                IntHolder out3 = new IntHolder();
+                out3 .value = 0;
+                out0 = out3;
+            }
+            constant4 = out0;
+            int[] fieldIds6 = new int[ 1 ] ;
+            fieldIds6 [ 0 ] = -1;
+            Object tmp7 = (outgoing).getValueAccessorById(IntVector.class, fieldIds6).getValueVector();
+            if (tmp7 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv5 with id: TypedFieldId [fieldIds=[-1], remainder=null].");
+            }
+            vv5 = ((IntVector) tmp7);
+        }
+    }
+
+    public void __DRILL_INIT__()
+        throws SchemaChangeException
+    {
+    }
+
+}

--- a/exec/java-exec/src/test/resources/code/expr/lowerExponent.txt
+++ b/exec/java-exec/src/test/resources/code/expr/lowerExponent.txt
@@ -1,0 +1,91 @@
+# Expected output for org.apache.drill.exec.expr.ExpressionTest.testExprParseLowerExponent
+# Generated from: multiply(`$f0`, 1.0e-4)
+
+package org.apache.drill.exec.test.generated;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.holders.Float8Holder;
+import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.vector.NullableFloat8Vector;
+
+public class ProjectorGen {
+
+    NullableFloat8Vector vv0;
+    Float8Holder constant5;
+    NullableFloat8Vector vv7;
+
+    public void doEval(int inIndex, int outIndex)
+        throws SchemaChangeException
+    {
+        {
+            NullableFloat8Holder out3 = new NullableFloat8Holder();
+            {
+                out3 .isSet = vv0 .getAccessor().isSet((inIndex));
+                if (out3 .isSet == 1) {
+                    out3 .value = vv0 .getAccessor().get((inIndex));
+                }
+            }
+            //---- start of eval portion of multiply function. ----//
+            NullableFloat8Holder out6 = new NullableFloat8Holder();
+            {
+                if (out3 .isSet == 0) {
+                    out6 .isSet = 0;
+                } else {
+                    final NullableFloat8Holder out = new NullableFloat8Holder();
+                    NullableFloat8Holder in1 = out3;
+                    Float8Holder in2 = constant5;
+
+MultiplyFunctions$Float8Float8Multiply_eval: {
+    out.value = (double) (in1.value * in2.value);
+}
+
+                    out.isSet = 1;
+                    out6 = out;
+                    out.isSet = 1;
+                }
+            }
+            //---- end of eval portion of multiply function. ----//
+            if (!(out6 .isSet == 0)) {
+                vv7 .getMutator().set((outIndex), out6 .isSet, out6 .value);
+            }
+        }
+    }
+
+    public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing)
+        throws SchemaChangeException
+    {
+        {
+            int[] fieldIds1 = new int[ 1 ] ;
+            fieldIds1 [ 0 ] = 0;
+            Object tmp2 = (incoming).getValueAccessorById(NullableFloat8Vector.class, fieldIds1).getValueVector();
+            if (tmp2 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv0 with id: TypedFieldId [fieldIds=[0], remainder=null].");
+            }
+            vv0 = ((NullableFloat8Vector) tmp2);
+            Float8Holder out4 = new Float8Holder();
+            out4 .value = 1.0E-4D;
+            constant5 = out4;
+            /** start SETUP for function multiply **/
+            {
+                Float8Holder in2 = constant5;
+                 {}
+            }
+            /** end SETUP for function multiply **/
+            int[] fieldIds8 = new int[ 1 ] ;
+            fieldIds8 [ 0 ] = -1;
+            Object tmp9 = (outgoing).getValueAccessorById(NullableFloat8Vector.class, fieldIds8).getValueVector();
+            if (tmp9 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv7 with id: TypedFieldId [fieldIds=[-1], remainder=null].");
+            }
+            vv7 = ((NullableFloat8Vector) tmp9);
+        }
+    }
+
+    public void __DRILL_INIT__()
+        throws SchemaChangeException
+    {
+    }
+
+}

--- a/exec/java-exec/src/test/resources/code/expr/schemaExpr.txt
+++ b/exec/java-exec/src/test/resources/code/expr/schemaExpr.txt
@@ -1,0 +1,111 @@
+# Expected output for org.apache.drill.exec.expr.ExpressionTest.testSchemaExpression
+# Generated from: 1 + alpha
+
+package org.apache.drill.exec.test.generated;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.holders.BigIntHolder;
+import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.expr.holders.NullableBigIntHolder;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.vector.NullableBigIntVector;
+
+public class ProjectorGen {
+
+    BigIntHolder constant2;
+    NullableBigIntVector vv3;
+    NullableBigIntVector vv8;
+
+    public void doEval(int inIndex, int outIndex)
+        throws SchemaChangeException
+    {
+        {
+            NullableBigIntHolder out6 = new NullableBigIntHolder();
+            {
+                out6 .isSet = vv3 .getAccessor().isSet((inIndex));
+                if (out6 .isSet == 1) {
+                    out6 .value = vv3 .getAccessor().get((inIndex));
+                }
+            }
+            //---- start of eval portion of add function. ----//
+            NullableBigIntHolder out7 = new NullableBigIntHolder();
+            {
+                if (out6 .isSet == 0) {
+                    out7 .isSet = 0;
+                } else {
+                    final NullableBigIntHolder out = new NullableBigIntHolder();
+                    BigIntHolder in1 = constant2;
+                    NullableBigIntHolder in2 = out6;
+                     
+AddFunctions$BigIntBigIntAdd_eval: {
+    out.value = (long) (in1.value + in2.value);
+}
+ 
+                    out.isSet = 1;
+                    out7 = out;
+                    out.isSet = 1;
+                }
+            }
+            //---- end of eval portion of add function. ----//
+            if (!(out7 .isSet == 0)) {
+                vv8 .getMutator().set((outIndex), out7 .isSet, out7 .value);
+            }
+        }
+    }
+
+    public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing)
+        throws SchemaChangeException
+    {
+        {
+            IntHolder out0 = new IntHolder();
+            out0 .value = 1;
+            /** start SETUP for function castBIGINT **/ 
+            {
+                IntHolder in = out0;
+                 {}
+            }
+            /** end SETUP for function castBIGINT **/ 
+            //---- start of eval portion of castBIGINT function. ----//
+            BigIntHolder out1 = new BigIntHolder();
+            {
+                final BigIntHolder out = new BigIntHolder();
+                IntHolder in = out0;
+                 
+CastIntBigInt_eval: {
+    out.value = in.value;
+}
+ 
+                out1 = out;
+            }
+            //---- end of eval portion of castBIGINT function. ----//
+            constant2 = out1;
+            int[] fieldIds4 = new int[ 1 ] ;
+            fieldIds4 [ 0 ] = 0;
+            Object tmp5 = (incoming).getValueAccessorById(NullableBigIntVector.class, fieldIds4).getValueVector();
+            if (tmp5 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv3 with id: TypedFieldId [fieldIds=[0], remainder=null].");
+            }
+            vv3 = ((NullableBigIntVector) tmp5);
+            /** start SETUP for function add **/ 
+            {
+                BigIntHolder in1 = constant2;
+                 {}
+            }
+            /** end SETUP for function add **/ 
+            int[] fieldIds9 = new int[ 1 ] ;
+            fieldIds9 [ 0 ] = -1;
+            Object tmp10 = (outgoing).getValueAccessorById(NullableBigIntVector.class, fieldIds9).getValueVector();
+            if (tmp10 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv8 with id: TypedFieldId [fieldIds=[-1], remainder=null].");
+            }
+            vv8 = ((NullableBigIntVector) tmp10);
+        }
+    }
+
+    public void __DRILL_INIT__()
+        throws SchemaChangeException
+    {
+    }
+
+}

--- a/exec/java-exec/src/test/resources/code/expr/special.txt
+++ b/exec/java-exec/src/test/resources/code/expr/special.txt
@@ -1,0 +1,68 @@
+# Expected output for org.apache.drill.exec.expr.ExpressionTest.testSpecial
+# Generated from: 1 + 1
+
+package org.apache.drill.exec.test.generated;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.holders.IntHolder;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.vector.IntVector;
+
+public class ProjectorGen {
+
+    IntHolder constant2;
+    IntVector vv3;
+
+    public void doEval(int inIndex, int outIndex)
+        throws SchemaChangeException
+    {
+        {
+            vv3 .getMutator().set((outIndex), constant2 .value);
+        }
+    }
+
+    public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing)
+        throws SchemaChangeException
+    {
+        {
+            IntHolder out0 = new IntHolder();
+            out0 .value = 1;
+            /** start SETUP for function add **/
+            {
+                IntHolder in1 = out0;
+                IntHolder in2 = out0;
+                 {}
+            }
+            /** end SETUP for function add **/
+            //---- start of eval portion of add function. ----//
+            IntHolder out1 = new IntHolder();
+            {
+                final IntHolder out = new IntHolder();
+                IntHolder in1 = out0;
+                IntHolder in2 = out0;
+
+AddFunctions$IntIntAdd_eval: {
+    out.value = (int) (in1.value + in2.value);
+}
+
+                out1 = out;
+            }
+            //---- end of eval portion of add function. ----//
+            constant2 = out1;
+            int[] fieldIds4 = new int[ 1 ] ;
+            fieldIds4 [ 0 ] = -1;
+            Object tmp5 = (outgoing).getValueAccessorById(IntVector.class, fieldIds4).getValueVector();
+            if (tmp5 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv3 with id: TypedFieldId [fieldIds=[-1], remainder=null].");
+            }
+            vv3 = ((IntVector) tmp5);
+        }
+    }
+
+    public void __DRILL_INIT__()
+        throws SchemaChangeException
+    {
+    }
+
+}

--- a/exec/java-exec/src/test/resources/code/expr/upperExponent.txt
+++ b/exec/java-exec/src/test/resources/code/expr/upperExponent.txt
@@ -1,0 +1,91 @@
+# Expected output for org.apache.drill.exec.expr.ExpressionTest.testExprParseUpperExponent
+# Generated from: multiply(`$f0`, 1.0E-4)
+
+package org.apache.drill.exec.test.generated;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.holders.Float8Holder;
+import org.apache.drill.exec.expr.holders.NullableFloat8Holder;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.vector.NullableFloat8Vector;
+
+public class ProjectorGen {
+
+    NullableFloat8Vector vv0;
+    Float8Holder constant5;
+    NullableFloat8Vector vv7;
+
+    public void doEval(int inIndex, int outIndex)
+        throws SchemaChangeException
+    {
+        {
+            NullableFloat8Holder out3 = new NullableFloat8Holder();
+            {
+                out3 .isSet = vv0 .getAccessor().isSet((inIndex));
+                if (out3 .isSet == 1) {
+                    out3 .value = vv0 .getAccessor().get((inIndex));
+                }
+            }
+            //---- start of eval portion of multiply function. ----//
+            NullableFloat8Holder out6 = new NullableFloat8Holder();
+            {
+                if (out3 .isSet == 0) {
+                    out6 .isSet = 0;
+                } else {
+                    final NullableFloat8Holder out = new NullableFloat8Holder();
+                    NullableFloat8Holder in1 = out3;
+                    Float8Holder in2 = constant5;
+
+MultiplyFunctions$Float8Float8Multiply_eval: {
+    out.value = (double) (in1.value * in2.value);
+}
+
+                    out.isSet = 1;
+                    out6 = out;
+                    out.isSet = 1;
+                }
+            }
+            //---- end of eval portion of multiply function. ----//
+            if (!(out6 .isSet == 0)) {
+                vv7 .getMutator().set((outIndex), out6 .isSet, out6 .value);
+            }
+        }
+    }
+
+    public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing)
+        throws SchemaChangeException
+    {
+        {
+            int[] fieldIds1 = new int[ 1 ] ;
+            fieldIds1 [ 0 ] = 0;
+            Object tmp2 = (incoming).getValueAccessorById(NullableFloat8Vector.class, fieldIds1).getValueVector();
+            if (tmp2 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv0 with id: TypedFieldId [fieldIds=[0], remainder=null].");
+            }
+            vv0 = ((NullableFloat8Vector) tmp2);
+            Float8Holder out4 = new Float8Holder();
+            out4 .value = 1.0E-4D;
+            constant5 = out4;
+            /** start SETUP for function multiply **/
+            {
+                Float8Holder in2 = constant5;
+                 {}
+            }
+            /** end SETUP for function multiply **/
+            int[] fieldIds8 = new int[ 1 ] ;
+            fieldIds8 [ 0 ] = -1;
+            Object tmp9 = (outgoing).getValueAccessorById(NullableFloat8Vector.class, fieldIds8).getValueVector();
+            if (tmp9 == null) {
+                throw new SchemaChangeException("Failure while loading vector vv7 with id: TypedFieldId [fieldIds=[-1], remainder=null].");
+            }
+            vv7 = ((NullableFloat8Vector) tmp9);
+        }
+    }
+
+    public void __DRILL_INIT__()
+        throws SchemaChangeException
+    {
+    }
+
+}


### PR DESCRIPTION
A handy technique in testing is to compare generated code against a "golden" copy that defines the expected results. However, at present, Drill generates code using the method order returned by Class.getDeclaredMethods, but this method makes no guarantee about the order of the methods. The order varies from one run to the next. There is some evidence this link that order can vary even within a single run, though a quick test was unable to reproduce this case.

The fix is simple, in the SignatureHolder constructor, sort methods by name after retrieving them from the class. The sort ensures that method order is deterministic. Fortunately, the number of methods is small, so the sort step adds little cost.