### PR TITLE
DRILL-5319: Refactor "contexts" for unit testing

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassBuilder.java
@@ -27,11 +27,8 @@ import org.apache.drill.common.util.DrillStringUtils;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
 import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.expr.CodeGenerator;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.codehaus.commons.compiler.CompileException;
-import org.objectweb.asm.tree.ClassNode;
-
-import com.google.common.collect.Maps;
 
 /**
  * Implements the "plain Java" method of code generation and
@@ -86,15 +83,15 @@ public class ClassBuilder {
   public static final String CODE_DIR_OPTION = CodeCompiler.COMPILE_BASE + ".code_dir";
 
   private final DrillConfig config;
-  private final OptionManager options;
+  private final OptionSet options;
   private final File codeDir;
 
-  public ClassBuilder(DrillConfig config, OptionManager optionManager) {
+  public ClassBuilder(DrillConfig config, OptionSet optionManager) {
     this.config = config;
     options = optionManager;
 
     // Code can be saved per-class to enable debugging.
-    // Just mark the code generator as to be persisted,
+    // Just request the code generator to persist code,
     // point your debugger to the directory set below, and you
     // can step into the code for debugging. Code is not saved
     // be default because doing so is expensive and unnecessary.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
@@ -25,7 +25,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
 import org.apache.drill.exec.exception.ClassTransformationException;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.OptionValidator;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.TypeValidators.BooleanValidator;
@@ -82,7 +82,7 @@ public class ClassCompilerSelector {
 
   public static final StringValidator JAVA_COMPILER_VALIDATOR = new StringValidator(JAVA_COMPILER_OPTION, CompilerPolicy.DEFAULT.toString()) {
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       try {
         CompilerPolicy.valueOf(v.string_val.toUpperCase());
@@ -101,7 +101,7 @@ public class ClassCompilerSelector {
   private final AbstractClassCompiler jdkClassCompiler;
   private final AbstractClassCompiler janinoClassCompiler;
 
-  public ClassCompilerSelector(ClassLoader classLoader, DrillConfig config, OptionManager sessionOptions) {
+  public ClassCompilerSelector(ClassLoader classLoader, DrillConfig config, OptionSet sessionOptions) {
     OptionValue value = sessionOptions.getOption(JAVA_COMPILER_OPTION);
     policy = CompilerPolicy.valueOf((value != null) ? value.string_val.toUpperCase() : config.getString(JAVA_COMPILER_CONFIG).toUpperCase());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassTransformer.java
@@ -28,7 +28,7 @@ import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.compile.MergeAdapter.MergedClassResult;
 import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.expr.CodeGenerator;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.TypeValidators.EnumeratedStringValidator;
 import org.codehaus.commons.compiler.CompileException;
 import org.objectweb.asm.ClassReader;
@@ -55,7 +55,7 @@ public class ClassTransformer {
 
   private final ByteCodeLoader byteCodeLoader = new ByteCodeLoader();
   private final DrillConfig config;
-  private final OptionManager optionManager;
+  private final OptionSet optionManager;
 
   public final static String SCALAR_REPLACEMENT_OPTION =
       "org.apache.drill.exec.compile.ClassTransformer.scalar_replacement";
@@ -89,7 +89,7 @@ public class ClassTransformer {
     }
   }
 
-  public ClassTransformer(final DrillConfig config, final OptionManager optionManager) {
+  public ClassTransformer(final DrillConfig config, final OptionSet optionManager) {
     this.config = config;
     this.optionManager = optionManager;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/CodeCompiler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/CodeCompiler.java
@@ -23,6 +23,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -51,7 +52,7 @@ public class CodeCompiler {
     private final ClassTransformer transformer;
     private final ClassBuilder classBuilder;
 
-    public CodeGenCompiler(final DrillConfig config, final OptionManager optionManager) {
+    public CodeGenCompiler(final DrillConfig config, final OptionSet optionManager) {
       transformer = new ClassTransformer(config, optionManager);
       classBuilder = new ClassBuilder(config, optionManager);
     }
@@ -134,7 +135,7 @@ public class CodeCompiler {
   private final LoadingCache<CodeGenerator<?>, GeneratedClassEntry> cache;
   private final boolean preferPlainJava;
 
-  public CodeCompiler(final DrillConfig config, final OptionManager optionManager) {
+  public CodeCompiler(final DrillConfig config, final OptionSet optionManager) {
     codeGenCompiler = new CodeGenCompiler(config, optionManager);
     useCache = ! config.getBoolean(DISABLE_CACHE_CONFIG);
     cache = CacheBuilder.newBuilder()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/QueryClassLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/QueryClassLoader.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
 import org.apache.drill.exec.exception.ClassTransformationException;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.codehaus.commons.compiler.CompileException;
 
 import com.google.common.collect.MapMaker;
@@ -44,7 +44,7 @@ public class QueryClassLoader extends URLClassLoader {
 
   private ConcurrentMap<String, byte[]> customClasses = new MapMaker().concurrencyLevel(4).makeMap();
 
-  public QueryClassLoader(DrillConfig config, OptionManager sessionOptions) {
+  public QueryClassLoader(DrillConfig config, OptionSet sessionOptions) {
     super(new URL[0], Thread.currentThread().getContextClassLoader());
     compilerSelector = new ClassCompilerSelector(this, config, sessionOptions);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
@@ -58,7 +58,7 @@ import com.sun.codemodel.JMod;
 import com.sun.codemodel.JTryBlock;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.JVar;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 
 public class ClassGenerator<T>{
 
@@ -79,7 +79,7 @@ public class ClassGenerator<T>{
   public final JDefinedClass clazz;
   private final LinkedList<SizedJBlock>[] blocks;
   private final JCodeModel model;
-  private final OptionManager optionManager;
+  private final OptionSet optionManager;
 
   private int index = 0;
   private int labelIndex = 0;
@@ -92,7 +92,7 @@ public class ClassGenerator<T>{
   @SuppressWarnings("unchecked")
   ClassGenerator(CodeGenerator<T> codeGenerator, MappingSet mappingSet, SignatureHolder signature,
                  EvaluationVisitor eval, JDefinedClass clazz, JCodeModel model,
-                 OptionManager optionManager) throws JClassAlreadyExistsException {
+                 OptionSet optionManager) throws JClassAlreadyExistsException {
     this.codeGenerator = codeGenerator;
     this.clazz = clazz;
     this.mappings = mappingSet;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
@@ -23,7 +23,7 @@ import org.apache.drill.exec.compile.ClassBuilder;
 import org.apache.drill.exec.compile.TemplateClassDefinition;
 import org.apache.drill.exec.compile.sig.MappingSet;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 
 import com.google.common.base.Preconditions;
 import com.sun.codemodel.JClassAlreadyExistsException;
@@ -90,12 +90,12 @@ public class CodeGenerator<T> {
   private String generatedCode;
   private String generifiedCode;
 
-  CodeGenerator(TemplateClassDefinition<T> definition, FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+  CodeGenerator(TemplateClassDefinition<T> definition, FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     this(ClassGenerator.getDefaultMapping(), definition, funcRegistry, optionManager);
   }
 
   CodeGenerator(MappingSet mappingSet, TemplateClassDefinition<T> definition,
-     FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+     FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     Preconditions.checkNotNull(definition.getSignature(),
         "The signature for defintion %s was incorrectly initialized.", definition);
     this.definition = definition;
@@ -224,22 +224,22 @@ public class CodeGenerator<T> {
   }
 
   public static <T> CodeGenerator<T> get(TemplateClassDefinition<T> definition,
-      FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+      FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     return new CodeGenerator<T>(definition, funcRegistry, optionManager);
   }
 
   public static <T> ClassGenerator<T> getRoot(TemplateClassDefinition<T> definition,
-      FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+      FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     return get(definition, funcRegistry, optionManager).getRoot();
   }
 
   public static <T> ClassGenerator<T> getRoot(MappingSet mappingSet, TemplateClassDefinition<T> definition,
-      FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+      FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     return get(mappingSet, definition, funcRegistry, optionManager).getRoot();
   }
 
   public static <T> CodeGenerator<T> get(MappingSet mappingSet, TemplateClassDefinition<T> definition,
-      FunctionImplementationRegistry funcRegistry, OptionManager optionManager) {
+      FunctionImplementationRegistry funcRegistry, OptionSet optionManager) {
     return new CodeGenerator<T>(mappingSet, definition, funcRegistry, optionManager);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -60,6 +60,7 @@ import org.apache.drill.exec.proto.UserBitShared.Jar;
 import org.apache.drill.exec.resolver.FunctionResolver;
 import org.apache.drill.exec.resolver.FunctionResolverFactory;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -83,12 +84,12 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
   private boolean deleteTmpDir = false;
   private File tmpDir;
   private List<PluggableFunctionRegistry> pluggableFuncRegistries = Lists.newArrayList();
-  private final OptionManager optionManager;
+  private OptionSet optionManager;
   private final boolean useDynamicUdfs;
 
   @VisibleForTesting
-  public FunctionImplementationRegistry(DrillConfig config) {
-    this(config, ClassPathScanner.fromPrescan(config), null);
+  public FunctionImplementationRegistry(DrillConfig config){
+    this(config, ClassPathScanner.fromPrescan(config));
   }
 
   public FunctionImplementationRegistry(DrillConfig config, ScanResult classpathScan) {
@@ -134,6 +135,11 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
     logger.info("Function registry loaded.  {} functions loaded in {} ms.", localFunctionRegistry.size(), w.elapsed(TimeUnit.MILLISECONDS));
     this.remoteFunctionRegistry = new RemoteFunctionRegistry(new UnregistrationListener());
     this.localUdfDir = getLocalUdfDir(config);
+  }
+
+  public FunctionImplementationRegistry(DrillConfig config, ScanResult classpathScan, OptionSet optionManager) {
+    this(config, classpathScan);
+    this.optionManager = optionManager;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentExecContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentExecContext.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.expr.ClassGenerator;
+import org.apache.drill.exec.expr.CodeGenerator;
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.server.options.OptionSet;
+import org.apache.drill.exec.testing.ExecutionControls;
+
+/**
+ * Services passed to fragments that deal only with execution details
+ * such as the function registry, options, code generation and the like.
+ * Does not include top-level services such as network endpoints. Code
+ * written to use this interface can be unit tested quite easily using
+ * the {@link OperatorContext} class. Code that uses the wider,
+ * more global {@link FragmentContext} must be tested in the context
+ * of the entire Drill server, or using mocks for the global services.
+ */
+
+public interface FragmentExecContext {
+  /**
+   * Returns the UDF registry.
+   * @return the UDF registry
+   */
+  FunctionImplementationRegistry getFunctionRegistry();
+  /**
+   * Returns a read-only version of the session options.
+   * @return the session options
+   */
+  OptionSet getOptionSet();
+
+  /**
+   * Generates code for a class given a {@link ClassGenerator},
+   * and returns a single instance of the generated class. (Note
+   * that the name is a misnomer, it would be better called
+   * <tt>getImplementationInstance</tt>.)
+   *
+   * @param cg the class generator
+   * @return an instance of the generated class
+   */
+
+  <T> T getImplementationClass(final ClassGenerator<T> cg)
+      throws ClassTransformationException, IOException;
+
+  /**
+   * Generates code for a class given a {@link CodeGenerator},
+   * and returns a single instance of the generated class. (Note
+   * that the name is a misnomer, it would be better called
+   * <tt>getImplementationInstance</tt>.)
+   *
+   * @param cg the code generator
+   * @return an instance of the generated class
+   */
+
+  <T> T getImplementationClass(final CodeGenerator<T> cg)
+      throws ClassTransformationException, IOException;
+
+  /**
+   * Generates code for a class given a {@link ClassGenerator}, and returns the
+   * specified number of instances of the generated class. (Note that the name
+   * is a misnomer, it would be better called
+   * <tt>getImplementationInstances</tt>.)
+   *
+   * @param cg
+   *          the class generator
+   * @return list of instances of the generated class
+   */
+
+  <T> List<T> getImplementationClass(final ClassGenerator<T> cg, final int instanceCount)
+      throws ClassTransformationException, IOException;
+
+  /**
+   * Generates code for a class given a {@link CodeGenerator}, and returns the
+   * specified number of instances of the generated class. (Note that the name
+   * is a misnomer, it would be better called
+   * <tt>getImplementationInstances</tt>.)
+   *
+   * @param cg
+   *          the code generator
+   * @return list of instances of the generated class
+   */
+
+  <T> List<T> getImplementationClass(final CodeGenerator<T> cg, final int instanceCount)
+      throws ClassTransformationException, IOException;
+
+  /**
+   * Determine if fragment execution has been interrupted.
+   * @return true if execution should continue, false if an interruption has
+   * occurred and fragment execution should halt
+   */
+
+  boolean shouldContinue();
+
+  /**
+   * Return the set of execution controls used to inject faults into running
+   * code for testing.
+   *
+   * @return the execution controls
+   */
+  ExecutionControls getExecutionControls();
+
+  /**
+   * Returns the Drill configuration for this run. Note that the config is
+   * global and immutable.
+   *
+   * @return the Drill configuration
+   */
+
+  DrillConfig getConfig();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperExecContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperExecContext.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.testing.ControlsInjector;
+
+/**
+ * Defines the set of services used by operator implementations. This
+ * is a subset of the full {@link OperatorContext} which removes global
+ * services such as network endpoints. Code written to this interface
+ * can be easily unit tested using the {@link OperatorFixture} class.
+ * Code that needs global services must be tested in the Drill server
+ * as a whole, or using mocks for global services.
+ */
+
+public interface OperExecContext extends FragmentExecContext {
+
+  /**
+   * Return the physical operator definition created by the planner and passed
+   * into the Drillbit executing the query.
+   * @return the physical operator definition
+   */
+
+  <T extends PhysicalOperator> T getOperatorDefn();
+
+  /**
+   * Return the memory allocator for this operator.
+   *
+   * @return the per-operator memory allocator
+   */
+
+  BufferAllocator getAllocator();
+
+  /**
+   * A write-only interface to the Drill statistics mechanism. Allows
+   * operators to update statistics.
+   * @return operator statistics
+   */
+
+  OperatorStatReceiver getStats();
+
+  /**
+   * Returns the fault injection mechanism used to introduce faults at runtime
+   * for testing.
+   * @return the fault injector
+   */
+
+  ControlsInjector getInjector();
+
+  /**
+   * Insert an unchecked fault (exception). Handles the details of checking if
+   * fault injection is enabled and this particular fault is selected.
+   * @param desc the description of the fault used to match a fault
+   * injection parameter to determine if the fault should be injected
+   * @throws RuntimeException an unchecked exception if the fault is enabled
+   */
+
+  void injectUnchecked(String desc);
+
+  /**
+   * Insert a checked fault (exception) of the given class. Handles the details
+   * of checking if fault injection is enabled and this particular fault is
+   * selected.
+   *
+   * @param desc the description of the fault used to match a fault
+   * injection parameter to determine if the fault should be injected
+   * @param exceptionClass the class of exeception to be thrown
+   * @throws T if the fault is enabled
+   */
+
+  <T extends Throwable> void injectChecked(String desc, Class<T> exceptionClass)
+      throws T;
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperExecContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperExecContextImpl.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.expr.ClassGenerator;
+import org.apache.drill.exec.expr.CodeGenerator;
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.server.options.OptionSet;
+import org.apache.drill.exec.testing.ControlsInjector;
+import org.apache.drill.exec.testing.ExecutionControls;
+
+/**
+ * Implementation of the context used by low-level operator
+ * tasks.
+ */
+
+public class OperExecContextImpl implements OperExecContext {
+
+  private FragmentExecContext fragmentContext;
+  private PhysicalOperator operDefn;
+  private ControlsInjector injector;
+  private BufferAllocator allocator;
+  private OperatorStatReceiver stats;
+
+  public OperExecContextImpl(FragmentExecContext fragContext, OperatorContext opContext, PhysicalOperator opDefn, ControlsInjector injector) {
+    this(fragContext, opContext.getAllocator(), opContext.getStats(), opDefn, injector);
+  }
+
+  public OperExecContextImpl(FragmentExecContext fragContext, BufferAllocator allocator, OperatorStatReceiver stats, PhysicalOperator opDefn, ControlsInjector injector) {
+    this.fragmentContext = fragContext;
+    this.operDefn = opDefn;
+    this.injector = injector;
+    this.allocator = allocator;
+    this.stats = stats;
+  }
+
+  @Override
+  public FunctionImplementationRegistry getFunctionRegistry() {
+    return fragmentContext.getFunctionRegistry();
+  }
+
+  @Override
+  public OptionSet getOptionSet() {
+    return fragmentContext.getOptionSet();
+  }
+
+  @Override
+  public <T> T getImplementationClass(ClassGenerator<T> cg)
+      throws ClassTransformationException, IOException {
+    return fragmentContext.getImplementationClass(cg);
+  }
+
+  @Override
+  public <T> T getImplementationClass(CodeGenerator<T> cg)
+      throws ClassTransformationException, IOException {
+    return fragmentContext.getImplementationClass(cg);
+  }
+
+  @Override
+  public <T> List<T> getImplementationClass(ClassGenerator<T> cg,
+      int instanceCount) throws ClassTransformationException, IOException {
+    return fragmentContext.getImplementationClass(cg, instanceCount);
+  }
+
+  @Override
+  public <T> List<T> getImplementationClass(CodeGenerator<T> cg,
+      int instanceCount) throws ClassTransformationException, IOException {
+    return fragmentContext.getImplementationClass(cg, instanceCount);
+  }
+
+  @Override
+  public boolean shouldContinue() {
+    return fragmentContext.shouldContinue();
+  }
+
+  @Override
+  public ExecutionControls getExecutionControls() {
+    return fragmentContext.getExecutionControls();
+  }
+
+  @Override
+  public BufferAllocator getAllocator() {
+    return allocator;
+  }
+
+  @Override
+  public OperatorStatReceiver getStats() {
+    return stats;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T extends PhysicalOperator> T getOperatorDefn() {
+    return (T) operDefn;
+  }
+
+  @Override
+  public DrillConfig getConfig() {
+    return fragmentContext.getConfig();
+  }
+
+  @Override
+  public ControlsInjector getInjector() {
+    return injector;
+  }
+
+  @Override
+  public void injectUnchecked(String desc) {
+    ExecutionControls executionControls = fragmentContext.getExecutionControls();
+    if (injector != null  &&  executionControls != null) {
+      injector.injectUnchecked(executionControls, desc);
+    }
+  }
+
+  @Override
+  public <T extends Throwable> void injectChecked(String desc, Class<T> exceptionClass)
+      throws T {
+    ExecutionControls executionControls = fragmentContext.getExecutionControls();
+    if (injector != null  &&  executionControls != null) {
+      injector.injectChecked(executionControls, desc, exceptionClass);
+    }
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStatReceiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStatReceiver.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+/**
+ * Interface for updating a statistic. Provides just the methods
+ * to add to or update a statistic, hiding implementation. Allows
+ * a test-time implementation that differs from the run-time
+ * version.
+ */
+
+public interface OperatorStatReceiver {
+
+  /**
+   * Add a long value to the existing value. Creates the stat
+   * (with an initial value of zero) if the stat does not yet
+   * exist.
+   *
+   * @param metric the metric to update
+   * @param value the value to add to the existing value
+   */
+
+  void addLongStat(MetricDef metric, long value);
+
+  /**
+   * Add a double value to the existing value. Creates the stat
+   * (with an initial value of zero) if the stat does not yet
+   * exist.
+   *
+   * @param metric the metric to update
+   * @param value the value to add to the existing value
+   */
+
+  void addDoubleStat(MetricDef metric, double value);
+
+  /**
+   * Set a stat to the specified long value. Creates the stat
+   * if the stat does not yet exist.
+   *
+   * @param metric the metric to update
+   * @param value the value to set
+   */
+
+  void setLongStat(MetricDef metric, long value);
+
+  /**
+   * Set a stat to the specified double value. Creates the stat
+   * if the stat does not yet exist.
+   *
+   * @param metric the metric to update
+   * @param value the value to set
+   */
+
+  void setDoubleStat(MetricDef metric, double value);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -33,7 +33,7 @@ import com.carrotsearch.hppc.cursors.IntLongCursor;
 import com.carrotsearch.hppc.procedures.IntDoubleProcedure;
 import com.carrotsearch.hppc.procedures.IntLongProcedure;
 
-public class OperatorStats {
+public class OperatorStats implements OperatorStatReceiver {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OperatorStats.class);
 
   protected final int operatorId;
@@ -60,7 +60,7 @@ public class OperatorStats {
   private long setupMark;
   private long waitMark;
 
-  private long schemas;
+//  private long schemas;
   private int inputCount;
 
   public OperatorStats(OpProfileDef def, BufferAllocator allocator){
@@ -74,6 +74,7 @@ public class OperatorStats {
    * @param original - OperatorStats object to create a copy from
    * @param isClean - flag to indicate whether to start with clean state indicators or inherit those from original object
    */
+
   public OperatorStats(OperatorStats original, boolean isClean) {
     this(original.operatorId, original.operatorType, original.inputCount, original.allocator);
 
@@ -102,6 +103,7 @@ public class OperatorStats {
   private String assertionError(String msg){
     return String.format("Failure while %s for operator id %d. Currently have states of processing:%s, setup:%s, waiting:%s.", msg, operatorId, inProcessing, inSetup, inWait);
   }
+
   /**
    * OperatorStats merger - to merge stats from other OperatorStats
    * this is needed in case some processing is multithreaded that needs to have
@@ -110,6 +112,7 @@ public class OperatorStats {
    * @param from - OperatorStats from where to merge to "this"
    * @return OperatorStats - for convenience so one can merge multiple stats in one go
    */
+
   public OperatorStats mergeMetrics(OperatorStats from) {
     final IntLongHashMap fromMetrics = from.longMetrics;
 
@@ -265,26 +268,30 @@ public class OperatorStats {
     public void apply(int key, double value) {
       builder.addMetric(MetricValue.newBuilder().setMetricId(key).setDoubleValue(value));
     }
-
   }
+
   public void addDoubleMetrics(OperatorProfile.Builder builder) {
     if (doubleMetrics.size() > 0) {
       doubleMetrics.forEach(new DoubleProc(builder));
     }
   }
 
+  @Override
   public void addLongStat(MetricDef metric, long value){
     longMetrics.putOrAdd(metric.metricId(), value, value);
   }
 
+  @Override
   public void addDoubleStat(MetricDef metric, double value){
     doubleMetrics.putOrAdd(metric.metricId(), value, value);
   }
 
+  @Override
   public void setLongStat(MetricDef metric, long value){
     longMetrics.put(metric.metricId(), value);
   }
 
+  @Override
   public void setDoubleStat(MetricDef metric, double value){
     doubleMetrics.put(metric.metricId(), value);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
@@ -284,7 +284,7 @@ public abstract class FlattenTemplate implements Flattener {
         throw new UnsupportedOperationException("Flatten does not support selection vector inputs.");
     }
     this.transfers = ImmutableList.copyOf(transfers);
-    outputAllocator = outgoing.getOutgoingContainer().getOperatorContext().getAllocator();
+    outputAllocator = outgoing.getOutgoingContainer().getAllocator();
     doSetup(context, incoming, outgoing);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorter.java
@@ -19,13 +19,14 @@ package org.apache.drill.exec.physical.impl.xsort;
 
 import org.apache.drill.exec.compile.TemplateClassDefinition;
 import org.apache.drill.exec.exception.SchemaChangeException;
-import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.ops.FragmentExecContext;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 
 public interface SingleBatchSorter {
-  public void setup(FragmentContext context, SelectionVector2 vector2, VectorAccessible incoming) throws SchemaChangeException;
+  public void setup(FragmentExecContext context, SelectionVector2 vector2, VectorAccessible incoming) throws SchemaChangeException;
   public void sort(SelectionVector2 vector2) throws SchemaChangeException;
 
-  public static TemplateClassDefinition<SingleBatchSorter> TEMPLATE_DEFINITION = new TemplateClassDefinition<SingleBatchSorter>(SingleBatchSorter.class, SingleBatchSorterTemplate.class);
+  public static TemplateClassDefinition<SingleBatchSorter> TEMPLATE_DEFINITION =
+      new TemplateClassDefinition<SingleBatchSorter>(SingleBatchSorter.class, SingleBatchSorterTemplate.class);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorterTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/SingleBatchSorterTemplate.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 
 import org.apache.drill.exec.exception.SchemaChangeException;
-import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.ops.FragmentExecContext;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.selection.SelectionVector2;
@@ -38,7 +38,7 @@ public abstract class SingleBatchSorterTemplate implements SingleBatchSorter, In
   private SelectionVector2 vector2;
 
   @Override
-  public void setup(FragmentContext context, SelectionVector2 vector2, VectorAccessible incoming) throws SchemaChangeException{
+  public void setup(FragmentExecContext context, SelectionVector2 vector2, VectorAccessible incoming) throws SchemaChangeException{
     Preconditions.checkNotNull(vector2);
     this.vector2 = vector2;
     try {
@@ -76,7 +76,7 @@ public abstract class SingleBatchSorterTemplate implements SingleBatchSorter, In
     }
   }
 
-  public abstract void doSetup(@Named("context") FragmentContext context,
+  public abstract void doSetup(@Named("context") FragmentExecContext context,
                                @Named("incoming") VectorAccessible incoming,
                                @Named("outgoing") RecordBatch outgoing)
                        throws SchemaChangeException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -59,7 +59,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     this.popConfig = popConfig;
     this.oContext = oContext;
     stats = oContext.getStats();
-    container = new VectorContainer(this.oContext);
+    container = new VectorContainer(this.oContext.getAllocator());
     if (buildSchema) {
       state = BatchState.BUILD_SCHEMA;
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,7 +28,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared.UserCredentials;
 import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.TypeValidators.StringValidator;
 import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -91,7 +91,7 @@ public class InboundImpersonationManager {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
 
       final List<ImpersonationPolicy> policies;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,7 +22,7 @@ import org.apache.drill.exec.server.options.TypeValidators.DoubleValidator;
 import org.apache.drill.exec.server.options.TypeValidators.LongValidator;
 import org.apache.drill.exec.server.options.TypeValidators.StringValidator;
 
-abstract class BaseOptionManager implements OptionManager {
+public abstract class BaseOptionManager implements OptionSet {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseOptionManager.class);
 
   /**
@@ -33,7 +33,8 @@ abstract class BaseOptionManager implements OptionManager {
    * @throws IllegalArgumentException - if the validator is not found
    */
   private OptionValue getOptionSafe(OptionValidator validator)  {
-    return getOption(validator.getOptionName());
+    OptionValue value = getOption(validator.getOptionName());
+    return value == null ? validator.getDefault() : value;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -31,7 +31,7 @@ import org.apache.drill.exec.server.options.OptionValue.OptionType;
  * {@link FragmentOptionManager} and {@link SessionOptionManager} use {@link SystemOptionManager} as the fall back
  * manager. {@link QueryOptionManager} uses {@link SessionOptionManager} as the fall back manager.
  */
-public abstract class FallbackOptionManager extends BaseOptionManager {
+public abstract class FallbackOptionManager extends BaseOptionManager implements OptionManager {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FallbackOptionManager.class);
 
   protected final OptionManager fallback;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionManager.java
@@ -22,7 +22,7 @@ import org.apache.drill.exec.server.options.OptionValue.OptionType;
 /**
  * Manager for Drill {@link OptionValue options}. Implementations must be case-insensitive to the name of an option.
  */
-public interface OptionManager extends Iterable<OptionValue> {
+public interface OptionManager extends OptionSet, Iterable<OptionValue> {
 
   /**
    * Sets an option value.
@@ -55,52 +55,6 @@ public interface OptionManager extends Iterable<OptionValue> {
    * @throws org.apache.drill.common.exceptions.UserException message to describe error with value
    */
   void deleteAllOptions(OptionType type);
-
-  /**
-   * Gets the option value for the given option name.
-   *
-   * This interface also provides convenient methods to get typed option values:
-   * {@link #getOption(TypeValidators.BooleanValidator validator)},
-   * {@link #getOption(TypeValidators.DoubleValidator validator)},
-   * {@link #getOption(TypeValidators.LongValidator validator)}, and
-   * {@link #getOption(TypeValidators.StringValidator validator)}.
-   *
-   * @param name option name
-   * @return the option value, null if the option does not exist
-   */
-  OptionValue getOption(String name);
-
-  /**
-   * Gets the boolean value (from the option value) for the given boolean validator.
-   *
-   * @param validator the boolean validator
-   * @return the boolean value
-   */
-  boolean getOption(TypeValidators.BooleanValidator validator);
-
-  /**
-   * Gets the double value (from the option value) for the given double validator.
-   *
-   * @param validator the double validator
-   * @return the double value
-   */
-  double getOption(TypeValidators.DoubleValidator validator);
-
-  /**
-   * Gets the long value (from the option value) for the given long validator.
-   *
-   * @param validator the long validator
-   * @return the long value
-   */
-  long getOption(TypeValidators.LongValidator validator);
-
-  /**
-   * Gets the string value (from the option value) for the given string validator.
-   *
-   * @param validator the string validator
-   * @return the string value
-   */
-  String getOption(TypeValidators.StringValidator validator);
 
   /**
    * Gets the list of options managed this manager.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionSet.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.options;
+
+/**
+ * Immutable set of options accessible by name or validator.
+ */
+
+public interface OptionSet {
+
+  /**
+   * Gets the option value for the given option name.
+   *
+   * This interface also provides convenient methods to get typed option values:
+   * {@link #getOption(TypeValidators.BooleanValidator validator)},
+   * {@link #getOption(TypeValidators.DoubleValidator validator)},
+   * {@link #getOption(TypeValidators.LongValidator validator)}, and
+   * {@link #getOption(TypeValidators.StringValidator validator)}.
+   *
+   * @param name option name
+   * @return the option value, null if the option does not exist
+   */
+  OptionValue getOption(String name);
+
+  /**
+   * Gets the boolean value (from the option value) for the given boolean validator.
+   *
+   * @param validator the boolean validator
+   * @return the boolean value
+   */
+  boolean getOption(TypeValidators.BooleanValidator validator);
+
+  /**
+   * Gets the double value (from the option value) for the given double validator.
+   *
+   * @param validator the double validator
+   * @return the double value
+   */
+  double getOption(TypeValidators.DoubleValidator validator);
+
+  /**
+   * Gets the long value (from the option value) for the given long validator.
+   *
+   * @param validator the long validator
+   * @return the long value
+   */
+  long getOption(TypeValidators.LongValidator validator);
+
+  /**
+   * Gets the string value (from the option value) for the given string validator.
+   *
+   * @param validator the string validator
+   * @return the string value
+   */
+  String getOption(TypeValidators.StringValidator validator);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
@@ -97,7 +97,7 @@ public abstract class OptionValidator {
    * @param manager the manager for accessing validation dependencies (options)
    * @throws UserException message to describe error with value, including range or list of expected values
    */
-  public abstract void validate(OptionValue value, OptionManager manager);
+  public abstract void validate(OptionValue value, OptionSet manager);
 
   /**
    * Gets the kind of this option value for this validator.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValue.java
@@ -76,8 +76,9 @@ public class OptionValue implements Comparable<OptionValue> {
         return createString(type, name, val);
       case DOUBLE:
         return createDouble(type, name, Double.valueOf(val));
+      default:
+        return null;
     }
-    return null;
   }
 
   @JsonCreator
@@ -114,8 +115,9 @@ public class OptionValue implements Comparable<OptionValue> {
         return string_val;
       case DOUBLE:
         return float_val;
+      default:
+        return null;
     }
-    return null;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -48,7 +48,7 @@ import com.google.common.collect.Sets;
  * Only one instance of this class exists per drillbit. Options set at the system level affect the entire system and
  * persist between restarts.
  */
-public class SystemOptionManager extends BaseOptionManager implements AutoCloseable {
+public class SystemOptionManager extends BaseOptionManager implements OptionManager, AutoCloseable {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SystemOptionManager.class);
 
   private static final CaseInsensitiveMap<OptionValidator> VALIDATORS;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
@@ -37,7 +37,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       if (v.num_val > max || v.num_val < 1) {
         throw UserException.validationError()
@@ -54,7 +54,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       if (!isPowerOfTwo(v.num_val)) {
         throw UserException.validationError()
@@ -79,7 +79,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       if (v.float_val > max || v.float_val < min) {
         throw UserException.validationError()
@@ -90,19 +90,15 @@ public class TypeValidators {
   }
 
   public static class MinRangeDoubleValidator extends RangeDoubleValidator {
-    private final double min;
-    private final double max;
     private final String maxValidatorName;
 
     public MinRangeDoubleValidator(String name, double min, double max, double def, String maxValidatorName) {
       super(name, min, max, def);
-      this.min = min;
-      this.max = max;
       this.maxValidatorName = maxValidatorName;
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       OptionValue maxValue = manager.getOption(maxValidatorName);
       if (v.float_val > maxValue.float_val) {
@@ -115,19 +111,15 @@ public class TypeValidators {
   }
 
   public static class MaxRangeDoubleValidator extends RangeDoubleValidator {
-    private final double min;
-    private final double max;
     private final String minValidatorName;
 
     public MaxRangeDoubleValidator(String name, double min, double max, double def, String minValidatorName) {
       super(name, min, max, def);
-      this.min = min;
-      this.max = max;
       this.minValidatorName = minValidatorName;
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       OptionValue minValue = manager.getOption(minValidatorName);
       if (v.float_val < minValue.float_val) {
@@ -190,7 +182,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       if (v.num_val > max || v.num_val < min) {
         throw UserException.validationError()
@@ -215,7 +207,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       super.validate(v, manager);
       if (!valuesSet.contains(v.string_val.toLowerCase())) {
         throw UserException.validationError()
@@ -246,7 +238,7 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       if (v.kind != kind) {
         throw UserException.validationError()
             .message(String.format("Option %s must be of type %s but you tried to set to %s.", getOptionName(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControls.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControls.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,6 +27,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.OptionType;
 import org.apache.drill.exec.server.options.TypeValidators.TypeValidator;
@@ -96,7 +97,7 @@ public final class ExecutionControls {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionManager manager) {
+    public void validate(final OptionValue v, final OptionSet manager) {
       if (v.type != OptionType.SESSION) {
         throw UserException.validationError()
             .message("Controls can be set only at SESSION level.")


### PR DESCRIPTION
This PR is purely a refactoring: no functionality is added or changed.
The refactoring splits various context and related classes into a set
of new interfaces with needed for operator-level unit tests. The other,
Drillbit-related methods are left in the original interfaces. Most code
need not change.

The changes here allow operator-level unit tests to mock up the
exec-time methods so we can use them without firing up a Drillbit (or
using mocking libraries).

A later PR will provide the sub-operator test framework that uses this
refactoring.

Changes include:

* The OptionManager is split, with read-only methods moving to a new
OptionSet interface.
* The FragmentContext is split, with an exec-only FragmentExecContext
proving low-level methods.
* OperatorStats is split, with a new OperatorStatReceiver class
providing write-only support to operators.
* Several places that accepted an OperatorContext or FragmentContext,
but needed only an allocator, are changed to accept the allocator
directly.