### PR TITLE
Drill-4139: Exception while trying to prune partition. java.lang.UnsupportedOperationException: Unsupported type: BIT & Interval

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/MetadataVersion.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/MetadataVersion.java
@@ -141,7 +141,7 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
     public static final String V3_2 = "3.2";
 
     /**
-     * Version 3.2: Changed serialization of BINARY and FIXED_LEN_BYTE_ARRAY fields.<br>
+     * Version 3.3: Changed serialization of BINARY and FIXED_LEN_BYTE_ARRAY fields.<br>
      * See DRILL-4139
      */
     public static final String V3_3 = "3.3";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/MetadataVersion.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/MetadataVersion.java
@@ -141,6 +141,12 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
     public static final String V3_2 = "3.2";
 
     /**
+     * Version 3.2: Changed serialization of BINARY and FIXED_LEN_BYTE_ARRAY fields.<br>
+     * See DRILL-4139
+     */
+    public static final String V3_3 = "3.3";
+
+    /**
      * All historical versions of the Drill metadata cache files. In case of introducing a new parquet metadata version
      * please follow the {@link MetadataVersion#FORMAT}.
      */
@@ -149,7 +155,8 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
         new MetadataVersion(V2),
         new MetadataVersion(V3),
         new MetadataVersion(V3_1),
-        new MetadataVersion(V3_2)
+        new MetadataVersion(V3_2),
+        new MetadataVersion(V3_3)
     );
 
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
@@ -76,6 +76,7 @@ import org.apache.drill.exec.store.schedule.CompleteWork;
 import org.apache.drill.exec.store.schedule.EndpointByteMap;
 import org.apache.drill.exec.store.schedule.EndpointByteMapImpl;
 import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.exec.vector.NullableBitVector;
 import org.apache.drill.exec.vector.NullableBigIntVector;
 import org.apache.drill.exec.vector.NullableDateVector;
 import org.apache.drill.exec.vector.NullableDecimal18Vector;
@@ -477,6 +478,12 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
     String f = Path.getPathWithoutSchemeAndAuthority(new Path(file)).toString();
     MinorType type = getTypeForColumn(column).getMinorType();
     switch (type) {
+      case BIT: {
+        NullableBitVector bitVector = (NullableBitVector) v;
+        Boolean value = (Boolean) partitionValueMap.get(f).get(column);
+        bitVector.getMutator().setSafe(index, value ? 1 : 0);
+        return;
+      }
       case INT: {
         NullableIntVector intVector = (NullableIntVector) v;
         Integer value = (Integer) partitionValueMap.get(f).get(column);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetReaderUtility.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetReaderUtility.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.store.parquet;
 
+import com.google.common.collect.Sets;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.PathSegment;
 import org.apache.drill.common.expression.SchemaPath;
@@ -38,6 +40,7 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.joda.time.Chronology;
 import org.joda.time.DateTimeConstants;
 import org.apache.parquet.example.data.simple.NanoTime;
@@ -48,6 +51,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Utility class where we can capture common logic between the two parquet readers
@@ -157,11 +161,12 @@ public class ParquetReaderUtility {
         // Drill has only ever written a single row group per file, only need to correct the statistics
         // on the first row group
         Metadata.RowGroupMetadata rowGroupMetadata = file.getRowGroups().get(0);
+        Long rowCount = rowGroupMetadata.getRowCount();
         for (Metadata.ColumnMetadata columnMetadata : rowGroupMetadata.getColumns()) {
           // Setting Min/Max values for ParquetTableMetadata_v1
           if (new MetadataVersion(1, 0).equals(new MetadataVersion(parquetTableMetadata.getMetadataVersion()))) {
             OriginalType originalType = columnMetadata.getOriginalType();
-            if (OriginalType.DATE.equals(originalType) && columnMetadata.hasSingleValue() &&
+            if (OriginalType.DATE.equals(originalType) && columnMetadata.hasSingleValue(rowCount) &&
                 (Integer) columnMetadata.getMaxValue() > ParquetReaderUtility.DATE_CORRUPTION_THRESHOLD) {
               int newMinMax = ParquetReaderUtility.autoCorrectCorruptedDate((Integer) columnMetadata.getMaxValue());
               columnMetadata.setMax(newMinMax);
@@ -171,12 +176,115 @@ public class ParquetReaderUtility {
           // Setting Max values for ParquetTableMetadata_v2
           else if (new MetadataVersion(2, 0).equals(new MetadataVersion(parquetTableMetadata.getMetadataVersion())) &&
               columnMetadata.getName() != null && Arrays.equals(columnMetadata.getName(), names) &&
-              columnMetadata.hasSingleValue() && (Integer) columnMetadata.getMaxValue() >
+              columnMetadata.hasSingleValue(rowCount) && (Integer) columnMetadata.getMaxValue() >
               ParquetReaderUtility.DATE_CORRUPTION_THRESHOLD) {
             int newMax = ParquetReaderUtility.autoCorrectCorruptedDate((Integer) columnMetadata.getMaxValue());
             columnMetadata.setMax(newMax);
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Checks assigns byte arrays to min/max values obtained from the deserialized string
+   * for BINARY.
+   *
+   * @param parquetTableMetadata table metadata that should be corrected
+   */
+  public static void correctBinaryInMetadataCache(Metadata.ParquetTableMetadataBase parquetTableMetadata) {
+    // Looking for the names of the columns with BINARY data type
+    // in the metadata cache file for V2 and all v3 versions
+    Set<List<String>> columnsNames = getBinaryColumnsNames(parquetTableMetadata);
+
+    for (Metadata.ParquetFileMetadata file : parquetTableMetadata.getFiles()) {
+      for (Metadata.RowGroupMetadata rowGroupMetadata : file.getRowGroups()) {
+        Long rowCount = rowGroupMetadata.getRowCount();
+        for (Metadata.ColumnMetadata columnMetadata : rowGroupMetadata.getColumns()) {
+          // Setting Min/Max values for ParquetTableMetadata_v1
+          if (new MetadataVersion(1, 0).equals(new MetadataVersion(parquetTableMetadata.getMetadataVersion()))) {
+            if (columnMetadata.getPrimitiveType() == PrimitiveTypeName.BINARY
+                || columnMetadata.getPrimitiveType() == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+              setMinMaxValues(columnMetadata, rowCount);
+            }
+          }
+          // Setting Min/Max values for V2 and all V3 versions before V3_2
+          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 2)) < 0
+                    && columnsNames.contains(Arrays.asList(columnMetadata.getName()))) {
+            setMinMaxValues(columnMetadata, rowCount);
+          }
+          // Setting Min/Max values for V3_2 and all younger versions
+          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 2)) >= 0
+                      && columnsNames.contains(Arrays.asList(columnMetadata.getName()))) {
+            convertMinMaxValues(columnMetadata, rowCount);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the set of the lists with names of the columns with BINARY or
+   * FIXED_LEN_BYTE_ARRAY data type from {@code ParquetTableMetadataBase columnTypeMetadataCollection}
+   * if parquetTableMetadata has version v2 or v3 (including minor versions).
+   *
+   * @param parquetTableMetadata table metadata the source of the columns to check
+   * @return set of the lists with column names
+   */
+  private static Set<List<String>> getBinaryColumnsNames(Metadata.ParquetTableMetadataBase parquetTableMetadata) {
+    Set<List<String>> names = Sets.newHashSet();
+    if (parquetTableMetadata instanceof Metadata.ParquetTableMetadata_v2) {
+      for (Metadata.ColumnTypeMetadata_v2 columnTypeMetadata :
+        ((Metadata.ParquetTableMetadata_v2) parquetTableMetadata).columnTypeInfo.values()) {
+        if (columnTypeMetadata.primitiveType == PrimitiveTypeName.BINARY
+            || columnTypeMetadata.primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+          names.add(Arrays.asList(columnTypeMetadata.name));
+        }
+      }
+    } else if (parquetTableMetadata instanceof Metadata.ParquetTableMetadata_v3) {
+      for (Metadata.ColumnTypeMetadata_v3 columnTypeMetadata :
+        ((Metadata.ParquetTableMetadata_v3) parquetTableMetadata).columnTypeInfo.values()) {
+        if (columnTypeMetadata.primitiveType == PrimitiveTypeName.BINARY
+            || columnTypeMetadata.primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+          names.add(Arrays.asList(columnTypeMetadata.name));
+        }
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Checks that column has single value and replaces Min and Max by their byte values
+   * in {@code Metadata.ColumnMetadata columnMetadata} if their values were stored as strings.
+   *
+   * @param columnMetadata column metadata that should be changed
+   * @param rowCount       rows count in column chunk
+   */
+  private static void setMinMaxValues(Metadata.ColumnMetadata columnMetadata, long rowCount) {
+    if (columnMetadata.hasSingleValue(rowCount)) {
+      Object minValue = columnMetadata.getMinValue();
+      if (minValue != null && minValue instanceof String) {
+        byte[] bytes = ((String) minValue).getBytes();
+        columnMetadata.setMax(bytes);
+        columnMetadata.setMin(bytes);
+      }
+    }
+  }
+
+  /**
+   * Checks that column has single value and replaces Min and Max by their byte values from Base64 data
+   * in Metadata.ColumnMetadata columnMetadata if their values were stored as strings.
+   *
+   * @param columnMetadata column metadata that should be changed
+   * @param rowCount       rows count in column chunk
+   */
+  private static void convertMinMaxValues(Metadata.ColumnMetadata columnMetadata, long rowCount) {
+    if (columnMetadata.hasSingleValue(rowCount)) {
+      Object minValue = columnMetadata.getMinValue();
+      if (minValue != null && minValue instanceof String) {
+        byte[] bytes = Base64.decodeBase64(((String) minValue).getBytes());
+        columnMetadata.setMax(bytes);
+        columnMetadata.setMin(bytes);
       }
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetReaderUtility.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetReaderUtility.java
@@ -208,13 +208,13 @@ public class ParquetReaderUtility {
               setMinMaxValues(columnMetadata, rowCount);
             }
           }
-          // Setting Min/Max values for V2 and all V3 versions before V3_2
-          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 2)) < 0
+          // Setting Min/Max values for V2 and all V3 versions before V3_3
+          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 3)) < 0
                     && columnsNames.contains(Arrays.asList(columnMetadata.getName()))) {
             setMinMaxValues(columnMetadata, rowCount);
           }
-          // Setting Min/Max values for V3_2 and all younger versions
-          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 2)) >= 0
+          // Setting Min/Max values for V3_3 and all younger versions
+          else if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(3, 3)) >= 0
                       && columnsNames.contains(Arrays.asList(columnMetadata.getName()))) {
             convertMinMaxValues(columnMetadata, rowCount);
           }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
@@ -21,10 +21,12 @@ import com.google.common.io.Resources;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
+import com.google.common.collect.Lists;
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.common.util.TestTools;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.exec.store.dfs.MetadataContext;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.hadoop.fs.Path;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -714,6 +716,220 @@ public class TestParquetMetadataCache extends PlanTestBase {
     }
   }
 
+  @Test // DRILL-4139
+  public void testBooleanPartitionPruning() throws Exception {
+    final String boolPartitionTable = "dfs_test.tmp.`interval_bool_partition`";
+    try {
+      test("create table %s partition by (col_bln) as " +
+        "select * from cp.`parquet/alltypes_required.parquet`", boolPartitionTable);
+
+      String query = String.format("select * from %s where col_bln = true", boolPartitionTable);
+      int expectedRowCount = 2;
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata %s", boolPartitionTable);
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test("drop table if exists %s", boolPartitionTable);
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testIntervalDayPartitionPruning() throws Exception {
+    final String intervalDayPartitionTable = "dfs_test.tmp.`interval_day_partition`";
+    try {
+      test("create table %s partition by (col_intrvl_day) as " +
+        "select * from cp.`parquet/alltypes_optional.parquet`", intervalDayPartitionTable);
+
+      String query = String.format("select * from %s " +
+        "where col_intrvl_day = cast('P26DT27386S' as interval day)", intervalDayPartitionTable);
+      int expectedRowCount = 1;
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata %s", intervalDayPartitionTable);
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test(String.format("drop table if exists %s", intervalDayPartitionTable));
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testIntervalYearPartitionPruning() throws Exception {
+    final String intervalYearPartitionTable = "dfs_test.tmp.`interval_yr_partition`";
+    try {
+      test("create table %s partition by (col_intrvl_yr) as " +
+        "select * from cp.`parquet/alltypes_optional.parquet`", intervalYearPartitionTable);
+
+      String query = String.format("select * from %s where col_intrvl_yr = cast('P314M' as interval year)",
+        intervalYearPartitionTable);
+      int expectedRowCount = 1;
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata %s", intervalYearPartitionTable);
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test("drop table if exists %s", intervalYearPartitionTable);
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testVarCharWithNullsPartitionPruning() throws Exception {
+    final String intervalYearPartitionTable = "dfs_test.tmp.`varchar_optional_partition`";
+    try {
+      test("create table %s partition by (col_vrchr) as " +
+        "select * from cp.`parquet/alltypes_optional.parquet`", intervalYearPartitionTable);
+
+      String query = String.format("select * from %s where col_vrchr = 'Nancy Cloke'",
+        intervalYearPartitionTable);
+      int expectedRowCount = 1;
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata %s", intervalYearPartitionTable);
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test("drop table if exists %s", intervalYearPartitionTable);
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testDecimalPartitionPruning() throws Exception {
+    List<String> ctasQueries = Lists.newArrayList();
+    // decimal stores as fixed_len_byte_array
+    ctasQueries.add("create table %s partition by (manager_id) as " +
+      "select * from cp.`parquet/fixedlenDecimal.parquet`");
+    // decimal stores as int32
+    ctasQueries.add("create table %s partition by (manager_id) as " +
+      "select cast(manager_id as decimal(6, 0)) as manager_id, EMPLOYEE_ID, FIRST_NAME, LAST_NAME " +
+      "from cp.`parquet/fixedlenDecimal.parquet`");
+    // decimal stores as int64
+    ctasQueries.add("create table %s partition by (manager_id) as " +
+      "select cast(manager_id as decimal(18, 6)) as manager_id, EMPLOYEE_ID, FIRST_NAME, LAST_NAME " +
+      "from cp.`parquet/fixedlenDecimal.parquet`");
+    final String decimalPartitionTable = "dfs_test.tmp.`decimal_optional_partition`";
+    for (String ctasQuery : ctasQueries) {
+      try {
+        test("alter session set `%s` = true", PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+        test(ctasQuery, decimalPartitionTable);
+
+        String query = String.format("select * from %s where manager_id = 148", decimalPartitionTable);
+        int expectedRowCount = 6;
+
+        int actualRowCount = testSql(query);
+        assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+        PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+        test("refresh table metadata %s", decimalPartitionTable);
+
+        actualRowCount = testSql(query);
+        assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+        PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+      } finally {
+        test("drop table if exists %s", decimalPartitionTable);
+        test("alter session set `%s` = false", PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      }
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testIntWithNullsPartitionPruning() throws Exception {
+    try {
+      test("create table dfs_test.tmp.`t5/a` as\n" +
+        "select 100 as mykey from cp.`tpch/nation.parquet`\n" +
+        "union all\n" +
+        "select col_notexist from cp.`tpch/region.parquet`");
+
+      test("create table dfs_test.tmp.`t5/b` as\n" +
+        "select 200 as mykey from cp.`tpch/nation.parquet`\n" +
+        "union all\n" +
+        "select col_notexist from cp.`tpch/region.parquet`");
+
+      String query = "select mykey from dfs_test.tmp.`t5` where mykey = 100";
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 25, actualRowCount);
+
+      test("refresh table metadata dfs_test.tmp.`t5`");
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 25, actualRowCount);
+    } finally {
+      test("drop table if exists dfs_test.tmp.`t5`");
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testPartitionPruningWithIsNull() throws Exception {
+    try {
+      test("create table dfs_test.tmp.`t6/a` as\n" +
+        "select col_notexist as mykey from cp.`tpch/region.parquet`");
+
+      test("create table dfs_test.tmp.`t6/b` as\n" +
+        "select 100 as mykey from cp.`tpch/region.parquet`");
+
+      String query = "select mykey from dfs_test.tmp.t6 where mykey is null";
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata dfs_test.tmp.`t6`");
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test("drop table if exists dfs_test.tmp.`t6`");
+    }
+  }
+
+  @Test // DRILL-4139
+  public void testPartitionPruningWithIsNotNull() throws Exception {
+    try {
+      test("create table dfs_test.tmp.`t7/a` as\n" +
+        "select col_notexist as mykey from cp.`tpch/region.parquet`");
+
+      test("create table dfs_test.tmp.`t7/b` as\n" +
+        "select 100 as mykey from cp.`tpch/region.parquet`");
+
+      String query = "select mykey from dfs_test.tmp.t7 where mykey is null";
+
+      int actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=false"}, new String[]{"Filter"});
+
+      test("refresh table metadata dfs_test.tmp.`t7`");
+
+      actualRowCount = testSql(query);
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      PlanTestBase.testPlanMatchingPatterns(query, new String[]{"usedMetadataFile=true"}, new String[]{"Filter"});
+    } finally {
+      test("drop table if exists dfs_test.tmp.`t7`");
+    }
+  }
+
   /**
    * Helper method for checking the metadata file existence
    *
@@ -726,5 +942,4 @@ public class TestParquetMetadataCache extends PlanTestBase {
     assertTrue(String.format("There is no metadata cache file for the %s table", table),
         Files.exists(metaFile.toPath()));
   }
-
 }


### PR DESCRIPTION
Add missing BIT partition pruning support.
Add missing Interval, VarBinary and Varchar with nulls partition pruning support.
Fix metadata serialization for fixed_len_byte_array and binary types.
Fix partition pruning for decimal type.