### PR TITLE
DRILL-5167: Send escape character for metadata queries

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -513,12 +513,16 @@ DrillClientQueryResult* DrillClientImpl::ExecuteQuery(const PreparedStatement& p
     return sendMsg(factory, ::exec::user::RUN_QUERY, query);
 }
 
+static void updateLikeFilter(exec::user::LikeFilter& likeFilter, const std::string& pattern) {
+	likeFilter.set_pattern(pattern);
+	likeFilter.set_escape(meta::DrillMetadata::s_searchEscapeString);
+}
+
 DrillClientCatalogResult* DrillClientImpl::getCatalogs(const std::string& catalogPattern,
         Metadata::pfnCatalogMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetCatalogsReq query;
-    exec::user::LikeFilter* catalogFilter(query.mutable_catalog_name_filter());
-    catalogFilter->set_pattern(catalogPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
 
     boost::function<DrillClientCatalogResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientCatalogResult*>(),
@@ -534,8 +538,8 @@ DrillClientSchemaResult* DrillClientImpl::getSchemas(const std::string& catalogP
         Metadata::pfnSchemaMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetSchemasReq query;
-    query.mutable_catalog_name_filter()->set_pattern(catalogPattern);
-    query.mutable_schema_name_filter()->set_pattern(schemaPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
 
     boost::function<DrillClientSchemaResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientSchemaResult*>(),
@@ -553,9 +557,10 @@ DrillClientTableResult* DrillClientImpl::getTables(const std::string& catalogPat
         Metadata::pfnTableMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetTablesReq query;
-    query.mutable_catalog_name_filter()->set_pattern(catalogPattern);
-    query.mutable_schema_name_filter()->set_pattern(schemaPattern);
-    query.mutable_table_name_filter()->set_pattern(tablePattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
+    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern);
+
     if (tableTypes) {
     	std::copy(tableTypes->begin(), tableTypes->end(),
     			google::protobuf::RepeatedFieldBackInserter(query.mutable_table_type_filter()));
@@ -577,10 +582,10 @@ DrillClientColumnResult* DrillClientImpl::getColumns(const std::string& catalogP
         Metadata::pfnColumnMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetColumnsReq query;
-    query.mutable_catalog_name_filter()->set_pattern(catalogPattern);
-    query.mutable_schema_name_filter()->set_pattern(schemaPattern);
-    query.mutable_table_name_filter()->set_pattern(tablePattern);
-    query.mutable_column_name_filter()->set_pattern(columnsPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
+    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern);
+    updateLikeFilter(*query.mutable_column_name_filter(), columnsPattern);
 
     boost::function<DrillClientColumnResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientColumnResult*>(),


### PR DESCRIPTION
Escape character was not sent when doing metadata queries, which caused
the server to return incorrect results as the pattern is interpreted
differently form what the user asked for.