### PR TITLE
DRILL-5104: Foreman should not alter physical plan memory

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/PhysicalPlan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/PhysicalPlan.java
@@ -62,9 +62,7 @@ public class PhysicalPlan {
     }else{
       return list;
     }
-
   }
-
 
   @JsonProperty("head")
   public PlanProperties getProperties() {
@@ -89,5 +87,4 @@ public class PhysicalPlan {
       throw new RuntimeException(e);
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/MemoryAllocationUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/MemoryAllocationUtilities.java
@@ -41,6 +41,13 @@ public class MemoryAllocationUtilities {
    * @param queryContext
    */
   public static void setupSortMemoryAllocations(final PhysicalPlan plan, final QueryContext queryContext) {
+
+    // Test plans may already have a pre-defined memory plan.
+    // Otherwise, determine memory allocation.
+
+    if (plan.getProperties().hasResourcePlan) {
+      return;
+    }
     // look for external sorts
     final List<ExternalSort> sortList = new LinkedList<>();
     for (final PhysicalOperator op : plan.getSortedOperators()) {
@@ -64,6 +71,6 @@ public class MemoryAllocationUtilities {
         externalSort.setMaxAllocation(maxSortAlloc);
       }
     }
+    plan.getProperties().hasResourcePlan = true;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -775,6 +775,7 @@ public class Foreman implements Runnable {
       }
     }
 
+    @SuppressWarnings("resource")
     @Override
     public void close() {
       Preconditions.checkState(!isClosed);
@@ -1187,7 +1188,7 @@ public class Foreman implements Runnable {
       final DrillbitEndpoint drillbitEndpoint;
       final RpcException rpcException;
 
-      SubmissionException(@SuppressWarnings("unused") final DrillbitEndpoint drillbitEndpoint,
+      SubmissionException(final DrillbitEndpoint drillbitEndpoint,
           final RpcException rpcException) {
         this.drillbitEndpoint = drillbitEndpoint;
         this.rpcException = rpcException;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
@@ -42,7 +42,6 @@ import org.junit.rules.TestRule;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
-@Ignore
 public class TestSimpleExternalSort extends BaseTestQuery {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleExternalSort.class);
   DrillConfig c = DrillConfig.create();
@@ -50,6 +49,7 @@ public class TestSimpleExternalSort extends BaseTestQuery {
 
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(80000);
 
+  @Ignore
   @Test
   public void mergeSortWithSv2() throws Exception {
     List<QueryDataBatch> results = testPhysicalFromFileWithResults("xsort/one_key_sort_descending_sv2.json");
@@ -132,6 +132,7 @@ public class TestSimpleExternalSort extends BaseTestQuery {
   }
 
   @Test
+  @Ignore
   public void sortOneKeyDescendingExternalSort() throws Throwable{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
@@ -186,6 +187,7 @@ public class TestSimpleExternalSort extends BaseTestQuery {
   }
 
   @Test
+  @Ignore
   public void outOfMemoryExternalSort() throws Throwable{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 

--- a/exec/java-exec/src/test/resources/xsort/one_key_sort_descending.json
+++ b/exec/java-exec/src/test/resources/xsort/one_key_sort_descending.json
@@ -4,7 +4,8 @@
         version:"1",
         generator:{
             type:"manual"
-        }
+        },
+        hasRMPlan: true
     },
     graph:[
         {

--- a/logical/src/main/java/org/apache/drill/common/logical/PlanProperties.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/PlanProperties.java
@@ -35,6 +35,12 @@ public class PlanProperties {
   public JSONOptions options;
   public int queue;
 
+  /**
+   * Indicates if the plan has been planned for resource management
+   * (memory, etc.) or if this plan must still be computed.
+   */
+  public boolean hasResourcePlan;
+
 //  @JsonInclude(Include.NON_NULL)
   public static class Generator {
     public String type;
@@ -55,7 +61,8 @@ public class PlanProperties {
                          @JsonProperty("type") PlanType type,
                          @JsonProperty("mode") ResultMode resultMode,
                          @JsonProperty("options") JSONOptions options,
-                         @JsonProperty("queue") int queue
+                         @JsonProperty("queue") int queue,
+                         @JsonProperty("hasRMPlan") boolean hasRMPlan
                          ) {
     this.version = version;
     this.queue = queue;
@@ -63,6 +70,7 @@ public class PlanProperties {
     this.type = type;
     this.resultMode = resultMode == null ? ResultMode.EXEC : resultMode;
     this.options = options;
+    this.hasResourcePlan = hasRMPlan;
   }
 
   public static PlanPropertiesBuilder builder() {
@@ -76,6 +84,7 @@ public class PlanProperties {
     private ResultMode mode = ResultMode.EXEC;
     private JSONOptions options;
     private int queueNumber = 0;
+    private boolean hasRMPlan = false;
 
     public PlanPropertiesBuilder type(PlanType type) {
       this.type = type;
@@ -112,8 +121,13 @@ public class PlanProperties {
       return this;
     }
 
+    public PlanPropertiesBuilder generator(boolean hasRMPLan) {
+      this.hasRMPlan = hasRMPlan;
+      return this;
+    }
+
     public PlanProperties build() {
-      return new PlanProperties(version, generator, type, mode, options, queueNumber);
+      return new PlanProperties(version, generator, type, mode, options, queueNumber, hasRMPlan);
     }
 
   }


### PR DESCRIPTION
Foreman should not set external sort memory for a physical plan

Physical plans include a plan for memory allocations. However, the code
path in Foreman replans external sort memory, even for a physical plan.
This makes it impossible to use a physical plan to test memory
configuration.

This change avoids changing memory settings in a physical plan; while
preserving the adjustments for logical plans or SQL queries.