### PR TITLE
DRILL-5313: Fix compilation issue in C++ connector

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -661,16 +661,18 @@ DrillClientQueryResult* DrillClientImpl::ExecuteQuery(const PreparedStatement& p
     return sendMsg(factory, ::exec::user::RUN_QUERY, query);
 }
 
-static void updateLikeFilter(exec::user::LikeFilter& likeFilter, const std::string& pattern) {
+static void updateLikeFilter(exec::user::LikeFilter& likeFilter, const std::string& pattern,
+        const std::string& searchEscapeString) {
 	likeFilter.set_pattern(pattern);
-	likeFilter.set_escape(meta::DrillMetadata::s_searchEscapeString);
+	likeFilter.set_escape(searchEscapeString);
 }
 
 DrillClientCatalogResult* DrillClientImpl::getCatalogs(const std::string& catalogPattern,
+        const std::string& searchEscapeString,
         Metadata::pfnCatalogMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetCatalogsReq query;
-    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern, searchEscapeString);
 
     boost::function<DrillClientCatalogResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientCatalogResult*>(),
@@ -683,11 +685,12 @@ DrillClientCatalogResult* DrillClientImpl::getCatalogs(const std::string& catalo
 
 DrillClientSchemaResult* DrillClientImpl::getSchemas(const std::string& catalogPattern,
         const std::string& schemaPattern,
+        const std::string& searchEscapeString,
         Metadata::pfnSchemaMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetSchemasReq query;
-    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
-    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern, searchEscapeString);
 
     boost::function<DrillClientSchemaResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientSchemaResult*>(),
@@ -702,12 +705,13 @@ DrillClientTableResult* DrillClientImpl::getTables(const std::string& catalogPat
         const std::string& schemaPattern,
         const std::string& tablePattern,
 		const std::vector<std::string>* tableTypes,
+        const std::string& searchEscapeString,
         Metadata::pfnTableMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetTablesReq query;
-    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
-    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
-    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern, searchEscapeString);
 
     if (tableTypes) {
     	std::copy(tableTypes->begin(), tableTypes->end(),
@@ -727,13 +731,14 @@ DrillClientColumnResult* DrillClientImpl::getColumns(const std::string& catalogP
         const std::string& schemaPattern,
         const std::string& tablePattern,
         const std::string& columnsPattern,
+        const std::string& searchEscapeString,
         Metadata::pfnColumnMetadataListener listener,
         void* listenerCtx) {
     exec::user::GetColumnsReq query;
-    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern);
-    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern);
-    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern);
-    updateLikeFilter(*query.mutable_column_name_filter(), columnsPattern);
+    updateLikeFilter(*query.mutable_catalog_name_filter(), catalogPattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_schema_name_filter(), schemaPattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_table_name_filter(), tablePattern, searchEscapeString);
+    updateLikeFilter(*query.mutable_column_name_filter(), columnsPattern, searchEscapeString);
 
     boost::function<DrillClientColumnResult*(int32_t)> factory = boost::bind(
             boost::factory<DrillClientColumnResult*>(),

--- a/contrib/native/client/src/clientlib/drillClientImpl.hpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.hpp
@@ -527,10 +527,10 @@ class DrillClientImpl : public DrillClientImplBase{
         Handle* sendMsg(boost::function<Handle*(int32_t)> handleFactory, ::exec::user::RpcType type, const ::google::protobuf::Message& msg);
 
         // metadata requests
-        DrillClientCatalogResult* getCatalogs(const std::string& catalogPattern, Metadata::pfnCatalogMetadataListener listener, void* listenerCtx);
-        DrillClientSchemaResult* getSchemas(const std::string& catalogPattern, const std::string& schemaPattern, Metadata::pfnSchemaMetadataListener listener, void* listenerCtx);
-        DrillClientTableResult* getTables(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& tablePattern, const std::vector<std::string>* tableTypes, Metadata::pfnTableMetadataListener listener, void* listenerCtx);
-        DrillClientColumnResult* getColumns(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& tablePattern, const std::string& columnPattern, Metadata::pfnColumnMetadataListener listener, void* listenerCtx);
+        DrillClientCatalogResult* getCatalogs(const std::string& catalogPattern, const std::string& searchEscapeString, Metadata::pfnCatalogMetadataListener listener, void* listenerCtx);
+        DrillClientSchemaResult* getSchemas(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& searchEscapeString, Metadata::pfnSchemaMetadataListener listener, void* listenerCtx);
+        DrillClientTableResult* getTables(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& tablePattern, const std::vector<std::string>* tableTypes, const std::string& searchEscapeString, Metadata::pfnTableMetadataListener listener, void* listenerCtx);
+        DrillClientColumnResult* getColumns(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& tablePattern, const std::string& columnPattern, const std::string& searchEscapeString, Metadata::pfnColumnMetadataListener listener, void* listenerCtx);
 
         // SASL exchange
         connectionStatus_t handleAuthentication(const DrillUserProperties *userProperties);

--- a/contrib/native/client/src/clientlib/metadata.cpp
+++ b/contrib/native/client/src/clientlib/metadata.cpp
@@ -1143,7 +1143,7 @@ uint32_t DrillMetadata::getServerPatchVersion() const {
 }
 
 status_t DrillMetadata::getCatalogs(const std::string& catalogPattern, Metadata::pfnCatalogMetadataListener listener, void* listenerCtx, QueryHandle_t* qHandle) {
-	DrillClientCatalogResult* result = m_client.getCatalogs(catalogPattern, listener, listenerCtx);
+	DrillClientCatalogResult* result = m_client.getCatalogs(catalogPattern, m_searchEscapeString, listener, listenerCtx);
 	if(result==NULL){
 		*qHandle=NULL;
 		return static_cast<status_t>(m_client.getError()->status);
@@ -1152,7 +1152,7 @@ status_t DrillMetadata::getCatalogs(const std::string& catalogPattern, Metadata:
 	return QRY_SUCCESS;
 }
 status_t DrillMetadata::getSchemas(const std::string& catalogPattern, const std::string& schemaPattern, Metadata::pfnSchemaMetadataListener listener, void* listenerCtx, QueryHandle_t* qHandle) {
-	DrillClientSchemaResult* result = m_client.getSchemas(catalogPattern, schemaPattern, listener, listenerCtx);
+	DrillClientSchemaResult* result = m_client.getSchemas(catalogPattern, schemaPattern, m_searchEscapeString, listener, listenerCtx);
 	if(result==NULL){
 		*qHandle=NULL;
 		return static_cast<status_t>(m_client.getError()->status);
@@ -1161,7 +1161,7 @@ status_t DrillMetadata::getSchemas(const std::string& catalogPattern, const std:
 	return QRY_SUCCESS;
 }
 status_t DrillMetadata::getTables(const std::string& catalogPattern, const std::string& schemaPattern, const std::string& tablePattern, const std::vector<std::string>* tableTypes, Metadata::pfnTableMetadataListener listener, void* listenerCtx, QueryHandle_t* qHandle) {
-	DrillClientTableResult* result = m_client.getTables(catalogPattern, schemaPattern, tablePattern, tableTypes, listener, listenerCtx);
+	DrillClientTableResult* result = m_client.getTables(catalogPattern, schemaPattern, tablePattern, tableTypes, m_searchEscapeString, listener, listenerCtx);
 	if(result==NULL){
 		*qHandle=NULL;
 		return static_cast<status_t>(m_client.getError()->status);
@@ -1170,7 +1170,7 @@ status_t DrillMetadata::getTables(const std::string& catalogPattern, const std::
 	return QRY_SUCCESS;
 }
 status_t DrillMetadata::getColumns(const std::string& catalogPattern, const std::string& schemaPattern, const std:: string& tablePattern, const std::string& columnPattern, Metadata::pfnColumnMetadataListener listener, void* listenerCtx, QueryHandle_t* qHandle) {
-	DrillClientColumnResult* result = m_client.getColumns(catalogPattern, schemaPattern, tablePattern, columnPattern, listener, listenerCtx);
+	DrillClientColumnResult* result = m_client.getColumns(catalogPattern, schemaPattern, tablePattern, columnPattern, m_searchEscapeString, listener, listenerCtx);
 	if(result==NULL){
 		*qHandle=NULL;
 		return static_cast<status_t>(m_client.getError()->status);


### PR DESCRIPTION
DRILL-5301 and DRILL-5167 have conflicting changes, which causes
the C++ connector to not compile: the static symbol for the search
escape string has been removed as the server might use a different one.

Fix the issue by using the current search escape string (injected from the
meta to the internal drill client when querying metadata).