### PR TITLE
DRILL-5326: Unit tests failures related to the SERVER_METADTA

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -151,6 +151,7 @@ public class Types {
       case LATE:            return "ANY";
       case NULL:            return "NULL";
       case UNION:           return "UNION";
+      case GENERIC_OBJECT:  return "JAVA_OBJECT";
 
       // Internal types not actually used at level of SQL types(?):
 
@@ -198,6 +199,7 @@ public class Types {
       case "TIMESTAMP":                     return java.sql.Types.TIMESTAMP;
       case "TINYINT":                       return java.sql.Types.TINYINT;
       case "UNION":                         return java.sql.Types.OTHER;
+      case "JAVA_OBJECT":                   return java.sql.Types.JAVA_OBJECT;
       default:
         // TODO:  This isn't really an unsupported-operation/-type case; this
         //   is an unexpected, code-out-of-sync-with-itself case, so use an

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/ServerMethod.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/ServerMethod.java
@@ -85,7 +85,7 @@ public enum ServerMethod {
   /**
    * Get server metadata
    */
-  SERVER_META(RpcType.SERVER_META, Constants.DRILL_1_10_0);
+  GET_SERVER_META(RpcType.GET_SERVER_META, Constants.DRILL_1_10_0);
 
   private static class Constants {
     private static final Version DRILL_0_0_0 = new Version("0.0.0", 0, 0, 0, 0, "");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/ServerMetaProvider.java
@@ -76,7 +76,7 @@ public class ServerMetaProvider {
       .setReadOnly(false)
       .setGroupBySupport(GroupBySupport.GB_UNRELATED)
       .setLikeEscapeClauseSupported(true)
-      .setNullCollation(NullCollation.NC_AT_END)
+      .setNullCollation(NullCollation.NC_HIGH)
       .setSchemaTerm("schema")
       .setSearchEscapeString("\\")
       .setTableTerm("table")

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillDatabaseMetaDataImpl.java
@@ -138,7 +138,7 @@ class DrillDatabaseMetaDataImpl extends AvaticaDatabaseMetaData
     DrillConnectionImpl connection = (DrillConnectionImpl) getConnection();
     return
         !connection.getConfig().isServerMetadataDisabled()
-        && connection.getClient().getSupportedMethods().contains(ServerMethod.SERVER_META);
+        && connection.getClient().getSupportedMethods().contains(ServerMethod.GET_SERVER_META);
   }
 
   private String getServerName() throws SQLException {


### PR DESCRIPTION
- adding of the sql type name for the "GENERIC_OBJECT";
- changing "NullCollation" in the "ServerMetaProvider" to the correct default value;