### PR TITLE
DRILL-5737: Hash Agg uses more than the allocated memory under certai…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -106,6 +106,8 @@ public interface ExecConstants {
   LongValidator HASHAGG_MIN_BATCHES_PER_PARTITION_VALIDATOR = new RangeLongValidator(HASHAGG_MIN_BATCHES_PER_PARTITION_KEY, 2, 5);
   String HASHAGG_SPILL_DIRS = "drill.exec.hashagg.spill.directories";
   String HASHAGG_SPILL_FILESYSTEM = "drill.exec.hashagg.spill.fs";
+  String HASHAGG_FALLBACK_ENABLED_KEY = "drill.exec.hashagg.fallback.enabled";
+  BooleanValidator HASHAGG_FALLBACK_ENABLED_VALIDATOR = new BooleanValidator(HASHAGG_FALLBACK_ENABLED_KEY);
 
   String TEXT_LINE_READER_BATCH_SIZE = "drill.exec.storage.file.text.batch.size";
   String TEXT_LINE_READER_BUFFER_SIZE = "drill.exec.storage.file.text.buffer.size";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -118,6 +118,7 @@ public class SystemOptionManager extends BaseOptionManager implements OptionMana
       ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR,
       ExecConstants.HASHAGG_MAX_MEMORY_VALIDATOR,
       ExecConstants.HASHAGG_MIN_BATCHES_PER_PARTITION_VALIDATOR, // for tuning
+      ExecConstants.HASHAGG_FALLBACK_ENABLED_VALIDATOR, // for enable/disable unbounded HashAgg
       ExecConstants.CAST_TO_NULLABLE_NUMERIC_OPTION,
       ExecConstants.OUTPUT_FORMAT_VALIDATOR,
       ExecConstants.PARQUET_BLOCK_SIZE_VALIDATOR,

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -370,6 +370,12 @@ drill.exec.options:  {
     debug.validate_vectors :false,
     drill.exec.functions.cast_empty_string_to_null: false,
     drill.exec.hashagg.min_batches_per_partition : 3,
+    # Setting to control if HashAgg should fallback to older behavior of consuming
+    # unbounded memory. In case of 2 phase Agg when available memory is not enough
+    # to start at least 2 partitions then HashAgg fallbacks to this case. It can be
+    # enabled by setting this flag to true. By default it's set to false such that
+    # query will fail if there is not enough memory
+    drill.exec.hashagg.fallback.enabled: false,
     drill.exec.storage.file.partition.column.label: "dir",
     drill.exec.storage.implicit.filename.column.label: "filename",
     drill.exec.storage.implicit.filepath.column.label: "filepath",


### PR DESCRIPTION
…n low memory conditions

            Note: Provide a new config parameter HASHAGG_FALLBACK_ENABLED which is set to true by default. When 2 Phase
            HashAgg doesn't have enough memory to hold 2 partitions then based on this flag it either fallsback to old
            behavior of consuming unbounded memory or it fails the query.