### PR TITLE
DRILL-5238: CTTAS: unable to resolve temporary table if workspace is …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -93,7 +93,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     plannerSettings.setNumEndPoints(drillbitContext.getBits().size());
     table = new DrillOperatorTable(getFunctionRegistry(), drillbitContext.getOptionManager());
 
-    queryContextInfo = Utilities.createQueryContextInfo(session.getDefaultSchemaName());
+    queryContextInfo = Utilities.createQueryContextInfo(session.getDefaultSchemaPath());
     contextInformation = new ContextInformation(session.getCredentials(), queryContextInfo);
 
     allocator = drillbitContext.getAllocator().newChildAllocator(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
@@ -66,8 +66,8 @@ public class UserSession implements Closeable {
 
   private boolean supportComplexTypes = false;
   private UserCredentials credentials;
-  private Map<String, String> properties;
   private OptionManager sessionOptions;
+  private final Map<String, String> properties;
   private final AtomicInteger queryCount;
   private final String sessionId;
 
@@ -122,7 +122,6 @@ public class UserSession implements Closeable {
     }
 
     public Builder withUserProperties(UserProperties properties) {
-      userSession.properties = Maps.newHashMap();
       if (properties != null) {
         for (int i = 0; i < properties.getPropertiesCount(); i++) {
           final Property property = properties.getProperties(i);
@@ -158,6 +157,7 @@ public class UserSession implements Closeable {
     sessionId = UUID.randomUUID().toString();
     temporaryTables = Maps.newConcurrentMap();
     temporaryLocations = Maps.newConcurrentMap();
+    properties = Maps.newHashMap();
   }
 
   public boolean isSupportComplexTypes() {
@@ -188,10 +188,6 @@ public class UserSession implements Closeable {
 
   public String getTargetUserName() {
     return properties.get(IMPERSONATION_TARGET);
-  }
-
-  public String getDefaultSchemaName() {
-    return getProp(SCHEMA);
   }
 
   public void incrementQueryCount(final QueryCountIncrementer incrementer) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
@@ -143,6 +143,20 @@ public class TestCTTAS extends BaseTestQuery {
   }
 
   @Test
+  public void testResolveTemporaryTableWithPartialSchema() throws Exception {
+    String temporaryTableName = "temporary_table_with_partial_schema";
+    test("use %s", test_schema);
+    test("create temporary table tmp.%s as select 'A' as c1 from (values(1))", temporaryTableName);
+
+    testBuilder()
+        .sqlQuery("select * from tmp.%s", temporaryTableName)
+        .unOrdered()
+        .baselineColumns("c1")
+        .baselineValues("A")
+        .go();
+  }
+
+  @Test
   public void testPartitionByWithTemporaryTables() throws Exception {
     String temporaryTableName = "temporary_table_with_partitions";
     mockRandomUUID(UUID.nameUUIDFromBytes(temporaryTableName.getBytes()));


### PR DESCRIPTION
…indicated without schema

1. Added additional check for passed table is temporary if default workspace is partially indicated (issue is described in Jira DRILL-5238).
2. Removed `UserSession.getDefaultSchemaName()` method as it contained exactly the same logic as `UserSession.getDefaultSchemaPath()`.
3. Since `UserSession.properties` are set using builder, they are not required but when not set, they may cause NPE when `UserSession.getProp()` method is called. Moved `UserSession.properties` into constructor.
4. Unit test for partial schema usage with temporary table.