### PR TITLE
DRILL-5156: BootStrapContext should close threads

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -124,6 +124,16 @@ public class BootStrapContext implements AutoCloseable {
   @Override
   public void close() {
     try {
+      loop2.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+    } catch ( Exception e ) {
+      logger.warn("Failure During Bit-Client shutdown.", e);
+    }
+    try {
+      loop.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+    } catch ( Exception e ) {
+      logger.warn("Failure During Bit-Server shutdown.", e);
+    }
+    try {
       DrillMetrics.resetMetrics();
     } catch (Error | Exception e) {
       logger.warn("failure resetting metrics.", e);


### PR DESCRIPTION
The Bit-Client thread (that's the thread name) finds a closed allocator in TestDrillbitResilience unit test. This fix (along with DRILL-5157) eliminates two run-time problems seen in this unit tests.

BootStrapContext creates two thread pools, but does not close them. This allows the code running in the threads to attempt to access their allocators after the allocator is closed. This fix ensures that the
thread pools are closed to avoid the issue.