### PR TITLE
DRILL-5351: Minimize bounds checking in var len vectors for Parquet

### DIFF
--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -509,7 +509,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
       <#if type.major != "VarLen">
       throw new UnsupportedOperationException();
       <#else>
-      fillEmpties(index);
+      if (index > lastSet + 1) {
+        fillEmpties(index);
+      }
 
       bits.getMutator().setSafe(index, 1);
       values.getMutator().setSafe(index, value, start, length);
@@ -522,7 +524,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
       <#if type.major != "VarLen">
       throw new UnsupportedOperationException();
       <#else>
-      fillEmpties(index);
+      if (index > lastSet + 1) {
+        fillEmpties(index);
+      }
 
       bits.getMutator().setSafe(index, 1);
       values.getMutator().setSafe(index, value, start, length);
@@ -587,7 +591,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
     public void setSafe(int index, int isSet<#list fields as field><#if field.include!true >, ${field.type} ${field.name}Field</#if></#list> ) {
       <#if type.major == "VarLen">
-      fillEmpties(index);
+      if (index > lastSet + 1) {
+        fillEmpties(index);
+      }
       </#if>
 
       bits.getMutator().setSafe(index, isSet);
@@ -600,7 +606,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     public void setSafe(int index, Nullable${minor.class}Holder value) {
 
       <#if type.major == "VarLen">
-      fillEmpties(index);
+      if (index > lastSet + 1) {
+        fillEmpties(index);
+      }
       </#if>
       bits.getMutator().setSafe(index, value.isSet);
       values.getMutator().setSafe(index, value);
@@ -611,7 +619,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     public void setSafe(int index, ${minor.class}Holder value) {
 
       <#if type.major == "VarLen">
-      fillEmpties(index);
+      if (index > lastSet + 1) {
+        fillEmpties(index);
+      }
       </#if>
       bits.getMutator().setSafe(index, 1);
       values.getMutator().setSafe(index, value);
@@ -622,7 +632,9 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     <#if !(type.major == "VarLen" || minor.class == "Decimal28Sparse" || minor.class == "Decimal38Sparse" || minor.class == "Decimal28Dense" || minor.class == "Decimal38Dense" || minor.class == "Interval" || minor.class == "IntervalDay")>
       public void setSafe(int index, ${minor.javaType!type.javaType} value) {
         <#if type.major == "VarLen">
-        fillEmpties(index);
+        if (index > lastSet + 1) {
+          fillEmpties(index);
+        }
         </#if>
         bits.getMutator().setSafe(index, 1);
         values.getMutator().setSafe(index, value);

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -502,11 +502,15 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       assert index >= 0;
 
       final int currentOffset = offsetVector.getAccessor().get(index);
-      while (data.capacity() < currentOffset + bytes.length) {
-        reAlloc();
-      }
       offsetVector.getMutator().setSafe(index + 1, currentOffset + bytes.length);
-      data.setBytes(currentOffset, bytes, 0, bytes.length);
+      try {
+        data.setBytes(currentOffset, bytes, 0, bytes.length);
+      } catch (IndexOutOfBoundsException e) {
+        while (data.capacity() < currentOffset + bytes.length) {
+          reAlloc();
+        }
+        data.setBytes(currentOffset, bytes, 0, bytes.length);
+      }
     }
 
     /**
@@ -528,12 +532,15 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       assert index >= 0;
 
       int currentOffset = offsetVector.getAccessor().get(index);
-
-      while (data.capacity() < currentOffset + length) {
-        reAlloc();
-      }
       offsetVector.getMutator().setSafe(index + 1, currentOffset + length);
-      data.setBytes(currentOffset, bytes, start, length);
+      try {
+        data.setBytes(currentOffset, bytes, start, length);
+      } catch (IndexOutOfBoundsException e) {
+        while (data.capacity() < currentOffset + length) {
+          reAlloc();
+        }
+        data.setBytes(currentOffset, bytes, start, length);
+      }
     }
 
     public void setSafe(int index, byte[] bytes, int start, int length) {
@@ -541,11 +548,15 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
 
       final int currentOffset = offsetVector.getAccessor().get(index);
 
-      while (data.capacity() < currentOffset + length) {
-        reAlloc();
-      }
       offsetVector.getMutator().setSafe(index + 1, currentOffset + length);
-      data.setBytes(currentOffset, bytes, start, length);
+      try {
+        data.setBytes(currentOffset, bytes, start, length);
+      } catch (IndexOutOfBoundsException e) {
+        while (data.capacity() < currentOffset + length) {
+          reAlloc();
+        }
+        data.setBytes(currentOffset, bytes, start, length);
+      }
     }
 
     @Override
@@ -562,12 +573,16 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       final int len = end - start;
       final int outputStart = offsetVector.data.get${(minor.javaType!type.javaType)?cap_first}(index * ${type.width});
 
-      while(data.capacity() < outputStart + len) {
-        reAlloc();
+      offsetVector.getMutator().setSafe( index+1,  outputStart + len);
+      try{
+        buffer.getBytes(start, data, outputStart, len);
+      } catch (IndexOutOfBoundsException e) {
+        while (data.capacity() < outputStart + len) {
+          reAlloc();
+        }
+        buffer.getBytes(start, data, outputStart, len);
       }
 
-      offsetVector.getMutator().setSafe( index+1,  outputStart + len);
-      buffer.getBytes(start, data, outputStart, len);
     }
 
     public void setSafe(int index, Nullable${minor.class}Holder holder){
@@ -579,11 +594,14 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
 
       int outputStart = offsetVector.data.get${(minor.javaType!type.javaType)?cap_first}(index * ${type.width});
 
-      while(data.capacity() < outputStart + len) {
-        reAlloc();
+      try {
+        holder.buffer.getBytes(start, data, outputStart, len);
+      } catch (IndexOutOfBoundsException e) {
+        while (data.capacity() < outputStart + len) {
+          reAlloc();
+        }
+        holder.buffer.getBytes(start, data, outputStart, len);
       }
-
-      holder.buffer.getBytes(start, data, outputStart, len);
       offsetVector.getMutator().setSafe( index+1,  outputStart + len);
     }
 
@@ -593,11 +611,15 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       final int len = end - start;
       final int outputStart = offsetVector.data.get${(minor.javaType!type.javaType)?cap_first}(index * ${type.width});
 
-      while(data.capacity() < outputStart + len) {
-        reAlloc();
-      }
 
-      holder.buffer.getBytes(start, data, outputStart, len);
+      try {
+        holder.buffer.getBytes(start, data, outputStart, len);
+      } catch (IndexOutOfBoundsException e) {
+        while(data.capacity() < outputStart + len) {
+          reAlloc();
+        }
+        holder.buffer.getBytes(start, data, outputStart, len);
+      }
       offsetVector.getMutator().setSafe( index+1,  outputStart + len);
     }
 


### PR DESCRIPTION
reader

Two changes in var len vectors: 
1) Instead of checking to see if we need to realloc for every setSafe call, let the write fail and catch the exception. The exception, though expensive, will happen very rarely.
2) Call fillEmpties only if there are empty values to fill. 
This saves a bunch of CPU on every setSafe call.