### PR TITLE
DRILL-5136: Server unable to prepare non SELECT queries

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/prepare/PreparedStatementProvider.java
@@ -130,10 +130,11 @@ public class PreparedStatementProvider {
       try {
         UserClientConnectionWrapper wrapper = new UserClientConnectionWrapper(connection);
 
+        boolean isSelectQry = req.getSqlQuery().trim().toUpperCase().startsWith("SELECT");
         final RunQuery limit0Query =
             RunQuery.newBuilder()
                 .setType(QueryType.SQL)
-                .setPlan(String.format("SELECT * FROM (%s) LIMIT 0", req.getSqlQuery()))
+                .setPlan((isSelectQry)?String.format("SELECT * FROM (%s) LIMIT 0", req.getSqlQuery()):req.getSqlQuery())
                 .build();
 
         final QueryId limit0QueryId = userWorker.submitWork(wrapper, limit0Query);


### PR DESCRIPTION
Currently, the server makes every incoming queries a limit 0 query during server prepare. This is causing some non select queries to fail.

We need to add an additional check to determine if the query is a SELECT query before wrapping it with LIMIT 0.