### PR TITLE
DRILL-5215: CTTAS: disallow temp tables in view expansion logic

### DIFF
--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -185,8 +185,7 @@ drill.exec: {
       root: "/app/drill"
     }
   },
-  # Settings for Temporary Tables.
-  # See https://gist.github.com/arina-ielchiieva/50158175867a18eee964b5ba36455fbf#file-temporarytablessupport-md.
+  # Settings for Temporary Tables (see https://issues.apache.org/jira/browse/DRILL-4956 for details).
   # Temporary table can be created ONLY in default temporary workspace.
   # Full workspace name should be indicated (including schema and workspace separated by dot).
   # Workspace MUST be file-based and writable. Workspace name is case-sensitive.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -333,6 +333,7 @@ public class SqlConverter {
     }
 
     private RelNode expandView(String queryString, SqlConverter converter) {
+      converter.disallowTemporaryTables();
       final SqlNode parsedNode = converter.parse(queryString);
       final SqlNode validatedNode = converter.validate(parsedNode);
       return converter.toRel(validatedNode);


### PR DESCRIPTION
1. Disallowed temporary table usage during in view expansion.
2. Added appropriate unit test.
3. Replace link to gist with CTTAS design doc to Jira link.