### PR TITLE
DRILL-5284: Roll-up of final fixes for managed sort

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -66,7 +66,6 @@ public interface ExecConstants {
 
   // External Sort Boot configuration
 
-  String EXTERNAL_SORT_TARGET_BATCH_SIZE = "drill.exec.sort.external.batch.size";
   String EXTERNAL_SORT_TARGET_SPILL_BATCH_SIZE = "drill.exec.sort.external.spill.batch.size";
   String EXTERNAL_SORT_SPILL_GROUP_SIZE = "drill.exec.sort.external.spill.group.size";
   String EXTERNAL_SORT_SPILL_THRESHOLD = "drill.exec.sort.external.spill.threshold";
@@ -79,6 +78,8 @@ public interface ExecConstants {
   String EXTERNAL_SORT_SPILL_BATCH_SIZE = "drill.exec.sort.external.spill.spill_batch_size";
   String EXTERNAL_SORT_MERGE_BATCH_SIZE = "drill.exec.sort.external.spill.merge_batch_size";
   String EXTERNAL_SORT_MAX_MEMORY = "drill.exec.sort.external.mem_limit";
+
+  // Used only by the "unmanaged" sort.
   String EXTERNAL_SORT_BATCH_LIMIT = "drill.exec.sort.external.batch_limit";
 
   // External Sort Runtime options

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
@@ -238,14 +238,15 @@ public class SortRecordBatchBuilder implements AutoCloseable {
   }
 
   /**
-   * For given recordcount how muchmemory does SortRecordBatchBuilder needs for its own purpose. This is used in
+   * For given record count how much memory does SortRecordBatchBuilder needs for its own purpose. This is used in
    * ExternalSortBatch to make decisions about whether to spill or not.
    *
    * @param recordCount
    * @return
    */
   public static long memoryNeeded(int recordCount) {
-    // We need 4 bytes (SV4) for each record.
-    return recordCount * 4;
+    // We need 4 bytes (SV4) for each record. Due to power-of-two allocations, the
+    // backing buffer might be twice this size.
+    return recordCount * 2 * 4;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/BatchGroup.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/BatchGroup.java
@@ -113,7 +113,7 @@ public class BatchGroup implements VectorAccessible, AutoCloseable {
     if (schema != null) {
       c = SchemaUtil.coerceContainer(c, schema, context);
     }
-//    logger.debug("Took {} us to read {} records", watch.elapsed(TimeUnit.MICROSECONDS), c.getRecordCount());
+    logger.trace("Took {} us to read {} records", watch.elapsed(TimeUnit.MICROSECONDS), c.getRecordCount());
     spilledBatches--;
     currentContainer.zeroVectors();
     Iterator<VectorWrapper<?>> wrapperIterator = c.iterator();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
@@ -78,6 +78,7 @@ public class SimpleVectorWrapper<T extends ValueVector> implements VectorWrapper
   }
 
 
+  @SuppressWarnings("resource")
   @Override
   public VectorWrapper<?> getChildWrapper(int[] ids) {
     if (ids.length == 1) {
@@ -106,6 +107,15 @@ public class SimpleVectorWrapper<T extends ValueVector> implements VectorWrapper
     Preconditions.checkArgument(destination instanceof SimpleVectorWrapper);
     Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
     vector.makeTransferPair(((SimpleVectorWrapper<?>)destination).vector).transfer();
+  }
+
+  @Override
+  public String toString() {
+    if (vector == null) {
+      return "null";
+    } else {
+      return vector.toString();
+    }
   }
 
 }

--- a/exec/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -69,7 +69,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
 
   @Override
   public int getValueCapacity(){
-    return (int) (data.capacity() *1.0 / ${type.width});
+    return data.capacity() / ${type.width};
   }
 
   @Override
@@ -196,7 +196,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
     data = buffer.slice(0, actualLength);
     data.retain(1);
     data.writerIndex(actualLength);
-    }
+  }
 
   public TransferPair getTransferPair(BufferAllocator allocator){
     return new TransferImpl(getField(), allocator);
@@ -225,6 +225,11 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
     target.clear();
     target.data = data.slice(startPoint, sliceLength).transferOwnership(target.allocator).buffer;
     target.data.writerIndex(sliceLength);
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return getAccessor().getValueCount() * ${type.width};
   }
 
   private class TransferImpl implements TransferPair{
@@ -390,7 +395,6 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
       return p.plusDays(days).plusMillis(millis);
     }
 
-
     public StringBuilder getAsStringBuilder(int index) {
       final int offsetIndex = index * ${type.width};
 
@@ -539,6 +543,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
     public ${friendlyType} getObject(int index) {
       return get(index);
     }
+
     public ${minor.javaType!type.javaType} getPrimitiveObject(int index) {
       return get(index);
     }
@@ -557,9 +562,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
       holder.isSet = 1;
       holder.value = data.get${(minor.javaType!type.javaType)?cap_first}(index * ${type.width});
     }
-
-
-   </#if> <#-- type.width -->
+    </#if> <#-- type.width -->
  }
 
  /**
@@ -728,84 +731,84 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
    }
 
    <#else> <#-- type.width <= 8 -->
-   public void set(int index, <#if (type.width >= 4)>${minor.javaType!type.javaType}<#else>int</#if> value) {
-     data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, value);
-   }
+    public void set(int index, <#if (type.width >= 4)>${minor.javaType!type.javaType}<#else>int</#if> value) {
+      data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, value);
+    }
 
    public void setSafe(int index, <#if (type.width >= 4)>${minor.javaType!type.javaType}<#else>int</#if> value) {
      while(index >= getValueCapacity()) {
-       reAlloc();
-     }
-     set(index, value);
-   }
+        reAlloc();
+      }
+      set(index, value);
+    }
 
-   protected void set(int index, ${minor.class}Holder holder){
-     data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, holder.value);
-   }
+    protected void set(int index, ${minor.class}Holder holder){
+      data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, holder.value);
+    }
 
-   public void setSafe(int index, ${minor.class}Holder holder){
-     while(index >= getValueCapacity()) {
-       reAlloc();
-     }
-     set(index, holder);
-   }
+    public void setSafe(int index, ${minor.class}Holder holder){
+      while(index >= getValueCapacity()) {
+        reAlloc();
+      }
+      set(index, holder);
+    }
 
-   protected void set(int index, Nullable${minor.class}Holder holder){
-     data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, holder.value);
-   }
+    protected void set(int index, Nullable${minor.class}Holder holder){
+      data.set${(minor.javaType!type.javaType)?cap_first}(index * ${type.width}, holder.value);
+    }
 
-   public void setSafe(int index, Nullable${minor.class}Holder holder){
-     while(index >= getValueCapacity()) {
-       reAlloc();
-     }
-     set(index, holder);
-   }
+    public void setSafe(int index, Nullable${minor.class}Holder holder){
+      while(index >= getValueCapacity()) {
+        reAlloc();
+      }
+      set(index, holder);
+    }
 
-   @Override
-   public void generateTestData(int size) {
-     setValueCount(size);
-     boolean even = true;
-     final int valueCount = getAccessor().getValueCount();
-     for(int i = 0; i < valueCount; i++, even = !even) {
-       if(even){
-         set(i, ${minor.boxedType!type.boxedType}.MIN_VALUE);
-       }else{
-         set(i, ${minor.boxedType!type.boxedType}.MAX_VALUE);
-       }
-     }
-   }
+    @Override
+    public void generateTestData(int size) {
+      setValueCount(size);
+      boolean even = true;
+      final int valueCount = getAccessor().getValueCount();
+      for(int i = 0; i < valueCount; i++, even = !even) {
+        if(even) {
+          set(i, ${minor.boxedType!type.boxedType}.MIN_VALUE);
+        } else {
+          set(i, ${minor.boxedType!type.boxedType}.MAX_VALUE);
+        }
+      }
+    }
 
-   public void generateTestDataAlt(int size) {
-     setValueCount(size);
-     boolean even = true;
-     final int valueCount = getAccessor().getValueCount();
-     for(int i = 0; i < valueCount; i++, even = !even) {
-       if(even){
-         set(i, (${(minor.javaType!type.javaType)}) 1);
-       }else{
-         set(i, (${(minor.javaType!type.javaType)}) 0);
-       }
-     }
-   }
+    public void generateTestDataAlt(int size) {
+      setValueCount(size);
+      boolean even = true;
+      final int valueCount = getAccessor().getValueCount();
+      for(int i = 0; i < valueCount; i++, even = !even) {
+        if(even) {
+          set(i, (${(minor.javaType!type.javaType)}) 1);
+        } else {
+          set(i, (${(minor.javaType!type.javaType)}) 0);
+        }
+      }
+    }
 
   </#if> <#-- type.width -->
 
-   @Override
-   public void setValueCount(int valueCount) {
-     final int currentValueCapacity = getValueCapacity();
-     final int idx = (${type.width} * valueCount);
-     while(valueCount > getValueCapacity()) {
-       reAlloc();
-     }
-     if (valueCount > 0 && currentValueCapacity > valueCount * 2) {
-       incrementAllocationMonitor();
-     } else if (allocationMonitor > 0) {
-       allocationMonitor = 0;
-     }
-     VectorTrimmer.trim(data, idx);
-     data.writerIndex(valueCount * ${type.width});
-   }
- }
+    @Override
+    public void setValueCount(int valueCount) {
+      final int currentValueCapacity = getValueCapacity();
+      final int idx = (${type.width} * valueCount);
+      while(valueCount > getValueCapacity()) {
+        reAlloc();
+      }
+      if (valueCount > 0 && currentValueCapacity > valueCount * 2) {
+        incrementAllocationMonitor();
+      } else if (allocationMonitor > 0) {
+        allocationMonitor = 0;
+      }
+      VectorTrimmer.trim(data, idx);
+      data.writerIndex(valueCount * ${type.width});
+    }
+  }
 }
 
 </#if> <#-- type.major -->

--- a/exec/vector/src/main/codegen/templates/UnionVector.java
+++ b/exec/vector/src/main/codegen/templates/UnionVector.java
@@ -202,6 +202,22 @@ public class UnionVector implements ValueVector {
   }
 
   @Override
+  public int getAllocatedByteCount() {
+    // Most vectors are held inside the internal map.
+
+    int count = internalMap.getAllocatedByteCount();
+    if (bit != null) {
+      count += bit.getAllocatedByteCount();
+    }
+    return count;
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return internalMap.getPayloadByteCount();
+  }
+
+  @Override
   public TransferPair getTransferPair(BufferAllocator allocator) {
     return new TransferImpl(field, allocator);
   }

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -238,6 +238,25 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
     return true;
   }
 
+  @Override
+  public int getAllocatedByteCount() {
+    return offsetVector.getAllocatedByteCount() + super.getAllocatedByteCount();
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    UInt${type.width}Vector.Accessor a = offsetVector.getAccessor();
+    int count = a.getValueCount();
+    if (count == 0) {
+      return 0;
+    } else {
+      // If 1 or more values, then the last value is set to
+      // the offset of the next value, which is the same as
+      // the length of existing values.
+      return a.get(count-1);
+    }
+  }
+
   private class TransferImpl implements TransferPair{
     ${minor.class}Vector to;
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BaseDataValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BaseDataValueVector.java
@@ -87,4 +87,9 @@ public abstract class BaseDataValueVector extends BaseValueVector {
    * the value vector. The purpose is to move the value vector to a "mutate" state
    */
   public void reset() {}
+
+  @Override
+  public int getAllocatedByteCount() {
+    return data.capacity();
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -449,4 +449,10 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
     this.valueCount = 0;
     super.clear();
   }
+
+  @Override
+  public int getPayloadByteCount() {
+    // One byte per value
+    return valueCount;
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
@@ -218,4 +218,16 @@ public class ObjectVector extends BaseValueVector {
       holder.obj = getObject(index);
     }
   }
+
+  @Override
+  public int getAllocatedByteCount() {
+    // Values not stored in direct memory?
+    return 0;
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    // Values not stored in direct memory?
+    return 0;
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -176,6 +176,18 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   void load(SerializedField metadata, DrillBuf buffer);
 
   /**
+   * Return the total memory consumed by all buffers within this vector.
+   */
+
+  int getAllocatedByteCount();
+
+  /**
+   * Return the number of value bytes consumed by actual data.
+   */
+
+  int getPayloadByteCount();
+
+  /**
    * An abstraction that is used to read from this vector instance.
    */
   interface Accessor {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/VariableWidthVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/VariableWidthVector.java
@@ -17,9 +17,7 @@
  */
 package org.apache.drill.exec.vector;
 
-import io.netty.buffer.DrillBuf;
-
-public interface VariableWidthVector extends ValueVector{
+public interface VariableWidthVector extends ValueVector {
 
   /**
    * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -176,4 +176,14 @@ public class ZeroVector implements ValueVector {
 
   @Override
   public void load(UserBitShared.SerializedField metadata, DrillBuf buffer) { }
+
+  @Override
+  public int getAllocatedByteCount() {
+    return 0;
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return 0;
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
@@ -266,7 +266,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
 
   @Override
   public int getBufferSize() {
-    int actualBufSize = 0 ;
+    int actualBufSize = 0;
 
     for (final ValueVector v : vectors.values()) {
       for (final DrillBuf buf : v.getBuffers(false)) {
@@ -274,5 +274,25 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
       }
     }
     return actualBufSize;
+  }
+
+  @Override
+  public int getAllocatedByteCount() {
+    int count = 0;
+
+    for (final ValueVector v : vectors.values()) {
+      count += v.getAllocatedByteCount();
+    }
+    return count;
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    int count = 0;
+
+    for (final ValueVector v : vectors.values()) {
+      count += v.getPayloadByteCount();
+    }
+    return count;
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
@@ -209,6 +209,17 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     vector = v;
   }
 
+
+  @Override
+  public int getAllocatedByteCount() {
+    return offsets.getAllocatedByteCount() + vector.getAllocatedByteCount();
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return offsets.getPayloadByteCount() + vector.getPayloadByteCount();
+  }
+
   public abstract class BaseRepeatedAccessor extends BaseValueVector.BaseAccessor implements RepeatedAccessor {
 
     @Override
@@ -256,5 +267,4 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
       vector.getMutator().setValueCount(childValueCount);
     }
   }
-
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -317,4 +317,14 @@ public class ListVector extends BaseRepeatedValueVector {
       bits.getMutator().setValueCount(valueCount);
     }
   }
+
+  @Override
+  public int getAllocatedByteCount() {
+    return offsets.getAllocatedByteCount() + bits.getAllocatedByteCount() + super.getAllocatedByteCount();
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return offsets.getPayloadByteCount() + bits.getPayloadByteCount() + super.getPayloadByteCount();
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
@@ -426,4 +426,14 @@ public class RepeatedListVector extends AbstractContainerVector
   public void copyFromSafe(int fromIndex, int thisIndex, RepeatedListVector from) {
     delegate.copyFromSafe(fromIndex, thisIndex, from.delegate);
   }
+
+  @Override
+  public int getAllocatedByteCount() {
+    return delegate.getAllocatedByteCount();
+  }
+
+  @Override
+  public int getPayloadByteCount() {
+    return delegate.getPayloadByteCount();
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
@@ -584,4 +584,9 @@ public class RepeatedMapVector extends AbstractMapVector
       vector.clear();
     }
   }
+
+  @Override
+  public int getAllocatedByteCount() {
+    return super.getAllocatedByteCount( ) + offsets.getAllocatedByteCount();
+  }
 }


### PR DESCRIPTION
See subtasks for details.

* Provide detailed, accurate estimate of size consumed by a record batch
* Managed external sort spills too often with Parquet data
* Managed External Sort fails with OOM
* External sort refers to the deprecated HDFS fs.default.name param
* Config param drill.exec.sort.external.batch.size is not used
* NPE in managed external sort while spilling to disk
* External Sort BatchGroup leaks memory if an OOM occurs during read
* Ensure at least two batches are merged in low-memory conditions