### PR TITLE
DRILL-5664: Enable security for Drill HiveStoragePlugin based on a co…

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePluginConfig.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveStoragePluginConfig.java
@@ -33,6 +33,8 @@ public class HiveStoragePluginConfig extends StoragePluginConfigBase {
 
   public static final String NAME = "hive";
 
+  public static final String HIVE_SECURITY_CONFIG = "hive.metastore.sasl.enabled";
+
   @JsonIgnore
   public Map<String, String> getHiveConfigOverride() {
     return configProps;
@@ -64,6 +66,42 @@ public class HiveStoragePluginConfig extends StoragePluginConfigBase {
     }
 
     return true;
+  }
+
+
+  @Override
+  public boolean enableSecurity() {
+    return compareAndUpdateSecurityConfig("true");
+  }
+
+  @Override
+  public boolean disableSecurity() {
+    return compareAndUpdateSecurityConfig("false");
+  }
+
+  /**
+   * Compare the newValue with current value of security setting for Hive Plugin
+   *
+   * @param newValue - new value for security setting.
+   * @return true - if modified
+   *         false - if not modified
+   */
+  public boolean compareAndUpdateSecurityConfig(String newValue) {
+
+    final String oldValue = configProps.get(HIVE_SECURITY_CONFIG).trim();
+
+    if (!(oldValue.equals(newValue))) {
+      configProps.put(HIVE_SECURITY_CONFIG, newValue);
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean isValidSecurityConfig(boolean enablePluginSecurity) {
+    final boolean securityConfig = Boolean.parseBoolean(configProps.get(HIVE_SECURITY_CONFIG).trim());
+    return securityConfig == enablePluginSecurity;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -144,6 +144,7 @@ public interface ExecConstants {
   String USER_ENCRYPTION_SASL_MAX_WRAPPED_SIZE = "drill.exec.security.user.encryption.sasl.max_wrapped_size";
   String BIT_ENCRYPTION_SASL_ENABLED = "drill.exec.security.bit.encryption.sasl.enabled";
   String BIT_ENCRYPTION_SASL_MAX_WRAPPED_SIZE = "drill.exec.security.bit.encryption.sasl.max_wrapped_size";
+  String SECURITY_STORAGE_PLUGIN_ENABLED = "drill.exec.security.storage_plugin.enabled";
 
   /** Size of JDBC batch queue (in batches) above which throttling begins. */
   String JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD =

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -155,6 +155,10 @@ drill.exec: {
     enabled: false,
     max_chained_user_hops: 3
   },
+
+  // Setting to control security for storage_plugins. For now this is only for Hive
+  security.storage_plugin.enabled: false,
+
   security.user.auth {
     enabled: false
   },

--- a/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/StoragePluginConfig.java
@@ -40,4 +40,40 @@ public abstract class StoragePluginConfig{
   @Override
   public abstract int hashCode();
 
+  /**
+   * Function to enable the security setting for storage plugin and return true/false
+   * based on any modification was done in config or not.
+   * @return - true - if there was any modification
+   *         - false - if no modification was done
+   */
+  public boolean enableSecurity() {
+    // no-op by default
+    return false;
+  }
+
+  /**
+   * Function to disable the security setting for storage plugin and return true/false
+   * based on any modification was done in config or not.
+   *
+   * @return - true - if there was any modification
+   *         - false - if no modification was done
+   */
+  public boolean disableSecurity() {
+    // no-op by default
+    return false;
+  }
+
+  /**
+   * Verify if security is enabled/disabled in StoragePluginConfig as compared to
+   * Drill config to enable/disable security of StoragePlugin
+   * @param enablePluginSecurity - flag to indicate if Drill is configured to enable security
+   *                             for StoragePlugins.
+   * @return true -  Plugin security config matches enablePluginSecurity. i.e. plugin security is enabled
+   *                 when enablePluginSecurity is true and disabled when enablePluginSecurity is false
+   *         false - Plugin security config doesn't matches enablePluginSecurity. Opposite of above case.
+   */
+  public boolean isValidSecurityConfig(boolean enablePluginSecurity) {
+    return true;
+  }
+
 }


### PR DESCRIPTION
…nfig parameter

         Change to enable/disable HiveStoragePlugin security configuration based on Drill's "security.storage_plugin.enabled" configuration. This will help to open secure channel between Drill's HiveClient and HiveMetastore