### PR TITLE
DRILL-5481: Persist profiles in-memory only with a max capacity

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -107,8 +107,9 @@ public interface ExecConstants {
   String SYS_STORE_PROVIDER_CLASS = "drill.exec.sys.store.provider.class";
   String SYS_STORE_PROVIDER_ZK_BLOBROOT = "drill.exec.sys.store.provider.zk.blobroot";
   String SYS_STORE_PROVIDER_LOCAL_PATH = "drill.exec.sys.store.provider.local.path";
-  String SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE = "drill.exec.sys.store.provider.local.inmemory.write";
-  String SYS_STORE_CAPACITY_PROFILES = "drill.exec.sys.store.capacity.profiles";
+  String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.enable.write";
+  String SYS_STORE_PROFILES_INMEMORY = "drill.exec.sys.store.profiles.inmemory";
+  String SYS_STORE_PROFILES_CAPACITY = "drill.exec.sys.store.profiles.capacity";
   String IMPERSONATION_ENABLED = "drill.exec.impersonation.enabled";
   String IMPERSONATION_MAX_CHAINED_USER_HOPS = "drill.exec.impersonation.max_chained_user_hops";
   String AUTHENTICATION_MECHANISMS = "drill.exec.security.auth.mechanisms";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -105,8 +105,10 @@ public interface ExecConstants {
   String HTTP_TRUSTSTORE_PATH = "javax.net.ssl.trustStore";
   String HTTP_TRUSTSTORE_PASSWORD = "javax.net.ssl.trustStorePassword";
   String SYS_STORE_PROVIDER_CLASS = "drill.exec.sys.store.provider.class";
+  String SYS_STORE_PROVIDER_ZK_BLOBROOT = "drill.exec.sys.store.provider.zk.blobroot";
   String SYS_STORE_PROVIDER_LOCAL_PATH = "drill.exec.sys.store.provider.local.path";
-  String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";
+  String SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE = "drill.exec.sys.store.provider.local.inmemory.write";
+  String SYS_STORE_CAPACITY_PROFILES = "drill.exec.sys.store.capacity.profiles";
   String IMPERSONATION_ENABLED = "drill.exec.impersonation.enabled";
   String IMPERSONATION_MAX_CHAINED_USER_HOPS = "drill.exec.impersonation.max_chained_user_hops";
   String AUTHENTICATION_MECHANISMS = "drill.exec.security.auth.mechanisms";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -39,6 +39,7 @@ import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.server.QueryProfileStoreContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.QueryOptionManager;
@@ -209,6 +210,10 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     return drillbitContext.getConfig();
   }
 
+  public QueryProfileStoreContext getProfileStoreContext() {
+    return drillbitContext.getProfileStoreContext();
+  }
+
   @Override
   public FunctionImplementationRegistry getFunctionRegistry() {
     return drillbitContext.getFunctionImplementationRegistry();
@@ -225,7 +230,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   }
 
   public boolean isImpersonationEnabled() {
-     return getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
+    return getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
   }
 
   public boolean isUserAuthenticationEnabled() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -46,7 +46,7 @@ import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import com.codahale.metrics.MetricRegistry;
 
 public class DrillbitContext implements AutoCloseable {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillbitContext.class);
+  //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillbitContext.class);
 
   private final BootStrapContext context;
   private final PhysicalPlanReader reader;
@@ -65,6 +65,7 @@ public class DrillbitContext implements AutoCloseable {
   private final LogicalPlanPersistence lpPersistence;
   // operator table for standard SQL operators and functions, Drill built-in UDFs
   private final DrillOperatorTable table;
+  private final QueryProfileStoreContext profileStore;
 
 
   public DrillbitContext(
@@ -97,6 +98,13 @@ public class DrillbitContext implements AutoCloseable {
 
     // This operator table is built once and used for all queries which do not need dynamic UDF support.
     this.table = new DrillOperatorTable(functionRegistry, systemOptions);
+
+
+    this.profileStore = new QueryProfileStoreContext(context.getConfig(), provider, coord);
+  }
+
+  public QueryProfileStoreContext getProfileStoreContext() {
+    return profileStore;
   }
 
   public FunctionImplementationRegistry getFunctionImplementationRegistry() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -47,14 +47,19 @@ public class QueryProfileStoreContext {
 
   public QueryProfileStoreContext(DrillConfig config, PersistentStoreProvider storeProvider,
                                   ClusterCoordinator coordinator) {
-    profileStoreConfig = PersistentStoreConfig.newProtoBuilder(SchemaUserBitShared.QueryProfile.WRITE,
+    StoreConfigBuilder profileStoreConfigBuilder = PersistentStoreConfig.newProtoBuilder(SchemaUserBitShared.QueryProfile.WRITE,
         SchemaUserBitShared.QueryProfile.MERGE)
         .name(PROFILES)
         .blob()
-        .isInMemory()
         //This will only take effect if the store enforces it
-        .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_PROFILES_CAPACITY))
-        .build();
+        .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_PROFILES_CAPACITY));
+
+    //In Memory
+    if (config.getBoolean(ExecConstants.SYS_STORE_PROFILES_INMEMORY)) {
+      profileStoreConfigBuilder = profileStoreConfigBuilder.setInMemory();
+    }
+
+    profileStoreConfig = profileStoreConfigBuilder.build();
 
     try {
       completedProfiles = storeProvider.getOrCreateStore(profileStoreConfig);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -51,8 +51,9 @@ public class QueryProfileStoreContext {
         SchemaUserBitShared.QueryProfile.MERGE)
         .name(PROFILES)
         .blob()
+        .inMemory()
         //This will only take effect if the store enforces it
-        .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_CAPACITY_PROFILES))
+        .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_PROFILES_CAPACITY))
         .build();
 
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -51,7 +51,7 @@ public class QueryProfileStoreContext {
         SchemaUserBitShared.QueryProfile.MERGE)
         .name(PROFILES)
         .blob()
-        .inMemory()
+        .isInMemory()
         //This will only take effect if the store enforces it
         .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_PROFILES_CAPACITY))
         .build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.coord.ClusterCoordinator;
+import org.apache.drill.exec.coord.store.TransientStore;
+import org.apache.drill.exec.coord.store.TransientStoreConfig;
+import org.apache.drill.exec.proto.SchemaUserBitShared;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.proto.UserBitShared.QueryInfo;
+import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
+import org.apache.drill.exec.store.sys.PersistentStore;
+import org.apache.drill.exec.store.sys.PersistentStoreConfig;
+import org.apache.drill.exec.store.sys.PersistentStoreProvider;
+import org.apache.drill.exec.store.sys.PersistentStoreConfig.StoreConfigBuilder;
+
+public class QueryProfileStoreContext {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryProfileStoreContext.class);
+
+  private static final String PROFILES = "profiles";
+
+  private static final String RUNNING = "running";
+
+  private final PersistentStore<UserBitShared.QueryProfile> completedProfiles;
+
+  private final TransientStore<UserBitShared.QueryInfo> runningProfiles;
+
+  private final PersistentStoreConfig<QueryProfile> profileStoreConfig;
+
+  public QueryProfileStoreContext(DrillConfig config, PersistentStoreProvider storeProvider,
+                                  ClusterCoordinator coordinator) {
+    profileStoreConfig = PersistentStoreConfig.newProtoBuilder(SchemaUserBitShared.QueryProfile.WRITE,
+        SchemaUserBitShared.QueryProfile.MERGE)
+        .name(PROFILES)
+        .blob()
+        //This will only take effect if the store enforces it
+        .setMaxCapacity(config.getInt(ExecConstants.SYS_STORE_CAPACITY_PROFILES))
+        .build();
+
+    try {
+      completedProfiles = storeProvider.getOrCreateStore(profileStoreConfig);
+    } catch (final Exception e) {
+      throw new DrillRuntimeException(e);
+    }
+
+    runningProfiles = coordinator.getOrCreateTransientStore(TransientStoreConfig
+        .newProtoBuilder(SchemaUserBitShared.QueryInfo.WRITE, SchemaUserBitShared.QueryInfo.MERGE)
+        .name(RUNNING)
+        .build());
+  }
+
+  public PersistentStoreConfig<QueryProfile> getProfileStoreConfig() {
+    return profileStoreConfig;
+  }
+
+  public PersistentStore<QueryProfile> getCompletedProfileStore() {
+    return completedProfiles;
+  }
+
+  public TransientStore<QueryInfo> getRunningProfileStore() {
+    return runningProfiles;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
@@ -47,6 +47,7 @@ import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.QueryInfo;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.server.QueryProfileStoreContext;
 import org.apache.drill.exec.server.rest.DrillRestServer.UserAuthEnabled;
 import org.apache.drill.exec.server.rest.ViewableWithPermissions;
 import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
@@ -180,8 +181,9 @@ public class ProfileResources {
   @Produces(MediaType.APPLICATION_JSON)
   public QProfiles getProfilesJSON(@Context UriInfo uriInfo) {
     try {
-      final PersistentStore<QueryProfile> completed = getProvider().getOrCreateStore(QueryManager.QUERY_PROFILE);
-      final TransientStore<QueryInfo> running = getCoordinator().getOrCreateTransientStore(QueryManager.RUNNING_QUERY_INFO);
+      final QueryProfileStoreContext profileStoreContext = work.getContext().getProfileStoreContext();
+      final PersistentStore<QueryProfile> completed = profileStoreContext.getCompletedProfileStore();
+      final TransientStore<QueryInfo> running = profileStoreContext.getRunningProfileStore();
 
       final List<String> errors = Lists.newArrayList();
 
@@ -258,7 +260,7 @@ public class ProfileResources {
 
     // then check remote running
     try {
-      final TransientStore<QueryInfo> running = getCoordinator().getOrCreateTransientStore(QueryManager.RUNNING_QUERY_INFO);
+      final TransientStore<QueryInfo> running = work.getContext().getProfileStoreContext().getRunningProfileStore();
       final QueryInfo info = running.get(queryId);
       if (info != null) {
         QueryProfile queryProfile = work.getContext()
@@ -275,7 +277,7 @@ public class ProfileResources {
 
     // then check blob store
     try {
-      final PersistentStore<QueryProfile> profiles = getProvider().getOrCreateStore(QueryManager.QUERY_PROFILE);
+      final PersistentStore<QueryProfile> profiles = work.getContext().getProfileStoreContext().getCompletedProfileStore();
       final QueryProfile queryProfile = profiles.get(queryId);
       if (queryProfile != null) {
         checkOrThrowProfileViewAuthorization(queryProfile);
@@ -296,7 +298,9 @@ public class ProfileResources {
   @Produces(MediaType.APPLICATION_JSON)
   public String getProfileJSON(@PathParam("queryid") String queryId) {
     try {
-      return new String(QueryManager.QUERY_PROFILE.getSerializer().serialize(getQueryProfile(queryId)));
+      return new String(
+          work.getContext().getProfileStoreContext().getProfileStoreConfig().getSerializer().serialize(getQueryProfile(queryId))
+          );
     } catch (Exception e) {
       logger.debug("Failed to serialize profile for: " + queryId);
       return ("{ 'message' : 'error (unable to serialize profile)' }");
@@ -329,7 +333,7 @@ public class ProfileResources {
 
     // then check remote running
     try {
-      final TransientStore<QueryInfo> running = getCoordinator().getOrCreateTransientStore(QueryManager.RUNNING_QUERY_INFO);
+      final TransientStore<QueryInfo> running = work.getContext().getProfileStoreContext().getRunningProfileStore();
       final QueryInfo info = running.get(queryId);
       checkOrThrowQueryCancelAuthorization(info.getUser(), queryId);
       Ack a = work.getContext().getController().getTunnel(info.getForeman()).requestCancelQuery(id).checkedGet(2, TimeUnit.SECONDS);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
@@ -38,11 +38,17 @@ public class PersistentStoreConfig<V> {
   private final String name;
   private final InstanceSerializer<V> valueSerializer;
   private final PersistentStoreMode mode;
+  private final int maxCapacity;
 
-  protected PersistentStoreConfig(String name, InstanceSerializer<V> valueSerializer, PersistentStoreMode mode) {
+  protected PersistentStoreConfig(String name, InstanceSerializer<V> valueSerializer, PersistentStoreMode mode, int maxCapacity) {
     this.name = name;
     this.valueSerializer = valueSerializer;
     this.mode = mode;
+    this.maxCapacity = maxCapacity;
+  }
+
+  public int getMaxCapacity() {
+    return maxCapacity;
   }
 
   public PersistentStoreMode getMode() {
@@ -85,6 +91,7 @@ public class PersistentStoreConfig<V> {
     private String name;
     private InstanceSerializer<V> serializer;
     private PersistentStoreMode mode = PersistentStoreMode.PERSISTENT;
+    private int maxCapacity = Integer.MAX_VALUE;
 
     protected StoreConfigBuilder(InstanceSerializer<V> serializer) {
       super();
@@ -106,9 +113,14 @@ public class PersistentStoreConfig<V> {
       return this;
     }
 
+    public StoreConfigBuilder<V> setMaxCapacity(int maxCapacity) {
+      this.maxCapacity = maxCapacity;
+      return this;
+    }
+
     public PersistentStoreConfig<V> build(){
       Preconditions.checkNotNull(name);
-      return new PersistentStoreConfig<>(name, serializer, mode);
+      return new PersistentStoreConfig<>(name, serializer, mode, maxCapacity);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreConfig.java
@@ -38,13 +38,19 @@ public class PersistentStoreConfig<V> {
   private final String name;
   private final InstanceSerializer<V> valueSerializer;
   private final PersistentStoreMode mode;
+  private final boolean inMemory;
   private final int maxCapacity;
 
-  protected PersistentStoreConfig(String name, InstanceSerializer<V> valueSerializer, PersistentStoreMode mode, int maxCapacity) {
+  protected PersistentStoreConfig(String name, InstanceSerializer<V> valueSerializer, PersistentStoreMode mode, boolean inMemory, int maxCapacity) {
     this.name = name;
     this.valueSerializer = valueSerializer;
     this.mode = mode;
+    this.inMemory = inMemory;
     this.maxCapacity = maxCapacity;
+  }
+
+  public boolean isInMemory() {
+    return inMemory;
   }
 
   public int getMaxCapacity() {
@@ -91,6 +97,7 @@ public class PersistentStoreConfig<V> {
     private String name;
     private InstanceSerializer<V> serializer;
     private PersistentStoreMode mode = PersistentStoreMode.PERSISTENT;
+    private boolean inMemory = false;
     private int maxCapacity = Integer.MAX_VALUE;
 
     protected StoreConfigBuilder(InstanceSerializer<V> serializer) {
@@ -113,6 +120,11 @@ public class PersistentStoreConfig<V> {
       return this;
     }
 
+    public StoreConfigBuilder<V> setInMemory() {
+      this.inMemory = true;
+      return this;
+    }
+
     public StoreConfigBuilder<V> setMaxCapacity(int maxCapacity) {
       this.maxCapacity = maxCapacity;
       return this;
@@ -120,7 +132,7 @@ public class PersistentStoreConfig<V> {
 
     public PersistentStoreConfig<V> build(){
       Preconditions.checkNotNull(name);
-      return new PersistentStoreConfig<>(name, serializer, mode, maxCapacity);
+      return new PersistentStoreConfig<>(name, serializer, mode, inMemory, maxCapacity);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/InMemoryPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/InMemoryPersistentStore.java
@@ -27,6 +27,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.drill.common.concurrent.AutoCloseableLock;
 import org.apache.drill.exec.exception.VersionMismatchException;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
+import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreMode;
 
 import com.google.common.collect.Iterables;
@@ -42,8 +43,8 @@ public class InMemoryPersistentStore<V> extends BasePersistentStore<V> {
   private final int maxCapacity;
   private final AtomicInteger currentSize = new AtomicInteger();
 
-  public InMemoryPersistentStore(int maximumCapacity) {
-    this.maxCapacity = maximumCapacity;
+  public InMemoryPersistentStore(PersistentStoreConfig<V> config) {
+    this.maxCapacity = config.getMaxCapacity();
     //Allows us to trim out the oldest elements to maintain finite max size
     this.store = new ConcurrentSkipListMap<String, V>();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/InMemoryPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/InMemoryPersistentStore.java
@@ -15,28 +15,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.testing.store;
+package org.apache.drill.exec.store.sys.store;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import org.apache.drill.common.concurrent.AutoCloseableLock;
 import org.apache.drill.exec.exception.VersionMismatchException;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreMode;
-import org.apache.drill.exec.store.sys.store.DataChangeVersion;
 
-public class NoWriteLocalStore<V> extends BasePersistentStore<V> {
+import com.google.common.collect.Iterables;
+
+public class InMemoryPersistentStore<V> extends BasePersistentStore<V> {
+  // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InMemoryPersistentStore.class);
+
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private final AutoCloseableLock readLock = new AutoCloseableLock(readWriteLock.readLock());
   private final AutoCloseableLock writeLock = new AutoCloseableLock(readWriteLock.writeLock());
-  private final ConcurrentMap<String, V> store = Maps.newConcurrentMap();
+  private final ConcurrentSkipListMap<String, V> store;
   private int version = -1;
+  private final int maxCapacity;
+  private final AtomicInteger currentSize = new AtomicInteger();
+
+  public InMemoryPersistentStore(int maximumCapacity) {
+    this.maxCapacity = maximumCapacity;
+    //Allows us to trim out the oldest elements to maintain finite max size
+    this.store = new ConcurrentSkipListMap<String, V>();
+  }
 
   @Override
   public void delete(final String key) {
@@ -48,7 +58,7 @@ public class NoWriteLocalStore<V> extends BasePersistentStore<V> {
 
   @Override
   public PersistentStoreMode getMode() {
-    return PersistentStoreMode.PERSISTENT;
+    return PersistentStoreMode.BLOB_PERSISTENT;
   }
 
   @Override
@@ -93,6 +103,12 @@ public class NoWriteLocalStore<V> extends BasePersistentStore<V> {
         throw new VersionMismatchException("Version mismatch detected", dataChangeVersion.getVersion());
       }
       store.put(key, value);
+      if (currentSize.incrementAndGet() > maxCapacity) {
+        //Pop Out Oldest
+        store.pollLastEntry();
+        currentSize.decrementAndGet();
+      }
+
       version++;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -68,6 +68,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
 
   public LocalPersistentStore(DrillFileSystem fs, Path base, PersistentStoreConfig<V> config) {
     super();
+    logger.info("Config:{} \t FS:{}", config.getName(), fs.getName());
     this.basePath = new Path(base, config.getName());
     this.config = config;
     this.fs = fs;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -27,20 +27,20 @@ import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
 import org.apache.drill.exec.store.sys.store.LocalPersistentStore;
-import org.apache.drill.exec.testing.store.NoWriteLocalStore;
+import org.apache.drill.exec.store.sys.store.InMemoryPersistentStore;
 import org.apache.hadoop.fs.Path;
 
 /**
  * A really simple provider that stores data in the local file system, one value per file.
  */
 public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
-//  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStoreProvider.class);
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LocalPersistentStoreProvider.class);
 
   private final Path path;
   private final DrillFileSystem fs;
   // This flag is used in testing. Ideally, tests should use a specific PersistentStoreProvider that knows
   // how to handle this flag.
-  private final boolean enableWrite;
+  private final boolean writeInMemory;
 
   public LocalPersistentStoreProvider(final PersistentStoreRegistry<?> registry) throws StoreException {
     this(registry.getConfig());
@@ -48,7 +48,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
 
   public LocalPersistentStoreProvider(final DrillConfig config) throws StoreException {
     this.path = new Path(config.getString(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH));
-    this.enableWrite = config.getBoolean(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE);
+    this.writeInMemory = config.getBoolean(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE);
     try {
       this.fs = LocalPersistentStore.getFileSystem(config, path);
     } catch (IOException e) {
@@ -57,14 +57,15 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
   }
 
   @Override
-  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> storeConfig) {
+  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> storeConfig) throws StoreException {
     switch(storeConfig.getMode()){
     case BLOB_PERSISTENT:
     case PERSISTENT:
-      if (enableWrite) {
+      if (!writeInMemory) {
         return new LocalPersistentStore<>(fs, path, storeConfig);
       }
-      return new NoWriteLocalStore<>();
+      int maxInMemoryCapacity = storeConfig.getMaxCapacity();
+      return new InMemoryPersistentStore<V>(maxInMemoryCapacity);
     default:
       throw new IllegalStateException();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
+import org.apache.drill.exec.store.sys.store.InMemoryPersistentStore;
 import org.apache.drill.exec.store.sys.store.LocalPersistentStore;
 import org.apache.drill.exec.store.sys.store.ZookeeperPersistentStore;
 import org.apache.hadoop.fs.Path;
@@ -65,7 +66,12 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
   public <V> PersistentStore<V> getOrCreateStore(final PersistentStoreConfig<V> config) throws StoreException {
     switch(config.getMode()){
     case BLOB_PERSISTENT:
-      return new LocalPersistentStore<>(fs, blobRoot, config);
+      //Check for InMemory requirement
+      if (config.isInMemory()) {
+        return new InMemoryPersistentStore<>(config);
+      } else {
+        return new LocalPersistentStore<>(fs, blobRoot, config);
+      }
     case PERSISTENT:
       final ZookeeperPersistentStore<V> store = new ZookeeperPersistentStore<>(curator, config);
       try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/ZookeeperPersistentStoreProvider.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.coord.zk.ZKClusterCoordinator;
 import org.apache.drill.exec.exception.StoreException;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
@@ -35,8 +36,6 @@ import org.apache.hadoop.fs.Path;
 public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvider {
 //  private static final Logger logger = LoggerFactory.getLogger(ZookeeperPersistentStoreProvider.class);
 
-  public static final String DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT = "drill.exec.sys.store.provider.zk.blobroot";
-
   private final CuratorFramework curator;
   private final DrillFileSystem fs;
   private final Path blobRoot;
@@ -49,8 +48,8 @@ public class ZookeeperPersistentStoreProvider extends BasePersistentStoreProvide
   public ZookeeperPersistentStoreProvider(final DrillConfig config, final CuratorFramework curator) throws StoreException {
     this.curator = curator;
 
-    if (config.hasPath(DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT)) {
-      blobRoot = new Path(config.getString(DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT));
+    if (config.hasPath(ExecConstants.SYS_STORE_PROVIDER_ZK_BLOBROOT)) {
+      blobRoot = new Path(config.getString(ExecConstants.SYS_STORE_PROVIDER_ZK_BLOBROOT));
     }else{
       blobRoot = LocalPersistentStore.getLogDir();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -172,8 +172,7 @@ public class Foreman implements Runnable {
     closeFuture.addListener(closeListener);
 
     queryContext = new QueryContext(connection.getSession(), drillbitContext, queryId);
-    queryManager = new QueryManager(queryId, queryRequest, drillbitContext.getStoreProvider(),
-        drillbitContext.getClusterCoordinator(), this);
+    queryManager = new QueryManager(queryId, queryRequest, this);
 
     final OptionManager optionManager = queryContext.getOptions();
     queuingEnabled = optionManager.getOption(ExecConstants.ENABLE_QUEUE);

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -134,11 +134,16 @@ drill.exec: {
   work: {
     affinity.factor: 1.2
   },
-  sys.store.provider: {
-    class: "org.apache.drill.exec.store.sys.store.provider.ZookeeperPersistentStoreProvider",
-    local: {
-      path: "/tmp/drill",
-      write: true
+  sys.store {
+    capacity.profiles: 1000,
+    provider: {
+      class: "org.apache.drill.exec.store.sys.store.provider.ZookeeperPersistentStoreProvider",
+      local: {
+        path: "/tmp/drill",
+        inmemory: {
+          write: false
+        }
+      }
     }
   },
   impersonation: {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -135,14 +135,14 @@ drill.exec: {
     affinity.factor: 1.2
   },
   sys.store {
-    capacity.profiles: 1000,
+    profiles {
+      inmemory: false,
+      capacity: 1000
+    }
     provider: {
       class: "org.apache.drill.exec.store.sys.store.provider.ZookeeperPersistentStoreProvider",
       local: {
-        path: "/tmp/drill",
-        inmemory: {
-          write: false
-        }
+        path: "/tmp/drill"
       }
     }
   },

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -82,7 +82,7 @@ public class BaseTestQuery extends ExecTest {
   @SuppressWarnings("serial")
   private static final Properties TEST_CONFIGURATIONS = new Properties() {
     {
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
+      put(ExecConstants.SYS_STORE_PROFILES_INMEMORY, "true");
       put(ExecConstants.HTTP_ENABLE, "false");
     }
   };

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -82,7 +82,7 @@ public class BaseTestQuery extends ExecTest {
   @SuppressWarnings("serial")
   private static final Properties TEST_CONFIGURATIONS = new Properties() {
     {
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
       put(ExecConstants.HTTP_ENABLE, "false");
     }
   };

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
@@ -51,7 +51,7 @@ public abstract class PopUnitTestBase  extends ExecTest{
     // Properties here mimic those in drill-root/pom.xml, Surefire plugin
     // configuration. They allow tests to run successfully in Eclipse.
 
-    props.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+    props.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
     props.put(ExecConstants.HTTP_ENABLE, "false");
     props.put(Drillbit.SYSTEM_OPTIONS_NAME, "org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on");
     props.put(QueryTestUtil.TEST_QUERY_PRINTING_SILENT, "true");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/PopUnitTestBase.java
@@ -51,7 +51,7 @@ public abstract class PopUnitTestBase  extends ExecTest{
     // Properties here mimic those in drill-root/pom.xml, Surefire plugin
     // configuration. They allow tests to run successfully in Eclipse.
 
-    props.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
+    props.put(ExecConstants.SYS_STORE_PROFILES_INMEMORY, "true");
     props.put(ExecConstants.HTTP_ENABLE, "false");
     props.put(Drillbit.SYSTEM_OPTIONS_NAME, "org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on");
     props.put(QueryTestUtil.TEST_QUERY_PRINTING_SILENT, "true");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
@@ -74,7 +74,7 @@ public class TestResourceLeak extends DrillTest {
   @SuppressWarnings("serial")
   private static final Properties TEST_CONFIGURATIONS = new Properties() {
     {
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
+      put(ExecConstants.SYS_STORE_PROFILES_INMEMORY, "true");
       put(ExecConstants.HTTP_ENABLE, "false");
     }
   };

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestResourceLeak.java
@@ -74,7 +74,7 @@ public class TestResourceLeak extends DrillTest {
   @SuppressWarnings("serial")
   private static final Properties TEST_CONFIGURATIONS = new Properties() {
     {
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
       put(ExecConstants.HTTP_ENABLE, "false");
     }
   };

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -79,7 +79,7 @@ public class ClusterFixture implements AutoCloseable {
       // Properties here mimic those in drill-root/pom.xml, Surefire plugin
       // configuration. They allow tests to run successfully in Eclipse.
 
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, false);
+      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, true);
 
       // The CTTAS function requires that the default temporary workspace be
       // writable. By default, the default temporary workspace points to
@@ -117,7 +117,7 @@ public class ClusterFixture implements AutoCloseable {
       // storage. Profiles will go here when running in distributed
       // mode.
 
-      put(ZookeeperPersistentStoreProvider.DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT, "/tmp/drill/log");
+      put(ExecConstants.SYS_STORE_PROVIDER_ZK_BLOBROOT, "/tmp/drill/log");
     }
   };
 
@@ -760,7 +760,7 @@ public class ClusterFixture implements AutoCloseable {
   public File getProfileDir() {
     File baseDir;
     if (usesZk) {
-      baseDir = new File(config.getString(ZookeeperPersistentStoreProvider.DRILL_EXEC_SYS_STORE_PROVIDER_ZK_BLOBROOT));
+      baseDir = new File(config.getString(ExecConstants.SYS_STORE_PROVIDER_ZK_BLOBROOT));
     } else {
       baseDir = getDrillTempDir();
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -79,7 +79,7 @@ public class ClusterFixture implements AutoCloseable {
       // Properties here mimic those in drill-root/pom.xml, Surefire plugin
       // configuration. They allow tests to run successfully in Eclipse.
 
-      put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, true);
+      put(ExecConstants.SYS_STORE_PROFILES_INMEMORY, true);
 
       // The CTTAS function requires that the default temporary workspace be
       // writable. By default, the default temporary workspace points to

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
@@ -205,7 +205,7 @@ public class ExampleTest {
   public void fifthTest() throws Exception {
     FixtureBuilder builder = ClusterFixture.builder()
         .maxParallelization(1)
-        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, false)
         ;
 
     try (ClusterFixture cluster = builder.build();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
@@ -205,7 +205,7 @@ public class ExampleTest {
   public void fifthTest() throws Exception {
     FixtureBuilder builder = ClusterFixture.builder()
         .maxParallelization(1)
-        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, false)
+        .configProperty(ExecConstants.SYS_STORE_PROFILES_INMEMORY, false)
         ;
 
     try (ClusterFixture cluster = builder.build();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
@@ -291,7 +291,7 @@ public class FixtureBuilder {
    */
 
   public FixtureBuilder saveProfiles() {
-    configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, false);
+    configProperty(ExecConstants.SYS_STORE_PROFILES_INMEMORY, false);
     systemOption(ExecConstants.ENABLE_QUERY_PROFILE_OPTION, true);
     systemOption(ExecConstants.QUERY_PROFILE_DEBUG_OPTION, true);
     return this;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
@@ -291,7 +291,7 @@ public class FixtureBuilder {
    */
 
   public FixtureBuilder saveProfiles() {
-    configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true);
+    configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, false);
     systemOption(ExecConstants.ENABLE_QUERY_PROFILE_OPTION, true);
     systemOption(ExecConstants.QUERY_PROFILE_DEBUG_OPTION, true);
     return this;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/package-info.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/package-info.java
@@ -53,7 +53,7 @@
     // Configure the cluster. One Drillbit by default.
     FixtureBuilder builder = ClusterFixture.builder()
         // Set up per-test specialized config and session options.
-        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, true)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_EPHEMERAL_WRITE, false)
         .configProperty(ExecConstants.REMOVER_ENABLE_GENERIC_COPIER, true)
         .sessionOption(ExecConstants.MAX_QUERY_MEMORY_PER_NODE_KEY, 3L * 1024 * 1024 * 1024)
         .maxParallelization(1)

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
@@ -70,7 +70,7 @@ public class JdbcAssert {
     // Must set this to false to ensure that the tests ignore any existing
     // plugin configurations stored in /tmp/drill.
 
-    properties.setProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, "false");
+    properties.setProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
     properties.setProperty(ExecConstants.HTTP_ENABLE, "false");
     return properties;
   }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcAssert.java
@@ -70,7 +70,7 @@ public class JdbcAssert {
     // Must set this to false to ensure that the tests ignore any existing
     // plugin configurations stored in /tmp/drill.
 
-    properties.setProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_INMEMORY_WRITE, "true");
+    properties.setProperty(ExecConstants.SYS_STORE_PROFILES_INMEMORY, "true");
     properties.setProperty(ExecConstants.HTTP_ENABLE, "false");
     return properties;
   }


### PR DESCRIPTION
Refactored NoWriteLocalStore to  InMemoryPersistentStore with the ability to maintain a max capacity
Updated Default values, and added Zookeeper's property to ExecConstants