### PR TITLE
DRILL-5349: Fix TestParquetWriter unit tests when synchronous parquet…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
@@ -254,6 +254,9 @@ class PageReader {
           this.parentColumnReader.parentReader.hadoopPath,
           this.parentColumnReader.columnDescriptor.toString(), start, 0, 0, timeToRead);
       timer.reset();
+      if (pageHeader.getType() == PageType.DICTIONARY_PAGE) {
+        readDictionaryPage(pageHeader, parentColumnReader);
+      }
     } while (pageHeader.getType() == PageType.DICTIONARY_PAGE);
 
     int compressedSize = pageHeader.getCompressed_page_size();


### PR DESCRIPTION
… reader is used.

Seems like I removed some lines from the code that I should not have. This PR reinstates them.