### PR TITLE
DRILL-5518: Test framework enhancements

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AbstractOperatorExecContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AbstractOperatorExecContext.java
@@ -36,15 +36,16 @@ public class AbstractOperatorExecContext implements OperatorExecContext {
   protected final ExecutionControls executionControls;
   protected final PhysicalOperator popConfig;
   protected final BufferManager manager;
-  protected final OperatorStatReceiver statsWriter;
+  protected OperatorStatReceiver statsWriter;
 
   public AbstractOperatorExecContext(BufferAllocator allocator, PhysicalOperator popConfig,
                                      ExecutionControls executionControls,
                                      OperatorStatReceiver stats) {
     this.allocator = allocator;
     this.popConfig = popConfig;
-    manager = new BufferManagerImpl(allocator);
+    this.manager = new BufferManagerImpl(allocator);
     statsWriter = stats;
+
     this.executionControls = executionControls;
   }
 
@@ -64,10 +65,9 @@ public class AbstractOperatorExecContext implements OperatorExecContext {
   }
 
   @Override
-  public ExecutionControls getExecutionControls() { return executionControls; }
-
-  @Override
-  public OperatorStatReceiver getStatsWriter() { return statsWriter; }
+  public ExecutionControls getExecutionControls() {
+    return executionControls;
+  }
 
   @Override
   public BufferAllocator getAllocator() {
@@ -86,5 +86,10 @@ public class AbstractOperatorExecContext implements OperatorExecContext {
         allocator.close();
       }
     }
+  }
+
+  @Override
+  public OperatorStatReceiver getStatsWriter() {
+    return statsWriter;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -41,7 +41,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class VectorContainer implements VectorAccessible {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorContainer.class);
 
   protected final List<VectorWrapper<?>> wrappers = Lists.newArrayList();
   private BatchSchema schema;
@@ -148,7 +147,6 @@ public class VectorContainer implements VectorAccessible {
         return (T) newVector;
       }
     } else {
-
       vector = TypeHelper.getNewVector(field, this.getAllocator(), callBack);
       add(vector);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
@@ -137,7 +137,7 @@ public class TestBatchSerialization extends DrillTest {
 
     assertTrue(origSize >= result.size());
     new RowSetComparison(expected)
-      .verifyAndClear(result);
+      .verifyAndClearAll(result);
     outFile.delete();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
@@ -123,7 +123,7 @@ public class SortTestUtilities {
         assertTrue(merger.next());
         RowSet rowSet = new DirectRowSet(fixture.allocator(), dest);
         new RowSetComparison(expectedSet)
-              .verifyAndClear(rowSet);
+              .verifyAndClearAll(rowSet);
       }
       assertFalse(merger.next());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSorter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSorter.java
@@ -85,7 +85,7 @@ public class TestSorter extends DrillTest {
     sorter.sortBatch(rowSet.container(), rowSet.getSv2());
 
     new RowSetComparison(expected)
-        .verifyAndClear(rowSet);
+        .verifyAndClearAll(rowSet);
     sorter.close();
   }
 
@@ -219,16 +219,12 @@ public class TestSorter extends DrillTest {
       DataItem expected[] = Arrays.copyOf(data, data.length);
       doSort(expected);
       RowSet expectedRows = makeDataSet(actual.allocator(), actual.schema().batch(), expected);
-//      System.out.println("Expected:");
-//      expectedRows.print();
-//      System.out.println("Actual:");
-//      actual.print();
       doVerify(expected, expectedRows, actual);
     }
 
     protected void doVerify(DataItem[] expected, RowSet expectedRows, RowSet actual) {
       new RowSetComparison(expectedRows)
-            .verifyAndClear(actual);
+            .verifyAndClearAll(actual);
     }
 
     protected abstract void doSort(DataItem[] expected);
@@ -300,7 +296,7 @@ public class TestSorter extends DrillTest {
             .offset(offset)
             .span(nullCount)
             .withMask(true, false)
-            .verifyAndClear(actual);
+            .verifyAndClearAll(actual);
     }
   }
 
@@ -370,7 +366,7 @@ public class TestSorter extends DrillTest {
         int mo = rand.nextInt(12);
         int yr = rand.nextInt(10);
         Period period = makePeriod(yr, mo, day, hr, min, sec, ms);
-         builder.add(period);
+        builder.add(period);
       }
       return builder.build();
     }
@@ -385,7 +381,6 @@ public class TestSorter extends DrillTest {
       long prevMs = 0;
       while (reader.next()) {
         Period period = reader.column(0).getPeriod().normalizedStandard();
-//        System.out.println(period);
         int years = period.getYears();
         assertTrue(prevYears <= years);
         if (prevYears != years) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestVectorContainer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestVectorContainer.java
@@ -108,7 +108,7 @@ public class TestVectorContainer extends DrillTest {
     // Merge containers via row set facade
 
     RowSet mergedRs = left.merge(right);
-    comparison.verifyAndClear(mergedRs);
+    comparison.verifyAndClearAll(mergedRs);
 
     // Add a selection vector. Merging is forbidden, in the present code,
     // for batches that have a selection vector.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
@@ -150,7 +150,7 @@ public class TestCsv extends ClusterTest {
         .add("10", "foo", "bar")
         .build();
     new RowSetComparison(expected)
-      .verifyAndClear(actual);
+      .verifyAndClearAll(actual);
   }
 
   private String makeStatement(String fileName) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
@@ -98,13 +98,11 @@ public class TestCsv extends ClusterTest {
         .add("b", MinorType.VARCHAR)
         .add("c", MinorType.VARCHAR)
         .build();
-    assertEquals(expectedSchema, actual.batchSchema());
-
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
         .add("10", "foo", "bar")
         .build();
     new RowSetComparison(expected)
-      .verifyAndClear(actual);
+      .verifyAndClearAll(actual);
   }
 
   String invalidHeaders[] = {
@@ -126,13 +124,11 @@ public class TestCsv extends ClusterTest {
         .add("c_2", MinorType.VARCHAR)
         .add("c_2_2", MinorType.VARCHAR)
         .build();
-    assertEquals(expectedSchema, actual.batchSchema());
-
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
         .add("10", "foo", "bar", "fourth", "fifth", "sixth")
         .build();
     new RowSetComparison(expected)
-      .verifyAndClear(actual);
+      .verifyAndClearAll(actual);
   }
 
   // Test fix for DRILL-5590

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -27,12 +27,14 @@ import org.apache.drill.TestBuilder;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.testing.Controls;
 import org.apache.drill.exec.testing.ControlsInjectionUtil;
 import org.apache.drill.test.ClusterFixture.FixtureTestServices;
 import org.apache.drill.test.QueryBuilder.QuerySummary;
+import org.apache.drill.test.rowSet.RowSetBuilder;
 
 /**
  * Represents a Drill client. Provides many useful test-specific operations such
@@ -224,5 +226,9 @@ public class ClientFixture implements AutoCloseable {
   public void setControls(String controls) {
     ControlsInjectionUtil.validateControlsString(controls);
     alterSession(ExecConstants.DRILLBIT_CONTROL_INJECTIONS, controls);
+  }
+
+  public RowSetBuilder rowSetBuilder(BatchSchema schema) {
+    return new RowSetBuilder(allocator(), schema);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
@@ -118,5 +118,4 @@ public class ClusterTest extends DrillTest {
   public QueryBuilder queryBuilder( ) {
     return client.queryBuilder();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -32,10 +32,12 @@ import org.apache.drill.exec.expr.ClassGenerator;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
+import org.apache.drill.exec.ops.AbstractOperatorExecContext;
 import org.apache.drill.exec.ops.FragmentExecContext;
 import org.apache.drill.exec.ops.MetricDef;
 import org.apache.drill.exec.ops.OperExecContext;
 import org.apache.drill.exec.ops.OperExecContextImpl;
+import org.apache.drill.exec.ops.OperatorExecContext;
 import org.apache.drill.exec.ops.OperatorStatReceiver;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.record.BatchSchema;
@@ -50,7 +52,6 @@ import org.apache.drill.test.rowSet.HyperRowSetImpl;
 import org.apache.drill.test.rowSet.IndirectRowSet;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.ExtendableRowSet;
-import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
 import org.apache.drill.test.rowSet.RowSetBuilder;
 
 /**
@@ -222,7 +223,7 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
   }
 
   /**
-   * Implements a write-only version of the stats collector for use by opeators,
+   * Implements a write-only version of the stats collector for use by operators,
    * then provides simplified test-time accessors to get the stats values when
    * validating code in tests.
    */
@@ -327,5 +328,9 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     default:
       throw new IllegalStateException( "Unexpected selection mode" );
     }
+  }
+
+  public OperatorExecContext operatorContext(PhysicalOperator config) {
+    return new AbstractOperatorExecContext(allocator(), config, context.getExecutionControls(), stats);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/SubOperatorTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/SubOperatorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class SubOperatorTest extends DrillTest {
+
+  protected static OperatorFixture fixture;
+
+  @BeforeClass
+  public static void classSetup() throws Exception {
+    fixture = OperatorFixture.standardFixture();
+  }
+
+  @AfterClass
+  public static void classTeardown() throws Exception {
+    fixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
@@ -56,11 +56,44 @@ public final class RowSetBuilder {
    * <tt>add(10, new int[] {100, 200});</tt><br>
    * @param values column values in column index order
    * @return this builder
+   * @see {@link #addSingleCol(Object)} to create a row of a single column when
+   * the value to <tt>add()</tt> is ambiguous
    */
 
   public RowSetBuilder add(Object...values) {
     writer.setRow(values);
     return this;
+  }
+
+  /**
+   * The {@link #add(Object...)} method uses Java variable-length arguments to
+   * pass a row of values. But, when the row consists of a single array, Java
+   * gets confused: is that an array for variable-arguments or is it the value
+   * of the first argument? This method clearly states that the single value
+   * (including an array) is meant to be the value of the first (and only)
+   * column.
+   * <p>
+   * Examples:<code><pre>
+   *     RowSetBuilder twoColsBuilder = ...
+   *     // Fine, second item is an array of strings for a repeated Varchar
+   *     // column.
+   *     twoColsBuilder.add("First", new String[] {"a", "b", "c"});
+   *     ...
+   *     RowSetBuilder oneColBuilder = ...
+   *     // Ambiguous: is this a varargs array of three items?
+   *     // That is how Java will perceive it.
+   *     oneColBuilder.add(new String[] {"a", "b", "c"});
+   *     // Unambiguous: this is a single column value for the
+   *     // repeated Varchar column.
+   *     oneColBuilder.addSingleCol(new String[] {"a", "b", "c"});
+   * </pre></code>
+   * @param value value of the first column, which may be an array for a
+   * repeated column
+   * @return this builder
+   */
+
+  public RowSetBuilder addSingleCol(Object value) {
+    return add(new Object[] { value });
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetComparison.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetComparison.java
@@ -138,11 +138,25 @@ public class RowSetComparison {
 
   /**
    * Convenience method to verify the actual results, then free memory
-   * for both the expected and actual result sets.
+   * for the actual result sets.
    * @param actual the actual results to verify
    */
 
   public void verifyAndClear(RowSet actual) {
+    try {
+      verify(actual);
+    } finally {
+      actual.clear();
+    }
+  }
+
+  /**
+   * Convenience method to verify the actual results, then free memory
+   * for both the expected and actual result sets.
+   * @param actual the actual results to verify
+   */
+
+  public void verifyAndClearAll(RowSet actual) {
     try {
       verify(actual);
     } finally {
@@ -158,7 +172,7 @@ public class RowSetComparison {
       }
       ColumnReader ec = er.column(i);
       ColumnReader ac = ar.column(i);
-      String label = er.index() + ":" + i;
+      String label = (er.index() + 1) + ":" + i;
       assertEquals(label, ec.valueType(), ac.valueType());
       if (ec.isNull()) {
         assertTrue(label + " - column not null", ac.isNull());

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnReader.java
@@ -58,6 +58,7 @@ public interface ColumnReader extends ColumnAccessor {
   byte[] getBytes();
   BigDecimal getDecimal();
   Period getPeriod();
+  Object getObject();
   TupleReader map();
   ArrayReader array();
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/AbstractColumnReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/AbstractColumnReader.java
@@ -47,6 +47,34 @@ public abstract class AbstractColumnReader extends AbstractColumnAccessor implem
   }
 
   @Override
+  public Object getObject() {
+    switch (valueType()) {
+    case ARRAY:
+      // TODO: build an array. Just a bit tedious...
+      throw new UnsupportedOperationException();
+    case BYTES:
+      return getBytes();
+    case DECIMAL:
+      return getDecimal();
+    case DOUBLE:
+      return getDouble();
+    case INTEGER:
+      return getInt();
+    case LONG:
+      return getLong();
+    case MAP:
+      // TODO: build an array. Just a bit tedious...
+      throw new UnsupportedOperationException();
+    case PERIOD:
+      return getPeriod();
+    case STRING:
+      return getString();
+    default:
+      throw new IllegalStateException("Unexpected type: " + valueType());
+    }
+  }
+
+  @Override
   public boolean isNull() {
     return false;
   }


### PR DESCRIPTION
* Create a SubOperatorTest base class to do routine setup and shutdown.
* Additional methods to simplify creating complex schemas with field
widths.
* Define a test workspace with plugin-specific options (as for the CSV
storage plugin)
* When verifying row sets, add methods to verify and release just the
"actual" batch in addition to the existing method for verify and free
both the actual and expected batches.
* Allow reading of row set values as object for generic comparisons.
* "Column builder" within schema builder to simplify building a single
MatrializedField for tests.
* Misc. code cleanup.