### PR TITLE
DRILL-5122: DrillBuf performs expensive logging if -ea set

### DIFF
--- a/exec/memory/base/pom.xml
+++ b/exec/memory/base/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-  license agreements. See the NOTICE file distributed with this work for additional 
-  information regarding copyright ownership. The ASF licenses this file to 
-  You under the Apache License, Version 2.0 (the "License"); you may not use 
-  this file except in compliance with the License. You may obtain a copy of 
-  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-  by applicable law or agreed to in writing, software distributed under the 
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-  OF ANY KIND, either express or implied. See the License for the specific 
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
   language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -40,10 +40,21 @@
     </dependency>
   </dependencies>
 
-
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <!-- Configure memory (only) to use the expensive
+               memory logging. (Tests here fail without the logging. -->
+
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <drill.memory.debug.allocator>true</drill.memory.debug.allocator>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
-
-
-
 </project>

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -40,12 +40,25 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   public static final String DEBUG_ALLOCATOR = "drill.memory.debug.allocator";
 
+  @SuppressWarnings("unused")
   private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
   private static final int CHUNK_SIZE = AllocationManager.INNER_ALLOCATOR.getChunkSize();
 
   public static final int DEBUG_LOG_LENGTH = 6;
+  /**
+   * Indicate if debug logging is enabled. This logging is quite expensive,
+   * adding 10x-20x to query cost. It is enabled only if two conditions are
+   * both true:
+   * <ul>
+   * <li>Assertions are enabled (-ea JVM option), and</li>
+   * <li>-Ddrill.memory.debug.allocator=true is also on the JVM
+   * command line.</li>
+   * </ul>
+   * Note: in earlier versions the condition was OR, resulting in
+   * very slow performance whenever assertions were enabled.
+   */
   public static final boolean DEBUG = AssertionUtil.isAssertionsEnabled()
-      || Boolean.parseBoolean(System.getProperty(DEBUG_ALLOCATOR, "false"));
+      && Boolean.parseBoolean(System.getProperty(DEBUG_ALLOCATOR, "false"));
   private final Object DEBUG_LOCK = DEBUG ? new Object() : null;
 
   private final BaseAllocator parentAllocator;
@@ -98,9 +111,9 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       historicalLog = null;
       childLedgers = null;
     }
-
   }
 
+  @Override
   public void assertOpen() {
     if (AssertionUtil.ASSERT_ENABLED) {
       if (isClosed) {
@@ -289,6 +302,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       }
     }
 
+    @Override
     public boolean add(final int nBytes) {
       assertOpen();
 
@@ -310,6 +324,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       return true;
     }
 
+    @Override
     public DrillBuf allocateBuffer() {
       assertOpen();
 
@@ -321,14 +336,17 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       return drillBuf;
     }
 
+    @Override
     public int getSize() {
       return nBytes;
     }
 
+    @Override
     public boolean isUsed() {
       return used;
     }
 
+    @Override
     public boolean isClosed() {
       return closed;
     }
@@ -366,6 +384,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       closed = true;
     }
 
+    @Override
     public boolean reserve(int nBytes) {
       assertOpen();
 
@@ -511,6 +530,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   }
 
+  @Override
   public String toString() {
     final Verbosity verbosity = logger.isTraceEnabled() ? Verbosity.LOG_WITH_STACKTRACE
         : Verbosity.BASIC;
@@ -525,6 +545,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
    *
    * @return A Verbose string of current allocator state.
    */
+  @Override
   public String toVerboseString() {
     final StringBuilder sb = new StringBuilder();
     print(sb, 0, Verbosity.LOG_WITH_STACKTRACE);

--- a/pom.xml
+++ b/pom.xml
@@ -423,14 +423,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
           <configuration>
-            <argLine>-Xms512m -Xmx3g -Ddrill.exec.http.enabled=false
-              -Ddrill.exec.sys.store.provider.local.write=false
-              -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
-              -Ddrill.test.query.printing.silent=true
-              -Ddrill.catastrophic_to_standard_out=true
+            <argLine>-Xms512m -Xmx3g
               -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=3072M
-              -Djava.net.preferIPv4Stack=true
-              -Djava.awt.headless=true
               -XX:+CMSClassUnloadingEnabled -ea</argLine>
             <forkCount>${forkCount}</forkCount>
             <reuseForks>true</reuseForks>
@@ -438,6 +432,14 @@
               <additionalClasspathElement>./exec/jdbc/src/test/resources/storage-plugins.json</additionalClasspathElement>
             </additionalClasspathElements>
             <systemPropertyVariables>
+              <drill.exec.http.enabled>false</drill.exec.http.enabled>
+              <drill.exec.sys.store.provider.local.write>false</drill.exec.sys.store.provider.local.write>
+              <org.apache.drill.exec.server.Drillbit.system_options>"org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"</org.apache.drill.exec.server.Drillbit.system_options>
+              <drill.test.query.printing.silent>true</drill.test.query.printing.silent>
+              <drill.catastrophic_to_standard_out>true</drill.catastrophic_to_standard_out>
+              <drill.memory.debug.allocator>true</drill.memory.debug.allocator>
+              <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+              <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
           </configuration>


### PR DESCRIPTION
In Drill, once assertions are enabled, the dominant cost of a query
becomes DrillBuf logging. One example showed that DrillBuf logging
increases query cost by 10x.

Logging was enabled by the -ea option, which should be available for
many other uses. Changed to require a specific option to be turned on.

Enabled the option for memory tests (which require the option) but off
by default and for all other tests.

To do this, converted Surefire system options from command line args to
system variables so that they can be customized in sub-project poms.