### PR TITLE
DRILL-5665: planner.force_2phase_aggr only overrides small inputs

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPruleBase.java
@@ -61,12 +61,11 @@ public abstract class AggPruleBase extends Prule {
   // currently won't generate a 2 phase plan.
   protected boolean create2PhasePlan(RelOptRuleCall call, DrillAggregateRel aggregate) {
     PlannerSettings settings = PrelUtil.getPlannerSettings(call.getPlanner());
-    if ( settings.isForce2phaseAggr() ) { // for testing - force 2 phase aggr
-      return true;
-    }
     RelNode child = call.rel(0).getInputs().get(0);
     boolean smallInput = child.getRows() < settings.getSliceTarget();
-    if (! settings.isMultiPhaseAggEnabled() || settings.isSingleMode() || smallInput) {
+    if (! settings.isMultiPhaseAggEnabled() || settings.isSingleMode() ||
+        // Can override a small child - e.g., for testing with a small table
+        ( smallInput && ! settings.isForce2phaseAggr() ) ) {
       return false;
     }
 


### PR DESCRIPTION
The planner option planner.force_2phase_aggr was created for testing, but may be used someday by a customer to allow spilling (currently single phase can not spill).
That option was implemented unconditionally, thus potentially violating other checks.

The code change is to only use this option to bypass a single check -- for small input tables.
  