### PR TITLE
DRILL-5344: Priority queue copier fails with an empty batch

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierTemplate.java
@@ -57,9 +57,12 @@ public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier
 
     queueSize = 0;
     for (int i = 0; i < size; i++) {
-      vector4.set(i, i, batchGroups.get(i).getNextIndex());
-      siftUp();
-      queueSize++;
+      int index = batchGroups.get(i).getNextIndex();
+      vector4.set(i, i, index);
+      if (index > -1) {
+        siftUp();
+        queueSize++;
+      }
     }
   }
 


### PR DESCRIPTION
DRILL-5344:  External sort priority queue copier fails with an empty
batch

Unit tests showed that the “priority queue copier” does not handle an
empty batch. This has not been an issue because code elsewhere in the
sort specifically works around this issue. This fix resolves the issue
at the source to avoid the need for future work-arounds.