### PR TITLE
DRILL-5219: Relax user properties validation in C++ client

### DIFF
--- a/contrib/native/client/src/clientlib/drillClient.cpp
+++ b/contrib/native/client/src/clientlib/drillClient.cpp
@@ -345,11 +345,7 @@ connectionStatus_t DrillClient::connect(const char* connectStr, DrillUserPropert
     connectionStatus_t ret=CONN_SUCCESS;
     ret=this->m_pImpl->connect(connectStr);
     if(ret==CONN_SUCCESS){
-        if(properties!=NULL){
-            ret=this->m_pImpl->validateHandshake(properties);
-        }else{
-            ret=this->m_pImpl->validateHandshake(NULL);
-        }
+        ret=this->m_pImpl->validateHandshake(properties);
     }
     return ret;
 }

--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -372,8 +372,13 @@ connectionStatus_t DrillClientImpl::validateHandshake(DrillUserProperties* prope
         for(size_t i=0; i<properties->size(); i++){
             std::map<std::string,uint32_t>::const_iterator it=DrillUserProperties::USER_PROPERTIES.find(properties->keyAt(i));
             if(it==DrillUserProperties::USER_PROPERTIES.end()){
-                DRILL_MT_LOG(DRILL_LOG(LOG_WARNING) << "Connection property ("<< properties->keyAt(i)
-                    << ") is unknown and is being skipped" << std::endl;)
+                DRILL_MT_LOG(DRILL_LOG(LOG_INFO) << "Connection property ("<< properties->keyAt(i)
+                    << ") is unknown" << std::endl;)
+
+                exec::user::Property* connProp = userProperties->add_properties();
+                connProp->set_key(properties->keyAt(i));
+                connProp->set_value(properties->valueAt(i));
+
                 continue;
             }
             if(IS_BITSET((*it).second,USERPROP_FLAGS_SERVERPROP)){


### PR DESCRIPTION
Unlike Java client, C++ client only allows user properties present in a
whitelist. Relax this restriction so that user can add extra properties.