### PR TITLE
DRILL-5218: Support disabling hearbeats from C++ client

### DIFF
--- a/contrib/native/client/example/querySubmitter.cpp
+++ b/contrib/native/client/example/querySubmitter.cpp
@@ -41,6 +41,7 @@ struct Option{
     {"syncSend", "Send query only after previous result is received", false},
     {"hshakeTimeout", "Handshake timeout (second).", false},
     {"queryTimeout", "Query timeout (second).", false},
+    {"heartbeatFrequency", "Heartbeat frequency (second). Disabled if set to 0.", false},
     {"user", "Username", false},
     {"password", "Password", false}
 };
@@ -282,6 +283,7 @@ int main(int argc, char* argv[]) {
         std::string syncSend=qsOptionValues["syncSend"];
         std::string hshakeTimeout=qsOptionValues["hshakeTimeout"];
         std::string queryTimeout=qsOptionValues["queryTimeout"];
+        std::string heartbeatFrequency=qsOptionValues["heartbeatFrequency"];
         std::string user=qsOptionValues["user"];
         std::string password=qsOptionValues["password"];
 
@@ -342,6 +344,9 @@ int main(int argc, char* argv[]) {
         }
         if (!queryTimeout.empty()){
             Drill::DrillClientConfig::setQueryTimeout(atoi(queryTimeout.c_str()));
+        }
+        if(!heartbeatFrequency.empty()) {
+            Drill::DrillClientConfig::setHeartbeatFrequency(atoi(heartbeatFrequency.c_str()));
         }
 
         Drill::DrillUserProperties props;

--- a/contrib/native/client/src/clientlib/drillClient.cpp
+++ b/contrib/native/client/src/clientlib/drillClient.cpp
@@ -105,7 +105,7 @@ void DrillClientConfig::setQueryTimeout(int32_t t){
 }
 
 void DrillClientConfig::setHeartbeatFrequency(int32_t t){
-    if (t>0){
+    if (t>=0){
         boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
         s_heartbeatFrequency=t;
     }

--- a/contrib/native/client/src/clientlib/drillClientImpl.hpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.hpp
@@ -451,9 +451,8 @@ class DrillClientImpl : public DrillClientImplBase{
         // Direct connection to a drillbit
         // host can be name or ip address, port can be port number or name of service in /etc/services
         connectionStatus_t connect(const char* host, const char* port);
-        void startHeartbeatTimer();// start a heartbeat timer
+        void startHeartbeatTimer();// start or restart the heartbeat timer
         connectionStatus_t sendHeartbeat(); // send a heartbeat to the server
-        void resetHeartbeatTimer(); // reset the heartbeat timer (called every time one sends a message to the server (after sendAck, or submitQuery)
         void handleHeartbeatTimeout(const boost::system::error_code & err); // send a heartbeat. If send fails, broadcast error, close connection and bail out.
 
         int32_t getNextCoordinationId(){ return ++m_coordinationId; };


### PR DESCRIPTION
+ remove invalid code (server should not request "handshake" type), in fact, client should fail in that case