### PR TITLE
DRILL-5255: Remove default temporary workspace check at drillbit star…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -21,9 +21,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.tools.ValidationException;
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.AbstractSchema;
@@ -70,10 +68,9 @@ public class SchemaUtilites {
   /**
    * Same utility as {@link #findSchema(SchemaPlus, List)} except the search schema path given here is complete path
    * instead of list. Use "." separator to divided the schema into nested schema names.
-   * @param defaultSchema
-   * @param schemaPath
-   * @return
-   * @throws ValidationException
+   * @param defaultSchema default schema
+   * @param schemaPath current schema path
+   * @return found schema path
    */
   public static SchemaPlus findSchema(final SchemaPlus defaultSchema, final String schemaPath) {
     final List<String> schemaPathAsList = Lists.newArrayList(schemaPath.split("\\."));
@@ -92,9 +89,8 @@ public class SchemaUtilites {
   }
 
   /**
-   * Returns true if the given <i>schema</i> is root schema. False otherwise.
-   * @param schema
-   * @return
+   * @param schema current schema
+   * @return true if the given <i>schema</i> is root schema. False otherwise.
    */
   public static boolean isRootSchema(SchemaPlus schema) {
     return schema.getParentSchema() == null;
@@ -128,7 +124,7 @@ public class SchemaUtilites {
   /** Utility method to get the schema path as list for given schema instance. */
   public static List<String> getSchemaPathAsList(SchemaPlus schema) {
     if (isRootSchema(schema)) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
 
     List<String> path = Lists.newArrayListWithCapacity(5);
@@ -156,12 +152,13 @@ public class SchemaUtilites {
   /**
    * Given reference to default schema in schema tree, search for schema with given <i>schemaPath</i>. Once a schema is
    * found resolve it into a mutable <i>AbstractDrillSchema</i> instance. A {@link UserException} is throws when:
-   *   1. No schema for given <i>schemaPath</i> is found,
-   *   2. Schema found for given <i>schemaPath</i> is a root schema
-   *   3. Resolved schema is not a mutable schema.
-   * @param defaultSchema
-   * @param schemaPath
-   * @return
+   *   <li>No schema for given <i>schemaPath</i> is found.</li>
+   *   <li>Schema found for given <i>schemaPath</i> is a root schema.</li>
+   *   <li>Resolved schema is not a mutable schema.</li>
+   *
+   * @param defaultSchema default schema
+   * @param schemaPath current schema path
+   * @return mutable schema, exception otherwise
    */
   public static AbstractSchema resolveToMutableDrillSchema(final SchemaPlus defaultSchema, List<String> schemaPath) {
     final SchemaPlus schema = findSchema(defaultSchema, schemaPath);
@@ -171,7 +168,7 @@ public class SchemaUtilites {
     }
 
     if (isRootSchema(schema)) {
-      throw UserException.parseError()
+      throw UserException.validationError()
           .message("Root schema is immutable. Creating or dropping tables/views is not allowed in root schema." +
               "Select a schema using 'USE schema' command.")
           .build(logger);
@@ -179,7 +176,7 @@ public class SchemaUtilites {
 
     final AbstractSchema drillSchema = unwrapAsDrillSchemaInstance(schema);
     if (!drillSchema.isMutable()) {
-      throw UserException.parseError()
+      throw UserException.validationError()
           .message("Unable to create or drop tables/views. Schema [%s] is immutable.", getSchemaPath(schema))
           .build(logger);
     }
@@ -189,21 +186,16 @@ public class SchemaUtilites {
 
   /**
    * Looks in schema tree for default temporary workspace instance.
-   * Makes sure that temporary workspace is mutable and file-based
-   * (instance of {@link WorkspaceSchemaFactory.WorkspaceSchema}).
    *
    * @param defaultSchema default schema
    * @param config drill config
-   * @return default temporary workspace
+   * @return default temporary workspace, null if workspace was not found
    */
   public static AbstractSchema getTemporaryWorkspace(SchemaPlus defaultSchema, DrillConfig config) {
-    List<String> temporarySchemaPath = Lists.newArrayList(config.getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE));
-    AbstractSchema temporarySchema = resolveToMutableDrillSchema(defaultSchema, temporarySchemaPath);
-    if (!(temporarySchema instanceof WorkspaceSchemaFactory.WorkspaceSchema)) {
-      DrillRuntimeException.format("Temporary workspace [%s] must be file-based, instance of " +
-          "WorkspaceSchemaFactory.WorkspaceSchema", temporarySchemaPath);
-    }
-    return temporarySchema;
+    String temporarySchema = config.getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE);
+    List<String> temporarySchemaPath = Lists.newArrayList(temporarySchema);
+    SchemaPlus schema = findSchema(defaultSchema, temporarySchemaPath);
+    return schema == null ? null : unwrapAsDrillSchemaInstance(schema);
   }
 
   /**
@@ -217,4 +209,46 @@ public class SchemaUtilites {
   public static boolean isTemporaryWorkspace(String schemaPath, DrillConfig config) {
     return schemaPath.equals(config.getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE));
   }
+
+  /**
+   * Makes sure that passed workspace exists, is default temporary workspace, mutable and file-based
+   * (instance of {@link WorkspaceSchemaFactory.WorkspaceSchema}).
+   *
+   * @param schema drill schema
+   * @param config drill config
+   * @return mutable & file-based workspace instance, otherwise throws validation error
+   */
+  public static WorkspaceSchemaFactory.WorkspaceSchema resolveToValidTemporaryWorkspace(AbstractSchema schema,
+                                                                                        DrillConfig config) {
+    if (schema == null) {
+      throw UserException.validationError()
+          .message("Default temporary workspace is not found")
+          .build(logger);
+    }
+
+    if (!isTemporaryWorkspace(schema.getFullSchemaName(), config)) {
+      throw UserException
+          .validationError()
+          .message(String.format("Temporary tables are not allowed to be created / dropped " +
+                  "outside of default temporary workspace [%s].",
+              config.getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE)))
+          .build(logger);
+    }
+
+    if (!schema.isMutable()) {
+      throw UserException.validationError()
+          .message("Unable to create or drop temporary table. Schema [%s] is immutable.", schema.getFullSchemaName())
+          .build(logger);
+    }
+
+    if (schema instanceof WorkspaceSchemaFactory.WorkspaceSchema) {
+      return (WorkspaceSchemaFactory.WorkspaceSchema) schema;
+    } else {
+      throw UserException.validationError()
+          .message("Temporary workspace [%s] must be file-based, instance of " +
+              "WorkspaceSchemaFactory.WorkspaceSchema", schema)
+          .build(logger);
+    }
+  }
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
@@ -52,9 +52,6 @@ public class DropTableHandler extends DefaultSqlHandler {
    * @param sqlNode - SqlDropTable (SQL parse tree of drop table [if exists] query)
    * @return - Single row indicating drop succeeded or table is not found while IF EXISTS statement is used,
    * raise exception otherwise
-   * @throws ValidationException
-   * @throws RelConversionException
-   * @throws IOException
    */
   @Override
   public PhysicalPlan getPlan(SqlNode sqlNode) throws ValidationException, RelConversionException, IOException {
@@ -69,7 +66,7 @@ public class DropTableHandler extends DefaultSqlHandler {
     boolean isTemporaryTable = session.isTemporaryTable(temporarySchema, drillConfig, originalTableName);
 
     if (isTemporaryTable) {
-      session.removeTemporaryTable(temporarySchema, originalTableName);
+      session.removeTemporaryTable(temporarySchema, originalTableName, drillConfig);
     } else {
       AbstractSchema drillSchema = SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
       Table tableToDrop = SqlHandlerUtil.getTableFromSchema(drillSchema, originalTableName);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.server;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.StackTrace;
 import org.apache.drill.common.config.DrillConfig;
@@ -31,17 +30,13 @@ import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.coord.ClusterCoordinator.RegistrationHandle;
 import org.apache.drill.exec.coord.zk.ZKClusterCoordinator;
 import org.apache.drill.exec.exception.DrillbitStartupException;
-import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.OptionType;
 import org.apache.drill.exec.server.rest.WebServer;
 import org.apache.drill.exec.service.ServiceEngine;
-import org.apache.drill.exec.store.AbstractSchema;
-import org.apache.drill.exec.store.SchemaTreeProvider;
 import org.apache.drill.exec.store.StoragePluginRegistry;
-import org.apache.drill.exec.store.dfs.WorkspaceSchemaFactory;
 import org.apache.drill.exec.store.sys.store.provider.CachingPersistentStoreProvider;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
@@ -128,7 +123,6 @@ public class Drillbit implements AutoCloseable {
     storageRegistry.init();
     drillbitContext.getOptionManager().init();
     javaPropertiesToSystemOptions();
-    validateTemporaryWorkspace(manager.getContext());
     manager.getContext().getRemoteFunctionRegistry().init(context.getConfig(), storeProvider, coord);
     registrationHandle = coord.register(md);
     webServer.start();
@@ -217,21 +211,6 @@ public class Drillbit implements AutoCloseable {
       final OptionValue optionValue = OptionValue.createOption(
           defaultValue.kind, OptionType.SYSTEM, optionName, optionString);
       optionManager.setOption(optionValue);
-    }
-  }
-
-  /**
-   * Validates that temporary workspace indicated in configuration is
-   * mutable and file-based (instance of {@link WorkspaceSchemaFactory.WorkspaceSchema}).
-   *
-   * @param context drillbit context
-   * @throws Exception in case when temporary table schema is not mutable or
-   *                   not file-based (instance of WorkspaceSchemaFactory.WorkspaceSchema)
-   */
-  private void validateTemporaryWorkspace(DrillbitContext context) throws Exception {
-    try (SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(context)) {
-      final SchemaPlus rootSchema = schemaTreeProvider.createRootSchema(context.getOptionManager());
-      SchemaUtilites.getTemporaryWorkspace(rootSchema, context.getConfig());
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -85,7 +85,6 @@ public class BaseTestQuery extends ExecTest {
     {
       put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
       put(ExecConstants.HTTP_ENABLE, "false");
-      put(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE, TEMP_SCHEMA);
     }
   };
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestDropTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestDropTable.java
@@ -168,7 +168,7 @@ public class TestDropTable extends PlanTestBase {
     try {
       test("drop table dfs.`/tmp`");
     } catch (UserException e) {
-      Assert.assertTrue(e.getMessage().contains("PARSE ERROR"));
+      Assert.assertTrue(e.getMessage().contains("VALIDATION ERROR"));
       dropFailed = true;
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/TemporaryTablesAutomaticDropTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/TemporaryTablesAutomaticDropTest.java
@@ -22,6 +22,7 @@ import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.util.TestUtilities;
 import org.junit.Before;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
@@ -47,7 +49,9 @@ public class TemporaryTablesAutomaticDropTest extends BaseTestQuery {
         return UUID.nameUUIDFromBytes(session_id.getBytes());
       }
     };
-    updateTestCluster(1, DrillConfig.create(cloneDefaultTestConfigProperties()));
+    Properties testConfigurations = cloneDefaultTestConfigProperties();
+    testConfigurations.put(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE, TEMP_SCHEMA);
+    updateTestCluster(1, DrillConfig.create(testConfigurations));
   }
 
   @Test


### PR DESCRIPTION
…t up

Check if default temporary workspace is valid (exists, file-based and writable) will be performed only if we attempt to create / drop temporary table, this will allow users who don't use temporary tables successfully use drill functionality even if default temporary workspace is not valid.

1. Removed default temporary workspace validity check at drillbit start up.
2. Ensured that default temporary workspace validity checks are only performed when user tries to create / drop temporary tables.
3. Replaced PARSE errors to VALIDATION ones if workspace is not valid (for CTAS tables).
4. Minor refactoring.