### PR TITLE
DRILL-5533: Fix flag assignment in FunctionInitializer.checkInit() method

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ImportGrabber.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ImportGrabber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -29,16 +29,15 @@ import org.codehaus.janino.util.Traverser;
 import com.google.common.collect.Lists;
 
 
-public class ImportGrabber{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ImportGrabber.class);
+public class ImportGrabber {
 
-  private List<String> imports = Lists.newArrayList();
+  private final List<String> imports = Lists.newArrayList();
   private final ImportFinder finder = new ImportFinder();
 
   private ImportGrabber() {
   }
 
-  public class ImportFinder extends Traverser{
+  public class ImportFinder extends Traverser {
 
     @Override
     public void traverseSingleTypeImportDeclaration(SingleTypeImportDeclaration stid) {
@@ -63,9 +62,21 @@ public class ImportGrabber{
 
   }
 
-  public static List<String> getMethods(Java.CompilationUnit cu){
-    ImportGrabber visitor = new ImportGrabber();
-    cu.getPackageMemberTypeDeclarations()[0].accept(visitor.finder.comprehensiveVisitor());
+  /**
+   * Creates list of imports that are present in compilation unit.
+   * For example:
+   * [import io.netty.buffer.DrillBuf;, import org.apache.drill.exec.expr.DrillSimpleFunc;]
+   *
+   * @param compilationUnit compilation unit
+   * @return list of imports
+   */
+  public static List<String> getImports(Java.CompilationUnit compilationUnit){
+    final ImportGrabber visitor = new ImportGrabber();
+
+    for (Java.CompilationUnit.ImportDeclaration importDeclaration : compilationUnit.importDeclarations) {
+      importDeclaration.accept(visitor.finder.comprehensiveVisitor());
+    }
+
     return visitor.imports;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/FunctionInitializerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/FunctionInitializerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn;
+
+import com.google.common.collect.Lists;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+import org.apache.drill.common.util.TestTools;
+import org.apache.drill.exec.util.JarUtil;
+import org.codehaus.janino.Java;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(JMockit.class)
+public class FunctionInitializerTest {
+
+  private static final String CLASS_NAME = "com.drill.udf.CustomLowerFunction";
+  private static URLClassLoader classLoader;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    File jars = new File(TestTools.getWorkingPath(), "/src/test/resources/jars");
+    String binaryName = "DrillUDF-1.0.jar";
+    String sourceName = JarUtil.getSourceName(binaryName);
+    URL[] urls = {new File(jars, binaryName).toURI().toURL(), new File(jars, sourceName).toURI().toURL()};
+    classLoader = new URLClassLoader(urls);
+  }
+
+  @Test
+  public void testGetImports() {
+    FunctionInitializer functionInitializer = new FunctionInitializer(CLASS_NAME, classLoader);
+    List<String> actualImports = functionInitializer.getImports();
+
+    List<String> expectedImports = Lists.newArrayList(
+        "import io.netty.buffer.DrillBuf;",
+        "import org.apache.drill.exec.expr.DrillSimpleFunc;",
+        "import org.apache.drill.exec.expr.annotations.FunctionTemplate;",
+        "import org.apache.drill.exec.expr.annotations.Output;",
+        "import org.apache.drill.exec.expr.annotations.Param;",
+        "import org.apache.drill.exec.expr.holders.VarCharHolder;",
+        "import javax.inject.Inject;"
+    );
+
+    assertEquals("List of imports should match", expectedImports, actualImports);
+  }
+
+  @Test
+  public void testGetMethod() {
+    FunctionInitializer functionInitializer = new FunctionInitializer(CLASS_NAME, classLoader);
+    String actualMethod = functionInitializer.getMethod("eval");
+    assertTrue("Method body should match", actualMethod.contains("CustomLowerFunction_eval:"));
+  }
+
+  @Test
+  public void testConcurrentFunctionBodyLoad() throws Exception {
+    final FunctionInitializer functionInitializer = new FunctionInitializer(CLASS_NAME, classLoader);
+
+    final AtomicInteger counter = new AtomicInteger();
+    new MockUp<FunctionInitializer>() {
+      @Mock
+      Java.CompilationUnit convertToCompilationUnit(Invocation inv, Class<?> clazz) {
+        counter.incrementAndGet();
+        return inv.proceed();
+      }
+    };
+
+    int threadsNumber = 5;
+    ExecutorService executor = Executors.newFixedThreadPool(threadsNumber);
+
+    try {
+      List<Future<String>> results = executor.invokeAll(Collections.nCopies(threadsNumber, new Callable<String>() {
+        @Override
+        public String call() throws Exception {
+          return functionInitializer.getMethod("eval");
+        }
+      }));
+
+      final Set<String> uniqueResults = new HashSet<>();
+      for (Future<String> result : results) {
+        uniqueResults.add(result.get());
+      }
+
+      assertEquals("All threads should have received the same result", 1, uniqueResults.size());
+      assertEquals("Number of function body loads should match", 1, counter.intValue());
+
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
Changes:
1. Fixed DCL in FunctionInitializer.checkInit() method (update flag parameter when function body is loaded).
2. Fixed ImportGrabber.getImports() method to return the list with imports.
3. Added unit tests for FunctionInitializer.
4. Minor refactoring (renamed methods, added javadoc).