### PR TITLE
DRILL-5659: Fix error code checking in reading from socket

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -252,11 +252,13 @@ void DrillClientImpl::doWriteToSocket(const char* dataPtr, size_t bytesToWrite,
     while(1) {
         size_t bytesWritten = m_socket.write_some(boost::asio::buffer(dataPtr, bytesToWrite), errorCode);
 
+        if(errorCode && boost::asio::error::interrupted != errorCode){
+            break;
+        } 
+
         // Update the state
         bytesToWrite -= bytesWritten;
         dataPtr += bytesWritten;
-
-        if(EINTR != errorCode.value()) break;
 
         // Check if all the data is written then break from loop
         if(0 == bytesToWrite) break;
@@ -412,17 +414,22 @@ void DrillClientImpl::doReadFromSocket(ByteBuf_t inBuf, size_t bytesToRead,
         return;
     }
 
+    DRILL_MT_LOG(DRILL_LOG(LOG_TRACE) << "Socket read: reading " << bytesToRead << "data bytes" << std::endl;)
     // Read all the bytes. In case when all the bytes were not read the proper
     // errorCode will be set.
     while(1){
         size_t dataBytesRead = m_socket.read_some(boost::asio::buffer(inBuf, bytesToRead),
                                            errorCode);
+        // Check if errorCode is EINTR then just retry otherwise break from loop
+        if(errorCode && boost::asio::error::interrupted != errorCode){
+            break;
+        } 
+
+        DRILL_MT_LOG(DRILL_LOG(LOG_TRACE) << "Socket read: actual bytes read = " << dataBytesRead << std::endl;)
         // Update the state
         bytesToRead -= dataBytesRead;
         inBuf += dataBytesRead;
 
-        // Check if errorCode is EINTR then just retry otherwise break from loop
-        if(EINTR != errorCode.value()) break;
 
         // Check if all the data is read then break from loop
         if(0 == bytesToRead) break;


### PR DESCRIPTION
Check if errorcode is set before checking if the error code is EINTR. Also, check for error first thing after making the read_some or write_some calls.
This fixes the case when we read (or write) only a part of the data in a call to read from or write to the socket.
Tested for the issue on Mac/Centos. Not tested on Windows. Not tested for the case with SASL encryption.
