### PR TITLE
DRILL-5137 - Optimize count(*) queries on MapR-DB Binary Tables

### DIFF
--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
@@ -124,6 +124,11 @@ public class HBaseRecordReader extends AbstractRecordReader implements DrillHBas
     } else {
       rowKeyOnly = false;
       transformed.add(ROW_KEY_PATH);
+      /* DRILL-5137 - optimize count(*) queries on MapR-DB Binary tables */
+      if (isSkipQuery()) {
+        hbaseScan.setFilter(
+            HBaseUtils.andFilterAtIndex(hbaseScan.getFilter(), HBaseUtils.LAST_FILTER, new FirstKeyOnlyFilter()));
+      }
     }
 
 


### PR DESCRIPTION
This diff uses the same optimization as that for the rowKeyOnly queries.
We use the FirstKeyOnlyFilter for count(*) queries.
This fix will optimize these queries for HBase tables, as well as MapR-DB Binary tables.