### PR TITLE
DRILL-5195: Publish Operator and MajorFragment Stats in Profile page

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/FragmentWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/FragmentWrapper.java
@@ -17,9 +17,12 @@
  */
 package org.apache.drill.exec.server.rest.profile;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.drill.exec.proto.UserBitShared.MajorFragmentProfile;
 import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
@@ -49,75 +52,174 @@ public class FragmentWrapper {
     return String.format("fragment-%s", major.getMajorFragmentId());
   }
 
-  public static final String[] FRAGMENT_OVERVIEW_COLUMNS = {"Major Fragment", "Minor Fragments Reporting",
-    "First Start", "Last Start", "First End", "Last End", "Min Runtime", "Avg Runtime", "Max Runtime", "Last Update",
-    "Last Progress", "Max Peak Memory"};
+  public static final String[] ACTIVE_FRAGMENT_OVERVIEW_COLUMNS = {
+      OverviewTblTxt.MAJOR_FRAGMENT, OverviewTblTxt.MINOR_FRAGMENTS_REPORTING,
+      OverviewTblTxt.FIRST_START, OverviewTblTxt.LAST_START, OverviewTblTxt.FIRST_END, OverviewTblTxt.LAST_END,
+      OverviewTblTxt.MIN_RUNTIME, OverviewTblTxt.AVG_RUNTIME, OverviewTblTxt.MAX_RUNTIME,
+      OverviewTblTxt.PERCENT_BUSY,
+      OverviewTblTxt.LAST_UPDATE, OverviewTblTxt.LAST_PROGRESS,
+      OverviewTblTxt.MAX_PEAK_MEMORY
+  };
+
+  public static final String[] ACTIVE_FRAGMENT_OVERVIEW_COLUMNS_TOOLTIP = {
+      OverviewTblTooltip.MAJOR_FRAGMENT, OverviewTblTooltip.MINOR_FRAGMENTS_REPORTING,
+      OverviewTblTooltip.FIRST_START, OverviewTblTooltip.LAST_START, OverviewTblTooltip.FIRST_END, OverviewTblTooltip.LAST_END,
+      OverviewTblTooltip.MIN_RUNTIME, OverviewTblTooltip.AVG_RUNTIME, OverviewTblTooltip.MAX_RUNTIME,
+      OverviewTblTooltip.PERCENT_BUSY,
+      OverviewTblTooltip.LAST_UPDATE, OverviewTblTooltip.LAST_PROGRESS,
+      OverviewTblTooltip.MAX_PEAK_MEMORY
+  };
 
   // Not including Major Fragment ID and Minor Fragments Reporting
-  public static final int NUM_NULLABLE_OVERVIEW_COLUMNS = FRAGMENT_OVERVIEW_COLUMNS.length - 2;
+  public static final int NUM_NULLABLE_ACTIVE_OVERVIEW_COLUMNS = ACTIVE_FRAGMENT_OVERVIEW_COLUMNS.length - 2;
 
   public void addSummary(TableBuilder tb) {
     // Use only minor fragments that have complete profiles
     // Complete iff the fragment profile has at least one operator profile, and start and end times.
     final List<MinorFragmentProfile> complete = new ArrayList<>(
-      Collections2.filter(major.getMinorFragmentProfileList(), Filters.hasOperatorsAndTimes));
+        Collections2.filter(major.getMinorFragmentProfileList(), Filters.hasOperatorsAndTimes));
 
-    tb.appendCell(new OperatorPathBuilder().setMajor(major).build(), null);
-    tb.appendCell(complete.size() + " / " + major.getMinorFragmentProfileCount(), null);
+    tb.appendCell(new OperatorPathBuilder().setMajor(major).build());
+    tb.appendCell(complete.size() + " / " + major.getMinorFragmentProfileCount());
 
     // If there are no stats to aggregate, create an empty row
     if (complete.size() < 1) {
-      tb.appendRepeated("", null, NUM_NULLABLE_OVERVIEW_COLUMNS);
+      tb.appendRepeated("", null, NUM_NULLABLE_ACTIVE_OVERVIEW_COLUMNS);
       return;
     }
 
     final MinorFragmentProfile firstStart = Collections.min(complete, Comparators.startTime);
     final MinorFragmentProfile lastStart = Collections.max(complete, Comparators.startTime);
-    tb.appendMillis(firstStart.getStartTime() - start, null);
-    tb.appendMillis(lastStart.getStartTime() - start, null);
+    tb.appendMillis(firstStart.getStartTime() - start);
+    tb.appendMillis(lastStart.getStartTime() - start);
 
     final MinorFragmentProfile firstEnd = Collections.min(complete, Comparators.endTime);
     final MinorFragmentProfile lastEnd = Collections.max(complete, Comparators.endTime);
-    tb.appendMillis(firstEnd.getEndTime() - start, null);
-    tb.appendMillis(lastEnd.getEndTime() - start, null);
+    tb.appendMillis(firstEnd.getEndTime() - start);
+    tb.appendMillis(lastEnd.getEndTime() - start);
 
-    long total = 0;
+    long cumulativeFragmentDurationInMillis = 0L;
+    long cumulativeProcessInNanos = 0L;
+    long cumulativeWaitInNanos = 0L;
     for (final MinorFragmentProfile p : complete) {
-      total += p.getEndTime() - p.getStartTime();
+      cumulativeFragmentDurationInMillis += p.getEndTime() - p.getStartTime();
+      //Capture Busy & Wait Time
+      List<OperatorProfile> opProfileList = p.getOperatorProfileList();
+      for (OperatorProfile operatorProfile : opProfileList) {
+        cumulativeProcessInNanos += operatorProfile.getProcessNanos();
+        cumulativeWaitInNanos += operatorProfile.getWaitNanos();
+      }
+    }
+    double totalProcessInMillis = Math.round(cumulativeProcessInNanos/1E6);
+    double totalWaitInMillis = Math.round(cumulativeWaitInNanos/1E6);
+
+    final MinorFragmentProfile shortRun = Collections.min(complete, Comparators.runTime);
+    final MinorFragmentProfile longRun = Collections.max(complete, Comparators.runTime);
+    tb.appendMillis(shortRun.getEndTime() - shortRun.getStartTime());
+    tb.appendMillis(cumulativeFragmentDurationInMillis / complete.size());
+    tb.appendMillis(longRun.getEndTime() - longRun.getStartTime());
+
+    tb.appendPercent(totalProcessInMillis / (totalProcessInMillis + totalWaitInMillis), null,
+        //#8721 is the summation sign: sum(Busy): ## + sum(Wait): ##
+        String.format("&#8721;Busy: %,.2fs + &#8721;Wait: %,.2fs", totalProcessInMillis/1E3, totalWaitInMillis/1E3));
+
+    final MinorFragmentProfile lastUpdate = Collections.max(complete, Comparators.lastUpdate);
+    tb.appendMillis(System.currentTimeMillis()-lastUpdate.getLastUpdate());
+
+    final MinorFragmentProfile lastProgress = Collections.max(complete, Comparators.lastProgress);
+    tb.appendMillis(System.currentTimeMillis()-lastProgress.getLastProgress());
+
+    // TODO(DRILL-3494): Names (maxMem, getMaxMemoryUsed) are misleading; the value is peak memory allocated to fragment
+    final MinorFragmentProfile maxMem = Collections.max(complete, Comparators.fragmentPeakMemory);
+    tb.appendBytes(maxMem.getMaxMemoryUsed());
+  }
+
+  public static final String[] COMPLETED_FRAGMENT_OVERVIEW_COLUMNS = {
+      OverviewTblTxt.MAJOR_FRAGMENT, OverviewTblTxt.MINOR_FRAGMENTS_REPORTING,
+      OverviewTblTxt.FIRST_START, OverviewTblTxt.LAST_START, OverviewTblTxt.FIRST_END, OverviewTblTxt.LAST_END,
+      OverviewTblTxt.MIN_RUNTIME, OverviewTblTxt.AVG_RUNTIME, OverviewTblTxt.MAX_RUNTIME,
+      OverviewTblTxt.PERCENT_BUSY, OverviewTblTxt.MAX_PEAK_MEMORY
+  };
+
+  public static final String[] COMPLETED_FRAGMENT_OVERVIEW_COLUMNS_TOOLTIP = {
+      OverviewTblTooltip.MAJOR_FRAGMENT, OverviewTblTooltip.MINOR_FRAGMENTS_REPORTING,
+      OverviewTblTooltip.FIRST_START, OverviewTblTooltip.LAST_START, OverviewTblTooltip.FIRST_END, OverviewTblTooltip.LAST_END,
+      OverviewTblTooltip.MIN_RUNTIME, OverviewTblTooltip.AVG_RUNTIME, OverviewTblTooltip.MAX_RUNTIME,
+      OverviewTblTooltip.PERCENT_BUSY, OverviewTblTooltip.MAX_PEAK_MEMORY
+  };
+
+  //Not including Major Fragment ID and Minor Fragments Reporting
+  public static final int NUM_NULLABLE_COMPLETED_OVERVIEW_COLUMNS = COMPLETED_FRAGMENT_OVERVIEW_COLUMNS.length - 2;
+
+  public void addFinalSummary(TableBuilder tb) {
+
+    // Use only minor fragments that have complete profiles
+    // Complete iff the fragment profile has at least one operator profile, and start and end times.
+    final List<MinorFragmentProfile> complete = new ArrayList<>(
+        Collections2.filter(major.getMinorFragmentProfileList(), Filters.hasOperatorsAndTimes));
+
+    tb.appendCell(new OperatorPathBuilder().setMajor(major).build());
+    tb.appendCell(complete.size() + " / " + major.getMinorFragmentProfileCount());
+
+    // If there are no stats to aggregate, create an empty row
+    if (complete.size() < 1) {
+      tb.appendRepeated("", null, NUM_NULLABLE_COMPLETED_OVERVIEW_COLUMNS);
+      return;
+    }
+
+    final MinorFragmentProfile firstStart = Collections.min(complete, Comparators.startTime);
+    final MinorFragmentProfile lastStart = Collections.max(complete, Comparators.startTime);
+    tb.appendMillis(firstStart.getStartTime() - start);
+    tb.appendMillis(lastStart.getStartTime() - start);
+
+    final MinorFragmentProfile firstEnd = Collections.min(complete, Comparators.endTime);
+    final MinorFragmentProfile lastEnd = Collections.max(complete, Comparators.endTime);
+    tb.appendMillis(firstEnd.getEndTime() - start);
+    tb.appendMillis(lastEnd.getEndTime() - start);
+
+    long totalDuration = 0L;
+    double totalProcessInMillis = 0.0d;
+    double totalWaitInMillis = 0.0d;
+    for (final MinorFragmentProfile p : complete) {
+      totalDuration += p.getEndTime() - p.getStartTime();
+      //Capture Busy & Wait Time
+      List<OperatorProfile> opProfileList = p.getOperatorProfileList();
+      for (OperatorProfile operatorProfile : opProfileList) {
+        totalProcessInMillis += operatorProfile.getProcessNanos()/1E6;
+        totalWaitInMillis += operatorProfile.getWaitNanos()/1E6;
+      }
     }
 
     final MinorFragmentProfile shortRun = Collections.min(complete, Comparators.runTime);
     final MinorFragmentProfile longRun = Collections.max(complete, Comparators.runTime);
-    tb.appendMillis(shortRun.getEndTime() - shortRun.getStartTime(), null);
-    tb.appendMillis(total / complete.size(), null);
-    tb.appendMillis(longRun.getEndTime() - longRun.getStartTime(), null);
+    tb.appendMillis(shortRun.getEndTime() - shortRun.getStartTime());
+    tb.appendMillis(totalDuration / complete.size());
+    tb.appendMillis(longRun.getEndTime() - longRun.getStartTime());
 
-    final MinorFragmentProfile lastUpdate = Collections.max(complete, Comparators.lastUpdate);
-    tb.appendTime(lastUpdate.getLastUpdate(), null);
-
-    final MinorFragmentProfile lastProgress = Collections.max(complete, Comparators.lastProgress);
-    tb.appendTime(lastProgress.getLastProgress(), null);
+    tb.appendPercent(totalProcessInMillis / (totalProcessInMillis + totalWaitInMillis), null,
+        //#8721 is the summation sign: sum(Busy): ## + sum(Wait): ##
+        String.format("&#8721;Busy: %,.2fs + &#8721;Wait: %,.2fs", totalProcessInMillis/1E3, totalWaitInMillis/1E3));
 
     // TODO(DRILL-3494): Names (maxMem, getMaxMemoryUsed) are misleading; the value is peak memory allocated to fragment
     final MinorFragmentProfile maxMem = Collections.max(complete, Comparators.fragmentPeakMemory);
-    tb.appendBytes(maxMem.getMaxMemoryUsed(), null);
+    tb.appendBytes(maxMem.getMaxMemoryUsed());
   }
 
   public static final String[] FRAGMENT_COLUMNS = {"Minor Fragment ID", "Host Name", "Start", "End",
-    "Runtime", "Max Records", "Max Batches", "Last Update", "Last Progress", "Peak Memory", "State"};
+      "Runtime", "Max Records", "Max Batches", "Last Update", "Last Progress", "Peak Memory", "State"};
 
   // Not including minor fragment ID
   private static final int NUM_NULLABLE_FRAGMENTS_COLUMNS = FRAGMENT_COLUMNS.length - 1;
 
   public String getContent() {
-    final TableBuilder builder = new TableBuilder(FRAGMENT_COLUMNS);
+    final TableBuilder builder = new TableBuilder(FRAGMENT_COLUMNS, null);
 
     // Use only minor fragments that have complete profiles
     // Complete iff the fragment profile has at least one operator profile, and start and end times.
     final List<MinorFragmentProfile> complete = new ArrayList<>(
-      Collections2.filter(major.getMinorFragmentProfileList(), Filters.hasOperatorsAndTimes));
+        Collections2.filter(major.getMinorFragmentProfileList(), Filters.hasOperatorsAndTimes));
     final List<MinorFragmentProfile> incomplete = new ArrayList<>(
-      Collections2.filter(major.getMinorFragmentProfileList(), Filters.missingOperatorsOrTimes));
+        Collections2.filter(major.getMinorFragmentProfileList(), Filters.missingOperatorsOrTimes));
 
     Collections.sort(complete, Comparators.minorId);
     for (final MinorFragmentProfile minor : complete) {
@@ -136,26 +238,60 @@ public class FragmentWrapper {
         biggestBatches = Math.max(biggestBatches, batches);
       }
 
-      builder.appendCell(new OperatorPathBuilder().setMajor(major).setMinor(minor).build(), null);
-      builder.appendCell(minor.getEndpoint().getAddress(), null);
-      builder.appendMillis(minor.getStartTime() - start, null);
-      builder.appendMillis(minor.getEndTime() - start, null);
-      builder.appendMillis(minor.getEndTime() - minor.getStartTime(), null);
+      builder.appendCell(new OperatorPathBuilder().setMajor(major).setMinor(minor).build());
+      builder.appendCell(minor.getEndpoint().getAddress());
+      builder.appendMillis(minor.getStartTime() - start);
+      builder.appendMillis(minor.getEndTime() - start);
+      builder.appendMillis(minor.getEndTime() - minor.getStartTime());
 
-      builder.appendFormattedInteger(biggestIncomingRecords, null);
-      builder.appendFormattedInteger(biggestBatches, null);
+      builder.appendFormattedInteger(biggestIncomingRecords);
+      builder.appendFormattedInteger(biggestBatches);
 
-      builder.appendTime(minor.getLastUpdate(), null);
-      builder.appendTime(minor.getLastProgress(), null);
+      builder.appendTime(minor.getLastUpdate());
+      builder.appendTime(minor.getLastProgress());
 
-      builder.appendBytes(minor.getMaxMemoryUsed(), null);
-      builder.appendCell(minor.getState().name(), null);
+      builder.appendBytes(minor.getMaxMemoryUsed());
+      builder.appendCell(minor.getState().name());
     }
 
     for (final MinorFragmentProfile m : incomplete) {
-      builder.appendCell(major.getMajorFragmentId() + "-" + m.getMinorFragmentId(), null);
+      builder.appendCell(major.getMajorFragmentId() + "-" + m.getMinorFragmentId());
       builder.appendRepeated(m.getState().toString(), null, NUM_NULLABLE_FRAGMENTS_COLUMNS);
     }
     return builder.build();
   }
+
+  private class OverviewTblTxt {
+    static final String MAJOR_FRAGMENT = "Major Fragment";
+    static final String MINOR_FRAGMENTS_REPORTING = "Minor Fragments Reporting";
+    static final String FIRST_START = "First Start";
+    static final String LAST_START = "Last Start";
+    static final String FIRST_END = "First End";
+    static final String LAST_END = "Last End";
+    static final String MIN_RUNTIME = "Min Runtime";
+    static final String AVG_RUNTIME = "Avg Runtime";
+    static final String MAX_RUNTIME = "Max Runtime";
+    static final String PERCENT_BUSY = "% Busy";
+    static final String LAST_UPDATE = "Last Update";
+    static final String LAST_PROGRESS = "Last Progress";
+    static final String MAX_PEAK_MEMORY = "Max Peak Memory";
+  }
+
+  private class OverviewTblTooltip {
+    static final String MAJOR_FRAGMENT = "Major fragment ID seen in the visual plan";
+    static final String MINOR_FRAGMENTS_REPORTING = "Number of minor fragments started";
+    static final String FIRST_START = "Time at which the first fragment started";
+    static final String LAST_START = "Time at which the last fragment started";
+    static final String FIRST_END = "Time at which the first fragment completed";
+    static final String LAST_END = "Time at which the last fragment completed";
+    static final String MIN_RUNTIME = "Shortest fragment runtime";
+    static final String AVG_RUNTIME = "Average fragment runtime";
+    static final String MAX_RUNTIME = "Longest fragment runtime";
+    static final String PERCENT_BUSY = "Percentage of run time that fragments were busy doing work";
+    static final String LAST_UPDATE = "Time since most recent heartbeat from a fragment";
+    static final String LAST_PROGRESS = "Time since most recent update from a fragment";
+    static final String MAX_PEAK_MEMORY = "Highest memory consumption by a fragment";
+  }
 }
+
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.server.rest.profile;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -34,6 +35,7 @@ import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
  * Wrapper class for profiles of ALL operator instances of the same operator type within a major fragment.
  */
 public class OperatorWrapper {
+  private static final String UNKNOWN_OPERATOR = "UNKNOWN_OPERATOR";
   private final int major;
   private final List<ImmutablePair<OperatorProfile, Integer>> ops; // operator profile --> minor fragment number
   private final OperatorProfile firstProfile;
@@ -46,7 +48,7 @@ public class OperatorWrapper {
     this.major = major;
     firstProfile = ops.get(0).getLeft();
     operatorType = CoreOperatorType.valueOf(firstProfile.getOperatorType());
-    operatorName = operatorType == null ? "UNKNOWN_OPERATOR" : operatorType.toString();
+    operatorName = operatorType == null ? UNKNOWN_OPERATOR : operatorType.toString();
     this.ops = ops;
     size = ops.size();
   }
@@ -61,20 +63,20 @@ public class OperatorWrapper {
   }
 
   public static final String [] OPERATOR_COLUMNS = {"Minor Fragment", "Setup Time", "Process Time", "Wait Time",
-    "Max Batches", "Max Records", "Peak Memory"};
+      "Max Batches", "Max Records", "Peak Memory"};
 
   public String getContent() {
-    TableBuilder builder = new TableBuilder(OPERATOR_COLUMNS);
+    TableBuilder builder = new TableBuilder(OPERATOR_COLUMNS, null);
 
     for (ImmutablePair<OperatorProfile, Integer> ip : ops) {
       int minor = ip.getRight();
       OperatorProfile op = ip.getLeft();
 
       String path = new OperatorPathBuilder().setMajor(major).setMinor(minor).setOperator(op).build();
-      builder.appendCell(path, null);
-      builder.appendNanos(op.getSetupNanos(), null);
-      builder.appendNanos(op.getProcessNanos(), null);
-      builder.appendNanos(op.getWaitNanos(), null);
+      builder.appendCell(path);
+      builder.appendNanos(op.getSetupNanos());
+      builder.appendNanos(op.getProcessNanos());
+      builder.appendNanos(op.getWaitNanos());
 
       long maxBatches = Long.MIN_VALUE;
       long maxRecords = Long.MIN_VALUE;
@@ -83,56 +85,82 @@ public class OperatorWrapper {
         maxRecords = Math.max(sp.getRecords(), maxRecords);
       }
 
-      builder.appendFormattedInteger(maxBatches, null);
-      builder.appendFormattedInteger(maxRecords, null);
-      builder.appendBytes(op.getPeakLocalMemoryAllocated(), null);
+      builder.appendFormattedInteger(maxBatches);
+      builder.appendFormattedInteger(maxRecords);
+      builder.appendBytes(op.getPeakLocalMemoryAllocated());
     }
     return builder.build();
   }
 
-  public static final String[] OPERATORS_OVERVIEW_COLUMNS = {"Operator ID", "Type", "Min Setup Time", "Avg Setup Time",
-    "Max Setup Time", "Min Process Time", "Avg Process Time", "Max Process Time", "Min Wait Time", "Avg Wait Time",
-    "Max Wait Time", "Avg Peak Memory", "Max Peak Memory"};
+  public static final String[] OPERATORS_OVERVIEW_COLUMNS = {
+      OverviewTblTxt.OPERATOR_ID, OverviewTblTxt.TYPE_OF_OPERATOR,
+      OverviewTblTxt.AVG_SETUP_TIME, OverviewTblTxt.MAX_SETUP_TIME,
+      OverviewTblTxt.AVG_PROCESS_TIME, OverviewTblTxt.MAX_PROCESS_TIME,
+      OverviewTblTxt.MIN_WAIT_TIME, OverviewTblTxt.AVG_WAIT_TIME, OverviewTblTxt.MAX_WAIT_TIME,
+      OverviewTblTxt.PERCENT_FRAGMENT_TIME, OverviewTblTxt.PERCENT_QUERY_TIME, OverviewTblTxt.ROWS,
+      OverviewTblTxt.AVG_PEAK_MEMORY, OverviewTblTxt.MAX_PEAK_MEMORY
+  };
 
-  public void addSummary(TableBuilder tb) {
+  public static final String[] OPERATORS_OVERVIEW_COLUMNS_TOOLTIP = {
+      OverviewTblTooltip.OPERATOR_ID, OverviewTblTooltip.TYPE_OF_OPERATOR,
+      OverviewTblTooltip.AVG_SETUP_TIME, OverviewTblTooltip.MAX_SETUP_TIME,
+      OverviewTblTooltip.AVG_PROCESS_TIME, OverviewTblTooltip.MAX_PROCESS_TIME,
+      OverviewTblTooltip.MIN_WAIT_TIME, OverviewTblTooltip.AVG_WAIT_TIME, OverviewTblTooltip.MAX_WAIT_TIME,
+      OverviewTblTooltip.PERCENT_FRAGMENT_TIME, OverviewTblTooltip.PERCENT_QUERY_TIME, OverviewTblTooltip.ROWS,
+      OverviewTblTooltip.AVG_PEAK_MEMORY, OverviewTblTooltip.MAX_PEAK_MEMORY
+  };
 
+  //Palette to help shade operators sharing a common major fragment
+  private static final String[] OPERATOR_OVERVIEW_BGCOLOR_PALETTE = {"#ffffff","#f2f2f2"};
+
+  public void addSummary(TableBuilder tb, HashMap<String, Long> majorFragmentBusyTally, long majorFragmentBusyTallyTotal) {
+    //Select background color from palette
+    String opTblBgColor = OPERATOR_OVERVIEW_BGCOLOR_PALETTE[major%OPERATOR_OVERVIEW_BGCOLOR_PALETTE.length];
     String path = new OperatorPathBuilder().setMajor(major).setOperator(firstProfile).build();
-    tb.appendCell(path, null);
-    tb.appendCell(operatorName, null);
+    tb.appendCell(path, null, null, opTblBgColor);
+    tb.appendCell(operatorName);
+
+    //Get MajorFragment Busy+Wait Time Tally
+    long majorBusyNanos = majorFragmentBusyTally.get(new OperatorPathBuilder().setMajor(major).build());
 
     double setupSum = 0.0;
     double processSum = 0.0;
     double waitSum = 0.0;
     double memSum = 0.0;
+    long recordSum = 0L;
     for (ImmutablePair<OperatorProfile, Integer> ip : ops) {
       OperatorProfile profile = ip.getLeft();
       setupSum += profile.getSetupNanos();
       processSum += profile.getProcessNanos();
       waitSum += profile.getWaitNanos();
       memSum += profile.getPeakLocalMemoryAllocated();
+      for (final StreamProfile sp : profile.getInputProfileList()) {
+        recordSum += sp.getRecords();
+      }
     }
 
-    final ImmutablePair<OperatorProfile, Integer> shortSetup = Collections.min(ops, Comparators.setupTime);
     final ImmutablePair<OperatorProfile, Integer> longSetup = Collections.max(ops, Comparators.setupTime);
-    tb.appendNanos(shortSetup.getLeft().getSetupNanos(), null);
-    tb.appendNanos(Math.round(setupSum / size), null);
-    tb.appendNanos(longSetup.getLeft().getSetupNanos(), null);
+    tb.appendNanos(Math.round(setupSum / size));
+    tb.appendNanos(longSetup.getLeft().getSetupNanos());
 
-    final ImmutablePair<OperatorProfile, Integer> shortProcess = Collections.min(ops, Comparators.processTime);
     final ImmutablePair<OperatorProfile, Integer> longProcess = Collections.max(ops, Comparators.processTime);
-    tb.appendNanos(shortProcess.getLeft().getProcessNanos(), null);
-    tb.appendNanos(Math.round(processSum / size), null);
-    tb.appendNanos(longProcess.getLeft().getProcessNanos(), null);
+    tb.appendNanos(Math.round(processSum / size));
+    tb.appendNanos(longProcess.getLeft().getProcessNanos());
 
     final ImmutablePair<OperatorProfile, Integer> shortWait = Collections.min(ops, Comparators.waitTime);
     final ImmutablePair<OperatorProfile, Integer> longWait = Collections.max(ops, Comparators.waitTime);
-    tb.appendNanos(shortWait.getLeft().getWaitNanos(), null);
-    tb.appendNanos(Math.round(waitSum / size), null);
-    tb.appendNanos(longWait.getLeft().getWaitNanos(), null);
+    tb.appendNanos(shortWait.getLeft().getWaitNanos());
+    tb.appendNanos(Math.round(waitSum / size));
+    tb.appendNanos(longWait.getLeft().getWaitNanos());
+
+    tb.appendPercent(processSum / majorBusyNanos);
+    tb.appendPercent(processSum / majorFragmentBusyTallyTotal);
+
+    tb.appendFormattedInteger(recordSum);
 
     final ImmutablePair<OperatorProfile, Integer> peakMem = Collections.max(ops, Comparators.operatorPeakMemory);
-    tb.appendBytes(Math.round(memSum / size), null);
-    tb.appendBytes(peakMem.getLeft().getPeakLocalMemoryAllocated(), null);
+    tb.appendBytes(Math.round(memSum / size));
+    tb.appendBytes(peakMem.getLeft().getPeakLocalMemoryAllocated());
   }
 
   public String getMetricsTable() {
@@ -150,17 +178,17 @@ public class OperatorWrapper {
     for (final String metricName : metricNames) {
       metricsTableColumnNames[i++] = metricName;
     }
-    final TableBuilder builder = new TableBuilder(metricsTableColumnNames);
+    final TableBuilder builder = new TableBuilder(metricsTableColumnNames, null);
+
     for (final ImmutablePair<OperatorProfile, Integer> ip : ops) {
       final OperatorProfile op = ip.getLeft();
 
       builder.appendCell(
           new OperatorPathBuilder()
-              .setMajor(major)
-              .setMinor(ip.getRight())
-              .setOperator(op)
-              .build(),
-          null);
+          .setMajor(major)
+          .setMinor(ip.getRight())
+          .setOperator(op)
+          .build());
 
       final Number[] values = new Number[metricNames.length];
       //Track new/Unknown Metrics
@@ -179,12 +207,47 @@ public class OperatorWrapper {
       }
       for (final Number value : values) {
         if (value != null) {
-          builder.appendFormattedNumber(value, null);
+          builder.appendFormattedNumber(value);
         } else {
-          builder.appendCell("", null);
+          builder.appendCell("");
         }
       }
     }
     return builder.build();
   }
+
+  private class OverviewTblTxt {
+    static final String OPERATOR_ID = "Operator ID";
+    static final String TYPE_OF_OPERATOR = "Type";
+    static final String AVG_SETUP_TIME = "Avg Setup Time";
+    static final String MAX_SETUP_TIME = "Max Setup Time";
+    static final String AVG_PROCESS_TIME = "Avg Process Time";
+    static final String MAX_PROCESS_TIME = "Max Process Time";
+    static final String MIN_WAIT_TIME = "Min Wait Time";
+    static final String AVG_WAIT_TIME = "Avg Wait Time";
+    static final String MAX_WAIT_TIME = "Max Wait Time";
+    static final String PERCENT_FRAGMENT_TIME = "% Fragment Time";
+    static final String PERCENT_QUERY_TIME = "% Query Time";
+    static final String ROWS = "Rows";
+    static final String AVG_PEAK_MEMORY = "Avg Peak Memory";
+    static final String MAX_PEAK_MEMORY = "Max Peak Memory";
+  }
+
+  private class OverviewTblTooltip {
+    static final String OPERATOR_ID = "Operator ID";
+    static final String TYPE_OF_OPERATOR = "Operator Type";
+    static final String AVG_SETUP_TIME = "Average time in setting up fragments";
+    static final String MAX_SETUP_TIME = "Longest time a fragment took in setup";
+    static final String AVG_PROCESS_TIME = "Average process time for a fragment";
+    static final String MAX_PROCESS_TIME = "Longest process time of any fragment";
+    static final String MIN_WAIT_TIME = "Shortest time a fragment spent in waiting";
+    static final String AVG_WAIT_TIME = "Average wait time for a fragment";
+    static final String MAX_WAIT_TIME = "Longest time a fragment spent in waiting";
+    static final String PERCENT_FRAGMENT_TIME = "Percentage of the total fragment time that was spent on the operator";
+    static final String PERCENT_QUERY_TIME = "Percentage of the total query time that was spent on the operator";
+    static final String ROWS = "Rows emitted by scans, or consumed by other operators";
+    static final String AVG_PEAK_MEMORY  =  "Average memory consumption by a fragment";
+    static final String MAX_PEAK_MEMORY  =  "Highest memory consumption by a fragment";
+  }
 }
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/TableBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/TableBuilder.java
@@ -33,24 +33,50 @@ public class TableBuilder {
   private int w = 0;
   private int width;
 
-  public TableBuilder(final String[] columns) {
+  public TableBuilder(final String[] columns, final String[] columnTooltip) {
     sb = new StringBuilder();
     width = columns.length;
 
     format.setMaximumFractionDigits(3);
 
     sb.append("<table class=\"table table-bordered text-right\">\n<tr>");
-    for (final String cn : columns) {
-      sb.append("<th>" + cn + "</th>");
+    for (int i = 0; i < columns.length; i++) {
+      String cn = columns[i];
+      String ctt = "";
+      if (columnTooltip != null) {
+        String tooltip = columnTooltip[i];
+        if (tooltip != null) {
+          ctt = " title=\""+tooltip+"\"";
+        }
+      }
+      sb.append("<th" + ctt + ">" + cn + "</th>");
     }
     sb.append("</tr>\n");
   }
 
+  public void appendCell(final String s) {
+    appendCell(s, null, null, null);
+  }
+
   public void appendCell(final String s, final String link) {
+    appendCell(s, link, null, null);
+  }
+
+  public void appendCell(final String s, final String link, final String titleText) {
+    appendCell(s, link, titleText, null);
+  }
+
+  public void appendCell(final String s, final String link, final String titleText, final String backgroundColor) {
     if (w == 0) {
-      sb.append("<tr>");
+      sb.append("<tr"
+          + (backgroundColor == null ? "" : " style=\"background-color:"+backgroundColor+"\"")
+          + ">");
     }
-    sb.append(String.format("<td>%s%s</td>", s, link != null ? link : ""));
+    if (titleText != null && titleText.length() > 0) {
+      sb.append(String.format("<td title=\""+titleText+"\">%s%s</td>", s, link != null ? link : ""));
+    } else {
+      sb.append(String.format("<td>%s%s</td>", s, link != null ? link : ""));
+    }
     if (++w >= width) {
       sb.append("</tr>\n");
       w = 0;
@@ -58,37 +84,101 @@ public class TableBuilder {
   }
 
   public void appendRepeated(final String s, final String link, final int n) {
+    appendRepeated(s, link, n, null);
+  }
+
+  public void appendRepeated(final String s, final String link, final int n, final String tooltip) {
     for (int i = 0; i < n; i++) {
-      appendCell(s, link);
+      appendCell(s, link, tooltip);
     }
   }
 
+  public void appendTime(final long d) {
+    appendCell(dateFormat.format(d), null, null);
+  }
+
   public void appendTime(final long d, final String link) {
-    appendCell(dateFormat.format(d), link);
+    appendCell(dateFormat.format(d), link, null);
+  }
+
+  public void appendTime(final long d, final String link, final String tooltip) {
+    appendCell(dateFormat.format(d), link, tooltip);
+  }
+
+  public void appendMillis(final long p) {
+    appendCell((new SimpleDurationFormat(0, p)).compact(), null, null);
   }
 
   public void appendMillis(final long p, final String link) {
-    appendCell((new SimpleDurationFormat(0, p)).compact(), link);
+    appendCell((new SimpleDurationFormat(0, p)).compact(), link, null);
+  }
+
+  public void appendMillis(final long p, final String link, final String tooltip) {
+    appendCell((new SimpleDurationFormat(0, p)).compact(), link, tooltip);
+  }
+
+  public void appendNanos(final long p) {
+    appendNanos(p, null, null);
   }
 
   public void appendNanos(final long p, final String link) {
-    appendMillis(Math.round(p / 1000.0 / 1000.0), link);
+    appendNanos(p, link, null);
+  }
+
+  public void appendNanos(final long p, final String link, final String tooltip) {
+    appendMillis(Math.round(p / 1000.0 / 1000.0), link, tooltip);
+  }
+
+  public void appendPercent(final double percentAsFraction) {
+    appendCell(dec.format(100*percentAsFraction).concat("%"), null, null);
+  }
+
+  public void appendPercent(final double percentAsFraction, final String link) {
+    appendCell(dec.format(100*percentAsFraction).concat("%"), link, null);
+  }
+
+  public void appendPercent(final double percentAsFraction, final String link, final String tooltip) {
+    appendCell(dec.format(100*percentAsFraction).concat("%"), link, tooltip);
+  }
+
+  public void appendFormattedNumber(final Number n) {
+    appendCell(format.format(n), null, null);
   }
 
   public void appendFormattedNumber(final Number n, final String link) {
-    appendCell(format.format(n), link);
+    appendCell(format.format(n), link, null);
+  }
+
+  public void appendFormattedNumber(final Number n, final String link, final String tooltip) {
+    appendCell(format.format(n), link, tooltip);
+  }
+
+  public void appendFormattedInteger(final long n) {
+    appendCell(intformat.format(n), null, null);
   }
 
   public void appendFormattedInteger(final long n, final String link) {
-    appendCell(intformat.format(n), link);
+    appendCell(intformat.format(n), link, null);
   }
 
-  public void appendInteger(final long l, final String link) {
-    appendCell(Long.toString(l), link);
+  public void appendFormattedInteger(final long n, final String link, final String tooltip) {
+    appendCell(intformat.format(n), link, tooltip);
   }
 
-  public void appendBytes(final long l, final String link){
-    appendCell(bytePrint(l), link);
+  public void appendInteger(final long l, final String link, final String tooltip) {
+    appendCell(Long.toString(l), link, tooltip);
+  }
+
+  public void appendBytes(final long l) {
+    appendCell(bytePrint(l), null, null);
+  }
+
+  public void appendBytes(final long l, final String link) {
+    appendCell(bytePrint(l), link, null);
+  }
+
+  public void appendBytes(final long l, final String link, final String tooltip) {
+    appendCell(bytePrint(l), link, tooltip);
   }
 
   private String bytePrint(final long size) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -418,9 +418,14 @@ public class Foreman implements Runnable {
   private void runPhysicalPlan(final PhysicalPlan plan) throws ExecutionSetupException {
     validatePlan(plan);
     MemoryAllocationUtilities.setupSortMemoryAllocations(plan, queryContext);
+    //Marking endTime of Planning
+    queryManager.markPlanningEndTime();
+
     if (queuingEnabled) {
       acquireQuerySemaphore(plan);
       moveToState(QueryState.STARTING, null);
+      //Marking endTime of Waiting in Queue
+      queryManager.markQueueWaitEndTime();
     }
 
     final QueryWorkUnit work = getQueryWorkUnit(plan);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -100,6 +100,8 @@ public class QueryManager implements AutoCloseable {
   private String planText;
   private long startTime = System.currentTimeMillis();
   private long endTime;
+  private long planningEndTime;
+  private long queueWaitEndTime;
 
   // How many nodes have finished their execution.  Query is complete when all nodes are complete.
   private final AtomicInteger finishedNodes = new AtomicInteger(0);
@@ -341,6 +343,8 @@ public class QueryManager implements AutoCloseable {
         .setForeman(foreman.getQueryContext().getCurrentEndpoint())
         .setStart(startTime)
         .setEnd(endTime)
+        .setPlanEnd(planningEndTime)
+        .setQueueWaitEnd(queueWaitEndTime)
         .setTotalFragments(fragmentDataSet.size())
         .setFinishedFragments(finishedFragments.get())
         .setOptionsJson(getQueryOptionsAsJson());
@@ -414,6 +418,14 @@ public class QueryManager implements AutoCloseable {
 
   void markEndTime() {
     endTime = System.currentTimeMillis();
+  }
+
+  void markPlanningEndTime() {
+    planningEndTime = System.currentTimeMillis();
+  }
+
+  void markQueueWaitEndTime() {
+    queueWaitEndTime = System.currentTimeMillis();
   }
 
   /**

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -107,6 +107,9 @@
   <p>FOREMAN: ${model.getProfile().getForeman().getAddress()}</p>
   <p>TOTAL FRAGMENTS: ${model.getProfile().getTotalFragments()}</p>
   <p>DURATION: ${model.getProfileDuration()}</p>
+  <p>&nbsp;&nbsp;&nbsp;&nbsp;PLANNING: ${model.getPlanningDuration()}</p>
+  <p>&nbsp;&nbsp;&nbsp;&nbsp;QUEUED: ${model.getQueuedDuration()}</p>
+  <p>&nbsp;&nbsp;&nbsp;&nbsp;EXECUTION: ${model.getExecutionDuration()}</p>
 
   <#assign options = model.getOptions()>
   <#if (options?keys?size > 0)>

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -84,7 +84,7 @@
       </p>
       <p>Failure node: ${model.getProfile().errorNode}</p>
       <p>Error ID: ${model.getProfile().errorId}</p>
-      
+
         <h3 class="panel-title">
           <a data-toggle="collapse" href="#error-verbose">
             Verbose Error Message...
@@ -107,9 +107,9 @@
   <p>FOREMAN: ${model.getProfile().getForeman().getAddress()}</p>
   <p>TOTAL FRAGMENTS: ${model.getProfile().getTotalFragments()}</p>
   <p>DURATION: ${model.getProfileDuration()}</p>
-  <p>&nbsp;&nbsp;&nbsp;&nbsp;PLANNING: ${model.getPlanningDuration()}</p>
-  <p>&nbsp;&nbsp;&nbsp;&nbsp;QUEUED: ${model.getQueuedDuration()}</p>
-  <p>&nbsp;&nbsp;&nbsp;&nbsp;EXECUTION: ${model.getExecutionDuration()}</p>
+  <p style="text-indent:5em;">PLANNING: ${model.getPlanningDuration()}</p>
+  <p style="text-indent:5em;">QUEUED: ${model.getQueuedDuration()}</p>
+  <p style="text-indent:5em;">EXECUTION: ${model.getExecutionDuration()}</p>
 
   <#assign options = model.getOptions()>
   <#if (options?keys?size > 0)>

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
@@ -1790,6 +1790,10 @@ public final class SchemaUserBitShared
                     output.writeString(16, message.getErrorNode(), false);
                 if(message.hasOptionsJson())
                     output.writeString(17, message.getOptionsJson(), false);
+                if(message.hasPlanEnd())
+                    output.writeInt64(18, message.getPlanEnd(), false);
+                if(message.hasQueueWaitEnd())
+                    output.writeInt64(19, message.getQueueWaitEnd(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserBitShared.QueryProfile message)
             {
@@ -1883,6 +1887,12 @@ public final class SchemaUserBitShared
                         case 17:
                             builder.setOptionsJson(input.readString());
                             break;
+                        case 18:
+                            builder.setPlanEnd(input.readInt64());
+                            break;
+                        case 19:
+                            builder.setQueueWaitEnd(input.readInt64());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -1940,6 +1950,8 @@ public final class SchemaUserBitShared
                 case 15: return "errorId";
                 case 16: return "errorNode";
                 case 17: return "optionsJson";
+                case 18: return "planEnd";
+                case 19: return "queueWaitEnd";
                 default: return null;
             }
         }
@@ -1968,6 +1980,8 @@ public final class SchemaUserBitShared
             fieldMap.put("errorId", 15);
             fieldMap.put("errorNode", 16);
             fieldMap.put("optionsJson", 17);
+            fieldMap.put("planEnd", 18);
+            fieldMap.put("queueWaitEnd", 19);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -13314,6 +13314,26 @@ public final class UserBitShared {
      */
     com.google.protobuf.ByteString
         getOptionsJsonBytes();
+
+    // optional int64 planEnd = 18;
+    /**
+     * <code>optional int64 planEnd = 18;</code>
+     */
+    boolean hasPlanEnd();
+    /**
+     * <code>optional int64 planEnd = 18;</code>
+     */
+    long getPlanEnd();
+
+    // optional int64 queueWaitEnd = 19;
+    /**
+     * <code>optional int64 queueWaitEnd = 19;</code>
+     */
+    boolean hasQueueWaitEnd();
+    /**
+     * <code>optional int64 queueWaitEnd = 19;</code>
+     */
+    long getQueueWaitEnd();
   }
   /**
    * Protobuf type {@code exec.shared.QueryProfile}
@@ -13480,6 +13500,16 @@ public final class UserBitShared {
             case 138: {
               bitField0_ |= 0x00008000;
               optionsJson_ = input.readBytes();
+              break;
+            }
+            case 144: {
+              bitField0_ |= 0x00010000;
+              planEnd_ = input.readInt64();
+              break;
+            }
+            case 152: {
+              bitField0_ |= 0x00020000;
+              queueWaitEnd_ = input.readInt64();
               break;
             }
           }
@@ -14045,6 +14075,38 @@ public final class UserBitShared {
       }
     }
 
+    // optional int64 planEnd = 18;
+    public static final int PLANEND_FIELD_NUMBER = 18;
+    private long planEnd_;
+    /**
+     * <code>optional int64 planEnd = 18;</code>
+     */
+    public boolean hasPlanEnd() {
+      return ((bitField0_ & 0x00010000) == 0x00010000);
+    }
+    /**
+     * <code>optional int64 planEnd = 18;</code>
+     */
+    public long getPlanEnd() {
+      return planEnd_;
+    }
+
+    // optional int64 queueWaitEnd = 19;
+    public static final int QUEUEWAITEND_FIELD_NUMBER = 19;
+    private long queueWaitEnd_;
+    /**
+     * <code>optional int64 queueWaitEnd = 19;</code>
+     */
+    public boolean hasQueueWaitEnd() {
+      return ((bitField0_ & 0x00020000) == 0x00020000);
+    }
+    /**
+     * <code>optional int64 queueWaitEnd = 19;</code>
+     */
+    public long getQueueWaitEnd() {
+      return queueWaitEnd_;
+    }
+
     private void initFields() {
       id_ = org.apache.drill.exec.proto.UserBitShared.QueryId.getDefaultInstance();
       type_ = org.apache.drill.exec.proto.UserBitShared.QueryType.SQL;
@@ -14063,6 +14125,8 @@ public final class UserBitShared {
       errorId_ = "";
       errorNode_ = "";
       optionsJson_ = "";
+      planEnd_ = 0L;
+      queueWaitEnd_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -14126,6 +14190,12 @@ public final class UserBitShared {
       }
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         output.writeBytes(17, getOptionsJsonBytes());
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        output.writeInt64(18, planEnd_);
+      }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        output.writeInt64(19, queueWaitEnd_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -14203,6 +14273,14 @@ public final class UserBitShared {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(17, getOptionsJsonBytes());
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(18, planEnd_);
+      }
+      if (((bitField0_ & 0x00020000) == 0x00020000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(19, queueWaitEnd_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -14369,6 +14447,10 @@ public final class UserBitShared {
         bitField0_ = (bitField0_ & ~0x00008000);
         optionsJson_ = "";
         bitField0_ = (bitField0_ & ~0x00010000);
+        planEnd_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00020000);
+        queueWaitEnd_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00040000);
         return this;
       }
 
@@ -14478,6 +14560,14 @@ public final class UserBitShared {
           to_bitField0_ |= 0x00008000;
         }
         result.optionsJson_ = optionsJson_;
+        if (((from_bitField0_ & 0x00020000) == 0x00020000)) {
+          to_bitField0_ |= 0x00010000;
+        }
+        result.planEnd_ = planEnd_;
+        if (((from_bitField0_ & 0x00040000) == 0x00040000)) {
+          to_bitField0_ |= 0x00020000;
+        }
+        result.queueWaitEnd_ = queueWaitEnd_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -14583,6 +14673,12 @@ public final class UserBitShared {
           bitField0_ |= 0x00010000;
           optionsJson_ = other.optionsJson_;
           onChanged();
+        }
+        if (other.hasPlanEnd()) {
+          setPlanEnd(other.getPlanEnd());
+        }
+        if (other.hasQueueWaitEnd()) {
+          setQueueWaitEnd(other.getQueueWaitEnd());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -15877,6 +15973,72 @@ public final class UserBitShared {
   }
   bitField0_ |= 0x00010000;
         optionsJson_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional int64 planEnd = 18;
+      private long planEnd_ ;
+      /**
+       * <code>optional int64 planEnd = 18;</code>
+       */
+      public boolean hasPlanEnd() {
+        return ((bitField0_ & 0x00020000) == 0x00020000);
+      }
+      /**
+       * <code>optional int64 planEnd = 18;</code>
+       */
+      public long getPlanEnd() {
+        return planEnd_;
+      }
+      /**
+       * <code>optional int64 planEnd = 18;</code>
+       */
+      public Builder setPlanEnd(long value) {
+        bitField0_ |= 0x00020000;
+        planEnd_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 planEnd = 18;</code>
+       */
+      public Builder clearPlanEnd() {
+        bitField0_ = (bitField0_ & ~0x00020000);
+        planEnd_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // optional int64 queueWaitEnd = 19;
+      private long queueWaitEnd_ ;
+      /**
+       * <code>optional int64 queueWaitEnd = 19;</code>
+       */
+      public boolean hasQueueWaitEnd() {
+        return ((bitField0_ & 0x00040000) == 0x00040000);
+      }
+      /**
+       * <code>optional int64 queueWaitEnd = 19;</code>
+       */
+      public long getQueueWaitEnd() {
+        return queueWaitEnd_;
+      }
+      /**
+       * <code>optional int64 queueWaitEnd = 19;</code>
+       */
+      public Builder setQueueWaitEnd(long value) {
+        bitField0_ |= 0x00040000;
+        queueWaitEnd_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 queueWaitEnd = 19;</code>
+       */
+      public Builder clearQueueWaitEnd() {
+        bitField0_ = (bitField0_ & ~0x00040000);
+        queueWaitEnd_ = 0L;
         onChanged();
         return this;
       }
@@ -22535,7 +22697,7 @@ public final class UserBitShared {
       "rt\030\002 \001(\003\0222\n\005state\030\003 \001(\0162#.exec.shared.Qu",
       "eryResult.QueryState\022\017\n\004user\030\004 \001(\t:\001-\022\'\n" +
       "\007foreman\030\005 \001(\0132\026.exec.DrillbitEndpoint\022\024" +
-      "\n\014options_json\030\006 \001(\t\"\320\003\n\014QueryProfile\022 \n" +
+      "\n\014options_json\030\006 \001(\t\"\367\003\n\014QueryProfile\022 \n" +
       "\002id\030\001 \001(\0132\024.exec.shared.QueryId\022$\n\004type\030" +
       "\002 \001(\0162\026.exec.shared.QueryType\022\r\n\005start\030\003" +
       " \001(\003\022\013\n\003end\030\004 \001(\003\022\r\n\005query\030\005 \001(\t\022\014\n\004plan" +
@@ -22547,58 +22709,59 @@ public final class UserBitShared {
       "agmentProfile\022\017\n\004user\030\014 \001(\t:\001-\022\r\n\005error\030" +
       "\r \001(\t\022\024\n\014verboseError\030\016 \001(\t\022\020\n\010error_id\030" +
       "\017 \001(\t\022\022\n\nerror_node\030\020 \001(\t\022\024\n\014options_jso" +
-      "n\030\021 \001(\t\"t\n\024MajorFragmentProfile\022\031\n\021major" +
-      "_fragment_id\030\001 \001(\005\022A\n\026minor_fragment_pro" +
-      "file\030\002 \003(\0132!.exec.shared.MinorFragmentPr" +
-      "ofile\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030" +
-      "\001 \001(\0162\032.exec.shared.FragmentState\022(\n\005err" +
-      "or\030\002 \001(\0132\031.exec.shared.DrillPBError\022\031\n\021m",
-      "inor_fragment_id\030\003 \001(\005\0226\n\020operator_profi" +
-      "le\030\004 \003(\0132\034.exec.shared.OperatorProfile\022\022" +
-      "\n\nstart_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013" +
-      "memory_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001" +
-      "(\003\022(\n\010endpoint\030\t \001(\0132\026.exec.DrillbitEndp" +
-      "oint\022\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progre" +
-      "ss\030\013 \001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_pr" +
-      "ofile\030\001 \003(\0132\032.exec.shared.StreamProfile\022" +
-      "\023\n\013operator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 " +
-      "\001(\005\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nano",
-      "s\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007" +
-      " \001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metri" +
-      "cValue\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProf" +
-      "ile\022\017\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n" +
-      "\007schemas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_" +
-      "id\030\001 \001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_v" +
-      "alue\030\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.ex" +
-      "ec.shared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022fu" +
-      "nction_signature\030\002 \003(\t*5\n\nRpcChannel\022\017\n\013" +
-      "BIT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n",
-      "\tQueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYS" +
-      "ICAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEM" +
-      "ENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023" +
-      "AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FI" +
-      "NISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026C" +
-      "ANCELLATION_REQUESTED\020\006*\335\005\n\020CoreOperator" +
-      "Type\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST_SEN" +
-      "DER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n" +
-      "\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH_PAR" +
-      "TITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGING_RE",
-      "CEIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER\020\t\022\013" +
-      "\n\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022\020\n\014R" +
-      "ANGE_SENDER\020\014\022\n\n\006SCREEN\020\r\022\034\n\030SELECTION_V" +
-      "ECTOR_REMOVER\020\016\022\027\n\023STREAMING_AGGREGATE\020\017" +
-      "\022\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERNAL_SORT\020\021\022\t\n\005T" +
-      "RACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_SORT\020\024\022\032\n\026PARQU" +
-      "ET_ROW_GROUP_SCAN\020\025\022\021\n\rHIVE_SUB_SCAN\020\026\022\025" +
-      "\n\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rMOCK_SUB_SCAN\020\030" +
-      "\022\022\n\016PARQUET_WRITER\020\031\022\023\n\017DIRECT_SUB_SCAN\020" +
-      "\032\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT_SUB_SCAN\020\034\022\021\n",
-      "\rJSON_SUB_SCAN\020\035\022\030\n\024INFO_SCHEMA_SUB_SCAN" +
-      "\020\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n\021PRODUCER_CONS" +
-      "UMER\020 \022\022\n\016HBASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024" +
-      "\n\020NESTED_LOOP_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$B" +
-      ".\n\033org.apache.drill.exec.protoB\rUserBitS" +
-      "haredH\001"
+      "n\030\021 \001(\t\022\017\n\007planEnd\030\022 \001(\003\022\024\n\014queueWaitEnd" +
+      "\030\023 \001(\003\"t\n\024MajorFragmentProfile\022\031\n\021major_" +
+      "fragment_id\030\001 \001(\005\022A\n\026minor_fragment_prof" +
+      "ile\030\002 \003(\0132!.exec.shared.MinorFragmentPro" +
+      "file\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030\001" +
+      " \001(\0162\032.exec.shared.FragmentState\022(\n\005erro",
+      "r\030\002 \001(\0132\031.exec.shared.DrillPBError\022\031\n\021mi" +
+      "nor_fragment_id\030\003 \001(\005\0226\n\020operator_profil" +
+      "e\030\004 \003(\0132\034.exec.shared.OperatorProfile\022\022\n" +
+      "\nstart_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013m" +
+      "emory_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(" +
+      "\003\022(\n\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpo" +
+      "int\022\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progres" +
+      "s\030\013 \001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_pro" +
+      "file\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023" +
+      "\n\013operator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 \001",
+      "(\005\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos" +
+      "\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007 " +
+      "\001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metric" +
+      "Value\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProfi" +
+      "le\022\017\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007" +
+      "schemas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_i" +
+      "d\030\001 \001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_va" +
+      "lue\030\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exe" +
+      "c.shared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022fun" +
+      "ction_signature\030\002 \003(\t*5\n\nRpcChannel\022\017\n\013B",
+      "IT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\t" +
+      "QueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSI" +
+      "CAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEME" +
+      "NT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023A" +
+      "WAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FIN" +
+      "ISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CA" +
+      "NCELLATION_REQUESTED\020\006*\335\005\n\020CoreOperatorT" +
+      "ype\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST_SEND" +
+      "ER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n\t" +
+      "HASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH_PART",
+      "ITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGING_REC" +
+      "EIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER\020\t\022\013\n" +
+      "\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022\020\n\014RA" +
+      "NGE_SENDER\020\014\022\n\n\006SCREEN\020\r\022\034\n\030SELECTION_VE" +
+      "CTOR_REMOVER\020\016\022\027\n\023STREAMING_AGGREGATE\020\017\022" +
+      "\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERNAL_SORT\020\021\022\t\n\005TR" +
+      "ACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_SORT\020\024\022\032\n\026PARQUE" +
+      "T_ROW_GROUP_SCAN\020\025\022\021\n\rHIVE_SUB_SCAN\020\026\022\025\n" +
+      "\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rMOCK_SUB_SCAN\020\030\022" +
+      "\022\n\016PARQUET_WRITER\020\031\022\023\n\017DIRECT_SUB_SCAN\020\032",
+      "\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT_SUB_SCAN\020\034\022\021\n\r" +
+      "JSON_SUB_SCAN\020\035\022\030\n\024INFO_SCHEMA_SUB_SCAN\020" +
+      "\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n\021PRODUCER_CONSU" +
+      "MER\020 \022\022\n\016HBASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024\n" +
+      "\020NESTED_LOOP_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$B." +
+      "\n\033org.apache.drill.exec.protoB\rUserBitSh" +
+      "aredH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -22688,7 +22851,7 @@ public final class UserBitShared {
           internal_static_exec_shared_QueryProfile_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_shared_QueryProfile_descriptor,
-              new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", });
+              new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", "PlanEnd", "QueueWaitEnd", });
           internal_static_exec_shared_MajorFragmentProfile_descriptor =
             getDescriptor().getMessageTypes().get(14);
           internal_static_exec_shared_MajorFragmentProfile_fieldAccessorTable = new

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/QueryProfile.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/QueryProfile.java
@@ -68,6 +68,8 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
     private String errorId;
     private String errorNode;
     private String optionsJson;
+    private long planEnd;
+    private long queueWaitEnd;
 
     public QueryProfile()
     {
@@ -297,6 +299,32 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
         return this;
     }
 
+    // planEnd
+
+    public long getPlanEnd()
+    {
+        return planEnd;
+    }
+
+    public QueryProfile setPlanEnd(long planEnd)
+    {
+        this.planEnd = planEnd;
+        return this;
+    }
+
+    // queueWaitEnd
+
+    public long getQueueWaitEnd()
+    {
+        return queueWaitEnd;
+    }
+
+    public QueryProfile setQueueWaitEnd(long queueWaitEnd)
+    {
+        this.queueWaitEnd = queueWaitEnd;
+        return this;
+    }
+
     // java serialization
 
     public void readExternal(ObjectInput in) throws IOException
@@ -407,6 +435,12 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
                 case 17:
                     message.optionsJson = input.readString();
                     break;
+                case 18:
+                    message.planEnd = input.readInt64();
+                    break;
+                case 19:
+                    message.queueWaitEnd = input.readInt64();
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -475,6 +509,12 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
 
         if(message.optionsJson != null)
             output.writeString(17, message.optionsJson, false);
+
+        if(message.planEnd != 0)
+            output.writeInt64(18, message.planEnd, false);
+
+        if(message.queueWaitEnd != 0)
+            output.writeInt64(19, message.queueWaitEnd, false);
     }
 
     public String getFieldName(int number)
@@ -498,6 +538,8 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
             case 15: return "errorId";
             case 16: return "errorNode";
             case 17: return "optionsJson";
+            case 18: return "planEnd";
+            case 19: return "queueWaitEnd";
             default: return null;
         }
     }
@@ -528,6 +570,8 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
         __fieldMap.put("errorId", 15);
         __fieldMap.put("errorNode", 16);
         __fieldMap.put("optionsJson", 17);
+        __fieldMap.put("planEnd", 18);
+        __fieldMap.put("queueWaitEnd", 19);
     }
     
 }

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -207,6 +207,8 @@ message QueryProfile {
   optional string error_id = 15;
   optional string error_node = 16;
   optional string options_json = 17;
+  optional int64 planEnd = 18;
+  optional int64 queueWaitEnd = 19;
 }
 
 message MajorFragmentProfile {


### PR DESCRIPTION
Improved UI
1. Introduction of Tooltips
2. Share of each operator as a percentages of the major fragment and of the query
  - This would help identify the most CPU intensive operators within a fragment and across the query
3. Rows emitted by each operator
4. For a running query, changes to 'last update' and 'last progress' now shows the elapsed time since.