### PR TITLE
DRILL-5663: Drillbit fails to start when only keystore path is provided without keystore password.

### DIFF
--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -214,7 +214,7 @@ drill.exec: {
 }
 
 # Below SSL parameters need to be set for custom transport layer settings.
-javax.net.ssl {
+ssl{
   keyStore: "/keystore.file",
   keyStorePassword: "ks_passwd",
   trustStore: "/truststore.file",

--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -93,6 +93,13 @@ drill.exec: {
       credentials: true
     }
   },
+  # Below SSL parameters need to be set for custom transport layer settings.
+  ssl{
+    keyStorePath: "/keystore.file",
+    keyStorePassword: "ks_passwd",
+    trustStorePath: "/truststore.file",
+    trustStorePassword: "ts_passwd"
+  },
   functions: ["org.apache.drill.expr.fn.impl"],
   network: {
     start: 35000
@@ -213,11 +220,5 @@ drill.exec: {
   default_temporary_workspace: "dfs.tmp"
 }
 
-# Below SSL parameters need to be set for custom transport layer settings.
-ssl{
-  keyStore: "/keystore.file",
-  keyStorePassword: "ks_passwd",
-  trustStore: "/truststore.file",
-  trustStorePassword: "ts_passwd"
-}
+
 

--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -94,7 +94,7 @@ drill.exec: {
     }
   },
   # Below SSL parameters need to be set for custom transport layer settings.
-  ssl{
+  ssl: {
     keyStorePath: "/keystore.file",
     keyStorePassword: "ks_passwd",
     trustStorePath: "/truststore.file",

--- a/distribution/src/resources/drill-override-example.conf
+++ b/distribution/src/resources/drill-override-example.conf
@@ -95,9 +95,13 @@ drill.exec: {
   },
   # Below SSL parameters need to be set for custom transport layer settings.
   ssl: {
+    #If not provided then the default value is java system property javax.net.ssl.keyStore value
     keyStorePath: "/keystore.file",
+    #If not provided then the default value is java system property javax.net.ssl.keyStorePassword value
     keyStorePassword: "ks_passwd",
+    #If not provided then the default value is java system property javax.net.ssl.trustStore value
     trustStorePath: "/truststore.file",
+    #If not provided then the default value is java system property javax.net.ssl.trustStorePassword value
     trustStorePassword: "ts_passwd"
   },
   functions: ["org.apache.drill.expr.fn.impl"],

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -122,10 +122,10 @@ public interface ExecConstants {
   String HTTP_SESSION_MEMORY_RESERVATION = "drill.exec.http.session.memory.reservation";
   String HTTP_SESSION_MEMORY_MAXIMUM = "drill.exec.http.session.memory.maximum";
   String HTTP_SESSION_MAX_IDLE_SECS = "drill.exec.http.session_max_idle_secs";
-  String HTTP_KEYSTORE_PATH = "javax.net.ssl.keyStore";
-  String HTTP_KEYSTORE_PASSWORD = "javax.net.ssl.keyStorePassword";
-  String HTTP_TRUSTSTORE_PATH = "javax.net.ssl.trustStore";
-  String HTTP_TRUSTSTORE_PASSWORD = "javax.net.ssl.trustStorePassword";
+  String HTTP_KEYSTORE_PATH = "ssl.keyStorePath";
+  String HTTP_KEYSTORE_PASSWORD = "ssl.keyStorePassword";
+  String HTTP_TRUSTSTORE_PATH = "ssl.trustStorePath";
+  String HTTP_TRUSTSTORE_PASSWORD = "ssl.trustStorePassword";
   String SYS_STORE_PROVIDER_CLASS = "drill.exec.sys.store.provider.class";
   String SYS_STORE_PROVIDER_LOCAL_PATH = "drill.exec.sys.store.provider.local.path";
   String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -122,10 +122,10 @@ public interface ExecConstants {
   String HTTP_SESSION_MEMORY_RESERVATION = "drill.exec.http.session.memory.reservation";
   String HTTP_SESSION_MEMORY_MAXIMUM = "drill.exec.http.session.memory.maximum";
   String HTTP_SESSION_MAX_IDLE_SECS = "drill.exec.http.session_max_idle_secs";
-  String HTTP_KEYSTORE_PATH = "ssl.keyStorePath";
-  String HTTP_KEYSTORE_PASSWORD = "ssl.keyStorePassword";
-  String HTTP_TRUSTSTORE_PATH = "ssl.trustStorePath";
-  String HTTP_TRUSTSTORE_PASSWORD = "ssl.trustStorePassword";
+  String HTTP_KEYSTORE_PATH = "drill.exec.ssl.keyStorePath";
+  String HTTP_KEYSTORE_PASSWORD = "drill.exec.ssl.keyStorePassword";
+  String HTTP_TRUSTSTORE_PATH = "drill.exec.ssl.trustStorePath";
+  String HTTP_TRUSTSTORE_PASSWORD = "drill.exec.ssl.trustStorePassword";
   String SYS_STORE_PROVIDER_CLASS = "drill.exec.sys.store.provider.class";
   String SYS_STORE_PROVIDER_LOCAL_PATH = "drill.exec.sys.store.provider.local.path";
   String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec;
+
+import com.typesafe.config.Config;
+import org.apache.drill.common.exceptions.DrillException;
+
+public class SSLConfig {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SSLConfig.class);
+
+  private final String keystorePath;
+
+  private final String keystorePassword;
+
+  private final String truststorePassword;
+
+  private final String truststorePath;
+
+  public boolean isValid = false;
+
+  public SSLConfig(Config config) throws DrillException {
+
+    keystorePath = config.getString(ExecConstants.HTTP_KEYSTORE_PATH).trim();
+
+    keystorePassword = config.getString(ExecConstants.HTTP_KEYSTORE_PASSWORD).trim();
+
+    truststorePath = config.getString(ExecConstants.HTTP_TRUSTSTORE_PATH).trim();
+
+    truststorePassword = config.getString(ExecConstants.HTTP_TRUSTSTORE_PASSWORD).trim();
+
+    /*If keystorePath or keystorePassword is provided in the configuration file use that*/
+    if (!keystorePath.isEmpty() || !keystorePassword.isEmpty()) {
+      if (keystorePath.isEmpty() || keystorePassword.isEmpty()) {
+        throw new DrillException(" *.ssl.keyStorePath and/or *.ssl.keyStorePassword in the configuration file can't be empty.");
+      }
+      isValid = true;
+    }
+  }
+
+  public String getkeystorePath() {
+    return keystorePath;
+  }
+
+  public String getkeystorePassword() {
+    return keystorePassword;
+  }
+
+  public String gettruststorePath() {
+    return truststorePath;
+  }
+
+  public String gettruststorePassword() {
+    return truststorePassword;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
@@ -21,17 +21,15 @@ import com.typesafe.config.Config;
 import org.apache.drill.common.exceptions.DrillException;
 
 public class SSLConfig {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SSLConfig.class);
 
   private final String keystorePath;
 
   private final String keystorePassword;
 
-  private final String truststorePassword;
-
   private final String truststorePath;
 
-  public boolean isValid = false;
+  private final String truststorePassword;
+
 
   public SSLConfig(Config config) throws DrillException {
 
@@ -45,26 +43,35 @@ public class SSLConfig {
 
     /*If keystorePath or keystorePassword is provided in the configuration file use that*/
     if (!keystorePath.isEmpty() || !keystorePassword.isEmpty()) {
-      if (keystorePath.isEmpty() || keystorePassword.isEmpty()) {
-        throw new DrillException(" *.ssl.keyStorePath and/or *.ssl.keyStorePassword in the configuration file can't be empty.");
+      if (keystorePath.isEmpty()) {
+        throw new DrillException(" *.ssl.keyStorePath in the configuration file is empty, but *.ssl.keyStorePassword is set");
       }
-      isValid = true;
+      else if (keystorePassword.isEmpty()){
+        throw new DrillException(" *.ssl.keyStorePassword in the configuration file is empty, but *.ssl.keyStorePath is set ");
+      }
+
     }
   }
 
-  public String getkeystorePath() {
+  public boolean isSslValid() { return !keystorePath.isEmpty() && !keystorePassword.isEmpty(); }
+
+  public String getKeyStorePath() {
     return keystorePath;
   }
 
-  public String getkeystorePassword() {
+  public String getKeyStorePassword() {
     return keystorePassword;
   }
 
-  public String gettruststorePath() {
+  public boolean hasTrustStorePath() { return !truststorePath.isEmpty(); }
+
+  public boolean hasTrustStorePassword() {return !truststorePassword.isEmpty(); }
+
+  public String getTrustStorePath() {
     return truststorePath;
   }
 
-  public String gettruststorePassword() {
+  public String getTrustStorePassword() {
     return truststorePassword;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/SSLConfig.java
@@ -53,25 +53,17 @@ public class SSLConfig {
     }
   }
 
-  public boolean isSslValid() { return !keystorePath.isEmpty() && !keystorePassword.isEmpty(); }
+  public boolean isSslValid() {  return !keystorePath.isEmpty() && !keystorePassword.isEmpty(); }
 
-  public String getKeyStorePath() {
-    return keystorePath;
-  }
+  public String getKeyStorePath() {  return keystorePath; }
 
-  public String getKeyStorePassword() {
-    return keystorePassword;
-  }
+  public String getKeyStorePassword() {  return keystorePassword; }
 
-  public boolean hasTrustStorePath() { return !truststorePath.isEmpty(); }
+  public boolean hasTrustStorePath() {  return !truststorePath.isEmpty(); }
 
-  public boolean hasTrustStorePassword() {return !truststorePassword.isEmpty(); }
+  public boolean hasTrustStorePassword() {  return !truststorePassword.isEmpty(); }
 
-  public String getTrustStorePath() {
-    return truststorePath;
-  }
+  public String getTrustStorePath() {  return truststorePath; }
 
-  public String getTrustStorePassword() {
-    return truststorePassword;
-  }
+  public String getTrustStorePassword() {  return truststorePassword; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -146,9 +146,8 @@ public class WebServer implements AutoCloseable {
         serverConnector = createHttpsConnector();
       }
       catch(DrillException e){
-        throw new DrillbitStartupException(e.getMessage(),e);
+        throw new DrillbitStartupException(e.getMessage(), e);
       }
-
     } else {
       serverConnector = createHttpConnector();
     }
@@ -273,7 +272,6 @@ public class WebServer implements AutoCloseable {
 
     final SslContextFactory sslContextFactory = new SslContextFactory();
     SSLConfig ssl = new SSLConfig(config);
-
     if(ssl.isSslValid()){
       logger.info("Using configured SSL settings for web server");
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -146,7 +146,7 @@ public class WebServer implements AutoCloseable {
         serverConnector = createHttpsConnector();
       }
       catch(DrillException e){
-        throw new DrillbitStartupException(e.getMessage(),e.getCause());
+        throw new DrillbitStartupException(e.getMessage(),e);
       }
 
     } else {
@@ -274,15 +274,15 @@ public class WebServer implements AutoCloseable {
     final SslContextFactory sslContextFactory = new SslContextFactory();
     SSLConfig ssl = new SSLConfig(config);
 
-    if(ssl.isValid){
+    if(ssl.isSslValid()){
       logger.info("Using configured SSL settings for web server");
 
-      sslContextFactory.setKeyStorePath(ssl.getkeystorePath());
-      sslContextFactory.setKeyStorePassword(ssl.getkeystorePassword());
-      if(!ssl.gettruststorePath().isEmpty()){
-        sslContextFactory.setTrustStorePath(ssl.gettruststorePath());
-        if(!ssl.gettruststorePassword().isEmpty()){
-          sslContextFactory.setTrustStorePassword(ssl.gettruststorePassword());
+      sslContextFactory.setKeyStorePath(ssl.getKeyStorePath());
+      sslContextFactory.setKeyStorePassword(ssl.getKeyStorePassword());
+      if(ssl.hasTrustStorePath()){
+        sslContextFactory.setTrustStorePath(ssl.getTrustStorePath());
+        if(ssl.hasTrustStorePassword()){
+          sslContextFactory.setTrustStorePassword(ssl.getTrustStorePassword());
         }
       }
     } else {
@@ -349,7 +349,6 @@ public class WebServer implements AutoCloseable {
     sslConnector.setPort(config.getInt(ExecConstants.HTTP_PORT));
 
     return sslConnector;
-
   }
 
   /**

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -51,15 +51,12 @@ drill.client: {
 // By default ${DRILL_TMP_DIR} is used if set or ${drill.tmp-dir} if it's been overridden.
 drill.tmp-dir: "/tmp"
 drill.tmp-dir: ${?DRILL_TMP_DIR}
-
-javax.net.ssl :
- {
- keyStore = "",
- keyStorePassword = "",
- trustStore = "",
- trustStorePassword = ""
- },
-
+javax.net.ssl: {
+  keyStore = "",
+  keyStorePassword = "",
+  trustStore = "",
+  trustStorePassword = ""
+},
 drill.exec: {
   cluster-id: "drillbits1"
   rpc: {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -338,3 +338,11 @@ drill.exec: {
 drill.jdbc: {
   batch_queue_throttling_threshold: 100
 }
+javax.net.ssl.keyStore = ""
+ssl.keyStorePath = ${?javax.net.ssl.keyStore}
+javax.net.ssl.keyStorePassword = ""
+ssl.keyStorePassword = ${?javax.net.ssl.keyStorePassword}
+javax.net.ssl.trustStore = ""
+ssl.trustStorePath = ${?javax.net.ssl.trustStore}
+javax.net.ssl.trustStorePassword = ""
+ssl.trustStorePassword =  ${?javax.net.ssl.trustStorePassword}

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -52,6 +52,14 @@ drill.client: {
 drill.tmp-dir: "/tmp"
 drill.tmp-dir: ${?DRILL_TMP_DIR}
 
+javax.net.ssl :
+ {
+ keyStore = "",
+ keyStorePassword = "",
+ trustStore = "",
+ trustStorePassword = ""
+ },
+
 drill.exec: {
   cluster-id: "drillbits1"
   rpc: {
@@ -133,6 +141,13 @@ drill.exec: {
             maximum: 9223372036854775807
         }
     }
+  },
+  //setting javax variables for ssl configurations is being deprecated.
+  ssl: {
+    keyStorePath = ${?javax.net.ssl.keyStore}
+    keyStorePassword = ${?javax.net.ssl.keyStorePassword}
+    trustStorePath = ${?javax.net.ssl.trustStore}
+    trustStorePassword =  ${?javax.net.ssl.trustStorePassword}
   },
   network: {
     start: 35000
@@ -338,11 +353,3 @@ drill.exec: {
 drill.jdbc: {
   batch_queue_throttling_threshold: 100
 }
-javax.net.ssl.keyStore = ""
-ssl.keyStorePath = ${?javax.net.ssl.keyStore}
-javax.net.ssl.keyStorePassword = ""
-ssl.keyStorePassword = ${?javax.net.ssl.keyStorePassword}
-javax.net.ssl.trustStore = ""
-ssl.trustStorePath = ${?javax.net.ssl.trustStore}
-javax.net.ssl.trustStorePassword = ""
-ssl.trustStorePassword =  ${?javax.net.ssl.trustStorePassword}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.DrillException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.SSLConfig;
+import org.apache.drill.test.OperatorFixture;
+import org.junit.Test;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestSSLConfig {
+
+
+  @Test
+  public void firstTest() throws Exception {
+
+    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "");
+    try (OperatorFixture fixture = builder.build()) {
+      DrillConfig config = fixture.config();
+      try {
+        SSLConfig sslv = new SSLConfig(config);
+        fail();
+      } catch (Exception e) {
+        assertTrue(e instanceof DrillException);
+      }
+    }
+  }
+
+  @Test
+  public void secondTest() throws Exception {
+
+    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "");
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
+    try (OperatorFixture fixture = builder.build()) {
+      DrillConfig config = fixture.config();
+      try {
+        SSLConfig sslv = new SSLConfig(config);
+        fail();
+      } catch (Exception e) {
+        assertTrue(e instanceof DrillException);
+      }
+    }
+  }
+
+  @Test
+  public void thirdTest() throws Exception {
+
+    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
+    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
+    try (OperatorFixture fixture = builder.build()) {
+      DrillConfig config = fixture.config();
+      SSLConfig sslv = new SSLConfig(config);
+      assertEquals("root", sslv.getkeystorePassword());
+      assertEquals("/root", sslv.getkeystorePath());
+    }
+  }
+}
+
+
+
+
+
+
+
+

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -18,11 +18,9 @@
 
 package org.apache.drill.exec;
 
-import org.apache.drill.common.config.DrillConfig;
+
 import org.apache.drill.common.exceptions.DrillException;
-import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.SSLConfig;
-import org.apache.drill.test.OperatorFixture;
+import org.apache.drill.test.ConfigBuilder;
 import org.junit.Test;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -30,53 +28,74 @@ import static org.junit.Assert.assertTrue;
 
 public class TestSSLConfig {
 
-
   @Test
-  public void firstTest() throws Exception {
+  public void testMissingKeystorePath() throws Exception {
 
-    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "");
-    try (OperatorFixture fixture = builder.build()) {
-      DrillConfig config = fixture.config();
-      try {
-        SSLConfig sslv = new SSLConfig(config);
-        fail();
-      } catch (Exception e) {
-        assertTrue(e instanceof DrillException);
-      }
+    ConfigBuilder config = new ConfigBuilder();
+    config.put(ExecConstants.HTTP_KEYSTORE_PATH, "");
+    config.put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
+    try {
+      SSLConfig sslv = new SSLConfig(config.build());
+      fail();
+      //Expected
+    } catch (Exception e) {
+      assertTrue(e instanceof DrillException);
     }
   }
 
   @Test
-  public void secondTest() throws Exception {
+  public void testMissingKeystorePassword() throws Exception {
 
-    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "");
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
-    try (OperatorFixture fixture = builder.build()) {
-      DrillConfig config = fixture.config();
-      try {
-        SSLConfig sslv = new SSLConfig(config);
-        fail();
-      } catch (Exception e) {
-        assertTrue(e instanceof DrillException);
-      }
+    ConfigBuilder config = new ConfigBuilder();
+    config.put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
+    config.put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "");
+    try {
+      SSLConfig sslv = new SSLConfig(config.build());
+      fail();
+      //Expected
+    } catch (Exception e) {
+      assertTrue(e instanceof DrillException);
     }
   }
 
   @Test
-  public void thirdTest() throws Exception {
+  public void testForKeystoreConfig() throws Exception {
 
-    OperatorFixture.OperatorFixtureBuilder builder = OperatorFixture.builder();
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
-    builder.configBuilder().put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
-    try (OperatorFixture fixture = builder.build()) {
-      DrillConfig config = fixture.config();
-      SSLConfig sslv = new SSLConfig(config);
-      assertEquals("root", sslv.getkeystorePassword());
-      assertEquals("/root", sslv.getkeystorePath());
+    ConfigBuilder config = new ConfigBuilder();
+    config.put(ExecConstants.HTTP_KEYSTORE_PATH, "/root");
+    config.put(ExecConstants.HTTP_KEYSTORE_PASSWORD, "root");
+    try {
+      SSLConfig sslv = new SSLConfig(config.build());
+      assertEquals("/root", sslv.getKeyStorePath());
+      assertEquals("root", sslv.getKeyStorePassword());
+    } catch (Exception e) {
+      fail();
+
     }
+  }
+
+  @Test
+  public void testForBackwardCompatability() throws Exception {
+
+    ConfigBuilder config = new ConfigBuilder();
+    config.put("javax.net.ssl.keyStore", "/root");
+    config.put("javax.net.ssl.keyStorePassword", "root");
+    SSLConfig sslv = new SSLConfig(config.build());
+    assertEquals("/root",sslv.getKeyStorePath());
+    assertEquals("root", sslv.getKeyStorePassword());
+  }
+
+  @Test
+  public void testForTrustStore() throws Exception {
+
+    ConfigBuilder config = new ConfigBuilder();
+    config.put(ExecConstants.HTTP_TRUSTSTORE_PATH, "/root");
+    config.put(ExecConstants.HTTP_TRUSTSTORE_PASSWORD, "root");
+    SSLConfig sslv = new SSLConfig(config.build());
+    assertEquals(true, sslv.hasTrustStorePath());
+    assertEquals(true,sslv.hasTrustStorePassword());
+    assertEquals("/root",sslv.getTrustStorePath());
+    assertEquals("root",sslv.getTrustStorePassword());
   }
 }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -98,11 +98,3 @@ public class TestSSLConfig {
     assertEquals("root",sslv.getTrustStorePassword());
   }
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
When we configure keystore path without keystore password inside drill-override.conf for WebServer, then Drillbit fails to start. We should explicitly check for either both being present or both being absent. If any one of them is only present then we should throw startup exception for Drill.
In the code change, added checks for both keystorepath and keystorepasword.