### PR TITLE
DRILL-5330: NPE in FunctionImplementationRegistry

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -144,6 +144,7 @@ public interface ExecConstants {
   String UDF_DIRECTORY_STAGING = "drill.exec.udf.directory.staging";
   String UDF_DIRECTORY_REGISTRY = "drill.exec.udf.directory.registry";
   String UDF_DIRECTORY_TMP = "drill.exec.udf.directory.tmp";
+  String UDF_DISABLE_DYNAMIC = "drill.exec.udf.disable_dynamic";
 
   /**
    * Local temporary directory is used as base for temporary storage of Dynamic UDF jars.
@@ -264,7 +265,7 @@ public interface ExecConstants {
       SLICE_TARGET_DEFAULT);
 
   String CAST_TO_NULLABLE_NUMERIC = "drill.exec.functions.cast_empty_string_to_null";
-  OptionValidator CAST_TO_NULLABLE_NUMERIC_OPTION = new BooleanValidator(CAST_TO_NULLABLE_NUMERIC, false);
+  BooleanValidator CAST_TO_NULLABLE_NUMERIC_OPTION = new BooleanValidator(CAST_TO_NULLABLE_NUMERIC, false);
 
   /**
    * HashTable runtime settings

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/store/TransientStoreListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/store/TransientStoreListener.java
@@ -27,6 +27,6 @@ public interface TransientStoreListener {
    *
    * @param event  event details
    */
-  void onChange(TransientStoreEvent event);
+  void onChange(TransientStoreEvent<?> event);
 
 }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -245,6 +245,9 @@ drill.exec: {
   },
   udf: {
     retry-attempts: 5,
+    // Disables (parts of) the dynamic UDF functionality.
+    // Primarily for testing.
+    disable_dynamic: false,
     directory: {
       // Base directory for remote and local udf directories, unique among clusters.
       base: ${drill.exec.zk.root}"/udf",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
@@ -52,7 +52,7 @@ public class ExecTest extends DrillTest {
     GuavaPatcher.patch();
   }
 
-  private static final DrillConfig c = DrillConfig.create();
+  protected static final DrillConfig c = DrillConfig.create();
 
   @After
   public void clear(){

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFunctions.java
@@ -61,11 +61,10 @@ import com.sun.codemodel.JClassAlreadyExistsException;
 import mockit.Injectable;
 
 public class TestSimpleFunctions extends ExecTest {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleFunctions.class);
-  private final DrillConfig c = DrillConfig.create();
 
   @Test
   public void testHashFunctionResolution() throws JClassAlreadyExistsException, IOException {
+    @SuppressWarnings("resource")
     final FunctionImplementationRegistry registry = new FunctionImplementationRegistry(c);
     // test required vs nullable Int input
     resolveHash(c,
@@ -133,7 +132,6 @@ public class TestSimpleFunctions extends ExecTest {
                                     FunctionImplementationRegistry registry) throws JClassAlreadyExistsException, IOException {
     final List<LogicalExpression> args = new ArrayList<>();
     args.add(arg);
-    final String[] registeredNames = { "hash" };
     FunctionCall call = new FunctionCall(
         "hash",
         args,


### PR DESCRIPTION
Fixes:

* DRILL-5330: NPE in
FunctionImplementationRegistry.functionReplacement()
* DRILL-5331:
NPE in FunctionImplementationRegistry.findDrillFunction() if dynamic
UDFs disabled

For DRILL-5331, we leverage an existing session option to determine if
DUDFs are enabled. If not, we skip the DUDF registry check.

For DRILL-5330, we use an existing option validator rather than
accessing the raw option directly.

Then, both options cached on setup rather than repeatedly resolved in
each function lookup.

Also includes a bit of code cleanup in the class in question.

The result is that the code now works when used in a sub-operator unit
test.