### PR TITLE
DRILL-5270: Improve loading of profiles listing in the WebUI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -165,6 +165,8 @@ public final class ExecConstants {
   public static final String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";
   public static final String PROFILES_STORE_INMEMORY = "drill.exec.profiles.store.inmemory";
   public static final String PROFILES_STORE_CAPACITY = "drill.exec.profiles.store.capacity";
+  public static final String PROFILES_STORE_ARCHIVE_ENABLED = "drill.exec.profiles.store.archive.enabled";
+  public static final String PROFILES_STORE_ARCHIVE_RATE = "drill.exec.profiles.store.archive.rate";
   public static final String IMPERSONATION_ENABLED = "drill.exec.impersonation.enabled";
   public static final String IMPERSONATION_MAX_CHAINED_USER_HOPS = "drill.exec.impersonation.max_chained_user_hops";
   public static final String AUTHENTICATION_MECHANISMS = "drill.exec.security.auth.mechanisms";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import static org.apache.drill.exec.ExecConstants.DRILL_SYS_FILE_SUFFIX;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+/**
+ * Filter for Drill System Files
+ */
+public class DrillSysFilePathFilter implements PathFilter {
+
+  //NOTE: The filename is a combination of query ID (which is monotonically
+  //decreasing value derived off epoch timestamp) and a random value. This
+  //filter helps eliminate that list
+  String cutoffFileName = null;
+  public DrillSysFilePathFilter() {}
+
+  public DrillSysFilePathFilter(String cutoffSysFileName) {
+    if (cutoffSysFileName != null) {
+      this.cutoffFileName = cutoffSysFileName + DRILL_SYS_FILE_SUFFIX;
+    }
+  }
+
+  /* (non-Javadoc)
+   * @see org.apache.hadoop.fs.PathFilter#accept(org.apache.hadoop.fs.Path)
+   */
+  @Override
+  public boolean accept(Path file){
+    if (file.getName().endsWith(DRILL_SYS_FILE_SUFFIX)) {
+      if (cutoffFileName != null) {
+        return (file.getName().compareTo(cutoffFileName) <= 0);
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -41,6 +41,8 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
   // This flag is used in testing. Ideally, tests should use a specific PersistentStoreProvider that knows
   // how to handle this flag.
   private final boolean enableWrite;
+  //Config reference for archiving
+  private final DrillConfig drillConfig;
 
   public LocalPersistentStoreProvider(final PersistentStoreRegistry<?> registry) throws StoreException {
     this(registry.getConfig());
@@ -48,6 +50,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
 
   public LocalPersistentStoreProvider(final DrillConfig config) throws StoreException {
     this.path = new Path(config.getString(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH));
+    this.drillConfig = config;
     this.enableWrite = config.getBoolean(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE);
     try {
       this.fs = LocalPersistentStore.getFileSystem(config, path);
@@ -62,7 +65,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
     case BLOB_PERSISTENT:
     case PERSISTENT:
       if (enableWrite) {
-        return new LocalPersistentStore<>(fs, path, storeConfig);
+        return new LocalPersistentStore<>(fs, path, storeConfig, drillConfig);
       }
       return new NoWriteLocalStore<>();
     default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
@@ -40,6 +40,8 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
   private final CuratorFramework curator;
   private final DrillFileSystem fs;
   private final Path blobRoot;
+  //Reference for Archiving
+  private final DrillConfig drillConfig;
 
   public ZookeeperPersistentStoreProvider(final PersistentStoreRegistry<ZKClusterCoordinator> registry) throws StoreException {
     this(registry.getConfig(), registry.getCoordinator().getCurator());
@@ -48,13 +50,12 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
   @VisibleForTesting
   public ZookeeperPersistentStoreProvider(final DrillConfig config, final CuratorFramework curator) throws StoreException {
     this.curator = curator;
-
+    this.drillConfig = config;
     if (config.hasPath(DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT)) {
       blobRoot = new Path(config.getString(DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT));
     }else{
       blobRoot = LocalPersistentStore.getLogDir();
     }
-
     try {
       this.fs = LocalPersistentStore.getFileSystem(config, blobRoot);
     } catch (IOException ex) {
@@ -66,7 +67,7 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
   public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) throws StoreException {
     switch(config.getMode()){
     case BLOB_PERSISTENT:
-      return new LocalPersistentStore<>(fs, blobRoot, config);
+      return new LocalPersistentStore<>(fs, blobRoot, config, drillConfig);
     case PERSISTENT:
       final ZookeeperPersistentStore<V> store = new ZookeeperPersistentStore<>(curator, config);
       try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/DrillFileSystemUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/DrillFileSystemUtil.java
@@ -88,4 +88,16 @@ public class DrillFileSystemUtil {
     return FileSystemUtil.listAll(fs, path, recursive, FileSystemUtil.mergeFilters(DRILL_SYSTEM_FILTER, filters));
   }
 
+  /**
+   * Returns the status of a file/directory specified in source path to be renamed/moved to a destination path
+   *
+   * @param fs current file system
+   * @param src path to source
+   * @param dst path to destination
+   * @return status of rename/move
+   */
+  public static boolean rename(FileSystem fs, Path src, Path dst) throws IOException {
+    return FileSystemUtil.rename(fs, src, dst);
+  }
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/FileSystemUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/FileSystemUtil.java
@@ -136,6 +136,18 @@ public class FileSystemUtil {
   }
 
   /**
+   * Helper method that will rename/move file specified in the source path to a destination path
+   *
+   * @param fs current file system
+   * @param src path to source
+   * @param dst path to destination
+   * @return status of rename/move
+   */
+  public static boolean rename(FileSystem fs, Path src, Path dst) throws IOException {
+    return fs.rename(src, dst);
+  }
+
+  /**
    * Helper method that will store in given holder statuses of all directories present in given path applying custom filter.
    * If recursive flag is set to true, will call itself recursively to add statuses of nested directories.
    *

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -174,7 +174,11 @@ drill.exec: {
   },
   profiles.store: {
     inmemory: false,
-    capacity: 1000
+    capacity: 1000,
+    archive: {
+      enabled: false,
+      rate: 1000
+    }
   },
   impersonation: {
     enabled: false,


### PR DESCRIPTION
Using Hadoop API to filter and reduce profile list load time
Using an in-memory treeSet-based cache, maintain the list of most recent
profiles.