### PR TITLE
DRILL-5121 A memory leak is observed when exact case is not specified for a column in a filter condition

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -53,6 +53,7 @@ import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.common.map.CaseInsensitiveMap;
 
 import com.google.common.collect.Maps;
 
@@ -67,8 +68,8 @@ public class ScanBatch implements CloseableRecordBatch {
   private final VectorContainer container = new VectorContainer();
 
   /** Fields' value vectors indexed by fields' keys. */
-  private final Map<String, ValueVector> fieldVectorMap =
-      Maps.newHashMap();
+  private final CaseInsensitiveMap<ValueVector> fieldVectorMap =
+          CaseInsensitiveMap.newHashMap();
 
   private int recordCount;
   private final FragmentContext context;


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/DRILL-5121.

Changes fieldVectorMap in ScanBatch to a CaseInsensitiveMap to workaround the memory leak described in the bug.