### PR TITLE
DRILL-3250: Drill fails to compare multi-byte characters from hive table

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/DrillHiveTable.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/schema/DrillHiveTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,8 +17,7 @@
  */
 package org.apache.drill.exec.store.hive.schema;
 
-import java.nio.charset.Charset;
-import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
+import org.apache.calcite.util.Util;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -118,7 +117,7 @@ public class DrillHiveTable extends DrillTable{
         int maxLen = TypeInfoUtils.getCharacterLengthForType(pTypeInfo);
         return typeFactory.createTypeWithCharsetAndCollation(
           typeFactory.createSqlType(SqlTypeName.VARCHAR, maxLen), /*input type*/
-          Charset.forName(DrillParserUtil.CHARSET),
+          Util.getDefaultCharset(),
           SqlCollation.IMPLICIT /* TODO: need to decide if implicit is the correct one */
         );
       }
@@ -126,9 +125,9 @@ public class DrillHiveTable extends DrillTable{
       case CHAR: {
         int maxLen = TypeInfoUtils.getCharacterLengthForType(pTypeInfo);
         return typeFactory.createTypeWithCharsetAndCollation(
-            typeFactory.createSqlType(SqlTypeName.CHAR, maxLen), /*input type*/
-            Charset.forName(DrillParserUtil.CHARSET),
-            SqlCollation.IMPLICIT
+          typeFactory.createSqlType(SqlTypeName.CHAR, maxLen), /*input type*/
+          Util.getDefaultCharset(),
+          SqlCollation.IMPLICIT
         );
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DescribeTableHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,7 +18,6 @@
 
 package org.apache.drill.exec.planner.sql.handlers;
 
-import static org.apache.drill.exec.planner.sql.parser.DrillParserUtil.CHARSET;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_COLUMN_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_DATA_TYPE;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.COLS_COL_IS_NULLABLE;
@@ -70,6 +69,7 @@ public class DescribeTableHandler extends DefaultSqlHandler {
       final SchemaPlus defaultSchema = config.getConverter().getDefaultSchema();
       final List<String> schemaPathGivenInCmd = Util.skipLast(table.names);
       final SchemaPlus schema = SchemaUtilites.findSchema(defaultSchema, schemaPathGivenInCmd);
+      final String charset = Util.getDefaultCharset().name();
 
       if (schema == null) {
         SchemaUtilites.throwSchemaNotFoundException(defaultSchema,
@@ -98,14 +98,14 @@ public class DescribeTableHandler extends DefaultSqlHandler {
         schemaCondition = DrillParserUtil.createCondition(
             new SqlIdentifier(SHRD_COL_TABLE_SCHEMA, SqlParserPos.ZERO),
             SqlStdOperatorTable.EQUALS,
-            SqlLiteral.createCharString(schemaPath, CHARSET, SqlParserPos.ZERO)
+            SqlLiteral.createCharString(schemaPath, charset, SqlParserPos.ZERO)
         );
       }
 
       SqlNode where = DrillParserUtil.createCondition(
           new SqlIdentifier(SHRD_COL_TABLE_NAME, SqlParserPos.ZERO),
           SqlStdOperatorTable.EQUALS,
-          SqlLiteral.createCharString(tableName, CHARSET, SqlParserPos.ZERO));
+          SqlLiteral.createCharString(tableName, charset, SqlParserPos.ZERO));
 
       where = DrillParserUtil.createCondition(schemaCondition, SqlStdOperatorTable.AND, where);
 
@@ -115,7 +115,7 @@ public class DescribeTableHandler extends DefaultSqlHandler {
             DrillParserUtil.createCondition(
                 new SqlIdentifier(COLS_COL_COLUMN_NAME, SqlParserPos.ZERO),
                 SqlStdOperatorTable.EQUALS,
-                SqlLiteral.createCharString(node.getColumn().toString(), CHARSET, SqlParserPos.ZERO));
+                SqlLiteral.createCharString(node.getColumn().toString(), charset, SqlParserPos.ZERO));
       } else if (node.getColumnQualifier() != null) {
         columnFilter =
             DrillParserUtil.createCondition(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ShowTablesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,7 +18,6 @@
 
 package org.apache.drill.exec.planner.sql.handlers;
 
-import static org.apache.drill.exec.planner.sql.parser.DrillParserUtil.CHARSET;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.IS_SCHEMA_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_NAME;
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.SHRD_COL_TABLE_SCHEMA;
@@ -35,6 +34,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.RelConversionException;
+import org.apache.calcite.util.Util;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.parser.DrillParserUtil;
@@ -83,10 +83,11 @@ public class ShowTablesHandler extends DefaultSqlHandler {
       tableSchema = drillSchema.getFullSchemaName();
     }
 
+    final String charset = Util.getDefaultCharset().name();
     where = DrillParserUtil.createCondition(
         new SqlIdentifier(SHRD_COL_TABLE_SCHEMA, SqlParserPos.ZERO),
         SqlStdOperatorTable.EQUALS,
-        SqlLiteral.createCharString(tableSchema, CHARSET, SqlParserPos.ZERO));
+        SqlLiteral.createCharString(tableSchema, charset, SqlParserPos.ZERO));
 
     SqlNode filter = null;
     final SqlNode likePattern = node.getLikePattern();


### PR DESCRIPTION
 - A small refactoring of original fix of this issue (DRILL-4039);
 - Added test for the fix.