### PR TITLE
DRILL-5254: Enhance default reduction factors in optimizer

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -413,4 +413,13 @@ public interface ExecConstants {
 
   String DYNAMIC_UDF_SUPPORT_ENABLED = "exec.udf.enable_dynamic_support";
   BooleanValidator DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR = new BooleanValidator(DYNAMIC_UDF_SUPPORT_ENABLED, true, true);
+
+  // Experimental enhanced default selectivity reduction factor
+  // calculations.
+
+  String OPTIMIZER_ENHANCED_DEFAULTS = "drill.exec.optimizer.enhanced_defaults";
+  String OPTIMIZER_ENHANCED_DEFAULTS_ENABLE = OPTIMIZER_ENHANCED_DEFAULTS + ".enable";
+  String OPTIMIZER_ENHANCED_DEFAULTS_PROB_EQ = OPTIMIZER_ENHANCED_DEFAULTS + ".prob_eq";
+  String OPTIMIZER_ENHANCED_DEFAULTS_PROB_NULL = OPTIMIZER_ENHANCED_DEFAULTS + ".prob_null";
+  String OPTIMIZER_ENHANCED_DEFAULTS_PROB_LIKE = OPTIMIZER_ENHANCED_DEFAULTS + ".prob_like";
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillDefaultRelMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillDefaultRelMetadataProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -29,5 +29,6 @@ public class DrillDefaultRelMetadataProvider {
   public static final RelMetadataProvider INSTANCE = ChainedRelMetadataProvider.of(ImmutableList
       .of(DrillRelMdRowCount.SOURCE,
           DrillRelMdDistinctRowCount.SOURCE,
+          DrillRelDefaultMdSelectivity.SOURCE,
           new DefaultRelMetadataProvider()));
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelDefaultMdSelectivity.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillRelDefaultMdSelectivity.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.apache.drill.exec.planner.cost;
+
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.ReflectiveRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMdSelectivity;
+import org.apache.calcite.rel.metadata.RelMdUtil;
+import org.apache.calcite.rel.metadata.RelMetadataProvider;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.util.BuiltInMethod;
+
+/**
+ * Implements revised rules for the default selectivity when no
+ * meta-data is available. While Calcite provides defaults, the defaults
+ * are too selective and don't follow the laws of probability.
+ * The revised rules are:
+ *
+ * <table>
+ * <tr><th>Operator</th><th>Revised</th><th>Notes</th><th>Calcite Default</th></tr>
+ * <tr><td>=</td><td>0.15</td><td>Default in Calcite</td><td>.15</td></tr>
+ * <tr><td>&lt;></td><td>0.85</td><td>1 - p(=)</td><td>.5</td></tr>
+ * <tr><td>&lt;</td><td>0.425</td><td>p(<>) / 2</td><td>.5</td></tr>
+ * <tr><td>></td><td>0.425</td><td>p(<>) / 2</td><td>.5</td></tr>
+ * <tr><td>&lt;=</td><td>0.575</td><td>p(<) + p(=)</td><td>.5</td></tr>
+ * <tr><td>>=</td><td>0.575</td><td>p(>) + p(=)</td><td>.5</td></tr>
+ * <tr><td>LIKE</td><td>0.25</td><td>Default in Calcite</td><td>.25</td></tr>
+ * <tr><td>NOT LIKE</td><td>0.75</td><td>1 - p(LIKE)</td><td>.25</td></tr>
+ * <tr><td>IN</td><td>0.15</td><td>IN same as =</td><td>.25</td></tr>
+ * <tr><td>IN A, B, ...</td><td>max(0.5, p(=)*n - p(=)<sup>n</sup>)</td><td>Same as OR</td><td>.25 ?</td></tr>
+ * <tr><td>IS NOT NULL</td><td>0.9</td><td>Default in Calcite</td><td>.9</td></tr>
+ * <tr><td>IS NULL</td><td>0.1</td><td>1 - p(IS NULL)</td><td>.25 ?</td></tr>
+ * <tr><td>IS TRUE</td><td>0.5</td><td>Assume Booleans not null</td><td>.25 ?</td></tr>
+ * <tr><td>IS NOT TRUE</td><td>0.55</td><td>1 - p(TRUE) - p(NULL)</td><td>.25 ?</td></tr>
+ * </table>
+ * <p>
+ * The OR operator is the sum of its operands, limited to 1.0. A series of
+ * IN items is the equivalent of a series of ORs (in fact, that is how
+ * Calcite implements an IN list.) The rules for IS FALSE and IS NOT FALSE
+ * are the same as IS TRUE and IS NOT TRUE.
+ */
+
+public class DrillRelDefaultMdSelectivity extends RelMdSelectivity {
+  public static final RelMetadataProvider SOURCE =
+      ReflectiveRelMetadataProvider.reflectiveSource(
+          BuiltInMethod.SELECTIVITY.method, new DrillRelDefaultMdSelectivity());
+
+  // Basic probabilities.
+  // The first set are strongly data dependent and can be customized.
+
+  public static final double PROB_A_EQ_B = 0.15; // From Calcite
+  public static final double PROB_A_NOT_NULL = 0.9; // From Calcite
+  public static final double PROB_A_IS_NULL = 1 - PROB_A_NOT_NULL;
+  public static final double PROB_A_LIKE_B = 0.25; // From Calcite
+
+  // The others are generic and are hard-coded.
+
+  public static final double PROB_A_IS_TRUE = 0.5; // Assumes booleans are not null
+  public static final double DEFAULT_PROB = 0.25; // From Calcite
+  public static final double MAX_OR_FACTOR = 0.5; // From System-R, etc.
+
+  public static final class ReductionCalculator {
+    private final double probEq;   // p(a = value)
+    private final double probNull; // p(a IS NULL)
+    private final double probLike; // p(a LIKE value)
+
+    public ReductionCalculator() {
+      probEq = PROB_A_EQ_B;
+      probNull = PROB_A_IS_NULL;
+      probLike = PROB_A_LIKE_B;
+    }
+
+    public ReductionCalculator(double peq, double pnull, double plike) {
+      probEq = peq;
+      probNull = pnull;
+      probLike = plike;
+    }
+
+    public double computeRedictionFactor(RexNode pred) {
+      switch ( pred.getKind() ) {
+      case BETWEEN:
+        // Never called in Calcite. Drill seems to rewrite
+        // a BETWEEN b AND c to a >= b AND a <= c.
+        // Half the range from (-infinity, lower) or
+        // half the range from (upper, infinity)
+        // Bounds are inclusive
+        // p(<=) / 2 = p(>=) / 2
+        return (1 + probEq) / 4;
+      case EQUALS:
+      case IN:
+        return probEq;
+      case NOT_EQUALS:
+        return 1 - probEq;
+      case GREATER_THAN:
+      case LESS_THAN:
+        // p(a <> b) / 2 = (1 - prob(=)) / 2
+        return (1 - probEq) / 2;
+      case GREATER_THAN_OR_EQUAL:
+      case LESS_THAN_OR_EQUAL:
+        // p(a <> b) / 2 + prob(=) =
+        // (1 - prob(=)) / 2 + prob(=)
+        // (1 + prob(=)) / 2
+        return (1 + probEq) / 2;
+      case IS_FALSE:
+      case IS_TRUE:
+        // p(a IS TRUE) = p(a IS FALSE)
+        return PROB_A_IS_TRUE;
+      case IS_NOT_FALSE:
+      case IS_NOT_TRUE:
+        // p(a NOT TRUE) = p(a IS FALSE) + p(a IS NULL)
+        // p(a NOT FALSE) = p(a NOT TRUE)
+        // Assumes that use of this construction implies nulls
+        return PROB_A_IS_TRUE + probNull;
+      case IS_NULL:
+        return probNull;
+      case IS_NOT_NULL:
+        return 1 - probNull;
+      case LIKE:
+        return probLike;
+      case NOT:
+        return 1.0 - computeRedictionFactor(((RexCall) pred).getOperands().get(0));
+      case OR: {
+          // p(A v B) = p(A) + p(B) - P(A ^ B)
+          RexCall rexCall = (RexCall) pred;
+          double sel = 0;
+          double andSel = 1;
+          for (RexNode op : rexCall.getOperands()) {
+            double opSel = computeRedictionFactor(op);
+            sel += opSel;
+            andSel *= opSel;
+          }
+
+          // Per System-R and several texts, an OR (also IN) assumed to reduce
+          // rows by at least 50%.
+          return Math.min(MAX_OR_FACTOR, sel - andSel);
+        }
+      case AND: {
+          // p(A ^ B) = p(A) * p(B)
+          RexCall rexCall = (RexCall) pred;
+          double sel = 1.0;
+          for (RexNode op : rexCall.getOperands()) {
+            sel *= computeRedictionFactor(op);
+          }
+          return sel;
+        }
+      default:
+        return DEFAULT_PROB;
+      }
+    }
+  }
+
+  private static boolean useEnhancedRules = false;
+  private static ReductionCalculator defaultReduction = new ReductionCalculator();
+
+  /**
+   * The enhanced rules are experimental and disabled by default.
+   * They are enabled with the <tt>drill.exec.planner.defaults.enable_enhanced: true</tt>
+   * boot-time config option.
+   *
+   * @param selection true to enable the enhanced rules
+   */
+  public static void useEnhancedRules(boolean selection) {
+    useEnhancedRules = selection;
+  }
+
+  public static void setDefaultRules(ReductionCalculator reduction) {
+    defaultReduction = reduction;
+  }
+
+  public static ReductionCalculator getReductionRules( ) { return defaultReduction; }
+
+  // Catch-all rule when none of the others apply.
+  @Override
+  public Double getSelectivity(RelNode rel, RexNode predicate) {
+    if (useEnhancedRules) {
+      return guessSelectivity(predicate);
+    } else {
+      return RelMdUtil.guessSelectivity(predicate);
+    }
+  }
+
+  /**
+   * Returns default estimates for reduction factors, in the absence of stats.
+   *
+   * @param predicate      predicate for which selectivity will be computed;
+   *                       null means true, so gives a reduction factor of 1.0
+   * @return estimated selectivity
+   */
+  public  double guessSelectivity(
+      RexNode predicate) {
+    double sel = 1.0;
+    if ((predicate == null) || predicate.isAlwaysTrue()) {
+      return sel;
+    }
+
+    for (RexNode pred : RelOptUtil.conjunctions(predicate)) {
+      sel *= defaultReduction.computeRedictionFactor(pred);
+    }
+
+    return sel;
+  }
+
+  // Calcite code for reference
+//    if (pred.getKind() == SqlKind.IS_NOT_NULL) {
+//      return .9;
+//    } else if (
+//        (pred instanceof RexCall)
+//            && (((RexCall) pred).getOperator()
+//            == RelMdUtil.ARTIFICIAL_SELECTIVITY_FUNC)) {
+//      return RelMdUtil.getSelectivityValue(pred);
+//    } else if (pred.isA(SqlKind.EQUALS)) {
+//      return .15;
+//    } else if (pred.isA(SqlKind.COMPARISON)) {
+//      return .5;
+//    } else {
+//      return .25;
+//    }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/BooleanGen.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/BooleanGen.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.mock;
+
+import java.util.Random;
+
+import org.apache.drill.exec.vector.BitVector;
+import org.apache.drill.exec.vector.ValueVector;
+
+public class BooleanGen implements FieldGen {
+
+  Random rand = new Random( );
+
+  @Override
+  public void setup(ColumnDef colDef) { }
+
+  public int value( ) {
+    return rand.nextBoolean() ? 1 : 0;
+  }
+
+  @Override
+  public void setValue( ValueVector v, int index ) {
+    BitVector vector = (BitVector) v;
+    vector.getMutator().set(index, value());
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/ColumnDef.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/ColumnDef.java
@@ -78,6 +78,7 @@ public class ColumnDef {
     case BIGINT:
       break;
     case BIT:
+      generator = new BooleanGen( );
       break;
     case DATE:
       break;

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -91,7 +91,22 @@ drill.exec: {
     use.ip : false
   },
   optimizer: {
-    implementation: "org.apache.drill.exec.opt.IdentityOptimizer"
+    implementation: "org.apache.drill.exec.opt.IdentityOptimizer",
+    enhanced_defaults: {
+      // If true, uses the enhanced Drill reduction factor rules.
+      // If false, uses the default Calcite rules.
+      enable: false,
+      // p(a = value)
+      // Probability that a column equals some value.
+      // Default is 0.15 in Calcite, 0.10 in most textbooks (and System-R)
+      prob_eq: 0.15,
+      // p(a IS NULL)
+      // Calcite defines p(a NOT NULL) as 0.9
+      prob_null: 0.10,
+      // p(a LIKE value)
+      // Calcite default is 0.25
+      prob_like: 0.25
+    }
   },
   storage: {
     registry: "org.apache.drill.exec.store.StoragePluginRegistryImpl",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestEnhancedSelectivity.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestEnhancedSelectivity.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.planner.cost.DrillRelDefaultMdSelectivity;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.FixtureBuilder;
+import org.apache.drill.test.QueryBuilder.QuerySummary;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+/**
+ * Tests enhanced filter selectivity. See DRILL-5254.
+ */
+
+public class TestEnhancedSelectivity {
+
+  // Compute the expected probabilities according to the
+  // rules outlined in DRILL-5254.
+
+  public static final double PROB_A_EQ_B = DrillRelDefaultMdSelectivity.PROB_A_EQ_B;
+  public static final double PROB_A_NE_B = 1 - PROB_A_EQ_B;
+  public static final double PROB_A_LT_B = PROB_A_NE_B / 2;
+  public static final double PROB_A_GT_B = PROB_A_NE_B / 2;
+  public static final double PROB_A_LE_B = PROB_A_LT_B + PROB_A_EQ_B;
+  public static final double PROB_A_GE_B = PROB_A_GT_B + PROB_A_EQ_B;
+  public static final double PROB_A_LIKE_B = DrillRelDefaultMdSelectivity.PROB_A_LIKE_B;
+  public static final double PROB_A_NOT_LIKE_B = 1 - PROB_A_LIKE_B;
+  public static final double PROB_A_IS_NULL = DrillRelDefaultMdSelectivity.PROB_A_IS_NULL;
+  public static final double PROB_A_NOT_NULL = 1 - PROB_A_IS_NULL;
+  public static final double PROB_A_IN_B = PROB_A_EQ_B;
+  public static final double PROB_A_BETWEEN_B_C = PROB_A_LE_B * PROB_A_GE_B;
+  public static final double PROB_A_IS_TRUE = DrillRelDefaultMdSelectivity.PROB_A_IS_TRUE;
+  public static final double PROB_A_IS_FALSE = 1 - PROB_A_IS_TRUE;
+  public static final double PROB_A_NOT_TRUE = PROB_A_IS_FALSE + PROB_A_IS_NULL;
+  public static final double PROB_A_NOT_FALSE = PROB_A_IS_TRUE + PROB_A_IS_NULL;
+  public static final double DEFAULT_PROB = DrillRelDefaultMdSelectivity.DEFAULT_PROB;
+
+  /**
+   * Verify the default enhanced selectivity rules.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testEnhancedDefaults() throws Exception {
+    FixtureBuilder builder = ClusterFixture.builder()
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_ENABLE, true)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true)
+//        .configProperty(ExecConstants.QUERY_PROFILE_OPTION, "sync") // Temporary until DRILL-5257 is available
+        .maxParallelization(1);
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture()) {
+      verifyBooleanBehavior(client);
+      verifyReduction(client, "id_i = 10", PROB_A_EQ_B);
+      verifyReduction(client, "id_i <> 10", PROB_A_NE_B);
+      verifyReduction(client, "id_i < 10", PROB_A_LT_B);
+      verifyReduction(client, "id_i > 10", PROB_A_GT_B);
+      verifyReduction(client, "id_i <= 10", PROB_A_LE_B);
+      verifyReduction(client, "id_i >= 10", PROB_A_GE_B);
+      verifyReduction(client, "id_i IN (10)", PROB_A_IN_B);
+      verifyReduction(client, "id_i IN (10, 20)", 2 * PROB_A_IN_B - Math.pow(PROB_A_IN_B, 2));
+      verifyReduction(client, "id_i IN (11, 12, 13, 14, 15, 16, 16, 18, 19, 20)", DrillRelDefaultMdSelectivity.MAX_OR_FACTOR);
+      verifyReduction(client, "name_s20 LIKE 'foo'", PROB_A_LIKE_B);
+      verifyReduction(client, "name_s20 NOT LIKE 'foo'", PROB_A_NOT_LIKE_B);
+      verifyReduction(client, "name_s20 IS NULL", PROB_A_IS_NULL);
+      verifyReduction(client, "name_s20 IS NOT NULL", PROB_A_NOT_NULL);
+      verifyReduction(client, "NOT ( id_i = 10 )", 1.0 - PROB_A_EQ_B);
+      verifyReduction(client, "flag_b IS TRUE", PROB_A_IS_TRUE);
+      verifyReduction(client, "flag_b IS FALSE", PROB_A_IS_FALSE);
+      verifyReduction(client, "flag_b IS NOT TRUE", PROB_A_NOT_TRUE);
+      verifyReduction(client, "flag_b IS NOT FALSE", PROB_A_NOT_FALSE);
+      verifyReduction(client, "id_i BETWEEN 10 AND 20", PROB_A_BETWEEN_B_C);
+      verifyReduction(client, "id_i NOT BETWEEN 10 AND 20", 1 - PROB_A_BETWEEN_B_C);
+      verifyReduction(client, "NOT ( id_i BETWEEN 10 AND 20 )", 1 - PROB_A_BETWEEN_B_C);
+      verifyReduction(client, "NOT ( id_i = 10 )", 1.0 - PROB_A_EQ_B);
+      testSample1Enhanced(client);
+    }
+  }
+
+  /**
+   * Tests a sanitized version of the production query that triggered
+   * the revision to the rules.
+   *
+   * @param client
+   * @throws Exception
+   */
+  private void testSample1Enhanced(ClientFixture client) throws Exception {
+    // col1_s20 in ('Value1','Value2','Value3','Value4',\n" +
+    //              'Value5','Value6','Value7','Value8','Value9') -- min( .15 * 9, 0.5 ) = 50%
+    //  AND col2_i <=3 -- 45%
+    //  AND col3_s1 = 'Y'\n -- 15%
+    //  AND col4_s1 = 'Y'\n -- 15%
+    //  AND col5_s6 not like '%str1%' -- 85%
+    //  AND col5_s6 not like '%str2%' -- 85%
+    //  AND col5_s6 not like '%str3%' -- 85%
+    //  AND col5_s6 not like '%str4%' -- 85%
+    double expected = DrillRelDefaultMdSelectivity.MAX_OR_FACTOR *
+        PROB_A_LE_B *
+        Math.pow(PROB_A_EQ_B, 2) *
+        Math.pow(PROB_A_NOT_LIKE_B, 4);
+    testSample1(client, expected);
+  }
+
+  private void testSample1(ClientFixture client, double expected) throws Exception {
+    String where = "col1_s20 in ('Value1','Value2','Value3','Value4',\n" +
+        "                        'Value5','Value6','Value7','Value8','Value9')\n" + // min( .15 * 9, 0.5 ) = 50%
+        "AND col2_i <=3\n" + // 45%
+        "AND col3_s1 = 'Y'\n" + // 15%
+        "AND col4_s1 = 'Y'\n" + // 15%
+        "AND col5_s6 not like '%str1%'\n" + // 85%
+        "AND col5_s6 not like '%str2%'\n" + // 85%
+        "AND col5_s6 not like '%str3%'\n" + // 85%
+        "AND col5_s6 not like '%str4%'\n"; // 85%
+
+    // Need many rows because selectivity is very low for default rules. Sorry!
+
+    String sql = "SELECT col1_s20, col2_i, col3_s1, col4_s1, col6_s6 FROM `mock`.`example_100K`\n" +
+                 "WHERE " + where;
+//    System.out.println("Sample 1 reduction: " + expected);
+    verifyReductionQuery(client, sql, "sample 1", expected);
+  }
+
+  /**
+   * Enhanced selectivity rules for NOT TRUE and NOT FALSE model the fact
+   * that NOT TRUE means (IS FALSE OR IS NULL) and so on. Verify this
+   * behavior.
+   *
+   * @param client
+   * @throws Exception
+   */
+  private void verifyBooleanBehavior(ClientFixture client) throws Exception {
+    String base = "SELECT * FROM `cp`.`planner/tf.json`";
+    QuerySummary summary = client.queryBuilder().sql(base).run();
+    assertEquals(4, summary.recordCount());
+    summary = client.queryBuilder().sql(base + " WHERE col IS TRUE").run();
+    assertEquals(1, summary.recordCount());
+    summary = client.queryBuilder().sql(base + " WHERE col IS NULL").run();
+    assertEquals(2, summary.recordCount());
+    summary = client.queryBuilder().sql(base + " WHERE col IS FALSE").run();
+    assertEquals(1, summary.recordCount());
+    summary = client.queryBuilder().sql(base + " WHERE NOT (col IS TRUE)").run();
+    assertEquals(3, summary.recordCount());
+    summary = client.queryBuilder().sql(base + " WHERE NOT (col IS FALSE)").run();
+    assertEquals(3, summary.recordCount());
+  }
+
+  private void verifyReduction(ClientFixture client, String where, double expected) throws Exception {
+    String sql = "SELECT id_i, name_s20, flag_b FROM `mock`.`customer_10K`";
+    if (where != null) {
+      sql += " WHERE " + where;
+    }
+    verifyReductionQuery(client, sql, where, expected);
+  }
+
+  private void verifyReductionQuery(ClientFixture client, String sql, String label, double expected) throws Exception {
+//    System.out.println(client.queryBuilder().sql(sql).explainText());
+
+    // Sad: must run the query to get the estimates. The above EXPLAIN PLAN
+    // does not fully explain the plan...
+
+    ClientFixture cf = client;
+    QuerySummary summary = cf.queryBuilder().sql(sql).run();
+
+    // Temporary until the test framework enhancements are submitted.
+
+    Thread.sleep(500); // Wait for profile to be written. Temporary until DRILL-5257 is available
+    File profileFile = client.getProfileFile(summary.queryIdString());
+    String text = Files.toString(profileFile, Charsets.UTF_8);
+    Pattern p = Pattern.compile("MockScanEntry \\[records=(\\d+),");
+    Matcher m = p.matcher(text);
+    assertTrue(m.find());
+    long scanRows = Long.parseLong(m.group(1));
+    p = Pattern.compile("Filter\\(condition=\\[[^\\]]+\\]\\) : rowType = RecordType\\([^)]+\\): rowcount = ([^,]+),");
+    m = p.matcher(text);
+    assertTrue(m.find());
+    double filterRows = Double.parseDouble(m.group(1));
+    double reduction = filterRows / scanRows;
+    if (filterRows == 1 && expected < reduction) {
+      System.out.println( label + ": Truncating expected result to " + reduction);
+      expected = reduction;
+    }
+
+    // Delete the above and use the following once the feature is
+    // available in the test framework.
+
+//    ProfileParser profile = client.parseProfile(summary.queryIdString());
+//    profile.printPlan();
+
+//    OpDefInfo scan = profile.getOpDefn("Scan").get(0);
+//    OpDefInfo filter = profile.getOpDefn("Filter").get(0);
+//    double reduction = filter.estRows / scan.estRows;
+
+    // Enable the following to see the details for each test
+//    System.out.println(label + " - " + reduction + ", ex: " + expected);
+
+    // Verify with a 2.5% margin of error.
+    assertEquals(label, expected, reduction, expected / 40);
+  }
+
+  /**
+   * Verify that we understand the Calcite defaults. Values determined by
+   * inspection and testing.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCalciteRules() throws Exception {
+    FixtureBuilder builder = ClusterFixture.builder()
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_ENABLE, false)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true)
+//      .configProperty(ExecConstants.QUERY_PROFILE_OPTION, "sync") // Temporary until DRILL-5257 is available
+        .systemOption(PlannerSettings.FILTER_MIN_SELECTIVITY_ESTIMATE_FACTOR.getOptionName(), 0.000)
+        .maxParallelization(1);
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture()) {
+      verifyReduction(client, "id_i = 10", 0.15);
+      verifyReduction(client, "id_i <> 10", 0.5);
+      verifyReduction(client, "id_i < 10", 0.5);
+      verifyReduction(client, "id_i > 10", 0.5);
+      verifyReduction(client, "id_i <= 10", 0.5);
+      verifyReduction(client, "id_i >= 10", 0.5);
+      verifyReduction(client, "id_i IN (10)", 0.15);
+      verifyReduction(client, "id_i IN (10, 20)", 0.25);
+      verifyReduction(client, "id_i IN (11, 12, 13, 14, 15, 16, 16, 18, 19, 20)", 0.25);
+      verifyReduction(client, "name_s20 LIKE 'foo'", 0.25);
+      verifyReduction(client, "name_s20 NOT LIKE 'foo'", 0.25);
+      verifyReduction(client, "name_s20 IS NULL", 0.25);
+      verifyReduction(client, "name_s20 IS NOT NULL", 0.9);
+      verifyReduction(client, "NOT ( id_i = 10 )", 0.25);
+      verifyReduction(client, "flag_b IS TRUE", 0.25);
+      verifyReduction(client, "flag_b IS FALSE", 0.25);
+      verifyReduction(client, "flag_b IS NOT TRUE", 0.25);
+      verifyReduction(client, "flag_b IS NOT FALSE", 0.25);
+      verifyReduction(client, "id_i BETWEEN 10 AND 20", 0.25);
+      verifyReduction(client, "id_i NOT BETWEEN 10 AND 20", 0.25);
+      verifyReduction(client, "NOT ( id_i BETWEEN 10 AND 20 )", 0.25);
+      verifyReduction(client, "NOT ( id_i = 10 )", 0.25);
+      testSample1Calcite(client);
+
+      // Demonstrate that selectivity limits work to refine overall estimates.
+      // Apply limit at session level for this client.
+
+      client.alterSession(PlannerSettings.FILTER_MIN_SELECTIVITY_ESTIMATE_FACTOR.getOptionName(), 0.005);
+      testSample1(client,0.005);
+      try (ClientFixture client2 = cluster.clientBuilder().build()) {
+
+        // Apply at system level using this client.
+
+        client.alterSystem(PlannerSettings.FILTER_MIN_SELECTIVITY_ESTIMATE_FACTOR.getOptionName(), 0.004);
+
+        // Should impact another client.
+
+        testSample1(client2,0.004);
+      } finally {
+
+        // Put things back so we don't break anything.
+
+        client.alterSystem(PlannerSettings.FILTER_MIN_SELECTIVITY_ESTIMATE_FACTOR.getOptionName(), 0.000);
+      }
+    }
+  }
+
+  private void testSample1Calcite(ClientFixture client) throws Exception {
+    // col1_s20 in ('Value1','Value2','Value3','Value4',\n" +
+    //              'Value5','Value6','Value7','Value8','Value9') -- 25%
+    //  AND col2_i <=3 -- 50%
+    //  AND col3_s1 = 'Y'\n -- 15%
+    //  AND col4_s1 = 'Y'\n -- 15%
+    //  AND col5_s6 not like '%str1%' -- 25%
+    //  AND col5_s6 not like '%str2%' -- 25%
+    //  AND col5_s6 not like '%str3%' -- 25%
+    //  AND col5_s6 not like '%str4%' -- 25%
+    double expected = 0.25 * 0.50 *
+        Math.pow(0.15, 2) *
+        Math.pow(0.25, 4);
+//    System.out.println( "Calcite sample 1: " + expected );
+    testSample1(client, expected);
+  }
+
+  /**
+   * Verify that custom base probabilities can be set in the
+   * config file and used by the planner.
+   * @throws Exception
+   */
+
+  @Test
+  public void testCustomRules() throws Exception {
+    FixtureBuilder builder = ClusterFixture.builder()
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_ENABLE, true)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true)
+//      .configProperty(ExecConstants.QUERY_PROFILE_OPTION, "sync") // Temporary until DRILL-5257 is available
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_PROB_EQ, 0.10)
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_PROB_LIKE, 0.20)
+        .configProperty(ExecConstants.OPTIMIZER_ENHANCED_DEFAULTS_PROB_NULL, 0.05)
+        .maxParallelization(1);
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture()) {
+      verifyBooleanBehavior(client);
+      verifyReduction(client, "id_i = 10", 0.10);
+      verifyReduction(client, "id_i <> 10", 0.90);
+      verifyReduction(client, "id_i < 10", 0.90 / 2);
+      verifyReduction(client, "id_i > 10", 0.90 / 2);
+      verifyReduction(client, "id_i IN (10)", 0.10);
+      verifyReduction(client, "name_s20 LIKE 'foo'", 0.20);
+      verifyReduction(client, "name_s20 NOT LIKE 'foo'", 0.80);
+      verifyReduction(client, "name_s20 IS NULL", 0.05);
+      verifyReduction(client, "name_s20 IS NOT NULL", 0.95);
+     }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -56,7 +56,7 @@ public class ClientFixture implements AutoCloseable {
       return this;
     }
 
-    ClientFixture build( ) {
+    public ClientFixture build( ) {
       try {
         return new ClientFixture(this);
       } catch (RpcException e) {
@@ -185,11 +185,14 @@ public class ClientFixture implements AutoCloseable {
    */
 
   public ProfileParser parseProfile(String queryId) throws IOException {
+    return new ProfileParser(getProfileFile(queryId));
+  }
+
+  public File getProfileFile(String queryId) {
     String tmpDir = cluster().config().getString(ExecConstants.DRILL_TMP_DIR);
     File drillTmp = new File(new File(tmpDir), "drill");
     File profileDir = new File(drillTmp, "profiles" );
-    File file = new File( profileDir, queryId + ".sys.drill" );
-    return new ProfileParser(file);
+    return new File( profileDir, queryId + ".sys.drill" );
   }
 
 }

--- a/exec/java-exec/src/test/resources/planner/tf.json
+++ b/exec/java-exec/src/test/resources/planner/tf.json
@@ -1,0 +1,4 @@
+{ col: true }
+{ col: false }
+{ col: null }
+{ }


### PR DESCRIPTION
Provides enhanced default selectivity rules as defined in DRILL-5254. Please see the JIRA entry for the details.

The rules are selectable with a boot-time option and are disabled by default to allow full testing of the rules before they become enabled by default.

Also provides a complete unit test. The test required enhancements to the new test framework; those enhancements are also included.