### PR TITLE
DRILL-3640: Support JDBC Statement.setQueryTimeout(int)

### DIFF
--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillPreparedStatement.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillPreparedStatement.java
@@ -31,6 +31,6 @@ import java.sql.PreparedStatement;
  * </p>
  * @see #unwrap
  */
-public interface DrillPreparedStatement extends PreparedStatement {
+public interface DrillPreparedStatement extends DrillStatement, PreparedStatement {
 
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillStatement.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillStatement.java
@@ -16,6 +16,7 @@
  */
 package org.apache.drill.jdbc;
 
+import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
@@ -34,11 +35,11 @@ public interface DrillStatement extends Statement {
    *            if connection is closed
    */
   @Override
-  int getQueryTimeout() throws AlreadyClosedSqlException;
+  int getQueryTimeout() throws AlreadyClosedSqlException, SQLException;
 
   /**
    * <strong>Drill</strong>:
-   * Not supported (for non-zero timeout value).
+   * Supported (for non-zero timeout value).
    * <p>
    *   Normally, just throws {@link SQLFeatureNotSupportedException} unless
    *   request is trivially for no timeout (zero {@code milliseconds} value).
@@ -54,7 +55,8 @@ public interface DrillStatement extends Statement {
   void setQueryTimeout( int milliseconds )
       throws AlreadyClosedSqlException,
              JdbcApiSqlException,
-             SQLFeatureNotSupportedException;
+             SQLFeatureNotSupportedException,
+             SQLException;
 
   /**
    * {@inheritDoc}
@@ -65,4 +67,22 @@ public interface DrillStatement extends Statement {
   @Override
   boolean isClosed();
 
+  /**
+   * <p>
+   *   <strong>Drill</strong>: Identify if the statement has already timed out
+   * </p>
+   */
+  boolean isTimedOut();
+
+  /**
+   * <p>
+   *   <strong>Drill</strong>: Allows cancel due to timeout.
+   *       The duration in which the cancellation occurred is retrieved from {@link Statement#getQueryTimeout() }.
+   *       The statement, however, is not closed to allow access to most getter methods
+   * </p>
+   *
+   * @throws SqlTimeoutException  if Timeout occurred (recommended exception)
+   * @throws SQLException         Non-timeout related exceptions
+   */
+  void cancelDueToTimeout() throws SqlTimeoutException, SQLException;
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/SqlTimeoutException.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/SqlTimeoutException.java
@@ -23,12 +23,17 @@ import java.sql.SQLException;
  * Indicates that an operation timed out. This is not an error; you can
  * retry the operation.
  */
-public class SqlTimeoutException
-    extends SQLException
-{
+public class SqlTimeoutException extends SQLException {
+
+  private static final long serialVersionUID = -1;
+
   SqlTimeoutException() {
     // SQLException(reason, SQLState, vendorCode)
     // REVIEW mb 19-Jul-05 Is there a standard SQLState?
     super("timeout", null, 0);
+  }
+
+  public SqlTimeoutException(int timeoutInSeconds) {
+    super("Cancelled due to query timeout in "+ timeoutInSeconds + " seconds");
   }
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/TimeoutTrigger.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/TimeoutTrigger.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.jdbc.impl;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.calcite.avatica.AvaticaStatement;
+import org.apache.drill.jdbc.DrillStatement;
+import org.apache.drill.jdbc.SqlTimeoutException;
+
+/**
+ * Timeout Trigger required for canceling of running queries
+ */
+class TimeoutTrigger implements Callable<Boolean> {
+  private int timeoutInSeconds;
+  private AvaticaStatement statementHandle;
+  private Future<Boolean> triggerFuture;
+  private DrillConnectionImpl connectionHandle;
+
+  public boolean isTriggered() {
+    return (triggerFuture != null);
+  }
+
+
+  //Default Constructor is Invalid
+  @SuppressWarnings("unused")
+  private TimeoutTrigger() {}
+
+  /**
+   * Timeout Constructor
+   * @param stmtContext   Statement Handle
+   * @param timeoutInSec  Timeout defined in seconds
+   * @throws SQLException
+   */
+  TimeoutTrigger(AvaticaStatement stmtContext, int timeoutInSec) throws SQLException {
+    timeoutInSeconds = timeoutInSec;
+    statementHandle = stmtContext;
+    connectionHandle = (DrillConnectionImpl) ((DrillStatement) stmtContext).getConnection();
+  }
+
+  @Override
+  public Boolean call() throws Exception {
+    try {
+      TimeUnit.SECONDS.sleep(timeoutInSeconds);
+    } catch (InterruptedException e) {
+      //Skip interruption that occur due due to query completion
+    }
+    try {
+      if (!statementHandle.isClosed()) {
+        // Cancel Statement
+        ((DrillStatement) statementHandle).cancelDueToTimeout();
+      }
+    } catch (SqlTimeoutException toe) {
+      throw toe;
+    }
+    return false;
+  }
+
+  /**
+   * Start the timer
+   * @return
+   */
+  public Future<Boolean> startCountdown() {
+    if (!isTriggered()) {
+      return (triggerFuture = connectionHandle.getTimeoutTriggerService().submit(this));
+    }
+    return triggerFuture;
+  }
+}


### PR DESCRIPTION
Allow for queries to be cancelled if they don't complete within the stipulated time.
Tests added to test different query timeout scenarios.
_Note:_
We submit a timeout-managing task that sleeps for the stipulated period before trying to cancel the query (JDBC Statement).
It might be worth having a similar feature as a System/Session variable so that the same can be achieved via SQLLine or REST APIs, but is beyond the scope of this JIRA's PR.