### PR TITLE
DRILL-5669: Add a configurable option for minimum memory allocation t…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -343,6 +343,15 @@ public interface ExecConstants {
       MAX_QUERY_MEMORY_PER_NODE_KEY, 1024 * 1024, Long.MAX_VALUE, 2 * 1024 * 1024 * 1024L);
 
   /**
+   * Minimum memory alocated to each buffered operator instance.
+   * <p/>
+   * DEFAULT: 40 MB
+   */
+  String MIN_MEMORY_PER_BUFFERED_OP_KEY = "planner.memory.min_memory_per_buffered_op";
+  LongValidator MIN_MEMORY_PER_BUFFERED_OP = new RangeLongValidator(
+      MIN_MEMORY_PER_BUFFERED_OP_KEY, 1024 * 1024, Long.MAX_VALUE, 40 * 1024 * 1024L);
+
+  /**
    * Extra query memory per node for non-blocking operators.
    * NOTE: This option is currently used only for memory estimation.
    * <p/>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -144,6 +144,7 @@ public class SystemOptionManager extends BaseOptionManager implements OptionMana
       ExecConstants.EARLY_LIMIT0_OPT,
       ExecConstants.ENABLE_MEMORY_ESTIMATION,
       ExecConstants.MAX_QUERY_MEMORY_PER_NODE,
+      ExecConstants.MIN_MEMORY_PER_BUFFERED_OP,
       ExecConstants.NON_BLOCKING_OPERATORS_MEMORY,
       ExecConstants.HASH_JOIN_TABLE_FACTOR,
       ExecConstants.HASH_AGG_TABLE_FACTOR,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/MemoryAllocationUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/MemoryAllocationUtilities.java
@@ -66,11 +66,15 @@ public class MemoryAllocationUtilities {
       final long maxOperatorAlloc = maxAllocPerNode / (bufferedOpList.size() * maxWidthPerNode);
       logger.debug("Max buffered operator alloc: {}", maxOperatorAlloc);
 
+      // User configurable option to allow forcing minimum memory.
+      // Ensure that the buffered ops receive the minimum memory needed to make progress.
+      // Without this, the math might work out to allocate too little memory.
+      final long opMinMem = queryContext.getOptions().getOption(ExecConstants.MIN_MEMORY_PER_BUFFERED_OP_KEY).num_val;
+
       for(final PhysicalOperator op : bufferedOpList) {
-        // Ensure that the sort receives the minimum memory needed to make progress.
-        // Without this, the math might work out to allocate too little memory.
 
         long alloc = Math.max(maxOperatorAlloc, op.getInitialAllocation());
+        alloc = Math.max(alloc, opMinMem);
         op.setMaxAllocation(alloc);
       }
     }


### PR DESCRIPTION
…o buffered ops

Added the option "planner.memory.min_memory_per_buffered_op" to enforce a minimum memory allocation to all buffered ops instances (i.e., External Sort or Hash Agg (either phase)).

Default value setting is 40 MB (to cover cases of a large incoming batch, while the query's memory divided among all buffered ops results in a small share per each).

There is a small risk of total allocation by default (i.e. 40MB * num-ops) may exceed the query's total memory; but this happens anyway with "uncontrolled" ops like hash join. 
