### PR TITLE
DRILL-4755: Fix IOBE for convert_from/convert_to functions with incorrect encoding type

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/PreProcessLogicalRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/PreProcessLogicalRel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,7 +28,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.exception.UnsupportedOperatorCollector;
 import org.apache.drill.exec.planner.StarColumnHelper;
-import org.apache.drill.exec.planner.sql.DrillCalciteSqlWrapper;
 import org.apache.drill.exec.planner.sql.DrillOperatorTable;
 import org.apache.drill.exec.planner.sql.parser.DrillCalciteWrapperUtility;
 import org.apache.drill.exec.util.ApproximateStringMatcher;
@@ -240,7 +239,7 @@ public class PreProcessLogicalRel extends RelShuttleImpl {
         ops.add(op.getName());
       }
       final String bestMatch = ApproximateStringMatcher.getBestMatch(ops, newFunctionName);
-      if (bestMatch != null && bestMatch.length() > 0 && bestMatch.toLowerCase().startsWith("convert")) {
+      if (bestMatch != null && bestMatch.length() > functionName.length() && bestMatch.toLowerCase().startsWith("convert")) {
         final StringBuilder s = new StringBuilder("Did you mean ")
                 .append(bestMatch.substring(functionName.length()))
                 .append("?");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillOperatorTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillOperatorTable.java
@@ -148,9 +148,9 @@ public class DrillOperatorTable extends SqlStdOperatorTable {
     final List<SqlOperator> sqlOperators = Lists.newArrayList();
     sqlOperators.addAll(calciteOperators);
     if(isInferenceEnabled()) {
-      sqlOperators.addAll(calciteOperators);
+      sqlOperators.addAll(drillOperatorsWithInference);
     } else {
-      sqlOperators.addAll(calciteOperators);
+      sqlOperators.addAll(drillOperatorsWithoutInference);
     }
 
     return sqlOperators;

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestExecutionExceptionsToClient.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestExecutionExceptionsToClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,7 @@ package org.apache.drill.jdbc.test;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -189,6 +190,27 @@ public class TestExecutionExceptionsToClient extends JdbcTestBase {
 
       assertThat("No expected current \"PLAN ERROR\"",
         e.getMessage(), startsWith("PLAN ERROR"));
+      throw e;
+    }
+  }
+
+  @Test(expected = SQLException.class)
+  public void testConvertFromError() throws Exception {
+    final Statement statement = connection.createStatement();
+    try {
+      statement.executeUpdate("select CONVERT_FROM('1','INTEGER') from (values(1))");
+    } catch (SQLException e) {
+      assertThat("Null getCause(); missing expected wrapped exception",
+        e.getCause(), notNullValue());
+
+      assertThat("Unexpectedly wrapped another SQLException",
+        e.getCause(), not(instanceOf(SQLException.class)));
+
+      assertThat("getCause() not UserRemoteException as expected",
+        e.getCause(), instanceOf(UserRemoteException.class));
+
+      assertTrue("No expected current \"UNSUPPORTED_OPERATION ERROR\" and/or \"Did you mean\"",
+        e.getMessage().matches("^UNSUPPORTED_OPERATION ERROR(.|\\n)*Did you mean(.|\\n)*"));
       throw e;
     }
   }


### PR DESCRIPTION
Please see the problem description in [DRILL-4755](https://issues.apache.org/jira/browse/DRILL-4755)