### PR TITLE
DRILL-5399: Fix race condition in DrillComplexWriterFuncHolder

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFuncHolder.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFuncHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.drill.exec.expr.fn;
 import java.util.List;
 
 import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.types.TypeProtos;
@@ -142,17 +143,11 @@ public class HiveFuncHolder extends AbstractFuncHolder {
     return workspaceJVars;
   }
 
-  /**
-   * Complete code generation
-   * @param g
-   * @param inputVariables
-   * @param workspaceJVars
-   * @return HoldingContainer for return value
-   */
   @Override
-  public HoldingContainer renderEnd(ClassGenerator<?> g, HoldingContainer[] inputVariables, JVar[]  workspaceJVars) {
-    generateSetup(g, workspaceJVars);
-    return generateEval(g, inputVariables, workspaceJVars);
+  public HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
+                                    JVar[] workspaceJVars, FieldReference fieldReference) {
+    generateSetup(classGenerator, workspaceJVars);
+    return generateEval(classGenerator, inputVariables, workspaceJVars);
   }
 
   private JInvocation getUDFInstance(JCodeModel m) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/DrillFuncHolderExpr.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/DrillFuncHolderExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,9 +23,7 @@ import java.util.List;
 import org.apache.drill.common.expression.ExpressionPosition;
 import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.expression.LogicalExpression;
-import org.apache.drill.common.expression.fn.FuncHolder;
 import org.apache.drill.common.types.TypeProtos.MajorType;
-import org.apache.drill.exec.expr.fn.DrillComplexWriterFuncHolder;
 import org.apache.drill.exec.expr.fn.DrillFuncHolder;
 
 public class DrillFuncHolderExpr extends FunctionHolderExpression implements Iterable<LogicalExpression>{
@@ -49,7 +47,7 @@ public class DrillFuncHolderExpr extends FunctionHolderExpression implements Ite
   }
 
   @Override
-  public FuncHolder getHolder() {
+  public DrillFuncHolder getHolder() {
     return holder;
   }
 
@@ -66,10 +64,6 @@ public class DrillFuncHolderExpr extends FunctionHolderExpression implements Ite
   @Override
   public boolean argConstantOnly(int i) {
     return holder.isConstant(i);
-  }
-
-  public boolean isComplexWriterFuncHolder() {
-    return holder instanceof DrillComplexWriterFuncHolder;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -202,7 +202,7 @@ public class EvaluationVisitor {
         generator.getMappingSet().exitChild();
       }
 
-      return holder.renderEnd(generator, args, workspaceVars);
+      return holder.renderEnd(generator, args, workspaceVars, holderExpr.getFieldReference());
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/AbstractFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/AbstractFuncHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.drill.exec.expr.fn;
 import java.util.List;
 
 import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.fn.FuncHolder;
@@ -37,7 +38,17 @@ public abstract class AbstractFuncHolder implements FuncHolder {
     // default implementation is add no code
   }
 
-  public abstract HoldingContainer renderEnd(ClassGenerator<?> g, HoldingContainer[] inputVariables, JVar[] workspaceJVars);
+  /**
+   * Generate methods body and complete the code generation.
+   *
+   * @param classGenerator the class responsible for code generation
+   * @param inputVariables the source of the vector holders
+   * @param workspaceJVars class fields
+   * @param fieldReference reference of the output field
+   * @return HoldingContainer for return value
+   */
+  public abstract HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
+                                             JVar[] workspaceJVars, FieldReference fieldReference);
 
   public boolean isNested() {
     return false;
@@ -48,4 +59,14 @@ public abstract class AbstractFuncHolder implements FuncHolder {
   public abstract MajorType getParmMajorType(int i);
 
   public abstract int getParamCount();
+
+  /**
+   * Checks that the current function holder stores output value
+   * using field writer instead of vector holder.
+   *
+   * @return true if current function holder uses field writer to store the output value
+   */
+  public boolean isComplexWriterFuncHolder() {
+    return false;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
@@ -34,56 +34,52 @@ import com.sun.codemodel.JVar;
 
 public class DrillComplexWriterFuncHolder extends DrillSimpleFuncHolder {
 
-  private FieldReference ref;
-
   public DrillComplexWriterFuncHolder(FunctionAttributes functionAttributes, FunctionInitializer initializer) {
     super(functionAttributes, initializer);
   }
 
-  public void setReference(FieldReference ref) {
-    this.ref = ref;
-  }
-
-  public FieldReference getReference() {
-    return ref;
+  @Override
+  public boolean isComplexWriterFuncHolder() {
+    return true;
   }
 
   @Override
-  protected HoldingContainer generateEvalBody(ClassGenerator<?> g, HoldingContainer[] inputVariables, String body, JVar[] workspaceJVars) {
+  protected HoldingContainer generateEvalBody(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables, String body,
+                                              JVar[] workspaceJVars, FieldReference fieldReference) {
 
-    g.getEvalBlock().directStatement(String.format("//---- start of eval portion of %s function. ----//", getRegisteredNames()[0]));
+    classGenerator.getEvalBlock().directStatement(String.format("//---- start of eval portion of %s function. ----//", getRegisteredNames()[0]));
 
     JBlock sub = new JBlock(true, true);
     JBlock topSub = sub;
 
-    JVar complexWriter = g.declareClassField("complexWriter", g.getModel()._ref(ComplexWriter.class));
+    JVar complexWriter = classGenerator.declareClassField("complexWriter", classGenerator.getModel()._ref(ComplexWriter.class));
 
 
-    JInvocation container = g.getMappingSet().getOutgoing().invoke("getOutgoingContainer");
+    JInvocation container = classGenerator.getMappingSet().getOutgoing().invoke("getOutgoingContainer");
 
     //Default name is "col", if not passed in a reference name for the output vector.
-    String refName = ref == null? "col" : ref.getRootSegment().getPath();
+    String refName = fieldReference == null ? "col" : fieldReference.getRootSegment().getPath();
 
-    JClass cwClass = g.getModel().ref(VectorAccessibleComplexWriter.class);
-    g.getSetupBlock().assign(complexWriter, cwClass.staticInvoke("getWriter").arg(refName).arg(container));
+    JClass cwClass = classGenerator.getModel().ref(VectorAccessibleComplexWriter.class);
+    classGenerator.getSetupBlock().assign(complexWriter, cwClass.staticInvoke("getWriter").arg(refName).arg(container));
 
-    JClass projBatchClass = g.getModel().ref(ProjectRecordBatch.class);
-    JExpression projBatch = JExpr.cast(projBatchClass, g.getMappingSet().getOutgoing());
+    JClass projBatchClass = classGenerator.getModel().ref(ProjectRecordBatch.class);
+    JExpression projBatch = JExpr.cast(projBatchClass, classGenerator.getMappingSet().getOutgoing());
 
-    g.getSetupBlock().add(projBatch.invoke("addComplexWriter").arg(complexWriter));
+    classGenerator.getSetupBlock().add(projBatch.invoke("addComplexWriter").arg(complexWriter));
 
 
-    g.getEvalBlock().add(complexWriter.invoke("setPosition").arg(g.getMappingSet().getValueWriteIndex()));
+    classGenerator.getEvalBlock().add(complexWriter.invoke("setPosition").arg(classGenerator.getMappingSet().getValueWriteIndex()));
 
-    sub.decl(g.getModel()._ref(ComplexWriter.class), getReturnValue().getName(), complexWriter);
+    sub.decl(classGenerator.getModel()._ref(ComplexWriter.class), getReturnValue().getName(), complexWriter);
 
     // add the subblock after the out declaration.
-    g.getEvalBlock().add(topSub);
+    classGenerator.getEvalBlock().add(topSub);
 
-    addProtectedBlock(g, sub, body, inputVariables, workspaceJVars, false);
+    addProtectedBlock(classGenerator, sub, body, inputVariables, workspaceJVars, false);
 
 
-//    JConditional jc = g.getEvalBlock()._if(complexWriter.invoke("ok").not());
+//    JConditional jc = classGenerator.getEvalBlock()._if(complexWriter.invoke("ok").not());
 
 //    jc._then().add(complexWriter.invoke("reset"));
     //jc._then().directStatement("System.out.println(\"debug : write ok fail!, inIndex = \" + inIndex);");
@@ -91,9 +87,8 @@ public class DrillComplexWriterFuncHolder extends DrillSimpleFuncHolder {
 
     //jc._else().directStatement("System.out.println(\"debug : write successful, inIndex = \" + inIndex);");
 
-    g.getEvalBlock().directStatement(String.format("//---- end of eval portion of %s function. ----//", getRegisteredNames()[0]));
+    classGenerator.getEvalBlock().directStatement(String.format("//---- end of eval portion of %s function. ----//", getRegisteredNames()[0]));
 
     return null;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillFuncHolder.java
@@ -85,17 +85,6 @@ public abstract class DrillFuncHolder extends AbstractFuncHolder {
   }
 
   @Override
-  public void renderMiddle(ClassGenerator<?> g, HoldingContainer[] inputVariables, JVar[] workspaceJVars) {
-  }
-
-  @Override
-  public abstract HoldingContainer renderEnd(ClassGenerator<?> g, HoldingContainer[] inputVariables,
-      JVar[] workspaceJVars);
-
-  @Override
-  public abstract boolean isNested();
-
-  @Override
   public FunctionHolderExpression getExpr(String name, List<LogicalExpression> args, ExpressionPosition pos) {
     return new DrillFuncHolderExpr(name, this, args, pos);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
@@ -38,7 +38,6 @@ import org.apache.drill.exec.expr.ExpressionTreeMaterializer;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.expr.ValueVectorReadExpression;
 import org.apache.drill.exec.expr.ValueVectorWriteExpression;
-import org.apache.drill.exec.expr.fn.DrillComplexWriterFuncHolder;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.FlattenPOP;
 import org.apache.drill.exec.record.AbstractSingleRecordBatch;
@@ -353,7 +352,7 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
         throw new SchemaChangeException(String.format("Failure while trying to materialize incoming schema.  Errors:\n %s.", collector.toErrorString()));
       }
       if (expr instanceof DrillFuncHolderExpr &&
-          ((DrillFuncHolderExpr) expr).isComplexWriterFuncHolder())  {
+          ((DrillFuncHolderExpr) expr).getHolder().isComplexWriterFuncHolder()) {
         // Need to process ComplexWriter function evaluation.
         // Lazy initialization of the list of complex writers, if not done yet.
         if (complexWriters == null) {
@@ -361,7 +360,7 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
         }
 
         // The reference name will be passed to ComplexWriter, used as the name of the output vector from the writer.
-        ((DrillComplexWriterFuncHolder) ((DrillFuncHolderExpr) expr).getHolder()).setReference(namedExpression.getRef());
+        ((DrillFuncHolderExpr) expr).getFieldReference(namedExpression.getRef());
         cg.addExpr(expr);
       } else {
         // need to do evaluation.

--- a/logical/src/main/java/org/apache/drill/common/expression/FunctionHolderExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FunctionHolderExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,6 +28,12 @@ import com.google.common.collect.Lists;
 public abstract class FunctionHolderExpression extends LogicalExpressionBase {
   public final ImmutableList<LogicalExpression> args;
   public final String nameUsed;
+
+  /**
+   * A field reference identifies the output field and
+   * is used to reference that field in the generated classes.
+   */
+  private FieldReference fieldReference;
 
   public FunctionHolderExpression(String nameUsed, ExpressionPosition pos, List<LogicalExpression> args) {
     super(pos);
@@ -80,4 +86,16 @@ public abstract class FunctionHolderExpression extends LogicalExpressionBase {
   /** Return the underlying function implementation holder. */
   public abstract FuncHolder getHolder();
 
+  public FieldReference getFieldReference() {
+    return fieldReference;
+  }
+
+  /**
+   * Set the FieldReference to be used during generating code.
+   *
+   * @param fieldReference FieldReference to set.
+   */
+  public void getFieldReference(FieldReference fieldReference) {
+    this.fieldReference = fieldReference;
+  }
 }


### PR DESCRIPTION
Move the `FieldReference ref` field from the `DrillComplexWriterFuncHolder` to the `FunctionHolderExpression` class to avoid race condition. 