### PR TITLE
DRILL-5234: External sort spill fails for maps

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -277,7 +277,10 @@ public class MapVector extends AbstractMapVector {
       bufOffset += child.getBufferLength();
     }
 
-    assert bufOffset == buf.capacity();
+    // We should have consumed all bytes written into the buffer
+    // during deserialization.
+
+    assert bufOffset == buf.writerIndex();
   }
 
   @Override


### PR DESCRIPTION
External sort's spilling functionality does not work when the spilled
columns contains a map type column.

The problem occurs only when assertions are on and is due to an
incorrect assumption used to verify that data is read correctly. The
original code used capacity as the number of bytes actually read, but
this is a poor choice; capacity reflects power-of-two rounding having
nothing to do with serialized data.

Changed to use the writerIndex instead which should be positioned past
the last byte written to the vector during deserialization.