### PR TITLE
DRILL-5601: Rollup of external sort fixes and improvements

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/cache/VectorAccessibleSerializable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/cache/VectorAccessibleSerializable.java
@@ -35,8 +35,6 @@ import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.record.selection.SelectionVector2;
-import org.apache.drill.exec.vector.NullableBigIntVector;
-import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.ValueVector;
 
 import com.codahale.metrics.MetricRegistry;
@@ -141,6 +139,7 @@ public class VectorAccessibleSerializable extends AbstractStreamSerializable {
   }
 
   // Like above, only preserve the original container and list of value-vectors
+  @SuppressWarnings("resource")
   public void readFromStreamWithContainer(VectorContainer myContainer, InputStream input) throws IOException {
     final VectorContainer container = new VectorContainer();
     final UserBitShared.RecordBatchDef batchDef = UserBitShared.RecordBatchDef.parseDelimitedFrom(input);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/ClusterCoordinator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/ClusterCoordinator.java
@@ -38,8 +38,12 @@ public abstract class ClusterCoordinator implements AutoCloseable {
       16, 0.75f, 16);
 
   /**
-   * Start the cluster coordinator.  Millis to wait is
-   * @param millisToWait The maximum time to wait before throwing an exception if the cluster coordination service has not successfully started.  Use 0 to wait indefinitely.
+   * Start the cluster coordinator. Millis to wait is
+   *
+   * @param millisToWait
+   *          The maximum time to wait before throwing an exception if the
+   *          cluster coordination service has not successfully started. Use 0
+   *          to wait indefinitely.
    * @throws Exception
    */
   public abstract void start(long millisToWait) throws Exception;
@@ -49,7 +53,7 @@ public abstract class ClusterCoordinator implements AutoCloseable {
   public abstract void unregister(RegistrationHandle handle);
 
   /**
-   * Get a collection of avialable Drillbit endpoints, Thread-safe.
+   * Get a collection of available Drillbit endpoints, Thread-safe.
    * Could be slightly out of date depending on refresh policy.
    *
    * @return A collection of available endpoints.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -343,7 +343,9 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
    */
   @SuppressWarnings("resource")
   public boolean syncWithRemoteRegistry(long version) {
-    if (isRegistrySyncNeeded(remoteFunctionRegistry.getRegistryVersion(), localFunctionRegistry.getVersion())) {
+    // Do the version check only if a remote registry exists. It does
+    // not exist for some JMockit-based unit tests.
+    if (isRegistrySyncNeeded()) {
       synchronized (this) {
         long localRegistryVersion = localFunctionRegistry.getVersion();
         if (isRegistrySyncNeeded(remoteFunctionRegistry.getRegistryVersion(), localRegistryVersion))  {
@@ -388,6 +390,11 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
     }
 
     return version != localFunctionRegistry.getVersion();
+  }
+
+  private boolean isRegistrySyncNeeded() {
+    return remoteFunctionRegistry.hasRegistry() &&
+           isRegistrySyncNeeded(remoteFunctionRegistry.getRegistryVersion(), localFunctionRegistry.getVersion());
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
@@ -128,6 +128,14 @@ public class RemoteFunctionRegistry implements AutoCloseable {
     }
   }
 
+  /**
+   * Report whether a remote registry exists. During some unit tests,
+   * no remote registry exists, so the other methods should not be called.
+   * @return true if a remote registry exists, false if this a local-only
+   * instance and no such registry exists
+   */
+  public boolean hasRegistry() { return registry != null; }
+
   public Registry getRegistry(DataChangeVersion version) {
     return registry.get(registry_path, version);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/InternalBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/InternalBatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -39,7 +39,7 @@ public class InternalBatch implements Iterable<VectorWrapper<?>>{
     this(incoming, null, oContext);
   }
 
-  public InternalBatch(RecordBatch incoming, VectorWrapper[] ignoreWrappers, OperatorContext oContext){
+  public InternalBatch(RecordBatch incoming, VectorWrapper<?>[] ignoreWrappers, OperatorContext oContext){
     switch(incoming.getSchema().getSelectionVectorMode()){
     case FOUR_BYTE:
       this.sv4 = incoming.getSelectionVector4().createNewWrapperCurrent();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.AllocationReservation;
+import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.BatchSchema;
@@ -244,15 +245,17 @@ public class SortRecordBatchBuilder implements AutoCloseable {
   }
 
   /**
-   * For given record count how much memory does SortRecordBatchBuilder needs for its own purpose. This is used in
-   * ExternalSortBatch to make decisions about whether to spill or not.
+   * For given record count, return the memory that SortRecordBatchBuilder needs
+   * for its own purpose. This is used in ExternalSortBatch to make decisions
+   * about whether to spill or not.
    *
-   * @param recordCount
-   * @return
+   * @param recordCount expected output record count
+   * @return number of bytes needed for an SV4, power-of-two rounded
    */
+
   public static long memoryNeeded(int recordCount) {
     // We need 4 bytes (SV4) for each record. Due to power-of-two allocations, the
     // backing buffer might be twice this size.
-    return recordCount * 2 * 4;
+    return BaseAllocator.nextPowerOfTwo(recordCount * 4);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/RecordBatchSizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/RecordBatchSizer.java
@@ -19,19 +19,29 @@ package org.apache.drill.exec.physical.impl.spill;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.expr.TypeHelper;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorInitializer;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.selection.SelectionVector2;
+import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+import org.apache.drill.exec.vector.complex.RepeatedMapVector;
+import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 import org.apache.drill.exec.vector.VariableWidthVector;
+
+import com.google.common.collect.Sets;
 
 /**
  * Given a record batch or vector container, determines the actual memory
@@ -39,25 +49,21 @@ import org.apache.drill.exec.vector.VariableWidthVector;
  */
 
 public class RecordBatchSizer {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RecordBatchSizer.class);
 
   /**
    * Column size information.
    */
   public static class ColumnSize {
+    public final String prefix;
     public final MaterializedField metadata;
 
     /**
-     * Assumed size from Drill metadata.
+     * Assumed size from Drill metadata. Note that this information is
+     * 100% bogus. Do not use it.
      */
 
+    @Deprecated
     public int stdSize;
-
-    /**
-     * Actual memory consumed by all the vectors associated with this column.
-     */
-
-    public int totalSize;
 
     /**
      * Actual average column width as determined from actual memory use. This
@@ -65,70 +71,168 @@ public class RecordBatchSizer {
      * column overhead such as any unused vector space, etc.
      */
 
-    public int estSize;
-    public int capacity;
-    public int density;
+    public final int estSize;
+
+    /**
+     * Number of times the value here (possibly repeated) appears in
+     * the record batch.
+     */
+
+    public final int valueCount;
+
+    /**
+     * The number of elements in the value vector. Consider two cases.
+     * A required or nullable vector has one element per row, so the
+     * <tt>entryCount</tt> is the same as the <tt>valueCount</tt> (which,
+     * in turn, is the same as the row count.) But, if this vector is an
+     * array, then the <tt>valueCount</tt> is the number of columns, while
+     * <tt>entryCount</tt> is the total number of elements in all the arrays
+     * that make up the columns, so <tt>entryCount</tt> will be different than
+     * the <tt>valueCount</tt> (normally larger, but possibly smaller if most
+     * arrays are empty.
+     * <p>
+     * Finally, the column may be part of another list. In this case, the above
+     * logic still applies, but the <tt>valueCount</tt> is the number of entries
+     * in the outer array, not the row count.
+     */
+
+    public int entryCount;
     public int dataSize;
-    public boolean variableWidth;
 
-    public ColumnSize(ValueVector vv) {
-      metadata = vv.getField();
-      stdSize = TypeHelper.getSize(metadata.getType());
+    /**
+     * The estimated, average number of elements. For a repeated type,
+     * this is the average entries per array (per repeated element).
+     */
 
-      // Can't get size estimates if this is an empty batch.
-      int rowCount = vv.getAccessor().getValueCount();
-      if (rowCount == 0) {
-        estSize = stdSize;
-        return;
-      }
+    public int estElementCount;
+    public final boolean isVariableWidth;
 
-      // Total size taken by all vectors (and underlying buffers)
-      // associated with this vector.
-
-      totalSize = vv.getAllocatedByteCount();
-
-      // Capacity is the number of values that the vector could
-      // contain. This is useful only for fixed-length vectors.
-
-      capacity = vv.getValueCapacity();
+    public ColumnSize(ValueVector v, String prefix, int valueCount) {
+      this.prefix = prefix;
+      this.valueCount = valueCount;
+      metadata = v.getField();
+      isVariableWidth = v instanceof VariableWidthVector;
 
       // The amount of memory consumed by the payload: the actual
       // data stored in the vectors.
 
-      dataSize = vv.getPayloadByteCount();
+      if (v.getField().getDataMode() == DataMode.REPEATED) {
+        buildRepeated(v);
+      }
+      estElementCount = 1;
+      entryCount = 1;
+      switch (metadata.getType().getMinorType()) {
+      case LIST:
+        buildList(v);
+        break;
+      case MAP:
+      case UNION:
+        // No standard size for Union type
+        dataSize = v.getPayloadByteCount(valueCount);
+        break;
+      default:
+        dataSize = v.getPayloadByteCount(valueCount);
+        stdSize = TypeHelper.getSize(metadata.getType());
+      }
+      estSize = roundUp(dataSize, valueCount);
+    }
 
-      // Determine "density" the number of rows compared to potential
-      // capacity. Low-density batches occur at block boundaries, ends
-      // of files and so on. Low-density batches throw off our estimates
-      // for Varchar columns because we don't know the actual number of
-      // bytes consumed (that information is hidden behind the Varchar
-      // implementation where we can't get at it.)
+    private void buildRepeated(ValueVector v) {
 
-      density = roundUp(dataSize * 100, totalSize);
-      estSize = roundUp(dataSize, rowCount);
-      variableWidth = vv instanceof VariableWidthVector ;
+      // Repeated vectors are special: they have an associated offset vector
+      // that changes the value count of the contained vectors.
+
+      @SuppressWarnings("resource")
+      UInt4Vector offsetVector = ((RepeatedValueVector) v).getOffsetVector();
+      buildArray(offsetVector);
+      if (metadata.getType().getMinorType() == MinorType.MAP) {
+
+        // For map, the only data associated with the map vector
+        // itself is the offset vector, if any.
+
+        dataSize = offsetVector.getPayloadByteCount(valueCount);
+      }
+    }
+
+    private void buildList(ValueVector v) {
+      @SuppressWarnings("resource")
+      UInt4Vector offsetVector = ((RepeatedListVector) v).getOffsetVector();
+      buildArray(offsetVector);
+      dataSize = offsetVector.getPayloadByteCount(valueCount);
+    }
+
+    private void buildArray(UInt4Vector offsetVector) {
+      entryCount = offsetVector.getAccessor().get(valueCount);
+      estElementCount = roundUp(entryCount, valueCount);
     }
 
     @Override
     public String toString() {
       StringBuilder buf = new StringBuilder()
+          .append(prefix)
           .append(metadata.getName())
           .append("(type: ")
+          .append(metadata.getType().getMode().name())
+          .append(" ")
           .append(metadata.getType().getMinorType().name())
-          .append(", std col. size: ")
+          .append(", count: ")
+          .append(valueCount);
+      if (metadata.getDataMode() == DataMode.REPEATED) {
+        buf.append(", total entries: ")
+           .append(entryCount)
+           .append(", per-array: ")
+           .append(estElementCount);
+      }
+      buf .append(", std size: ")
           .append(stdSize)
-          .append(", actual col. size: ")
+          .append(", actual size: ")
           .append(estSize)
-          .append(", total size: ")
-          .append(totalSize)
           .append(", data size: ")
           .append(dataSize)
-          .append(", row capacity: ")
-          .append(capacity)
-          .append(", density: ")
-          .append(density)
           .append(")");
       return buf.toString();
+    }
+
+    /**
+     * Add a single vector initializer to a collection for the entire batch.
+     * Uses the observed column size information to predict the size needed
+     * when allocating a new vector for the same data.
+     *
+     * @param initializer the vector initializer to hold the hints
+     * for this column
+     */
+
+    private void buildVectorInitializer(VectorInitializer initializer) {
+      int width = 0;
+      switch(metadata.getType().getMinorType()) {
+      case VAR16CHAR:
+      case VARBINARY:
+      case VARCHAR:
+
+        // Subtract out the offset vector width
+        width = estSize - 4;
+
+        // Subtract out the bits (is-set) vector width
+        if (metadata.getDataMode() == DataMode.OPTIONAL) {
+          width -= 1;
+        }
+        break;
+      default:
+        break;
+      }
+      String name = prefix + metadata.getName();
+      if (metadata.getDataMode() == DataMode.REPEATED) {
+        if (width > 0) {
+          // Estimated width is width of entire column. Divide
+          // by element count to get per-element size.
+          initializer.variableWidthArray(name, width / estElementCount, estElementCount);
+        } else {
+          initializer.fixedWidthArray(name, estElementCount);
+        }
+      }
+      else if (width > 0) {
+        initializer.variableWidth(name, width);
+      }
     }
   }
 
@@ -139,14 +243,16 @@ public class RecordBatchSizer {
    */
   private int rowCount;
   /**
-   * Standard row width using Drill meta-data.
+   * Standard row width using Drill meta-data. Note: this information is
+   * 100% bogus. Do not use it.
    */
+  @Deprecated
   private int stdRowWidth;
   /**
    * Actual batch size summing all buffers used to store data
    * for the batch.
    */
-  private int totalBatchSize;
+  private int accountedMemorySize;
   /**
    * Actual row width computed by dividing total batch memory by the
    * record count.
@@ -161,6 +267,8 @@ public class RecordBatchSizer {
   private boolean hasSv2;
   private int sv2Size;
   private int avgDensity;
+
+  private Set<BufferLedger> ledgers = Sets.newIdentityHashSet();
 
   private int netBatchSize;
 
@@ -177,42 +285,58 @@ public class RecordBatchSizer {
   /**
    *  Count the nullable columns; used for memory estimation
    */
-  public int numNullables;
+  public int nullableCount;
+
   /**
+   * Create empirical metadata for a record batch given a vector accessible
+   * (basically, an iterator over the vectors in the batch.)
    *
-   * @param va
+   * @param va iterator over the batch's vectors
    */
+
   public RecordBatchSizer(VectorAccessible va) {
     this(va, null);
   }
 
+  /**
+   * Create empirical metadata for a record batch given a vector accessible
+   * (basically, an iterator over the vectors in the batch) along with a
+   * selection vector for those records. The selection vector is used to
+   * pad the estimated row width with the extra two bytes needed per record.
+   * The selection vector memory is added ot the total memory consumed by
+   * this batch.
+   *
+   * @param va iterator over the batch's vectors
+   * @param sv2 selection vector associated with this batch
+   */
+
   public RecordBatchSizer(VectorAccessible va, SelectionVector2 sv2) {
     rowCount = va.getRecordCount();
     for (VectorWrapper<?> vw : va) {
-      int size = measureColumn(vw.getValueVector());
-      if ( size > maxSize ) { maxSize = size; }
-      if ( vw.getField().isNullable() ) { numNullables++; }
+      measureColumn(vw.getValueVector(), "", rowCount);
+    }
+
+    for (BufferLedger ledger : ledgers) {
+      accountedMemorySize += ledger.getAccountedSize();
     }
 
     if (rowCount > 0) {
-      grossRowWidth = roundUp(totalBatchSize, rowCount);
+      grossRowWidth = roundUp(accountedMemorySize, rowCount);
     }
 
     if (sv2 != null) {
       sv2Size = sv2.getBuffer(false).capacity();
-      grossRowWidth += roundUp(sv2Size, rowCount);
-      netRowWidth += 2;
+      accountedMemorySize += sv2Size;
+      hasSv2 = true;
     }
 
-    int totalDensity = 0;
-    int usableCount = 0;
-    for (ColumnSize colSize : columnSizes) {
-      if ( colSize.density > 0 ) {
-        usableCount++;
-      }
-      totalDensity += colSize.density;
-    }
-    avgDensity = roundUp(totalDensity, usableCount);
+    computeEstimates();
+  }
+
+  private void computeEstimates() {
+    grossRowWidth = roundUp(accountedMemorySize, rowCount);
+    netRowWidth = roundUp(netBatchSize, rowCount);
+    avgDensity = roundUp(netBatchSize * 100, accountedMemorySize);
   }
 
   public void applySv2() {
@@ -220,9 +344,10 @@ public class RecordBatchSizer {
       return;
     }
 
+    hasSv2 = true;
     sv2Size = BaseAllocator.nextPowerOfTwo(2 * rowCount);
-    grossRowWidth += roundUp(sv2Size, rowCount);
-    totalBatchSize += sv2Size;
+    accountedMemorySize += sv2Size;
+    computeEstimates();
   }
 
   /**
@@ -238,36 +363,61 @@ public class RecordBatchSizer {
     if ( arg <= 32 ) { return 32; }
     return 64;
   }
-  private int measureColumn(ValueVector vv) {
+
+  private void measureColumn(ValueVector v, String prefix, int valueCount) {
+
+    ColumnSize colSize = new ColumnSize(v, prefix, valueCount);
+    columnSizes.add(colSize);
+    stdRowWidth += colSize.stdSize;
+    netBatchSize += colSize.dataSize;
+    maxSize = Math.max(maxSize, colSize.dataSize);
+    if (colSize.metadata.isNullable()) {
+      nullableCount++;
+    }
+
     // Maps consume no size themselves. However, their contained
     // vectors do consume space, so visit columns recursively.
-    if (vv.getField().getType().getMinorType() == MinorType.MAP) {
-      return expandMap((AbstractMapVector) vv);
+
+    switch (v.getField().getType().getMinorType()) {
+    case MAP:
+      expandMap((AbstractMapVector) v, prefix + v.getField().getName() + ".", colSize.entryCount);
+      break;
+    case LIST:
+      expandList((RepeatedListVector) v, prefix + v.getField().getName() + ".", colSize.entryCount);
+      break;
+    default:
+      v.collectLedgers(ledgers);
     }
 
-    ColumnSize colSize = new ColumnSize(vv);
-    columnSizes.add(colSize);
-
-    stdRowWidth += colSize.stdSize;
-    totalBatchSize += colSize.totalSize;
-    netBatchSize += colSize.dataSize;
     netRowWidth += colSize.estSize;
-    netRowWidthCap50 += ! colSize.variableWidth ? colSize.estSize :
-        8 /* offset vector */ + roundUpToPowerOf2( Math.min(colSize.estSize,50) );
+    netRowWidthCap50 += ! colSize.isVariableWidth ? colSize.estSize :
+        8 /* offset vector */ + roundUpToPowerOf2(Math.min(colSize.estSize,50));
         // above change 8 to 4 after DRILL-5446 is fixed
-    return colSize.estSize;
   }
 
-  private int expandMap(AbstractMapVector mapVector) {
-    int accum = 0;
+  private void expandMap(AbstractMapVector mapVector, String prefix, int valueCount) {
     for (ValueVector vector : mapVector) {
-      accum += measureColumn(vector);
+      measureColumn(vector, prefix, valueCount);
     }
-    return accum;
+
+    // For a repeated map, we need the memory for the offset vector (only).
+    // Map elements are recursively expanded above.
+
+    if (mapVector.getField().getDataMode() == DataMode.REPEATED) {
+      ((RepeatedMapVector) mapVector).getOffsetVector().collectLedgers(ledgers);
+    }
+  }
+
+  private void expandList(RepeatedListVector vector, String prefix, int valueCount) {
+    measureColumn(vector.getDataVector(), prefix, valueCount);
+
+    // Determine memory for the offset vector (only).
+
+    vector.collectLedgers(ledgers);
   }
 
   public static int roundUp(int num, int denom) {
-    if(denom == 0) {
+    if (denom == 0) {
       return 0;
     }
     return (int) Math.ceil((double) num / denom);
@@ -283,8 +433,8 @@ public class RecordBatchSizer {
    * and null marking columns.
    * @return "real" width of the row
    */
-  public int netRowWidthCap50() { return netRowWidthCap50 + numNullables; }
-  public int actualSize() { return totalBatchSize; }
+  public int netRowWidthCap50() { return netRowWidthCap50 + nullableCount; }
+  public int actualSize() { return accountedMemorySize; }
   public boolean hasSv2() { return hasSv2; }
   public int avgDensity() { return avgDensity; }
   public int netSize() { return netBatchSize; }
@@ -304,14 +454,32 @@ public class RecordBatchSizer {
     buf.append( "  Records: " );
     buf.append(rowCount);
     buf.append(", Total size: ");
-    buf.append(totalBatchSize);
-    buf.append(", Gross row width:");
+    buf.append(accountedMemorySize);
+    buf.append(", Data size: ");
+    buf.append(netBatchSize);
+    buf.append(", Gross row width: ");
     buf.append(grossRowWidth);
-    buf.append(", Net row width:");
+    buf.append(", Net row width: ");
     buf.append(netRowWidth);
-    buf.append(", Density:");
+    buf.append(", Density: ");
     buf.append(avgDensity);
     buf.append("}");
     return buf.toString();
+  }
+
+  /**
+   * The column size information gathered here represents empirically-derived
+   * schema metadata. Use that metadata to create an instance of a class that
+   * allocates memory for new vectors based on the observed size information.
+   * The caller provides the row count; the size information here provides
+   * column widths, number of elements in each array, etc.
+   */
+
+  public VectorInitializer buildVectorInitializer() {
+    VectorInitializer initializer = new VectorInitializer();
+    for (ColumnSize colSize : columnSizes) {
+      colSize.buildVectorInitializer(initializer);
+    }
+    return initializer;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
@@ -281,7 +281,6 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
 
       // Validate schema when available.
       if (batchState == OK || batchState == OK_NEW_SCHEMA) {
-        final BatchSchema prevLastSchema = lastSchema;
         final BatchSchema prevLastNewSchema = lastNewSchema;
 
         lastSchema = incoming.getSchema();
@@ -364,5 +363,7 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
         String.format("You should not call getOutgoingContainer() for class %s",
                       this.getClass().getCanonicalName()));
   }
+
+  public RecordBatch getIncoming() { return incoming; }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
@@ -26,6 +26,7 @@ import javax.inject.Named;
 
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.RecordBatch;
@@ -92,8 +93,9 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
    * @return
    */
   public static long memoryNeeded(final int recordCount) {
-    // We need 4 bytes (SV4) for each record.
-    return recordCount * 4;
+    // We need 4 bytes (SV4) for each record, power of 2 rounded.
+
+    return BaseAllocator.nextPowerOfTwo(recordCount * 4);
   }
 
   private int merge(final int leftStart, final int rightStart, final int rightEnd, final int outStart) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BatchGroup.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BatchGroup.java
@@ -212,11 +212,16 @@ public abstract class BatchGroup implements VectorAccessible, AutoCloseable {
         reader = VectorSerializer.reader(allocator, inputStream);
       }
       Stopwatch watch = Stopwatch.createStarted();
+      long start = allocator.getAllocatedMemory();
       VectorContainer c =  reader.read();
+      long end = allocator.getAllocatedMemory();
+      logger.trace("Read {} records in {} us; size = {}, memory = {}",
+                   c.getRecordCount(),
+                   watch.elapsed(TimeUnit.MICROSECONDS),
+                   (end - start), end);
       if (schema != null) {
         c = SchemaUtil.coerceContainer(c, schema, allocator);
       }
-      logger.trace("Read {} records in {} us", c.getRecordCount(), watch.elapsed(TimeUnit.MICROSECONDS));
       spilledBatches--;
       currentContainer.zeroVectors();
       Iterator<VectorWrapper<?>> wrapperIterator = c.iterator();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BufferedBatches.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BufferedBatches.java
@@ -106,6 +106,7 @@ public class BufferedBatches {
     sorterWrapper.sortBatch(convertedBatch, sv2);
     bufferBatch(convertedBatch, sv2, batchSize);
   }
+
   /**
    * Convert an incoming batch into the agree-upon format.
    * @param incoming

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MSortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MSortTemplate.java
@@ -58,7 +58,7 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
 
   @Override
   public void setup(final FragmentExecContext context, final BufferAllocator allocator, final SelectionVector4 vector4,
-                    final VectorContainer hyperBatch, int outputBatchSize) throws SchemaChangeException{
+                    final VectorContainer hyperBatch, int outputBatchSize, int desiredBatchSize) throws SchemaChangeException{
     // we pass in the local hyperBatch since that is where we'll be reading data.
     Preconditions.checkNotNull(vector4);
     this.vector4 = vector4.createNewWrapperCurrent();
@@ -89,7 +89,7 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
 
     @SuppressWarnings("resource")
     final DrillBuf drillBuf = allocator.buffer(4 * totalCount);
-    desiredRecordBatchCount = Math.min(outputBatchSize, Character.MAX_VALUE);
+    desiredRecordBatchCount = Math.min(outputBatchSize, desiredBatchSize);
     desiredRecordBatchCount = Math.min(desiredRecordBatchCount, totalCount);
     aux = new SelectionVector4(drillBuf, totalCount, desiredRecordBatchCount);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MSorter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MSorter.java
@@ -30,7 +30,8 @@ import org.apache.drill.exec.record.selection.SelectionVector4;
  */
 
 public interface MSorter {
-  public void setup(FragmentExecContext context, BufferAllocator allocator, SelectionVector4 vector4, VectorContainer hyperBatch, int outputBatchSize) throws SchemaChangeException;
+  public void setup(FragmentExecContext context, BufferAllocator allocator, SelectionVector4 vector4,
+                    VectorContainer hyperBatch, int outputBatchSize, int desiredBatchSize) throws SchemaChangeException;
   public void sort();
   public SelectionVector4 getSV4();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierTemplate.java
@@ -66,7 +66,6 @@ public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier
 
   @Override
   public int next(int targetRecordCount) {
-    VectorAccessibleUtilities.allocateVectors(outgoing, targetRecordCount);
     for (int outgoingIndex = 0; outgoingIndex < targetRecordCount; outgoingIndex++) {
       if (queueSize == 0) {
         return 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortConfig.java
@@ -21,6 +21,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 
 public class SortConfig {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExternalSortBatch.class);
 
   /**
    * Smallest allowed output batch size. The smallest output batch
@@ -62,6 +63,12 @@ public class SortConfig {
 
   private final int bufferedBatchLimit;
 
+  /**
+   * Limit the size of the in-memory merge return batches.
+   * Primarily for testing.
+   */
+
+  private final int mSortBatchSize;
 
   public SortConfig(DrillConfig config) {
 
@@ -101,15 +108,26 @@ public class SortConfig {
     } else {
       bufferedBatchLimit = Math.max(value, 2);
     }
+
+    // Limit on memory merge batch size; primarily for testing
+
+    if (config.hasPath(ExecConstants.EXTERNAL_SORT_MSORT_MAX_BATCHSIZE)) {
+      mSortBatchSize = Math.max(1,
+            Math.min(Character.MAX_VALUE,
+                     config.getInt(ExecConstants.EXTERNAL_SORT_MSORT_MAX_BATCHSIZE)));
+    } else {
+      mSortBatchSize = Character.MAX_VALUE;
+    }
+
     logConfig();
   }
 
   private void logConfig() {
-    ExternalSortBatch.logger.debug("Config: " +
+    logger.debug("Config: " +
                  "spill file size = {}, spill batch size = {}, " +
-                 "merge limit = {}, merge batch size = {}",
-                  spillFileSize(), spillFileSize(),
-                  mergeLimit(), mergeBatchSize());
+                 "merge batch size = {}, mSort batch size = {}",
+                  spillFileSize, spillBatchSize,
+                  mergeBatchSize, mSortBatchSize);
   }
 
   public long maxMemory() { return maxMemory; }
@@ -118,4 +136,5 @@ public class SortConfig {
   public int spillBatchSize() { return spillBatchSize; }
   public int mergeBatchSize() { return mergeBatchSize; }
   public int getBufferedBatchLimit() { return bufferedBatchLimit; }
+  public int getMSortBatchSize() { return mSortBatchSize; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
@@ -19,7 +19,160 @@ package org.apache.drill.exec.physical.impl.xsort.managed;
 
 import com.google.common.annotations.VisibleForTesting;
 
+/**
+ * Computes the memory needs for input batches, spill batches and merge
+ * batches. The key challenges that this code tries to overcome are:
+ * <ul>
+ * <li>Drill is not designed for the small memory allocations,
+ * but the planner may provide such allocations because the memory per
+ * query is divided among slices (minor fragments) and among buffering
+ * operators, leaving very little per operator.</li>
+ * <li>Drill does not provide the detailed memory information needed to
+ * carefully manage memory in tight constraints.</li>
+ * <li>But, Drill has a death penalty for going over the memory limit.</li>
+ * </ul>
+ * As a result, this class is a bit of a hack: it attempt to consider a
+ * number of ill-defined factors in order to divide up memory use in a
+ * way that prevents OOM errors.
+ * <p>
+ * First, it is necessary to differentiate two concepts:
+ * <ul>
+ * <li>The <i>data size</i> of a batch: the amount of memory needed to hold
+ * the data itself. The data size is constant for any given batch.</li>
+ * <li>The <i>buffer size</i> of the buffers that hold the data. The buffer
+ * size varies wildly depending on how the batch was produced.</li>
+ * </ul>
+ * The three kinds of buffer layouts seen to date include:
+ * <ul>
+ * <li>One buffer per vector component (data, offsets, null flags, etc.)
+ * &ndash; create by readers, project and other operators.</li>
+ * <li>One buffer for the entire batch, with each vector component using
+ * a slice of the overall buffer. &ndash; case for batches deserialized from
+ * exchanges.</li>
+ * <li>One buffer for each top-level vector, with component vectors
+ * using slices of the overall vector buffer &ndash; the result of reading
+ * spilled batches from disk.</li>
+ * </ul>
+ * In each case, buffer sizes are power-of-two rounded from the data size.
+ * But since the data is grouped differently in each case, the resulting buffer
+ * sizes vary considerably.
+ * <p>
+ * As a result, we can never be sure of the amount of memory needed for a
+ * batch. So, we have to estimate based on a number of factors:
+ * <ul>
+ * <li>Uses the {@link RecordBatchSizer} to estimate the data size and
+ * buffer size of each incoming batch.</li>
+ * <li>Estimates the internal fragmentation due to power-of-two rounding.</li>
+ * <li>Configured preferences for spill and output batches.</li>
+ * </ul>
+ * The code handles "normal" and "low" memory conditions.
+ * <ul>
+ * <li>In normal memory, we simply work out the number of preferred-size
+ * batches that fit in memory (based on the predicted buffer size.)</li>
+ * <li>In low memory, we divide up the available memory to produce the
+ * spill and merge batch sizes. The sizes will be less than the configured
+ * preference.</li>
+ * </ul>
+ * <p>
+ * The sort has two key configured parameters: the spill file size and the
+ * size of the output (downstream) batch. The spill file size is chosen to
+ * be large enough to ensure efficient I/O, but not so large as to overwhelm
+ * any one spill directory. The output batch size is chosen to be large enough
+ * to amortize the per-batch overhead over the maximum number of records, but
+ * not so large as to overwhelm downstream operators. Setting these parameters
+ * is a judgment call.
+ * <p>
+ * Under limited memory, the above sizes may be too big for the space available.
+ * For example, the default spill file size is 256 MB. But, if the sort is
+ * only given 50 MB, then spill files will be smaller. The default output batch
+ * size is 16 MB, but if the sort is given only 20 MB, then the output batch must
+ * be smaller. The low memory logic starts with the memory available and works
+ * backwards to figure out spill batch size, output batch size and spill file
+ * size. The sizes will be smaller than optimal, but as large as will fit in
+ * the memory provided.
+ */
+
 public class SortMemoryManager {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExternalSortBatch.class);
+
+  /**
+   * Estimate for typical internal fragmentation in a buffer due to power-of-two
+   * rounding on vectors.
+   * <p>
+   * <p>
+   * <pre>[____|__$__]</pre>
+   * In the above, the brackets represent the whole vector. The
+   * first half is always full. The $ represents the end of data.
+   * When the first half filled, the second
+   * half was allocated. On average, the second half will be half full.
+   * This means that, on average, 1/4 of the allocated space is
+   * unused (the definition of internal fragmentation.)
+   */
+
+  public static final double INTERNAL_FRAGMENTATION_ESTIMATE = 1.0/4.0;
+
+  /**
+   * Given a buffer, this is the assumed amount of space
+   * available for data. (Adding more will double the buffer
+   * size half the time.)
+   */
+
+  public static final double PAYLOAD_FROM_BUFFER = 1 - INTERNAL_FRAGMENTATION_ESTIMATE;
+
+  /**
+   * Given a data size, this is the multiplier to create the buffer
+   * size estimate. (Note: since we work with aggregate batches, we
+   * cannot simply round up to the next power of two: rounding is done
+   * on a vector-by-vector basis. Here we need to estimate the aggregate
+   * effect of rounding.
+   */
+
+  public static final double BUFFER_FROM_PAYLOAD = 3.0 / 2.0;
+
+  /**
+   * On really bad days, we will add one more byte (or value) to a vector
+   * than fits in a power-of-two sized buffer, forcing a doubling. In this
+   * case, half the resulting buffer is empty.
+   */
+
+  public static final double WORST_CASE_BUFFER_RATIO = 2.0;
+
+  /**
+   * Desperate attempt to keep spill batches from being too small in low memory.
+   * <p>
+   * The number is also used for logging: the system will log a warning if
+   * batches fall below this number which may represent too little memory
+   * allocated for the job at hand. (Queries operate on big data: many records.
+   * Batches with too few records are a probable performance hit. But, what is
+   * too few? It is a judgment call.)
+   */
+
+  public static final int MIN_ROWS_PER_SORT_BATCH = 100;
+  public static final double LOW_MEMORY_MERGE_BATCH_RATIO = 0.25;
+
+  public static class BatchSizeEstimate {
+    int dataSize;
+    int expectedBufferSize;
+    int maxBufferSize;
+
+    public void setFromData(int dataSize) {
+      this.dataSize = dataSize;
+      expectedBufferSize = multiply(dataSize, BUFFER_FROM_PAYLOAD);
+      maxBufferSize = multiply(dataSize, WORST_CASE_BUFFER_RATIO);
+    }
+
+    public void setFromBuffer(int bufferSize) {
+      expectedBufferSize = bufferSize;
+      dataSize = multiply(bufferSize, PAYLOAD_FROM_BUFFER);
+      maxBufferSize = multiply(dataSize, WORST_CASE_BUFFER_RATIO);
+    }
+
+    public void setFromWorstCaseBuffer(int bufferSize) {
+      maxBufferSize = bufferSize;
+      dataSize = multiply(maxBufferSize, 1 / WORST_CASE_BUFFER_RATIO);
+      expectedBufferSize = multiply(dataSize, BUFFER_FROM_PAYLOAD);
+    }
+ }
 
   /**
    * Maximum memory this operator may use. Usually comes from the
@@ -42,13 +195,13 @@ public class SortMemoryManager {
    * value.
    */
 
-  private int expectedMergeBatchSize;
+  private final BatchSizeEstimate mergeBatchSize = new BatchSizeEstimate();
 
   /**
    * Estimate of the input batch size based on the largest batch seen
    * thus far.
    */
-  private int estimatedInputBatchSize;
+  private final BatchSizeEstimate inputBatchSize = new BatchSizeEstimate();
 
   /**
    * Maximum memory level before spilling occurs. That is, we can buffer input
@@ -86,7 +239,7 @@ public class SortMemoryManager {
    * details of the data rows for any particular query.
    */
 
-  private int expectedSpillBatchSize;
+  private final BatchSizeEstimate spillBatchSize = new BatchSizeEstimate();
 
   /**
    * The number of records to add to each output batch sent to the
@@ -97,24 +250,41 @@ public class SortMemoryManager {
 
   private SortConfig config;
 
-  private int estimatedInputSize;
-
   private boolean potentialOverflow;
 
-  public SortMemoryManager(SortConfig config, long memoryLimit) {
+  private boolean isLowMemory;
+
+  private boolean performanceWarning;
+
+  public SortMemoryManager(SortConfig config, long opMemoryLimit) {
     this.config = config;
 
     // The maximum memory this operator can use as set by the
     // operator definition (propagated to the allocator.)
 
-    if (config.maxMemory() > 0) {
-      this.memoryLimit = Math.min(memoryLimit, config.maxMemory());
-    } else {
-      this.memoryLimit = memoryLimit;
-    }
+    final long configMemoryLimit = config.maxMemory();
+    memoryLimit = (configMemoryLimit == 0) ? opMemoryLimit
+                : Math.min(opMemoryLimit, configMemoryLimit);
 
     preferredSpillBatchSize = config.spillBatchSize();;
     preferredMergeBatchSize = config.mergeBatchSize();
+
+    // Initialize the buffer memory limit for the first batch.
+    // Assume 1/2 of (allocated - spill batch size).
+
+    bufferMemoryLimit = (memoryLimit - config.spillBatchSize()) / 2;
+    if (bufferMemoryLimit < 0) {
+      // Bad news: not enough for even the spill batch.
+      // Assume half of memory, will adjust later.
+      bufferMemoryLimit = memoryLimit / 2;
+    }
+
+    if (memoryLimit == opMemoryLimit) {
+      logger.debug("Memory config: Allocator limit = {}", memoryLimit);
+    } else {
+      logger.debug("Memory config: Allocator limit = {}, Configured limit: {}",
+                   opMemoryLimit, memoryLimit);
+    }
   }
 
   /**
@@ -134,36 +304,39 @@ public class SortMemoryManager {
    * phase, and how many spill batches we can merge during the merge
    * phase.
    *
-   * @param batchSize the overall size of the current batch received from
+   * @param batchDataSize the overall size of the current batch received from
    * upstream
    * @param batchRowWidth the average width in bytes (including overhead) of
    * rows in the current input batch
    * @param batchRowCount the number of actual (not filtered) records in
    * that upstream batch
+   * @return true if the estimates changed, false if the previous estimates
+   * remain valid
    */
 
-  public void updateEstimates(int batchSize, int batchRowWidth, int batchRowCount) {
+  public boolean updateEstimates(int batchDataSize, int batchRowWidth, int batchRowCount) {
 
     // The record count should never be zero, but better safe than sorry...
 
     if (batchRowCount == 0) {
-      return; }
+      return false; }
 
 
     // Update input batch estimates.
     // Go no further if nothing changed.
 
-    if (! updateInputEstimates(batchSize, batchRowWidth, batchRowCount)) {
-      return;
+    if (! updateInputEstimates(batchDataSize, batchRowWidth, batchRowCount)) {
+      return false;
     }
 
     updateSpillSettings();
     updateMergeSettings();
     adjustForLowMemory();
     logSettings(batchRowCount);
+    return true;
   }
 
-  private boolean updateInputEstimates(int batchSize, int batchRowWidth, int batchRowCount) {
+  private boolean updateInputEstimates(int batchDataSize, int batchRowWidth, int batchRowCount) {
 
     // The row width may end up as zero if all fields are nulls or some
     // other unusual situation. In this case, assume a width of 10 just
@@ -192,17 +365,13 @@ public class SortMemoryManager {
     // batch. Because we are using the actual observed batch size,
     // the size already includes overhead due to power-of-two rounding.
 
-    long origInputBatchSize = estimatedInputBatchSize;
-    estimatedInputBatchSize = Math.max(estimatedInputBatchSize, batchSize);
-
-    // Estimate the total size of each incoming batch plus sv2. Note that, due
-    // to power-of-two rounding, the allocated sv2 size might be twice the data size.
-
-    estimatedInputSize = estimatedInputBatchSize + 4 * batchRowCount;
+    long origInputBatchSize = inputBatchSize.dataSize;
+    inputBatchSize.setFromData(Math.max(inputBatchSize.dataSize, batchDataSize));
 
     // Return whether anything changed.
 
-    return estimatedRowWidth != origRowEstimate || estimatedInputBatchSize != origInputBatchSize;
+    return estimatedRowWidth > origRowEstimate ||
+           inputBatchSize.dataSize > origInputBatchSize;
   }
 
   /**
@@ -215,18 +384,23 @@ public class SortMemoryManager {
 
     spillBatchRowCount = rowsPerBatch(preferredSpillBatchSize);
 
-    // Compute the actual spill batch size which may be larger or smaller
-    // than the preferred size depending on the row width. Double the estimated
-    // memory needs to allow for power-of-two rounding.
+    // But, don't allow spill batches to be too small; we pay too
+    // much overhead cost for small row counts.
 
-    expectedSpillBatchSize = batchForRows(spillBatchRowCount);
+    spillBatchRowCount = Math.max(spillBatchRowCount, MIN_ROWS_PER_SORT_BATCH);
+
+    // Compute the actual spill batch size which may be larger or smaller
+    // than the preferred size depending on the row width.
+
+    spillBatchSize.setFromData(spillBatchRowCount * estimatedRowWidth);
 
     // Determine the minimum memory needed for spilling. Spilling is done just
     // before accepting a spill batch, so we must spill if we don't have room for a
     // (worst case) input batch. To spill, we need room for the spill batch created
-    // by merging the batches already in memory.
+    // by merging the batches already in memory. This is a memory calculation,
+    // so use the buffer size for the spill batch.
 
-    bufferMemoryLimit = memoryLimit - expectedSpillBatchSize;
+    bufferMemoryLimit = memoryLimit - 2 * spillBatchSize.maxBufferSize;
   }
 
   /**
@@ -238,13 +412,21 @@ public class SortMemoryManager {
   private void updateMergeSettings() {
 
     mergeBatchRowCount = rowsPerBatch(preferredMergeBatchSize);
-    expectedMergeBatchSize = batchForRows(mergeBatchRowCount);
+
+    // But, don't allow merge batches to be too small; we pay too
+    // much overhead cost for small row counts.
+
+    mergeBatchRowCount = Math.max(mergeBatchRowCount, MIN_ROWS_PER_SORT_BATCH);
+
+    // Compute the actual merge batch size.
+
+    mergeBatchSize.setFromData(mergeBatchRowCount * estimatedRowWidth);
 
     // The merge memory pool assumes we can spill all input batches. The memory
     // available to hold spill batches for merging is total memory minus the
     // expected output batch size.
 
-    mergeMemoryLimit = memoryLimit - expectedMergeBatchSize;
+    mergeMemoryLimit = memoryLimit - mergeBatchSize.maxBufferSize;
   }
 
   /**
@@ -271,22 +453,27 @@ public class SortMemoryManager {
 
   private void adjustForLowMemory() {
 
-    long loadHeadroom = bufferMemoryLimit - 2 * estimatedInputSize;
-    long mergeHeadroom = mergeMemoryLimit - 2 * expectedSpillBatchSize;
-    if (loadHeadroom >= 0  &&  mergeHeadroom >= 0) {
-      return;
-    }
+    potentialOverflow = false;
+    performanceWarning = false;
 
-    lowMemorySpillBatchSize();
-    lowMemoryMergeBatchSize();
+    // Input batches are assumed to have typical fragmentation. Experience
+    // shows that spilled batches have close to the maximum fragmentation.
+
+    long loadHeadroom = bufferMemoryLimit - 2 * inputBatchSize.expectedBufferSize;
+    long mergeHeadroom = mergeMemoryLimit - 2 * spillBatchSize.maxBufferSize;
+    isLowMemory = (loadHeadroom < 0  |  mergeHeadroom < 0);
+    if (! isLowMemory) {
+      return; }
+
+    lowMemoryInternalBatchSizes();
 
     // Sanity check: if we've been given too little memory to make progress,
     // issue a warning but proceed anyway. Should only occur if something is
     // configured terribly wrong.
 
-    long minNeeds = 2 * estimatedInputSize + expectedSpillBatchSize;
+    long minNeeds = 2 * inputBatchSize.expectedBufferSize + spillBatchSize.maxBufferSize;
     if (minNeeds > memoryLimit) {
-      ExternalSortBatch.logger.warn("Potential memory overflow during load phase! " +
+      logger.warn("Potential memory overflow during load phase! " +
           "Minimum needed = {} bytes, actual available = {} bytes",
           minNeeds, memoryLimit);
       bufferMemoryLimit = 0;
@@ -295,13 +482,35 @@ public class SortMemoryManager {
 
     // Sanity check
 
-    minNeeds = 2 * expectedSpillBatchSize + expectedMergeBatchSize;
+    minNeeds = 2 * spillBatchSize.expectedBufferSize + mergeBatchSize.expectedBufferSize;
     if (minNeeds > memoryLimit) {
-      ExternalSortBatch.logger.warn("Potential memory overflow during merge phase! " +
+      logger.warn("Potential memory overflow during merge phase! " +
           "Minimum needed = {} bytes, actual available = {} bytes",
           minNeeds, memoryLimit);
       mergeMemoryLimit = 0;
       potentialOverflow = true;
+    }
+
+    // Performance warning
+
+    if (potentialOverflow) {
+      return;
+    }
+    if (spillBatchSize.dataSize < config.spillBatchSize()  &&
+        spillBatchRowCount < Character.MAX_VALUE) {
+      logger.warn("Potential performance degredation due to low memory. " +
+                  "Preferred spill batch size: {}, actual: {}, rows per batch: {}",
+                  config.spillBatchSize(), spillBatchSize.dataSize,
+                  spillBatchRowCount);
+      performanceWarning = true;
+    }
+    if (mergeBatchSize.dataSize < config.mergeBatchSize()  &&
+        mergeBatchRowCount < Character.MAX_VALUE) {
+      logger.warn("Potential performance degredation due to low memory. " +
+                  "Preferred merge batch size: {}, actual: {}, rows per batch: {}",
+                  config.mergeBatchSize(), mergeBatchSize.dataSize,
+                  mergeBatchRowCount);
+      performanceWarning = true;
     }
   }
 
@@ -312,52 +521,66 @@ public class SortMemoryManager {
    * one spill batch to make progress.
    */
 
-  private void lowMemorySpillBatchSize() {
+  private void lowMemoryInternalBatchSizes() {
 
     // The "expected" size is with power-of-two rounding in some vectors.
     // We later work backwards to the row count assuming average internal
     // fragmentation.
 
-    // Must hold two input batches. Use (most of) the rest for the spill batch.
+    // Must hold two input batches. Use half of the rest for the spill batch.
+    // In a really bad case, the number here may be negative. We'll fix
+    // it below.
 
-    expectedSpillBatchSize = (int) (memoryLimit - 2 * estimatedInputSize);
+    int spillBufferSize = (int) (memoryLimit - 2 * inputBatchSize.maxBufferSize) / 2;
 
     // But, in the merge phase, we need two spill batches and one output batch.
     // (Assume that the spill and merge are equal sizes.)
-    // Use 3/4 of memory for each batch (to allow power-of-two rounding:
 
-    expectedSpillBatchSize = (int) Math.min(expectedSpillBatchSize, memoryLimit/3);
+    spillBufferSize = (int) Math.min(spillBufferSize, memoryLimit/4);
 
-    // Never going to happen, but let's ensure we don't somehow create large batches.
+    // Compute the size from the buffer. Assume worst-case
+    // fragmentation (as is typical when reading from the spill file.)
 
-    expectedSpillBatchSize = Math.max(expectedSpillBatchSize, SortConfig.MIN_SPILL_BATCH_SIZE);
+    spillBatchSize.setFromWorstCaseBuffer(spillBufferSize);
 
     // Must hold at least one row to spill. That is, we can make progress if we
     // create spill files that consist of single-record batches.
 
-    expectedSpillBatchSize = Math.max(expectedSpillBatchSize, estimatedRowWidth);
+    int spillDataSize = Math.min(spillBatchSize.dataSize, config.spillBatchSize());
+    spillDataSize = Math.max(spillDataSize, estimatedRowWidth);
+    if (spillDataSize != spillBatchSize.dataSize) {
+      spillBatchSize.setFromData(spillDataSize);
+    }
 
     // Work out the spill batch count needed by the spill code. Allow room for
     // power-of-two rounding.
 
-    spillBatchRowCount = rowsPerBatch(expectedSpillBatchSize);
+    spillBatchRowCount = rowsPerBatch(spillBatchSize.dataSize);
 
     // Finally, figure out when we must spill.
 
-    bufferMemoryLimit = memoryLimit - expectedSpillBatchSize;
-  }
+    bufferMemoryLimit = memoryLimit - 2 * spillBatchSize.maxBufferSize;
+    bufferMemoryLimit = Math.max(bufferMemoryLimit, 0);
 
-  /**
-   * For merge batch, we must hold at least two spill batches and
-   * one output batch.
-   */
+    // Assume two spill batches must be merged (plus safety margin.)
+    // The rest can be give to the merge batch.
 
-  private void lowMemoryMergeBatchSize() {
-    expectedMergeBatchSize = (int) (memoryLimit - 2 * expectedSpillBatchSize);
-    expectedMergeBatchSize = Math.max(expectedMergeBatchSize, SortConfig.MIN_MERGE_BATCH_SIZE);
-    expectedMergeBatchSize = Math.max(expectedMergeBatchSize, estimatedRowWidth);
-    mergeBatchRowCount = rowsPerBatch(expectedMergeBatchSize);
-    mergeMemoryLimit = memoryLimit - expectedMergeBatchSize;
+    long mergeBufferSize = memoryLimit - 2 * spillBatchSize.maxBufferSize;
+
+    // The above calcs assume that the merge batch size is the same as
+    // the spill batch size (the division by three.)
+    // For merge batch, we must hold at least two spill batches and
+    // one output batch, which is why we assumed 3 spill batches.
+
+    mergeBatchSize.setFromBuffer((int) mergeBufferSize);
+    int mergeDataSize = Math.min(mergeBatchSize.dataSize, config.mergeBatchSize());
+    mergeDataSize = Math.max(mergeDataSize, estimatedRowWidth);
+    if (mergeDataSize != mergeBatchSize.dataSize) {
+      mergeBatchSize.setFromData(spillDataSize);
+    }
+
+    mergeBatchRowCount = rowsPerBatch(mergeBatchSize.dataSize);
+    mergeMemoryLimit = Math.max(2 * spillBatchSize.expectedBufferSize, memoryLimit - mergeBatchSize.maxBufferSize);
   }
 
   /**
@@ -367,14 +590,34 @@ public class SortMemoryManager {
 
   private void logSettings(int actualRecordCount) {
 
-    ExternalSortBatch.logger.debug("Input Batch Estimates: record size = {} bytes; input batch = {} bytes, {} records",
-                 estimatedRowWidth, estimatedInputBatchSize, actualRecordCount);
-    ExternalSortBatch.logger.debug("Merge batch size = {} bytes, {} records; spill file size: {} bytes",
-                 expectedSpillBatchSize, spillBatchRowCount, config.spillFileSize());
-    ExternalSortBatch.logger.debug("Output batch size = {} bytes, {} records",
-                 expectedMergeBatchSize, mergeBatchRowCount);
-    ExternalSortBatch.logger.debug("Available memory: {}, buffer memory = {}, merge memory = {}",
+    logger.debug("Input Batch Estimates: record size = {} bytes; net = {} bytes, gross = {}, records = {}",
+                 estimatedRowWidth, inputBatchSize.dataSize,
+                 inputBatchSize.expectedBufferSize, actualRecordCount);
+    logger.debug("Spill batch size: net = {} bytes, gross = {} bytes, records = {}; spill file = {} bytes",
+                 spillBatchSize.dataSize, spillBatchSize.expectedBufferSize,
+                 spillBatchRowCount, config.spillFileSize());
+    logger.debug("Output batch size: net = {} bytes, gross = {} bytes, records = {}",
+                 mergeBatchSize.dataSize, mergeBatchSize.expectedBufferSize,
+                 mergeBatchRowCount);
+    logger.debug("Available memory: {}, buffer memory = {}, merge memory = {}",
                  memoryLimit, bufferMemoryLimit, mergeMemoryLimit);
+
+    // Performance warnings due to low row counts per batch.
+    // Low row counts cause excessive per-batch overhead and hurt
+    // performance.
+
+    if (spillBatchRowCount < MIN_ROWS_PER_SORT_BATCH) {
+      logger.warn("Potential performance degredation due to low memory or large input row. " +
+                  "Preferred spill batch row count: {}, actual: {}",
+                  MIN_ROWS_PER_SORT_BATCH, spillBatchRowCount);
+      performanceWarning = true;
+    }
+    if (mergeBatchRowCount < MIN_ROWS_PER_SORT_BATCH) {
+      logger.warn("Potential performance degredation due to low memory or large input row. " +
+                  "Preferred merge batch row count: {}, actual: {}",
+                  MIN_ROWS_PER_SORT_BATCH, mergeBatchRowCount);
+      performanceWarning = true;
+    }
   }
 
   public enum MergeAction { SPILL, MERGE, NONE }
@@ -389,86 +632,120 @@ public class SortMemoryManager {
     }
   }
 
+  /**
+   * Choose a consolidation option during the merge phase depending on memory
+   * available. Preference is given to moving directly onto merging (with no
+   * additional spilling) when possible. But, if memory pressures don't allow
+   * this, we must spill batches and/or merge on-disk spilled runs, to reduce
+   * the final set of runs to something that can be merged in the available
+   * memory.
+   * <p>
+   * Logic is here (returning an enum) rather than in the merge code to allow
+   * unit testing without actually needing batches in memory.
+   *
+   * @param allocMemory
+   *          amount of memory currently allocated (this class knows the total
+   *          memory available)
+   * @param inMemCount
+   *          number of incoming batches in memory (the number is important, not
+   *          the in-memory size; we get the memory size from
+   *          <tt>allocMemory</tt>)
+   * @param spilledRunsCount
+   *          the number of runs sitting on disk to be merged
+   * @return whether to <tt>SPILL</tt> in-memory batches, whether to
+   *         <tt>MERGE<tt> on-disk batches to create a new, larger run, or whether
+   *         to do nothing (<tt>NONE</tt>) and instead advance to the final merge
+   */
+
   public MergeTask consolidateBatches(long allocMemory, int inMemCount, int spilledRunsCount) {
+
+    assert allocMemory == 0 || inMemCount > 0;
+    assert inMemCount + spilledRunsCount > 0;
+
+    // If only one spilled run, then merging is not productive regardless
+    // of memory limits.
+
+    if (inMemCount == 0 && spilledRunsCount <= 1) {
+      return new MergeTask(MergeAction.NONE, 0);
+    }
+
+    // If memory is above the merge memory limit, then must spill
+    // merge to create room for a merge batch.
+
+    if (allocMemory > mergeMemoryLimit) {
+      return new MergeTask(MergeAction.SPILL, 0);
+    }
 
     // Determine additional memory needed to hold one batch from each
     // spilled run.
 
-    // If the on-disk batches and in-memory batches need more memory than
-    // is available, spill some in-memory batches.
+    // Maximum spill batches that fit into available memory.
 
-    if (inMemCount > 0) {
-      long mergeSize = spilledRunsCount * expectedSpillBatchSize;
-      if (allocMemory + mergeSize > mergeMemoryLimit) {
-        return new MergeTask(MergeAction.SPILL, 0);
-      }
+    int memMergeLimit = (int) ((mergeMemoryLimit - allocMemory) /
+                                spillBatchSize.expectedBufferSize);
+    memMergeLimit = Math.max(0, memMergeLimit);
+
+    // If batches are in memory, and we need more memory to merge
+    // them all than is actually available, then spill some in-memory
+    // batches.
+
+    if (inMemCount > 0  &&  memMergeLimit < spilledRunsCount) {
+      return new MergeTask(MergeAction.SPILL, 0);
     }
 
-    // Maximum batches that fit into available memory.
+    // If all batches fit in memory, then no need for a second-generation
+    // merge/spill.
 
-    int mergeLimit = (int) ((mergeMemoryLimit - allocMemory) / expectedSpillBatchSize);
-
-    // Can't merge more than the merge limit.
-
-    mergeLimit = Math.min(mergeLimit, config.mergeLimit());
-
-    // How many batches to merge?
-
-    int mergeCount = spilledRunsCount - mergeLimit;
-    if (mergeCount <= 0) {
+    memMergeLimit = Math.min(memMergeLimit, config.mergeLimit());
+    int mergeRunCount = spilledRunsCount - memMergeLimit;
+    if (mergeRunCount <= 0) {
       return new MergeTask(MergeAction.NONE, 0);
     }
 
-    // We will merge. This will create yet another spilled
-    // run. Account for that.
+    // We need a second generation load-merge-spill cycle
+    // to reduce the number of spilled runs to a smaller set
+    // that will fit in memory.
 
-    mergeCount += 1;
+    // Merging creates another batch. Include one more run
+    // in the merge to create space for the new run.
+
+    mergeRunCount += 1;
+
+    // Merge only as many batches as fit in memory.
+    // Use all memory for this process; no need to reserve space for a
+    // merge output batch. Assume worst case since we are forced to
+    // accept spilled batches blind: we can't limit reading based on memory
+    // limits. Subtract one to allow for the output spill batch.
+
+    memMergeLimit = (int)(memoryLimit / spillBatchSize.maxBufferSize) - 1;
+    mergeRunCount = Math.min(mergeRunCount, memMergeLimit);
 
     // Must merge at least 2 batches to make progress.
-    // This is the the (at least one) excess plus the allowance
-    // above for the new one.
+    // We know we have at least two because of the check done above.
 
-    // Can't merge more than the limit.
+    mergeRunCount = Math.max(mergeRunCount, 2);
 
-    mergeCount = Math.min(mergeCount, config.mergeLimit());
+    // Can't merge more than the merge limit.
 
-    // Do the merge, then loop to try again in case not
-    // all the target batches spilled in one go.
+    mergeRunCount = Math.min(mergeRunCount, config.mergeLimit());
 
-    return new MergeTask(MergeAction.MERGE, mergeCount);
+    return new MergeTask(MergeAction.MERGE, mergeRunCount);
   }
 
   /**
-   * Compute the number of rows per batch assuming that the batch is
-   * subject to average internal fragmentation due to power-of-two
-   * rounding on vectors.
-   * <p>
-   * <pre>[____|__$__]</pre>
-   * In the above, the brackets represent the whole vector. The
-   * first half is always full. When the first half filled, the second
-   * half was allocated. On average, the second half will be half full.
+   * Compute the number of rows that fit into a given batch data size.
    *
    * @param batchSize expected batch size, including internal fragmentation
    * @return number of rows that fit into the batch
    */
 
   private int rowsPerBatch(int batchSize) {
-    int rowCount = batchSize * 3 / 4 / estimatedRowWidth;
+    int rowCount = batchSize / estimatedRowWidth;
     return Math.max(1, Math.min(rowCount, Character.MAX_VALUE));
   }
 
-  /**
-   * Compute the expected number of rows that fit into a given size
-   * batch, accounting for internal fragmentation due to power-of-two
-   * rounding on vector allocations.
-   *
-   * @param rowCount the desired number of rows in the batch
-   * @return the size of resulting batch, including power-of-two
-   * rounding.
-   */
-
-  private int batchForRows(int rowCount) {
-    return estimatedRowWidth * rowCount * 4 / 3;
+  public static int multiply(int byteSize, double multiplier) {
+    return (int) Math.floor(byteSize * multiplier);
   }
 
   // Must spill if we are below the spill point (the amount of memory
@@ -497,17 +774,21 @@ public class SortMemoryManager {
   @VisibleForTesting
   public int getRowWidth() { return estimatedRowWidth; }
   @VisibleForTesting
-  public int getInputBatchSize() { return estimatedInputBatchSize; }
+  public BatchSizeEstimate getInputBatchSize() { return inputBatchSize; }
   @VisibleForTesting
   public int getPreferredSpillBatchSize() { return preferredSpillBatchSize; }
   @VisibleForTesting
   public int getPreferredMergeBatchSize() { return preferredMergeBatchSize; }
   @VisibleForTesting
-  public int getSpillBatchSize() { return expectedSpillBatchSize; }
+  public BatchSizeEstimate getSpillBatchSize() { return spillBatchSize; }
   @VisibleForTesting
-  public int getMergeBatchSize() { return expectedMergeBatchSize; }
+  public BatchSizeEstimate getMergeBatchSize() { return mergeBatchSize; }
   @VisibleForTesting
   public long getBufferMemoryLimit() { return bufferMemoryLimit; }
   @VisibleForTesting
   public boolean mayOverflow() { return potentialOverflow; }
+  @VisibleForTesting
+  public boolean isLowMemory() { return isLowMemory; }
+  @VisibleForTesting
+  public boolean hasPerformanceWarning() { return performanceWarning; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SorterWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SorterWrapper.java
@@ -83,10 +83,9 @@ public class SorterWrapper extends BaseSortWrapper {
     ClassGenerator<SingleBatchSorter> g = cg.getRoot();
     cg.plainJavaCapable(true);
     // Uncomment out this line to debug the generated code.
-  cg.saveCodeForDebugging(true);
+//    cg.saveCodeForDebugging(true);
 
     generateComparisons(g, batch, logger);
     return getInstance(cg, logger);
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SpilledRuns.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SpilledRuns.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.physical.impl.spill.SpillSet;
 import org.apache.drill.exec.physical.impl.xsort.managed.BatchGroup.SpilledRun;
 import org.apache.drill.exec.physical.impl.xsort.managed.SortImpl.SortResults;
 import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.VectorInitializer;
 import org.apache.drill.exec.record.VectorContainer;
 
 import com.google.common.collect.Lists;
@@ -86,13 +87,14 @@ public class SpilledRuns {
     return batchesToSpill;
   }
 
-  public void mergeAndSpill(List<BatchGroup> batchesToSpill, int spillBatchRowCount) {
-    spilledRuns.add(safeMergeAndSpill(batchesToSpill, spillBatchRowCount));
+  public void mergeAndSpill(List<BatchGroup> batchesToSpill, int spillBatchRowCount, VectorInitializer allocHelper) {
+    spilledRuns.add(safeMergeAndSpill(batchesToSpill, spillBatchRowCount, allocHelper));
     logger.trace("Completed spill: memory = {}",
         context.getAllocator().getAllocatedMemory());
   }
 
-  public void mergeRuns(int targetCount, long mergeMemoryPool, int spillBatchRowCount) {
+  public void mergeRuns(int targetCount, long mergeMemoryPool,
+                  int spillBatchRowCount, VectorInitializer allocHelper) {
 
     long allocated = context.getAllocator().getAllocatedMemory();
     mergeMemoryPool -= context.getAllocator().getAllocatedMemory();
@@ -128,12 +130,12 @@ public class SpilledRuns {
     // Do the actual spill.
 
     List<BatchGroup> batchesToSpill = prepareSpillBatches(spilledRuns, mergeCount);
-    mergeAndSpill(batchesToSpill, spillBatchRowCount);
+    mergeAndSpill(batchesToSpill, spillBatchRowCount, allocHelper);
   }
 
-  private BatchGroup.SpilledRun safeMergeAndSpill(List<? extends BatchGroup> batchesToSpill, int spillBatchRowCount) {
+  private BatchGroup.SpilledRun safeMergeAndSpill(List<? extends BatchGroup> batchesToSpill, int spillBatchRowCount, VectorInitializer allocHelper) {
     try {
-      return doMergeAndSpill(batchesToSpill, spillBatchRowCount);
+      return doMergeAndSpill(batchesToSpill, spillBatchRowCount, allocHelper);
     }
     // If error is a User Exception, just use as is.
 
@@ -145,7 +147,8 @@ public class SpilledRuns {
     }
   }
 
-  private BatchGroup.SpilledRun doMergeAndSpill(List<? extends BatchGroup> batchesToSpill, int spillBatchRowCount) throws Throwable {
+  private BatchGroup.SpilledRun doMergeAndSpill(List<? extends BatchGroup> batchesToSpill,
+                        int spillBatchRowCount, VectorInitializer allocHelper) throws Throwable {
 
     // Merge the selected set of matches and write them to the
     // spill file. After each write, we release the memory associated
@@ -155,7 +158,8 @@ public class SpilledRuns {
     BatchGroup.SpilledRun newGroup = null;
     VectorContainer dest = new VectorContainer();
     try (AutoCloseable ignored = AutoCloseables.all(batchesToSpill);
-         PriorityQueueCopierWrapper.BatchMerger merger = copierHolder.startMerge(schema, batchesToSpill, dest, spillBatchRowCount)) {
+         PriorityQueueCopierWrapper.BatchMerger merger = copierHolder.startMerge(schema, batchesToSpill,
+                                         dest, spillBatchRowCount, allocHelper)) {
       newGroup = new BatchGroup.SpilledRun(spillSet, outputFile, context.getAllocator());
       logger.trace("Spilling {} batches, into spill batches of {} rows, to {}",
           batchesToSpill.size(), spillBatchRowCount, outputFile);
@@ -175,9 +179,9 @@ public class SpilledRuns {
       }
       context.injectChecked(ExternalSortBatch.INTERRUPTION_WHILE_SPILLING, IOException.class);
       newGroup.closeOutputStream();
-      logger.trace("Spilled {} output batches, each of {} by bytes, {} records to {}",
-                   merger.getBatchCount(), merger.getRecordCount(),
-                   merger.getEstBatchSize(), outputFile);
+      logger.trace("Spilled {} output batches, each of {} bytes, {} records, to {}",
+                   merger.getBatchCount(), merger.getEstBatchSize(),
+                   spillBatchRowCount, outputFile);
       newGroup.setBatchSize(merger.getEstBatchSize());
       return newGroup;
     } catch (Throwable e) {
@@ -192,7 +196,8 @@ public class SpilledRuns {
     }
   }
 
-  public SortResults finalMerge(List<? extends BatchGroup> bufferedBatches, VectorContainer container, int mergeRowCount) {
+  public SortResults finalMerge(List<? extends BatchGroup> bufferedBatches,
+                    VectorContainer container, int mergeRowCount, VectorInitializer allocHelper) {
     List<BatchGroup> allBatches = new LinkedList<>();
     allBatches.addAll(bufferedBatches);
     bufferedBatches.clear();
@@ -200,7 +205,7 @@ public class SpilledRuns {
     spilledRuns.clear();
     logger.debug("Starting merge phase. Runs = {}, Alloc. memory = {}",
         allBatches.size(), context.getAllocator().getAllocatedMemory());
-    return copierHolder.startMerge(schema, allBatches, container, mergeRowCount);
+    return copierHolder.startMerge(schema, allBatches, container, mergeRowCount, allocHelper);
   }
 
   public void close() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -117,16 +117,18 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
         return IterOutcome.STOP;
       }
       next = b.next();
-    }finally{
+    } finally {
       stats.startProcessing();
     }
 
-    switch(next){
+    switch(next) {
     case OK_NEW_SCHEMA:
       stats.batchReceived(inputIndex, b.getRecordCount(), true);
       break;
     case OK:
       stats.batchReceived(inputIndex, b.getRecordCount(), false);
+      break;
+    default:
       break;
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -81,6 +81,7 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     }
   }
 
+  @SuppressWarnings("resource")
   @Override
   public VectorWrapper<?> getChildWrapper(int[] ids) {
     if (ids.length == 1) {
@@ -105,6 +106,7 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     return new HyperVectorWrapper<ValueVector>(vectors[0].getField(), vectors);
   }
 
+  @SuppressWarnings("resource")
   @Override
   public TypedFieldId getFieldIdIfMatches(int id, SchemaPath expectedPath) {
     ValueVector v = vectors[0];
@@ -112,7 +114,6 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public VectorWrapper<T> cloneAndTransfer(BufferAllocator allocator) {
     return new HyperVectorWrapper<T>(f, vectors, false);
 //    T[] newVectors = (T[]) Array.newInstance(vectors.getClass().getComponentType(), vectors.length);
@@ -128,12 +129,14 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     return new HyperVectorWrapper<T>(f, v, releasable);
   }
 
+  @SuppressWarnings("unchecked")
   public void addVector(ValueVector v) {
     Preconditions.checkArgument(v.getClass() == this.getVectorClass(), String.format("Cannot add vector type %s to hypervector type %s for field %s",
       v.getClass(), this.getVectorClass(), v.getField()));
     vectors = (T[]) ArrayUtils.add(vectors, v);// TODO optimize this so not copying every time
   }
 
+  @SuppressWarnings("unchecked")
   public void addVectors(ValueVector[] vv) {
     vectors = (T[]) ArrayUtils.add(vectors, vv);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,8 +19,6 @@ package org.apache.drill.exec.record;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.record.selection.SelectionVector2;
-import org.apache.drill.exec.record.selection.SelectionVector4;
 
 /**
  * A record batch contains a set of field values for a particular range of

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorInitializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorInitializer.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.record;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.drill.exec.vector.AllocationHelper;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.exec.vector.complex.RepeatedMapVector;
+
+/**
+ * Prototype mechanism to allocate vectors based on expected
+ * data sizes. This version uses a name-based map of fields
+ * to sizes. Better to represent the batch structurally and
+ * simply iterate over the schema rather than doing a per-field
+ * lookup. But, the mechanisms needed to do the efficient solution
+ * don't exist yet.
+ */
+
+public class VectorInitializer {
+
+  private static class AllocationHint {
+    public final int entryWidth;
+    public final int elementCount;
+
+    private AllocationHint(int width, int elements) {
+      entryWidth = width;
+      elementCount = elements;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder()
+          .append("{");
+      String sep = "";
+      if (entryWidth > 0) {
+        buf.append("width=")
+           .append(entryWidth);
+        sep = ", ";
+      }
+      if (elementCount > 0) {
+        buf.append(sep)
+           .append("elements=")
+           .append(elementCount);
+      }
+      buf.append("}");
+      return buf.toString();
+    }
+  }
+
+  private Map<String, AllocationHint> hints = new HashMap<>();
+
+  public void variableWidth(String name, int width) {
+    hints.put(name, new AllocationHint(width, 1));
+  }
+
+  public void fixedWidthArray(String name, int elements) {
+    hints.put(name, new AllocationHint(0, elements));
+  }
+
+  public void variableWidthArray(String name, int width, int elements) {
+    hints.put(name, new AllocationHint(width, elements));
+  }
+
+  public void allocateBatch(VectorAccessible va, int recordCount) {
+    for (VectorWrapper<?> w: va) {
+      allocateVector(w.getValueVector(), "", recordCount);
+    }
+  }
+
+  private void allocateVector(ValueVector vector, String prefix, int recordCount) {
+    String key = prefix + vector.getField().getName();
+    AllocationHint hint = hints.get(key);
+    if (vector instanceof AbstractMapVector) {
+      allocateMap((AbstractMapVector) vector, prefix, recordCount, hint);
+    } else {
+      allocateVector(vector, recordCount, hint);
+    }
+//    Set<BufferLedger> ledgers = new HashSet<>();
+//    vector.getLedgers(ledgers);
+//    int size = 0;
+//    for (BufferLedger ledger : ledgers) {
+//      size += ledger.getAccountedSize();
+//    }
+//    System.out.println(key + ": " + vector.getField().toString() +
+//        " " +
+//        ((hint == null) ? "no hint" : hint.toString()) +
+//        ", " + size);
+  }
+
+  private void allocateVector(ValueVector vector, int recordCount, AllocationHint hint) {
+    if (hint == null) {
+      // Use hard-coded values. Same as ScanBatch
+
+      AllocationHelper.allocate(vector, recordCount, 50, 10);
+    } else {
+      AllocationHelper.allocate(vector, recordCount, hint.entryWidth, hint.elementCount);
+    }
+  }
+
+  private void allocateMap(AbstractMapVector map, String prefix, int recordCount, AllocationHint hint) {
+    if (map instanceof RepeatedMapVector) {
+      ((RepeatedMapVector) map).allocateOffsetsNew(recordCount);
+      if (hint == null) {
+        recordCount *= 10;
+      } else {
+        recordCount *= hint.elementCount;
+      }
+    }
+    prefix += map.getField().getName() + ".";
+    for (ValueVector vector : map) {
+      allocateVector(vector, prefix, recordCount);
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder();
+    buf.append("[" + getClass().getSimpleName())
+       .append(" ");
+    boolean first = true;
+    for (Entry<String, AllocationHint>entry : hints.entrySet()) {
+      if (! first) {
+        buf.append(", ");
+      }
+      first = false;
+      buf.append("[")
+         .append(entry.getKey())
+         .append(" ")
+         .append(entry.getValue().toString())
+         .append("]");
+    }
+    buf.append("]");
+    return buf.toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -80,6 +80,7 @@ public class WritableBatch implements AutoCloseable {
         len += b.capacity();
       }
 
+      @SuppressWarnings("resource")
       DrillBuf newBuf = allocator.buffer(len);
       try {
         /* Copy data from each buffer into the compound buffer */
@@ -101,7 +102,9 @@ public class WritableBatch implements AutoCloseable {
 
         for (VectorWrapper<?> vv : container) {
           SerializedField fmd = fields.get(vectorIndex);
+          @SuppressWarnings("resource")
           ValueVector v = vv.getValueVector();
+          @SuppressWarnings("resource")
           DrillBuf bb = newBuf.slice(bufferOffset, fmd.getBufferLength());
 //        v.load(fmd, cbb.slice(bufferOffset, fmd.getBufferLength()));
           v.load(fmd, bb);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -293,6 +293,7 @@ public class Drillbit implements AutoCloseable {
     return start(config, null);
   }
 
+  @SuppressWarnings("resource")
   public static Drillbit start(final DrillConfig config, final RemoteServiceSet remoteServiceSet)
       throws DrillbitStartupException {
     logger.debug("Starting new Drillbit.");

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -239,8 +239,6 @@ drill.exec: {
     external: {
       // Drill uses the managed External Sort Batch by default.
       // Set this to true to use the legacy, unmanaged version.
-      // Disabled in the intial commit, to be enabled after
-      // tests are committed.
       disable_managed: true,
       // Limit on the number of batches buffered in memory.
       // Primarily for testing.
@@ -270,9 +268,9 @@ drill.exec: {
         directories:  ${drill.exec.spill.directories},
         // Size of the batches written to, and read from, the spill files.
         // Determines the ratio of memory to input data size for a single-
-        // generation sort. Smaller values give larger ratios, but at a
-        // (high) cost of much greater disk seek times.
-        spill_batch_size = 8M,
+        // generation sort. Smaller values are better, but too small
+        // incurs per-batch overhead.
+        spill_batch_size = 1M,
         // Preferred file size for "first-generation" spill files.
         // Set large enough to get long, continuous writes, but not so
         // large as to overwhelm a temp directory.
@@ -280,7 +278,8 @@ drill.exec: {
         file_size: 256M,
         // Size of the batch sent downstream from the sort operator during
         // the merge phase. Don't change this unless you know what you are doing,
-        // larger sizes can result in memory fragmentation.
+        // larger sizes can result in memory fragmentation, smaller sizes
+        // in excessive operator iterator overhead.
         merge_batch_size = 16M
       }
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.List;
 
 public class TestUnionAll extends BaseTestQuery{
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestUnionAll.class);
 
   private static final String sliceTargetSmall = "alter session set `planner.slice_target` = 1";
   private static final String sliceTargetDefault = "alter session reset `planner.slice_target`";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
@@ -17,9 +17,6 @@
  */
 package org.apache.drill.exec.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -119,8 +116,6 @@ public class TestBatchSerialization extends DrillTest {
    */
   private void verifySerialize(SingleRowSet rowSet, SingleRowSet expected) throws IOException {
 
-    long origSize = rowSet.size();
-
     File dir = OperatorFixture.getTempDir("serial");
     File outFile = new File(dir, "serialze.dat");
     try (OutputStream out = new BufferedOutputStream(new FileOutputStream(outFile))) {
@@ -135,7 +130,6 @@ public class TestBatchSerialization extends DrillTest {
           .read());
     }
 
-    assertTrue(origSize >= result.size());
     new RowSetComparison(expected)
       .verifyAndClearAll(result);
     outFile.delete();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
@@ -440,6 +440,11 @@ public class TestWindowFrame extends BaseTestQuery {
       .go();
   }
 
+  // Note: This test is unstable. It works when forcing the merge/sort batch
+  // size to 20, but not for other sizes. The problem is either that the results
+  // are not ordered (and so subject to sort instability), or there is some bug
+  // somewhere in the window functions.
+
   @Test
   public void test4657() throws Exception {
     testBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
@@ -35,14 +35,17 @@ import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.DrillTest;
 import org.apache.drill.test.FixtureBuilder;
+import org.apache.drill.test.SecondaryTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
+@Category(SecondaryTest.class)
 public class TestSimpleExternalSort extends DrillTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSimpleExternalSort.class);
 
-  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(80000);
+  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(80_000);
 
   @Test
   public void mergeSortWithSv2Managed() throws Exception {
@@ -100,7 +103,7 @@ public class TestSimpleExternalSort extends DrillTest {
          ClientFixture client = cluster.clientFixture()) {
       chooseImpl(client, testLegacy);
       List<QueryDataBatch> results = client.queryBuilder().physicalResource("xsort/one_key_sort_descending.json").results();
-      assertEquals(1000000, client.countResults(results));
+      assertEquals(1_000_000, client.countResults(results));
       validateResults(client.allocator(), results);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSortSpillWithException.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSortSpillWithException.java
@@ -64,8 +64,8 @@ public class TestSortSpillWithException extends ClusterTest {
     // inject exception in sort while spilling
     final String controls = Controls.newBuilder()
       .addExceptionOnBit(
-          org.apache.drill.exec.physical.impl.xsort.ExternalSortBatch.class,
-          org.apache.drill.exec.physical.impl.xsort.ExternalSortBatch.INTERRUPTION_WHILE_SPILLING,
+          ExternalSortBatch.class,
+          ExternalSortBatch.INTERRUPTION_WHILE_SPILLING,
           IOException.class,
           cluster.drillbit().getContext().getEndpoint())
       .build();
@@ -87,8 +87,8 @@ public class TestSortSpillWithException extends ClusterTest {
     // inject exception in sort while spilling
     final String controls = Controls.newBuilder()
       .addExceptionOnBit(
-          org.apache.drill.exec.physical.impl.xsort.managed.ExternalSortBatch.class,
-          org.apache.drill.exec.physical.impl.xsort.managed.ExternalSortBatch.INTERRUPTION_WHILE_SPILLING,
+          ExternalSortBatch.class,
+          ExternalSortBatch.INTERRUPTION_WHILE_SPILLING,
           IOException.class,
           cluster.drillbit().getContext().getEndpoint())
       .build();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
@@ -104,7 +104,7 @@ public class SortTestUtilities {
       VectorContainer dest = new VectorContainer();
       @SuppressWarnings("resource")
       BatchMerger merger = copier.startMerge(schema.toBatchSchema(SelectionVectorMode.NONE),
-                                             batches, dest, rowCount);
+                                             batches, dest, rowCount, null);
 
       verifyResults(merger, dest);
       dest.clear();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestCopier.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestCopier.java
@@ -69,8 +69,13 @@ public class TestCopier extends DrillTest {
     PriorityQueueCopierWrapper copier = SortTestUtilities.makeCopier(fixture, Ordering.ORDER_ASC, Ordering.NULLS_UNSPECIFIED);
     VectorContainer dest = new VectorContainer();
     try {
+      // TODO: Create a vector allocator to pass as last parameter so
+      // that the test uses the same vector allocator as the production
+      // code. Only nuisance is that we don't have the required metadata
+      // readily at hand here...
+
       @SuppressWarnings({ "resource", "unused" })
-      BatchMerger merger = copier.startMerge(schema, batches, dest, 10);
+      BatchMerger merger = copier.startMerge(schema, batches, dest, 10, null);
       fail();
     } catch (AssertionError e) {
       // Expected

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestExternalSortInternals.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestExternalSortInternals.java
@@ -47,12 +47,14 @@ public class TestExternalSortInternals extends DrillTest {
     assertEquals(Integer.MAX_VALUE, sortConfig.mergeLimit());
     // Default size: 256 MiB
     assertEquals(256 * ONE_MEG, sortConfig.spillFileSize());
-    // Default size: 8 MiB
-    assertEquals(8 * ONE_MEG, sortConfig.spillBatchSize());
+    // Default size: 1 MiB
+    assertEquals(ONE_MEG, sortConfig.spillBatchSize());
     // Default size: 16 MiB
     assertEquals(16 * ONE_MEG, sortConfig.mergeBatchSize());
     // Default: unlimited
     assertEquals(Integer.MAX_VALUE, sortConfig.getBufferedBatchLimit());
+    // Default: 64K
+    assertEquals(Character.MAX_VALUE, sortConfig.getMSortBatchSize());
   }
 
   /**
@@ -69,6 +71,7 @@ public class TestExternalSortInternals extends DrillTest {
         .put(ExecConstants.EXTERNAL_SORT_SPILL_BATCH_SIZE, 500_000)
         .put(ExecConstants.EXTERNAL_SORT_MERGE_BATCH_SIZE, 600_000)
         .put(ExecConstants.EXTERNAL_SORT_BATCH_LIMIT, 50)
+        .put(ExecConstants.EXTERNAL_SORT_MSORT_MAX_BATCHSIZE, 10)
         .build();
     SortConfig sortConfig = new SortConfig(drillConfig);
     assertEquals(2000 * 1024, sortConfig.maxMemory());
@@ -77,6 +80,7 @@ public class TestExternalSortInternals extends DrillTest {
     assertEquals(500_000, sortConfig.spillBatchSize());
     assertEquals(600_000, sortConfig.mergeBatchSize());
     assertEquals(50, sortConfig.getBufferedBatchLimit());
+    assertEquals(10, sortConfig.getMSortBatchSize());
   }
 
   /**
@@ -90,6 +94,7 @@ public class TestExternalSortInternals extends DrillTest {
         .put(ExecConstants.EXTERNAL_SORT_SPILL_BATCH_SIZE, SortConfig.MIN_SPILL_BATCH_SIZE - 1)
         .put(ExecConstants.EXTERNAL_SORT_MERGE_BATCH_SIZE, SortConfig.MIN_MERGE_BATCH_SIZE - 1)
         .put(ExecConstants.EXTERNAL_SORT_BATCH_LIMIT, 1)
+        .put(ExecConstants.EXTERNAL_SORT_MSORT_MAX_BATCHSIZE, 0)
         .build();
     SortConfig sortConfig = new SortConfig(drillConfig);
     assertEquals(SortConfig.MIN_MERGE_LIMIT, sortConfig.mergeLimit());
@@ -97,13 +102,14 @@ public class TestExternalSortInternals extends DrillTest {
     assertEquals(SortConfig.MIN_SPILL_BATCH_SIZE, sortConfig.spillBatchSize());
     assertEquals(SortConfig.MIN_MERGE_BATCH_SIZE, sortConfig.mergeBatchSize());
     assertEquals(2, sortConfig.getBufferedBatchLimit());
+    assertEquals(1, sortConfig.getMSortBatchSize());
   }
 
   @Test
   public void testMemoryManagerBasics() {
     DrillConfig drillConfig = DrillConfig.create();
     SortConfig sortConfig = new SortConfig(drillConfig);
-    long memoryLimit = 50 * ONE_MEG;
+    long memoryLimit = 70 * ONE_MEG;
     SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
 
     // Basic setup
@@ -120,35 +126,35 @@ public class TestExternalSortInternals extends DrillTest {
     int rowCount = 10000;
     int batchSize = rowWidth * rowCount * 2;
 
-    memManager.updateEstimates(batchSize, rowWidth, rowCount);
+    assertTrue(memManager.updateEstimates(batchSize, rowWidth, rowCount));
     verifyCalcs(sortConfig, memoryLimit, memManager, batchSize, rowWidth, rowCount);
 
     // Zero rows - no update
 
-    memManager.updateEstimates(batchSize, rowWidth, 0);
+    assertFalse(memManager.updateEstimates(batchSize, rowWidth, 0));
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Larger batch size, update batch size
 
     rowCount = 20000;
     batchSize = rowWidth * rowCount * 2;
-    memManager.updateEstimates(batchSize, rowWidth, rowCount);
+    assertTrue(memManager.updateEstimates(batchSize, rowWidth, rowCount));
     verifyCalcs(sortConfig, memoryLimit, memManager, batchSize, rowWidth, rowCount);
 
     // Smaller batch size: no change
 
     rowCount = 5000;
     int lowBatchSize = rowWidth * rowCount * 2;
-    memManager.updateEstimates(lowBatchSize, rowWidth, rowCount);
+    assertFalse(memManager.updateEstimates(lowBatchSize, rowWidth, rowCount));
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Different batch density, update batch size
 
     rowCount = 10000;
     batchSize = rowWidth * rowCount * 5;
-    memManager.updateEstimates(batchSize, rowWidth, rowCount);
+    assertTrue(memManager.updateEstimates(batchSize, rowWidth, rowCount));
     verifyCalcs(sortConfig, memoryLimit, memManager, batchSize, rowWidth, rowCount);
 
     // Smaller row size, no update
@@ -156,23 +162,23 @@ public class TestExternalSortInternals extends DrillTest {
     int lowRowWidth = 200;
     rowCount = 10000;
     lowBatchSize = rowWidth * rowCount * 2;
-    memManager.updateEstimates(lowBatchSize, lowRowWidth, rowCount);
+    assertFalse(memManager.updateEstimates(lowBatchSize, lowRowWidth, rowCount));
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Larger row size, updates calcs
 
     rowWidth = 400;
     rowCount = 10000;
     lowBatchSize = rowWidth * rowCount * 2;
-    memManager.updateEstimates(lowBatchSize, rowWidth, rowCount);
+    assertTrue(memManager.updateEstimates(lowBatchSize, rowWidth, rowCount));
     verifyCalcs(sortConfig, memoryLimit, memManager, batchSize, rowWidth, rowCount);
 
     // EOF: very low density
 
-    memManager.updateEstimates(lowBatchSize, rowWidth, 5);
+    assertFalse(memManager.updateEstimates(lowBatchSize, rowWidth, 5));
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
   }
 
   private void verifyCalcs(SortConfig sortConfig, long memoryLimit, SortMemoryManager memManager, int batchSize,
@@ -183,7 +189,7 @@ public class TestExternalSortInternals extends DrillTest {
     // Row and batch sizes should be exact
 
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Spill sizes will be rounded, but within reason.
 
@@ -191,9 +197,9 @@ public class TestExternalSortInternals extends DrillTest {
     assertTrue(count >= memManager.getSpillBatchRowCount());
     assertTrue(count/2 <= memManager.getSpillBatchRowCount());
     int spillSize = memManager.getSpillBatchRowCount() * rowWidth;
-    assertTrue(spillSize <= memManager.getSpillBatchSize());
-    assertTrue(spillSize >= memManager.getSpillBatchSize()/2);
-    assertEquals(memoryLimit - memManager.getSpillBatchSize(), memManager.getBufferMemoryLimit());
+    assertTrue(spillSize <= memManager.getSpillBatchSize().dataSize);
+    assertTrue(spillSize >= memManager.getSpillBatchSize().dataSize/2);
+    assertTrue(memManager.getBufferMemoryLimit() <= memoryLimit - memManager.getSpillBatchSize().expectedBufferSize );
 
     // Merge sizes will also be rounded, within reason.
 
@@ -201,9 +207,9 @@ public class TestExternalSortInternals extends DrillTest {
     assertTrue(count >= memManager.getMergeBatchRowCount());
     assertTrue(count/2 <= memManager.getMergeBatchRowCount());
     int mergeSize = memManager.getMergeBatchRowCount() * rowWidth;
-    assertTrue(mergeSize <= memManager.getMergeBatchSize());
-    assertTrue(mergeSize >= memManager.getMergeBatchSize()/2);
-    assertEquals(memoryLimit - memManager.getMergeBatchSize(), memManager.getMergeMemoryLimit());
+    assertTrue(mergeSize <= memManager.getMergeBatchSize().dataSize);
+    assertTrue(mergeSize >= memManager.getMergeBatchSize().dataSize/2);
+    assertTrue(memManager.getMergeMemoryLimit() <= memoryLimit - memManager.getMergeBatchSize().expectedBufferSize);
   }
 
   @Test
@@ -220,7 +226,7 @@ public class TestExternalSortInternals extends DrillTest {
     int batchSize = rowCount * 2;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertEquals(10, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Truncate spill, merge batch row count
 
@@ -234,12 +240,12 @@ public class TestExternalSortInternals extends DrillTest {
 
     // Small, but non-zero, row
 
-    rowWidth = 20;
+    rowWidth = 10;
     rowCount = 10000;
     batchSize = rowWidth * rowCount;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
 
     // Truncate spill, merge batch row count
 
@@ -256,69 +262,89 @@ public class TestExternalSortInternals extends DrillTest {
   public void testLowMemory() {
     DrillConfig drillConfig = DrillConfig.create();
     SortConfig sortConfig = new SortConfig(drillConfig);
-    long memoryLimit = 10 * ONE_MEG;
+    int memoryLimit = 10 * ONE_MEG;
     SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
 
     // Tight squeeze, but can be made to work.
-    // Input batches are a quarter of memory.
+    // Input batch buffer size is a quarter of memory.
 
     int rowWidth = 1000;
-    int rowCount = (int) (memoryLimit / 4 / rowWidth);
-    int batchSize = rowCount * rowWidth;
+    int batchSize = SortMemoryManager.multiply(memoryLimit / 4, SortMemoryManager.PAYLOAD_FROM_BUFFER);
+    int rowCount = batchSize / rowWidth;
+    batchSize = rowCount * rowWidth;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
     assertFalse(memManager.mayOverflow());
+    assertTrue(memManager.hasPerformanceWarning());
 
     // Spill, merge batches should be constrained
 
-    int spillBatchSize = memManager.getSpillBatchSize();
+    int spillBatchSize = memManager.getSpillBatchSize().dataSize;
     assertTrue(spillBatchSize < memManager.getPreferredSpillBatchSize());
     assertTrue(spillBatchSize >= rowWidth);
     assertTrue(spillBatchSize <= memoryLimit / 3);
     assertTrue(spillBatchSize + 2 * batchSize <= memoryLimit);
     assertTrue(spillBatchSize / rowWidth >= memManager.getSpillBatchRowCount());
 
-    int mergeBatchSize = memManager.getMergeBatchSize();
+    int mergeBatchSize = memManager.getMergeBatchSize().dataSize;
     assertTrue(mergeBatchSize < memManager.getPreferredMergeBatchSize());
     assertTrue(mergeBatchSize >= rowWidth);
     assertTrue(mergeBatchSize + 2 * spillBatchSize <= memoryLimit);
     assertTrue(mergeBatchSize / rowWidth >= memManager.getMergeBatchRowCount());
 
-    // Should spill after just two batches
+    // Should spill after just two or three batches
 
-    assertFalse(memManager.isSpillNeeded(0, batchSize));
-    assertFalse(memManager.isSpillNeeded(batchSize, batchSize));
-    assertTrue(memManager.isSpillNeeded(2 * batchSize, batchSize));
+    int inputBufferSize = memManager.getInputBatchSize().expectedBufferSize;
+    assertFalse(memManager.isSpillNeeded(0, inputBufferSize));
+    assertFalse(memManager.isSpillNeeded(batchSize, inputBufferSize));
+    assertTrue(memManager.isSpillNeeded(3 * inputBufferSize, inputBufferSize));
+  }
+
+  @Test
+  public void testLowerMemory() {
+    DrillConfig drillConfig = DrillConfig.create();
+    SortConfig sortConfig = new SortConfig(drillConfig);
+    int memoryLimit = 10 * ONE_MEG;
+    SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
 
     // Tighter squeeze, but can be made to work.
     // Input batches are 3/8 of memory; two fill 3/4,
     // but small spill and merge batches allow progress.
 
-    rowWidth = 1000;
-    rowCount = (int) (memoryLimit * 3 / 8 / rowWidth);
+    int rowWidth = 1000;
+    int batchSize = SortMemoryManager.multiply(memoryLimit * 3 / 8, SortMemoryManager.PAYLOAD_FROM_BUFFER);
+    int rowCount = batchSize / rowWidth;
     batchSize = rowCount * rowWidth;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
     assertFalse(memManager.mayOverflow());
+    assertTrue(memManager.hasPerformanceWarning());
 
     // Spill, merge batches should be constrained
 
-    spillBatchSize = memManager.getSpillBatchSize();
+    int spillBatchSize = memManager.getSpillBatchSize().dataSize;
     assertTrue(spillBatchSize < memManager.getPreferredSpillBatchSize());
     assertTrue(spillBatchSize >= rowWidth);
     assertTrue(spillBatchSize <= memoryLimit / 3);
     assertTrue(spillBatchSize + 2 * batchSize <= memoryLimit);
-    assertTrue(memManager.getSpillBatchRowCount() > 1);
+    assertTrue(memManager.getSpillBatchRowCount() >= 1);
     assertTrue(spillBatchSize / rowWidth >= memManager.getSpillBatchRowCount());
 
-    mergeBatchSize = memManager.getMergeBatchSize();
+    int mergeBatchSize = memManager.getMergeBatchSize().dataSize;
     assertTrue(mergeBatchSize < memManager.getPreferredMergeBatchSize());
     assertTrue(mergeBatchSize >= rowWidth);
     assertTrue(mergeBatchSize + 2 * spillBatchSize <= memoryLimit);
     assertTrue(memManager.getMergeBatchRowCount() > 1);
     assertTrue(mergeBatchSize / rowWidth >= memManager.getMergeBatchRowCount());
+
+    // Should spill after just two batches
+
+    int inputBufferSize = memManager.getInputBatchSize().expectedBufferSize;
+    assertFalse(memManager.isSpillNeeded(0, inputBufferSize));
+    assertFalse(memManager.isSpillNeeded(batchSize, inputBufferSize));
+    assertTrue(memManager.isSpillNeeded(2 * inputBufferSize, inputBufferSize));
   }
 
   @Test
@@ -333,21 +359,22 @@ public class TestExternalSortInternals extends DrillTest {
     // Have to back off the exact size a bit to allow for internal fragmentation
     // in the merge and output batches.
 
-    int rowWidth = (int) (memoryLimit / 3 * 0.75);
+    int rowWidth = (int) (memoryLimit / 3 / 2);
     int rowCount = 1;
     int batchSize = rowWidth;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertEquals(rowWidth, memManager.getRowWidth());
-    assertEquals(batchSize, memManager.getInputBatchSize());
+    assertEquals(batchSize, memManager.getInputBatchSize().dataSize);
     assertFalse(memManager.mayOverflow());
+    assertTrue(memManager.hasPerformanceWarning());
 
-    int spillBatchSize = memManager.getSpillBatchSize();
+    int spillBatchSize = memManager.getSpillBatchSize().dataSize;
     assertTrue(spillBatchSize >= rowWidth);
     assertTrue(spillBatchSize <= memoryLimit / 3);
     assertTrue(spillBatchSize + 2 * batchSize <= memoryLimit);
     assertEquals(1, memManager.getSpillBatchRowCount());
 
-    int mergeBatchSize = memManager.getMergeBatchSize();
+    int mergeBatchSize = memManager.getMergeBatchSize().dataSize;
     assertTrue(mergeBatchSize >= rowWidth);
     assertTrue(mergeBatchSize + 2 * spillBatchSize <= memoryLimit);
     assertEquals(1, memManager.getMergeBatchRowCount());
@@ -357,12 +384,26 @@ public class TestExternalSortInternals extends DrillTest {
     assertFalse(memManager.isSpillNeeded(0, batchSize));
     assertFalse(memManager.isSpillNeeded(batchSize, batchSize));
     assertTrue(memManager.isSpillNeeded(2 * batchSize, batchSize));
+  }
 
-    // In trouble now, can't fit even three rows.
+  @Test
+  public void testMemoryOverflow() {
+    DrillConfig drillConfig = DrillConfig.create();
+    SortConfig sortConfig = new SortConfig(drillConfig);
+    long memoryLimit = 10 * ONE_MEG;
+    SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
 
-    rowWidth = (int) (memoryLimit / 2);
-    rowCount = 1;
-    batchSize = rowWidth;
+    // In trouble now, can't fit even two input batches.
+    // A better implementation would spill the first batch to a file,
+    // leave it open, and append the second batch. Slicing each big input
+    // batch into small spill batches will allow the sort to proceed as
+    // long as it can hold a single input batch and single merge batch. But,
+    // the current implementation requires all batches to be spilled are in
+    // memory at the same time...
+
+    int rowWidth = (int) (memoryLimit / 2);
+    int rowCount = 1;
+    int batchSize = rowWidth;
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
     assertTrue(memManager.mayOverflow());
   }
@@ -406,7 +447,7 @@ public class TestExternalSortInternals extends DrillTest {
 
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
 
-    int spillBatchSize = memManager.getSpillBatchSize();
+    int spillBatchSize = memManager.getSpillBatchSize().dataSize;
 
     // Test various memory fill levels
 
@@ -432,63 +473,67 @@ public class TestExternalSortInternals extends DrillTest {
         .build();
     SortConfig sortConfig = new SortConfig(drillConfig);
     // Allow four spill batches, 8 MB each, plus one output of 16
-    long memoryLimit = 50 * ONE_MEG;
+    // Allow for internal fragmentation
+    // 96 > (4 * 8 + 16) * 2
+    long memoryLimit = 96 * ONE_MEG;
     SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
 
-    // Prime the estimates
+    // Prime the estimates. Batch size is data size, not buffer size.
 
     int rowWidth = 300;
     int rowCount = 10000;
     int batchSize = rowWidth * rowCount * 2;
 
     memManager.updateEstimates(batchSize, rowWidth, rowCount);
-    int spillBatchSize = memManager.getSpillBatchSize();
-    int mergeBatchSize = memManager.getMergeBatchSize();
+    assertFalse(memManager.isLowMemory());
+    int spillBatchBufferSize = memManager.getSpillBatchSize().expectedBufferSize;
+    int inputBatchBufferSize = memManager.getInputBatchSize().expectedBufferSize;
 
     // One in-mem batch, no merging.
 
-    long allocMemory = memoryLimit - mergeBatchSize;
+    long allocMemory = inputBatchBufferSize;
     MergeTask task = memManager.consolidateBatches(allocMemory, 1, 0);
     assertEquals(MergeAction.NONE, task.action);
 
     // Many in-mem batches, just enough to merge
 
-    allocMemory = memoryLimit - mergeBatchSize;
-    int memBatches = (int) (allocMemory / batchSize);
-    allocMemory = memBatches * batchSize;
+    int memBatches = (int) (memManager.getMergeMemoryLimit() / inputBatchBufferSize);
+    allocMemory = memBatches * inputBatchBufferSize;
     task = memManager.consolidateBatches(allocMemory, memBatches, 0);
     assertEquals(MergeAction.NONE, task.action);
 
     // Spills if no room for spill and in-memory batches
 
-    task = memManager.consolidateBatches(allocMemory, memBatches, 1);
+    int spillCount = (int) Math.ceil((memManager.getMergeMemoryLimit() - allocMemory) / (1.0 * spillBatchBufferSize));
+    assertTrue(spillCount >= 1);
+    task = memManager.consolidateBatches(allocMemory, memBatches, spillCount);
     assertEquals(MergeAction.SPILL, task.action);
 
     // One more in-mem batch: now needs to spill
 
     memBatches++;
-    allocMemory = memBatches * batchSize;
+    allocMemory = memBatches * inputBatchBufferSize;
     task = memManager.consolidateBatches(allocMemory, memBatches, 0);
     assertEquals(MergeAction.SPILL, task.action);
 
     // No spill for various in-mem/spill run combinations
 
-    allocMemory = memoryLimit - spillBatchSize - mergeBatchSize;
-    memBatches = (int) (allocMemory / batchSize);
-    allocMemory = memBatches * batchSize;
+    long freeMem = memManager.getMergeMemoryLimit() - spillBatchBufferSize;
+    memBatches = (int) (freeMem / inputBatchBufferSize);
+    allocMemory = memBatches * inputBatchBufferSize;
     task = memManager.consolidateBatches(allocMemory, memBatches, 1);
     assertEquals(MergeAction.NONE, task.action);
 
-    allocMemory = memoryLimit - 2 * spillBatchSize - mergeBatchSize;
-    memBatches = (int) (allocMemory / batchSize);
-    allocMemory = memBatches * batchSize;
+    freeMem = memManager.getMergeMemoryLimit() - 2 * spillBatchBufferSize;
+    memBatches = (int) (freeMem / inputBatchBufferSize);
+    allocMemory = memBatches * inputBatchBufferSize;
     task = memManager.consolidateBatches(allocMemory, memBatches, 2);
     assertEquals(MergeAction.NONE, task.action);
 
     // No spill if no in-memory, only spill, and spill fits
 
-    long freeMem = memoryLimit - mergeBatchSize;
-    int spillBatches = (int) (freeMem / spillBatchSize);
+    freeMem = memManager.getMergeMemoryLimit();
+    int spillBatches = (int) (freeMem / spillBatchBufferSize);
     task = memManager.consolidateBatches(0, 0, spillBatches);
     assertEquals(MergeAction.NONE, task.action);
 
@@ -503,6 +548,47 @@ public class TestExternalSortInternals extends DrillTest {
     task = memManager.consolidateBatches(0, 0, spillBatches + 2);
     assertEquals(MergeAction.MERGE, task.action);
     assertEquals(3, task.count);
+
+    // If only one spilled run, and no in-memory batches,
+    // skip merge.
+
+    task = memManager.consolidateBatches(0, 0, 1);
+    assertEquals(MergeAction.NONE, task.action);
+
+    // Very large number of spilled runs. Limit to what fits in memory.
+
+    task = memManager.consolidateBatches(0, 0, 1000);
+    assertEquals(MergeAction.MERGE, task.action);
+    assertTrue(task.count <= (int)(memoryLimit / spillBatchBufferSize) - 1);
+  }
+
+  @Test
+  public void testMergeCalcsExtreme() {
+
+    DrillConfig drillConfig = DrillConfig.create();
+    SortConfig sortConfig = new SortConfig(drillConfig);
+
+    // Force odd situation in which the spill batch is larger
+    // than memory. Won't actually run, but needed to test
+    // odd merge case.
+
+    long memoryLimit = ONE_MEG / 2;
+    SortMemoryManager memManager = new SortMemoryManager(sortConfig, memoryLimit);
+
+    // Prime the estimates. Batch size is data size, not buffer size.
+
+    int rowWidth = (int) memoryLimit;
+    int rowCount = 1;
+    int batchSize = rowWidth;
+
+    memManager.updateEstimates(batchSize, rowWidth, rowCount);
+    assertTrue(memManager.getMergeMemoryLimit() < rowWidth);
+
+    // Only one spill batch, that batch is above the merge memory limit,
+    // but nothing useful comes from merging.
+
+    MergeTask task = memManager.consolidateBatches(0, 0, 1);
+    assertEquals(MergeAction.NONE, task.action);
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSortImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSortImpl.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.ops.OperExecContext;
 import org.apache.drill.exec.physical.config.Sort;
 import org.apache.drill.exec.physical.impl.spill.SpillSet;
 import org.apache.drill.exec.physical.impl.xsort.managed.SortImpl.SortResults;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.record.BatchSchema;
@@ -90,8 +91,15 @@ public class TestSortImpl extends DrillTest {
           .setQueryId(queryId)
           .build();
     SortConfig sortConfig = new SortConfig(opContext.getConfig());
+    DrillbitEndpoint ep = DrillbitEndpoint.newBuilder()
+        .setAddress("foo.bar.com")
+        .setUserPort(1234)
+        .setControlPort(1235)
+        .setDataPort(1236)
+        .setVersion("1.11")
+        .build();
     SpillSet spillSet = new SpillSet(opContext.getConfig(), handle,
-                                     popConfig);
+                                     popConfig, ep);
     PriorityQueueCopierWrapper copierHolder = new PriorityQueueCopierWrapper(opContext);
     SpilledRuns spilledRuns = new SpilledRuns(opContext, spillSet, copierHolder);
     return new SortImpl(opContext, sortConfig, spilledRuns, outputBatch);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -119,6 +119,7 @@ public class TestDrillbitResilience extends DrillTest {
     }
 
     try {
+      @SuppressWarnings("resource")
       final Drillbit drillbit = Drillbit.start(zkHelper.getConfig(), remoteServiceSet);
       drillbits.put(name, drillbit);
     } catch (final DrillbitStartupException e) {
@@ -132,6 +133,7 @@ public class TestDrillbitResilience extends DrillTest {
    * @param name name of the drillbit
    */
   private static void stopDrillbit(final String name) {
+    @SuppressWarnings("resource")
     final Drillbit drillbit = drillbits.get(name);
     if (drillbit == null) {
       throw new IllegalStateException("No Drillbit named \"" + name + "\" found");
@@ -168,8 +170,8 @@ public class TestDrillbitResilience extends DrillTest {
    * @param name name of the drillbit
    * @return endpoint of the drillbit
    */
+  @SuppressWarnings("resource")
   private static DrillbitEndpoint getEndpoint(final String name) {
-    @SuppressWarnings("resource")
     final Drillbit drillbit = drillbits.get(name);
     if (drillbit == null) {
       throw new IllegalStateException("No Drillbit named \"" + name + "\" found.");
@@ -508,9 +510,11 @@ public class TestDrillbitResilience extends DrillTest {
   }
 
   /**
-   * Given the result of {@link WaitUntilCompleteListener#waitForCompletion}, this method fails if the completed state
-   * is not as expected, or if an exception is thrown. The completed state could be COMPLETED or CANCELED. This state
-   * is set when {@link WaitUntilCompleteListener#queryCompleted} is called.
+   * Given the result of {@link WaitUntilCompleteListener#waitForCompletion},
+   * this method fails if the completed state is not as expected, or if an
+   * exception is thrown. The completed state could be COMPLETED or CANCELED.
+   * This state is set when {@link WaitUntilCompleteListener#queryCompleted} is
+   * called.
    */
   private static void assertStateCompleted(final Pair<QueryState, Exception> result, final QueryState expectedState) {
     final QueryState actualState = result.getFirst();
@@ -758,8 +762,8 @@ public class TestDrillbitResilience extends DrillTest {
   }
 
   /**
-   * Test cancelling query interrupts currently blocked FragmentExecutor threads waiting for some event to happen.
-   * Specifically tests cancelling fragment which has {@link MergingRecordBatch} blocked waiting for data.
+   * Test canceling query interrupts currently blocked FragmentExecutor threads waiting for some event to happen.
+   * Specifically tests canceling fragment which has {@link MergingRecordBatch} blocked waiting for data.
    */
   @Test
   @Repeat(count = NUM_RUNS)
@@ -776,8 +780,8 @@ public class TestDrillbitResilience extends DrillTest {
   }
 
   /**
-   * Test cancelling query interrupts currently blocked FragmentExecutor threads waiting for some event to happen.
-   * Specifically tests cancelling fragment which has {@link UnorderedReceiverBatch} blocked waiting for data.
+   * Test canceling query interrupts currently blocked FragmentExecutor threads waiting for some event to happen.
+   * Specifically tests canceling fragment which has {@link UnorderedReceiverBatch} blocked waiting for data.
    */
   @Test
   @Repeat(count = NUM_RUNS)
@@ -931,7 +935,13 @@ public class TestDrillbitResilience extends DrillTest {
 
   @Test // DRILL-3065
   public void failsAfterMSorterSorting() {
-    final String query = "select n_name from cp.`tpch/nation.parquet` order by n_name";
+
+    // Note: must use an input table that returns more than one
+    // batch. The sort uses an optimization for single-batch inputs
+    // which bypasses the code where this partiucular fault is
+    // injected.
+
+    final String query = "select n_name from cp.`tpch/lineitem.parquet` order by n_name";
     final Class<? extends Exception> typeOfException = RuntimeException.class;
 
     final long before = countAllocatedMemory();
@@ -946,7 +956,13 @@ public class TestDrillbitResilience extends DrillTest {
 
   @Test // DRILL-3085
   public void failsAfterMSorterSetup() {
-    final String query = "select n_name from cp.`tpch/nation.parquet` order by n_name";
+
+    // Note: must use an input table that returns more than one
+    // batch. The sort uses an optimization for single-batch inputs
+    // which bypasses the code where this partiucular fault is
+    // injected.
+
+    final String query = "select n_name from cp.`tpch/lineitem.parquet` order by n_name";
     final Class<? extends Exception> typeOfException = RuntimeException.class;
 
     final long before = countAllocatedMemory();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ProfileParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ProfileParser.java
@@ -545,7 +545,7 @@ public class ProfileParser {
 
       p = Pattern.compile("rowcount = ([\\d.E]+), cumulative cost = \\{([\\d.E]+) rows, ([\\d.E]+) cpu, ([\\d.E]+) io, ([\\d.E]+) network, ([\\d.E]+) memory\\}, id = (\\d+)");
       m = p.matcher(tail);
-      if (! m.matches()) {
+      if (! m.find()) {
         throw new IllegalStateException("Could not parse costs: " + tail);
       }
       estRows = Double.parseDouble(m.group(1));

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -17,6 +17,11 @@
  */
 package org.apache.drill.test;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -48,6 +53,7 @@ import org.apache.drill.exec.util.VectorUtil;
 import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.test.BufferingQueryEventListener.QueryEvent;
+import org.apache.drill.test.ClientFixture.StatementParser;
 import org.apache.drill.test.rowSet.DirectRowSet;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.RowSetReader;
@@ -228,6 +234,25 @@ public class QueryBuilder {
 
   public QueryBuilder sql(String query, Object... args) {
     return sql(String.format(query, args));
+  }
+
+  /**
+   * Parse a single SQL statement (with optional ending semi-colon) from
+   * the file provided.
+   * @param file the file containing exactly one SQL statement, with
+   * optional ending semi-colon
+   * @return this builder
+   */
+
+  public QueryBuilder sql(File file) throws FileNotFoundException, IOException {
+    try (BufferedReader in = new BufferedReader(new FileReader(file))) {
+      StatementParser parser = new StatementParser(in);
+      String sql = parser.parseNext();
+      if (sql == null) {
+        throw new IllegalArgumentException("No query found");
+      }
+      return sql(sql);
+    }
   }
 
   public QueryBuilder physical(String plan) {

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -81,7 +81,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     if (BaseAllocator.DEBUG) {
       historicalLog.recordEvent("create()");
     }
-
   }
 
   public DrillBuf reallocIfNeeded(final int size) {
@@ -184,15 +183,15 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   /**
    * Transfer the memory accounting ownership of this DrillBuf to another allocator. This will generate a new DrillBuf
    * that carries an association with the underlying memory of this DrillBuf. If this DrillBuf is connected to the
-   * owning BufferLedger of this memory, that memory ownership/accounting will be transferred to the taret allocator. If
+   * owning BufferLedger of this memory, that memory ownership/accounting will be transferred to the target allocator. If
    * this DrillBuf does not currently own the memory underlying it (and is only associated with it), this does not
    * transfer any ownership to the newly created DrillBuf.
-   *
+   * <p>
    * This operation has no impact on the reference count of this DrillBuf. The newly created DrillBuf with either have a
    * reference count of 1 (in the case that this is the first time this memory is being associated with the new
    * allocator) or the current value of the reference count for the other AllocationManager/BufferLedger combination in
    * the case that the provided allocator already had an association to this underlying memory.
-   *
+   * <p>
    * Transfers will always succeed, even if that puts the other allocator into an overlimit situation. This is possible
    * due to the fact that the original owning allocator may have allocated this memory out of a local reservation
    * whereas the target allocator may need to allocate new memory from a parent or RootAllocator. This operation is done
@@ -218,6 +217,13 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
+   * Visible only for memory allocation calculations.
+   *
+   * @return
+   */
+  public BufferLedger getLedger() { return ledger; }
+
+  /**
    * The outcome of a Transfer.
    */
   public class TransferResult {
@@ -236,7 +242,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
       this.allocationFit = allocationFit;
       this.buffer = buffer;
     }
-
   }
 
   @Override
@@ -269,9 +274,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
       throw new IllegalStateException(
           String.format("DrillBuf[%d] refCnt has gone negative. Buffer Info: %s", id, toVerboseString()));
     }
-
     return refCnt == 0;
-
   }
 
   @Override

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.memory.BaseAllocator.Verbosity;
 import org.apache.drill.exec.metrics.DrillMetrics;
 import org.apache.drill.exec.ops.BufferManager;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 /**
@@ -246,7 +247,6 @@ public class AllocationManager {
         owningLedger = target;
         return overlimit;
       }
-
     }
 
     /**
@@ -387,11 +387,10 @@ public class AllocationManager {
       }
 
       return buf;
-
     }
 
     /**
-     * What is the total size (in bytes) of memory underlying this ledger.
+     * The total size (in bytes) of memory underlying this ledger.
      *
      * @return Size in bytes
      */
@@ -400,7 +399,7 @@ public class AllocationManager {
     }
 
     /**
-     * How much memory is accounted for by this ledger. This is either getSize() if this is the owning ledger for the
+     * Amount of memory accounted for by this ledger. This is either getSize() if this is the owning ledger for the
      * memory or zero in the case that this is not the owning ledger associated with this memory.
      *
      * @return Amount of accounted(owned) memory associated with this ledger.
@@ -418,17 +417,17 @@ public class AllocationManager {
     /**
      * Package visible for debugging/verification only.
      */
-    UnsafeDirectLittleEndian getUnderlying() {
+    @VisibleForTesting
+    protected UnsafeDirectLittleEndian getUnderlying() {
       return underlying;
     }
 
     /**
      * Package visible for debugging/verification only.
      */
-    boolean isOwningLedger() {
+    @VisibleForTesting
+    protected boolean isOwningLedger() {
       return this == owningLedger;
     }
-
   }
-
 }

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -841,6 +841,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public void write(DrillBuf buf, OutputStream out) throws IOException {
+    assert(buf.readerIndex() == 0);
     write(buf, buf.readableBytes(), out);
   }
 

--- a/exec/vector/src/main/codegen/includes/vv_imports.ftl
+++ b/exec/vector/src/main/codegen/includes/vv_imports.ftl
@@ -43,12 +43,14 @@ import org.apache.drill.exec.vector.complex.writer.*;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.drill.exec.util.JsonStringArrayList;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
 
 import java.util.Arrays;
 import java.util.Random;
 import java.util.List;
+import java.util.Set;
 
 import java.io.Closeable;
 import java.io.InputStream;

--- a/exec/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -266,8 +266,8 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
   }
 
   @Override
-  public int getPayloadByteCount() {
-    return getAccessor().getValueCount() * VALUE_WIDTH;
+  public int getPayloadByteCount(int valueCount) {
+    return valueCount * ${type.width};
   }
 
   private class TransferImpl implements TransferPair{

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -15,12 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.util.DecimalUtility;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.NullableVectorDefinitionSetter;
 
 import java.lang.Override;
 import java.lang.UnsupportedOperationException;
+import java.util.Set;
 
 <@pp.dropOutputFile />
 <#list vv.types as type>
@@ -177,15 +179,16 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public int getAllocatedByteCount() {
-    return bits.getAllocatedByteCount() + values.getAllocatedByteCount();
+  public void collectLedgers(Set<BufferLedger> ledgers) {
+    bits.collectLedgers(ledgers);
+    values.collectLedgers(ledgers);
   }
 
   @Override
-  public int getPayloadByteCount() {
+  public int getPayloadByteCount(int valueCount) {
     // For nullable, we include all values, null or not, in computing
     // the value length.
-    return bits.getPayloadByteCount() + values.getPayloadByteCount();
+    return bits.getPayloadByteCount(valueCount) + values.getPayloadByteCount(valueCount);
   }
 
   <#if type.major == "VarLen">
@@ -225,7 +228,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   public void allocateNew(int valueCount) {
     try {
       values.allocateNew(valueCount);
-      bits.allocateNew(valueCount+1);
+      bits.allocateNew(valueCount);
     } catch(OutOfMemoryException e) {
       clear();
       throw e;

--- a/exec/vector/src/main/codegen/templates/UnionVector.java
+++ b/exec/vector/src/main/codegen/templates/UnionVector.java
@@ -29,9 +29,12 @@ package org.apache.drill.exec.vector.complex;
 
 <#include "/@includes/vv_imports.ftl" />
 import java.util.Iterator;
+import java.util.Set;
+
 import org.apache.drill.exec.vector.complex.impl.ComplexCopier;
 import org.apache.drill.exec.util.CallBack;
 import org.apache.drill.exec.expr.BasicTypeHelper;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 
 /*
  * This class is generated using freemarker and the ${.template_name} template.
@@ -203,19 +206,18 @@ public class UnionVector implements ValueVector {
   }
 
   @Override
-  public int getAllocatedByteCount() {
+  public void collectLedgers(Set<BufferLedger> ledgers) {
     // Most vectors are held inside the internal map.
 
-    int count = internalMap.getAllocatedByteCount();
+    internalMap.collectLedgers(ledgers);
     if (bit != null) {
-      count += bit.getAllocatedByteCount();
+      bit.collectLedgers(ledgers);
     }
-    return count;
   }
 
   @Override
-  public int getPayloadByteCount() {
-    return internalMap.getPayloadByteCount();
+  public int getPayloadByteCount(int valueCount) {
+    return internalMap.getPayloadByteCount(valueCount);
   }
 
   @Override

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -17,8 +17,10 @@
  */
 
 import java.lang.Override;
+import java.util.Set;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.BaseValueVector;
 import org.apache.drill.exec.vector.VariableWidthVector;
@@ -247,27 +249,26 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
   }
 
   @Override
-  public int getAllocatedByteCount() {
-    return offsetVector.getAllocatedByteCount() + super.getAllocatedByteCount();
+  public void collectLedgers(Set<BufferLedger> ledgers) {
+    offsetVector.collectLedgers(ledgers);
+    super.collectLedgers(ledgers);
   }
 
   @Override
-  public int getPayloadByteCount() {
-    UInt${type.width}Vector.Accessor a = offsetVector.getAccessor();
-    int count = a.getValueCount();
-    if (count == 0) {
+  public int getPayloadByteCount(int valueCount) {
+    if (valueCount == 0) {
       return 0;
-    } else {
-      // If 1 or more values, then the last value is set to
-      // the offset of the next value, which is the same as
-      // the length of existing values.
-      // In addition to the actual data bytes, we must also
-      // include the "overhead" bytes: the offset vector entries
-      // that accompany each column value. Thus, total payload
-      // size is consumed text bytes + consumed offset vector
-      // bytes.
-      return a.get(count-1) + offsetVector.getPayloadByteCount();
     }
+    // If 1 or more values, then the last value is set to
+    // the offset of the next value, which is the same as
+    // the length of existing values.
+    // In addition to the actual data bytes, we must also
+    // include the "overhead" bytes: the offset vector entries
+    // that accompany each column value. Thus, total payload
+    // size is consumed text bytes + consumed offset vector
+    // bytes.
+    return offsetVector.getAccessor().get(valueCount) +
+           offsetVector.getPayloadByteCount(valueCount);
   }
 
   private class TransferImpl implements TransferPair{
@@ -308,7 +309,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
     if (size > MAX_ALLOCATION_SIZE) {
       throw new OversizedAllocationException("Requested amount of memory is more than max allowed allocation size");
     }
-    allocationSizeInBytes = (int)size;
+    allocationSizeInBytes = (int) size;
     offsetVector.setInitialCapacity(valueCount + 1);
   }
 
@@ -385,7 +386,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
       throw new OversizedAllocationException("Unable to expand the buffer. Max allowed buffer size is reached.");
     }
 
-    logger.trace("Reallocating VarChar, new size {}",newAllocationSize);
+    logger.trace("Reallocating VarChar, new size {}", newAllocationSize);
     final DrillBuf newBuf = allocator.buffer((int)newAllocationSize);
     newBuf.setBytes(0, data, 0, data.capacity());
     data.release();

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/AllocationHelper.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/AllocationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,41 +21,42 @@ import org.apache.drill.exec.vector.complex.RepeatedFixedWidthVectorLike;
 import org.apache.drill.exec.vector.complex.RepeatedVariableWidthVectorLike;
 
 public class AllocationHelper {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AllocationHelper.class);
 
-  public static void allocate(ValueVector v, int valueCount, int bytesPerValue) {
-    allocate(v, valueCount, bytesPerValue, 5);
+  public static void allocate(ValueVector vector, int valueCount, int bytesPerValue) {
+    allocate(vector, valueCount, bytesPerValue, 5);
   }
 
-  public static void allocatePrecomputedChildCount(ValueVector v, int valueCount, int bytesPerValue, int childValCount){
-    if(v instanceof FixedWidthVector) {
-      ((FixedWidthVector) v).allocateNew(valueCount);
-    } else if (v instanceof VariableWidthVector) {
-      ((VariableWidthVector) v).allocateNew(valueCount * bytesPerValue, valueCount);
-    } else if(v instanceof RepeatedFixedWidthVectorLike) {
-      ((RepeatedFixedWidthVectorLike) v).allocateNew(valueCount, childValCount);
-    } else if(v instanceof RepeatedVariableWidthVectorLike) {
-      ((RepeatedVariableWidthVectorLike) v).allocateNew(childValCount * bytesPerValue, valueCount, childValCount);
+  public static void allocatePrecomputedChildCount(ValueVector vector, int valueCount, int bytesPerValue, int childValCount) {
+    if (vector instanceof FixedWidthVector) {
+      ((FixedWidthVector) vector).allocateNew(valueCount);
+    } else if (vector instanceof VariableWidthVector) {
+      ((VariableWidthVector) vector).allocateNew(valueCount * bytesPerValue, valueCount);
+    } else if (vector instanceof RepeatedFixedWidthVectorLike) {
+      ((RepeatedFixedWidthVectorLike) vector).allocateNew(valueCount, childValCount);
+    } else if (vector instanceof RepeatedVariableWidthVectorLike && childValCount > 0 && bytesPerValue > 0) {
+      // Assertion thrown if byte count is zero in the full allocateNew,
+      // so use default version instead.
+      ((RepeatedVariableWidthVectorLike) vector).allocateNew(childValCount * bytesPerValue, valueCount, childValCount);
     } else {
-      v.allocateNew();
+      vector.allocateNew();
     }
   }
 
-  public static void allocate(ValueVector v, int valueCount, int bytesPerValue, int repeatedPerTop){
-    allocatePrecomputedChildCount(v, valueCount, bytesPerValue, repeatedPerTop * valueCount);
+  public static void allocate(ValueVector vector, int valueCount, int bytesPerValue, int repeatedPerTop){
+    allocatePrecomputedChildCount(vector, valueCount, bytesPerValue, repeatedPerTop * valueCount);
   }
 
   /**
    * Allocates the exact amount if v is fixed width, otherwise falls back to dynamic allocation
-   * @param v value vector we are trying to allocate
+   * @param vector value vector we are trying to allocate
    * @param valueCount  size we are trying to allocate
    * @throws org.apache.drill.exec.memory.OutOfMemoryException if it can't allocate the memory
    */
-  public static void allocateNew(ValueVector v, int valueCount) {
-    if (v instanceof  FixedWidthVector) {
-      ((FixedWidthVector) v).allocateNew(valueCount);
+  public static void allocateNew(ValueVector vector, int valueCount) {
+    if (vector instanceof  FixedWidthVector) {
+      ((FixedWidthVector) vector).allocateNew(valueCount);
     } else {
-      v.allocateNew();
+      vector.allocateNew();
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BaseDataValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BaseDataValueVector.java
@@ -18,7 +18,11 @@
 package org.apache.drill.exec.vector;
 
 import io.netty.buffer.DrillBuf;
+
+import java.util.Set;
+
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.record.MaterializedField;
 
 
@@ -87,9 +91,6 @@ public abstract class BaseDataValueVector extends BaseValueVector {
   public void reset() {}
 
   @Override
-  public int getAllocatedByteCount() { return data.capacity(); }
-
-  @Override
   public void exchange(ValueVector other) {
     BaseDataValueVector target = (BaseDataValueVector) other;
     DrillBuf temp = data;
@@ -98,5 +99,12 @@ public abstract class BaseDataValueVector extends BaseValueVector {
     getReader().reset();
     getMutator().exchange(target.getMutator());
     // No state in an Accessor to reset
+  }
+
+  public void collectLedgers(Set<BufferLedger> ledgers) {
+    BufferLedger ledger = data.getLedger();
+    if (ledger != null) {
+      ledgers.add(ledger);
+    }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -528,8 +528,7 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
   }
 
   @Override
-  public int getPayloadByteCount() {
-    // One byte per value
-    return valueCount;
+  public int getPayloadByteCount(int valueCount) {
+    return getSizeFromCount(valueCount);
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
@@ -22,9 +22,11 @@ import io.netty.buffer.DrillBuf;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.drill.exec.expr.holders.ObjectHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
@@ -229,13 +231,10 @@ public class ObjectVector extends BaseValueVector {
   }
 
   @Override
-  public int getAllocatedByteCount() {
-    // Values not stored in direct memory?
-    return 0;
-  }
+  public void collectLedgers(Set<BufferLedger> ledgers) {}
 
   @Override
-  public int getPayloadByteCount() {
+  public int getPayloadByteCount(int valueCount) {
     // Values not stored in direct memory?
     return 0;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -18,10 +18,12 @@
 package org.apache.drill.exec.vector;
 
 import java.io.Closeable;
+import java.util.Set;
 
 import io.netty.buffer.DrillBuf;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
 import org.apache.drill.exec.record.MaterializedField;
@@ -204,16 +206,19 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   void copyEntry(int toIndex, ValueVector from, int fromIndex);
 
   /**
-   * Return the total memory consumed by all buffers within this vector.
+   * Add the ledgers underlying the buffers underlying the components of the
+   * vector to the set provided. Used to determine actual memory allocation.
+   *
+   * @param ledgers set of ledgers to which to add ledgers for this vector
    */
 
-  int getAllocatedByteCount();
+  void collectLedgers(Set<BufferLedger> ledgers);
 
   /**
    * Return the number of value bytes consumed by actual data.
    */
 
-  int getPayloadByteCount();
+  int getPayloadByteCount(int valueCount);
 
   /**
    * Exchange state with another value vector of the same type.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -18,11 +18,13 @@
 package org.apache.drill.exec.vector;
 
 import java.util.Iterator;
+import java.util.Set;
 
 import com.google.common.collect.Iterators;
 import io.netty.buffer.DrillBuf;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
@@ -158,11 +160,10 @@ public class ZeroVector implements ValueVector {
   public void copyEntry(int toIndex, ValueVector from, int fromIndex) { }
 
   @Override
-  public int getAllocatedByteCount() { return 0; }
-
-  @Override
-  public int getPayloadByteCount() { return 0; }
-
-  @Override
   public void exchange(ValueVector other) { }
+
+  public void collectLedgers(Set<BufferLedger> ledgers) {}
+
+  @Override
+  public int getPayloadByteCount(int valueCount) { return 0; }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
@@ -22,11 +22,13 @@ import io.netty.buffer.DrillBuf;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.drill.common.collections.MapWithOrdinal;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.expr.BasicTypeHelper;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.util.CallBack;
 import org.apache.drill.exec.vector.ValueVector;
@@ -117,6 +119,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    *
    * @return resultant {@link org.apache.drill.exec.vector.ValueVector}
    */
+  @SuppressWarnings("unchecked")
   @Override
   public <T extends ValueVector> T addOrGet(String name, TypeProtos.MajorType type, Class<T> clazz) {
     final ValueVector existing = getChild(name);
@@ -277,21 +280,18 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
   }
 
   @Override
-  public int getAllocatedByteCount() {
-    int count = 0;
-
+  public void collectLedgers(Set<BufferLedger> ledgers) {
     for (final ValueVector v : vectors.values()) {
-      count += v.getAllocatedByteCount();
+      v.collectLedgers(ledgers);
     }
-    return count;
   }
 
   @Override
-  public int getPayloadByteCount() {
+  public int getPayloadByteCount(int valueCount) {
     int count = 0;
 
     for (final ValueVector v : vectors.values()) {
-      count += v.getPayloadByteCount();
+      count += v.getPayloadByteCount(valueCount);
     }
     return count;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -22,6 +22,7 @@ import io.netty.buffer.DrillBuf;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
@@ -41,6 +42,7 @@ import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.FieldWriter;
 
 import java.util.List;
+import java.util.Set;
 
 public class ListVector extends BaseRepeatedValueVector {
 
@@ -323,12 +325,15 @@ public class ListVector extends BaseRepeatedValueVector {
   }
 
   @Override
-  public int getAllocatedByteCount() {
-    return offsets.getAllocatedByteCount() + bits.getAllocatedByteCount() + super.getAllocatedByteCount();
+  public void collectLedgers(Set<BufferLedger> ledgers) {
+    offsets.collectLedgers(ledgers);
+    bits.collectLedgers(ledgers);
+    super.collectLedgers(ledgers);
   }
 
   @Override
-  public int getPayloadByteCount() {
-    return offsets.getPayloadByteCount() + bits.getPayloadByteCount() + super.getPayloadByteCount();
+  public int getPayloadByteCount(int valueCount) {
+    return offsets.getPayloadByteCount(valueCount) + bits.getPayloadByteCount(valueCount) +
+           super.getPayloadByteCount(valueCount);
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
@@ -23,6 +23,7 @@ import io.netty.buffer.DrillBuf;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -30,6 +31,7 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.expr.holders.ComplexHolder;
 import org.apache.drill.exec.expr.holders.RepeatedListHolder;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
 import org.apache.drill.exec.record.MaterializedField;
@@ -415,6 +417,7 @@ public class RepeatedListVector extends AbstractContainerVector
   public void allocateNew(int valueCount, int innerValueCount) {
     clear();
     getOffsetVector().allocateNew(valueCount + 1);
+    getOffsetVector().getMutator().setSafe(0, 0);
     getMutator().reset();
   }
 
@@ -435,14 +438,13 @@ public class RepeatedListVector extends AbstractContainerVector
     copyFromSafe(fromIndex, toIndex, (RepeatedListVector) from);
   }
 
-  @Override
-  public int getAllocatedByteCount() {
-    return delegate.getAllocatedByteCount();
+  public void collectLedgers(Set<BufferLedger> ledgers) {
+    delegate.collectLedgers(ledgers);
   }
 
   @Override
-  public int getPayloadByteCount() {
-    return delegate.getPayloadByteCount();
+  public int getPayloadByteCount(int valueCount) {
+    return delegate.getPayloadByteCount(valueCount);
   }
 
   @Override
@@ -450,5 +452,4 @@ public class RepeatedListVector extends AbstractContainerVector
     // TODO: Figure out how to test this scenario, then what to do...
     throw new UnsupportedOperationException("Exchange() not yet supported for repeated lists");
   }
-
 }


### PR DESCRIPTION
- DRILL-5513: Managed External Sort : OOM error during the merge phase
- DRILL-5519: Sort fails to spill and results in an OOM
- DRILL-5522: OOM during the merge and spill process of the managed external sort
- DRILL-5594: Excessive buffer reallocations during merge phase of external sort
- DRILL-5597: Incorrect "bits" vector allocation in nullable vectors allocateNew()
- DRILL-5602: Repeated List Vector fails to initialize the offset vector

All of the bugs have to do with handling low-memory conditions, and with correctly estimating the sizes of vectors, even when those vectors come from the spill file or from an exchange. Hence, the changes for all of the above issues are interrelated.

# Vector Sizing

Testing revealed that Drill has three different memory layouts for vectors:

* Buffer-per-vector as created by the scan operator.
* Buffer-per-batch as created by the exchange receiver.
* Buffer-per-top-level-vector as created when reading a spill file

As it turns out, each layout produces radically different memory allocations for the same data. In general, the buffer-per-vector is the most compact, followed by the buffer-per-top-vector, with the buffer-per-batch the most variable. The reason is simple: the larger the allocation, the larger the internal fragmentation due to unused average 25% of memory in the power-of-two rounded buffers.

The original record batch sizer computed batch size by summing vectors. This worked for the first case above, but was far off for the other two cases. The estimation error caused the sort to incorrectly predict memory needs and thus triggered OOM errors.

To solve this, the implementation no longer looks at vectors to infer size. Instead, it reaches down through layers of abstraction to the "ledgers" that Drill uses to track memory assignment. In the buffer-per-batch case, computing size by vector ignores the very large 25% of memory that is unused. On the other hand, when sizing by ledger, the sizer learns that all vectors are backed by the same ledger, and asks the ledger for its size.

Since vector sizes are not reliable, the portion of the sizer based on that size was deprecated. Instead, the sizer computes actual data size per column, and computes total size per batch. The previous "gross" vector size (which was the buffer size) was dropped in favor of the "net" size.

# Repeated Map Vector Offset Vector

Another memory estimation error occurred with repeated map vectors. Let us first consider non-repeated maps. A "map" in Drill is really a "struct": just a collection of columns that happen to have nested names. That is, Map "m" may have members "a" and "b", referenced as "m.a" and "m.b". But, the vectors for a and b are implemented the same a any top-level vector. As a result, map vectors have no size; they are just containers. The previous "sizer" ignored maps for this reason.

Repeated map vectors are different. Not only are they containers, they are also arrays, and thus have an offset vector. That offset vector must be considered when computing overall batch size. The sizer needs a place to hold the size information. So, the sizer was extended to store a “ColumnSize” instance even for maps. This instance holds the offset vector size for repeated maps.

# Vector Allocation

Drill provides (at least) two tools for allocating buffers for vectors. One is the plain “allocateNew()” method which allocates memory for 4096 entries. The “allocateNew(valueCount)” variant takes additional arguments (here, just value count) needed to determine buffer size. For fixed-width vectors, we need only row count. For Varchar vectors, we need row count and average column width. And so on.

If we use the “basic” method, we end up doubling the buffers multiple times. Assume we start with 4096 entries. If the output needs 64K records, we double buffers from 4K to 8K, 16K, 32K and eventually 64K, copying the data every time.

Worse, some vectors allocate very little memory on initial allocation, causing an extreme number of doublings.

Turning on vector logging during sort tests revealed a very large number of doublings. (As it turns out, Project has the same problem, but that is an exercise for later.)

The solution is to use the “allocateNew()” variant that takes the desired data size. We know the record count, but where do we get average Varchar size or average number of entires per repeated column?

The answer is: from the record batch sizer. So, this PR contains code to pull information from the sizer, organize it as needed to allocate vectors, then use the existing methods to do the allocation. The new “SmartAllocationHelper” class performs this task. It is “Smart” in contrast to the existing “AllocationHelper” which assumes column widths and array sizes.

The “SmartAllocationHelper” is organized around hints that can be associated with each column. For efficiency, these hints should be part of the column metadata. But, for now, to prove the concept, the hints are stored in a hash table indexed by column name. If this approach to vector sizing works, the class will evolve to combine schema and size information into a single column description object, perhaps shared with the record batch sizer.

Code changes require passing the “smart allocation helper” into the sort components that do vector allocation. These components are designed to be independently unit tested. To ease testing, components also allow the helper to be null, in which case they continue to allocate vectors the “old fashioned” way: perfectly fine for testing.

Because the allocation helper depends on observed column sizes, the helper is discarded and recreated each time a significant change occurs in incoming batch size.

# Data, Expected and Worst-Case Batch Sizes

The sort code contains a “memory manager” that plans sort operator memory use. As discussed above, the sort must handle three distinct batch layouts. This revealed the complexity of dealing with the internal fragmentation that comes from Drill’s power-of-two vector allocations.

As it turns out, we must consider three distinct sizes for the input batch, spill batch and the merge batch:

* The data size (which determines size on disk)
* The “expected” size (which assumes, on average, 25% internal fragmentation, used when estimating the total size of a collection of batches)
* The “worst” case size (which assumes 50% internal fragmentation, used when computing memory needs for the single, large, output batches)

Several tests happened to hit the worst-case size, pointing out the need for the three estimates.

Some rather complex code is needed to convert between the sizes depending on where we start.

* If we start with data size (from the record batch sizer, say), we have to expand the size to get the expected and worst-case size.
* If we start from a memory budget (space available for a merge batch, say), we have to shrink that memory estimate to get the data estimate.

Since the sort operates based on row counts, to go from a memory budget to a row count:

* Determine the memory budget
* Choose whether this represents an expected or worst case batch size
* Work backward to the data size, assuming internal fragmentation
* Divide the batch size by average row width to get the row count

Sometimes we have to take a round trip if we are in tight memory.

# Sort Memory Management

Efforts continue to refine the algorithms used to manage memory within the sort.

A problem seen in several tests is that the incoming batch is so large that we can’t keep two in memory as (thought to be) needed for spilling. The “isSpillNeeded” method was changed to long a message if this case occurs as this problem indicates an issue with the scan operator and/or too little memory provided to the sort. That is, it indicates a configuration issue, not a sort bug.

(The two-batch restriction is a bug: see DRILL-5635.)

# Low Memory Revisions

Several revisions were made to the code that handles low-memory situations to better reflect the various buffer layouts and worst-case buffer sizes. Basically, if memory is plentiful, spill and merge batch sizes are of fixed sizes to tune performance.

But, if memory is short, we have to reduce spill and output batch sizes to fit the memory available. (Alas, we cannot do anything about input batch sizes.) In this case, we have to work up from available memory to sizes, subject to a variety of constraints such as the need to put at least one record per batch, and so on.

This code is quite messy; it is hard to explain in the abstract other than as “come up with the best memory layout possible given the constraints provided.” See the code comments for details.

Additional logging was added for the various ways we can be short on memory:

* Records and/or input batches too large for available sort memory during loading
* Records and spill batches too large for available memory during merge

Since these conditions may lead to query failure, detailed logging was added to help diagnose memory-related issues so we can differentiate between those due to bugs and those due to an unhappy collision of low sort memory and large input batches (or rows.)

# Revised Merge Phase Planning

The merge phase occurs when spill files exist on disk, buffered batches occur in memory, and we must merge all of these to produce output batches. Output batches should be large due to Drill’s large per-batch overhead. (More rows per batch amortizes the per-batch cost over more rows.)

The existing merge phase calculations omitted certain obscure cases, such as having a single merge file, and anticipating the extra memory needed to conduct a spill. Again, the code is complex, so see the detailed comments.

# Sort Spill Batch Size

It finally dawned on the code author that there is no advantage at all to having large spill *batches*, though there is advantage to having large spill *files*. Spill batch size was greatly reduced from 8 MB to 1 MB, which helped with tests that torture the sort with very low memory allocations.

# Unit Tests

The sort code allows detailed unit tests. These tests were adjusted for changes made above. New cases were added as needed to reproduce additional issues found in system tests.

# Vector Size Methods

The “getPayloadByteCount” method was revised to take a value count. It turned out that using the value count from the mutator did not always work for deserialized vectors.

The “getAllocatedByteCount” method was removed; replaced with the “getLedgers” method to estimate actual memory allocations, as described earlier.

# Minor Changes

Some minor fixes include:

* Consider power-of-two rounding when estimating the size needed for the in-memory sort SV4.
* Log more detail for spilled batches.
* Pass the “SmartAllocationHelper” into sort components that do vector allocation.
* Moved the “EmptyResults” class within its SortImpl parent file to clean up the code a bit.
* The sort “cheats” a bit by giving itself a 10% memory allocation margin for rounding errors. Logged this adjustment to aid debugging.
* Random code and comment cleanup.
* Minor bug in the profile parser, used for tests, was fixed.