### PR TITLE
DRILL-5394: Optimize query planning for MapR-DB tables by caching row…

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBPushFilterIntoScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBPushFilterIntoScan.java
@@ -184,8 +184,10 @@ public abstract class MapRDBPushFilterIntoScan extends StoragePluginOptimizerRul
       return; //no filter pushdown ==> No transformation.
     }
 
+    // Pass tableStats from old groupScan so we do not go and fetch stats (an expensive operation) again from MapR DB client.
     final BinaryTableGroupScan newGroupsScan = new BinaryTableGroupScan(groupScan.getUserName(), groupScan.getStoragePlugin(),
-                                                              groupScan.getFormatPlugin(), newScanSpec, groupScan.getColumns());
+                                                                        groupScan.getFormatPlugin(), newScanSpec, groupScan.getColumns(),
+                                                                        groupScan.getTableStats());
     newGroupsScan.setFilterPushedDown(true);
 
     final ScanPrel newScanPrel = ScanPrel.create(scan, filter.getTraitSet(), newGroupsScan, scan.getRowType());


### PR DESCRIPTION
… counts

During the planning phase, we fetch MapR DB table row count multiple times. This is an expensive operation and fetching it multiple times increases planning time considerably.  Implemented per query cache. Fetch table rowCount only once, cache it in hbaseScanSpec and reuse it. Copy the rowCount from old to new hbaseScanSpec when a new groupScan is created i.e. when the filter is pushed down into scan.