### PR TITLE
DRILL-5523: Revert if condition in UnionAllRecordBatch changed in DRI…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -204,7 +204,17 @@ public class UnionAllRecordBatch extends AbstractRecordBatch<UnionAll> {
         MajorType outputFieldType = outputFields.get(index).getType();
         MaterializedField outputField = MaterializedField.create(outputPath.getAsUnescapedPath(), outputFieldType);
 
-        if (outputFields.get(index).getPath().equals(inputPath.getAsUnescapedPath())) {
+        /*
+          todo: Fix if condition when DRILL-4824 is merged
+          If condition should be changed to:
+          `if (outputFields.get(index).getPath().equals(inputPath.getAsUnescapedPath())) {`
+          DRILL-5419 has changed condition to correct one but this caused regression (DRILL-5521).
+          Root cause is missing indication of child column in map types when it is null.
+          DRILL-4824 is re-working json reader implementation, including map types and will fix this problem.
+          Reverting condition to previous one to avoid regression till DRILL-4824 is merged.
+          Unit test - TestJsonReader.testKvgenWithUnionAll().
+         */
+        if (outputFields.get(index).getPath().equals(inputPath)) {
           ValueVector vvOut = container.addOrGet(outputField);
           TransferPair tp = vvIn.makeTransferPair(vvOut);
           transfers.add(tp);


### PR DESCRIPTION
…LL-5419

If condition in UnionAllRecordBatch which was changed to correct one in DRILL-5419 but this change caused the regression (DRILL-5521).
The root cause is not in change itself but rather in missing indication of child column in map types when it is null. There is a big project upcoming re-working json reader implementation, including map types (DRILL-4824) which will fix the problem.
So far reverting change to initial state so users won't see the regression till DRILL-4824 is merged.