### PR TITLE
DRILL-5220: Provide API to set application/client names in C++ connector

### DIFF
--- a/contrib/native/client/src/clientlib/drillClient.cpp
+++ b/contrib/native/client/src/clientlib/drillClient.cpp
@@ -52,6 +52,8 @@ int32_t DrillClientConfig::s_socketTimeout=0;
 int32_t DrillClientConfig::s_handshakeTimeout=5;
 int32_t DrillClientConfig::s_queryTimeout=180;
 int32_t DrillClientConfig::s_heartbeatFrequency=15; // 15 seconds
+std::string DrillClientConfig::s_clientName(DRILL_CONNECTOR_NAME);
+std::string DrillClientConfig::s_applicationName;
 
 boost::mutex DrillClientConfig::s_mutex;
 
@@ -134,6 +136,26 @@ int32_t DrillClientConfig::getHeartbeatFrequency(){
 logLevel_t DrillClientConfig::getLogLevel(){
     boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
     return s_logLevel;
+}
+
+const std::string& DrillClientConfig::getClientName() {
+	boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
+	return s_clientName;
+}
+
+void DrillClientConfig::setClientName(const std::string& name) {
+	boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
+	s_clientName = name;
+}
+
+const std::string& DrillClientConfig::getApplicationName() {
+	boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
+	return s_applicationName;
+}
+
+void DrillClientConfig::setApplicationName(const std::string& name) {
+	boost::lock_guard<boost::mutex> configLock(DrillClientConfig::s_mutex);
+	s_applicationName = name;
 }
 
 //Using boost assign to initialize maps. 

--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -354,7 +354,8 @@ connectionStatus_t DrillClientImpl::validateHandshake(DrillUserProperties* prope
 
     // Adding version info
     exec::user::RpcEndpointInfos* infos = u2b.mutable_client_infos();
-    infos->set_name(DRILL_CONNECTOR_NAME);
+    infos->set_name(DrillClientConfig::getClientName());
+    infos->set_application(DrillClientConfig::getApplicationName());
     infos->set_version(DRILL_VERSION_STRING);
     infos->set_majorversion(DRILL_VERSION_MAJOR);
     infos->set_minorversion(DRILL_VERSION_MINOR);

--- a/contrib/native/client/src/include/drill/drillClient.hpp
+++ b/contrib/native/client/src/include/drill/drillClient.hpp
@@ -91,6 +91,43 @@ class DECLSPEC_DRILL_CLIENT DrillClientConfig{
         static int32_t getQueryTimeout();
         static int32_t getHeartbeatFrequency();
         static logLevel_t getLogLevel();
+
+        /**
+         * Return the client name sent to the server when connecting
+         *
+         * @return the current client name
+         */
+        static const std::string& getClientName();
+
+        /**
+         * Set the client name to be sent to the server when connecting.
+         *
+         * Only new connections will use the new value. Existing connections
+         * will be left unchanged.
+         *
+         * @param name the name to be send to the server
+         */
+        static void setClientName(const std::string& name);
+
+        /**
+         * Return the application name sent to the server when connecting
+         *
+         * @return the current application name
+         */
+        static const std::string& getApplicationName();
+
+        /**
+         * Set the application name to be sent to the server when connecting.
+         *
+         * Only new connections will use the new value. Existing connections
+         * will be left unchanged.
+         *
+         * @param name the name to be send to the server
+         */
+        static void setApplicationName(const std::string& name);
+
+
+
     private:
         // The logging level
         static logLevel_t s_logLevel;
@@ -122,6 +159,11 @@ class DECLSPEC_DRILL_CLIENT DrillClientConfig{
         static int32_t s_queryTimeout;
         static int32_t s_heartbeatFrequency;
         static boost::mutex s_mutex;
+
+        // The client name (default to DRILL_CONNECTOR_NAME)
+        static std::string s_clientName;
+        // The application name (default to <empty>)
+        static std::string s_applicationName;
 };
 
 


### PR DESCRIPTION
Add method to DrillClientConfig to set the client and the application names
in the C++ connector.

Allow the ODBC driver (or any user of the C++ connector) to provide more
specific informations like the application using the client.