### PR TITLE
DRILL-5114: Rationalize use of Logback logging in unit tests

### DIFF
--- a/exec/java-exec/src/test/resources/logback-test.xml
+++ b/exec/java-exec/src/test/resources/logback-test.xml
@@ -32,12 +32,13 @@
   </appender>
 
   <logger name="org.apache.drill" additivity="false">
-    <level value="debug" />
+    <level value="error" />
     <appender-ref ref="SOCKET" />
+    <appender-ref ref="STDOUT" />
   </logger>
 
   <logger name="query.logger" additivity="false">
-    <level value="info" />
+    <level value="error" />
     <appender-ref ref="SOCKET" />
   </logger>
 


### PR DESCRIPTION
Renamed logback.xml file used for testing to logback-test.xml as per
the Logback documentation. Made logging less detailed in the test
version to reduce verbose output.