### PR TITLE
DRILL-5259: Allow listing a user-defined number of profiles

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -90,6 +90,7 @@ public interface ExecConstants {
   String TEXT_LINE_READER_BUFFER_SIZE = "drill.exec.storage.file.text.buffer.size";
   String HAZELCAST_SUBNETS = "drill.exec.cache.hazel.subnets";
   String HTTP_ENABLE = "drill.exec.http.enabled";
+  String HTTP_MAX_PROFILES = "drill.exec.http.max_profiles";
   String HTTP_PORT = "drill.exec.http.port";
   String HTTP_ENABLE_SSL = "drill.exec.http.ssl_enabled";
   String HTTP_CORS_ENABLED = "drill.exec.http.cors.enabled";

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -115,7 +115,8 @@ drill.exec: {
   http: {
     enabled: true,
     ssl_enabled: false,
-    port: 8047
+    port: 8047,
+    max_profiles: 100,
     session_max_idle_secs: 3600, # Default value 1hr
     cors: {
       enabled: false,


### PR DESCRIPTION
Allow changing default number of finished queries in web UI, when starting up Drillbits
-Ddrill.exec.http.max_profiles=100
Alternatively, the page can be loaded dynamically for the same.
e.g. appending the parameter **max=\<listSize\>**
`https://<hostname>:8047/profiles?max=100`