### PR TITLE
DRILL-5304: Queries fail intermittently when there is skew in data di…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SoftAffinityFragmentParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SoftAffinityFragmentParallelizer.java
@@ -117,7 +117,7 @@ public class SoftAffinityFragmentParallelizer implements FragmentParallelizer {
 
       // Find the maximum number of slots which should go to endpoints with affinity (See DRILL-825 for details)
       int affinedSlots =
-          Math.max(1, (int) (parameters.getAffinityFactor() * width / activeEndpoints.size())) * sortedAffinityList.size();
+          Math.max(1, (int) (Math.ceil((double)parameters.getAffinityFactor() * width / activeEndpoints.size()) * sortedAffinityList.size()));
 
       // Make sure affined slots is at least the number of mandatory nodes
       affinedSlots = Math.max(affinedSlots, numRequiredNodes);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
@@ -106,13 +106,16 @@ public class AssignmentCreator<T extends CompleteWork> {
     LinkedList<WorkEndpointListPair<T>> unassignedWorkList;
     Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators = getEndpointIterators();
 
-    // Assign upto minCount per node based on locality.
-    unassignedWorkList = assign(workList, endpointIterators, true);
     // Assign upto maxCount per node based on locality.
-    unassignedWorkList = assign(unassignedWorkList, endpointIterators, false);
+    unassignedWorkList = assign(workList, endpointIterators, false);
+
     // Assign upto minCount per node in a round robin fashion.
     assignLeftovers(unassignedWorkList, endpointIterators, true);
-    // Assign upto maxCount per node in a round robin fashion.
+
+    // Assign upto maxCount + leftovers per node based on locality.
+    unassignedWorkList = assign(unassignedWorkList, endpointIterators,  true);
+
+    // Assign upto maxCount + leftovers per node in a round robin fashion.
     assignLeftovers(unassignedWorkList, endpointIterators, false);
 
     if (unassignedWorkList.size() != 0) {
@@ -127,10 +130,12 @@ public class AssignmentCreator<T extends CompleteWork> {
    *
    * @param workList the list of work units to assign
    * @param endpointIterators the endpointIterators to assign to
-   * @param assignMinimum whether to assign only up to the minimum required
+   * @param assignMaxLeftOvers whether to assign upto maximum including leftovers
    * @return a list of unassigned work units
    */
-  private LinkedList<WorkEndpointListPair<T>> assign(List<WorkEndpointListPair<T>> workList, Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators, boolean assignMinimum) {
+  private LinkedList<WorkEndpointListPair<T>> assign(List<WorkEndpointListPair<T>> workList,
+                                                     Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators,
+                                                     boolean assignMaxLeftOvers) {
     LinkedList<WorkEndpointListPair<T>> currentUnassignedList = Lists.newLinkedList();
     outer: for (WorkEndpointListPair<T> workPair : workList) {
       List<DrillbitEndpoint> endpoints = workPair.sortedEndpoints;
@@ -139,7 +144,7 @@ public class AssignmentCreator<T extends CompleteWork> {
         if (iteratorWrapper == null) {
           continue;
         }
-        if (iteratorWrapper.count < (assignMinimum ? iteratorWrapper.minCount : iteratorWrapper.maxCount)) {
+        if (iteratorWrapper.count < (assignMaxLeftOvers ? (iteratorWrapper.maxCount + iteratorWrapper.maxCountLeftOver) : iteratorWrapper.maxCount)) {
           Integer assignment = iteratorWrapper.iter.next();
           iteratorWrapper.count++;
           mappings.put(assignment, workPair.work);
@@ -157,9 +162,11 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @param endpointIterators the endpointIterators to assign to
    * @param assignMinimum wheterh to assign the minimum amount
    */
-  private void assignLeftovers(LinkedList<WorkEndpointListPair<T>> unassignedWorkList, Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators, boolean assignMinimum) {
+  private void assignLeftovers(LinkedList<WorkEndpointListPair<T>> unassignedWorkList,
+                               Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators,
+                               boolean assignMinimum) {
     outer: for (FragIteratorWrapper iteratorWrapper : endpointIterators.values()) {
-      while (iteratorWrapper.count < (assignMinimum ? iteratorWrapper.minCount : iteratorWrapper.maxCount)) {
+      while (iteratorWrapper.count < (assignMinimum ? iteratorWrapper.minCount : (iteratorWrapper.maxCount + iteratorWrapper.maxCountLeftOver))) {
         WorkEndpointListPair<T> workPair = unassignedWorkList.poll();
         if (workPair == null) {
           break outer;
@@ -261,7 +268,7 @@ public class AssignmentCreator<T extends CompleteWork> {
     while (totalMaxCount < units.size()) {
       for (Entry<DrillbitEndpoint, FragIteratorWrapper> entry : map.entrySet()) {
         FragIteratorWrapper iteratorWrapper = entry.getValue();
-        iteratorWrapper.maxCount++;
+        iteratorWrapper.maxCountLeftOver++;
         totalMaxCount++;
         if (totalMaxCount == units.size()) {
           break;
@@ -279,6 +286,7 @@ public class AssignmentCreator<T extends CompleteWork> {
   private static class FragIteratorWrapper {
     int count = 0;
     int maxCount;
+    int maxCountLeftOver;
     int minCount;
     Iterator<Integer> iter;
   }


### PR DESCRIPTION
…stribution

Change the assignment logic so we first make sure we assign up to minCount for all nodes before going up to maxCount per node. 
Also, fixed a small issue in parallelization code where we are rounding down the calculation of number of fragments to run on nodes with affinity, because of which, sometimes, we schedule less fragments on nodes with affinity vs. nodes without affinity.