### PR TITLE
DRILL-5457: Spill implementation for Hash Aggregate

### DIFF
--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -142,6 +142,13 @@ drill.exec: {
     }
   },
   cache.hazel.subnets: ["*.*.*.*"],
+  spill: {
+     # These options are common to all spilling operators.
+     # They can be overriden, per operator (but this is just for
+     # backward compatibility, and may be deprecated in the future)
+     directories : [ "/tmp/drill/spill" ],
+     fs : "file:///"
+  }
   sort: {
     purge.threshold : 100,
     external: {
@@ -150,9 +157,24 @@ drill.exec: {
         batch.size : 4000,
         group.size : 100,
         threshold : 200,
+        # The 2 options below override the common ones
+        # they should be deprecated in the future
         directories : [ "/tmp/drill/spill" ],
         fs : "file:///"
       }
+    }
+  },
+  hashagg: {
+    # The partitions divide the work inside the hashagg, to ease
+    # handling spilling. This initial figure is tuned down when
+    # memory is limited.
+    #  Setting this option to 1 disables spilling !
+    num_partitions: 32,
+    spill: {
+        # The 2 options below override the common ones
+        # they should be deprecated in the future
+        directories : [ "/tmp/drill/spill" ],
+        fs : "file:///"
     }
   },
   memory: {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -64,6 +64,12 @@ public interface ExecConstants {
   String SPOOLING_BUFFER_MEMORY = "drill.exec.buffer.spooling.size";
   String BATCH_PURGE_THRESHOLD = "drill.exec.sort.purge.threshold";
 
+  // Spill boot-time Options common to all spilling operators
+  // (Each individual operator may override the common options)
+
+  String SPILL_FILESYSTEM = "drill.exec.spill.fs";
+  String SPILL_DIRS = "drill.exec.spill.directories";
+
   // External Sort Boot configuration
 
   String EXTERNAL_SORT_TARGET_SPILL_BATCH_SIZE = "drill.exec.sort.external.spill.batch.size";
@@ -86,6 +92,22 @@ public interface ExecConstants {
 
   BooleanValidator EXTERNAL_SORT_DISABLE_MANAGED_OPTION = new BooleanValidator("exec.sort.disable_managed", false);
 
+  // Hash Aggregate Options
+
+  String HASHAGG_NUM_PARTITIONS = "drill.exec.hashagg.num_partitions";
+  String HASHAGG_NUM_PARTITIONS_KEY = "exec.hashagg.num_partitions";
+  LongValidator HASHAGG_NUM_PARTITIONS_VALIDATOR = new RangeLongValidator(HASHAGG_NUM_PARTITIONS_KEY, 1, 128, 32); // 1 means - no spilling
+  String HASHAGG_MAX_MEMORY = "drill.exec.hashagg.mem_limit";
+  String HASHAGG_MAX_MEMORY_KEY = "exec.hashagg.mem_limit";
+  LongValidator HASHAGG_MAX_MEMORY_VALIDATOR = new RangeLongValidator(HASHAGG_MAX_MEMORY_KEY, 0, Integer.MAX_VALUE, 0);
+  // min batches is used for tuning (each partition needs so many batches when planning the number of partitions,
+  // or reserve this number when calculating whether the remaining available memory is too small and requires a spill.)
+  // Low value may OOM (e.g., when incoming rows become wider), higher values use fewer partitions but are safer
+  String HASHAGG_MIN_BATCHES_PER_PARTITION = "drill.exec.hashagg.min_batches_per_partition";
+  String HASHAGG_MIN_BATCHES_PER_PARTITION_KEY = "drill.exec.hashagg.min_batches_per_partition";
+  LongValidator HASHAGG_MIN_BATCHES_PER_PARTITION_VALIDATOR = new RangeLongValidator(HASHAGG_MIN_BATCHES_PER_PARTITION_KEY, 2, 5, 3);
+  String HASHAGG_SPILL_DIRS = "drill.exec.hashagg.spill.directories";
+  String HASHAGG_SPILL_FILESYSTEM = "drill.exec.hashagg.spill.fs";
 
   String TEXT_LINE_READER_BATCH_SIZE = "drill.exec.storage.file.text.batch.size";
   String TEXT_LINE_READER_BUFFER_SIZE = "drill.exec.storage.file.text.buffer.size";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractBase.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.physical.base;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.graph.GraphVisitor;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
@@ -102,16 +104,30 @@ public abstract class AbstractBase implements PhysicalOperator{
     this.cost = cost;
   }
 
-  // Not available. Presumably because Drill does not currently use
-  // this value, though it does appear in some test physical plans.
-//  public void setMaxAllocation(long alloc) {
-//    maxAllocation = alloc;
-//  }
-
   @Override
   public long getMaxAllocation() {
     return maxAllocation;
   }
+
+  /**
+   * Any operator that supports spilling should override this method
+   * @param maxAllocation The max memory allocation to be set
+   */
+  @Override
+  public void setMaxAllocation(long maxAllocation) {
+    this.maxAllocation = maxAllocation;
+    /*throw new DrillRuntimeException("Unsupported method: setMaxAllocation()");*/
+  }
+
+  /**
+   * Any operator that supports spilling should override this method (and return true)
+   * @return false
+   */
+  @Override @JsonIgnore
+  public boolean isBufferedOperator() { return false; }
+
+  // @Override
+  // public void setBufferedOperator(boolean bo) {}
 
   @Override
   public String getUserName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
@@ -83,6 +83,21 @@ public interface PhysicalOperator extends GraphValue<PhysicalOperator> {
    */
   public long getMaxAllocation();
 
+  /**
+   *
+   * @param maxAllocation The max memory allocation to be set
+   */
+  public void setMaxAllocation(long maxAllocation);
+
+  /**
+   *
+   * @return True iff this operator manages its memory (including disk spilling)
+   */
+  @JsonIgnore
+  public boolean isBufferedOperator();
+
+  // public void setBufferedOperator(boolean bo);
+
   @JsonProperty("@id")
   public int getOperatorId();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ExternalSort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ExternalSort.java
@@ -49,12 +49,19 @@ public class ExternalSort extends Sort {
     return CoreOperatorType.EXTERNAL_SORT_VALUE;
   }
 
-  // Set here, rather than the base class, because this is the only
-  // operator, at present, that makes use of the maximum allocation.
-  // Remove this, in favor of the base class version, when Drill
-  // sets the memory allocation for all operators.
-
+  /**
+   *
+   * @param maxAllocation The max memory allocation to be set
+   */
+  @Override
   public void setMaxAllocation(long maxAllocation) {
     this.maxAllocation = maxAllocation;
   }
+
+  /**
+   * The External Sort operator supports spilling
+   * @return true
+   */
+  @Override
+  public boolean isBufferedOperator() { return true; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -18,82 +18,155 @@
 package org.apache.drill.exec.physical.impl.aggregate;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
 
+import com.google.common.base.Stopwatch;
+
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.ExpressionPosition;
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.LogicalExpression;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.cache.VectorAccessibleSerializable;
 import org.apache.drill.exec.compile.sig.RuntimeOverridden;
 import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.TypeHelper;
+
+import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.MetricDef;
+import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.ops.OperatorStats;
+import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.config.HashAggregate;
 import org.apache.drill.exec.physical.impl.common.ChainedHashTable;
 import org.apache.drill.exec.physical.impl.common.HashTable;
 import org.apache.drill.exec.physical.impl.common.HashTableConfig;
 import org.apache.drill.exec.physical.impl.common.HashTableStats;
 import org.apache.drill.exec.physical.impl.common.IndexPointer;
+
+import org.apache.drill.exec.physical.impl.spill.RecordBatchSizer;
+
+import org.apache.drill.exec.physical.impl.spill.SpillSet;
+import org.apache.drill.exec.planner.physical.AggPrelBase;
+
+import org.apache.drill.exec.proto.UserBitShared;
+
 import org.apache.drill.exec.record.MaterializedField;
+
 import org.apache.drill.exec.record.RecordBatch;
-import org.apache.drill.exec.record.RecordBatch.IterOutcome;
-import org.apache.drill.exec.record.TypedFieldId;
+import org.apache.drill.exec.record.BatchSchema;
+
 import org.apache.drill.exec.record.VectorContainer;
+
+import org.apache.drill.exec.record.TypedFieldId;
+
+import org.apache.drill.exec.record.RecordBatch.IterOutcome;
 import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.record.WritableBatch;
+
 import org.apache.drill.exec.vector.AllocationHelper;
+
 import org.apache.drill.exec.vector.FixedWidthVector;
 import org.apache.drill.exec.vector.ObjectVector;
 import org.apache.drill.exec.vector.ValueVector;
+
 import org.apache.drill.exec.vector.VariableWidthVector;
 
-public abstract class HashAggTemplate implements HashAggregator {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashAggregator.class);
+import static org.apache.drill.exec.record.RecordBatch.MAX_BATCH_SIZE;
 
-//  private static final long ALLOCATOR_INITIAL_RESERVATION = 1 * 1024 * 1024;
-//  private static final long ALLOCATOR_MAX_RESERVATION = 20L * 1000 * 1000 * 1000;
-  private static final int VARIABLE_WIDTH_VALUE_SIZE = 50;
+public abstract class HashAggTemplate implements HashAggregator {
+  protected static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashAggregator.class);
+
+  private static final int VARIABLE_MAX_WIDTH_VALUE_SIZE = 50;
+  private static final int VARIABLE_MIN_WIDTH_VALUE_SIZE = 8;
 
   private static final boolean EXTRA_DEBUG_1 = false;
   private static final boolean EXTRA_DEBUG_2 = false;
-//  private static final String TOO_BIG_ERROR =
-//      "Couldn't add value to an empty batch.  This likely means that a single value is too long for a varlen field.";
-//  private boolean newSchema = false;
+  private static final boolean EXTRA_DEBUG_SPILL = false;
+
+  // Fields needed for partitioning (the groups into partitions)
+  private int numPartitions = 0; // must be 2 to the power of bitsInMask (set in setup())
+  private int partitionMask; // numPartitions - 1
+  private int bitsInMask; // number of bits in the MASK
+  private int nextPartitionToReturn = 0; // which partition to return the next batch from
+  // The following members are used for logging, metrics, etc.
+  private int rowsInPartition = 0; // counts #rows in each partition
+  private int rowsNotSpilled = 0;
+  private int rowsSpilled = 0;
+  private int rowsSpilledReturned = 0;
+  private int rowsReturnedEarly = 0;
+
+  private boolean isTwoPhase = false; // 1 phase or 2 phase aggr?
+  private boolean is2ndPhase = false;
+  private boolean canSpill = true; // make it false in case can not spill
+  private ChainedHashTable baseHashTable;
+  private boolean earlyOutput = false; // when 1st phase returns a partition due to no memory
+  private int earlyPartition = 0; // which partition to return early
+
+  private long memoryLimit; // max memory to be used by this oerator
+  private long estMaxBatchSize = 0; // used for adjusting #partitions
+  private long estRowWidth = 0;
+  private int maxColumnWidth = VARIABLE_MIN_WIDTH_VALUE_SIZE; // to control memory allocation for varchars
+  private long minBatchesPerPartition; // for tuning - num partitions and spill decision
+  private long plannedBatches = 0; // account for planned, but not yet allocated batches
+
   private int underlyingIndex = 0;
   private int currentIndex = 0;
   private IterOutcome outcome;
-//  private int outputCount = 0;
   private int numGroupedRecords = 0;
-  private int outBatchIndex = 0;
+  private int currentBatchRecordCount = 0; // Performance: Avoid repeated calls to getRecordCount()
+
   private int lastBatchOutputCount = 0;
   private RecordBatch incoming;
-//  private BatchSchema schema;
+  private BatchSchema schema;
   private HashAggBatch outgoing;
   private VectorContainer outContainer;
-//  private FragmentContext context;
+
+  private FragmentContext context;
+  private OperatorContext oContext;
   private BufferAllocator allocator;
 
-//  private HashAggregate hashAggrConfig;
-  private HashTable htable;
-  private ArrayList<BatchHolder> batchHolders;
+  private HashTable htables[];
+  private ArrayList<BatchHolder> batchHolders[];
+  private int outBatchIndex[];
+
+  // For handling spilling
+  private SpillSet spillSet;
+  SpilledRecordbatch newIncoming; // when reading a spilled file - work like an "incoming"
+  private OutputStream outputStream[]; // an output stream for each spilled partition
+  private int spilledBatchesCount[]; // count number of batches spilled, in each partition
+  private String spillFiles[];
+  private int cycleNum = 0; // primary, secondary, tertiary, etc.
+  private int originalPartition = -1; // the partition a secondary reads from
+
+  private static class SpilledPartition { public int spilledBatches; public String spillFile; int cycleNum; int origPartn; int prevOrigPartn; }
+
+  private ArrayList<SpilledPartition> spilledPartitionsList;
+  private int operatorId; // for the spill file name
+
   private IndexPointer htIdxHolder; // holder for the Hashtable's internal index returned by put()
   private IndexPointer outStartIdxHolder;
   private IndexPointer outNumRecordsHolder;
   private int numGroupByOutFields = 0; // Note: this should be <= number of group-by fields
-
-  ErrorCollector collector = new ErrorCollectorImpl();
+  private TypedFieldId[] groupByOutFieldIds;
 
   private MaterializedField[] materializedValueFields;
   private boolean allFlushed = false;
   private boolean buildComplete = false;
+  private boolean handlingSpills = false; // True once starting to process spill files
 
   private OperatorStats stats = null;
   private HashTableStats htStats = new HashTableStats();
@@ -103,7 +176,15 @@ public abstract class HashAggTemplate implements HashAggregator {
     NUM_BUCKETS,
     NUM_ENTRIES,
     NUM_RESIZING,
-    RESIZING_TIME;
+    RESIZING_TIME,
+    NUM_PARTITIONS,
+    SPILLED_PARTITIONS, // number of partitions spilled to disk
+    SPILL_MB,         // Number of MB of data spilled to disk. This amount is first written,
+                      // then later re-read. So, disk I/O is twice this amount.
+                      // For first phase aggr -- this is an estimate of the amount of data
+                      // returned early (analogous to a spill in the 2nd phase).
+    SPILL_CYCLE       // 0 - no spill, 1 - spill, 2 - SECONDARY, 3 - TERTIARY
+    ;
 
     // duplicate for hash ag
 
@@ -121,7 +202,6 @@ public abstract class HashAggTemplate implements HashAggregator {
     private int batchOutputCount = 0;
 
     private int capacity = Integer.MAX_VALUE;
-    private boolean allocatedNextBatch = false;
 
     @SuppressWarnings("resource")
     public BatchHolder() {
@@ -145,8 +225,8 @@ public abstract class HashAggTemplate implements HashAggregator {
           if (vector instanceof FixedWidthVector) {
             ((FixedWidthVector) vector).allocateNew(HashTable.BATCH_SIZE);
           } else if (vector instanceof VariableWidthVector) {
-            ((VariableWidthVector) vector).allocateNew(HashTable.VARIABLE_WIDTH_VECTOR_SIZE * HashTable.BATCH_SIZE,
-                HashTable.BATCH_SIZE);
+            // This case is never used .... a varchar falls under ObjectVector which is allocated on the heap !
+            ((VariableWidthVector) vector).allocateNew(maxColumnWidth, HashTable.BATCH_SIZE);
           } else if (vector instanceof ObjectVector) {
             ((ObjectVector) vector).allocateNew(HashTable.BATCH_SIZE);
           } else {
@@ -166,20 +246,23 @@ public abstract class HashAggTemplate implements HashAggregator {
     }
 
     private boolean updateAggrValues(int incomingRowIdx, int idxWithinBatch) {
-      updateAggrValuesInternal(incomingRowIdx, idxWithinBatch);
+      try { updateAggrValuesInternal(incomingRowIdx, idxWithinBatch); }
+      catch (SchemaChangeException sc) { throw new UnsupportedOperationException(sc); }
       maxOccupiedIdx = Math.max(maxOccupiedIdx, idxWithinBatch);
       return true;
     }
 
     private void setup() {
-      setupInterior(incoming, outgoing, aggrValuesContainer);
+      try { setupInterior(incoming, outgoing, aggrValuesContainer); }
+      catch (SchemaChangeException sc) { throw new UnsupportedOperationException(sc);}
     }
 
     private void outputValues(IndexPointer outStartIdxHolder, IndexPointer outNumRecordsHolder) {
       outStartIdxHolder.value = batchOutputCount;
       outNumRecordsHolder.value = 0;
       for (int i = batchOutputCount; i <= maxOccupiedIdx; i++) {
-        outputRecordValues(i, batchOutputCount);
+        try { outputRecordValues(i, batchOutputCount); }
+        catch (SchemaChangeException sc) { throw new UnsupportedOperationException(sc);}
         if (EXTRA_DEBUG_2) {
           logger.debug("Outputting values to output index: {}", batchOutputCount);
         }
@@ -204,24 +287,23 @@ public abstract class HashAggTemplate implements HashAggregator {
 
     @RuntimeOverridden
     public void setupInterior(@Named("incoming") RecordBatch incoming, @Named("outgoing") RecordBatch outgoing,
-        @Named("aggrValuesContainer") VectorContainer aggrValuesContainer) {
+        @Named("aggrValuesContainer") VectorContainer aggrValuesContainer) throws SchemaChangeException {
     }
 
     @RuntimeOverridden
-    public void updateAggrValuesInternal(@Named("incomingRowIdx") int incomingRowIdx, @Named("htRowIdx") int htRowIdx) {
+    public void updateAggrValuesInternal(@Named("incomingRowIdx") int incomingRowIdx, @Named("htRowIdx") int htRowIdx) throws SchemaChangeException{
     }
 
     @RuntimeOverridden
-    public void outputRecordValues(@Named("htRowIdx") int htRowIdx, @Named("outRowIdx") int outRowIdx) {
+    public void outputRecordValues(@Named("htRowIdx") int htRowIdx, @Named("outRowIdx") int outRowIdx) throws SchemaChangeException{
     }
   }
 
-
   @Override
   public void setup(HashAggregate hashAggrConfig, HashTableConfig htConfig, FragmentContext context,
-      OperatorStats stats, BufferAllocator allocator, RecordBatch incoming, HashAggBatch outgoing,
-      LogicalExpression[] valueExprs, List<TypedFieldId> valueFieldIds, TypedFieldId[] groupByOutFieldIds,
-      VectorContainer outContainer) throws SchemaChangeException, ClassTransformationException, IOException {
+                    OperatorStats stats, OperatorContext oContext, RecordBatch incoming, HashAggBatch outgoing,
+                    LogicalExpression[] valueExprs, List<TypedFieldId> valueFieldIds, TypedFieldId[] groupByOutFieldIds,
+                    VectorContainer outContainer) throws SchemaChangeException, IOException {
 
     if (valueExprs == null || valueFieldIds == null) {
       throw new IllegalArgumentException("Invalid aggr value exprs or workspace variables.");
@@ -230,15 +312,34 @@ public abstract class HashAggTemplate implements HashAggregator {
       throw new IllegalArgumentException("Wrong number of workspace variables.");
     }
 
-//    this.context = context;
+    this.context = context;
     this.stats = stats;
-    this.allocator = allocator;
+    this.allocator = oContext.getAllocator();
+    this.oContext = oContext;
     this.incoming = incoming;
-//    this.schema = incoming.getSchema();
     this.outgoing = outgoing;
     this.outContainer = outContainer;
+    this.operatorId = hashAggrConfig.getOperatorId();
 
-//    this.hashAggrConfig = hashAggrConfig;
+    is2ndPhase = hashAggrConfig.getAggPhase() == AggPrelBase.OperatorPhase.PHASE_2of2;
+    isTwoPhase = hashAggrConfig.getAggPhase() != AggPrelBase.OperatorPhase.PHASE_1of1;
+    canSpill = isTwoPhase; // single phase can not spill
+
+    // Typically for testing - force a spill after a partition has more than so many batches
+    minBatchesPerPartition = context.getConfig().getLong(ExecConstants.HASHAGG_MIN_BATCHES_PER_PARTITION);
+
+    // Set the memory limit
+    memoryLimit = allocator.getLimit();
+    // Optional configured memory limit, typically used only for testing.
+    long configLimit = context.getConfig().getLong(ExecConstants.HASHAGG_MAX_MEMORY);
+    if (configLimit > 0) {
+      logger.warn("Memory limit was changed to {}",configLimit);
+      memoryLimit = Math.min(memoryLimit, configLimit);
+      allocator.setLimit(memoryLimit); // enforce at the allocator
+    }
+
+    // All the settings that require the number of partitions were moved into delayedSetup()
+    // which would be called later, after the actuall data first arrives
 
     // currently, hash aggregation is only applicable if there are group-by expressions.
     // For non-grouped (a.k.a Plain) aggregations that don't involve DISTINCT, there is no
@@ -266,112 +367,278 @@ public abstract class HashAggTemplate implements HashAggregator {
       }
     }
 
-    ChainedHashTable ht =
+    spillSet = new SpillSet(context,hashAggrConfig, UserBitShared.CoreOperatorType.HASH_AGGREGATE);
+    baseHashTable =
         new ChainedHashTable(htConfig, context, allocator, incoming, null /* no incoming probe */, outgoing);
-    this.htable = ht.createAndSetupHashTable(groupByOutFieldIds);
-
+    this.groupByOutFieldIds = groupByOutFieldIds; // retain these for delayedSetup, and to allow recreating hash tables (after a spill)
     numGroupByOutFields = groupByOutFieldIds.length;
-    batchHolders = new ArrayList<BatchHolder>();
-    // First BatchHolder is created when the first put request is received.
 
     doSetup(incoming);
   }
 
-  @Override
-  public AggOutcome doWork() {
-    try {
-      // Note: Keeping the outer and inner try blocks here to maintain some similarity with
-      // StreamingAggregate which does somethings conditionally in the outer try block.
-      // In the future HashAggregate may also need to perform some actions conditionally
-      // in the outer try block.
+  /**
+   *  Delayed setup are the parts from setup() that can only be set after actual data arrives in incoming
+   *  This data is used to compute the number of partitions.
+   */
+  private void delayedSetup() {
 
-      outside:
-      while (true) {
-        // loop through existing records, aggregating the values as necessary.
-        if (EXTRA_DEBUG_1) {
-          logger.debug("Starting outer loop of doWork()...");
-        }
-        for (; underlyingIndex < incoming.getRecordCount(); incIndex()) {
-          if (EXTRA_DEBUG_2) {
-            logger.debug("Doing loop with values underlying {}, current {}", underlyingIndex, currentIndex);
+    // Set the number of partitions from the configuration (raise to a power of two, if needed)
+    numPartitions = context.getConfig().getInt(ExecConstants.HASHAGG_NUM_PARTITIONS);
+    if ( numPartitions == 1 ) {
+      canSpill = false;
+      logger.warn("Spilling was disabled due to configuration setting of num_partitions to 1");
+    }
+    numPartitions = BaseAllocator.nextPowerOfTwo(numPartitions); // in case not a power of 2
+
+    if ( schema == null ) { estMaxBatchSize = 0; } // incoming was an empty batch
+    else {
+      // Estimate the max batch size; should use actual data (e.g. lengths of varchars)
+      updateEstMaxBatchSize(incoming);
+    }
+    long memAvail = memoryLimit - allocator.getAllocatedMemory();
+    if ( !canSpill ) { // single phase, or spill disabled by configuation
+      numPartitions = 1; // single phase should use only a single partition (to save memory)
+    } else { // two phase
+      // Adjust down the number of partitions if needed - when the memory available can not hold as
+      // many batches (configurable option), plus overhead (e.g. hash table, links, hash values))
+      while ( numPartitions * ( estMaxBatchSize * minBatchesPerPartition + 8 * 1024 * 1024) > memAvail ) {
+        numPartitions /= 2;
+        if ( numPartitions < 2) {
+          if ( is2ndPhase ) {
+            canSpill = false;  // 2nd phase needs at least 2 to make progress
+            logger.warn("Spilling was disabled - not enough memory available for internal partitioning");
           }
-          checkGroupAndAggrValues(currentIndex);
-        }
-
-        if (EXTRA_DEBUG_1) {
-          logger.debug("Processed {} records", underlyingIndex);
-        }
-
-        try {
-
-          while (true) {
-            // Cleanup the previous batch since we are done processing it.
-            for (VectorWrapper<?> v : incoming) {
-              v.getValueVector().clear();
-            }
-            IterOutcome out = outgoing.next(0, incoming);
-            if (EXTRA_DEBUG_1) {
-              logger.debug("Received IterOutcome of {}", out);
-            }
-            switch (out) {
-              case OUT_OF_MEMORY:
-              case NOT_YET:
-                this.outcome = out;
-                return AggOutcome.RETURN_OUTCOME;
-
-              case OK_NEW_SCHEMA:
-                if (EXTRA_DEBUG_1) {
-                  logger.debug("Received new schema.  Batch has {} records.", incoming.getRecordCount());
-                }
-//                newSchema = true;
-                this.cleanup();
-                // TODO: new schema case needs to be handled appropriately
-                return AggOutcome.UPDATE_AGGREGATOR;
-
-              case OK:
-                resetIndex();
-                if (incoming.getRecordCount() == 0) {
-                  continue;
-                } else {
-                  checkGroupAndAggrValues(currentIndex);
-                  incIndex();
-
-                  if (EXTRA_DEBUG_1) {
-                    logger.debug("Continuing outside loop");
-                  }
-                  continue outside;
-                }
-
-              case NONE:
-                // outcome = out;
-
-                buildComplete = true;
-
-                updateStats(htable);
-
-                // output the first batch; remaining batches will be output
-                // in response to each next() call by a downstream operator
-
-                outputCurrentBatch();
-
-                // return setOkAndReturn();
-                return AggOutcome.RETURN_OUTCOME;
-
-              case STOP:
-              default:
-                outcome = out;
-                return AggOutcome.CLEANUP_AND_RETURN;
-            }
-          }
-
-        } finally {
-          // placeholder...
+          break;
         }
       }
-    } finally {
+    }
+    logger.debug("{} phase. Number of partitions chosen: {}. {} spill", isTwoPhase?(is2ndPhase?"2nd":"1st"):"Single",
+        numPartitions, canSpill ? "Can" : "Cannot");
+
+    // The following initial safety check should be revisited once we can lower the number of rows in a batch
+    // In cases of very tight memory -- need at least memory to process one batch, plus overhead (e.g. hash table)
+    if ( numPartitions == 1 ) {
+      // if too little memory - behave like the old code -- no memory limit for hash aggregate
+      allocator.setLimit(AbstractBase.MAX_ALLOCATION);  // 10_000_000_000L
+    }
+    // Based on the number of partitions: Set the mask and bit count
+    partitionMask = numPartitions - 1; // e.g. 32 --> 0x1F
+    bitsInMask = Integer.bitCount(partitionMask); // e.g. 0x1F -> 5
+
+    // Create arrays (one entry per partition)
+    htables = new HashTable[numPartitions] ;
+    batchHolders = (ArrayList<BatchHolder>[]) new ArrayList<?>[numPartitions] ;
+    outBatchIndex = new int[numPartitions] ;
+    outputStream = new OutputStream[numPartitions];
+    spilledBatchesCount = new int[numPartitions];
+    spillFiles = new String[numPartitions];
+    spilledPartitionsList = new ArrayList<SpilledPartition>();
+
+    plannedBatches = numPartitions; // each partition should allocate its first batch
+
+    // initialize every (per partition) entry in the arrays
+    for (int i = 0; i < numPartitions; i++ ) {
+      try {
+        this.htables[i] = baseHashTable.createAndSetupHashTable(groupByOutFieldIds, numPartitions);
+        this.htables[i].setMaxVarcharSize(maxColumnWidth);
+      } catch (ClassTransformationException e) {
+        throw UserException.unsupportedError(e)
+            .message("Code generation error - likely an error in the code.")
+            .build(logger);
+      } catch (IOException e) {
+        throw UserException.resourceError(e)
+            .message("IO Error while creating a hash table.")
+            .build(logger);
+      } catch (SchemaChangeException sce) {
+        throw new IllegalStateException("Unexpected Schema Change while creating a hash table",sce);
+      }
+      this.batchHolders[i] = new ArrayList<BatchHolder>(); // First BatchHolder is created when the first put request is received.
+    }
+  }
+  /**
+   * get new incoming: (when reading spilled files like an "incoming")
+   * @return The (newly replaced) incoming
+   */
+  @Override
+  public RecordBatch getNewIncoming() { return newIncoming; }
+
+  private void initializeSetup(RecordBatch newIncoming) throws SchemaChangeException, IOException {
+    baseHashTable.updateIncoming(newIncoming); // after a spill - a new incoming
+    this.incoming = newIncoming;
+    currentBatchRecordCount = newIncoming.getRecordCount(); // first batch in this spill file
+    nextPartitionToReturn = 0;
+    for (int i = 0; i < numPartitions; i++ ) {
+      htables[i].reinit(newIncoming);
+      if ( batchHolders[i] != null) {
+        for (BatchHolder bh : batchHolders[i]) {
+          bh.clear();
+        }
+        batchHolders[i].clear();
+        batchHolders[i] = new ArrayList<BatchHolder>();
+      }
+      outBatchIndex[i] = 0;
+      outputStream[i] = null;
+      spilledBatchesCount[i] = 0;
+      spillFiles[i] = null;
     }
   }
 
+  /**
+   *  Update the estimated max batch size to be used in the Hash Aggr Op.
+   *  using the record batch size to get the row width.
+   * @param incoming
+   */
+  private void updateEstMaxBatchSize(RecordBatch incoming) {
+    if ( estMaxBatchSize > 0 ) { return; }  // no handling of a schema (or varchar) change
+    RecordBatchSizer sizer = new RecordBatchSizer(incoming);
+    logger.trace("Incoming sizer: {}",sizer);
+    // An empty batch only has the schema, can not tell actual length of varchars
+    // else use the actual varchars length, each capped at 50 (to match the space allocation)
+    estRowWidth = sizer.rowCount() == 0 ? sizer.stdRowWidth() : sizer.netRowWidthCap50();
+    estMaxBatchSize = estRowWidth * MAX_BATCH_SIZE;
+
+    // Get approx max (varchar) column width to get better memory allocation
+    maxColumnWidth = Math.max(sizer.maxSize(), VARIABLE_MIN_WIDTH_VALUE_SIZE);
+    maxColumnWidth = Math.min(maxColumnWidth, VARIABLE_MAX_WIDTH_VALUE_SIZE);
+
+    logger.trace("{} phase. Estimated row width: {}  batch size: {}  memory limit: {}  max column width: {}",
+        isTwoPhase?(is2ndPhase?"2nd":"1st"):"Single",estRowWidth,estMaxBatchSize,memoryLimit,maxColumnWidth);
+
+    if ( estMaxBatchSize > memoryLimit ) {
+      logger.warn("HashAggregate: Estimated max batch size {} is larger than the memory limit {}",estMaxBatchSize,memoryLimit);
+    }
+  }
+
+  /**
+   *  Read and process (i.e., insert into the hash table and aggregate) records from the current batch.
+   *  Once complete, get the incoming NEXT batch and process it as well, etc.
+   *  For 1st phase, may return when an early output needs to be performed.
+   *
+   * @return Agg outcome status
+   */
+  @Override
+  public AggOutcome doWork() {
+
+    while (true) {
+
+      // This would be called only once - first time actual data arrives on incoming
+      if ( schema == null && incoming.getRecordCount() > 0 ) {
+        this.schema = incoming.getSchema();
+        currentBatchRecordCount = incoming.getRecordCount(); // initialize for first non empty batch
+        // Calculate the number of partitions based on actual incoming data
+        delayedSetup();
+      }
+
+      //
+      //  loop through existing records in this batch, aggregating the values as necessary.
+      //
+      if (EXTRA_DEBUG_1) {
+        logger.debug("Starting outer loop of doWork()...");
+      }
+      for (; underlyingIndex < currentBatchRecordCount; incIndex()) {
+        if (EXTRA_DEBUG_2) {
+          logger.debug("Doing loop with values underlying {}, current {}", underlyingIndex, currentIndex);
+        }
+        checkGroupAndAggrValues(currentIndex);
+        // If adding a group discovered a memory pressure during 1st phase, then start
+        // outputing some partition downstream in order to free memory.
+        if ( earlyOutput ) {
+          outputCurrentBatch();
+          incIndex(); // next time continue with the next incoming row
+          return AggOutcome.RETURN_OUTCOME;
+        }
+      }
+
+      if (EXTRA_DEBUG_1) {
+        logger.debug("Processed {} records", underlyingIndex);
+      }
+
+      // Cleanup the previous batch since we are done processing it.
+      for (VectorWrapper<?> v : incoming) {
+        v.getValueVector().clear();
+      }
+      //
+      // Get the NEXT input batch, initially from the upstream, later (if there was a spill)
+      // from one of the spill files (The spill case is handled differently here to avoid
+      // collecting stats on the spilled records)
+      //
+      if ( handlingSpills ) {
+        outcome = context.shouldContinue() ? incoming.next() : IterOutcome.STOP;
+      } else {
+        long beforeAlloc = allocator.getAllocatedMemory();
+
+        // Get the next RecordBatch from the incoming (i.e. upstream operator)
+        outcome = outgoing.next(0, incoming);
+
+        // If incoming batch is bigger than our estimate - adjust the estimate to match
+        long afterAlloc = allocator.getAllocatedMemory();
+        long incomingBatchSize = afterAlloc - beforeAlloc;
+        if ( estMaxBatchSize < incomingBatchSize) {
+          logger.trace("Found a bigger incoming batch: {} , prior estimate was: {}", incomingBatchSize, estMaxBatchSize);
+          estMaxBatchSize = incomingBatchSize;
+        }
+      }
+
+      if (EXTRA_DEBUG_1) {
+        logger.debug("Received IterOutcome of {}", outcome);
+      }
+
+      // Handle various results from getting the next batch
+      switch (outcome) {
+        case OUT_OF_MEMORY:
+        case NOT_YET:
+          return AggOutcome.RETURN_OUTCOME;
+
+        case OK_NEW_SCHEMA:
+          if (EXTRA_DEBUG_1) {
+            logger.debug("Received new schema.  Batch has {} records.", incoming.getRecordCount());
+          }
+          this.cleanup();
+          // TODO: new schema case needs to be handled appropriately
+          return AggOutcome.UPDATE_AGGREGATOR;
+
+        case OK:
+          currentBatchRecordCount = incoming.getRecordCount(); // size of next batch
+
+          resetIndex(); // initialize index (a new batch needs to be processed)
+
+          if (EXTRA_DEBUG_1) {
+            logger.debug("Continue to start processing the next batch");
+          }
+          break;
+
+        case NONE:
+          resetIndex(); // initialize index (in case spill files need to be processed)
+
+          buildComplete = true;
+
+          updateStats(htables);
+
+          // output the first batch; remaining batches will be output
+          // in response to each next() call by a downstream operator
+          AggIterOutcome aggOutcome = outputCurrentBatch();
+
+          if ( aggOutcome == AggIterOutcome.AGG_RESTART ) {
+            // Output of first batch returned a RESTART (all new partitions were spilled)
+            return AggOutcome.CALL_WORK_AGAIN; // need to read/process the next partition
+          }
+
+          if ( aggOutcome != AggIterOutcome.AGG_NONE ) { outcome = IterOutcome.OK; }
+
+          return AggOutcome.RETURN_OUTCOME;
+
+        case STOP:
+        default:
+          return AggOutcome.CLEANUP_AND_RETURN;
+      }
+    }
+  }
+
+  /**
+   *   Allocate space for the returned aggregate columns
+   *   (Note DRILL-5588: Maybe can eliminate this allocation (and copy))
+   * @param records
+   */
   private void allocateOutgoing(int records) {
     // Skip the keys and only allocate for outputting the workspace values
     // (keys will be output through splitAndTransfer)
@@ -382,14 +649,8 @@ public abstract class HashAggTemplate implements HashAggregator {
     while (outgoingIter.hasNext()) {
       @SuppressWarnings("resource")
       ValueVector vv = outgoingIter.next().getValueVector();
-//      MajorType type = vv.getField().getType();
 
-      /*
-       * In build schema we use the allocation model that specifies exact record count
-       * so we need to stick with that allocation model until DRILL-2211 is resolved. Using
-       * 50 as the average bytes per value as is used in HashTable.
-       */
-      AllocationHelper.allocatePrecomputedChildCount(vv, records, VARIABLE_WIDTH_VALUE_SIZE, 0);
+      AllocationHelper.allocatePrecomputedChildCount(vv, records, maxColumnWidth, 0);
     }
   }
 
@@ -400,45 +661,82 @@ public abstract class HashAggTemplate implements HashAggregator {
 
   @Override
   public int getOutputCount() {
-    // return outputCount;
     return lastBatchOutputCount;
   }
 
   @Override
   public void cleanup() {
-    if (htable != null) {
-      htable.clear();
-      htable = null;
+    if ( schema == null ) { return; } // not set up; nothing to clean
+    if ( is2ndPhase && spillSet.getWriteBytes() > 0 ) {
+      stats.setLongStat(Metric.SPILL_MB, // update stats - total MB spilled
+          (int) Math.round(spillSet.getWriteBytes() / 1024.0D / 1024.0));
     }
+    // clean (and deallocate) each partition
+    for ( int i = 0; i < numPartitions; i++) {
+          if (htables[i] != null) {
+              htables[i].clear();
+              htables[i] = null;
+          }
+          if ( batchHolders[i] != null) {
+              for (BatchHolder bh : batchHolders[i]) {
+                    bh.clear();
+              }
+              batchHolders[i].clear();
+              batchHolders[i] = null;
+          }
+
+          // delete any (still active) output spill file
+          if ( outputStream[i] != null && spillFiles[i] != null) {
+            try {
+              outputStream[i].close();
+              outputStream[i] = null;
+              spillSet.delete(spillFiles[i]);
+              spillFiles[i] = null;
+            } catch(IOException e) {
+              logger.warn("Cleanup: Failed to delete spill file {}",spillFiles[i]);
+            }
+          }
+    }
+    // delete any spill file left in unread spilled partitions
+    while ( ! spilledPartitionsList.isEmpty() ) {
+        SpilledPartition sp = spilledPartitionsList.remove(0);
+        try {
+          spillSet.delete(sp.spillFile);
+        } catch(IOException e) {
+          logger.warn("Cleanup: Failed to delete spill file {}",sp.spillFile);
+        }
+    }
+    // Delete the currently handled (if any) spilled file
+    if ( newIncoming != null ) { newIncoming.close();  }
+    spillSet.close(); // delete the spill directory(ies)
     htIdxHolder = null;
     materializedValueFields = null;
     outStartIdxHolder = null;
     outNumRecordsHolder = null;
-
-    if (batchHolders != null) {
-      for (BatchHolder bh : batchHolders) {
-        bh.clear();
-      }
-      batchHolders.clear();
-      batchHolders = null;
-    }
   }
 
-//  private final AggOutcome setOkAndReturn() {
-//    this.outcome = IterOutcome.OK;
-//    for (VectorWrapper<?> v : outgoing) {
-//      v.getValueVector().getMutator().setValueCount(outputCount);
-//    }
-//    return AggOutcome.RETURN_OUTCOME;
-//  }
+  // First free the memory used by the given (spilled) partition (i.e., hash table plus batches)
+  // then reallocate them in pristine state to allow the partition to continue receiving rows
+  private void reinitPartition(int part) /* throws SchemaChangeException /*, IOException */ {
+    assert htables[part] != null;
+    htables[part].reset();
+    if ( batchHolders[part] != null) {
+      for (BatchHolder bh : batchHolders[part]) {
+        bh.clear();
+      }
+      batchHolders[part].clear();
+    }
+    batchHolders[part] = new ArrayList<BatchHolder>(); // First BatchHolder is created when the first put request is received.
+  }
 
   private final void incIndex() {
     underlyingIndex++;
-    if (underlyingIndex >= incoming.getRecordCount()) {
+    if (underlyingIndex >= currentBatchRecordCount) {
       currentIndex = Integer.MAX_VALUE;
       return;
     }
-    currentIndex = getVectorIndex(underlyingIndex);
+    try { currentIndex = getVectorIndex(underlyingIndex); }
+    catch (SchemaChangeException sc) { throw new UnsupportedOperationException(sc);}
   }
 
   private final void resetIndex() {
@@ -446,71 +744,337 @@ public abstract class HashAggTemplate implements HashAggregator {
     incIndex();
   }
 
-  private void addBatchHolder() {
+  private boolean isSpilled(int part) {
+    return outputStream[part] != null;
+  }
+  /**
+   * Which partition to choose for flushing out (i.e. spill or return) ?
+   * - The current partition (to which a new bach holder is added) has a priority,
+   *   because its last batch holder is full.
+   * - Also the largest prior spilled partition has some priority, as it is already spilled;
+   *   but spilling too few rows (e.g. a single batch) gets us nothing.
+   * - So the largest non-spilled partition has some priority, to get more memory freed.
+   * Need to weigh the above three options.
+   *
+   *  @param currPart - The partition that hit the memory limit (gets a priority)
+   *  @return The partition (number) chosen to be spilled
+   */
+  private int chooseAPartitionToFlush(int currPart) {
+    if ( ! is2ndPhase ) { return currPart; } // 1st phase: just use the current partition
+    int currPartSize = batchHolders[currPart].size();
+    if ( currPartSize == 1 ) { currPartSize = -1; } // don't pick current if size is 1
+    // first find the largest spilled partition
+    int maxSizeSpilled = -1;
+    int indexMaxSpilled = -1;
+    for (int isp = 0; isp < numPartitions; isp++ ) {
+      if ( isSpilled(isp) && maxSizeSpilled < batchHolders[isp].size() ) {
+        maxSizeSpilled = batchHolders[isp].size();
+        indexMaxSpilled = isp;
+      }
+    }
+    // Give the current (if already spilled) some priority
+    if ( isSpilled(currPart) && ( currPartSize + 1 >= maxSizeSpilled )) {
+      maxSizeSpilled = currPartSize ;
+      indexMaxSpilled = currPart;
+    }
+    // now find the largest non-spilled partition
+    int maxSize = -1;
+    int indexMax = -1;
+    // Use the largest spilled (if found) as a base line, with a factor of 4
+    if ( indexMaxSpilled > -1 && maxSizeSpilled > 1 ) {
+      indexMax = indexMaxSpilled;
+      maxSize = 4 * maxSizeSpilled ;
+    }
+    for ( int insp = 0; insp < numPartitions; insp++) {
+      if ( ! isSpilled(insp) && maxSize < batchHolders[insp].size() ) {
+        indexMax = insp;
+        maxSize = batchHolders[insp].size();
+      }
+    }
+    // again - priority to the current partition
+    if ( ! isSpilled(currPart) && (currPartSize + 1 >= maxSize) ) {
+      return currPart;
+    }
+    if ( maxSize <= 1 ) { // Can not make progress by spilling a single batch!
+      return -1; // try skipping this spill
+    }
+    return indexMax;
+  }
+
+  /**
+   * Iterate through the batches of the given partition, writing them to a file
+   *
+   * @param part The partition (number) to spill
+   */
+  private void spillAPartition(int part) {
+
+    ArrayList<BatchHolder> currPartition = batchHolders[part];
+    rowsInPartition = 0;
+    if ( EXTRA_DEBUG_SPILL ) {
+      logger.debug("HashAggregate: Spilling partition {} current cycle {} part size {}", part, cycleNum, currPartition.size());
+    }
+
+    if ( currPartition.size() == 0 ) { return; } // in case empty - nothing to spill
+
+    // If this is the first spill for this partition, create an output stream
+    if ( ! isSpilled(part) ) {
+
+      spillFiles[part] = spillSet.getNextSpillFile(cycleNum > 0 ? Integer.toString(cycleNum) : null);
+
+      try {
+        outputStream[part] = spillSet.openForOutput(spillFiles[part]);
+      } catch (IOException ioe) {
+        throw UserException.resourceError(ioe)
+            .message("Hash Aggregation failed to open spill file: " + spillFiles[part])
+            .build(logger);
+      }
+    }
+
+    for (int currOutBatchIndex = 0; currOutBatchIndex < currPartition.size(); currOutBatchIndex++ ) {
+
+      // get the number of records in the batch holder that are pending output
+      int numPendingOutput = currPartition.get(currOutBatchIndex).getNumPendingOutput();
+
+      rowsInPartition += numPendingOutput;  // for logging
+      rowsSpilled += numPendingOutput;
+
+      allocateOutgoing(numPendingOutput);
+
+      currPartition.get(currOutBatchIndex).outputValues(outStartIdxHolder, outNumRecordsHolder);
+      int numOutputRecords = outNumRecordsHolder.value;
+
+      this.htables[part].outputKeys(currOutBatchIndex, this.outContainer, outStartIdxHolder.value, outNumRecordsHolder.value);
+
+      // set the value count for outgoing batch value vectors
+      /* int i = 0; */
+      for (VectorWrapper<?> v : outgoing) {
+        v.getValueVector().getMutator().setValueCount(numOutputRecords);
+        /*
+        // print out the first row to be spilled ( varchar, varchar, bigint )
+        try {
+          if (i++ < 2) {
+            NullableVarCharVector vv = ((NullableVarCharVector) v.getValueVector());
+            logger.info("FIRST ROW = {}", vv.getAccessor().get(0));
+          } else {
+            NullableBigIntVector vv = ((NullableBigIntVector) v.getValueVector());
+            logger.info("FIRST ROW = {}", vv.getAccessor().get(0));
+          }
+        } catch (Exception e) { logger.info("While printing the first row - Got an exception = {}",e); }
+        */
+      }
+
+      outContainer.setRecordCount(numPendingOutput);
+      WritableBatch batch = WritableBatch.getBatchNoHVWrap(numPendingOutput, outContainer, false);
+      VectorAccessibleSerializable outputBatch = new VectorAccessibleSerializable(batch, allocator);
+      Stopwatch watch = Stopwatch.createStarted();
+      try {
+        outputBatch.writeToStream(outputStream[part]);
+      } catch (IOException ioe) {
+        throw UserException.dataWriteError(ioe)
+            .message("Hash Aggregation failed to write to output stream: " + outputStream[part].toString())
+            .build(logger);
+      }
+      outContainer.zeroVectors();
+      logger.trace("HASH AGG: Took {} us to spill {} records", watch.elapsed(TimeUnit.MICROSECONDS), numPendingOutput);
+    }
+
+    spilledBatchesCount[part] += currPartition.size(); // update count of spilled batches
+
+    logger.trace("HASH AGG: Spilled {} rows from {} batches of partition {}", rowsInPartition, currPartition.size(), part);
+  }
+
+  private void addBatchHolder(int part) {
+
     BatchHolder bh = newBatchHolder();
-    batchHolders.add(bh);
+    batchHolders[part].add(bh);
 
     if (EXTRA_DEBUG_1) {
-      logger.debug("HashAggregate: Added new batch; num batches = {}.", batchHolders.size());
+      logger.debug("HashAggregate: Added new batch; num batches = {}.", batchHolders[part].size());
     }
 
     bh.setup();
   }
 
-  // Overridden in the generated class when created as plain Java code.
-
+  // These methods are overridden in the generated class when created as plain Java code.
   protected BatchHolder newBatchHolder() {
     return new BatchHolder();
   }
 
+  /**
+   * Output the next batch from partition "nextPartitionToReturn"
+   *
+   * @return iteration outcome (e.g., OK, NONE ...)
+   */
   @Override
-  public IterOutcome outputCurrentBatch() {
-    if (outBatchIndex >= batchHolders.size()) {
-      this.outcome = IterOutcome.NONE;
-      return outcome;
+  public AggIterOutcome outputCurrentBatch() {
+
+    // when incoming was an empty batch, just finish up
+    if ( schema == null ) {
+      logger.trace("Incoming was empty; output is an empty batch.");
+      this.outcome = IterOutcome.NONE; // no records were read
+      allFlushed = true;
+      return AggIterOutcome.AGG_NONE;
+    }
+
+    // Initialization (covers the case of early output)
+    ArrayList<BatchHolder> currPartition = batchHolders[earlyPartition];
+    int currOutBatchIndex = outBatchIndex[earlyPartition];
+    int partitionToReturn = earlyPartition;
+
+    if ( ! earlyOutput ) {
+      // Update the next partition to return (if needed)
+      // skip fully returned (or spilled) partitions
+      while (nextPartitionToReturn < numPartitions) {
+        //
+        // If this partition was spilled - spill the rest of it and skip it
+        //
+        if ( isSpilled(nextPartitionToReturn) ) {
+          spillAPartition(nextPartitionToReturn); // spill the rest
+          SpilledPartition sp = new SpilledPartition();
+          sp.spillFile = spillFiles[nextPartitionToReturn];
+          sp.spilledBatches = spilledBatchesCount[nextPartitionToReturn];
+          sp.cycleNum = cycleNum; // remember the current cycle
+          sp.origPartn = nextPartitionToReturn; // for debugging / filename
+          sp.prevOrigPartn = originalPartition; // for debugging / filename
+          spilledPartitionsList.add(sp);
+
+          reinitPartition(nextPartitionToReturn); // free the memory
+          long posn = spillSet.getPosition(outputStream[nextPartitionToReturn]);
+          spillSet.tallyWriteBytes(posn); // for the IO stats
+          try {
+            outputStream[nextPartitionToReturn].close();
+          } catch (IOException ioe) {
+            throw UserException.resourceError(ioe)
+                .message("IO Error while closing output stream")
+                .build(logger);
+          }
+          outputStream[nextPartitionToReturn] = null;
+        }
+        else {
+          currPartition = batchHolders[nextPartitionToReturn];
+          currOutBatchIndex = outBatchIndex[nextPartitionToReturn];
+          // If curr batch (partition X index) is not empty - proceed to return it
+          if (currOutBatchIndex < currPartition.size() && 0 != currPartition.get(currOutBatchIndex).getNumPendingOutput()) {
+            break;
+          }
+        }
+        nextPartitionToReturn++; // else check next partition
+      }
+
+      // if passed the last partition - either done or need to restart and read spilled partitions
+      if (nextPartitionToReturn >= numPartitions) {
+        // The following "if" is probably never used; due to a similar check at the end of this method
+        if ( spilledPartitionsList.isEmpty() ) { // and no spilled partitions
+          allFlushed = true;
+          this.outcome = IterOutcome.NONE;
+          if ( is2ndPhase ) {
+            stats.setLongStat(Metric.SPILL_MB, // update stats - total MB spilled
+                (int) Math.round(spillSet.getWriteBytes() / 1024.0D / 1024.0));
+          }
+          return AggIterOutcome.AGG_NONE;  // then return NONE
+        }
+        // Else - there are still spilled partitions to process - pick one and handle just like a new incoming
+        buildComplete = false; // go back and call doWork() again
+        handlingSpills = true; // beginning to work on the spill files
+        // pick a spilled partition; set a new incoming ...
+        SpilledPartition sp = spilledPartitionsList.remove(0);
+        // Create a new "incoming" out of the spilled partition spill file
+        newIncoming = new SpilledRecordbatch(sp.spillFile, sp.spilledBatches, context, schema, oContext, spillSet);
+        originalPartition = sp.origPartn; // used for the filename
+        logger.trace("Reading back spilled original partition {} as an incoming",originalPartition);
+        // Initialize .... new incoming, new set of partitions
+        try { initializeSetup(newIncoming); } catch (Exception e) { throw new RuntimeException(e); }
+        // update the cycle num if needed
+        // The current cycle num should always be one larger than in the spilled partition
+        if ( cycleNum == sp.cycleNum ) {
+          cycleNum = 1 + sp.cycleNum;
+          stats.setLongStat(Metric.SPILL_CYCLE, cycleNum); // update stats
+          // report first spill or memory stressful situations
+          if ( cycleNum == 1 ) { logger.info("Started reading spilled records "); }
+          if ( cycleNum == 2 ) { logger.info("SECONDARY SPILLING "); }
+          if ( cycleNum == 3 ) { logger.warn("TERTIARY SPILLING "); }
+          if ( cycleNum == 4 ) { logger.warn("QUATERNARY SPILLING "); }
+          if ( cycleNum == 5 ) { logger.warn("QUINARY SPILLING "); }
+        }
+        if ( EXTRA_DEBUG_SPILL ) {
+          logger.debug("Start reading spilled partition {} (prev {}) from cycle {} (with {} batches). More {} spilled partitions left.",
+              sp.origPartn, sp.prevOrigPartn, sp.cycleNum, sp.spilledBatches, spilledPartitionsList.size());
+        }
+        return AggIterOutcome.AGG_RESTART;
+      }
+
+      partitionToReturn = nextPartitionToReturn ;
+
     }
 
     // get the number of records in the batch holder that are pending output
-    int numPendingOutput = batchHolders.get(outBatchIndex).getNumPendingOutput();
+    int numPendingOutput = currPartition.get(currOutBatchIndex).getNumPendingOutput();
 
-    if (numPendingOutput == 0) {
-      this.outcome = IterOutcome.NONE;
-      return outcome;
-    }
+    // The following accounting is for logging, metrics, etc.
+    rowsInPartition += numPendingOutput ;
+    if ( ! handlingSpills ) { rowsNotSpilled += numPendingOutput; }
+    else { rowsSpilledReturned += numPendingOutput; }
+    if ( earlyOutput ) { rowsReturnedEarly += numPendingOutput; }
 
     allocateOutgoing(numPendingOutput);
 
-    batchHolders.get(outBatchIndex).outputValues(outStartIdxHolder, outNumRecordsHolder);
+    currPartition.get(currOutBatchIndex).outputValues(outStartIdxHolder, outNumRecordsHolder);
     int numOutputRecords = outNumRecordsHolder.value;
 
     if (EXTRA_DEBUG_1) {
       logger.debug("After output values: outStartIdx = {}, outNumRecords = {}", outStartIdxHolder.value, outNumRecordsHolder.value);
     }
-    this.htable.outputKeys(outBatchIndex, this.outContainer, outStartIdxHolder.value, outNumRecordsHolder.value);
+
+    this.htables[partitionToReturn].outputKeys(currOutBatchIndex, this.outContainer, outStartIdxHolder.value, outNumRecordsHolder.value);
 
     // set the value count for outgoing batch value vectors
     for (VectorWrapper<?> v : outgoing) {
       v.getValueVector().getMutator().setValueCount(numOutputRecords);
     }
 
-//    outputCount += numOutputRecords;
-
     this.outcome = IterOutcome.OK;
 
-    logger.debug("HashAggregate: Output current batch index {} with {} records.", outBatchIndex, numOutputRecords);
-
-    lastBatchOutputCount = numOutputRecords;
-    outBatchIndex++;
-    if (outBatchIndex == batchHolders.size()) {
-      allFlushed = true;
-
-      logger.debug("HashAggregate: All batches flushed.");
-
-      // cleanup my internal state since there is nothing more to return
-      this.cleanup();
+    if ( EXTRA_DEBUG_SPILL && is2ndPhase ) {
+      logger.debug("So far returned {} + SpilledReturned {}  total {} (spilled {})",rowsNotSpilled,rowsSpilledReturned,
+        rowsNotSpilled+rowsSpilledReturned,
+        rowsSpilled);
     }
 
-    return this.outcome;
+    lastBatchOutputCount = numOutputRecords;
+    outBatchIndex[partitionToReturn]++;
+    // if just flushed the last batch in the partition
+    if (outBatchIndex[partitionToReturn] == currPartition.size()) {
+
+      if ( EXTRA_DEBUG_SPILL ) {
+        logger.debug("HashAggregate: {} Flushed partition {} with {} batches total {} rows",
+            earlyOutput ? "(Early)" : "",
+            partitionToReturn, outBatchIndex[partitionToReturn], rowsInPartition);
+      }
+      rowsInPartition = 0; // reset to count for the next partition
+
+      // deallocate memory used by this partition, and re-initialize
+      reinitPartition(partitionToReturn);
+
+      if ( earlyOutput ) {
+
+        if ( EXTRA_DEBUG_SPILL ) {
+          logger.debug("HASH AGG: Finished (early) re-init partition {}, mem allocated: {}", earlyPartition, allocator.getAllocatedMemory());
+        }
+        outBatchIndex[earlyPartition] = 0; // reset, for next time
+        earlyOutput = false ; // done with early output
+      }
+      else if ( (partitionToReturn + 1 == numPartitions) && spilledPartitionsList.isEmpty() ) { // last partition ?
+
+        allFlushed = true; // next next() call will return NONE
+
+        logger.trace("HashAggregate: All batches flushed.");
+
+        // cleanup my internal state since there is nothing more to return
+        this.cleanup();
+      }
+    }
+
+    return AggIterOutcome.AGG_OK;
   }
 
   @Override
@@ -522,9 +1086,31 @@ public abstract class HashAggTemplate implements HashAggregator {
   public boolean buildComplete() {
     return buildComplete;
   }
+  @Override
+  public boolean earlyOutput() { return earlyOutput; }
 
   public int numGroupedRecords() {
     return numGroupedRecords;
+  }
+
+  /**
+   *  Generate a detailed error message in case of "Out Of Memory"
+   * @return err msg
+   */
+  private String getOOMErrorMsg() {
+    String errmsg;
+    if ( !isTwoPhase ) {
+      errmsg = "Single Phase Hash Aggregate operator can not spill." ;
+    } else if ( ! canSpill ) {  // 2nd phase, with only 1 partition
+      errmsg = "Too little memory available to operator to facilitate spilling.";
+    } else { // a bug ?
+      errmsg = "OOM at " + (is2ndPhase ? "Second Phase" : "First Phase") + ". Partitions: " + numPartitions +
+      ". Estimated batch size: " + estMaxBatchSize + ". Planned batches: " + plannedBatches;
+      if ( rowsSpilled > 0 ) { errmsg += ". Rows spilled so far: " + rowsSpilled; }
+    }
+    errmsg += " Memory limit: " + allocator.getLimit() + " so far allocated: " + allocator.getAllocatedMemory() + ". ";
+
+    return errmsg;
   }
 
   // Check if a group is present in the hash table; if not, insert it in the hash table.
@@ -534,6 +1120,8 @@ public abstract class HashAggTemplate implements HashAggregator {
     if (incomingRowIdx < 0) {
       throw new IllegalArgumentException("Invalid incoming row index.");
     }
+
+    assert ! earlyOutput;
 
     /** for debugging
      Object tmp = (incoming).getValueAccessorById(0, BigIntVector.class).getValueVector();
@@ -546,44 +1134,189 @@ public abstract class HashAggTemplate implements HashAggregator {
      holder.value = vv0.getAccessor().get(incomingRowIdx) ;
      }
      */
+    /*
+    if ( handlingSpills && ( incomingRowIdx == 0 ) ) {
+      // for debugging -- show the first row from a spilled batch
+      Object tmp0 = (incoming).getValueAccessorById(NullableVarCharVector.class, 0).getValueVector();
+      Object tmp1 = (incoming).getValueAccessorById(NullableVarCharVector.class, 1).getValueVector();
+      Object tmp2 = (incoming).getValueAccessorById(NullableBigIntVector.class, 2).getValueVector();
 
-    htable.put(incomingRowIdx, htIdxHolder, 1 /* retry count */);
+      if (tmp0 != null && tmp1 != null && tmp2 != null) {
+        NullableVarCharVector vv0 = ((NullableVarCharVector) tmp0);
+        NullableVarCharVector vv1 = ((NullableVarCharVector) tmp1);
+        NullableBigIntVector  vv2 = ((NullableBigIntVector) tmp2);
+        logger.debug("The first row = {} , {} , {}", vv0.getAccessor().get(incomingRowIdx), vv1.getAccessor().get(incomingRowIdx), vv2.getAccessor().get(incomingRowIdx));
+      }
+    }
+    */
+    // The hash code is computed once, then its lower bits are used to determine the
+    // partition to use, and the higher bits determine the location in the hash table.
+    int hashCode;
+    try {
+      htables[0].updateBatches();
+      hashCode = htables[0].getHashCode(incomingRowIdx);
+    } catch (SchemaChangeException e) {
+      throw new UnsupportedOperationException("Unexpected schema change", e);
+    }
 
+    // right shift hash code for secondary (or tertiary...) spilling
+    for (int i = 0; i < cycleNum; i++) { hashCode >>>= bitsInMask; }
+
+    int currentPartition = hashCode & partitionMask ;
+    hashCode >>>= bitsInMask;
+    HashTable.PutStatus putStatus = null;
+    long allocatedBefore = allocator.getAllocatedMemory();
+
+    // Insert the key columns into the hash table
+    try {
+      putStatus = htables[currentPartition].put(incomingRowIdx, htIdxHolder, hashCode);
+    } catch (OutOfMemoryException exc) {
+      throw new OutOfMemoryException(getOOMErrorMsg(), exc); // may happen when can not spill
+    } catch (SchemaChangeException e) {
+      throw new UnsupportedOperationException("Unexpected schema change", e);
+    }
     int currentIdx = htIdxHolder.value;
 
-    // get the batch index and index within the batch
-    if (currentIdx >= batchHolders.size() * HashTable.BATCH_SIZE) {
-      addBatchHolder();
+    long addedMem = allocator.getAllocatedMemory() - allocatedBefore;
+    if ( addedMem > 0 ) {
+      logger.trace("MEMORY CHECK HT: allocated {}  added {} partition {}",allocatedBefore,addedMem,currentPartition);
     }
-    BatchHolder bh = batchHolders.get((currentIdx >>> 16) & HashTable.BATCH_MASK);
+
+    // Check if put() added a new batch (for the keys) inside the hash table, hence a matching batch
+    // (for the aggregate columns) needs to be created
+    if ( putStatus == HashTable.PutStatus.NEW_BATCH_ADDED ) {
+      try {
+        long allocatedBeforeAggCol = allocator.getAllocatedMemory();
+
+        addBatchHolder(currentPartition);
+
+        if ( plannedBatches > 0 ) { plannedBatches--; } // just allocated a planned batch
+        long totalAddedMem = allocator.getAllocatedMemory() - allocatedBefore;
+        logger.trace("MEMORY CHECK AGG: added {}  total (with HT) added {}",allocator.getAllocatedMemory()-allocatedBeforeAggCol,totalAddedMem);
+        // resize the batch estimate if needed (e.g., varchars may take more memory than estimated)
+        if ( totalAddedMem > estMaxBatchSize ) {
+          logger.trace("Adjusting Batch size estimate from {} to {}",estMaxBatchSize,totalAddedMem);
+          estMaxBatchSize = totalAddedMem;
+        }
+      } catch (OutOfMemoryException exc) {
+        throw new OutOfMemoryException(getOOMErrorMsg(), exc); // may happen when can not spill
+      }
+    }
+    BatchHolder bh = batchHolders[currentPartition].get((currentIdx >>> 16) & HashTable.BATCH_MASK);
     int idxWithinBatch = currentIdx & HashTable.BATCH_MASK;
-
-    // Check if we have almost filled up the workspace vectors and add a batch if necessary
-    if ((idxWithinBatch == (bh.capacity - 1)) && (bh.allocatedNextBatch == false)) {
-      htable.addNewKeyBatch();
-      addBatchHolder();
-      bh.allocatedNextBatch = true;
-    }
-
 
     if (bh.updateAggrValues(incomingRowIdx, idxWithinBatch)) {
       numGroupedRecords++;
     }
+
+    // ===================================================================================
+    // If the last batch just became full - that is the time to check the memory limits !!
+    // If exceeded, then need to spill (if 2nd phase) or output early (1st)
+    // (Skip this if cannot spill; in such case an OOM may be encountered later)
+    // ===================================================================================
+    if ( putStatus == HashTable.PutStatus.KEY_ADDED_LAST && canSpill ) {
+
+      plannedBatches++; // planning to allocate one more batch
+
+      // calculate the (max) new memory needed now
+      long hashTableDoublingSizeNeeded = 0; // in case the hash table(s) would resize
+      for ( HashTable ht : htables ) {
+        hashTableDoublingSizeNeeded += ht.extraMemoryNeededForResize();
+      }
+
+      // Plan ahead for at least MIN batches, to account for size changing, and some overhead
+      long maxMemoryNeeded = minBatchesPerPartition * plannedBatches *
+          ( estMaxBatchSize + MAX_BATCH_SIZE * ( 4 + 4 /* links + hash-values */) ) +
+          hashTableDoublingSizeNeeded;
+
+      // log a detailed debug message explaining why a spill may be needed
+      logger.trace("MEMORY CHECK: Allocated mem: {}, agg phase: {}, trying to add to partition {} with {} batches. " +
+          "Memory needed {}, Est batch size {}, mem limit {}",
+          allocator.getAllocatedMemory(), isTwoPhase?(is2ndPhase?"2ND":"1ST"):"Single", currentPartition,
+          batchHolders[currentPartition].size(), maxMemoryNeeded, estMaxBatchSize, memoryLimit);
+      //
+      //   Spill if the allocated memory plus the memory needed exceeds the memory limit.
+      //
+      if ( allocator.getAllocatedMemory() + maxMemoryNeeded > memoryLimit ) {
+
+        // Pick a "victim" partition to spill or return
+        int victimPartition = chooseAPartitionToFlush(currentPartition);
+
+        // In case no partition has more than one batch -- try and "push the limits"; maybe next
+        // time the spill could work.
+        if ( victimPartition < 0 ) { return; }
+
+        if ( is2ndPhase ) {
+          long before = allocator.getAllocatedMemory();
+
+          spillAPartition(victimPartition);
+          logger.trace("RAN OUT OF MEMORY: Spilled partition {}",victimPartition);
+
+          // Re-initialize (free memory, then recreate) the partition just spilled/returned
+          reinitPartition(victimPartition);
+
+          // in some "edge" cases (e.g. testing), spilling one partition may not be enough
+          if ( allocator.getAllocatedMemory() + maxMemoryNeeded > memoryLimit ) {
+              int victimPartition2 = chooseAPartitionToFlush(victimPartition);
+              if ( victimPartition2 < 0 ) { return; }
+              long after = allocator.getAllocatedMemory();
+              spillAPartition(victimPartition2);
+              reinitPartition(victimPartition2);
+              logger.warn("A Second Spill was Needed: allocated before {}, after first spill {}, after second {}, memory needed {}",
+                  before, after, allocator.getAllocatedMemory(), maxMemoryNeeded);
+              logger.trace("Second Partition Spilled: {}",victimPartition2);
+          }
+        }
+        else {
+          // 1st phase need to return a partition early in order to free some memory
+          earlyOutput = true;
+          earlyPartition = victimPartition;
+
+          if ( EXTRA_DEBUG_SPILL ) {
+            logger.debug("picked partition {} for early output", victimPartition);
+          }
+        }
+      }
+    }
   }
 
-  private void updateStats(HashTable htable) {
-    htable.getStats(htStats);
+  /**
+   * Updates the stats at the time after all the input was read.
+   * Note: For spilled partitions, their hash-table stats from before the spill are lost.
+   * And the SPILLED_PARTITIONS only counts the spilled partitions in the primary, not SECONDARY etc.
+   * @param htables
+   */
+  private void updateStats(HashTable[] htables) {
+    if ( cycleNum > 0 ) { return; } // These stats are only for before processing spilled files
+    long numSpilled = 0;
+    HashTableStats newStats = new HashTableStats();
+    // sum the stats from all the partitions
+    for (int ind = 0; ind < numPartitions; ind++) {
+      htables[ind].getStats(newStats);
+      htStats.addStats(newStats);
+      if (isSpilled(ind)) {
+        numSpilled++;
+      }
+    }
     this.stats.setLongStat(Metric.NUM_BUCKETS, htStats.numBuckets);
     this.stats.setLongStat(Metric.NUM_ENTRIES, htStats.numEntries);
     this.stats.setLongStat(Metric.NUM_RESIZING, htStats.numResizing);
     this.stats.setLongStat(Metric.RESIZING_TIME, htStats.resizingTime);
+    this.stats.setLongStat(Metric.NUM_PARTITIONS, numPartitions);
+    if ( is2ndPhase ) {
+      this.stats.setLongStat(Metric.SPILLED_PARTITIONS, numSpilled);
+    }
+    if ( rowsReturnedEarly > 0 ) {
+      stats.setLongStat(Metric.SPILL_MB, // update stats - est. total MB returned early
+          (int) Math.round( rowsReturnedEarly * estRowWidth / 1024.0D / 1024.0));
+    }
   }
 
   // Code-generated methods (implemented in HashAggBatch)
-  public abstract void doSetup(@Named("incoming") RecordBatch incoming);
+  public abstract void doSetup(@Named("incoming") RecordBatch incoming) throws SchemaChangeException;
 
-  public abstract int getVectorIndex(@Named("recordIndex") int recordIndex);
+  public abstract int getVectorIndex(@Named("recordIndex") int recordIndex) throws SchemaChangeException;
 
-  public abstract boolean resetValues();
+  public abstract boolean resetValues() throws SchemaChangeException;
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.aggregate;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.cache.VectorAccessibleSerializable;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.spill.SpillSet;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.TypedFieldId;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.record.WritableBatch;
+import org.apache.drill.exec.record.selection.SelectionVector2;
+import org.apache.drill.exec.record.selection.SelectionVector4;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+/**
+ * A class to replace "incoming" - instead scanning a spilled partition file
+ */
+public class SpilledRecordbatch implements CloseableRecordBatch {
+  private VectorContainer container;
+  private InputStream spillStream;
+  private int spilledBatches;
+  private FragmentContext context;
+  private BatchSchema schema;
+  private OperatorContext oContext;
+  private SpillSet spillSet;
+  // Path spillStreamPath;
+  private String spillFile;
+  VectorAccessibleSerializable vas;
+
+  public SpilledRecordbatch(String spillFile,/* Path spillStreamPath,*/ int spilledBatches, FragmentContext context, BatchSchema schema, OperatorContext oContext, SpillSet spillSet) {
+    this.context = context;
+    this.schema = schema;
+    this.spilledBatches = spilledBatches;
+    this.oContext = oContext;
+    this.spillSet = spillSet;
+    //this.spillStreamPath = spillStreamPath;
+    this.spillFile = spillFile;
+    vas = new VectorAccessibleSerializable(oContext.getAllocator());
+    container = vas.get();
+
+    try {
+      this.spillStream = this.spillSet.openForInput(spillFile);
+    } catch (IOException e) { throw new RuntimeException(e);}
+
+    next(); // initialize the container
+  }
+
+  @Override
+  public SelectionVector2 getSelectionVector2() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public SelectionVector4 getSelectionVector4() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TypedFieldId getValueVectorId(SchemaPath path) {
+    return container.getValueVectorId(path);
+  }
+
+  @Override
+  public VectorWrapper<?> getValueAccessorById(Class<?> clazz, int... ids) {
+    return container.getValueAccessorById(clazz, ids);
+  }
+
+  @Override
+  public Iterator<VectorWrapper<?>> iterator() {
+    return container.iterator();
+  }
+
+  @Override
+  public FragmentContext getContext() { return context; }
+
+  @Override
+  public BatchSchema getSchema() { return schema; }
+
+  @Override
+  public WritableBatch getWritableBatch() {
+    return WritableBatch.get(this);
+  }
+
+  @Override
+  public VectorContainer getOutgoingContainer() { return container; }
+
+  @Override
+  public int getRecordCount() { return container.getRecordCount(); }
+
+  @Override
+  public void kill(boolean sendUpstream) {
+    this.close(); // delete the current spill file
+  }
+
+  /**
+   * Read the next batch from the spill file
+   *
+   * @return IterOutcome
+   */
+  @Override
+  public IterOutcome next() {
+
+    if ( spilledBatches <= 0 ) { // no more batches to read in this partition
+      this.close();
+      return IterOutcome.NONE;
+    }
+
+    if ( spillStream == null ) {
+      throw new IllegalStateException("Spill stream was null");
+    };
+
+    if ( spillSet.getPosition(spillStream)  < 0 ) {
+      HashAggTemplate.logger.warn("Position is {} for stream {}", spillSet.getPosition(spillStream), spillStream.toString());
+    }
+
+    try {
+      if ( container.getNumberOfColumns() > 0 ) { // container already initialized
+        // Pass our container to the reader because other classes (e.g. HashAggBatch, HashTable)
+        // may have a reference to this container (as an "incoming")
+        vas.readFromStreamWithContainer(container, spillStream);
+      }
+      else { // first time - create a container
+        vas.readFromStream(spillStream);
+        container = vas.get();
+      }
+    } catch (IOException e) {
+      throw UserException.dataReadError(e).addContext("Failed reading from a spill file").build(HashAggTemplate.logger);
+    }
+
+    spilledBatches-- ; // one less batch to read
+    return IterOutcome.OK;
+  }
+
+  @Override
+  public void close() {
+    container.clear();
+    try {
+      if (spillStream != null) {
+        spillStream.close();
+        spillStream = null;
+      }
+
+      spillSet.delete(spillFile);
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      spillSet.close();
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
@@ -114,7 +114,7 @@ public class ChainedHashTable {
   private HashTableConfig htConfig;
   private final FragmentContext context;
   private final BufferAllocator allocator;
-  private final RecordBatch incomingBuild;
+  private RecordBatch incomingBuild;
   private final RecordBatch incomingProbe;
   private final RecordBatch outgoing;
 
@@ -129,14 +129,18 @@ public class ChainedHashTable {
     this.outgoing = outgoing;
   }
 
-  public HashTable createAndSetupHashTable(TypedFieldId[] outKeyFieldIds) throws ClassTransformationException,
+  public void updateIncoming(RecordBatch incomingBuild) {
+    this.incomingBuild = incomingBuild;
+  }
+
+  public HashTable createAndSetupHashTable(TypedFieldId[] outKeyFieldIds, int numPartitions) throws ClassTransformationException,
       IOException, SchemaChangeException {
     CodeGenerator<HashTable> top = CodeGenerator.get(HashTable.TEMPLATE_DEFINITION, context.getFunctionRegistry(), context.getOptions());
     top.plainJavaCapable(true);
     // Uncomment out this line to debug the generated code.
     // This code is called from generated code, so to step into this code,
     // persist the code generated in HashAggBatch also.
-//  top.saveCodeForDebugging(true);
+    // top.saveCodeForDebugging(true);
     ClassGenerator<HashTable> cg = top.getRoot();
     ClassGenerator<HashTable> cgInner = cg.getInnerGenerator("BatchHolder");
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.physical.impl.common;
 
 import org.apache.drill.exec.compile.TemplateClassDefinition;
+import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.RecordBatch;
@@ -43,7 +44,7 @@ public interface HashTable {
    */
   static final public float DEFAULT_LOAD_FACTOR = 0.75f;
 
-  static public enum PutStatus {KEY_PRESENT, KEY_ADDED, PUT_FAILED;}
+  static public enum PutStatus {KEY_PRESENT, KEY_ADDED, NEW_BATCH_ADDED, KEY_ADDED_LAST, PUT_FAILED;}
 
   /**
    * The batch size used for internal batch holders
@@ -51,20 +52,19 @@ public interface HashTable {
   static final public int BATCH_SIZE = Character.MAX_VALUE + 1;
   static final public int BATCH_MASK = 0x0000FFFF;
 
-  /** Variable width vector size in bytes */
-  public static final int VARIABLE_WIDTH_VECTOR_SIZE = 50 * BATCH_SIZE;
+  public void setup(HashTableConfig htConfig, FragmentContext context, BufferAllocator allocator, RecordBatch incomingBuild, RecordBatch incomingProbe, RecordBatch outgoing, VectorContainer htContainerOrig);
 
-  public void setup(HashTableConfig htConfig, FragmentContext context, BufferAllocator allocator,
-      RecordBatch incomingBuild, RecordBatch incomingProbe,
-      RecordBatch outgoing, VectorContainer htContainerOrig);
+  public void updateBatches() throws SchemaChangeException;
 
-  public void updateBatches();
+  public int getHashCode(int incomingRowIdx) throws SchemaChangeException;
 
-  public void put(int incomingRowIdx, IndexPointer htIdxHolder, int retryCount);
+  public PutStatus put(int incomingRowIdx, IndexPointer htIdxHolder, int hashCode) throws SchemaChangeException;
 
-  public int containsKey(int incomingRowIdx, boolean isProbe);
+  public int containsKey(int incomingRowIdx, boolean isProbe) throws SchemaChangeException;
 
   public void getStats(HashTableStats stats);
+
+  public long extraMemoryNeededForResize();
 
   public int size();
 
@@ -72,9 +72,15 @@ public interface HashTable {
 
   public void clear();
 
+  public void reinit(RecordBatch newIncoming);
+
+  public void reset();
+
+  public void setMaxVarcharSize(int size);
+
   public boolean outputKeys(int batchIdx, VectorContainer outContainer, int outStartIndex, int numRecords);
 
-  public void addNewKeyBatch();
+  // public void addNewKeyBatch();
 }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableStats.java
@@ -26,6 +26,13 @@ public class HashTableStats {
 
   public HashTableStats() {
   }
+
+  public void addStats (HashTableStats newStats) {
+    this.numBuckets += newStats.numBuckets ;
+    this.numEntries += newStats.numEntries ;
+    this.numResizing += newStats.numResizing ;
+    this.resizingTime += newStats.resizingTime ;
+  }
 }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -315,7 +315,7 @@ public class HashJoinBatch extends AbstractRecordBatch<HashJoinPOP> {
     // Create the chained hash table
     final ChainedHashTable ht =
         new ChainedHashTable(htConfig, context, oContext.getAllocator(), this.right, this.left, null);
-    hashTable = ht.createAndSetupHashTable(null);
+    hashTable = ht.createAndSetupHashTable(null, 1);
   }
 
   public void executeBuildPhase() throws SchemaChangeException, ClassTransformationException, IOException {
@@ -374,7 +374,8 @@ public class HashJoinBatch extends AbstractRecordBatch<HashJoinPOP> {
 
         // For every record in the build batch , hash the key columns
         for (int i = 0; i < currentRecordCount; i++) {
-          hashTable.put(i, htIndex, 1 /* retry count */);
+          int hashCode = hashTable.getHashCode(i);
+          hashTable.put(i, htIndex, hashCode);
 
                         /* Use the global index returned by the hash table, to store
                          * the current record index and batch index. This will be used

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/ExternalSortBatch.java
@@ -39,6 +39,8 @@ import org.apache.drill.exec.physical.impl.xsort.MSortTemplate;
 import org.apache.drill.exec.physical.impl.xsort.SingleBatchSorter;
 import org.apache.drill.exec.physical.impl.xsort.managed.BatchGroup.InputBatch;
 import org.apache.drill.exec.physical.impl.xsort.managed.BatchGroup.SpilledRun;
+
+import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.AbstractRecordBatch;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
@@ -399,7 +401,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
     allocator = oContext.getAllocator();
     opCodeGen = new OperatorCodeGenerator(context, popConfig);
 
-    spillSet = new SpillSet(context, popConfig, "sort", "run");
+    spillSet = new SpillSet(context, popConfig, UserBitShared.CoreOperatorType.EXTERNAL_SORT);
     copierHolder = new CopierHolder(context, allocator, opCodeGen);
     configure(context.getConfig());
   }
@@ -1390,7 +1392,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
     // spill file. After each write, we release the memory associated
     // with the just-written batch.
 
-    String outputFile = spillSet.getNextSpillFile();
+    String outputFile = spillSet.getNextSpillFile(null);
     stats.setLongStat(Metric.SPILL_COUNT, spillSet.getFileCount());
     BatchGroup.SpilledRun newGroup = null;
     try (AutoCloseable ignored = AutoCloseables.all(batchesToSpill);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
@@ -51,7 +51,7 @@ import java.util.List;
 
 public abstract class AggPrelBase extends DrillAggregateRelBase implements Prel {
 
-  protected static enum OperatorPhase {PHASE_1of1, PHASE_1of2, PHASE_2of2};
+  public static enum OperatorPhase {PHASE_1of1, PHASE_1of2, PHASE_2of2};
 
   protected OperatorPhase operPhase = OperatorPhase.PHASE_1of1 ; // default phase
   protected List<NamedExpression> keys = Lists.newArrayList();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
@@ -61,6 +61,9 @@ public abstract class AggPruleBase extends Prule {
   // currently won't generate a 2 phase plan.
   protected boolean create2PhasePlan(RelOptRuleCall call, DrillAggregateRel aggregate) {
     PlannerSettings settings = PrelUtil.getPlannerSettings(call.getPlanner());
+    if ( settings.isForce2phaseAggr() ) { // for testing - force 2 phase aggr
+      return true;
+    }
     RelNode child = call.rel(0).getInputs().get(0);
     boolean smallInput = child.getRows() < settings.getSliceTarget();
     if (! settings.isMultiPhaseAggEnabled() || settings.isSingleMode() || smallInput) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashAggPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashAggPrel.java
@@ -73,7 +73,7 @@ public class HashAggPrel extends AggPrelBase implements Prel{
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
 
     Prel child = (Prel) this.getInput();
-    HashAggregate g = new HashAggregate(child.getPhysicalOperator(creator), keys, aggExprs, 1.0f);
+    HashAggregate g = new HashAggregate(child.getPhysicalOperator(creator), operPhase, keys, aggExprs, 1.0f);
 
     return creator.addMetadata(this, g);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -133,6 +133,9 @@ public class PlannerSettings implements Context{
      the need to turn off join optimization may go away.
    */
   public static final BooleanValidator JOIN_OPTIMIZATION = new BooleanValidator("planner.enable_join_optimization", true);
+  // for testing purpose
+  public static final String FORCE_2PHASE_AGGR_KEY = "planner.force_2phase_aggr";
+  public static final BooleanValidator FORCE_2PHASE_AGGR = new BooleanValidator(FORCE_2PHASE_AGGR_KEY, false);
 
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
@@ -273,6 +276,8 @@ public class PlannerSettings implements Context{
   public boolean isTypeInferenceEnabled() {
     return options.getOption(TYPE_INFERENCE);
   }
+
+  public boolean isForce2phaseAggr() { return options.getOption(FORCE_2PHASE_AGGR);} // for testing
 
   public long getInSubqueryThreshold() {
     return options.getOption(IN_SUBQUERY_THRESHOLD);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -34,7 +34,7 @@ import org.apache.drill.exec.record.selection.SelectionVector4;
  * <p>
  *   A key thing to know is that the Iterator provided by a record batch must
  *   align with the rank positions of the field IDs provided using
- *   {@link getValueVectorId}.
+ *   {@link #getValueVectorId}.
  * </p>
  */
 public interface RecordBatch extends VectorAccessible {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -93,6 +93,10 @@ public class SystemOptionManager extends BaseOptionManager implements OptionMana
       PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD,
       PlannerSettings.QUOTING_IDENTIFIERS,
       PlannerSettings.JOIN_OPTIMIZATION,
+      PlannerSettings.FORCE_2PHASE_AGGR, // for testing
+      ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR,
+      ExecConstants.HASHAGG_MAX_MEMORY_VALIDATOR,
+      ExecConstants.HASHAGG_MIN_BATCHES_PER_PARTITION_VALIDATOR, // for tuning
       ExecConstants.CAST_TO_NULLABLE_NUMERIC_OPTION,
       ExecConstants.OUTPUT_FORMAT_VALIDATOR,
       ExecConstants.PARQUET_BLOCK_SIZE_VALIDATOR,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -433,7 +433,7 @@ public class Foreman implements Runnable {
 
   private void runPhysicalPlan(final PhysicalPlan plan) throws ExecutionSetupException {
     validatePlan(plan);
-    MemoryAllocationUtilities.setupSortMemoryAllocations(plan, queryContext);
+    MemoryAllocationUtilities.setupBufferedOpsMemoryAllocations(plan, queryContext);
     //Marking endTime of Planning
     queryManager.markPlanningEndTime();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/PlanSplitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/PlanSplitter.java
@@ -97,7 +97,7 @@ public class PlanSplitter {
       throw new IllegalStateException("Planning fragments supports only SQL or PHYSICAL QueryType");
     }
 
-    MemoryAllocationUtilities.setupSortMemoryAllocations(plan, queryContext);
+    MemoryAllocationUtilities.setupBufferedOpsMemoryAllocations(plan, queryContext);
 
     final PhysicalOperator rootOperator = plan.getSortedOperators(false).iterator().next();
 

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -207,6 +207,33 @@ drill.exec: {
     // java ... -ea -Ddrill.exec.debug.validate_vectors=true ...
     validate_vectors: false
   },
+  spill: {
+    // *** Options common to all the operators that may spill
+    // File system to use. Local file system by default.
+    fs: "file:///",
+    // List of directories to use. Directories are created
+    // if they do not exist.
+    directories: [ "/tmp/drill/spill" ]
+  },
+  hashagg: {
+    // An internal tuning; should not be changed
+    min_batches_per_partition: 3,
+    // An option for testing - force a memory limit
+    mem_limit: 0,
+    // The max number of partitions in each hashagg operator
+    // This number is tuned down when memory is limited
+    // Setting it to 1 means: No spilling
+    num_partitions: 32,
+    spill: {
+        // -- The 2 options below can be used to override the common ones
+        // -- (common to all spilling operators)
+        // File system to use. Local file system by default.
+        fs: ${drill.exec.spill.fs},
+        // List of directories to use. Directories are created
+        // if they do not exist.
+        directories:  ${drill.exec.spill.directories},
+    }
+  },
   sort: {
     purge.threshold : 1000,
     external: {
@@ -232,11 +259,15 @@ drill.exec: {
         group.size: 40000,
         // Deprecated for managed xsort; used only by legacy xsort
         threshold: 40000,
+        // -- The two options below can be used to override the options common
+        // -- for all spilling operators (see "spill" above).
+        // -- This is done for backward compatibility; in the future they
+        // -- would be deprecated (you should be using only the common ones)
         // File system to use. Local file system by default.
-        fs: "file:///"
+        fs: ${drill.exec.spill.fs},
         // List of directories to use. Directories are created
         // if they do not exist.
-        directories: [ "/tmp/drill/spill" ],
+        directories:  ${drill.exec.spill.directories},
         // Size of the batches written to, and read from, the spill files.
         // Determines the ratio of memory to input data size for a single-
         // generation sort. Smaller values give larger ratios, but at a

--- a/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestBugFixes.java
@@ -211,12 +211,13 @@ public class TestBugFixes extends BaseTestQuery {
     int limit = 65536;
     ImmutableList.Builder<Map<String, Object>> baselineBuilder = ImmutableList.builder();
     for (int i = 0; i < limit; i++) {
-      baselineBuilder.add(Collections.<String, Object>singletonMap("`id`", String.valueOf(i + 1)));
+      baselineBuilder.add(Collections.<String, Object>singletonMap("`id`", /*String.valueOf */ (i + 1)));
     }
     List<Map<String, Object>> baseline = baselineBuilder.build();
 
     testBuilder()
-            .sqlQuery(String.format("select id from dfs_test.`%s/bugs/DRILL-4884/limit_test_parquet/test0_0_0.parquet` group by id limit %s", TEST_RES_PATH, limit))
+            .sqlQuery(String.format("select cast(id as int) as id from dfs_test.`%s/bugs/DRILL-4884/limit_test_parquet/test0_0_0.parquet` group by id order by 1 limit %s",
+                TEST_RES_PATH, limit))
             .unOrdered()
             .baselineRecords(baseline)
             .go();

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertNull;
  * any particular order of execution. We ignore the results.
  */
 public class TestTpchDistributedConcurrent extends BaseTestQuery {
-  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(140000); // Longer timeout than usual.
+  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(180000); // Longer timeout than usual.
 
   /*
    * Valid test names taken from TestTpchDistributed. Fuller path prefixes are

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.physical.impl.agg;
+
+import ch.qos.logback.classic.Level;
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.impl.aggregate.HashAggTemplate;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.FixtureBuilder;
+import org.apache.drill.test.LogFixture;
+import org.apache.drill.test.ProfileParser;
+import org.apache.drill.test.QueryBuilder;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *  Test spilling for the Hash Aggr operator (using the mock reader)
+ */
+public class TestHashAggrSpill extends BaseTestQuery {
+
+    private void runAndDump(ClientFixture client, String sql, long expectedRows, long spillCycle, long spilledPartitions) throws Exception {
+        String plan = client.queryBuilder().sql(sql).explainJson();
+
+        QueryBuilder.QuerySummary summary = client.queryBuilder().sql(sql).run();
+        if ( expectedRows > 0 ) {
+            assertEquals(expectedRows, summary.recordCount());
+        }
+        // System.out.println(String.format("======== \n Results: %,d records, %d batches, %,d ms\n ========", summary.recordCount(), summary.batchCount(), summary.runTimeMs() ) );
+
+        //System.out.println("Query ID: " + summary.queryIdString());
+        ProfileParser profile = client.parseProfile(summary.queryIdString());
+        //profile.print();
+        List<ProfileParser.OperatorProfile> ops = profile.getOpsOfType(UserBitShared.CoreOperatorType.HASH_AGGREGATE_VALUE);
+
+        assertTrue( ! ops.isEmpty() );
+        // check for the first op only
+        ProfileParser.OperatorProfile hag0 = ops.get(0);
+        long opCycle = hag0.getMetric(HashAggTemplate.Metric.SPILL_CYCLE.ordinal());
+        assertEquals(spillCycle, opCycle);
+        long op_spilled_partitions = hag0.getMetric(HashAggTemplate.Metric.SPILLED_PARTITIONS.ordinal());
+        assertEquals(spilledPartitions, op_spilled_partitions);
+        /* assertEquals(3, ops.size());
+        for ( int i = 0; i < ops.size(); i++ ) {
+            ProfileParser.OperatorProfile hag = ops.get(i);
+            long cycle = hag.getMetric(HashAggTemplate.Metric.SPILL_CYCLE.ordinal());
+            long num_partitions = hag.getMetric(HashAggTemplate.Metric.NUM_PARTITIONS.ordinal());
+            long spilled_partitions = hag.getMetric(HashAggTemplate.Metric.SPILLED_PARTITIONS.ordinal());
+            long mb_spilled = hag.getMetric(HashAggTemplate.Metric.SPILL_MB.ordinal());
+            System.out.println(String.format("(%d) Spill cycle: %d, num partitions: %d, spilled partitions: %d, MB spilled: %d", i,cycle, num_partitions, spilled_partitions,
+                mb_spilled));
+        } */
+    }
+
+    /**
+     * Test "normal" spilling: Only 2 partitions (out of 4) would require spilling
+     * ("normal spill" means spill-cycle = 1 )
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testHashAggrSpill() throws Exception {
+        LogFixture.LogFixtureBuilder logBuilder = LogFixture.builder()
+            .toConsole()
+            .logger("org.apache.drill.exec.physical.impl.aggregate", Level.DEBUG)
+            ;
+
+        FixtureBuilder builder = ClusterFixture.builder()
+            .configProperty(ExecConstants.HASHAGG_MAX_MEMORY,74_000_000)
+            .configProperty(ExecConstants.HASHAGG_NUM_PARTITIONS,16)
+            .configProperty(ExecConstants.HASHAGG_MIN_BATCHES_PER_PARTITION,3)
+            .sessionOption(PlannerSettings.FORCE_2PHASE_AGGR_KEY,true)
+            // .sessionOption(PlannerSettings.EXCHANGE.getOptionName(), true)
+            .maxParallelization(2)
+            .saveProfiles()
+            //.keepLocalFiles()
+            ;
+        try (LogFixture logs = logBuilder.build();
+             ClusterFixture cluster = builder.build();
+             ClientFixture client = cluster.clientFixture()) {
+            String sql = "SELECT empid_s17, dept_i, branch_i, AVG(salary_i) FROM `mock`.`employee_1200K` GROUP BY empid_s17, dept_i, branch_i";
+            runAndDump(client, sql, 1_200_000, 1, 1);
+        }
+    }
+
+    /**
+     *  Test "secondary" spilling -- Some of the spilled partitions cause more spilling as they are read back
+     *  (Hence spill-cycle = 2 )
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testHashAggrSecondaryTertiarySpill() throws Exception {
+        LogFixture.LogFixtureBuilder logBuilder = LogFixture.builder()
+            .toConsole()
+            .logger("org.apache.drill.exec.physical.impl.aggregate", Level.DEBUG)
+            .logger("org.apache.drill.exec.cache", Level.INFO)
+            ;
+
+        FixtureBuilder builder = ClusterFixture.builder()
+            .configProperty(ExecConstants.HASHAGG_MAX_MEMORY,58_000_000)
+            .configProperty(ExecConstants.HASHAGG_NUM_PARTITIONS,16)
+            .configProperty(ExecConstants.HASHAGG_MIN_BATCHES_PER_PARTITION,3)
+            .sessionOption(PlannerSettings.FORCE_2PHASE_AGGR_KEY,true)
+            .sessionOption(PlannerSettings.STREAMAGG.getOptionName(),false)
+            // .sessionOption(PlannerSettings.EXCHANGE.getOptionName(), true)
+            .maxParallelization(1)
+            .saveProfiles()
+            //.keepLocalFiles()
+            ;
+        try (LogFixture logs = logBuilder.build();
+             ClusterFixture cluster = builder.build();
+             ClientFixture client = cluster.clientFixture()) {
+            String sql = "SELECT empid_s44, dept_i, branch_i, AVG(salary_i) FROM `mock`.`employee_1100K` GROUP BY empid_s44, dept_i, branch_i";
+            runAndDump(client, sql, 1_100_000, 3, 2);
+        }
+    }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.physical.config.MergingReceiverPOP;
 import org.apache.drill.exec.physical.config.Project;
 import org.apache.drill.exec.physical.config.StreamingAggregate;
 import org.apache.drill.exec.physical.config.TopN;
+import org.apache.drill.exec.planner.physical.AggPrelBase;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -125,7 +126,7 @@ public class BasicPhysicalOpUnitTest extends PhysicalOpUnitTestBase {
 
   @Test
   public void testSimpleHashAgg() {
-    HashAggregate aggConf = new HashAggregate(null, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"), 1.0f);
+    HashAggregate aggConf = new HashAggregate(null, AggPrelBase.OperatorPhase.PHASE_1of1, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"), 1.0f);
     List<String> inputJsonBatches = Lists.newArrayList(
         "[{\"a\": 5, \"b\" : 1 }]",
         "[{\"a\": 5, \"b\" : 5},{\"a\": 3, \"b\" : 8}]");

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -119,6 +119,7 @@
             <exclude>**/.checkstyle</exclude>
             <exclude>**/.buildpath</exclude>
             <exclude>**/*.json</exclude>
+            <exclude>**/*.iml</exclude>
             <exclude>**/git.properties</exclude>
             <exclude>**/donuts-output-data.txt</exclude>
             <exclude>**/*.tbl</exclude>

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -192,8 +192,8 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
           r.pBody, r.dBodies);
       if (RpcConstants.EXTRA_DEBUGGING) {
         logger.debug("Adding message to outbound buffer. {}", outMessage);
+        logger.debug("Sending response with Sender {}", System.identityHashCode(this));
       }
-      logger.debug("Sending response with Sender {}", System.identityHashCode(this));
       connection.getChannel().writeAndFlush(outMessage);
     }
 

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -377,6 +377,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       throw new OversizedAllocationException("Unable to expand the buffer. Max allowed buffer size is reached.");
     }
 
+    logger.trace("Reallocating VarChar, new size {}",newAllocationSize);
     final DrillBuf newBuf = allocator.buffer((int)newAllocationSize);
     newBuf.setBytes(0, data, 0, data.capacity());
     data.release();


### PR DESCRIPTION
This pull-request is for the work on enabling memory spill for the Hash Aggregate Operator.

To assist in reviewing this extensive code change, listed below are various topics/issues that describe the implementation decisions and give some code pointers. The reviewer can read these items and peek into their relevant code, or read all the items first (and comment on the design decisions as well).

The last topic is not "least": It describes many issues and solutions related to the need to estimate the memory size of batches (and hash tables, etc.) This work took a significant amount of time, and will need some more to get better.

(Most of the code changes are in HashAggTemplate.java, hence this file is not mentioned specifically below)

### Aggregation phase:
   The code was changed to pass the aggregation phase information (whether this is a Single phase, or 1st of two phase, or 2nd of two phase) from the planner to the HAG operator code.
(See HashAggregate.java, AggPrelBase.java, HashAggPrel.java )

### Partitioning:
  The data (rows/groups) coming into the HAG is partitioned into (a power of 2) number of partitions, based on the N least significant bits of the hash value (computed out of the row's key columns).
  Each partition can be handled independently of the others. Ideally each partition should fit into the available memory. The number of partitions is initialized from the option "drill.exec.hashagg.num_partitions", and scaled down if the available memory seems too small (each partition needs to hold at least one batch in memory).
  The scaling down uses the formula:  AVAIL_MEMORY >  NUM_PARTITIONS * ( K * EST_BATCH_SIZE + 8M )
(see delayedSetup() ) where K is the option drill.exec.hashagg.min_batches_per_partition -- see below).
  Computing the number of partitions is delayed till actuall data arrives on incoming (in order to get an accurate sizing on varchars). See delayedSetup(). There is also special code for cases data never arrives (empty batches) hence no partitions (see beginning of outputCurrentBatch(), cleanUp(), delayedSetup() ).
  Many of the code changes made in order to implement multi-partitions follow the original code, only changing scalar members (of HashAggTemplate) into arrays, like "htable" becomes "htables[]".
  Each partition has its own hash table. After each time it is spilled, its hash table is freed and reallocated.

### Hash Code:
  The hash code computation result was extracted from the HashTable (needed for the partitions), and added as a parameter to the put() method. Thus for each new incoming row, first the hash code is computed, and the low N bits are used to select the partition, then the hash code is right shifted by N, and the result is passed back to the put() method.
  After spilling, the hash codes are not kept. When reading the rows (groups) from the spill, the hash codes are computed again (and right shifted before use - once per each cycle of spilling - thus repartitioning).
(See more about "spilling cycle" below).

### Hash Table put():
  The put() method for the hash table was rewriten and simplified. In addition to the hash-code parameter change, it was changed to return the PutStatus, with two new states: NEW_BATCH_ADDED notifies the caller that a new batch was created internally, hence a new batch (only needed for Hash Agg) is needed (prior code was getting this from comparing the returned index against the prior number of batches).
  A second new state is KEY_ADDED_LAST, which notifies that a batch was just filled, hence it is time for checking memory availability (because a new batch would be allocated soon).
  Similar rewriting was done for the hash table containsKey() method (and addBatchifNeeded() ).

### Memory pressure check:
  Logically the place to check for a memory pressure is when a new memory is needed (i.e., when a new group needs to be created.) However the code structure does not let this easily (e.g., a new batch is allocated inside the hash table object when a new group is detected, or the hash table structure is doubled in size),  thus instead the check is done AFTER a new group was added, in case this was the last group added to that batch  (see in checkGroupAndAggrValues() - checking for a new status KEY_ADDED_LAST  )
   This memory availability check checks if there is enough memory left between the allocated so far and the limit.
 Spill is initiated when:  MEMORY_USED + MAX_MEMORY_NEEDED > MEMORY_LIMIT   (see checkGroupAndAggrValues() )
 where the memory needed is:  (EST_BATCH_SIZE + 64K * (4+4)) * K * PLANNED_BATCHES + MAX_HASH_TABLES_RESIZE
(See K above, under Partitioning, and the rest well below, under memory estimations).

### When can not spill:
  Single phase HAG can not spill. Also under memory duress 2nd phase may end up with only a single partition, which can not allow spilling (no progress is made). In these two cases, the memory check is skipped, and the operator functions like the old code -- if runs out of memory then it will OOM. A try-catch was added into the code to provide more detail on the OOM (see getOOMErrorMsg() ).
   Also in case of a single partition the allocator's memory limit is set to 10GB, to be compatible with the prior code.
   Another "can't spill" situation is when choosing a partition to spill, but no partition has more than 1 batch  (hence memory can not be gained, as after spilling 1 batch need to reinitialize that partition with a new batch). See chooseAPartitionToFlush(). In such a case the code "crosses its fingers" and continues without spilling.

### 1st phase - Early return:
  The 1st phase HAG does not spill to disk. When the 1st detects a memory pressure it picks the current partition (the one whose last batch just got full) and returns that partition downstream (just like regular return, only early). Afterwards that partition is (deallocated and) initialized. Note the boolean "earlyOutput" in the code which controls special processing in this case - when turned on the code switches to output (e.g., innerNext() in HashAggBatch.java), and turned off when done (see  outputCurrentBatch() ).

### Spilling: 
  Using the SpillSet (like the External Sort does) for the actual IO.  Each partition spills into a single
file.  Changes to SpillSet: Generalize it for any kind of "buffered memory" operator (pass in the operator's type). Also small changes to the spill file name.

### 2nd phase - Flushing/spilling: 
  When a memory pressure is detected (while reading and processing the incoming), one of the
partitions is selected ( see chooseAPartitionToFlush() ) and flushed ( spillAPartition() ), and then its memory is freed and that partition is re-initialized ( reinitPartition() ). The choice of a partition gives some small priority to the current partition (since its last batch is full, unlike the others), and priority by a factor of 4 to partitions that are already spilled (i.e., a spilled partition with 10 batches would be chosen vs a pristine/non-spilled with 39 batches.)

Partition spilling (spillAPartition() ):  For each batch in the partition - Allocate an outgoing container, link the values and the keys into this container, and write it to the file/stream. 

2nd phase - End of incoming: After the last batch was read from the incoming - the original code ( next() ) returned a status of NONE. The new code - after spilling can't return NONE, so instead returning a special status of RESTART (see outputCurrentBatch() ). This RESTART is captured by the caller of the next() ( innerNext() in HashAggBatch.java ) which continues to drive the aggregation (instead of returning).

After the end of the incoming, all the (partially) spilled partitions finish spilling all their remaining in-memory batches to disk (see outputCurrentBatch() ). This is done to simplify the later processing of each spilled partition, as well as freeing memory which may be needed as partitions are processed. The spilled partitions are added into a list (spilledPartitionsList) to allow for later processing.

### 2nd phase reading of the spill: 
Reading of each spilled partition/file is performed like reading the incoming. For this purpose, a new class was added: SpilledRecordbatch. The main method there is next() which reads a batch from the stream -- first time it uses the original readFromStream() method, which creates a new container; subsequent calls use the new readFromStreamWithContainer() method, which is similar - only reuses the prior container. (This was done because many places in the code have references into the container).

### Spilling cycles: 
Reading a spilled partition "just like incoming" allows for that input to spill again (and again ...);
this was termed SECONDARY spilling (and TERTIARY ...). As the spilled partitions are kept in a FIFO list, processing of SECONDARY partitions would start only after all the regular spilled ones, etc. Hence a member "cycleNum" was created, incremented every time that processing the spilled list advances to another "cycle" (see outputCurrentBatch() ).
  The "cycleNum" is used for the hash-code computation; the same hash-code is computed at every cycle, but the cycle tells how much to right-shift that code so that different bits would be used (for partitioning and hash-table bucket).

### Configuration options:
- drill.exec.hashagg.num_partitions: Initial number of partitions in each HAG operator (the number may be down adjusted in case too little memory is available). Default value: 32 , allowed range 1 - 128 , where a value of 1 means "No spilling" (and thus setting 10GB limit).
- drill.exec.hashagg.min_batches_per_partition: Range 2--5. Default 3. Used for internal initial estimate of number of partitions, and later when predicting memory needed (to avoid a spill).
  (A value of 2 may be better, but it evokes some bug which would be addressed separately).

Also using options common to all the "buffered" operators (can be overriden, per operator):
- drill.exe.spill.fs: File system for spilling into.
- drill.exec.spill.directories: (Array of) directories to spill into.
(To override, per-operator: for the (managed) External Sort: "drill.exec.sort.external.spill.fs" and
 "drill.exec.sort.external.spill.directories", and for the Hash Aggregate:
 "drill.exec.hashagg.spill.fs" and "drill.exec.hashagg.spill.directories")

For testing:
- drill.exec.hashagg.mem_limit: Limit the memory for each HAG operator (also sets this number in the allocator, hence this is a "hard limit").

Also for testing (or for a customer workaround ??):
- planner.force_2phase_aggr: Forces the aggregation to be two phase.

### Stats and metrics:
  The hash-table stats were modified to sum the stats across all the partitions' hash tables. (This only applies to the first spilling cycle; does not count for SECONDARY, TERTIARY spilling etc.).
  New metrics added:
 - "num partitions" (actual number; may have been scaled down due to memory pressure)
 - "spilled partitions" (number that has spilled)
 - "MB spilled" (in case of 1st phase - that's the total data returned early).
 All the above three refer to the end of input into the HAG (does not include handling of spills, secondary spills, etc.)
 - "cycle": 0 - no spill (or 1st phase), 1 - regular spill, 2 - Secondary, 3 - Tertiary ...)
 
### Memory Allocation Utilities:
   Extended for all "buffered operators", not only for Sort. (Hash Join will be added later as well, etc.)

### Changes to Unit tests:
- New TestHashAggSpill : Runs two hash agg queries - One spills some of its partitions (1 out of 2), and the other test forces a smaller memory hence gets into a Secondary and Tertiary spills.
- TestBugFixes.testDRILL4884: This test implicitly relied on rows returned in order (the old Hash agg, plus the Parquet file).
    With the new division into partitions, that order was broken. Fix: added an "order by".
- TestTpchDistributedConcurrent.testConcurrentQueries: Needed longer timeout (probably spilled).

### MISC
- After a spill, check again if enough memory was freed, else spill (another partition) again. (Not sure if needed.)
- Suggestion not implemented: Scaling down the initial hash-table sizes by the number of partitions (e.g. when 4 partitions, each hash-table starts with 1/4 of the initial size). Reason for not changing: starting with a small size immediately causes doubling and another doubling etc. Better allocate a little more and save that work.
- The RecordBatchSizer had a recent change to handle MAPs (recursively). Merged this change with the modified measureColumn() which returns an int (the est size).

### MEMORY SIZE ESTIMATIONS
  As described above, we need to get good estimate of the memory needs in order to decide initially on the number of partitions, and later to decide each time (a batch gets filled) wheter to spill or not.
 These estimates are complicated due to:
(1) Possible changes in the incoming data batches (e.g., varchar(12) in the first batch becomes varchar(200) in the second incoming batch). This may invalidate prior estimates.
(2) Arbitrary setting of length 50 for varchar type (when sizing the allocation of DrillBufs)
(3) Allocation size aligned up to nearest power of 2 (DrillBufs for varchars)
(4) When an internal batch gets filled, and estimation shows ample memory -- a second batch may get filled before the first one's partition allocated a new batch (hence may cause "double booking").
(5) Inserting a single value may cause the "start indices" (the real actual "hash table") to double in size. This structure can get pretty large (few MB).
(6) Does the size of the incoming batch being charged against the HAG's memory allocator limit ? (Not sure; usually not a problem as the prior batch is deallocated before the next one comes; unless the next one is "much bigger")
(7) For varchars: The memory is allocated as a power of 2 (e.g. doubled via setSafe()). This can cause a big memory waste, like if the total memory needed for 64k varchars is ~5MB, then 8MB is allocated, wasting 3MB).
(8) The varchar value vector uses an internal "offset vector" that allocates "size+1", hence for 64K it allocates 512kb, of which 256kb are wasted (see DRILL-5446).

### Solutions for the memory estimation issues:
(1)+(6) above: Monitor the size of each incoming batch. Resize batch size estimate if the incoming batch is bigger (see doWork() )

(5) When estimating memory needs, take into account hash table size doubling in all partitions (using the new hash table method extraMemoryNeededForResize() ).

(4) Track "plannedBatches"; when "promising" few partitions a new batch each, take this into account when checking for available memory. (Though "more than 1" situation seems very rare).

(2)+(3) Idealy tracking the size of EACH varchar column could work better, but not simple to implement. Instead -- just find the maximum size of any of the incoming columns (for simplicity - not only varchars), and use this value (capped at 50, min value of 8; rounded up to the next power of 2 if needed).  This addresses the common situation of multiple short varchar key columns but not the (very rare) situation of a huge varchar KEY column, plus few short ones.

(7) Update RecordBatchSizer.java -- added a method  netRowWidthCap50()  which takes into account the rounding up (per each column in a row), plus nulls arrays as needed, for each row (will multiply that by 64K in updateEstMaxBatchSize() ).

==== END ====
