### PR TITLE
DRILL-5089: Get only partial schemas of relevant storage plugins inst…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillCatalogReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillCatalogReader.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.CalciteSchemaImpl;
+import org.apache.calcite.jdbc.SimpleCalciteSchema;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.prepare.RelOptTableImpl;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ops.QueryContext;
+import org.apache.drill.exec.store.SchemaConfig;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Implementation of {@link org.apache.calcite.prepare.Prepare.CatalogReader}
+ * and also {@link org.apache.calcite.sql.SqlOperatorTable} based on tables and
+ * functions defined schemas.
+ *
+ */
+public class DrillCatalogReader extends CalciteCatalogReader {
+  private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillCatalogReader.class);
+
+  final private QueryContext queryContext;
+  private boolean allowTemporaryTables;
+  private String temporarySchema;
+
+  public DrillCatalogReader(
+      QueryContext qcontext,
+      CalciteSchema rootSchema,
+      boolean caseSensitive,
+      List<String> defaultSchema,
+      JavaTypeFactory typeFactory,
+      String temporarySchema) {
+    super(rootSchema, caseSensitive, defaultSchema, typeFactory);
+    assert rootSchema != defaultSchema;
+    queryContext = qcontext;
+    this.temporarySchema = temporarySchema;
+    this.allowTemporaryTables = true;
+  }
+
+  /** Disallow temporary tables presence in sql statement (ex: in view definitions) */
+  public void disallowTemporaryTables() {
+    this.allowTemporaryTables = false;
+  }
+
+  /**
+   * If schema is not indicated (only one element in the list) or schema is default temporary workspace,
+   * we need to check among session temporary tables first in default temporary workspace.
+   * If temporary table is found and temporary tables usage is allowed, its table instance will be returned,
+   * otherwise search will be conducted in original workspace.
+   *
+   * @param names list of schema and table names, table name is always the last element
+   * @return table instance, null otherwise
+   * @throws UserException if temporary tables usage is disallowed
+   */
+  @Override
+  public RelOptTableImpl getTable(final List<String> names) {
+    RelOptTableImpl temporaryTable = null;
+    if (mightBeTemporaryTable(names, queryContext.getSession().getDefaultSchemaPath(), queryContext.getConfig())) {
+      String temporaryTableName = queryContext.getSession().resolveTemporaryTableName(names.get(names.size() - 1));
+      if (temporaryTableName != null) {
+        List<String> temporaryNames = Lists.newArrayList(temporarySchema, temporaryTableName);
+        temporaryTable = super.getTable(temporaryNames);
+      }
+    }
+    if (temporaryTable != null) {
+      if (allowTemporaryTables) {
+        return temporaryTable;
+      }
+      throw UserException
+          .validationError()
+          .message("Temporary tables usage is disallowed. Used temporary table name: %s.", names)
+          .build(logger);
+    }
+    return super.getTable(names);
+  }
+
+  /**
+   * We should check if passed table is temporary or not if:
+   * <li>schema is not indicated (only one element in the names list)<li/>
+   * <li>current schema or indicated schema is default temporary workspace<li/>
+   *
+   * Examples (where dfs.tmp is default temporary workspace):
+   * <li>select * from t<li/>
+   * <li>select * from dfs.tmp.t<li/>
+   * <li>use dfs; select * from tmp.t<li/>
+   *
+   * @param names             list of schema and table names, table name is always the last element
+   * @param defaultSchemaPath current schema path set using USE command
+   * @param drillConfig       drill config
+   * @return true if check for temporary table should be done, false otherwise
+   */
+  private boolean mightBeTemporaryTable(List<String> names, String defaultSchemaPath, DrillConfig drillConfig) {
+    if (names.size() == 1) {
+      return true;
+    }
+
+    String schemaPath = SchemaUtilites.getSchemaPath(names.subList(0, names.size() - 1));
+    return SchemaUtilites.isTemporaryWorkspace(schemaPath, drillConfig) ||
+        SchemaUtilites.isTemporaryWorkspace(
+            SchemaUtilites.SCHEMA_PATH_JOINER.join(defaultSchemaPath, schemaPath), drillConfig);
+  }
+  public DrillCatalogReader withSchemaPath(List<String> schemaPath) {
+    return new DrillCatalogReader(queryContext, super.getSchema(ImmutableList.<String>of()),
+        this.isCaseSensitive(), schemaPath, (JavaTypeFactory)getTypeFactory(), temporarySchema);
+  }
+
+  public QueryContext getQueryContext() {
+    return queryContext;
+  }
+
+  public CalciteSchema getSchema(Iterable<String> schemaNames) {
+
+    //get 'rootSchema'
+    CalciteSchema existingRootSchema = super.getSchema(ImmutableList.<String>of());
+    CalciteSchema schema = existingRootSchema;
+    int layer = 0;
+    for (String schemaName : schemaNames) {
+      schema = schema.getSubSchema(schemaName, isCaseSensitive());
+      if (schema == null) {
+        if (layer == 0) {
+          final Set<String> strSet = Sets.newHashSet();
+          strSet.add(schemaName);
+          if(schemaName.contains(".")) {
+            String[] schemaArray = schemaName.split("\\.");
+            String prefix = schemaArray[0];
+            for(int i=1; i<schemaArray.length; ++i) {
+              strSet.add(prefix);
+              prefix = Joiner.on(".").join(prefix, schemaArray[i]);
+            }
+          }
+
+          //queryContext.addNewRelevantSchema(strSet, existingRootSchema.plus());
+          SchemaPlus rootSchema = existingRootSchema.plus();
+          queryContext.getSchemaTreeProvider().addPartialRootSchema(queryContext.getQueryUserName(),
+              queryContext, strSet, rootSchema);
+          SchemaPlus plus = rootSchema.getSubSchema(schemaName);
+          if (plus != null) {
+            schema = SimpleCalciteSchema.from(plus);
+          }
+        }
+      }
+      if(schema == null) {
+        return null;
+      }
+      layer++;
+    }
+    return schema;
+  }
+
+
+}
+
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillSqlWorker.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.planner.sql;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -102,6 +103,7 @@ public class DrillSqlWorker {
 
     injector.injectChecked(context.getExecutionControls(), "sql-parsing", ForemanSetupException.class);
     final SqlNode sqlNode = parser.parse(sql);
+
     final AbstractSqlHandler handler;
     final SqlHandlerConfig config = new SqlHandlerConfig(context, parser);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -17,14 +17,15 @@
  */
 package org.apache.drill.exec.planner.sql;
 
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.jdbc.CalciteSchemaImpl;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.jdbc.SimpleCalciteSchema;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCostFactory;
@@ -77,27 +78,29 @@ public class SqlConverter {
 
   private static DrillTypeSystem DRILL_TYPE_SYSTEM = new DrillTypeSystem();
 
-  private final JavaTypeFactory typeFactory;
-  private final SqlParser.Config parserConfig;
   // Allow the default config to be modified using immutable configs
   private SqlToRelConverter.Config sqlToRelConverterConfig;
-  private final DrillCalciteCatalogReader catalog;
+  private DrillCatalogReader catalog;
+  private SchemaPlus rootSchema;
+  private SchemaPlus defaultSchema;
+  private SqlOperatorTable opTab;
+  private DrillValidator validator;
+  private  String temporarySchema;
+  private  UserSession session;
+  private  DrillConfig drillConfig;
+
   private final PlannerSettings settings;
-  private final SchemaPlus rootSchema;
-  private final SchemaPlus defaultSchema;
-  private final SqlOperatorTable opTab;
+  private final JavaTypeFactory typeFactory;
+  private final SqlParser.Config parserConfig;
+
   private final RelOptCostFactory costFactory;
-  private final DrillValidator validator;
+
   private final boolean isInnerQuery;
   private final UdfUtilities util;
   private final FunctionImplementationRegistry functions;
-  private final String temporarySchema;
-  private final UserSession session;
-  private final DrillConfig drillConfig;
 
   private String sql;
   private VolcanoPlanner planner;
-
 
   public SqlConverter(QueryContext context) {
     this.settings = context.getPlannerSettings();
@@ -107,11 +110,22 @@ public class SqlConverter {
     this.sqlToRelConverterConfig = new SqlToRelConverterConfig();
     this.isInnerQuery = false;
     this.typeFactory = new JavaTypeFactoryImpl(DRILL_TYPE_SYSTEM);
-    this.defaultSchema =  context.getNewDefaultSchema();
-    this.rootSchema = rootSchema(defaultSchema);
+
+    this.defaultSchema = context.getPartialDefaultSchema();
+    this.defaultSchema = defaultSchema == null? SimpleCalciteSchema.createRootSchema(false) : defaultSchema;
+    this.rootSchema = rootSchema(this.defaultSchema);
     this.temporarySchema = context.getConfig().getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE);
+    this.catalog = new DrillCatalogReader(
+        context,
+        SimpleCalciteSchema.from(this.rootSchema),
+        parserConfig.caseSensitive(),
+        SimpleCalciteSchema.from(this.defaultSchema).path(null),
+        typeFactory,
+        temporarySchema);
+
     this.session = context.getSession();
     this.drillConfig = context.getConfig();
+/*
     this.catalog = new DrillCalciteCatalogReader(
         CalciteSchemaImpl.from(rootSchema),
         parserConfig.caseSensitive(),
@@ -119,14 +133,28 @@ public class SqlConverter {
         typeFactory,
         drillConfig,
         session);
+*/
     this.opTab = new ChainedSqlOperatorTable(Arrays.asList(context.getDrillOperatorTable(), catalog));
     this.costFactory = (settings.useDefaultCosting()) ? null : new DrillCostBase.DrillCostFactory();
+
     this.validator = new DrillValidator(opTab, catalog, typeFactory, SqlConformance.DEFAULT);
     validator.setIdentifierExpansion(true);
   }
 
+  public SqlConverter(PlannerSettings settings, UdfUtilities util, FunctionImplementationRegistry functions) {
+    this.settings = settings;
+    this.util = util;
+    this.functions = functions;
+    this.parserConfig = new DrillParserConfig(settings);
+    this.sqlToRelConverterConfig = new SqlToRelConverterConfig();
+    this.isInnerQuery = false;
+    this.typeFactory = new JavaTypeFactoryImpl(DRILL_TYPE_SYSTEM);
+
+    this.costFactory = (settings.useDefaultCosting()) ? null : new DrillCostBase.DrillCostFactory();
+  }
+
   private SqlConverter(SqlConverter parent, SchemaPlus defaultSchema, SchemaPlus rootSchema,
-      DrillCalciteCatalogReader catalog) {
+      DrillCatalogReader catalog) {
     this.parserConfig = parent.parserConfig;
     this.sqlToRelConverterConfig = parent.sqlToRelConverterConfig;
     this.defaultSchema = defaultSchema;
@@ -146,7 +174,6 @@ public class SqlConverter {
     this.drillConfig = parent.drillConfig;
     validator.setIdentifierExpansion(true);
   }
-
 
   public SqlNode parse(String sql) {
     try {
@@ -203,6 +230,20 @@ public class SqlConverter {
     return defaultSchema;
   }
 
+
+  public SchemaPlus getExpandedDefaultSchema(List<String> schemaPaths) {
+    SchemaPlus workspaceSchema = catalog.getSchema(catalog.getSchemaName()).plus();
+    SchemaPlus retSchema = SchemaUtilites.findSchema(workspaceSchema, schemaPaths);
+    if (retSchema != null) {
+      return retSchema;
+    }
+    //else get it from rootSchema
+    CalciteSchema calSchema = catalog.getSchema(schemaPaths);
+    if (calSchema != null) {
+      return calSchema.plus();
+    }
+    return null;
+  }
   /** Disallow temporary tables presence in sql statement (ex: in view definitions) */
   public void disallowTemporaryTables() {
     catalog.disallowTemporaryTables();
@@ -279,26 +320,31 @@ public class SqlConverter {
 
     @Override
     public RelNode expandView(RelDataType rowType, String queryString, List<String> schemaPath) {
-      final DrillCalciteCatalogReader catalogReader = new DrillCalciteCatalogReader(
-          CalciteSchemaImpl.from(rootSchema),
+      final DrillCatalogReader catalogReader = new DrillCatalogReader(
+          catalog.getQueryContext(),
+          SimpleCalciteSchema.from(rootSchema),
           parserConfig.caseSensitive(),
           schemaPath,
           typeFactory,
-          drillConfig,
-          session);
+          temporarySchema);
       final SqlConverter parser = new SqlConverter(SqlConverter.this, defaultSchema, rootSchema, catalogReader);
       return expandView(queryString, parser);
     }
 
     @Override
-    public RelNode expandView(RelDataType rowType, String queryString, SchemaPlus rootSchema, List<String> schemaPath) {
-      final DrillCalciteCatalogReader catalogReader = new DrillCalciteCatalogReader(
-          CalciteSchemaImpl.from(rootSchema), // new root schema
+
+    public RelNode expandView(
+        RelDataType rowType,
+        String queryString,
+        SchemaPlus rootSchema, // new root schema
+        List<String> schemaPath) {
+      final DrillCatalogReader catalogReader = new DrillCatalogReader(
+          catalog.getQueryContext(),
+          SimpleCalciteSchema.from(rootSchema),
           parserConfig.caseSensitive(),
           schemaPath,
           typeFactory,
-          drillConfig,
-          session);
+          temporarySchema);
       SchemaPlus schema = rootSchema;
       for (String s : schemaPath) {
         SchemaPlus newSchema = schema.getSubSchema(s);
@@ -417,96 +463,6 @@ public class SqlConverter {
         RexNode node,
         boolean matchNullability) {
       return node;
-    }
-  }
-
-  /**
-   * Extension of {@link CalciteCatalogReader} to add ability to check for temporary tables first
-   * if schema is not indicated near table name during query parsing
-   * or indicated workspace is default temporary workspace.
-   */
-  private class DrillCalciteCatalogReader extends CalciteCatalogReader {
-
-    private final DrillConfig drillConfig;
-    private final UserSession session;
-    private boolean allowTemporaryTables;
-
-    DrillCalciteCatalogReader(CalciteSchema rootSchema,
-                              boolean caseSensitive,
-                              List<String> defaultSchema,
-                              JavaTypeFactory typeFactory,
-                              DrillConfig drillConfig,
-                              UserSession session) {
-      super(rootSchema, caseSensitive, defaultSchema, typeFactory);
-      this.drillConfig = drillConfig;
-      this.session = session;
-      this.allowTemporaryTables = true;
-    }
-
-    /**
-     * Disallow temporary tables presence in sql statement (ex: in view definitions)
-     */
-    public void disallowTemporaryTables() {
-      this.allowTemporaryTables = false;
-    }
-
-    /**
-     * If schema is not indicated (only one element in the list) or schema is default temporary workspace,
-     * we need to check among session temporary tables in default temporary workspace first.
-     * If temporary table is found and temporary tables usage is allowed, its table instance will be returned,
-     * otherwise search will be conducted in original workspace.
-     *
-     * @param names list of schema and table names, table name is always the last element
-     * @return table instance, null otherwise
-     * @throws UserException if temporary tables usage is disallowed
-     */
-    @Override
-    public RelOptTableImpl getTable(final List<String> names) {
-      RelOptTableImpl temporaryTable = null;
-
-      if (mightBeTemporaryTable(names, session.getDefaultSchemaPath(), drillConfig)) {
-        String temporaryTableName = session.resolveTemporaryTableName(names.get(names.size() - 1));
-        if (temporaryTableName != null) {
-          List<String> temporaryNames = Lists.newArrayList(temporarySchema, temporaryTableName);
-          temporaryTable = super.getTable(temporaryNames);
-        }
-      }
-      if (temporaryTable != null) {
-        if (allowTemporaryTables) {
-          return temporaryTable;
-        }
-        throw UserException
-            .validationError()
-            .message("Temporary tables usage is disallowed. Used temporary table name: %s.", names)
-            .build(logger);
-      }
-      return super.getTable(names);
-    }
-
-    /**
-     * We should check if passed table is temporary or not if:
-     * <li>schema is not indicated (only one element in the names list)<li/>
-     * <li>current schema or indicated schema is default temporary workspace<li/>
-     *
-     * Examples (where dfs.tmp is default temporary workspace):
-     * <li>select * from t<li/>
-     * <li>select * from dfs.tmp.t<li/>
-     * <li>use dfs; select * from tmp.t<li/>
-     *
-     * @param names             list of schema and table names, table name is always the last element
-     * @param defaultSchemaPath current schema path set using USE command
-     * @param drillConfig       drill config
-     * @return true if check for temporary table should be done, false otherwise
-     */
-    private boolean mightBeTemporaryTable(List<String> names, String defaultSchemaPath, DrillConfig drillConfig) {
-      if (names.size() == 1) {
-        return true;
-      }
-
-      String schemaPath = SchemaUtilites.getSchemaPath(names.subList(0, names.size() - 1));
-      return SchemaUtilites.isTemporaryWorkspace(schemaPath, drillConfig) ||
-          SchemaUtilites.isTemporaryWorkspace(
-              SchemaUtilites.SCHEMA_PATH_JOINER.join(defaultSchemaPath, schemaPath), drillConfig);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeSchemaHandler.java
@@ -70,7 +70,7 @@ public class DescribeSchemaHandler extends DefaultSqlHandler {
   @Override
   public PhysicalPlan getPlan(SqlNode sqlNode) {
     SqlIdentifier schema = ((SqlDescribeSchema) sqlNode).getSchema();
-    SchemaPlus drillSchema = SchemaUtilites.findSchema(config.getConverter().getDefaultSchema(), schema.names);
+    SchemaPlus drillSchema = config.getConverter().getExpandedDefaultSchema(schema.names);
 
     if (drillSchema != null) {
       StoragePlugin storagePlugin;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
@@ -67,12 +67,11 @@ public class DescribeTableHandler extends DefaultSqlHandler {
           ImmutableList.of(IS_SCHEMA_NAME, TAB_COLUMNS), null, SqlParserPos.ZERO, null);
 
       final SqlIdentifier table = node.getTable();
-      final SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
       final List<String> schemaPathGivenInCmd = Util.skipLast(table.names);
-      final SchemaPlus schema = SchemaUtilites.findSchema(defaultSchema, schemaPathGivenInCmd);
+      final SchemaPlus schema = config.getConverter().getExpandedDefaultSchema(schemaPathGivenInCmd);
 
       if (schema == null) {
-        SchemaUtilites.throwSchemaNotFoundException(defaultSchema,
+        SchemaUtilites.throwSchemaNotFoundException(config.getConverter().getDefaultSchema(),
             SchemaUtilites.SCHEMA_PATH_JOINER.join(schemaPathGivenInCmd));
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DropTableHandler.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.planner.sql.handlers;
 import java.io.IOException;
 import java.util.List;
 
+import com.google.common.collect.Lists;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
@@ -28,6 +29,7 @@ import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
@@ -56,19 +58,22 @@ public class DropTableHandler extends DefaultSqlHandler {
   @Override
   public PhysicalPlan getPlan(SqlNode sqlNode) throws ValidationException, RelConversionException, IOException {
     SqlDropTable dropTableNode = ((SqlDropTable) sqlNode);
+
     String originalTableName = dropTableNode.getName();
-    SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
-    List<String> tableSchema = dropTableNode.getSchema();
+    //List<String> tableSchema = dropTableNode.getSchema();
+    //SchemaPlus defaultSchema = config.getConverter().getExpandedDefaultSchema(tableSchema);
     DrillConfig drillConfig = context.getConfig();
     UserSession session = context.getSession();
 
-    AbstractSchema temporarySchema = resolveToTemporarySchema(tableSchema, defaultSchema, drillConfig);
+    AbstractSchema temporarySchema = resolveToTemporarySchema(dropTableNode);//tableSchema, defaultSchema, drillConfig);
     boolean isTemporaryTable = session.isTemporaryTable(temporarySchema, drillConfig, originalTableName);
 
     if (isTemporaryTable) {
       session.removeTemporaryTable(temporarySchema, originalTableName, drillConfig);
     } else {
-      AbstractSchema drillSchema = SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
+      AbstractSchema drillSchema =  SchemaUtilites.toMutableDrillSchema(
+          config.getConverter().getExpandedDefaultSchema(dropTableNode.getSchema()));
+
       Table tableToDrop = SqlHandlerUtil.getTableFromSchema(drillSchema, originalTableName);
       if (tableToDrop == null || tableToDrop.getJdbcTableType() != Schema.TableType.TABLE) {
         if (dropTableNode.checkTableExistence()) {
@@ -88,17 +93,20 @@ public class DropTableHandler extends DefaultSqlHandler {
   /**
    * If table schema is not indicated in sql call, returns temporary workspace.
    * If schema is indicated, resolves to mutable table schema.
-   *
-   * @param tableSchema table schema
-   * @param defaultSchema default schema
-   * @param config drill config
    * @return resolved schema
    */
-  private AbstractSchema resolveToTemporarySchema(List<String> tableSchema, SchemaPlus defaultSchema, DrillConfig config) {
+  private AbstractSchema resolveToTemporarySchema(SqlDropTable sqlDropTable) {
+  //List<String> tableSchema, SchemaPlus defaultSchema, DrillConfig config) {
+    List<String> tableSchema = sqlDropTable.getSchema();
+    SchemaPlus defaultSchema = config.getConverter().getExpandedDefaultSchema(tableSchema);
     if (tableSchema.size() == 0) {
-      return SchemaUtilites.getTemporaryWorkspace(defaultSchema, config);
+      List<String> temporarySchemaPath = Lists.newArrayList(context.getConfig().
+              getString(ExecConstants.DEFAULT_TEMPORARY_WORKSPACE));
+      defaultSchema = config.getConverter().getExpandedDefaultSchema(temporarySchemaPath);
+      return SchemaUtilites.getTemporaryWorkspace(defaultSchema, context.getConfig());
     } else {
-      return SchemaUtilites.resolveToMutableDrillSchema(defaultSchema, tableSchema);
+      AbstractSchema resolvedSchema = SchemaUtilites.toMutableDrillSchema(defaultSchema);
+      return resolvedSchema;
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.planner.sql.handlers;
 
-import static org.apache.drill.exec.planner.sql.SchemaUtilites.findSchema;
-
 import java.io.IOException;
 
 import org.apache.calcite.schema.SchemaPlus;
@@ -62,8 +60,7 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
 
     try {
 
-      final SchemaPlus schema = findSchema(config.getConverter().getDefaultSchema(),
-          refreshTable.getSchemaPath());
+      final SchemaPlus schema = config.getConverter().getExpandedDefaultSchema(refreshTable.getSchemaPath());
 
       if (schema == null) {
         return direct(false, "Storage plugin or workspace does not exist [%s]",

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowFileHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowFileHandler.java
@@ -54,17 +54,16 @@ public class ShowFileHandler extends DefaultSqlHandler {
     String defaultLocation = null;
     String fromDir = "./";
 
-    SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
-    SchemaPlus drillSchema = defaultSchema;
+    SchemaPlus drillSchema = config.getConverter().getDefaultSchema();
 
     // Show files can be used without from clause, in which case we display the files in the default schema
     if (from != null) {
       // We are not sure if the full from clause is just the schema or includes table name,
       // first try to see if the full path specified is a schema
-      drillSchema = SchemaUtilites.findSchema(defaultSchema, from.names);
+      drillSchema = config.getConverter().getExpandedDefaultSchema(from.names);
       if (drillSchema == null) {
         // Entire from clause is not a schema, try to obtain the schema without the last part of the specified clause.
-        drillSchema = SchemaUtilites.findSchema(defaultSchema, from.names.subList(0, from.names.size() - 1));
+        drillSchema = config.getConverter().getExpandedDefaultSchema(from.names.subList(0, from.names.size() - 1));
         fromDir = fromDir + from.names.get((from.names.size() - 1));
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
@@ -38,6 +38,8 @@ import org.apache.drill.exec.planner.logical.CreateTableEntry;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
+import static java.lang.Math.abs;
+
 public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer, AutoCloseable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractSchema.class);
 
@@ -198,6 +200,10 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
 
   @Override
   public boolean contentsHaveChangedSince(long lastCheck, long now) {
+    //use cached schema for 1 second, it will be helpful if it is highly concurrent scenario
+    if( abs(now - lastCheck) < 1000 ) {
+      return false;
+    }
     return true;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -46,6 +46,7 @@ import org.apache.drill.exec.server.options.QueryOptionManager;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.SchemaTreeProvider;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistryImpl;
 import org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider;
@@ -111,6 +112,7 @@ public class PlanningBase extends ExecTest{
     final FunctionImplementationRegistry functionRegistry = new FunctionImplementationRegistry(config);
     final DrillOperatorTable table = new DrillOperatorTable(functionRegistry, systemOptions);
     final SchemaPlus root = SimpleCalciteSchema.createRootSchema(false);
+    final SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(dbContext);
     registry.getSchemaFactory().registerSchemas(SchemaConfig.newBuilder("foo", context).build(), root);
 
     new NonStrictExpectations() {
@@ -141,8 +143,10 @@ public class PlanningBase extends ExecTest{
         result = allocator;
         context.getExecutionControls();
         result = executionControls;
-        dbContext.getLpPersistence();
-        result = logicalPlanPersistence;
+        context.getSchemaTreeProvider();
+        result = schemaTreeProvider;
+        dbContext.getStorage();
+        result = registry;
       }
     };
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dep.guava.version>18.0</dep.guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
-    <calcite.version>1.4.0-drill-r19</calcite.version>
+    <calcite.version>1.4.0-drill-r20-test</calcite.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>
     <jackson.version>2.7.1</jackson.version>
     <mapr.release.version>5.2.0.40963-mapr</mapr.release.version>


### PR DESCRIPTION
…ead of all storages ahead.

1. For each query, rootSchema is empty, add schemas of a storage plugin only when needed -- when asked for a schemaPath.

2. Allow mock environments to provide dynamic schemas.

3. SchemaUtils.findSchema used in many Sql handlers now is handled by SqlConverter.catalog to allow expand schema dynamically

4. Temp table resolve also could not take a schema tree and assume it is complete.

NOTE: pom.xml in this pull request is pointing to temporary calcite versoin 'r20-test', this should change to 'r20' once this pull request is ready to commit