### PR TITLE
DRILL-4971: Query encounters system error, when there aren't eval subexpressions of any function in boolean and/or expressions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
@@ -186,6 +186,26 @@ public class ClassGenerator<T>{
     return getEvalBlock().label(prefix + labelIndex ++);
   }
 
+  /**
+   * Creates an inner braced and indented block
+   * @param type type of the created block
+   * @return a newly created inner block
+   */
+  private JBlock createInnerBlock(BlockType type) {
+    final JBlock currBlock = getBlock(type);
+    final JBlock innerBlock = new JBlock();
+    currBlock.add(innerBlock);
+    return innerBlock;
+  }
+
+  /**
+   * Creates an inner braced and indented block for evaluation of the expression.
+   * @return a newly created inner eval block
+   */
+  protected JBlock createInnerEvalBlock() {
+    return createInnerBlock(BlockType.EVAL);
+  }
+
   public JVar declareVectorValueSetupAndMember(String batchName, TypedFieldId fieldId) {
     return declareVectorValueSetupAndMember(DirectExpression.direct(batchName), fieldId);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -144,6 +144,9 @@ public class EvaluationVisitor {
     previousExpressions = mapStack.pop();
   }
 
+  /**
+   * Get a HoldingContainer for the expression if it had been already evaluated
+   */
   private HoldingContainer getPrevious(LogicalExpression expression, MappingSet mappingSet) {
     HoldingContainer previous = previousExpressions.get(new ExpressionHolder(expression, mappingSet));
     if (previous != null) {
@@ -671,8 +674,8 @@ public class EvaluationVisitor {
       HoldingContainer out = generator.declare(op.getMajorType());
 
       JLabel label = generator.getEvalBlockLabel("AndOP");
-      JBlock eval = generator.getEvalBlock().block();  // enter into nested block
-      generator.nestEvalBlock(eval);
+      JBlock eval = generator.createInnerEvalBlock();
+      generator.nestEvalBlock(eval);  // enter into nested block
 
       HoldingContainer arg = null;
 
@@ -733,7 +736,7 @@ public class EvaluationVisitor {
       HoldingContainer out = generator.declare(op.getMajorType());
 
       JLabel label = generator.getEvalBlockLabel("OrOP");
-      JBlock eval = generator.getEvalBlock().block();
+      JBlock eval = generator.createInnerEvalBlock();
       generator.nestEvalBlock(eval);   // enter into nested block.
 
       HoldingContainer arg = null;

--- a/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -229,6 +229,37 @@ public class TestBugFixes extends BaseTestQuery {
         .unOrdered()
         .baselineColumns("cnt")
         .baselineValues(1L)
+        .go();
+  }
+
+  @Test // DRILL-4971
+  public void testVisitBooleanOrWithoutFunctionsEvaluation() throws Exception {
+    String query = "SELECT\n" +
+        "CASE WHEN employee_id IN (1) THEN 1 ELSE 0 END `first`\n" +
+        ", CASE WHEN employee_id IN (2) THEN 1 ELSE 0 END `second`\n" +
+        ", CASE WHEN employee_id IN (1, 2) THEN 1 ELSE 0 END `any`\n" +
+        "FROM cp.`employee.json` ORDER BY employee_id limit 2";
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("first", "second", "any")
+        .baselineValues(1, 0, 1)
+        .baselineValues(0, 1, 1)
+        .go();
+  }
+
+  @Test // DRILL-4971
+  public void testVisitBooleanAndWithoutFunctionsEvaluation() throws Exception {
+    String query = "SELECT employee_id FROM cp.`employee.json` WHERE\n" +
+        "((employee_id > 1 AND employee_id < 3) OR (employee_id > 9 AND employee_id < 11))\n" +
+        "AND (employee_id > 1 AND employee_id < 3)";
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("employee_id")
+        .baselineValues((long) 2)
         .go();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestEvaluationVisitor.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestEvaluationVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,7 +19,6 @@ package org.apache.drill.exec.compile;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
-import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
@@ -37,7 +36,7 @@ import org.apache.drill.exec.physical.impl.project.Projector;
 import org.apache.drill.exec.record.TypedFieldId;
 import org.junit.Test;
 
-public class TestEvaluationVisitor extends BaseTestQuery {
+public class TestEvaluationVisitor {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestEvaluationVisitor.class);
 
 
@@ -71,37 +70,6 @@ public class TestEvaluationVisitor extends BaseTestQuery {
 
     v.addExpr(e2,  g.getRoot());
     logger.debug(g.generateAndGet());
-  }
-
-  @Test
-  public void testVisitBooleanOrWithoutFunctionsEvaluation() throws Exception {
-    String query = "SELECT\n" +
-        "CASE WHEN employee_id IN (1) THEN 1 ELSE 0 END `first`\n" +
-        ", CASE WHEN employee_id IN (2) THEN 1 ELSE 0 END `second`\n" +
-        ", CASE WHEN employee_id IN (1, 2) THEN 1 ELSE 0 END `any`\n" +
-        "FROM cp.`employee.json` ORDER BY employee_id limit 2";
-
-    testBuilder()
-        .sqlQuery(query)
-        .ordered()
-        .baselineColumns("first", "second", "any")
-        .baselineValues(1, 0, 1)
-        .baselineValues(0, 1, 1)
-        .go();
-  }
-
-  @Test
-  public void testVisitBooleanAndWithoutFunctionsEvaluation() throws Exception {
-    String query = "SELECT employee_id FROM cp.`employee.json` WHERE\n" +
-        "((employee_id > 1 AND employee_id < 3) OR (employee_id > 9 AND employee_id < 11))\n" +
-        "AND (employee_id > 1 AND employee_id < 3)";
-
-    testBuilder()
-        .sqlQuery(query)
-        .ordered()
-        .baselineColumns("employee_id")
-        .baselineValues((long) 2)
-        .go();
   }
 
   private LogicalExpression getExpr(String expr) throws Exception{


### PR DESCRIPTION
- New evaluated blocks for boolean operators should be with braces always, since they use labels.