### PR TITLE
DRILL-5266: Parquet returns low-density batches

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
@@ -101,8 +101,10 @@ public abstract class ColumnReader<V extends ValueVector> {
     }
     if (columnDescriptor.getType() != PrimitiveType.PrimitiveTypeName.BINARY) {
       if (columnDescriptor.getType() == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+        // Here "bits" means "bytes"
         dataTypeLengthInBits = columnDescriptor.getTypeLength() * 8;
       } else {
+        // While here, "bits" means "bits"
         dataTypeLengthInBits = ParquetRecordReader.getTypeLengthInBits(columnDescriptor.getType());
       }
     }
@@ -153,9 +155,7 @@ public abstract class ColumnReader<V extends ValueVector> {
           .pushContext("File: ", this.parentReader.getHadoopPath().toString() )
           .build(logger);
       throw ex;
-
     }
-
   }
 
   protected abstract void readField(long recordsToRead);
@@ -172,25 +172,18 @@ public abstract class ColumnReader<V extends ValueVector> {
    */
   public boolean determineSize(long recordsReadInCurrentPass, Integer lengthVarFieldsInCurrentRecord) throws IOException {
 
-    boolean doneReading = readPage();
-    if (doneReading) {
+    if (readPage()) {
       return true;
     }
 
-    doneReading = processPageData((int) recordsReadInCurrentPass);
-    if (doneReading) {
+    if (processPageData((int) recordsReadInCurrentPass)) {
       return true;
     }
 
     // Never used in this code path. Hard to remove because the method is overidden by subclasses
     lengthVarFieldsInCurrentRecord = -1;
 
-    doneReading = checkVectorCapacityReached();
-    if (doneReading) {
-      return true;
-    }
-
-    return false;
+    return checkVectorCapacityReached();
   }
 
   protected Future<Integer> readRecordsAsync(int recordsToRead){
@@ -264,14 +257,17 @@ public abstract class ColumnReader<V extends ValueVector> {
   protected void hitRowGroupEnd() {}
 
   protected boolean checkVectorCapacityReached() {
+    // Here "bits" means "bytes"
+    // But, inside "capacity", "bits" sometimes means "bits".
+    // Note that bytesReadInCurrentPass is never updated, so this next
+    // line is a no-op.
     if (bytesReadInCurrentPass + dataTypeLengthInBits > capacity()) {
       logger.debug("Reached the capacity of the data vector in a variable length value vector.");
       return true;
     }
-    else if (valuesReadInCurrentPass > valueVec.getValueCapacity()) {
-      return true;
-    }
-    return false;
+    // No op: already checked this earlier and would not be here if this
+    // condition is true.
+    return valuesReadInCurrentPass > valueVec.getValueCapacity();
   }
 
   // copied out of parquet library, didn't want to deal with the uneeded throws statement they had declared

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedWidthRepeatedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/FixedWidthRepeatedReader.java
@@ -140,6 +140,7 @@ public class FixedWidthRepeatedReader extends VarLengthColumn<RepeatedValueVecto
     }
   }
 
+  @SuppressWarnings("resource")
   @Override
   protected boolean readAndStoreValueSizeInformation() {
     int numLeftoverVals = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableVarLengthValuesColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableVarLengthValuesColumn.java
@@ -91,12 +91,8 @@ public abstract class NullableVarLengthValuesColumn<V extends ValueVector> exten
       dataTypeLengthInBits = pageReader.pageData.getInt((int) pageReader.readyToReadPosInBytes);
     }
     // I think this also needs to happen if it is null for the random access
-    boolean success = setSafe(valuesReadInCurrentPass + pageReader.valuesReadyToRead, pageReader.pageData,
+    return ! setSafe(valuesReadInCurrentPass + pageReader.valuesReadyToRead, pageReader.pageData,
         (int) pageReader.readyToReadPosInBytes + 4, dataTypeLengthInBits);
-    if ( ! success ) {
-      return true;
-    }
-    return false;
   }
 
   @Override


### PR DESCRIPTION
Fixes one glaring problem related to bit/byte confusion.

Includes a few clean-up items found along the way.