### PR TITLE
DRILL-5385: Vector serializer fails to read saved SV2

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/cache/CachedVectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/cache/CachedVectorContainer.java
@@ -61,9 +61,7 @@ public class CachedVectorContainer extends LoopedAbstractDrillSerializable {
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
-
   }
-
 
   @Override
   public void read(DataInput input) throws IOException {
@@ -95,5 +93,4 @@ public class CachedVectorContainer extends LoopedAbstractDrillSerializable {
   public byte[] getData() {
     return data;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector2.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -37,6 +37,12 @@ public class SelectionVector2 implements AutoCloseable {
 
   public SelectionVector2(BufferAllocator allocator) {
     this.allocator = allocator;
+  }
+
+  public SelectionVector2(BufferAllocator allocator, DrillBuf buf, int count) {
+    this.allocator = allocator;
+    buffer = buf;
+    recordCount = count;
   }
 
   public int getCount() {

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
@@ -160,6 +160,9 @@ public interface BufferAllocator extends AutoCloseable {
    * Write the contents of a DrillBuf to a stream. Use this method, rather
    * than calling the DrillBuf.getBytes() method, because this method
    * avoids repeated heap allocation for the intermediate heap buffer.
+   * Uses the reader and writer indexes to determine
+   * the number of bytes to write. Useful only for bufs created using
+   * those indexes.
    *
    * @param buf the Drillbuf to write
    * @param output the output stream
@@ -169,15 +172,42 @@ public interface BufferAllocator extends AutoCloseable {
   public void write(DrillBuf buf, OutputStream out) throws IOException;
 
   /**
+   * Write the contents of a DrillBuf to a stream. Use this method, rather
+   * than calling the DrillBuf.getBytes() method, because this method
+   * avoids repeated heap allocation for the intermediate heap buffer.
+   * Writes the specified number of bytes starting from the head of the
+   * given Drillbuf.
+   *
+   * @param buf the Drillbuf to write
+   * @param length the number of bytes to read. Must be less than or
+   * equal to number of bytes allocated in the buffer.
+   * @param out the output stream
+   * @throws IOException if a write error occurs
+   */
+
+  public void write(DrillBuf buf, int length, OutputStream out) throws IOException;
+
+  /**
    * Read the contents of a DrillBuf from a stream. Use this method, rather
    * than calling the DrillBuf.writeBytes() method, because this method
    * avoids repeated heap allocation for the intermediate heap buffer.
+   * The buffer must have already been allocated.
    *
    * @param buf the buffer to read with space already allocated
-   * @param input input stream from which to read data
-   * @param bufLength number of bytes to read
+   * @param length number of bytes to read
+   * @param in input stream from which to read data
    * @throws IOException if a read error occurs
    */
 
-  public void read(DrillBuf buf, InputStream in, int length) throws IOException;
+  public void read(DrillBuf buf, int length, InputStream in) throws IOException;
+
+  /**
+   * Reads the specified number of bytes into a new Drillbuf.
+   * @param length number of bytes to read
+   * @param in input stream from which to read data
+   * @return the buffer holding the data read from the stream
+   * @throws IOException if a read error occurs
+   */
+
+  public DrillBuf read(int length, InputStream in) throws IOException;
 }


### PR DESCRIPTION
Unit testing revealed that the VectorAccessorSerializable class claims
to serialize SV2s, but, in fact, does not. Actually, it writes them,
but does not read them, resulting in corrupted data on read.

Fortunately, no code appears to serialize sv2s at present. Still, it is
a bug and needs to be fixed.

First task is to add serialization code for the sv2.

That revealed that the recently-added code to save DrillBufs using a
shared buffer had a bug: it relied on the writer index to know how much
data is in the buffer. Turns out sv2 buffers don’t set this index. So,
new versions of the write function takes a write length.

Then, closer inspection of the read code revealed duplicated code. So,
DrillBuf allocation moved into a version of the read function that now
does reading and DrillBuf allocation.

Turns out that value vectors, but not SV2s, can be built from a
Drillbuf. Added a matching constructor to the SV2 class.

Finally, cleaned up the code a bit to make it easier to follow. Also
allowed test code to access the handy timer already present in the code.