### PR TITLE
DRILL-4286 Graceful shutdown of drillbit

### DIFF
--- a/distribution/src/resources/drillbit.sh
+++ b/distribution/src/resources/drillbit.sh
@@ -92,15 +92,18 @@ waitForProcessEnd()
 {
   pidKilled=$1
   commandName=$2
+  kill_drillbit=$3
   processedAt=`date +%s`
   origcnt=${DRILL_STOP_TIMEOUT:-120}
   while kill -0 $pidKilled > /dev/null 2>&1;
    do
      echo -n "."
      sleep 1;
-     # if process persists more than $DRILL_STOP_TIMEOUT (default 120 sec) no mercy
-     if [ $(( `date +%s` - $processedAt )) -gt $origcnt ]; then
-       break;
+     if [ "$kill_drillbit" = true ] ; then
+        # if process persists more than $DRILL_STOP_TIMEOUT (default 120 sec) no mercy
+        if [ $(( `date +%s` - $processedAt )) -gt $origcnt ]; then
+          break;
+        fi
      fi
   done
   echo
@@ -155,6 +158,7 @@ start_bit ( )
 
 stop_bit ( )
 {
+  kill_drillbit=$1
   if [ -f $pid ]; then
     pidToKill=`cat $pid`
     # kill -0 == see if the PID exists
@@ -162,7 +166,7 @@ stop_bit ( )
       echo "Stopping $command"
       echo "`date` Terminating $command pid $pidToKill" >> "$DRILLBIT_LOG_PATH"
       kill $pidToKill > /dev/null 2>&1
-      waitForProcessEnd $pidToKill $command
+      waitForProcessEnd $pidToKill $command $kill_drillbit
       retval=0
     else
       retval=$?
@@ -199,7 +203,18 @@ case $startStopStatus in
   ;;
 
 (stop)
-  stop_bit
+  kill_drillbit=true
+  stop_bit $kill_drillbit
+  exit $?
+  ;;
+
+# Shutdown the drillbit gracefully without disrupting the in-flight queries.
+# In this case, if there are any long running queries the drillbit will take a
+# little longer to shutdown. Incase if the user wishes to shutdown immediately
+# they can issue stop instead of graceful_stop.
+(graceful_stop)
+  kill_drillbit=false
+  stop_bit $kill_drillbit
   exit $?
   ;;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -590,4 +590,17 @@ public final class ExecConstants {
   public static String bootDefaultFor(String name) {
     return OPTION_DEFAULTS_ROOT + name;
 }
+  /**
+   * Boot-time config option provided to modify duration of the grace period.
+   * Grace period is the amount of time where the drillbit accepts work after
+   * the shutdown request is triggered. The primary use of grace period is to
+   * avoid the race conditions caused by zookeeper delay in updating the state
+   * information of the drillbit that is shutting down. So, it is advisable
+   * to have a grace period that is atleast twice the amount of zookeeper
+   * refresh time.
+   */
+  public static final String GRACE_PERIOD = "drill.exec.grace_period_ms";
+
+  public static final String DRILL_PORT_HUNT = "drill.exec.port_hunt";
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKClusterCoordinator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKClusterCoordinator.java
@@ -23,15 +23,16 @@ import static com.google.common.collect.Collections2.transform;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
+import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -54,6 +55,7 @@ import org.apache.drill.exec.coord.store.TransientStore;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
 import org.apache.drill.exec.coord.store.TransientStoreFactory;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State;
 
 import com.google.common.base.Function;
 
@@ -70,7 +72,10 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
   private final CountDownLatch initialConnection = new CountDownLatch(1);
   private final TransientStoreFactory factory;
   private ServiceCache<DrillbitEndpoint> serviceCache;
+  private DrillbitEndpoint endpoint;
 
+  // endpointsMap maps Multikey( comprises of endoint address and port) to Drillbit endpoints
+  private ConcurrentHashMap<MultiKey, DrillbitEndpoint> endpointsMap = new ConcurrentHashMap<MultiKey,DrillbitEndpoint>();
   private static final Pattern ZK_COMPLEX_STRING = Pattern.compile("(^.*?)/(.*)/([^/]*)$");
 
   public ZKClusterCoordinator(DrillConfig config) throws IOException{
@@ -169,9 +174,10 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
   @Override
   public RegistrationHandle register(DrillbitEndpoint data) {
     try {
+      data = data.toBuilder().setState(State.ONLINE).build();
       ServiceInstance<DrillbitEndpoint> serviceInstance = newServiceInstance(data);
       discovery.registerService(serviceInstance);
-      return new ZKRegistrationHandle(serviceInstance.getId());
+      return new ZKRegistrationHandle(serviceInstance.getId(),data);
     } catch (Exception e) {
       throw propagate(e);
     }
@@ -200,11 +206,50 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
     }
   }
 
+  /**
+   * Update drillbit endpoint state. Drillbit advertises its
+   * state in Zookeeper when a shutdown request of drillbit is
+   * triggered. State information is used during planning and
+   * initial client connection phases.
+   */
+  public RegistrationHandle update(RegistrationHandle handle, State state) {
+    ZKRegistrationHandle h = (ZKRegistrationHandle) handle;
+      try {
+        endpoint = h.endpoint.toBuilder().setState(state).build();
+        ServiceInstance<DrillbitEndpoint> serviceInstance = ServiceInstance.<DrillbitEndpoint>builder()
+                .name(serviceName)
+                .id(h.id)
+                .payload(endpoint).build();
+        discovery.updateService(serviceInstance);
+      } catch (Exception e) {
+        propagate(e);
+      }
+      return handle;
+  }
+
   @Override
   public Collection<DrillbitEndpoint> getAvailableEndpoints() {
     return this.endpoints;
   }
 
+  /*
+   * Get a collection of ONLINE Drillbit endpoints by excluding the drillbits
+   * that are in QUIESCENT state (drillbits shutting down). Primarily used by the planner
+   * to plan queries only on ONLINE drillbits and used by the client during initial connection
+   * phase to connect to a drillbit (foreman)
+   * @return A collection of ONLINE endpoints
+   */
+  @Override
+  public Collection<DrillbitEndpoint> getOnlineEndPoints() {
+    Collection<DrillbitEndpoint> runningEndPoints = new ArrayList<>();
+    for (DrillbitEndpoint endpoint: endpoints){
+      if(isDrillbitInState(endpoint, State.ONLINE)) {
+        runningEndPoints.add(endpoint);
+      }
+    }
+    logger.debug("Online endpoints in ZK are" + runningEndPoints.toString());
+    return runningEndPoints;
+  }
 
   @Override
   public DistributedSemaphore getSemaphore(String name, int maximumLeases) {
@@ -219,6 +264,7 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
 
   private synchronized void updateEndpoints() {
     try {
+      // All active bits in the Zookeeper
       Collection<DrillbitEndpoint> newDrillbitSet =
       transform(discovery.queryForInstances(serviceName),
         new Function<ServiceInstance<DrillbitEndpoint>, DrillbitEndpoint>() {
@@ -229,27 +275,42 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
         });
 
       // set of newly dead bits : original bits - new set of active bits.
-      Set<DrillbitEndpoint> unregisteredBits = new HashSet<>(endpoints);
-      unregisteredBits.removeAll(newDrillbitSet);
-
+      Set<DrillbitEndpoint> unregisteredBits = new HashSet<>();
       // Set of newly live bits : new set of active bits - original bits.
-      Set<DrillbitEndpoint> registeredBits = new HashSet<>(newDrillbitSet);
-      registeredBits.removeAll(endpoints);
+      Set<DrillbitEndpoint> registeredBits = new HashSet<>();
 
-      endpoints = newDrillbitSet;
 
+      // Updates the endpoints map if there is a change in state of the endpoint or with the addition
+      // of new drillbit endpoints. Registered endpoints is set to newly live drillbit endpoints.
+      for ( DrillbitEndpoint endpoint : newDrillbitSet) {
+        String endpointAddress = endpoint.getAddress();
+        int endpointPort = endpoint.getUserPort();
+        if (! endpointsMap.containsKey(new MultiKey(endpointAddress, endpointPort))) {
+          registeredBits.add(endpoint);
+        }
+        endpointsMap.put(new MultiKey(endpointAddress, endpointPort),endpoint);
+      }
+      // Remove all the endpoints that are newly dead
+      for ( MultiKey key: endpointsMap.keySet()) {
+        if(!newDrillbitSet.contains(endpointsMap.get(key))) {
+          unregisteredBits.add(endpointsMap.get(key));
+          endpointsMap.remove(key);
+        }
+      }
+      endpoints = endpointsMap.values();
       if (logger.isDebugEnabled()) {
         StringBuilder builder = new StringBuilder();
         builder.append("Active drillbit set changed.  Now includes ");
         builder.append(newDrillbitSet.size());
         builder.append(" total bits. New active drillbits:\n");
-        builder.append("Address | User Port | Control Port | Data Port | Version |\n");
+        builder.append("Address | User Port | Control Port | Data Port | Version | State\n");
         for (DrillbitEndpoint bit: newDrillbitSet) {
           builder.append(bit.getAddress()).append(" | ");
           builder.append(bit.getUserPort()).append(" | ");
           builder.append(bit.getControlPort()).append(" | ");
           builder.append(bit.getDataPort()).append(" | ");
           builder.append(bit.getVersion()).append(" |");
+          builder.append(bit.getState()).append(" | ");
           builder.append('\n');
         }
         logger.debug(builder.toString());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKRegistrationHandle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKRegistrationHandle.java
@@ -18,15 +18,27 @@
 package org.apache.drill.exec.coord.zk;
 
 import org.apache.drill.exec.coord.ClusterCoordinator.RegistrationHandle;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 
 public class ZKRegistrationHandle implements RegistrationHandle {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ZKRegistrationHandle.class);
 
   public final String id;
+  public DrillbitEndpoint endpoint;
 
-  public ZKRegistrationHandle(String id) {
+  public DrillbitEndpoint getEndPoint() {
+    return endpoint;
+  }
+
+  @Override
+  public void setEndPoint(DrillbitEndpoint endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public ZKRegistrationHandle(String id, DrillbitEndpoint endpoint) {
     super();
     this.id = id;
+    this.endpoint = endpoint;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -213,6 +213,10 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     return drillbitContext.getBits();
   }
 
+  public Collection<DrillbitEndpoint> getOnlineEndpoints() {
+    return drillbitContext.getBits();
+  }
+
   public DrillConfig getConfig() {
     return drillbitContext.getConfig();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.StackTrace;
+import org.apache.drill.common.concurrent.ExtendedLatch;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.common.scanner.ClassPathScanner;
@@ -32,6 +33,7 @@ import org.apache.drill.exec.coord.ClusterCoordinator.RegistrationHandle;
 import org.apache.drill.exec.coord.zk.ZKClusterCoordinator;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.server.DrillbitStateManager.DrillbitState;
 import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.OptionScope;
@@ -48,6 +50,7 @@ import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.exec.work.WorkManager;
 import org.apache.zookeeper.Environment;
 
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 
@@ -77,6 +80,23 @@ public class Drillbit implements AutoCloseable {
   private final WorkManager manager;
   private final BootStrapContext context;
   private final WebServer webServer;
+  private final int gracePeriod;
+  private DrillbitStateManager stateManager;
+  private boolean quiescentMode;
+  private boolean forcefulShutdown = false;
+
+  public void setQuiescentMode(boolean quiescentMode) {
+    this.quiescentMode = quiescentMode;
+  }
+
+  public void setForcefulShutdown(boolean forcefulShutdown) {
+    this.forcefulShutdown = forcefulShutdown;
+  }
+
+  public RegistrationHandle getRegistrationHandle() {
+    return registrationHandle;
+  }
+
   private RegistrationHandle registrationHandle;
   private volatile StoragePluginRegistry storageRegistry;
   private final PersistentStoreProvider profileStoreProvider;
@@ -110,13 +130,15 @@ public class Drillbit implements AutoCloseable {
     final CaseInsensitiveMap<OptionDefinition> definitions,
     final RemoteServiceSet serviceSet,
     final ScanResult classpathScan) throws Exception {
+    gracePeriod = config.getInt(ExecConstants.GRACE_PERIOD);
     final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Construction started.");
-    final boolean allowPortHunting = serviceSet != null;
+    boolean drillPortHunt = config.getBoolean(ExecConstants.DRILL_PORT_HUNT);
+    final boolean allowPortHunting = (serviceSet != null) || drillPortHunt;
     context = new BootStrapContext(config, definitions, classpathScan);
     manager = new WorkManager(context);
 
-    webServer = new WebServer(context, manager);
+    webServer = new WebServer(context, manager, this);
     boolean isDistributedMode = false;
     if (serviceSet != null) {
       coord = serviceSet.getCoordinator();
@@ -137,6 +159,7 @@ public class Drillbit implements AutoCloseable {
 
     engine = new ServiceEngine(manager, context, allowPortHunting, isDistributedMode);
 
+    stateManager = new DrillbitStateManager(DrillbitState.STARTUP);
     logger.info("Construction completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS));
   }
 
@@ -152,6 +175,7 @@ public class Drillbit implements AutoCloseable {
     final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Startup begun.");
     coord.start(10000);
+    stateManager.setState(DrillbitState.ONLINE);
     storeProvider.start();
     if (profileStoreProvider != storeProvider) {
       profileStoreProvider.start();
@@ -176,18 +200,43 @@ public class Drillbit implements AutoCloseable {
     logger.info("Startup completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS));
   }
 
+  /*
+    Wait uninterruptibly
+   */
+  public void waitForGracePeriod() {
+    ExtendedLatch exitLatch = new ExtendedLatch();
+    exitLatch.awaitUninterruptibly(gracePeriod);
+  }
+
+  /*
+
+   */
+  public void shutdown() {
+    this.close();
+  }
+ /*
+  The drillbit is moved into Quiescent state and the drillbit waits for grace period amount of time.
+  Then drillbit moves into draining state and waits for all the queries and fragments to complete.
+  */
   @Override
   public synchronized void close() {
-    // avoid complaints about double closing
-    if (isClosed) {
+    if ( !stateManager.getState().equals(DrillbitState.ONLINE)) {
       return;
     }
     final Stopwatch w = Stopwatch.createStarted();
     logger.debug("Shutdown begun.");
-
-    // wait for anything that is running to complete
-    manager.waitToExit();
-
+    registrationHandle = coord.update(registrationHandle, State.QUIESCENT);
+    stateManager.setState(DrillbitState.GRACE);
+    waitForGracePeriod();
+    stateManager.setState(DrillbitState.DRAINING);
+    // wait for all the in-flight queries to finish
+    manager.waitToExit(this, forcefulShutdown);
+    //safe to exit
+    registrationHandle = coord.update(registrationHandle, State.OFFLINE);
+    stateManager.setState(DrillbitState.OFFLINE);
+    if(quiescentMode == true) {
+      return;
+    }
     if (coord != null && registrationHandle != null) {
       coord.unregister(registrationHandle);
     }
@@ -219,8 +268,8 @@ public class Drillbit implements AutoCloseable {
       logger.warn("Failure on close()", e);
     }
 
-    logger.info("Shutdown completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS));
-    isClosed = true;
+    logger.info("Shutdown completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS) );
+    stateManager.setState(DrillbitState.SHUTDOWN);
   }
 
   private void javaPropertiesToSystemOptions() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -157,8 +157,37 @@ public class DrillbitContext implements AutoCloseable {
     return context.getConfig();
   }
 
-  public Collection<DrillbitEndpoint> getBits() {
+  public Collection<DrillbitEndpoint> getAvailableBits() {
     return coord.getAvailableEndpoints();
+  }
+
+  public Collection<DrillbitEndpoint> getBits() {
+    return coord.getOnlineEndPoints();
+  }
+
+  public boolean isOnline(DrillbitEndpoint endpoint) {
+    return endpoint.getState().equals(DrillbitEndpoint.State.ONLINE);
+  }
+
+  public boolean isForeman(DrillbitEndpoint endpoint) {
+    DrillbitEndpoint foreman = getEndpoint();
+    if(endpoint.getAddress().equals(foreman.getAddress()) &&
+            endpoint.getUserPort() == foreman.getUserPort()) {
+      return true;
+    }
+    return false;
+  }
+
+  public boolean isForemanOnline() {
+    Collection<DrillbitEndpoint> dbs = getAvailableBits();
+    for (DrillbitEndpoint db : dbs) {
+      if( isForeman(db)) {
+        if (isOnline(db)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   public BufferAllocator getAllocator() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitStateManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitStateManager.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server;
+/*
+  State manager to manage the state of drillbit.
+ */
+public class DrillbitStateManager {
+
+  public enum DrillbitState {
+    STARTUP, ONLINE, GRACE, DRAINING, OFFLINE, SHUTDOWN
+  }
+
+  private DrillbitState currentState;
+
+  public DrillbitStateManager(DrillbitState currentState) {
+    this.currentState = currentState;
+  }
+
+  public DrillbitState getState() {
+    return currentState;
+  }
+
+  public void setState(DrillbitState newState) {
+    switch (newState) {
+      case ONLINE:
+        if (currentState == DrillbitState.STARTUP) {
+          currentState = newState;
+        } else {
+          throw new IllegalStateException("Cannot set drillbit to" + newState + "from" + currentState);
+        }
+        break;
+      case GRACE:
+        if (currentState == DrillbitState.ONLINE) {
+          currentState = newState;
+        } else {
+          throw new IllegalStateException("Cannot set drillbit to" + newState + "from" + currentState);
+        }
+        break;
+      case DRAINING:
+        if (currentState == DrillbitState.GRACE) {
+          currentState = newState;
+        } else {
+          throw new IllegalStateException("Cannot set drillbit to" + newState + "from" + currentState);
+        }
+        break;
+      case OFFLINE:
+        if (currentState == DrillbitState.DRAINING) {
+          currentState = newState;
+        } else {
+          throw new IllegalStateException("Cannot set drillbit to" + newState + "from" + currentState);
+        }
+        break;
+      case SHUTDOWN:
+        if (currentState == DrillbitState.OFFLINE) {
+          currentState = newState;
+        } else {
+          throw new IllegalStateException("Cannot set drillbit to" + newState + "from" + currentState);
+        }
+        break;
+    }
+  }
+
+}
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -37,6 +37,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.rest.WebUserConnection.AnonWebUserConnection;
 import org.apache.drill.exec.server.rest.auth.AuthDynamicFeature;
@@ -73,7 +74,7 @@ import java.util.List;
 public class DrillRestServer extends ResourceConfig {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRestServer.class);
 
-  public DrillRestServer(final WorkManager workManager, final ServletContext servletContext) {
+  public DrillRestServer(final WorkManager workManager, final ServletContext servletContext, final Drillbit drillbit) {
     register(DrillRoot.class);
     register(StatusResources.class);
     register(StorageResources.class);
@@ -120,6 +121,7 @@ public class DrillRestServer extends ResourceConfig {
     register(new AbstractBinder() {
       @Override
       protected void configure() {
+        bind(drillbit).to(Drillbit.class);
         bind(workManager).to(WorkManager.class);
         bind(executor).to(EventExecutor.class);
         bind(workManager.getContext().getLpPersistence().getMapper()).to(ObjectMapper.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -18,12 +18,16 @@
 package org.apache.drill.exec.server.rest;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -33,6 +37,7 @@ import com.google.common.collect.Sets;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.rest.DrillRestServer.UserAuthEnabled;
@@ -55,15 +60,108 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public class DrillRoot {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRoot.class);
 
-  @Inject UserAuthEnabled authEnabled;
-  @Inject WorkManager work;
-  @Inject SecurityContext sc;
+  @Inject
+  UserAuthEnabled authEnabled;
+  @Inject
+  WorkManager work;
+  @Inject
+  SecurityContext sc;
+  @Inject
+  Drillbit drillbit;
+
+  public enum ShutdownMode {
+    forcefulShutdown, gracefulShutdown, quiescent
+  }
 
   @GET
   @Produces(MediaType.TEXT_HTML)
   public Viewable getClusterInfo() {
     return ViewableWithPermissions.create(authEnabled.get(), "/rest/index.ftl", sc, getClusterInfoJSON());
   }
+
+
+  @SuppressWarnings("resource")
+  @GET
+  @Path("/state")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getDrillbitStatus() {
+    Collection<DrillbitInfo> drillbits = getClusterInfoJSON().getDrillbits();
+    Map<String, String> drillStatusMap = new HashMap<String, String>();
+    for (DrillbitInfo drillbit : drillbits) {
+      drillStatusMap.put(drillbit.getAddress() + "-" + drillbit.getUserPort(), drillbit.getState());
+    }
+    Response response = setResponse(drillStatusMap);
+    return response;
+  }
+
+  @SuppressWarnings("resource")
+  @GET
+  @Path("/gracePeriod")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, Integer> getGracePeriod() {
+
+    final DrillConfig config = work.getContext().getConfig();
+    final int gracePeriod = config.getInt(ExecConstants.GRACE_PERIOD);
+    Map<String, Integer> gracePeriodMap = new HashMap<String, Integer>();
+    gracePeriodMap.put("graceperiod", gracePeriod);
+    return gracePeriodMap;
+  }
+
+  @SuppressWarnings("resource")
+  @GET
+  @Path("/portNum")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, Integer> getPortNum() {
+
+    final DrillConfig config = work.getContext().getConfig();
+    final int port = config.getInt(ExecConstants.HTTP_PORT);
+    Map<String, Integer> portMap = new HashMap<String, Integer>();
+    portMap.put("port", port);
+    return portMap;
+  }
+
+  @SuppressWarnings("resource")
+  @GET
+  @Path("/queriesCount")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getRemainingQueries() {
+    Map<String, Integer> queriesInfo = new HashMap<String, Integer>();
+    queriesInfo = work.getRemainingQueries();
+    Response response = setResponse(queriesInfo);
+    return response;
+  }
+
+  @SuppressWarnings("resource")
+  @POST
+  @Path("/gracefulShutdown")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response shutdownDrillbit() throws Exception {
+    String resp = "Graceful Shutdown request is triggered";
+    return shutdown(resp);
+
+  }
+
+  @SuppressWarnings("resource")
+  @POST
+  @Path("/shutdown")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response ShutdownForcefully() throws Exception {
+    drillbit.setForcefulShutdown(true);
+    String resp = "Forceful shutdown request is triggered";
+    return shutdown(resp);
+
+  }
+
+  @SuppressWarnings("resource")
+  @POST
+  @Path("/quiescent")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response drillbitToQuiescentMode() throws Exception {
+    drillbit.setQuiescentMode(true);
+    String resp = "Request to put drillbit in Quiescent mode is triggered";
+    return shutdown(resp);
+  }
+
 
   @SuppressWarnings("resource")
   @GET
@@ -79,8 +177,8 @@ public class DrillRoot {
 
     final DrillConfig config = dbContext.getConfig();
     final boolean userEncryptionEnabled =
-        config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) ||
-            config .getBoolean(ExecConstants.USER_SSL_ENABLED);
+            config.getBoolean(ExecConstants.USER_ENCRYPTION_SASL_ENABLED) ||
+                    config .getBoolean(ExecConstants.USER_SSL_ENABLED);
     final boolean bitEncryptionEnabled = config.getBoolean(ExecConstants.BIT_ENCRYPTION_SASL_ENABLED);
     // If the user is logged in and is admin user then show the admin user info
     // For all other cases the user info need-not or should-not be displayed
@@ -94,7 +192,7 @@ public class DrillRoot {
     final boolean shouldShowUserInfo = isUserLoggedIn &&
             ((DrillUserPrincipal)sc.getUserPrincipal()).isAdminUser();
 
-    for (DrillbitEndpoint endpoint : work.getContext().getBits()) {
+    for (DrillbitEndpoint endpoint : work.getContext().getAvailableBits()) {
       final DrillbitInfo drillbit = new DrillbitInfo(endpoint,
               currentDrillbit.equals(endpoint),
               currentVersion.equals(endpoint.getVersion()));
@@ -107,219 +205,254 @@ public class DrillRoot {
             " userLoggedIn "  + isUserLoggedIn + " shouldShowUserInfo: " + shouldShowUserInfo );
 
     return new ClusterInfo(drillbits, currentVersion, mismatchedVersions,
-      userEncryptionEnabled, bitEncryptionEnabled, processUser, processUserGroups, adminUsers,
-      adminUserGroups, shouldShowUserInfo, QueueInfo.build(dbContext.getResourceManager()));
+            userEncryptionEnabled, bitEncryptionEnabled, processUser, processUserGroups, adminUsers,
+            adminUserGroups, shouldShowUserInfo, QueueInfo.build(dbContext.getResourceManager()));
   }
+
+  public Response setResponse(Map entity) {
+    return Response.ok()
+            .entity(entity)
+            .header("Access-Control-Allow-Origin", "*")
+            .header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT")
+            .header("Access-Control-Allow-Credentials","true")
+            .allow("OPTIONS").build();
+  }
+
+  public Response shutdown(String resp) throws Exception {
+    Map<String, String> shutdownInfo = new HashMap<String, String>();
+    new Thread(new Runnable() {
+        public void run() {
+          try {
+            drillbit.close();
+          } catch (Exception e) {
+            logger.error("Request to shutdown drillbit failed", e);
+          }
+        }
+      }).start();
+    shutdownInfo.put("response",resp);
+    Response response = setResponse(shutdownInfo);
+    return response;
+  }
+
+
+/**
+ * Pretty-printing wrapper class around the ZK-based queue summary.
+ */
+
+@XmlRootElement
+public static class QueueInfo {
+  private final ZKQueueInfo zkQueueInfo;
+
+  public static QueueInfo build(ResourceManager rm) {
+
+    // Consider queues enabled only if the ZK-based queues are in use.
+
+    ThrottledResourceManager throttledRM = null;
+    if (rm != null && rm instanceof DynamicResourceManager) {
+      DynamicResourceManager dynamicRM = (DynamicResourceManager) rm;
+      rm = dynamicRM.activeRM();
+    }
+    if (rm != null && rm instanceof ThrottledResourceManager) {
+      throttledRM = (ThrottledResourceManager) rm;
+    }
+    if (throttledRM == null) {
+      return new QueueInfo(null);
+    }
+    QueryQueue queue = throttledRM.queue();
+    if (queue == null || !(queue instanceof DistributedQueryQueue)) {
+      return new QueueInfo(null);
+    }
+
+    return new QueueInfo(((DistributedQueryQueue) queue).getInfo());
+  }
+
+  @JsonCreator
+  public QueueInfo(ZKQueueInfo queueInfo) {
+    zkQueueInfo = queueInfo;
+  }
+
+  public boolean isEnabled() { return zkQueueInfo != null; }
+
+  public int smallQueueSize() {
+    return isEnabled() ? zkQueueInfo.smallQueueSize : 0;
+  }
+
+  public int largeQueueSize() {
+    return isEnabled() ? zkQueueInfo.largeQueueSize : 0;
+  }
+
+  public String threshold() {
+    return isEnabled()
+            ? Double.toString(zkQueueInfo.queueThreshold)
+            : "N/A";
+  }
+
+  public String smallQueueMemory() {
+    return isEnabled()
+            ? toBytes(zkQueueInfo.memoryPerSmallQuery)
+            : "N/A";
+  }
+
+  public String largeQueueMemory() {
+    return isEnabled()
+            ? toBytes(zkQueueInfo.memoryPerLargeQuery)
+            : "N/A";
+  }
+
+  public String totalMemory() {
+    return isEnabled()
+            ? toBytes(zkQueueInfo.memoryPerNode)
+            : "N/A";
+  }
+
+  private final long ONE_MB = 1024 * 1024;
+
+  private String toBytes(long memory) {
+    if (memory < 10 * ONE_MB) {
+      return String.format("%,d bytes", memory);
+    } else {
+      return String.format("%,.0f MB", memory * 1.0D / ONE_MB);
+    }
+  }
+}
+
+@XmlRootElement
+public static class ClusterInfo {
+  private final Collection<DrillbitInfo> drillbits;
+  private final String currentVersion;
+  private final Collection<String> mismatchedVersions;
+  private final boolean userEncryptionEnabled;
+  private final boolean bitEncryptionEnabled;
+  private final String adminUsers;
+  private final String adminUserGroups;
+  private final String processUser;
+  private final String processUserGroups;
+  private final boolean shouldShowUserInfo;
+  private final QueueInfo queueInfo;
+
+  @JsonCreator
+  public ClusterInfo(Collection<DrillbitInfo> drillbits,
+                     String currentVersion,
+                     Collection<String> mismatchedVersions,
+                     boolean userEncryption,
+                     boolean bitEncryption,
+                     String processUser,
+                     String processUserGroups,
+                     String adminUsers,
+                     String adminUserGroups,
+                     boolean shouldShowUserInfo,
+                     QueueInfo queueInfo) {
+    this.drillbits = Sets.newTreeSet(drillbits);
+    this.currentVersion = currentVersion;
+    this.mismatchedVersions = Sets.newTreeSet(mismatchedVersions);
+    this.userEncryptionEnabled = userEncryption;
+    this.bitEncryptionEnabled = bitEncryption;
+    this.processUser = processUser;
+    this.processUserGroups = processUserGroups;
+    this.adminUsers = adminUsers;
+    this.adminUserGroups = adminUserGroups;
+    this.shouldShowUserInfo = shouldShowUserInfo;
+    this.queueInfo = queueInfo;
+  }
+
+  public Collection<DrillbitInfo> getDrillbits() {
+    return Sets.newTreeSet(drillbits);
+  }
+
+  public String getCurrentVersion() {
+    return currentVersion;
+  }
+
+  public Collection<String> getMismatchedVersions() {
+    return Sets.newTreeSet(mismatchedVersions);
+  }
+
+  public boolean isUserEncryptionEnabled() { return userEncryptionEnabled; }
+
+  public boolean isBitEncryptionEnabled() { return bitEncryptionEnabled; }
+
+  public String getProcessUser() { return processUser; }
+
+  public String getProcessUserGroups() { return processUserGroups; }
+
+  public String getAdminUsers() { return adminUsers; }
+
+  public String getAdminUserGroups() { return adminUserGroups; }
+
+  public boolean shouldShowUserInfo() { return shouldShowUserInfo; }
+
+  public QueueInfo queueInfo() { return queueInfo; }
+}
+
+public static class DrillbitInfo implements Comparable<DrillbitInfo> {
+  private final String address;
+  private final String userPort;
+  private final String controlPort;
+  private final String dataPort;
+  private final String version;
+  private final boolean current;
+  private final boolean versionMatch;
+  private final String state;
+
+  @JsonCreator
+  public DrillbitInfo(DrillbitEndpoint drillbit, boolean current, boolean versionMatch) {
+    this.address = drillbit.getAddress();
+    this.userPort = String.valueOf(drillbit.getUserPort());
+    this.controlPort = String.valueOf(drillbit.getControlPort());
+    this.dataPort = String.valueOf(drillbit.getDataPort());
+    this.version = Strings.isNullOrEmpty(drillbit.getVersion()) ? "Undefined" : drillbit.getVersion();
+    this.current = current;
+    this.versionMatch = versionMatch;
+    this.state = String.valueOf(drillbit.getState());
+  }
+
+  public String getAddress() { return address; }
+
+  public String getUserPort() { return userPort; }
+
+  public String getControlPort() { return controlPort; }
+
+  public String getDataPort() { return dataPort; }
+
+  public String getVersion() { return version; }
+
+  public boolean isCurrent() { return current; }
+
+  public boolean isVersionMatch() { return versionMatch; }
+
+  public String getState() { return state; }
 
   /**
-   * Pretty-printing wrapper class around the ZK-based queue summary.
+   * Method used to sort Drillbits. Current Drillbit goes first.
+   * Then Drillbits with matching versions, after them Drillbits with mismatching versions.
+   * Matching Drillbits are sorted according address natural order,
+   * mismatching Drillbits are sorted according version, address natural order.
+   *
+   * @param drillbitToCompare Drillbit to compare against
+   * @return -1 if Drillbit should be before, 1 if after in list
    */
-
-  @XmlRootElement
-  public static class QueueInfo {
-    private final ZKQueueInfo zkQueueInfo;
-
-    public static QueueInfo build(ResourceManager rm) {
-
-      // Consider queues enabled only if the ZK-based queues are in use.
-
-      ThrottledResourceManager throttledRM = null;
-      if (rm != null && rm instanceof DynamicResourceManager) {
-        DynamicResourceManager dynamicRM = (DynamicResourceManager) rm;
-        rm = dynamicRM.activeRM();
-      }
-      if (rm != null && rm instanceof ThrottledResourceManager) {
-        throttledRM = (ThrottledResourceManager) rm;
-      }
-      if (throttledRM == null) {
-        return new QueueInfo(null);
-      }
-      QueryQueue queue = throttledRM.queue();
-      if (queue == null || !(queue instanceof DistributedQueryQueue)) {
-        return new QueueInfo(null);
-      }
-
-      return new QueueInfo(((DistributedQueryQueue) queue).getInfo());
+  @Override
+  public int compareTo(DrillbitInfo drillbitToCompare) {
+    if (this.isCurrent()) {
+      return -1;
     }
 
-    @JsonCreator
-    public QueueInfo(ZKQueueInfo queueInfo) {
-      zkQueueInfo = queueInfo;
+    if (drillbitToCompare.isCurrent()) {
+      return 1;
     }
 
-    public boolean isEnabled() { return zkQueueInfo != null; }
-
-    public int smallQueueSize() {
-      return isEnabled() ? zkQueueInfo.smallQueueSize : 0;
-    }
-
-    public int largeQueueSize() {
-      return isEnabled() ? zkQueueInfo.largeQueueSize : 0;
-    }
-
-    public String threshold() {
-      return isEnabled()
-          ? Double.toString(zkQueueInfo.queueThreshold)
-          : "N/A";
-    }
-
-    public String smallQueueMemory() {
-      return isEnabled()
-          ? toBytes(zkQueueInfo.memoryPerSmallQuery)
-          : "N/A";
-    }
-
-    public String largeQueueMemory() {
-      return isEnabled()
-          ? toBytes(zkQueueInfo.memoryPerLargeQuery)
-          : "N/A";
-    }
-
-    public String totalMemory() {
-      return isEnabled()
-          ? toBytes(zkQueueInfo.memoryPerNode)
-          : "N/A";
-    }
-
-    private final long ONE_MB = 1024 * 1024;
-
-    private String toBytes(long memory) {
-      if (memory < 10 * ONE_MB) {
-        return String.format("%,d bytes", memory);
-      } else {
-        return String.format("%,.0f MB", memory * 1.0D / ONE_MB);
-      }
-    }
-  }
-
-  @XmlRootElement
-  public static class ClusterInfo {
-    private final Collection<DrillbitInfo> drillbits;
-    private final String currentVersion;
-    private final Collection<String> mismatchedVersions;
-    private final boolean userEncryptionEnabled;
-    private final boolean bitEncryptionEnabled;
-    private final String adminUsers;
-    private final String adminUserGroups;
-    private final String processUser;
-    private final String processUserGroups;
-    private final boolean shouldShowUserInfo;
-    private final QueueInfo queueInfo;
-
-    @JsonCreator
-    public ClusterInfo(Collection<DrillbitInfo> drillbits,
-                       String currentVersion,
-                       Collection<String> mismatchedVersions,
-                       boolean userEncryption,
-                       boolean bitEncryption,
-                       String processUser,
-                       String processUserGroups,
-                       String adminUsers,
-                       String adminUserGroups,
-                       boolean shouldShowUserInfo,
-                       QueueInfo queueInfo) {
-      this.drillbits = Sets.newTreeSet(drillbits);
-      this.currentVersion = currentVersion;
-      this.mismatchedVersions = Sets.newTreeSet(mismatchedVersions);
-      this.userEncryptionEnabled = userEncryption;
-      this.bitEncryptionEnabled = bitEncryption;
-      this.processUser = processUser;
-      this.processUserGroups = processUserGroups;
-      this.adminUsers = adminUsers;
-      this.adminUserGroups = adminUserGroups;
-      this.shouldShowUserInfo = shouldShowUserInfo;
-      this.queueInfo = queueInfo;
-    }
-
-    public Collection<DrillbitInfo> getDrillbits() {
-      return Sets.newTreeSet(drillbits);
-    }
-
-    public String getCurrentVersion() {
-      return currentVersion;
-    }
-
-    public Collection<String> getMismatchedVersions() {
-      return Sets.newTreeSet(mismatchedVersions);
-    }
-
-    public boolean isUserEncryptionEnabled() { return userEncryptionEnabled; }
-
-    public boolean isBitEncryptionEnabled() { return bitEncryptionEnabled; }
-
-    public String getProcessUser() { return processUser; }
-
-    public String getProcessUserGroups() { return processUserGroups; }
-
-    public String getAdminUsers() { return adminUsers; }
-
-    public String getAdminUserGroups() { return adminUserGroups; }
-
-    public boolean shouldShowUserInfo() { return shouldShowUserInfo; }
-
-    public QueueInfo queueInfo() { return queueInfo; }
-  }
-
-  public static class DrillbitInfo implements Comparable<DrillbitInfo> {
-    private final String address;
-    private final String userPort;
-    private final String controlPort;
-    private final String dataPort;
-    private final String version;
-    private final boolean current;
-    private final boolean versionMatch;
-
-    @JsonCreator
-    public DrillbitInfo(DrillbitEndpoint drillbit, boolean current, boolean versionMatch) {
-      this.address = drillbit.getAddress();
-      this.userPort = String.valueOf(drillbit.getUserPort());
-      this.controlPort = String.valueOf(drillbit.getControlPort());
-      this.dataPort = String.valueOf(drillbit.getDataPort());
-      this.version = Strings.isNullOrEmpty(drillbit.getVersion()) ? "Undefined" : drillbit.getVersion();
-      this.current = current;
-      this.versionMatch = versionMatch;
-    }
-
-    public String getAddress() { return address; }
-
-    public String getUserPort() { return userPort; }
-
-    public String getControlPort() { return controlPort; }
-
-    public String getDataPort() { return dataPort; }
-
-    public String getVersion() { return version; }
-
-    public boolean isCurrent() { return current; }
-
-    public boolean isVersionMatch() { return versionMatch; }
-
-    /**
-     * Method used to sort Drillbits. Current Drillbit goes first.
-     * Then Drillbits with matching versions, after them Drillbits with mismatching versions.
-     * Matching Drillbits are sorted according address natural order,
-     * mismatching Drillbits are sorted according version, address natural order.
-     *
-     * @param drillbitToCompare Drillbit to compare against
-     * @return -1 if Drillbit should be before, 1 if after in list
-     */
-    @Override
-    public int compareTo(DrillbitInfo drillbitToCompare) {
-      if (this.isCurrent()) {
-        return -1;
-      }
-
-      if (drillbitToCompare.isCurrent()) {
-        return 1;
-      }
-
-      if (this.isVersionMatch() == drillbitToCompare.isVersionMatch()) {
-        if (this.version.equals(drillbitToCompare.getVersion())) {
-          return this.address.compareTo(drillbitToCompare.getAddress());
+    if (this.isVersionMatch() == drillbitToCompare.isVersionMatch()) {
+      if (this.version.equals(drillbitToCompare.getVersion())) {
+        {
+          if (this.address.equals(drillbitToCompare.getAddress())) {
+            return (this.controlPort.compareTo(drillbitToCompare.getControlPort()));
+          }
+          return (this.address.compareTo(drillbitToCompare.getAddress()));
         }
-        return this.version.compareTo(drillbitToCompare.getVersion());
       }
-      return this.versionMatch ? -1 : 1;
+      return this.version.compareTo(drillbitToCompare.getVersion());
     }
+    return this.versionMatch ? -1 : 1;
   }
+}
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -23,13 +23,14 @@ import com.codahale.metrics.servlets.ThreadDumpServlet;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ssl.SSLConfig;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.rpc.security.plain.PlainFactory;
 import org.apache.drill.exec.server.BootStrapContext;
+import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.rest.auth.DrillRestLoginService;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
 import org.apache.drill.exec.work.WorkManager;
@@ -106,6 +107,8 @@ public class WebServer implements AutoCloseable {
 
   private Server embeddedJetty;
 
+  private final Drillbit drillbit;
+
   private int port;
 
   /**
@@ -114,11 +117,12 @@ public class WebServer implements AutoCloseable {
    * @param context Bootstrap context.
    * @param workManager WorkManager instance.
    */
-  public WebServer(final BootStrapContext context, final WorkManager workManager) {
+  public WebServer(final BootStrapContext context, final WorkManager workManager, final Drillbit drillbit) {
     this.context = context;
     this.config = context.getConfig();
     this.metrics = context.getMetrics();
     this.workManager = workManager;
+    this.drillbit = drillbit;
   }
 
   private static final String BASE_STATIC_PATH = "/rest/static/";
@@ -193,7 +197,7 @@ public class WebServer implements AutoCloseable {
     servletContextHandler.setErrorHandler(errorHandler);
     servletContextHandler.setContextPath("/");
 
-    final ServletHolder servletHolder = new ServletHolder(new ServletContainer(new DrillRestServer(workManager, servletContextHandler.getServletContext())));
+    final ServletHolder servletHolder = new ServletHolder(new ServletContainer(new DrillRestServer(workManager, servletContextHandler.getServletContext(), drillbit)));
     servletHolder.setInitOrder(1);
     servletContextHandler.addServlet(servletHolder, "/*");
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State;
 import org.apache.drill.exec.rpc.TransportCheck;
 import org.apache.drill.exec.rpc.control.Controller;
 import org.apache.drill.exec.rpc.control.ControllerImpl;
@@ -102,6 +103,7 @@ public class ServiceEngine implements AutoCloseable {
         .setAddress(hostName)
         .setUserPort(userPort)
         .setVersion(DrillVersionInfo.getVersion())
+        .setState(State.STARTUP)
         .build();
 
     partialEndpoint = controller.start(partialEndpoint, allowPortHunting);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/DrillbitIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/DrillbitIterator.java
@@ -29,7 +29,7 @@ public class DrillbitIterator implements Iterator<Object> {
   private DrillbitEndpoint current;
 
   public DrillbitIterator(FragmentContext c) {
-    this.endpoints = c.getDrillbitContext().getBits().iterator();
+    this.endpoints = c.getDrillbitContext().getAvailableBits().iterator();
     this.current = c.getIdentity();
   }
 
@@ -40,6 +40,7 @@ public class DrillbitIterator implements Iterator<Object> {
     public int data_port;
     public boolean current;
     public String version;
+    public String state;
   }
 
   @Override
@@ -51,13 +52,26 @@ public class DrillbitIterator implements Iterator<Object> {
   public Object next() {
     DrillbitEndpoint ep = endpoints.next();
     DrillbitInstance i = new DrillbitInstance();
-    i.current = ep.equals(current);
+    i.current = isCurrent(ep);
     i.hostname = ep.getAddress();
     i.user_port = ep.getUserPort();
     i.control_port = ep.getControlPort();
     i.data_port = ep.getDataPort();
     i.version = ep.getVersion();
+    i.state = ep.getState().toString();
     return i;
+  }
+
+  public boolean isCurrent(DrillbitEndpoint ep) {
+
+    String epAddress = ep.getAddress();
+    int epPort = ep.getUserPort();
+    String currentEpAddress = current.getAddress();
+    int currentEpPort = current.getUserPort();
+    if (currentEpAddress.equals(epAddress) && currentEpPort == epPort) {
+      return true;
+    }
+    return false;
   }
 
   @Override

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -369,6 +369,16 @@ drill.exec: {
     // planning and managing queries. Primarily for testing.
     cpus_per_node: 0,
   }
+  # Grace period is the amount of time where the drillbit accepts work after
+  # the shutdown request is triggered. The primary use of grace period is to
+  # avoid the race conditions caused by zookeeper delay in updating the state
+  # information of the drillbit that is shutting down. So, it is advisable
+  # to have a grace period that is atleast twice the amount of zookeeper
+  # refresh time.
+  grace_period_ms : 0,
+  //port hunting for drillbits. Enabled only for testing purposes.
+  port_hunt : false
+
 }
 
 drill.jdbc: {

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -46,7 +46,7 @@
 
   <div class="row">
     <div class="col-md-12">
-      <h3>Drillbits <span class="label label-primary">${model.getDrillbits()?size}</span></h3>
+      <h3>Drillbits <span class="label label-primary" id="size" >${model.getDrillbits()?size}</span></h3>
       <div class="table-responsive">
         <table class="table table-hover">
           <thead>
@@ -57,19 +57,19 @@
               <th>Control Port</th>
               <th>Data Port</th>
               <th>Version</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
             <#assign i = 1>
             <#list model.getDrillbits() as drillbit>
-              <tr>
+              <tr id="row-${i}">
                 <td>${i}</td>
-                <td>${drillbit.getAddress()}
-                  <#if drillbit.isCurrent()>
+                <td id="address" >${drillbit.getAddress()}<#if drillbit.isCurrent()>
                     <span class="label label-info">Current</span>
                   </#if>
                 </td>
-                <td>${drillbit.getUserPort()}</td>
+                <td id="port" >${drillbit.getUserPort()}</td>
                 <td>${drillbit.getControlPort()}</td>
                 <td>${drillbit.getDataPort()}</td>
                 <td>
@@ -78,6 +78,11 @@
                     ${drillbit.getVersion()}
                   </span>
                 </td>
+                <td id="status" >${drillbit.getState()}</td>
+                <td>
+                    <button type="button" id="shutdown" onClick="shutdown('${drillbit.getAddress()}',$(this));"> SHUTDOWN </button>
+                </td>
+                <td id="queriesCount">  </td>
               </tr>
               <#assign i = i + 1>
             </#list>
@@ -179,6 +184,101 @@
         </div>
       </div>
   </div>
+   <script charset="utf-8">
+      var refreshTime = 2000;
+      var refresh = getRefreshTime();
+      var portNum = 0;
+      var port = getPortNum();
+      console.log(portNum);
+      var timeout;
+      var size = $("#size").html();
+
+
+      function getPortNum() {
+          var port = $.ajax({
+                          type: 'GET',
+                          url: '/portNum',
+                          dataType: "json",
+                          complete: function(data) {
+                                portNum = data.responseJSON["port"];
+                                }
+                          });
+      }
+
+      function getRefreshTime() {
+          var refresh = $.ajax({
+                          type: 'GET',
+                          url: '/gracePeriod',
+                          dataType: "json",
+                          complete: function(data) {
+                                refreshTime = data.responseJSON["graceperiod"];
+                                refreshTime = refreshTime/3;
+                                timeout = setTimeout(reloadStatus,refreshTime );
+                                }
+                          });
+      }
+      function reloadStatus () {
+          console.log(refreshTime);
+          var result = $.ajax({
+                      type: 'GET',
+                      url: '/state',
+                      dataType: "json",
+                      complete: function(data) {
+                            fillStatus(data,size);
+                            }
+                      });
+          timeout = setTimeout(reloadStatus, refreshTime);
+      }
+
+      function fillStatus(data,size) {
+          var status_map = (data.responseJSON);
+          for (i = 1; i <= size; i++) {
+            var address = $("#row-"+i).find("#address").contents().get(0).nodeValue;
+            address = address.trim();
+            var port = $("#row-"+i).find("#port").html();
+            var key = address+"-"+port;
+
+            if (status_map[key] == null) {
+                $("#row-"+i).find("#status").text("OFFLINE");
+                $("#row-"+i).find("#shutdown").prop('disabled',true).css('opacity',0.5);
+                $("#row-"+i).find("#queriesCount").text("");
+            }
+            else {
+                if( status_map[key] == "ONLINE") {
+                    $("#row-"+i).find("#status").text(status_map[key]);
+                }
+                else {
+                    fillQueryCount(address,i);
+                    $("#row-"+i).find("#status").text(status_map[key]);
+                }
+            }
+          }
+      }
+      function fillQueryCount(address,row_id) {
+          url = "http://"+address+":"+portNum+"/queriesCount";
+          var result = $.ajax({
+                        type: 'GET',
+                        url: url,
+                        complete: function(data) {
+                              queries = data.responseJSON["queriesCount"];
+                              fragments = data.responseJSON["fragmentsCount"];
+                              $("#row-"+row_id).find("#queriesCount").text(queries+" queries and "+fragments+" fragments remaining before shutting down");
+                              }
+                        });
+      }
+      function shutdown(address,button) {
+          url = "http://"+address+":"+portNum+"/gracefulShutdown";
+          var result = $.ajax({
+                type: 'POST',
+                url: url,
+                contentType : 'text/plain',
+                complete: function(data) {
+                    alert(data.responseJSON["response"]);
+                    button.prop('disabled',true).css('opacity',0.5);
+                }
+          });
+      }
+    </script>
 </#macro>
 
 <@page_html/>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -248,7 +248,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(92, columns.size());
+    assertEquals(93, columns.size());
     // too many records to verify the output.
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -404,6 +404,25 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
   }
 
   /**
+   * Shutdown the drillbit given the name of the drillbit.
+   */
+  public void closeDrillbit(final String drillbitName) throws Exception {
+    Exception ex = null;
+    for (Drillbit bit : drillbits()) {
+      if (bit.equals(bits.get(drillbitName))) {
+        try {
+          bit.close();
+        } catch (Exception e) {
+          ex = ex == null ? e :ex;
+        }
+      }
+    }
+    if (ex != null) {
+      throw ex;
+    }
+  }
+
+  /**
    * Close a resource, suppressing the exception, and keeping
    * only the first exception that may occur. We assume that only
    * the first is useful, any others are probably down-stream effects

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.test;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.server.Drillbit;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Properties;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import java.nio.file.Path;
+import java.io.BufferedWriter;
+
+
+
+
+public class TestGracefulShutdown extends BaseTestQuery{
+
+  @BeforeClass
+  public static void setUpTestData() throws Exception {
+
+    for( int i = 0; i < 300; i++) {
+      setupFile(i);
+    }
+  }
+
+
+  public static final Properties WEBSERVER_CONFIGURATION = new Properties() {
+    {
+      put(ExecConstants.HTTP_ENABLE, true);
+      put(ExecConstants.HTTP_PORT_HUNT, true);
+      put(ExecConstants.DRILL_PORT_HUNT, true);
+      put(ExecConstants.GRACE_PERIOD, 10000);
+    }
+  };
+
+  public static final Properties DRILL_PORT_CONFIGURATION = new Properties() {
+    {
+      put(ExecConstants.DRILL_PORT_HUNT, true);
+      put(ExecConstants.GRACE_PERIOD, 10000);
+    }
+  };
+
+  public ClusterFixtureBuilder enableWebServer(ClusterFixtureBuilder builder) {
+    Properties props = new Properties();
+    props.putAll(WEBSERVER_CONFIGURATION);
+    builder.configBuilder.configProps(props);
+    builder.sessionOption(ExecConstants.SLICE_TARGET, 10);
+    return builder;
+  }
+
+  public ClusterFixtureBuilder enableDrillPortHunting(ClusterFixtureBuilder builder) {
+    Properties props = new Properties();
+    props.putAll(DRILL_PORT_CONFIGURATION);
+    builder.configBuilder.configProps(props);
+    return builder;
+  }
+
+
+
+  /*
+  Start multiple drillbits and then shutdown a drillbit. Query the online
+  endpoints and check if the drillbit still exists.
+   */
+  @Test
+  public void testOnlineEndPoints() throws  Exception {
+
+    String[] drillbits = {"db1" ,"db2","db3", "db4", "db5", "db6"};
+    ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withBits(drillbits).withLocalZk();
+    enableDrillPortHunting(builder);
+
+    try ( ClusterFixture cluster = builder.build();
+          ClientFixture client = cluster.clientFixture()) {
+
+      Drillbit drillbit = cluster.drillbit("db2");
+      DrillbitEndpoint drillbitEndpoint =  drillbit.getRegistrationHandle().getEndPoint();
+      int grace_period = drillbit.getContext().getConfig().getInt(ExecConstants.GRACE_PERIOD);
+      new Thread(new Runnable() {
+        public void run() {
+          try {
+            cluster.closeDrillbit("db2");
+          } catch (Exception e) {
+            fail();
+          }
+        }
+      }).start();
+      //wait for graceperiod
+      Thread.sleep(grace_period);
+      Collection<DrillbitEndpoint> drillbitEndpoints = cluster.drillbit().getContext()
+              .getClusterCoordinator()
+              .getOnlineEndPoints();
+      Assert.assertFalse(drillbitEndpoints.contains(drillbitEndpoint));
+    }
+  }
+  /*
+    Test if the drillbit transitions from ONLINE state when a shutdown
+    request is initiated
+   */
+  @Test
+  public void testStateChange() throws  Exception {
+
+    String[] drillbits = {"db1" ,"db2", "db3", "db4", "db5", "db6"};
+    ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withBits(drillbits).withLocalZk();
+    enableDrillPortHunting(builder);
+
+    try ( ClusterFixture cluster = builder.build();
+          ClientFixture client = cluster.clientFixture()) {
+      Drillbit drillbit = cluster.drillbit("db2");
+      int grace_period = drillbit.getContext().getConfig().getInt(ExecConstants.GRACE_PERIOD);
+      DrillbitEndpoint drillbitEndpoint =  drillbit.getRegistrationHandle().getEndPoint();
+      new Thread(new Runnable() {
+        public void run() {
+          try {
+            cluster.closeDrillbit("db2");
+          } catch (Exception e) {
+            fail();
+          }
+        }
+      }).start();
+      Thread.sleep(grace_period);
+      Collection<DrillbitEndpoint> drillbitEndpoints = cluster.drillbit().getContext()
+              .getClusterCoordinator()
+              .getAvailableEndpoints();
+      for (DrillbitEndpoint dbEndpoint : drillbitEndpoints) {
+        if(drillbitEndpoint.getAddress().equals(dbEndpoint.getAddress()) && drillbitEndpoint.getUserPort() == dbEndpoint.getUserPort()) {
+          assertNotEquals(dbEndpoint.getState(),DrillbitEndpoint.State.ONLINE);
+        }
+      }
+    }
+  }
+
+  /*
+   Test shutdown through RestApi
+   */
+  @Test
+  public void testRestApi() throws Exception {
+
+    String[] drillbits = { "db1" ,"db2", "db3" };
+    ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withBits(drillbits).withLocalZk();
+    builder = enableWebServer(builder);
+    QueryBuilder.QuerySummaryFuture listener;
+    final String sql = "select * from dfs.root.`.`";
+    try ( ClusterFixture cluster = builder.build();
+          final ClientFixture client = cluster.clientFixture()) {
+      Drillbit drillbit = cluster.drillbit("db1");
+      int port = drillbit.getContext().getConfig().getInt("drill.exec.http.port");
+      int grace_period = drillbit.getContext().getConfig().getInt(ExecConstants.GRACE_PERIOD);
+      listener =  client.queryBuilder().sql(sql).futureSummary();
+      Thread.sleep(60000);
+      while( port < 8049) {
+        URL url = new URL("http://localhost:"+port+"/gracefulShutdown");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        if (conn.getResponseCode() != 200) {
+          throw new RuntimeException("Failed : HTTP error code : "
+                  + conn.getResponseCode());
+        }
+        port++;
+      }
+      Thread.sleep(grace_period);
+      Collection<DrillbitEndpoint> drillbitEndpoints = cluster.drillbit().getContext()
+              .getClusterCoordinator()
+              .getOnlineEndPoints();
+      while(!listener.isDone()) {
+        Thread.sleep(10);
+      }
+      Assert.assertTrue(listener.isDone());
+      Assert.assertEquals(1,drillbitEndpoints.size());
+    }
+  }
+
+  /*
+   Test default shutdown through RestApi
+   */
+  @Test
+  public void testRestApiShutdown() throws Exception {
+
+    String[] drillbits = {"db1" ,"db2", "db3"};
+    ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withBits(drillbits).withLocalZk();
+    builder = enableWebServer(builder);
+    QueryBuilder.QuerySummaryFuture listener;
+    final String sql = "select * from dfs.root.`.`";
+    try ( ClusterFixture cluster = builder.build();
+          final ClientFixture client = cluster.clientFixture()) {
+      Drillbit drillbit = cluster.drillbit("db1");
+      int port = drillbit.getContext().getConfig().getInt("drill.exec.http.port");
+      int grace_period = drillbit.getContext().getConfig().getInt(ExecConstants.GRACE_PERIOD);
+      listener =  client.queryBuilder().sql(sql).futureSummary();
+      Thread.sleep(10000);
+      while( port < 8048) {
+        URL url = new URL("http://localhost:"+port+"/shutdown");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        if (conn.getResponseCode() != 200) {
+          throw new RuntimeException("Failed : HTTP error code : "
+                  + conn.getResponseCode());
+        }
+        port++;
+      }
+      Thread.sleep(grace_period);
+      Thread.sleep(5000);
+      Collection<DrillbitEndpoint> drillbitEndpoints = cluster.drillbit().getContext()
+              .getClusterCoordinator().getAvailableEndpoints();
+      while(!listener.isDone()) {
+        Thread.sleep(10);
+      }
+      Assert.assertTrue(listener.isDone());
+      Assert.assertEquals(2,drillbitEndpoints.size());
+    }
+  }
+
+  private static void setupFile(int file_num) throws Exception {
+    final String file = "employee"+file_num+".json";
+    final Path path = dirTestWatcher.getRootDir().toPath().resolve(file);
+    try(PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(path.toFile(), true)))) {
+      out.println("{\"employee_id\":1,\"full_name\":\"Sheri Nowmer\",\"first_name\":\"Sheri\",\"last_name\":\"Nowmer\",\"position_id\":1,\"position_title\":\"President\",\"store_id\":0,\"department_id\":1,\"birth_date\":\"1961-08-26\",\"hire_date\":\"1994-12-01 00:00:00.0\",\"end_date\":null,\"salary\":80000.0000,\"supervisor_id\":0,\"education_level\":\"Graduate Degree\",\"marital_status\":\"S\",\"gender\":\"F\",\"management_role\":\"Senior Management\"}\n" +
+              "{\"employee_id\":2,\"full_name\":\"Derrick Whelply\",\"first_name\":\"Derrick\",\"last_name\":\"Whelply\",\"position_id\":2,\"position_title\":\"VP Country Manager\",\"store_id\":0,\"department_id\":1,\"birth_date\":\"1915-07-03\",\"hire_date\":\"1994-12-01 00:00:00.0\",\"end_date\":null,\"salary\":40000.0000,\"supervisor_id\":1,\"education_level\":\"Graduate Degree\",\"marital_status\":\"M\",\"gender\":\"M\",\"management_role\":\"Senior Management\"}\n" +
+              "{\"employee_id\":4,\"full_name\":\"Michael Spence\",\"first_name\":\"Michael\",\"last_name\":\"Spence\",\"position_id\":2,\"position_title\":\"VP Country Manager\",\"store_id\":0,\"department_id\":1,\"birth_date\":\"1969-06-20\",\"hire_date\":\"1998-01-01 00:00:00.0\",\"end_date\":null,\"salary\":40000.0000,\"supervisor_id\":1,\"education_level\":\"Graduate Degree\",\"marital_status\":\"S\",\"gender\":\"M\",\"management_role\":\"Senior Management\"}\n" +
+              "{\"employee_id\":5,\"full_name\":\"Maya Gutierrez\",\"first_name\":\"Maya\",\"last_name\":\"Gutierrez\",\"position_id\":2,\"position_title\":\"VP Country Manager\",\"store_id\":0,\"department_id\":1,\"birth_date\":\"1951-05-10\",\"hire_date\":\"1998-01-01 00:00:00.0\",\"end_date\":null,\"salary\":35000.0000,\"supervisor_id\":1,\"education_level\":\"Bachelors Degree\",\"marital_status\":\"M\",\"gender\":\"F\",\"management_role\":\"Senior Management\"}\n" +
+              "{\"employee_id\":6,\"full_name\":\"Roberta Damstra\",\"first_name\":\"Roberta\",\"last_name\":\"Damstra\",\"position_id\":3,\"position_title\":\"VP Information Systems\",\"store_id\":0,\"department_id\":2,\"birth_date\":\"1942-10-08\",\"hire_date\":\"1994-12-01 00:00:00.0\",\"end_date\":null,\"salary\":25000.0000,\"supervisor_id\":1,\"education_level\":\"Bachelors Degree\",\"marital_status\":\"M\",\"gender\":\"F\",\"management_role\":\"Senior Management\"}\n" +
+              "{\"employee_id\":7,\"full_name\":\"Rebecca Kanagaki\",\"first_name\":\"Rebecca\",\"last_name\":\"Kanagaki\",\"position_id\":4,\"position_title\":\"VP Human Resources\",\"store_id\":0,\"department_id\":3,\"birth_date\":\"1949-03-27\",\"hire_date\":\"1994-12-01 00:00:00.0\",\"end_date\":null,\"salary\":15000.0000,\"supervisor_id\":1,\"education_level\":\"Bachelors Degree\",\"marital_status\":\"M\",\"gender\":\"F\",\"management_role\":\"Senior Management\"}\n");
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+}

--- a/protocol/src/main/java/org/apache/drill/exec/proto/CoordinationProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/CoordinationProtos.java
@@ -101,6 +101,16 @@ public final class CoordinationProtos {
      */
     com.google.protobuf.ByteString
         getVersionBytes();
+
+    // optional .exec.DrillbitEndpoint.State state = 7;
+    /**
+     * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+     */
+    boolean hasState();
+    /**
+     * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+     */
+    org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State getState();
   }
   /**
    * Protobuf type {@code exec.DrillbitEndpoint}
@@ -191,6 +201,17 @@ public final class CoordinationProtos {
               version_ = input.readBytes();
               break;
             }
+            case 56: {
+              int rawValue = input.readEnum();
+              org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State value = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(7, rawValue);
+              } else {
+                bitField0_ |= 0x00000040;
+                state_ = value;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -228,6 +249,106 @@ public final class CoordinationProtos {
     @java.lang.Override
     public com.google.protobuf.Parser<DrillbitEndpoint> getParserForType() {
       return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code exec.DrillbitEndpoint.State}
+     */
+    public enum State
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>STARTUP = 0;</code>
+       */
+      STARTUP(0, 0),
+      /**
+       * <code>ONLINE = 1;</code>
+       */
+      ONLINE(1, 1),
+      /**
+       * <code>QUIESCENT = 2;</code>
+       */
+      QUIESCENT(2, 2),
+      /**
+       * <code>OFFLINE = 3;</code>
+       */
+      OFFLINE(3, 3),
+      ;
+
+      /**
+       * <code>STARTUP = 0;</code>
+       */
+      public static final int STARTUP_VALUE = 0;
+      /**
+       * <code>ONLINE = 1;</code>
+       */
+      public static final int ONLINE_VALUE = 1;
+      /**
+       * <code>QUIESCENT = 2;</code>
+       */
+      public static final int QUIESCENT_VALUE = 2;
+      /**
+       * <code>OFFLINE = 3;</code>
+       */
+      public static final int OFFLINE_VALUE = 3;
+
+
+      public final int getNumber() { return value; }
+
+      public static State valueOf(int value) {
+        switch (value) {
+          case 0: return STARTUP;
+          case 1: return ONLINE;
+          case 2: return QUIESCENT;
+          case 3: return OFFLINE;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<State>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<State>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<State>() {
+              public State findValueByNumber(int number) {
+                return State.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final State[] VALUES = values();
+
+      public static State valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private State(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:exec.DrillbitEndpoint.State)
     }
 
     private int bitField0_;
@@ -387,6 +508,22 @@ public final class CoordinationProtos {
       }
     }
 
+    // optional .exec.DrillbitEndpoint.State state = 7;
+    public static final int STATE_FIELD_NUMBER = 7;
+    private org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State state_;
+    /**
+     * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+     */
+    public boolean hasState() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+     */
+    public org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State getState() {
+      return state_;
+    }
+
     private void initFields() {
       address_ = "";
       userPort_ = 0;
@@ -394,6 +531,7 @@ public final class CoordinationProtos {
       dataPort_ = 0;
       roles_ = org.apache.drill.exec.proto.CoordinationProtos.Roles.getDefaultInstance();
       version_ = "";
+      state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -424,6 +562,9 @@ public final class CoordinationProtos {
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeBytes(6, getVersionBytes());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeEnum(7, state_.getNumber());
       }
       getUnknownFields().writeTo(output);
     }
@@ -457,6 +598,10 @@ public final class CoordinationProtos {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(6, getVersionBytes());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(7, state_.getNumber());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -591,6 +736,8 @@ public final class CoordinationProtos {
         bitField0_ = (bitField0_ & ~0x00000010);
         version_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
+        state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -647,6 +794,10 @@ public final class CoordinationProtos {
           to_bitField0_ |= 0x00000020;
         }
         result.version_ = version_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.state_ = state_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -684,6 +835,9 @@ public final class CoordinationProtos {
           bitField0_ |= 0x00000020;
           version_ = other.version_;
           onChanged();
+        }
+        if (other.hasState()) {
+          setState(other.getState());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1072,6 +1226,42 @@ public final class CoordinationProtos {
   }
   bitField0_ |= 0x00000020;
         version_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional .exec.DrillbitEndpoint.State state = 7;
+      private org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
+      /**
+       * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+       */
+      public boolean hasState() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+       */
+      public org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State getState() {
+        return state_;
+      }
+      /**
+       * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+       */
+      public Builder setState(org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000040;
+        state_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
+       */
+      public Builder clearState() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
         onChanged();
         return this;
       }
@@ -2575,19 +2765,21 @@ public final class CoordinationProtos {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\022Coordination.proto\022\004exec\"\214\001\n\020DrillbitE" +
+      "\n\022Coordination.proto\022\004exec\"\367\001\n\020DrillbitE" +
       "ndpoint\022\017\n\007address\030\001 \001(\t\022\021\n\tuser_port\030\002 " +
       "\001(\005\022\024\n\014control_port\030\003 \001(\005\022\021\n\tdata_port\030\004" +
       " \001(\005\022\032\n\005roles\030\005 \001(\0132\013.exec.Roles\022\017\n\007vers" +
-      "ion\030\006 \001(\t\"i\n\024DrillServiceInstance\022\n\n\002id\030" +
-      "\001 \001(\t\022\033\n\023registrationTimeUTC\030\002 \001(\003\022(\n\010en" +
-      "dpoint\030\003 \001(\0132\026.exec.DrillbitEndpoint\"\227\001\n" +
-      "\005Roles\022\027\n\tsql_query\030\001 \001(\010:\004true\022\032\n\014logic" +
-      "al_plan\030\002 \001(\010:\004true\022\033\n\rphysical_plan\030\003 \001" +
-      "(\010:\004true\022\033\n\rjava_executor\030\004 \001(\010:\004true\022\037\n",
-      "\021distributed_cache\030\005 \001(\010:\004trueB3\n\033org.ap" +
-      "ache.drill.exec.protoB\022CoordinationProto" +
-      "sH\001"
+      "ion\030\006 \001(\t\022+\n\005state\030\007 \001(\0162\034.exec.Drillbit" +
+      "Endpoint.State\"<\n\005State\022\013\n\007STARTUP\020\000\022\n\n\006" +
+      "ONLINE\020\001\022\r\n\tQUIESCENT\020\002\022\013\n\007OFFLINE\020\003\"i\n\024" +
+      "DrillServiceInstance\022\n\n\002id\030\001 \001(\t\022\033\n\023regi" +
+      "strationTimeUTC\030\002 \001(\003\022(\n\010endpoint\030\003 \001(\0132" +
+      "\026.exec.DrillbitEndpoint\"\227\001\n\005Roles\022\027\n\tsql",
+      "_query\030\001 \001(\010:\004true\022\032\n\014logical_plan\030\002 \001(\010" +
+      ":\004true\022\033\n\rphysical_plan\030\003 \001(\010:\004true\022\033\n\rj" +
+      "ava_executor\030\004 \001(\010:\004true\022\037\n\021distributed_" +
+      "cache\030\005 \001(\010:\004trueB3\n\033org.apache.drill.ex" +
+      "ec.protoB\022CoordinationProtosH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -2599,7 +2791,7 @@ public final class CoordinationProtos {
           internal_static_exec_DrillbitEndpoint_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_DrillbitEndpoint_descriptor,
-              new java.lang.String[] { "Address", "UserPort", "ControlPort", "DataPort", "Roles", "Version", });
+              new java.lang.String[] { "Address", "UserPort", "ControlPort", "DataPort", "Roles", "Version", "State", });
           internal_static_exec_DrillServiceInstance_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_exec_DrillServiceInstance_fieldAccessorTable = new

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaCoordinationProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaCoordinationProtos.java
@@ -48,6 +48,8 @@ public final class SchemaCoordinationProtos
 
                 if(message.hasVersion())
                     output.writeString(6, message.getVersion(), false);
+                if(message.hasState())
+                    output.writeEnum(7, message.getState().getNumber(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint message)
             {
@@ -106,6 +108,9 @@ public final class SchemaCoordinationProtos
                         case 6:
                             builder.setVersion(input.readString());
                             break;
+                        case 7:
+                            builder.setState(org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.valueOf(input.readEnum()));
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -152,6 +157,7 @@ public final class SchemaCoordinationProtos
                 case 4: return "dataPort";
                 case 5: return "roles";
                 case 6: return "version";
+                case 7: return "state";
                 default: return null;
             }
         }
@@ -169,6 +175,7 @@ public final class SchemaCoordinationProtos
             fieldMap.put("dataPort", 4);
             fieldMap.put("roles", 5);
             fieldMap.put("version", 6);
+            fieldMap.put("state", 7);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/DrillbitEndpoint.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/DrillbitEndpoint.java
@@ -33,6 +33,38 @@ import com.dyuproject.protostuff.Schema;
 
 public final class DrillbitEndpoint implements Externalizable, Message<DrillbitEndpoint>, Schema<DrillbitEndpoint>
 {
+    public enum State implements com.dyuproject.protostuff.EnumLite<State>
+    {
+        STARTUP(0),
+        ONLINE(1),
+        QUIESCENT(2),
+        OFFLINE(3);
+        
+        public final int number;
+        
+        private State (int number)
+        {
+            this.number = number;
+        }
+        
+        public int getNumber()
+        {
+            return number;
+        }
+        
+        public static State valueOf(int number)
+        {
+            switch(number) 
+            {
+                case 0: return STARTUP;
+                case 1: return ONLINE;
+                case 2: return QUIESCENT;
+                case 3: return OFFLINE;
+                default: return null;
+            }
+        }
+    }
+
 
     public static Schema<DrillbitEndpoint> getSchema()
     {
@@ -53,6 +85,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
     private int dataPort;
     private Roles roles;
     private String version;
+    private State state;
 
     public DrillbitEndpoint()
     {
@@ -139,6 +172,19 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
         return this;
     }
 
+    // state
+
+    public State getState()
+    {
+        return state == null ? State.STARTUP : state;
+    }
+
+    public DrillbitEndpoint setState(State state)
+    {
+        this.state = state;
+        return this;
+    }
+
     // java serialization
 
     public void readExternal(ObjectInput in) throws IOException
@@ -212,6 +258,9 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
                 case 6:
                     message.version = input.readString();
                     break;
+                case 7:
+                    message.state = State.valueOf(input.readEnum());
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -239,6 +288,9 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
 
         if(message.version != null)
             output.writeString(6, message.version, false);
+
+        if(message.state != null)
+             output.writeEnum(7, message.state.number, false);
     }
 
     public String getFieldName(int number)
@@ -251,6 +303,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
             case 4: return "dataPort";
             case 5: return "roles";
             case 6: return "version";
+            case 7: return "state";
             default: return null;
         }
     }
@@ -270,6 +323,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
         __fieldMap.put("dataPort", 4);
         __fieldMap.put("roles", 5);
         __fieldMap.put("version", 6);
+        __fieldMap.put("state", 7);
     }
     
 }

--- a/protocol/src/main/protobuf/Coordination.proto
+++ b/protocol/src/main/protobuf/Coordination.proto
@@ -11,6 +11,13 @@ message DrillbitEndpoint{
   optional int32 data_port = 4;
   optional Roles roles = 5;
   optional string version = 6;
+  enum State {
+      STARTUP = 0;
+      ONLINE = 1;
+      QUIESCENT = 2;
+      OFFLINE = 3;
+  }
+  optional State state = 7;
 }
 
 message DrillServiceInstance{


### PR DESCRIPTION
Following is the design document https://docs.google.com/document/d/1AauIwVCjsBKBSbbU6sQODErrEp7n3IwniMtgK4m09MQ/edit#heading=h.224lbmcaxu2d.

I will be doing minor modifications and adding more tests for a couple of days.

NOTE : PCAP_SUB_SCAN in UserBitShared.proto is missing. I have added that since I made some changes to protobuf and generated code. Once it is added as part of DRILL-5432 I will remove it from my commit.

TODOS: 
- Adding Cors support in WebUI.
- Post request to put the Drillbit in offline mode. (Estimate - 2 days)
- Allow port hunting for unit tests. Drillbit allows port hunting only in embedded mode. But port hunting is needed in scenarios where unit tests require running multiple drillbits on the same machine with Zookeeper. (Need some discussion)
               


