### PR TITLE
DRILL-5428: submit_plan fails after Drill 1.8 script revisions

### DIFF
--- a/distribution/src/resources/submit_plan
+++ b/distribution/src/resources/submit_plan
@@ -22,4 +22,4 @@ bin=`cd -P "$bin">/dev/null; pwd`
 
 DRILL_SHELL_JAVA_OPTS="$DRILL_SHELL_JAVA_OPTS -Dlog.path=$DRILL_LOG_DIR/submitter.log -Dlog.query.path=$DRILL_LOG_DIR/submitter_queries.json"
 
-exec $JAVA $DRILL_SHELL_JAVA_OPTS $DRILL_JAVA_OPTS -cp $CP org.apache.drill.exec.client.QuerySubmitter "$@"
+exec $JAVA $DRILL_SHELL_JAVA_OPTS $DRILL_JAVA_OPTS -cp $CP org.apache.drill.exec.client.QuerySubmitter "${args[@]}"


### PR DESCRIPTION
When the other scripts were updated, submit_plan was not corrected.
After Drill 1.8, drill-config.sh consumes all command line arguments,
finds the —config and —site options, removes them, and places the rest
in the new args array.

This PR updates submit_plan to use the new args array.

The fix was tested on a test cluster: we verified that a physical plan
was submitted and ran.