### PR TITLE
DRILL-5257: Run-time control of query profiles

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -413,4 +413,22 @@ public interface ExecConstants {
 
   String DYNAMIC_UDF_SUPPORT_ENABLED = "exec.udf.enable_dynamic_support";
   BooleanValidator DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR = new BooleanValidator(DYNAMIC_UDF_SUPPORT_ENABLED, true, true);
+
+  /**
+   * Option to save query profiles. If false, no query profile will be saved
+   * for any query.
+   */
+  String ENABLE_QUERY_PROFILE_OPTION = "exec.query_profile.save";
+  BooleanValidator ENABLE_QUERY_PROFILE_VALIDATOR = new BooleanValidator(
+      ENABLE_QUERY_PROFILE_OPTION, true, false);
+
+  /**
+   * Profiles are normally written after the last client message to reduce latency.
+   * When running tests, however, we want the profile written <i>before</i> the
+   * return so that the client can immediately read the profile for test
+   * verification.
+   */
+  String QUERY_PROFILE_DEBUG_OPTION = "exec.query_profile.debug_mode";
+  BooleanValidator QUERY_PROFILE_DEBUG_VALIDATOR = new BooleanValidator(
+      QUERY_PROFILE_DEBUG_OPTION, false, false);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -163,7 +163,9 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       ExecConstants.CODE_GEN_EXP_IN_METHOD_SIZE_VALIDATOR,
       ExecConstants.CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS_VALIDATOR,
       ExecConstants.DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR,
-      ExecConstants.EXTERNAL_SORT_DISABLE_MANAGED_OPTION
+      ExecConstants.EXTERNAL_SORT_DISABLE_MANAGED_OPTION,
+      ExecConstants.ENABLE_QUERY_PROFILE_VALIDATOR,
+      ExecConstants.QUERY_PROFILE_DEBUG_VALIDATOR
     };
     final Map<String, OptionValidator> tmp = new HashMap<>();
     for (final OptionValidator validator : validators) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
@@ -232,6 +232,24 @@ public class FixtureBuilder {
   }
 
   /**
+   * Enable saving of query profiles. The only way to save them is
+   * to enable local store provider writes, which also saves the
+   * storage plugin configs. Doing so causes the CTTAS feature to
+   * fail on the next run, so the test fixture deletes all local
+   * files on start and close, unless
+   * {@link #keepLocalFiles()} is set.
+   *
+   * @return this builder
+   */
+
+  public FixtureBuilder saveProfiles() {
+    configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true);
+    systemOption(ExecConstants.ENABLE_QUERY_PROFILE_OPTION, true);
+    systemOption(ExecConstants.QUERY_PROFILE_DEBUG_OPTION, true);
+    return this;
+  }
+
+  /**
    * Create the embedded Drillbit and client, applying the options set
    * in the builder. Best to use this in a try-with-resources block:
    * <pre><code>


### PR DESCRIPTION
Adds a run-time option to save query profiles before final query
response, after, or not at all.

Tests for normal “async” case are normal unit tests. Tests for “sync”
case are unit tests using the new framework that parse profiles.
The test framework is extended to save query profiles using this
new option.

See DRILL-5257 JIRA for details.