### PR TITLE
DRILL-5241: JDBC proxy driver: Do not put null value in map

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/ProxiesManager.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/ProxiesManager.java
@@ -54,7 +54,7 @@ class ProxiesManager {
       Class<Proxy> newProxyReturnClass =
           (Class<Proxy>) Proxy.getProxyClass( interfaceType.getClassLoader(),
                                               new Class[] { interfaceType });
-      interfacesToProxyClassesMap.put( interfaceType, proxyReturnClass );
+      interfacesToProxyClassesMap.put( interfaceType, newProxyReturnClass );
       proxyReturnClass = newProxyReturnClass;
     }
     return proxyReturnClass;


### PR DESCRIPTION
Hello everyone,

proxyReturnClass is always null, so interfacesToProxyClassesMap will contain null values only. Adding newProxyReturnClass should be correct.

This bug does not affect functionality, but probably decreases performance because you get "cache misses" all the time.

Best regards,
David.