### PR TITLE
DRILL-5420: ParquetAsyncPgReader goes into infinite loop during cleanup

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/BatchReader.java
@@ -68,7 +68,9 @@ public abstract class BatchReader {
     ArrayList<Future<Long>> futures = Lists.newArrayList();
     for (ColumnReader<?> crs : readState.getColumnReaders()) {
       Future<Long> f = crs.processPagesAsync(recordsToRead);
-      futures.add(f);
+      if (f != null) {
+        futures.add(f);
+      }
     }
     Exception exception = null;
     for(Future<Long> f: futures){

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBinaryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBinaryReader.java
@@ -119,7 +119,9 @@ public class VarLenBinaryReader {
     ArrayList<Future<Integer>> futures = Lists.newArrayList();
     for (VarLengthColumn<?> columnReader : columns) {
       Future<Integer> f = columnReader.readRecordsAsync(columnReader.pageReader.valuesReadyToRead);
-      futures.add(f);
+      if (f != null) {
+        futures.add(f);
+      }
     }
     Exception exception = null;
     for(Future<Integer> f: futures){


### PR DESCRIPTION
PageQueue is cleaned up using poll() instead of take(), which constantly gets interrupted and causes CPU churn.
During a columnReader shutdown, a flag is set so as to block any new page reading tasks from being submitted, before the queues are finally cleared and memory occupied by the pages released.
More details are in this JIRA comment : https://issues.apache.org/jira/browse/DRILL-5420?focusedCommentId=16066933&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16066933