### PR TITLE
DRILL-5355: Misc. code cleanup

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
@@ -368,6 +368,7 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
         final MaterializedField outputField;
         if (expr instanceof ValueVectorReadExpression) {
           final TypedFieldId id = ValueVectorReadExpression.class.cast(expr).getFieldId();
+          @SuppressWarnings("resource")
           final ValueVector incomingVector = incoming.getValueAccessorById(id.getIntermediateClass(), id.getFieldIds()).getValueVector();
           // outputField is taken from the incoming schema to avoid the loss of nested fields
           // when the first batch will be empty.
@@ -379,6 +380,7 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
         } else {
           outputField = MaterializedField.create(outputName, expr.getMajorType());
         }
+        @SuppressWarnings("resource")
         final ValueVector vector = TypeHelper.getNewVector(outputField, oContext.getAllocator());
         allocationVectors.add(vector);
         TypedFieldId fid = container.add(vector);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
@@ -105,7 +105,8 @@ public abstract class ProjectorTemplate implements Projector {
                                @Named("incoming") RecordBatch incoming,
                                @Named("outgoing") RecordBatch outgoing)
                        throws SchemaChangeException;
-  public abstract void doEval(@Named("inIndex") int inIndex, @Named("outIndex") int outIndex)
+  public abstract void doEval(@Named("inIndex") int inIndex,
+                              @Named("outIndex") int outIndex)
                        throws SchemaChangeException;
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/PrelVisualizerVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/PrelVisualizerVisitor.java
@@ -30,6 +30,17 @@ import org.apache.drill.exec.planner.physical.WriterPrel;
  * inspection. Insert this into code during development to see
  * the state of the tree at various points of interest during
  * the planning process.
+ * <p>
+ * Use this by inserting lines into our prel transforms to see
+ * what is happening. This is useful if you must understand the transforms,
+ * or change them. For example:
+ * <p>
+ * In file: {@link DefaultSqlHandler#convertToPrel()}:
+ * <pre><code>
+ * PrelVisualizerVisitor.print("Before EER", phyRelNode); // Debug only
+ * phyRelNode = ExcessiveExchangeIdentifier.removeExcessiveEchanges(phyRelNode, targetSliceSize);
+ * PrelVisualizerVisitor.print("After EER", phyRelNode); // Debug only
+ * <code></pre>
  */
 
 public class PrelVisualizerVisitor

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/PrelVisualizerVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/PrelVisualizerVisitor.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical.visitor;
+
+import org.apache.drill.exec.planner.physical.ExchangePrel;
+import org.apache.drill.exec.planner.physical.JoinPrel;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.ProjectPrel;
+import org.apache.drill.exec.planner.physical.ScanPrel;
+import org.apache.drill.exec.planner.physical.ScreenPrel;
+import org.apache.drill.exec.planner.physical.WriterPrel;
+
+/**
+ * Debug-time class that prints a PRel tree to the console for
+ * inspection. Insert this into code during development to see
+ * the state of the tree at various points of interest during
+ * the planning process.
+ */
+
+public class PrelVisualizerVisitor
+    implements PrelVisitor<Void, PrelVisualizerVisitor.VisualizationState, Exception> {
+
+  public static class VisualizationState {
+
+    public static String INDENT = "  ";
+
+    StringBuilder out = new StringBuilder();
+    int level;
+
+    public void startNode(Prel prel) {
+      indent();
+      out.append("{ ");
+      out.append(prel.getClass().getSimpleName());
+      out.append("\n");
+      push();
+    }
+
+    public void endNode() {
+      pop();
+      indent();
+      out.append("}");
+      out.append("\n");
+    }
+
+    private void indent() {
+      for (int i = 0;  i < level;  i++) {
+        out.append(INDENT);
+      }
+    }
+
+    public void push() {
+      level++;
+    }
+
+    public void pop() {
+      level--;
+    }
+
+    public void endFields() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void field(String label, boolean value) {
+      field(label, Boolean.toString(value));
+    }
+
+    private void field(String label, String value) {
+      indent();
+      out.append(label)
+         .append(" = ")
+         .append(value)
+         .append("\n");
+    }
+
+    public void listField(String label,
+        Object[] values) {
+      if (values == null) {
+        field(label, "null");
+        return;
+      }
+      StringBuilder buf = new StringBuilder();
+      buf.append("[");
+      boolean first = true;
+      for (Object obj : values) {
+        if (! first) {
+          buf.append(", ");
+        }
+        first = false;
+        if (obj == null) {
+          buf.append("null");
+        } else {
+          buf.append(obj.toString());
+        }
+      }
+      buf.append("]");
+      field(label, buf.toString());
+    }
+
+    @Override
+    public String toString() {
+      return out.toString();
+    }
+
+  }
+
+  public static void print(String label, Prel prel) {
+    System.out.println(label);
+    System.out.println(visualize(prel));
+  }
+
+  public static String visualize(Prel prel) {
+    try {
+      VisualizationState state = new VisualizationState();
+      prel.accept(new PrelVisualizerVisitor(), state);
+      return state.toString();
+    } catch (Exception e) {
+      e.printStackTrace();
+      return "** ERROR **";
+    }
+  }
+
+  @Override
+  public Void visitExchange(ExchangePrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  private void visitBasePrel(Prel prel, VisualizationState value) {
+    value.startNode(prel);
+    value.listField("encodings", prel.getSupportedEncodings());
+    value.field("needsReorder", prel.needsFinalColumnReordering());
+  }
+
+  private void endNode(Prel prel, VisualizationState value) throws Exception {
+    value.endFields();
+    visitChildren(prel, value);
+    value.endNode();
+  }
+
+  private void visitChildren(Prel prel, VisualizationState value) throws Exception {
+    value.indent();
+    value.out.append("children = [\n");
+    value.push();
+    for (Prel child : prel) {
+      child.accept(this, value);
+    }
+    value.pop();
+    value.indent();
+    value.out.append("]\n");
+  }
+
+  @Override
+  public Void visitScreen(ScreenPrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  @Override
+  public Void visitWriter(WriterPrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  @Override
+  public Void visitScan(ScanPrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  @Override
+  public Void visitJoin(JoinPrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  @Override
+  public Void visitProject(ProjectPrel prel, VisualizationState value)
+      throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+  @Override
+  public Void visitPrel(Prel prel, VisualizationState value) throws Exception {
+    visitBasePrel(prel, value);
+    endNode(prel, value);
+    return null;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/ControllerImpl.java
@@ -87,6 +87,7 @@ public class ControllerImpl implements Controller {
   }
 
 
+  @Override
   public void close() throws Exception {
     List<AutoCloseable> closeables = Lists.newArrayList();
     closeables.add(server);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -47,7 +47,12 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 public class BootStrapContext implements AutoCloseable {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BootStrapContext.class);
-  private static final int MIN_SCAN_THREADPOOL_SIZE = 8; // Magic num
+  // Tests and embedded servers need a small footprint, so the minimum
+  // scan count is small. The actual value is set by the
+  // ExecConstants.SCAN_THREADPOOL_SIZE. If the number below
+  // is large, then tests cannot shrink the number using the
+  // config property.
+  private static final int MIN_SCAN_THREADPOOL_SIZE = 4; // Magic num
 
   // DRILL_HOST_NAME sets custom host name. See drill-env.sh for details.
   private static final String customHostName = System.getenv("DRILL_HOST_NAME");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -53,8 +53,7 @@ import com.google.common.collect.Maps;
  * Tables are file names, directories and path patterns. This storage engine delegates to FSFormatEngines but shares
  * references to the FileSystem configuration and path management.
  */
-public class FileSystemPlugin extends AbstractStoragePlugin{
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FileSystemPlugin.class);
+public class FileSystemPlugin extends AbstractStoragePlugin {
 
   private final FileSystemSchemaFactory schemaFactory;
   private final FormatCreator formatCreator;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/MagicString.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/MagicString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,8 +18,6 @@
 package org.apache.drill.exec.store.dfs;
 
 public class MagicString {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MagicString.class);
-
   private long offset;
   private byte[] bytes;
 
@@ -36,7 +34,4 @@ public class MagicString {
   public byte[] getBytes() {
     return bytes;
   }
-
-
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -126,6 +126,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   public abstract RecordReader getRecordReader(FragmentContext context, DrillFileSystem dfs, FileWork fileWork,
       List<SchemaPath> columns, String userName) throws ExecutionSetupException;
 
+  @SuppressWarnings("resource")
   CloseableRecordBatch getReaderBatch(FragmentContext context, EasySubScan scan) throws ExecutionSetupException {
     final ImplicitColumnExplorer columnExplorer = new ImplicitColumnExplorer(context, scan.getColumns());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -133,8 +133,6 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
       }
       return true;
     }
-
-
   }
 
   @Override
@@ -151,5 +149,4 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
   public boolean supportsPushDown() {
     return true;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -149,6 +149,7 @@ public class JSONRecordReader extends AbstractRecordReader {
     }
   }
 
+  @Override
   protected List<SchemaPath> getDefaultColumnsToRead() {
     return ImmutableList.of();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/CompliantTextRecordReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/RepeatedVarCharOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/RepeatedVarCharOutput.java
@@ -172,6 +172,7 @@ class RepeatedVarCharOutput extends TextOutput {
    * Start a new record batch. Resets all the offsets and pointers that
    * store buffer addresses
    */
+  @Override
   public void startBatch() {
     this.recordStart = characterDataOriginal;
     this.fieldOpen = false;
@@ -185,6 +186,7 @@ class RepeatedVarCharOutput extends TextOutput {
   }
 
   private void loadRepeatedOffsetAddress(){
+    @SuppressWarnings("resource")
     DrillBuf buf = vector.getOffsetVector().getBuffer();
     checkBuf(buf);
     this.repeatedOffset = buf.memoryAddress() + 4;
@@ -193,6 +195,7 @@ class RepeatedVarCharOutput extends TextOutput {
   }
 
   private void loadVarCharDataAddress(){
+    @SuppressWarnings("resource")
     DrillBuf buf = vector.getDataVector().getBuffer();
     checkBuf(buf);
     this.characterData = buf.memoryAddress();
@@ -201,6 +204,7 @@ class RepeatedVarCharOutput extends TextOutput {
   }
 
   private void loadVarCharOffsetAddress(){
+    @SuppressWarnings("resource")
     DrillBuf buf = vector.getDataVector().getOffsetVector().getBuffer();
     checkBuf(buf);
     this.charLengthOffset = buf.memoryAddress() + 4;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -89,6 +89,9 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   public static Path getLogDir() {
     String drillLogDir = System.getenv("DRILL_LOG_DIR");
     if (drillLogDir == null) {
+      drillLogDir = System.getProperty("drill.log.dir");
+    }
+    if (drillLogDir == null) {
       drillLogDir = "/var/log/drill";
     }
     return new Path(new File(drillLogDir).getAbsoluteFile().toURI());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/TestUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/TestUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/fn/JsonReader.java
@@ -101,6 +101,7 @@ public class JsonReader extends BaseJsonProcessor {
     this.readNumbersAsDouble = readNumbersAsDouble;
   }
 
+  @SuppressWarnings("resource")
   @Override
   public void ensureAtLeastOneField(ComplexWriter writer) {
     List<BaseWriter.MapWriter> writerList = Lists.newArrayList();
@@ -192,6 +193,7 @@ public class JsonReader extends BaseJsonProcessor {
     setSource(data.getBytes(Charsets.UTF_8));
   }
 
+  @SuppressWarnings("resource")
   public void setSource(byte[] bytes) throws IOException {
     setSource(new SeekableBAIS(bytes));
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/impl/VectorContainerWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/complex/impl/VectorContainerWriter.java
@@ -101,6 +101,7 @@ public class VectorContainerWriter extends AbstractFieldWriter implements Comple
       super("", null, callback);
     }
 
+    @SuppressWarnings("resource")
     @Override
     public <T extends ValueVector> T addOrGet(String name, MajorType type, Class<T> clazz) {
       try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
@@ -179,6 +179,7 @@ public class FragmentExecutor implements Runnable {
     eventProcessor.receiverFinished(handle);
   }
 
+  @SuppressWarnings("resource")
   @Override
   public void run() {
     // if a cancel thread has already entered this executor, we have not reason to continue.
@@ -224,6 +225,7 @@ public class FragmentExecutor implements Runnable {
           ImpersonationUtil.getProcessUserUGI();
 
       queryUserUgi.doAs(new PrivilegedExceptionAction<Void>() {
+        @Override
         public Void run() throws Exception {
           injector.injectChecked(fragmentContext.getExecutionControls(), "fragment-execution", IOException.class);
           /*

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -82,6 +82,7 @@ public class PlanningBase extends ExecTest{
     final LogicalPlanPersistence logicalPlanPersistence = new LogicalPlanPersistence(config, scanResult);
     final SystemOptionManager systemOptions = new SystemOptionManager(logicalPlanPersistence , provider);
     systemOptions.init();
+    @SuppressWarnings("resource")
     final UserSession userSession = UserSession.Builder.newBuilder().withOptionManager(systemOptions).build();
     final SessionOptionManager sessionOptions = (SessionOptionManager) userSession.getOptions();
     final QueryOptionManager queryOptions = new QueryOptionManager(sessionOptions);
@@ -150,6 +151,7 @@ public class PlanningBase extends ExecTest{
       if (sql.trim().isEmpty()) {
         continue;
       }
+      @SuppressWarnings("unused")
       final PhysicalPlan p = DrillSqlWorker.getPlan(context, sql);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
@@ -186,6 +186,7 @@ public class DrillSeparatePlanningTest extends BaseTestQuery {
     //AwaitableUserResultsListener listener =
     //    new AwaitableUserResultsListener(new SilentListener());
     client.runQuery(QueryType.SQL, query, listener);
+    @SuppressWarnings("unused")
     int rows = listener.await();
   }
 
@@ -211,6 +212,7 @@ public class DrillSeparatePlanningTest extends BaseTestQuery {
   private void getResultsHelper(final QueryPlanFragments planFragments) throws Exception {
     for (PlanFragment fragment : planFragments.getFragmentsList()) {
       DrillbitEndpoint assignedNode = fragment.getAssignment();
+      @SuppressWarnings("resource")
       DrillClient fragmentClient = new DrillClient(true);
       Properties props = new Properties();
       props.setProperty("drillbit", assignedNode.getAddress() + ":" + assignedNode.getUserPort());
@@ -250,6 +252,7 @@ public class DrillSeparatePlanningTest extends BaseTestQuery {
       AwaitableUserResultsListener listener =
           new AwaitableUserResultsListener(new SilentListener());
       fragmentClient.runQuery(QueryType.EXECUTION, fragmentList, listener);
+      @SuppressWarnings("unused")
       int rows = listener.await();
       fragmentClient.close();
     }
@@ -257,6 +260,7 @@ public class DrillSeparatePlanningTest extends BaseTestQuery {
 
   private void getCombinedResultsHelper(final QueryPlanFragments planFragments) throws Exception {
       ShowResultsUserResultsListener myListener = new ShowResultsUserResultsListener(getAllocator());
+      @SuppressWarnings("unused")
       AwaitableUserResultsListener listenerBits =
           new AwaitableUserResultsListener(myListener);
 
@@ -265,6 +269,7 @@ public class DrillSeparatePlanningTest extends BaseTestQuery {
       AwaitableUserResultsListener listener =
           new AwaitableUserResultsListener(new SilentListener());
       client.runQuery(QueryType.EXECUTION, planFragments.getFragmentsList(), listener);
+      @SuppressWarnings("unused")
       int rows = listener.await();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
@@ -17,13 +17,13 @@
  */
 package org.apache.drill.exec.physical.unit;
 
-import com.google.common.collect.Lists;
+import static org.apache.drill.TestBuilder.mapOf;
+
+import java.util.List;
+
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.drill.exec.physical.MinorFragmentEndpoint;
-import org.apache.drill.exec.physical.base.GroupScan;
-import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.physical.config.ComplexToJson;
 import org.apache.drill.exec.physical.config.ExternalSort;
 import org.apache.drill.exec.physical.config.Filter;
@@ -37,12 +37,7 @@ import org.apache.drill.exec.physical.config.TopN;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.lang.reflect.Constructor;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Set;
-
-import static org.apache.drill.TestBuilder.mapOf;
+import com.google.common.collect.Lists;
 
 public class BasicPhysicalOpUnitTest extends PhysicalOpUnitTestBase {
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -95,6 +95,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
 
   private static boolean kdcStarted;
 
+  @SuppressWarnings("restriction")
   @BeforeClass
   public static void setupKdc() throws Exception {
     kdc = new SimpleKdcServer();
@@ -159,6 +160,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
   }
 
   private static int getFreePort() throws IOException {
+    @SuppressWarnings("resource")
     ServerSocket s = null;
     try {
       s = new ServerSocket(0);
@@ -209,10 +211,13 @@ public class TestBitBitKerberos extends BaseTestQuery {
   public void success(@Injectable WorkerBee bee, @Injectable final WorkEventBus workBus) throws Exception {
 
     ScanResult result = ClassPathScanner.fromPrescan(newConfig);
+    @SuppressWarnings("resource")
     final BootStrapContext c1 = new BootStrapContext(newConfig, result);
+    @SuppressWarnings({ "unused", "resource" })
     final BootStrapContext c2 = new BootStrapContext(newConfig, result);
 
     final FragmentContext fcontext = new MockUp<FragmentContext>(){
+      @SuppressWarnings("unused")
       BufferAllocator getAllocator(){
         return c1.getAllocator();
       }
@@ -239,6 +244,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
         return true;
       }
 
+      @SuppressWarnings("unused")
       public FragmentContext getFragmentContext(){
         return fcontext;
       }
@@ -255,10 +261,12 @@ public class TestBitBitKerberos extends BaseTestQuery {
 
     DataConnectionConfig config = new DataConnectionConfig(c1.getAllocator(), c1,
         new DataServerRequestHandler(workBus, bee));
+    @SuppressWarnings("resource")
     DataServer server = new DataServer(config);
 
     port = server.bind(port, true);
     DrillbitEndpoint ep = DrillbitEndpoint.newBuilder().setAddress("localhost").setDataPort(port).build();
+    @SuppressWarnings("resource")
     DataConnectionManager connectionManager = new DataConnectionManager(ep, config);
     DataTunnel tunnel = new DataTunnel(connectionManager);
     AtomicLong max = new AtomicLong(0);
@@ -277,6 +285,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
   private static WritableBatch getRandomBatch(BufferAllocator allocator, int records) {
     List<ValueVector> vectors = Lists.newArrayList();
     for (int i = 0; i < 5; i++) {
+      @SuppressWarnings("resource")
       Float8Vector v = (Float8Vector) TypeHelper.getNewVector(
           MaterializedField.create("a", Types.required(MinorType.FLOAT8)),
           allocator);

--- a/logical/src/main/java/org/apache/drill/common/expression/FieldReference.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FieldReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -68,6 +68,15 @@ public class FieldReference extends SchemaPath {
     checkSimpleString(value);
   }
 
+  /**
+   * Create a {@link FieldReference} given an unquoted name. (Note: the
+   * name here is a misnomer: the name may have been quoted in SQL, but
+   * must be unquoted when passed in here.)
+   *
+   * @param safeString the unquoted field reference
+   * @return the field reference expression
+   */
+
   public static FieldReference getWithQuotedRef(CharSequence safeString) {
     return new FieldReference(safeString, ExpressionPosition.UNKNOWN, false);
   }
@@ -100,6 +109,7 @@ public class FieldReference extends SchemaPath {
     }
   }
 
+  @SuppressWarnings("serial")
   public static class De extends StdDeserializer<FieldReference> {
 
     public De() {
@@ -116,6 +126,7 @@ public class FieldReference extends SchemaPath {
 
   }
 
+  @SuppressWarnings("serial")
   public static class Se extends StdSerializer<FieldReference> {
 
     public Se() {

--- a/logical/src/main/java/org/apache/drill/common/expression/LogicalExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/LogicalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -55,6 +55,7 @@ public interface LogicalExpression extends Iterable<LogicalExpression>{
   public int getSelfCost();
   public int getCumulativeCost();
 
+  @SuppressWarnings("serial")
   public static class De extends StdDeserializer<LogicalExpression> {
     DrillConfig config;
 
@@ -90,6 +91,7 @@ public interface LogicalExpression extends Iterable<LogicalExpression>{
 
   }
 
+  @SuppressWarnings("serial")
   public static class Se extends StdSerializer<LogicalExpression> {
 
     protected Se() {


### PR DESCRIPTION
Recent work in Drill has identified a number of cases where code can be
cleaned up: adding missing annotations, etc. These changes don't fit as part of a separate ticket and so are rolled up into a this "general
hygiene" PR.