### PR TITLE
DRILL-5157: Multiple Snappy versions on class path

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -376,11 +376,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>1.0.5-M3</version>
-    </dependency>
-    <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
       <version>0.7.1</version>
@@ -429,6 +424,12 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.7.7</version>
+      <exclusions>
+    	<exclusion>
+    	  <groupId>org.xerial.snappy</groupId>
+    	  <artifactId>snappy-java</artifactId>
+    	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,11 @@
       <version>0.9.44</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.2.6</version>
+    </dependency>
 
   </dependencies>
 
@@ -1331,6 +1336,17 @@
             </exclusions>
           </dependency>
           <dependency>
+          	<groupId>org.apache.parquet</groupId>
+          	<artifactId>parquet-hadoop</artifactId>
+          	<version>${parquet.version}</version>
+          	<exclusions>
+          		<exclusion>
+          			<groupId>org.xerial.snappy</groupId>
+          			<artifactId>snappy-java</artifactId>
+          		</exclusion>
+          	</exclusions>
+          </dependency>
+          <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
@@ -1771,6 +1787,17 @@
             <groupId>sqlline</groupId>
             <artifactId>sqlline</artifactId>
             <version>${sqlline.version}</version>
+          </dependency>
+          <dependency>
+          	<groupId>org.apache.parquet</groupId>
+          	<artifactId>parquet-hadoop</artifactId>
+          	<version>${parquet.version}</version>
+          	<exclusions>
+          		<exclusion>
+          			<groupId>org.xerial.snappy</groupId>
+          			<artifactId>snappy-java</artifactId>
+          		</exclusion>
+          	</exclusions>
           </dependency>
           <!-- Test Dependencies -->
           <dependency>


### PR DESCRIPTION
Multiple Snappy versions on class path; causes unit test failures.

Drill's pom.xml files bring in multiple Snappy versions. Drill itself brings in a very old version that has a known problem loading the snappy native library. Other libraries bring in a newer version. The one that ends up first on the class path is non-deterministic, leading to random test failures.

This fix updates the Snappy library to the latest and adds dependency management to exclude older versions brought in by Avro and Parquet.