### PR TITLE
DRILL-5391: CTAS: make folder and file permission configurable

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -446,4 +446,7 @@ public interface ExecConstants {
   String QUERY_TRANSIENT_STATE_UPDATE_KEY = "exec.query.progress.update";
   BooleanValidator QUERY_TRANSIENT_STATE_UPDATE = new BooleanValidator(QUERY_TRANSIENT_STATE_UPDATE_KEY, true);
 
+  String PERSISTENT_TABLE_UMASK = "exec.persistent_table.umask";
+  StringValidator PERSISTENT_TABLE_UMASK_VALIDATOR = new StringValidator(PERSISTENT_TABLE_UMASK, "002");
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/CreateTableHandler.java
@@ -91,7 +91,8 @@ public class CreateTableHandler extends DefaultSqlHandler {
     log("Calcite", newTblRelNodeWithPCol, logger, null);
     // Convert the query to Drill Logical plan and insert a writer operator on top.
     StorageStrategy storageStrategy = sqlCreateTable.isTemporary() ?
-        StorageStrategy.TEMPORARY : StorageStrategy.PERSISTENT;
+        StorageStrategy.TEMPORARY :
+        new StorageStrategy(context.getOption(ExecConstants.PERSISTENT_TABLE_UMASK).string_val, false);
 
     // If we are creating temporary table, initial table name will be replaced with generated table name.
     // Generated table name is unique, UUID.randomUUID() is used for its generation.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -169,7 +169,8 @@ public class SystemOptionManager extends BaseOptionManager implements OptionMana
       ExecConstants.ENABLE_QUERY_PROFILE_VALIDATOR,
       ExecConstants.QUERY_PROFILE_DEBUG_VALIDATOR,
       ExecConstants.USE_DYNAMIC_UDFS,
-      ExecConstants.QUERY_TRANSIENT_STATE_UPDATE
+      ExecConstants.QUERY_TRANSIENT_STATE_UPDATE,
+      ExecConstants.PERSISTENT_TABLE_UMASK_VALIDATOR
     };
     final Map<String, OptionValidator> tmp = new HashMap<>();
     for (final OptionValidator validator : validators) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
@@ -140,7 +140,7 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
    * @return create table entry
    */
   public CreateTableEntry createNewTable(String tableName, List<String> partitionColumns) {
-    return createNewTable(tableName, partitionColumns, StorageStrategy.PERSISTENT);
+    return createNewTable(tableName, partitionColumns, StorageStrategy.DEFAULT);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonRecordWriter.java
@@ -65,7 +65,7 @@ public class JsonRecordWriter extends JSONOutputRecordWriter implements RecordWr
   private boolean fRecordStarted = false; // true once the startRecord() is called until endRecord() is called
 
   public JsonRecordWriter(StorageStrategy storageStrategy){
-    this.storageStrategy = storageStrategy == null ? StorageStrategy.PERSISTENT : storageStrategy;
+    this.storageStrategy = storageStrategy == null ? StorageStrategy.DEFAULT : storageStrategy;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRecordWriter.java
@@ -121,7 +121,7 @@ public class ParquetRecordWriter extends ParquetOutputRecordWriter {
     this.hasPartitions = partitionColumns != null && partitionColumns.size() > 0;
     this.extraMetaData.put(DRILL_VERSION_PROPERTY, DrillVersionInfo.getVersion());
     this.extraMetaData.put(WRITER_VERSION_PROPERTY, String.valueOf(ParquetWriter.WRITER_VERSION));
-    this.storageStrategy = writer.getStorageStrategy() == null ? StorageStrategy.PERSISTENT : writer.getStorageStrategy();
+    this.storageStrategy = writer.getStorageStrategy() == null ? StorageStrategy.DEFAULT : writer.getStorageStrategy();
     this.cleanUpLocations = Lists.newArrayList();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/text/DrillTextRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/text/DrillTextRecordWriter.java
@@ -58,7 +58,7 @@ public class DrillTextRecordWriter extends StringOutputRecordWriter {
 
   public DrillTextRecordWriter(BufferAllocator allocator, StorageStrategy storageStrategy) {
     super(allocator);
-    this.storageStrategy = storageStrategy == null ? StorageStrategy.PERSISTENT : storageStrategy;
+    this.storageStrategy = storageStrategy == null ? StorageStrategy.DEFAULT : storageStrategy;
   }
 
   @Override


### PR DESCRIPTION
1. Added new configuration option exec.persistent_table.umask which defaults to 002. User can modify this option on session or system level. If umask was set incorrectly, default umask will be used (002) and error will be logged.
2. Refactored `StorageStrategy` to use umask.
3. Added appropriate unit tests.