### PR TITLE
Fixed bug with java version detection

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -393,7 +393,7 @@ if [ ! -e "$JAVA" ]; then
 fi
 
 # Ensure that Java version is at least 1.7
-"$JAVA" -version 2>&1 | grep "version" | egrep -e "1.4|1.5|1.6" > /dev/null
+"$JAVA" -version 2>&1 | grep "version" | egrep -e "1\.4|1\.5|1\.6" > /dev/null
 if [ $? -eq 0 ]; then
   fatal_error "Java 1.7 or later is required to run Apache Drill."
 fi


### PR DESCRIPTION
e.g. `java version 1.8.0_144` was failing

![pobrane](https://user-images.githubusercontent.com/1618590/29026588-c900c3a0-7b7c-11e7-958a-0d72c9590844.png)
