### PR TITLE
DRILL-5125: Provide option to use generic code for sv remover

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -86,7 +86,7 @@ public interface ExecConstants {
 
   BooleanValidator EXTERNAL_SORT_DISABLE_MANAGED_OPTION = new BooleanValidator("exec.sort.disable_managed", false);
 
-
+  String REMOVER_ENABLE_GENERIC_COPIER = "drill.exec.sv_remover.enable_generic_copier";
   String TEXT_LINE_READER_BATCH_SIZE = "drill.exec.storage.file.text.batch.size";
   String TEXT_LINE_READER_BUFFER_SIZE = "drill.exec.storage.file.text.buffer.size";
   String HAZELCAST_SUBNETS = "drill.exec.cache.hazel.subnets";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV2Copier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV2Copier.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.svremover;
+
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.vector.ValueVector;
+
+/**
+ * Generic selection vector 2 copier implementation that can
+ * be used in place of the generated version. Relies on a
+ * virtual function in each value vector to choose the proper
+ * implementation. Tests suggest that this version performs
+ * better than the generated version for queries with many columns.
+ */
+
+public class GenericSV2Copier extends CopierTemplate2 {
+
+  private ValueVector[] vvOut;
+  private ValueVector[] vvIn;
+
+  @SuppressWarnings("unused")
+  @Override
+  public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing) {
+
+    // Seems to be no way to get the vector count without iterating...
+
+    int count = 0;
+    for(VectorWrapper<?> vv : incoming) {
+      count++;
+    }
+    vvIn = new ValueVector[count];
+    vvOut = new ValueVector[count];
+    int i = 0;
+    for(VectorWrapper<?> vv : incoming) {
+      vvIn[i] = incoming.getValueAccessorById(ValueVector.class, i).getValueVector();
+      vvOut[i] = outgoing.getValueAccessorById(ValueVector.class, i).getValueVector();
+      i++;
+    }
+  }
+
+  @Override
+  public void doEval(int inIndex, int outIndex) {
+    for ( int i = 0;  i < vvIn.length;  i++ ) {
+      vvOut[i].copyEntry(outIndex, vvIn[i], inIndex);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV4Copier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV4Copier.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.svremover;
+
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.vector.ValueVector;
+
+/**
+ * Generic selection vector 4 copier implementation that can
+ * be used in place of the generated version. Relies on a
+ * virtual function in each value vector to choose the proper
+ * implementation. Tests suggest that this version performs
+ * better than the generated version for queries with many columns.
+ */
+
+public class GenericSV4Copier extends CopierTemplate4 {
+
+  private ValueVector[] vvOut;
+  private ValueVector[][] vvIn;
+
+  @SuppressWarnings("unused")
+  @Override
+  public void doSetup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing) {
+
+    // Seems to be no way to get the vector count without iterating...
+
+    int count = 0;
+    for(VectorWrapper<?> vv : incoming) {
+      count++;
+    }
+    vvIn = new ValueVector[count][];
+    vvOut = new ValueVector[count];
+    int i = 0;
+    for(VectorWrapper<?> vv : incoming) {
+      vvIn[i] = incoming.getValueAccessorById(ValueVector.class, i).getValueVectors();
+      vvOut[i] = outgoing.getValueAccessorById(ValueVector.class, i).getValueVector();
+      i++;
+    }
+  }
+
+  @Override
+  public void doEval(int inIndex, int outIndex) {
+    int inOffset = inIndex & 0xFFFF;
+    int inVector = inIndex >>> 16;
+    for ( int i = 0;  i < vvIn.length;  i++ ) {
+      vvOut[i].copyEntry(outIndex, vvIn[i][inVector], inOffset);
+    }
+  }
+}

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -226,6 +226,9 @@ drill.exec: {
       }
     }
   },
+  sv_remover : {
+    enable_generic_copier: false
+  }
   memory: {
     operator: {
       max: 20000000000,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/svremover/TestSVRemover.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/svremover/TestSVRemover.java
@@ -19,7 +19,11 @@ package org.apache.drill.exec.physical.impl.svremover;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Properties;
+
 import org.apache.drill.BaseTestQuery;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
 import org.junit.Test;
 
 public class TestSVRemover extends BaseTestQuery {
@@ -32,6 +36,35 @@ public class TestSVRemover extends BaseTestQuery {
   @Test
   public void testSVRWithNoFilter() throws Exception {
     int numOutputRecords = testPhysical(getFile("remover/sv_with_no_filter.json"));
+    assertEquals(100, numOutputRecords);
+  }
+
+  /**
+   * Test the generic version of the selection vector remover copier
+   * class. The code uses the traditional generated version by default.
+   * This test sets the option to use the generic version, then runs
+   * a query that exercises that version.
+   * <p>
+   * Note that the tests here exercise only the SV2 version of the
+   * selection remover; no tests exist for the SV4 version.
+   */
+
+  // TODO: Add an SV4 test once the improved mock data generator
+  // is available.
+
+  @Test
+  public void testGenericCopier() throws Exception {
+    // TODO: replace this with new setup once revised test framework
+    // is available.
+    Properties config = new Properties( );
+    config.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+    config.put(ExecConstants.HTTP_ENABLE, "false");
+    config.put(ExecConstants.REMOVER_ENABLE_GENERIC_COPIER, "true");
+    updateTestCluster(1, DrillConfig.create(config));
+
+    int numOutputRecords = testPhysical(getFile("remover/test1.json"));
+    assertEquals(50, numOutputRecords);
+    numOutputRecords = testPhysical(getFile("remover/sv_with_no_filter.json"));
     assertEquals(100, numOutputRecords);
   }
 }

--- a/exec/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -198,6 +198,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
     data.writerIndex(actualLength);
   }
 
+  @Override
   public TransferPair getTransferPair(BufferAllocator allocator){
     return new TransferImpl(getField(), allocator);
   }
@@ -279,6 +280,11 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
         reAlloc();
     }
     copyFrom(fromIndex, thisIndex, from);
+  }
+
+  @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    ((${minor.class}Vector) from).data.getBytes(fromIndex * ${type.width}, data, toIndex * ${type.width}, ${type.width});
   }
 
   public void decrementAllocationMonitor() {

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -374,6 +374,19 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     values.copyFromSafe(fromIndex, thisIndex, from.values);
   }
 
+  @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    Nullable${minor.class}Vector fromVector = (Nullable${minor.class}Vector) from;
+    <#if type.major == "VarLen">
+
+    // This method is to be called only for loading the vector
+    // sequentially, so there should be no empties to fill.
+
+    </#if>
+    bits.copyFromSafe(fromIndex, toIndex, fromVector.bits);
+    values.copyFromSafe(fromIndex, toIndex, fromVector.values);
+  }
+
   public final class Accessor extends BaseDataValueVector.BaseAccessor <#if type.major = "VarLen">implements VariableWidthVector.VariableWidthAccessor</#if> {
     final UInt1Vector.Accessor bAccessor = bits.getAccessor();
     final ${valuesName}.Accessor vAccessor = values.getAccessor();

--- a/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
@@ -160,23 +160,28 @@ public final class Repeated${minor.class}Vector extends BaseRepeatedValueVector 
     }
   }
 
-    public void copyFrom(int inIndex, int outIndex, Repeated${minor.class}Vector v) {
-      final Accessor vAccessor = v.getAccessor();
-      final int count = vAccessor.getInnerValueCountAt(inIndex);
-      mutator.startNewValue(outIndex);
-      for (int i = 0; i < count; i++) {
-        mutator.add(outIndex, vAccessor.get(inIndex, i));
-      }
+  public void copyFrom(int inIndex, int outIndex, Repeated${minor.class}Vector v) {
+    final Accessor vAccessor = v.getAccessor();
+    final int count = vAccessor.getInnerValueCountAt(inIndex);
+    mutator.startNewValue(outIndex);
+    for (int i = 0; i < count; i++) {
+      mutator.add(outIndex, vAccessor.get(inIndex, i));
     }
+  }
 
-    public void copyFromSafe(int inIndex, int outIndex, Repeated${minor.class}Vector v) {
-      final Accessor vAccessor = v.getAccessor();
-      final int count = vAccessor.getInnerValueCountAt(inIndex);
-      mutator.startNewValue(outIndex);
-      for (int i = 0; i < count; i++) {
-        mutator.addSafe(outIndex, vAccessor.get(inIndex, i));
-      }
+  public void copyFromSafe(int inIndex, int outIndex, Repeated${minor.class}Vector v) {
+    final Accessor vAccessor = v.getAccessor();
+    final int count = vAccessor.getInnerValueCountAt(inIndex);
+    mutator.startNewValue(outIndex);
+    for (int i = 0; i < count; i++) {
+      mutator.addSafe(outIndex, vAccessor.get(inIndex, i));
     }
+  }
+
+  @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (Repeated${minor.class}Vector) from);
+  }
 
   public boolean allocateNewSafe() {
     /* boolean to keep track if all the memory allocation were successful

--- a/exec/vector/src/main/codegen/templates/UnionVector.java
+++ b/exec/vector/src/main/codegen/templates/UnionVector.java
@@ -80,6 +80,7 @@ public class UnionVector implements ValueVector {
     this.callBack = callBack;
   }
 
+  @Override
   public BufferAllocator getAllocator() {
     return allocator;
   }
@@ -246,6 +247,11 @@ public class UnionVector implements ValueVector {
 
   public void copyFromSafe(int inIndex, int outIndex, UnionVector from) {
     copyFrom(inIndex, outIndex, from);
+  }
+
+  @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (UnionVector) from);
   }
 
   public ValueVector addVector(ValueVector v) {

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -239,6 +239,11 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (${minor.class}Vector) from);
+  }
+
+  @Override
   public int getAllocatedByteCount() {
     return offsetVector.getAllocatedByteCount() + super.getAllocatedByteCount();
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -183,6 +183,11 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFrom(fromIndex, toIndex, (BitVector) from);
+  }
+
+  @Override
   public void load(SerializedField metadata, DrillBuf buffer) {
     Preconditions.checkArgument(this.field.getPath().equals(metadata.getNamePart().getName()), "The field %s doesn't match the provided metadata %s.", this.field, metadata);
     final int valueCount = metadata.getValueCount();

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
@@ -161,6 +161,11 @@ public class ObjectVector extends BaseValueVector {
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    throw new UnsupportedOperationException("ObjectVector does not support this");
+  }
+
+  @Override
   public int getValueCapacity() {
     return maxCount;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -175,6 +175,8 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    */
   void load(SerializedField metadata, DrillBuf buffer);
 
+  void copyEntry(int toIndex, ValueVector from, int fromIndex);
+
   /**
    * Return the total memory consumed by all buffers within this vector.
    */

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -178,12 +178,11 @@ public class ZeroVector implements ValueVector {
   public void load(UserBitShared.SerializedField metadata, DrillBuf buffer) { }
 
   @Override
-  public int getAllocatedByteCount() {
-    return 0;
-  }
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) { }
 
   @Override
-  public int getPayloadByteCount() {
-    return 0;
-  }
+  public int getAllocatedByteCount() { return 0; }
+
+  @Override
+  public int getPayloadByteCount() { return 0; }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -95,6 +95,11 @@ public class ListVector extends BaseRepeatedValueVector {
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (ListVector) from);
+  }
+
+  @Override
   public ValueVector getDataVector() {
     return vector;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -90,6 +90,11 @@ public class MapVector extends AbstractMapVector {
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (RepeatedMapVector) from);
+  }
+
+  @Override
   protected boolean supportsDirectRead() {
     return true;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
@@ -218,6 +218,10 @@ public class RepeatedListVector extends AbstractContainerVector
       ephPair.copyValueSafe(fromIndex, thisIndex);
     }
 
+    @Override
+    public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+      copyFromSafe(fromIndex, toIndex, (DelegateRepeatedVector) from);
+    }
   }
 
   protected class RepeatedListTransferPair implements TransferPair {
@@ -425,6 +429,10 @@ public class RepeatedListVector extends AbstractContainerVector
 
   public void copyFromSafe(int fromIndex, int thisIndex, RepeatedListVector from) {
     delegate.copyFromSafe(fromIndex, thisIndex, from.delegate);
+  }
+
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (RepeatedListVector) from);
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
@@ -402,6 +402,11 @@ public class RepeatedMapVector extends AbstractMapVector
   }
 
   @Override
+  public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
+    copyFromSafe(fromIndex, toIndex, (RepeatedMapVector) from);
+  }
+
+  @Override
   public int getValueCapacity() {
     return Math.max(offsets.getValueCapacity() - 1, 0);
   }


### PR DESCRIPTION
Performance tests showed that, for queries with a large number of
columns, it is faster to use a “generic” implementation of the
selection vector remover “copier” than to use a generated version.

This PR provides "generic" versions of the SV2 and SV4 copiers
used by the selection vector remover. The generic forms are
enabled using a new boot-time config parameter that is disabled
by default (preserving the traditional generated code.)

The generic form relies on a "virtual function" (really, just a
plain Java function) defined in the base ValueVector class and
implemented by each concrete vector: both the pre-defined and
generated forms. This form "does the right thing" for the copy
operation so that we don't need to generate code just to handle
the method dispatch operation (which Java does quite well on its
own.)

A unit tests validates that the generic form works by runing
the existing SV remover tests with the generic option turned on.

See the DRILL-5125 for details.

Add test