### PR TITLE
DRILL-5723: Added System Internal Options That can be Modified at Runtime

### DIFF
--- a/common/src/test/java/org/apache/drill/test/DrillTest.java
+++ b/common/src/test/java/org/apache/drill/test/DrillTest.java
@@ -57,7 +57,7 @@ public class DrillTest {
   static MemWatcher memWatcher;
   static String className;
 
-  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(50000);
+  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(1000000);
   @Rule public final TestLogReporter logOutcome = LOG_OUTCOME;
 
   @Rule public final TestRule REPEAT_RULE = TestTools.getRepeatRule(false);

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestInbuiltHiveUDFs.java
@@ -134,7 +134,7 @@ public class TestInbuiltHiveUDFs extends HiveTestBase {
 
     } finally {
       // restore the system option
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
     }
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -28,6 +28,7 @@ import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.UserProtos;
+import org.apache.drill.test.OperatorFixture;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.joda.time.DateTime;
@@ -73,9 +74,10 @@ public class TestHiveStorage extends HiveTestBase {
           .baselineValues(200l)
           .go();
     } finally {
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
       test(String.format("alter session set `%s` = %s",
           ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS,
-              ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS_VALIDATOR.getDefault().bool_val ? "true" : "false"));
+          Boolean.toString(testOptionSet.getDefault(ExecConstants.HIVE_OPTIMIZE_SCAN_WITH_NATIVE_READERS).bool_val)));
     }
   }
 

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -6,9 +6,7 @@
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
-
      http://www.apache.org/licenses/LICENSE-2.0
-
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +29,7 @@
     <mysql.connector.version>5.1.36</mysql.connector.version>
     <derby.database.name>drill_derby_test</derby.database.name>
     <mysql.database.name>drill_mysql_test</mysql.database.name>
+    <skipTests>false</skipTests>
   </properties>
 
   <dependencies>
@@ -39,7 +38,7 @@
       <artifactId>drill-java-exec</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -92,6 +91,11 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!--
+          Forking multiple processes can cause race conditions with the initialization of
+          the test databases.
+          -->
+          <forkCount combine.self="override">1</forkCount>
           <excludes>
             <exclude>**/*</exclude>
           </excludes>
@@ -102,12 +106,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.18.1</version>
+        <configuration>
+          <forkCount combine.self="override">1</forkCount>
+          <systemPropertyVariables>
+            <derby.port>${derby.reserved.port}</derby.port>
+            <mysql.port>${mysql.reserved.port}</mysql.port>
+            <mysql.name>${mysql.database.name}</mysql.name>
+          </systemPropertyVariables>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
         <executions>
           <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
+            <id>run-IT-Tests</id>
+            <phase>integration-test</phase>
           </execution>
         </executions>
       </plugin>
@@ -258,24 +271,6 @@
         </executions>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <forkCount>1</forkCount>
-            <systemPropertyVariables>
-              <derby.port>${derby.reserved.port}</derby.port>
-              <mysql.port>${mysql.reserved.port}</mysql.port>
-              <mysql.name>${mysql.database.name}</mysql.name>
-            </systemPropertyVariables>
-            <includes>
-              <include>**/*IT.java</include>
-            </includes>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
 </project>

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -80,9 +80,15 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-	  <includes>
-	    <include>${mongo.TestSuite}</include>
-	  </includes>
+          <includes>
+            <include>${mongo.TestSuite}</include>
+          </includes>
+          <excludes>
+            <exclude>**/TestMongoFilterPushDown.java</exclude>
+            <exclude>**/TestMongoProjectPushDown.java</exclude>
+            <exclude>**/TestMongoQueries.java</exclude>
+            <exclude>**/TestMongoChunkAssignment.java</exclude>
+          </excludes>
           <systemProperties>
             <property>
               <name>logback.log.dir</name>

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestBase.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 public class MongoTestBase extends PlanTestBase implements MongoTestConstants {
@@ -36,6 +37,8 @@ public class MongoTestBase extends PlanTestBase implements MongoTestConstants {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    // Make sure this test is only running as part of the suit
+    Assume.assumeTrue(MongoTestSuit.isRunningSuite());
     MongoTestSuit.initMongo();
     initMongoStoragePlugin();
   }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
@@ -76,6 +76,12 @@ public class MongoTestSuit implements MongoTestConstants {
 
   private static volatile AtomicInteger initCount = new AtomicInteger(0);
 
+  private static volatile boolean runningSuite = false;
+
+  public static boolean isRunningSuite() {
+    return runningSuite;
+  }
+
   private static class DistributedMode {
     private static MongosSystemForTestFactory mongosTestFactory;
 
@@ -223,6 +229,7 @@ public class MongoTestSuit implements MongoTestConstants {
         TestTableGenerator.importData(DATATYPE_DB, DATATYPE_COLLECTION, DATATYPE_DATA);
       }
       initCount.incrementAndGet();
+      runningSuite = true;
     }
   }
 
@@ -253,6 +260,7 @@ public class MongoTestSuit implements MongoTestConstants {
           }
         }
         finally {
+          runningSuite = false;
           if (mongoClient != null) {
             mongoClient.close();
           }

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -181,6 +181,11 @@
       <version>2.8</version>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>2.8</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${jackson.version}</version>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -116,6 +116,7 @@ public interface ExecConstants {
   String HTTP_ENABLE = "drill.exec.http.enabled";
   String HTTP_MAX_PROFILES = "drill.exec.http.max_profiles";
   String HTTP_PORT = "drill.exec.http.port";
+  String HTTP_PORT_HUNT = "drill.exec.http.porthunt";
   String HTTP_ENABLE_SSL = "drill.exec.http.ssl_enabled";
   String HTTP_CORS_ENABLED = "drill.exec.http.cors.enabled";
   String HTTP_CORS_ALLOWED_ORIGINS = "drill.exec.http.cors.allowedOrigins";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec;
 
 import org.apache.drill.exec.physical.impl.common.HashTable;
 import org.apache.drill.exec.rpc.user.InboundImpersonationManager;
+import org.apache.drill.exec.server.options.OptionMetaData;
 import org.apache.drill.exec.server.options.OptionValidator;
 import org.apache.drill.exec.server.options.TypeValidators.BooleanValidator;
 import org.apache.drill.exec.server.options.TypeValidators.DoubleValidator;
@@ -423,13 +424,13 @@ public interface ExecConstants {
    * such as changing system options.
    */
   String ADMIN_USERS_KEY = "security.admin.users";
-  StringValidator ADMIN_USERS_VALIDATOR = new StringValidator(ADMIN_USERS_KEY, true);
+  StringValidator ADMIN_USERS_VALIDATOR = new StringValidator(ADMIN_USERS_KEY);
 
   /**
    * Option whose value is a comma separated list of admin usergroups.
    */
   String ADMIN_USER_GROUPS_KEY = "security.admin.user_groups";
-  StringValidator ADMIN_USER_GROUPS_VALIDATOR = new StringValidator(ADMIN_USER_GROUPS_KEY, true);
+  StringValidator ADMIN_USER_GROUPS_VALIDATOR = new StringValidator(ADMIN_USER_GROUPS_KEY);
   /**
    * Option whose value is a string representing list of inbound impersonation policies.
    *
@@ -472,8 +473,7 @@ public interface ExecConstants {
    * for any query.
    */
   String ENABLE_QUERY_PROFILE_OPTION = "exec.query_profile.save";
-  BooleanValidator ENABLE_QUERY_PROFILE_VALIDATOR = new BooleanValidator(
-      ENABLE_QUERY_PROFILE_OPTION);
+  BooleanValidator ENABLE_QUERY_PROFILE_VALIDATOR = new BooleanValidator(ENABLE_QUERY_PROFILE_OPTION);
 
   /**
    * Profiles are normally written after the last client message to reduce latency.
@@ -482,8 +482,7 @@ public interface ExecConstants {
    * verification.
    */
   String QUERY_PROFILE_DEBUG_OPTION = "exec.query_profile.debug_mode";
-  BooleanValidator QUERY_PROFILE_DEBUG_VALIDATOR = new BooleanValidator(
-      QUERY_PROFILE_DEBUG_OPTION);
+  BooleanValidator QUERY_PROFILE_DEBUG_VALIDATOR = new BooleanValidator(QUERY_PROFILE_DEBUG_OPTION);
 
   String USE_DYNAMIC_UDFS_KEY = "exec.udf.use_dynamic";
   BooleanValidator USE_DYNAMIC_UDFS = new BooleanValidator(USE_DYNAMIC_UDFS_KEY);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/ClassCompilerSelector.java
@@ -25,6 +25,7 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.compile.ClassTransformer.ClassNames;
 import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.server.options.OptionMetaData;
 import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.OptionValidator;
 import org.apache.drill.exec.server.options.OptionValue;
@@ -82,8 +83,8 @@ public class ClassCompilerSelector {
 
   public static final StringValidator JAVA_COMPILER_VALIDATOR = new StringValidator(JAVA_COMPILER_OPTION) {
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       try {
         CompilerPolicy.valueOf(v.string_val.toUpperCase());
       } catch (IllegalArgumentException e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -40,7 +40,6 @@ import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.QueryProfileStoreContext;
-import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.QueryOptionManager;
 import org.apache.drill.exec.store.PartitionExplorer;
@@ -65,7 +64,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
 
   private final DrillbitContext drillbitContext;
   private final UserSession session;
-  private final OptionManager queryOptions;
+  private final QueryOptionManager queryOptions;
   private final PlannerSettings plannerSettings;
   private final ExecutionControls executionControls;
 
@@ -182,7 +181,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     return session.getCredentials().getUserName();
   }
 
-  public OptionManager getOptions() {
+  public QueryOptionManager getOptions() {
     return queryOptions;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -90,10 +90,10 @@ public class PlannerSettings implements Context{
 
   public static final DoubleValidator FILTER_MIN_SELECTIVITY_ESTIMATE_FACTOR =
           new MinRangeDoubleValidator("planner.filter.min_selectivity_estimate_factor",
-          0.0, 1.0, 0.0d, "planner.filter.max_selectivity_estimate_factor");
+          0.0, 1.0, "planner.filter.max_selectivity_estimate_factor");
   public static final DoubleValidator FILTER_MAX_SELECTIVITY_ESTIMATE_FACTOR =
           new MaxRangeDoubleValidator("planner.filter.max_selectivity_estimate_factor",
-          0.0, 1.0, 1.0d, "planner.filter.min_selectivity_estimate_factor");
+          0.0, 1.0, "planner.filter.min_selectivity_estimate_factor");
 
   public static final String TYPE_INFERENCE_KEY = "planner.enable_type_inference";
   public static final BooleanValidator TYPE_INFERENCE = new BooleanValidator(TYPE_INFERENCE_KEY);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -93,7 +93,6 @@ import org.apache.drill.exec.planner.physical.visitor.SwapHashJoinVisitor;
 import org.apache.drill.exec.planner.physical.visitor.TopProjectVisitor;
 import org.apache.drill.exec.planner.sql.parser.UnsupportedOperatorsVisitor;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.util.Pointer;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.apache.drill.exec.work.foreman.SqlUnsupportedException;
@@ -448,8 +447,8 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       log("Not enough memory for this plan", phyRelNode, logger, null);
       logger.debug("Re-planning without hash operations.");
 
-      queryOptions.setOption(OptionValue.createBoolean(OptionValue.OptionType.QUERY, PlannerSettings.HASHJOIN.getOptionName(), false, OptionValue.OptionScope.QUERY));
-      queryOptions.setOption(OptionValue.createBoolean(OptionValue.OptionType.QUERY, PlannerSettings.HASHAGG.getOptionName(), false, OptionValue.OptionScope.QUERY));
+      queryOptions.setLocalOption(PlannerSettings.HASHJOIN.getOptionName(), false);
+      queryOptions.setLocalOption(PlannerSettings.HASHAGG.getOptionName(), false);
 
       try {
         final RelNode relNode = transform(PlannerType.VOLCANO, PlannerPhase.PHYSICAL, drel, traits);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SetOptionHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SetOptionHandler.java
@@ -23,6 +23,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.ValidationException;
 
 import org.apache.calcite.util.NlsString;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.QueryContext;
@@ -30,8 +32,8 @@ import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.planner.sql.DirectPlan;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 import org.apache.drill.exec.server.options.OptionValue.OptionScope;
+import org.apache.drill.exec.server.options.QueryOptionManager;
 import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.apache.calcite.sql.SqlLiteral;
@@ -64,19 +66,15 @@ public class SetOptionHandler extends AbstractSqlHandler {
     }
 
     final String scope = option.getScope();
-    final OptionValue.OptionType type;
     final OptionValue.OptionScope optionScope;
     if (scope == null) { // No scope mentioned assumed SESSION
-      type = OptionType.SESSION;
       optionScope = OptionScope.SESSION;
     } else {
       switch (scope.toLowerCase()) {
       case "session":
-        type = OptionType.SESSION;
         optionScope = OptionScope.SESSION;
         break;
       case "system":
-        type = OptionType.SYSTEM;
         optionScope = OptionScope.SYSTEM;
         break;
       default:
@@ -86,8 +84,8 @@ public class SetOptionHandler extends AbstractSqlHandler {
       }
     }
 
-    final OptionManager options = context.getOptions();
-    if (type == OptionType.SYSTEM) {
+    final QueryOptionManager options = context.getOptions();
+    if (optionScope == OptionScope.SYSTEM) {
       // If the user authentication is enabled, make sure the user who is trying to change the system option has
       // administrative privileges.
       if (context.isUserAuthenticationEnabled() &&
@@ -101,53 +99,55 @@ public class SetOptionHandler extends AbstractSqlHandler {
       }
     }
 
+    final String optionName = option.getName().toString();
+
     // Currently, we convert multi-part identifier to a string.
-    final String name = option.getName().toString();
+    final OptionManager chosenOptions = options.getOptionManager(optionScope);
+
     if (value != null) { // SET option
-      final OptionValue optionValue = createOptionValue(name, type, (SqlLiteral) value, optionScope);
-      options.setOption(optionValue);
+      final Object literalObj = sqlLiteralToObject((SqlLiteral) value);
+      chosenOptions.setLocalOption(optionName, literalObj);
     } else { // RESET option
-      if ("ALL".equalsIgnoreCase(name)) {
-        options.deleteAllOptions(type);
+      if ("ALL".equalsIgnoreCase(optionName)) {
+        chosenOptions.deleteAllLocalOptions();
       } else {
-        options.deleteOption(name, type);
+        chosenOptions.deleteLocalOption(optionName);
       }
     }
 
-    return DirectPlan.createDirectPlan(context, true, String.format("%s updated.", name));
+    return DirectPlan.createDirectPlan(context, true, String.format("%s updated.", optionName));
   }
 
-  private static OptionValue createOptionValue(final String name, final OptionValue.OptionType type,
-                                               final SqlLiteral literal, final OptionValue.OptionScope scope) {
+  private static Object sqlLiteralToObject(final SqlLiteral literal) {
     final Object object = literal.getValue();
     final SqlTypeName typeName = literal.getTypeName();
     switch (typeName) {
     case DECIMAL: {
       final BigDecimal bigDecimal = (BigDecimal) object;
       if (bigDecimal.scale() == 0) {
-        return OptionValue.createLong(type, name, bigDecimal.longValue(), scope);
+        return bigDecimal.longValue();
       } else {
-        return OptionValue.createDouble(type, name, bigDecimal.doubleValue(), scope);
+        return bigDecimal.doubleValue();
       }
     }
 
     case DOUBLE:
     case FLOAT:
-      return OptionValue.createDouble(type, name, ((BigDecimal) object).doubleValue(), scope);
+      return ((BigDecimal) object).doubleValue();
 
     case SMALLINT:
     case TINYINT:
     case BIGINT:
     case INTEGER:
-      return OptionValue.createLong(type, name, ((BigDecimal) object).longValue(), scope);
+      return ((BigDecimal) object).longValue();
 
     case VARBINARY:
     case VARCHAR:
     case CHAR:
-      return OptionValue.createString(type, name, ((NlsString) object).getValue(), scope);
+      return ((NlsString) object).getValue().toString();
 
     case BOOLEAN:
-      return OptionValue.createBoolean(type, name, (Boolean) object, scope);
+      return object;
 
     default:
       throw UserException.validationError()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/InboundImpersonationManager.java
@@ -27,6 +27,7 @@ import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared.UserCredentials;
+import org.apache.drill.exec.server.options.OptionMetaData;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.TypeValidators.StringValidator;
@@ -87,12 +88,12 @@ public class InboundImpersonationManager {
   public static class InboundImpersonationPolicyValidator extends StringValidator {
 
     public InboundImpersonationPolicyValidator(String name) {
-      super(name, true);
+      super(name);
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
 
       final List<ImpersonationPolicy> policies;
       try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
@@ -40,13 +40,9 @@ import org.apache.drill.exec.planner.sql.handlers.SqlHandlerUtil;
 import org.apache.drill.exec.proto.UserBitShared.UserCredentials;
 import org.apache.drill.exec.proto.UserProtos.UserProperties;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionScope;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 
 import com.google.common.collect.Maps;
-import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.StorageStrategy;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
@@ -60,7 +56,7 @@ public class UserSession implements AutoCloseable {
   private boolean supportComplexTypes = false;
   private UserCredentials credentials;
   private DrillProperties properties;
-  private OptionManager sessionOptions;
+  private SessionOptionManager sessionOptions;
   private final AtomicInteger queryCount;
   private final String sessionId;
 
@@ -156,7 +152,7 @@ public class UserSession implements AutoCloseable {
     return supportComplexTypes;
   }
 
-  public OptionManager getOptions() {
+  public SessionOptionManager getOptions() {
     return sessionOptions;
   }
 
@@ -249,9 +245,7 @@ public class UserSession implements AutoCloseable {
    * @param value option value
    */
   public void setSessionOption(String name, String value) {
-    OptionValue.Kind optionKind = ((SessionOptionManager) sessionOptions).getFallbackOptionManager().getValidator(name).getKind();
-    OptionValue optionValue = OptionValue.createOption(optionKind, OptionType.SESSION, name, value, OptionScope.SESSION);
-    sessionOptions.setOption(optionValue);
+    sessionOptions.setLocalOption(name, value);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -31,6 +31,7 @@ import java.util.concurrent.SynchronousQueue;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.KerberosUtil;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.DrillbitStartupException;
@@ -41,6 +42,7 @@ import org.apache.drill.exec.rpc.NamedThreadFactory;
 import org.apache.drill.exec.rpc.TransportCheck;
 import org.apache.drill.exec.rpc.security.AuthenticatorProvider;
 import org.apache.drill.exec.rpc.security.AuthenticatorProviderImpl;
+import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -64,6 +66,7 @@ public class BootStrapContext implements AutoCloseable {
   public static final String KERBEROS_NAME_MAPPING = SERVICE_LOGIN_PREFIX + ".auth_to_local";
 
   private final DrillConfig config;
+  private final CaseInsensitiveMap<OptionDefinition> definitions;
   private final AuthenticatorProvider authProvider;
   private final EventLoopGroup loop;
   private final EventLoopGroup loop2;
@@ -75,8 +78,10 @@ public class BootStrapContext implements AutoCloseable {
   private final ExecutorService scanDecodeExecutor;
   private final String hostName;
 
-  public BootStrapContext(DrillConfig config, ScanResult classpathScan) throws DrillbitStartupException {
+  public BootStrapContext(DrillConfig config, CaseInsensitiveMap<OptionDefinition> definitions,
+                          ScanResult classpathScan) throws DrillbitStartupException {
     this.config = config;
+    this.definitions = definitions;
     this.classpathScan = classpathScan;
     this.hostName = getCanonicalHostName();
     login(config);
@@ -188,6 +193,10 @@ public class BootStrapContext implements AutoCloseable {
 
   public DrillConfig getConfig() {
     return config;
+  }
+
+  public CaseInsensitiveMap<OptionDefinition> getDefinitions() {
+    return definitions;
   }
 
   public EventLoopGroup getBitLoopGroup() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -104,7 +104,7 @@ public class DrillbitContext implements AutoCloseable {
 
     this.reader = new PhysicalPlanReader(context.getConfig(), classpathScan, lpPersistence, endpoint, storagePlugins);
     this.operatorCreatorRegistry = new OperatorCreatorRegistry(classpathScan);
-    this.systemOptions = new SystemOptionManager(lpPersistence, provider,context.getConfig());
+    this.systemOptions = new SystemOptionManager(lpPersistence, provider, context.getConfig(), context.getDefinitions());
     this.functionRegistry = new FunctionImplementationRegistry(context.getConfig(), classpathScan, systemOptions);
     this.compiler = new CodeCompiler(context.getConfig(), systemOptions);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionSet.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server.options;
+
+/**
+ * A basic implementation of an {@link OptionSet}.
+ */
+public abstract class BaseOptionSet implements OptionSet {
+  /**
+   * Gets the current option value given a validator.
+   *
+   * @param validator the validator
+   * @return option value
+   * @throws IllegalArgumentException - if the validator is not found
+   */
+  private OptionValue getOptionSafe(OptionValidator validator) {
+    final String optionName = validator.getOptionName();
+    OptionValue value = getOption(optionName);
+    return value == null ? getDefault(optionName) : value;
+  }
+
+  @Override
+  public boolean getOption(TypeValidators.BooleanValidator validator) {
+    return getOptionSafe(validator).bool_val;
+  }
+
+  @Override
+  public double getOption(TypeValidators.DoubleValidator validator) {
+    return getOptionSafe(validator).float_val;
+  }
+
+  @Override
+  public long getOption(TypeValidators.LongValidator validator) {
+    return getOptionSafe(validator).num_val;
+  }
+
+  @Override
+  public String getOption(TypeValidators.StringValidator validator) {
+    return getOptionSafe(validator).string_val;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/DrillConfigIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/DrillConfigIterator.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
+import org.apache.drill.exec.server.options.OptionValue.AccessibleScopes;
 import org.apache.drill.exec.server.options.OptionValue.OptionScope;
 
 import com.typesafe.config.ConfigValue;
@@ -58,17 +58,17 @@ public class DrillConfigIterator implements Iterable<OptionValue> {
       OptionValue optionValue = null;
       switch(cv.valueType()) {
       case BOOLEAN:
-        optionValue = OptionValue.createBoolean(OptionType.BOOT, name, (Boolean) cv.unwrapped(), OptionScope.BOOT);
+        optionValue = OptionValue.create(AccessibleScopes.BOOT, name, (Boolean) cv.unwrapped(), OptionScope.BOOT);
         break;
 
       case LIST:
       case OBJECT:
       case STRING:
-        optionValue = OptionValue.createString(OptionType.BOOT, name, cv.render(),OptionScope.BOOT);
+        optionValue = OptionValue.create(AccessibleScopes.BOOT, name, cv.render(),OptionScope.BOOT);
         break;
 
       case NUMBER:
-        optionValue = OptionValue.createLong(OptionType.BOOT, name, ((Number) cv.unwrapped()).longValue(),OptionScope.BOOT);
+        optionValue = OptionValue.create(OptionValue.AccessibleScopes.BOOT, name, ((Number) cv.unwrapped()).longValue(),OptionScope.BOOT);
         break;
 
       case NULL:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
@@ -20,18 +20,14 @@ package org.apache.drill.exec.server.options;
 import java.util.Iterator;
 
 import com.google.common.collect.Iterables;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 
 /**
- * An {@link OptionManager} which allows for falling back onto another {@link OptionManager}. This way method calls can
- * be delegated to the fallback manager in case the current manager does not handle the specified option. Also, all
- * options do not need to be stored at every contextual level. For example, if an option isn't changed from its default
- * within a session, then we can get the option from system options.
+ * An {@link OptionManager} which allows for falling back onto another {@link OptionManager} when retrieving options.
  * <p/>
  * {@link FragmentOptionManager} and {@link SessionOptionManager} use {@link SystemOptionManager} as the fall back
  * manager. {@link QueryOptionManager} uses {@link SessionOptionManager} as the fall back manager.
  */
-public abstract class FallbackOptionManager extends BaseOptionManager implements OptionManager {
+public abstract class FallbackOptionManager extends BaseOptionManager {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FallbackOptionManager.class);
 
   protected final OptionManager fallback;
@@ -75,65 +71,9 @@ public abstract class FallbackOptionManager extends BaseOptionManager implements
    */
   abstract OptionValue getLocalOption(String name);
 
-  /**
-   * Sets the option value for this manager without falling back.
-   *
-   * @param value the option value
-   * @return true iff the value was successfully set
-   */
-  abstract boolean setLocalOption(OptionValue value);
-
-  /**
-   * Deletes all options for this manager without falling back.
-   *
-   * If no options are set, calling this method should be no-op. See {@link OptionManager#deleteAllOptions}.
-   *
-   * @param type option type
-   * @return true iff the option type is supported
-   */
-  abstract boolean deleteAllLocalOptions(OptionType type);
-
-  /**
-   * Deletes the option with given name for this manager without falling back.
-   *
-   * This method will be called with an option name that is guaranteed to have an option validator. Also, if option
-   * with {@param name} does not exist within the manager, calling this method should be a no-op. See
-   * {@link OptionManager#deleteOption}.
-   *
-   * @param name option name
-   * @param type option type
-   * @return true iff the option type is supported
-   */
-  abstract boolean deleteLocalOption(String name, OptionType type);
-
   @Override
-  public void setOption(OptionValue value) {
-    final OptionValidator validator =  getSystemOptionManager().getValidator(value.name);
-
-    validator.validate(value, this); // validate the option
-
-    // fallback if unable to set locally
-    if (!setLocalOption(value)) {
-      fallback.setOption(value);
-    }
-  }
-
-  @Override
-  public void deleteOption(final String name, final OptionType type) {
-    getSystemOptionManager().getValidator(name); // ensure the option exists
-
-    // fallback if unable to delete locally
-    if (!deleteLocalOption(name, type)) {
-      fallback.deleteOption(name, type);
-    }
-  }
-
-  @Override
-  public void deleteAllOptions(final OptionType type) {
-    // fallback if unable to delete locally
-    if (!deleteAllLocalOptions(type)) {
-      fallback.deleteAllOptions(type);
-    }
+  public OptionDefinition getOptionDefinition(String name) {
+    return fallback.getOptionDefinition(name);
   }
 
   @Override
@@ -143,28 +83,5 @@ public abstract class FallbackOptionManager extends BaseOptionManager implements
       list.add(value);
     }
     return list;
-  }
-
-  public OptionManager getFallback() {
-    return fallback;
-  }
-
-  /**
-   * {@link FragmentOptionManager} and {@link SessionOptionManager} use {@link SystemOptionManager} as the fall back
-   * manager so for both FragmentOptionManager and SessionOptionManager fallback is the SystemOptionManager so it is
-   * returned. But in case of {@link QueryOptionManager}, it uses {@link SessionOptionManager} as the fallback manager
-   * and since SessionOptionManager uses SystemOptionManager as fallback, SystemOptionManager can be fetched from the
-   * SessionOptionManager.
-   */
-  public SystemOptionManager getSystemOptionManager() {
-    final SystemOptionManager systemOptionManager;
-    if(fallback instanceof SessionOptionManager) {
-      final SessionOptionManager sessionOptionManager = (SessionOptionManager) fallback;
-      systemOptionManager = sessionOptionManager.getFallbackOptionManager();
-    }
-    else {
-      systemOptionManager = (SystemOptionManager) fallback;
-    }
-    return systemOptionManager;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FragmentOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FragmentOptionManager.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.server.options;
 
 import com.google.common.collect.Maps;
 import org.apache.drill.common.map.CaseInsensitiveMap;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 
 import java.util.Map;
 
@@ -42,9 +41,27 @@ public class FragmentOptionManager extends InMemoryOptionManager {
   }
 
   @Override
-  boolean supportsOptionType(OptionType type) {
-    throw new UnsupportedOperationException("FragmentOptionManager does not support the given option value.");
+  public void deleteAllLocalOptions() {
+    throw new UnsupportedOperationException();
   }
 
+  @Override
+  public void deleteLocalOption(String name) {
+    throw new UnsupportedOperationException();
+  }
 
+  @Override
+  public OptionValue getDefault(String optionName) {
+    return fallback.getDefault(optionName);
+  }
+
+  @Override
+  protected OptionValue.OptionScope getScope() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setLocalOptionHelper(OptionValue value) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/InMemoryOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/InMemoryOptionManager.java
@@ -17,14 +17,12 @@
  */
 package org.apache.drill.exec.server.options;
 
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
-
 import java.util.Map;
 
 /**
- * {@link OptionManager} that hold options in memory rather than in a persistent store. Option stored in
+ * This is an {@link OptionManager} that holds options in memory rather than in a persistent store. Options stored in
  * {@link SessionOptionManager}, {@link QueryOptionManager}, and {@link FragmentOptionManager} are held in memory
- * (see {@link #options}) whereas {@link SystemOptionManager} stores options in a persistent store.
+ * (see {@link #options}) whereas the {@link SystemOptionManager} stores options in a persistent store.
  */
 public abstract class InMemoryOptionManager extends FallbackOptionManager {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InMemoryOptionManager.class);
@@ -42,13 +40,8 @@ public abstract class InMemoryOptionManager extends FallbackOptionManager {
   }
 
   @Override
-  boolean setLocalOption(final OptionValue value) {
-    if (supportsOptionType(value.type)) {
-      options.put(value.name, value);
-      return true;
-    } else {
-      return false;
-    }
+  public void setLocalOptionHelper(final OptionValue value) {
+    options.put(value.name, value);
   }
 
   @Override
@@ -57,31 +50,12 @@ public abstract class InMemoryOptionManager extends FallbackOptionManager {
   }
 
   @Override
-  boolean deleteAllLocalOptions(final OptionType type) {
-    if (supportsOptionType(type)) {
-      options.clear();
-      return true;
-    } else {
-      return false;
-    }
+  public void deleteAllLocalOptions() {
+    options.clear();
   }
 
   @Override
-  boolean deleteLocalOption(final String name, final OptionType type) {
-    if (supportsOptionType(type)) {
-      options.remove(name);
-      return true;
-    } else {
-      return false;
-    }
+  public void deleteLocalOption(final String name) {
+    options.remove(name);
   }
-
-  /**
-   * Check to see if implementations of this manager support the given option type.
-   *
-   * @param type option type
-   * @return true iff the type is supported
-   */
-  abstract boolean supportsOptionType(OptionType type);
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionDefinition.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionDefinition.java
@@ -15,14 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.util;
 
-public class Pointer<T> {
-  public volatile T value;
+package org.apache.drill.exec.server.options;
 
-  public Pointer(){}
+import com.google.common.base.Preconditions;
 
-  public Pointer(T value){
-    this.value = value;
+/**
+ * This holds all the information about an option.
+ */
+public class OptionDefinition {
+  private final OptionValidator validator;
+  private final OptionMetaData metaData;
+
+  public OptionDefinition(OptionValidator validator) {
+    this.validator = Preconditions.checkNotNull(validator);
+    this.metaData = OptionMetaData.DEFAULT;
+  }
+
+  public OptionDefinition(OptionValidator validator, OptionMetaData metaData) {
+    this.validator = Preconditions.checkNotNull(validator);
+    this.metaData = Preconditions.checkNotNull(metaData);
+  }
+
+  public OptionValidator getValidator() {
+    return validator;
+  }
+
+  public OptionMetaData getMetaData() {
+    return metaData;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionManager.java
@@ -17,44 +17,104 @@
  */
 package org.apache.drill.exec.server.options;
 
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
+import org.apache.drill.common.exceptions.UserException;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Manager for Drill {@link OptionValue options}. Implementations must be case-insensitive to the name of an option.
+ *
+ * The options governed by an {@link OptionManager} fall into various categories. These categories are described below.
+ *
+ * <ul>
+ *   <li>
+ *     <b>Local:</b> Local options are options who have a value stored in this {@link OptionManager}. Whether an option is <b>Local</b> to an {@link OptionManager} or not should
+ *      be irrelevant to the user.
+ *   </li>
+ *   <li>
+ *     <b>Public:</b> Public options are options that are visible to end users in all the standard tables and rest endpoints.
+ *   </li>
+ *   <li>
+ *     <b>Internal:</b> Internal options are options that are only visible to end users if they check special tables and rest endpoints that are not documented. These options
+ *     are not intended to be modified by users and should only be modified by support during debugging. Internal options are also not gauranteed to be consistent accross
+ *     patch, minor, or major releases.
+ *   </li>
+ * </ul>
+ *
  */
 public interface OptionManager extends OptionSet, Iterable<OptionValue> {
 
   /**
-   * Sets an option value.
-   *
-   * @param value option value
-   * @throws org.apache.drill.common.exceptions.UserException message to describe error with value
+   * Sets a boolean option on the {@link OptionManager}.
+   * @param name The name of the option.
+   * @param value The value of the option.
    */
-  void setOption(OptionValue value);
+  void setLocalOption(String name, boolean value);
 
   /**
-   * Deletes the option. Unfortunately, the type is required given the fallback structure of option managers.
-   * See {@link FallbackOptionManager}.
+   * Sets a long option on the {@link OptionManager}.
+   * @param name The name of the option.
+   * @param value The value of the option.
+   */
+  void setLocalOption(String name, long value);
+
+  /**
+   * Sets a double option on the {@link OptionManager}.
+   * @param name The name of the option.
+   * @param value The value of the option.
+   */
+  void setLocalOption(String name, double value);
+
+  /**
+   * Sets a String option on the {@link OptionManager}.
+   * @param name The name of the option.
+   * @param value The value of the option.
+   */
+  void setLocalOption(String name, String value);
+
+  /**
+   * Sets an option on the {@link OptionManager}.
+   * @param name The name of the option.
+   * @param value The value of the option.
+   */
+  void setLocalOption(String name, Object value);
+
+  /**
+   * Sets an option of the specified {@link OptionValue.Kind} on the {@link OptionManager}.
+   * @param kind The kind of the option.
+   * @param name The name of the option.
+   * @param value The value of the option.
+   */
+  void setLocalOption(OptionValue.Kind kind, String name, String value);
+
+  /**
+   * Deletes the option.
    *
-   * If the option name is valid (exists in {@link SystemOptionManager#VALIDATORS}),
+   * If the option name is valid (exists in the set of validators produced by {@link SystemOptionManager#createDefaultOptionDefinitions()}),
    * but the option was not set within this manager, calling this method should be a no-op.
    *
    * @param name option name
-   * @param type option type
    * @throws org.apache.drill.common.exceptions.UserException message to describe error with value
    */
-  void deleteOption(String name, OptionType type);
+  void deleteLocalOption(String name);
 
   /**
-   * Deletes all options. Unfortunately, the type is required given the fallback structure of option managers.
-   * See {@link FallbackOptionManager}.
+   * Deletes all options.
    *
    * If no options are set, calling this method should be no-op.
    *
-   * @param type option type
    * @throws org.apache.drill.common.exceptions.UserException message to describe error with value
    */
-  void deleteAllOptions(OptionType type);
+  void deleteAllLocalOptions();
+
+  /**
+   * Get the option definition corresponding to the given option name.
+   * @param name The name of the option to retrieve a validator for.
+   * @return The option validator corresponding to the given option name.
+   * @throws UserException - if the definition is not found
+   */
+  @NotNull
+  OptionDefinition getOptionDefinition(String name);
 
   /**
    * Gets the list of options managed this manager.
@@ -62,4 +122,20 @@ public interface OptionManager extends OptionSet, Iterable<OptionValue> {
    * @return the list of options
    */
   OptionList getOptionList();
+
+  /**
+   * Returns all the internal options contained in this option manager.
+   *
+   * @return All the internal options contained in this option manager.
+   */
+  @NotNull
+  OptionList getInternalOptionList();
+
+  /**
+   * Returns all the public options contained in this option manager.
+   *
+   * @return All the public options contained in this option manager.
+   */
+  @NotNull
+  OptionList getPublicOptionList();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionMetaData.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionMetaData.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server.options;
+
+/**
+ * Contains information about the scopes in which an option can be set, and an option's visibility.
+ */
+public class OptionMetaData {
+  public static final OptionMetaData DEFAULT = new OptionMetaData(OptionValue.AccessibleScopes.ALL, false, false);
+
+  private final OptionValue.AccessibleScopes type;
+  private final  boolean adminOnly;
+  private final boolean internal;
+
+  public OptionMetaData(OptionValue.AccessibleScopes type, boolean adminOnly, boolean internal) {
+    this.type = type;
+    this.adminOnly = adminOnly;
+    this.internal = internal;
+  }
+
+  public OptionValue.AccessibleScopes getType() {
+    return type;
+  }
+
+  public boolean isAdminOnly() {
+    return adminOnly;
+  }
+
+  public boolean isInternal() {
+    return internal;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()){
+      return false;
+    }
+
+    OptionMetaData metaData = (OptionMetaData) o;
+
+    return adminOnly == metaData.adminOnly;
+  }
+
+  @Override
+  public int hashCode() {
+    return (adminOnly ? 1 : 0);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionSet.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.server.options;
 /**
  * Immutable set of options accessible by name or validator.
  */
-
 public interface OptionSet {
 
   /**
@@ -36,6 +35,13 @@ public interface OptionSet {
    * @return the option value, null if the option does not exist
    */
   OptionValue getOption(String name);
+
+  /**
+   * Gets the default value for the specified option.
+   * @param optionName The option to retrieve the default value for.
+   * @return The default value for the option.
+   */
+  OptionValue getDefault(String optionName);
 
   /**
    * Gets the boolean value (from the option value) for the given boolean validator.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/OptionValidator.java
@@ -28,16 +28,11 @@ public abstract class OptionValidator {
   // Stored here as well as in the option static class to allow insertion of option optionName into
   // the error messages produced by the validator
   private final String optionName;
-  private final boolean isAdminOption;
   public static final String OPTION_DEFAULTS_ROOT = "drill.exec.options.";
+
   /** By default, if admin option value is not specified, it would be set to false.*/
   public OptionValidator(String optionName) {
-    this(optionName, false);
-  }
-
-  public OptionValidator(String optionName, boolean isAdminOption) {
     this.optionName = optionName;
-    this.isAdminOption = isAdminOption;
   }
 
   /**
@@ -78,27 +73,13 @@ public abstract class OptionValidator {
   }
 
   /**
-   * @return true is option is system-level property that can be only specified by admin (not user).
-   */
-  public boolean isAdminOption() {
-    return isAdminOption;
-  }
-
-  /**
-   * Gets the default option value for this validator.
-   *
-   * @return default option value
-   */
-  public abstract OptionValue getDefault();
-
-  /**
    * Validates the option value.
    *
    * @param value the value to validate
    * @param manager the manager for accessing validation dependencies (options)
    * @throws UserException message to describe error with value, including range or list of expected values
    */
-  public abstract void validate(OptionValue value, OptionSet manager);
+  public abstract void validate(OptionValue value, OptionMetaData optionMetaData, OptionSet manager);
 
   /**
    * Gets the kind of this option value for this validator.
@@ -107,11 +88,7 @@ public abstract class OptionValidator {
    */
   public abstract Kind getKind();
 
-  /**
-   * Loads the default option value for this validator.
-   *
-   * @return  default option value
-   */
-  public abstract void loadDefault(DrillConfig bootConfig);
-
+  public String getConfigProperty() {
+    return OPTION_DEFAULTS_ROOT + getOptionName();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/QueryOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/QueryOptionManager.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.server.options;
 
 import org.apache.drill.common.map.CaseInsensitiveMap;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 
 /**
  * {@link OptionManager} that holds options within {@link org.apache.drill.exec.ops.QueryContext}.
@@ -38,7 +37,31 @@ public class QueryOptionManager extends InMemoryOptionManager {
   }
 
   @Override
-  boolean supportsOptionType(OptionType type) {
-    return type == OptionType.QUERY;
+  public OptionValue getDefault(String optionName) {
+    return fallback.getDefault(optionName);
+  }
+
+  public SessionOptionManager getSessionOptionManager() {
+    return (SessionOptionManager) fallback;
+  }
+
+  public OptionManager getOptionManager(OptionValue.OptionScope scope) {
+    switch (scope) {
+      case SYSTEM:
+        return getSessionOptionManager().getSystemOptionManager();
+      case SESSION:
+        return getSessionOptionManager();
+      case QUERY:
+        return this;
+      case BOOT:
+        throw new UnsupportedOperationException("There is no option manager for " + OptionValue.OptionScope.BOOT);
+      default:
+        throw new UnsupportedOperationException("Invalid type: " + scope);
+    }
+  }
+
+  @Override
+  protected OptionValue.OptionScope getScope() {
+    return OptionValue.OptionScope.QUERY;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
@@ -20,10 +20,8 @@ package org.apache.drill.exec.server.options;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.exec.rpc.user.UserSession;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 
 import java.util.Collection;
 import java.util.Map;
@@ -55,13 +53,11 @@ public class SessionOptionManager extends InMemoryOptionManager {
   }
 
   @Override
-  boolean setLocalOption(final OptionValue value) {
-    final boolean set = super.setLocalOption(value);
-    if (!set) {
-      return false;
-    }
+  public void setLocalOptionHelper(final OptionValue value) {
+    super.setLocalOptionHelper(value);
     final String name = value.name;
-    final OptionValidator validator = getFallbackOptionManager().getValidator(name); // if set, validator must exist.
+    final OptionDefinition definition = getOptionDefinition(name); // if set, validator must exist.
+    final OptionValidator validator = definition.getValidator();
     final boolean shortLived = validator.isShortLived();
     if (shortLived) {
       final int start = session.getQueryCount() + 1; // start from the next query
@@ -69,7 +65,6 @@ public class SessionOptionManager extends InMemoryOptionManager {
       final int end = start + ttl;
       shortLivedOptions.put(name, new ImmutablePair<>(start, end));
     }
-    return true;
   }
 
   @Override
@@ -83,7 +78,7 @@ public class SessionOptionManager extends InMemoryOptionManager {
       final int start = shortLivedOptions.get(name).getLeft();
       // option is not in effect if queryNumber < start
       if (queryNumber < start) {
-        return getFallbackOptionManager().getValidator(name).getDefault();
+        return fallback.getOption(name);
       // reset if queryNumber <= end
       } else {
         options.remove(name);
@@ -116,14 +111,22 @@ public class SessionOptionManager extends InMemoryOptionManager {
     return liveOptions;
   }
 
-  @Override
-  boolean supportsOptionType(OptionType type) {
-    return type == OptionType.SESSION;
+  /**
+   * Gets the SystemOptionManager.
+   * @return The SystemOptionManager.
+   */
+  public SystemOptionManager getSystemOptionManager() {
+    final SystemOptionManager systemOptionManager = (SystemOptionManager) fallback;
+    return systemOptionManager;
   }
 
-  /* Gets fallback manager and returns it as SystemOptionManager */
-  public SystemOptionManager getFallbackOptionManager() {
-    final SystemOptionManager systemOptionManager = (SystemOptionManager) getFallback();
-    return systemOptionManager;
+  @Override
+  public OptionValue getDefault(String optionName) {
+    return fallback.getDefault(optionName);
+  }
+
+  @Override
+  protected OptionValue.OptionScope getScope() {
+    return OptionValue.OptionScope.SESSION;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/TypeValidators.java
@@ -20,17 +20,13 @@ package org.apache.drill.exec.server.options;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
-import org.apache.drill.exec.server.options.OptionValue.OptionScope;
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class TypeValidators {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeValidators.class);
   public static class PositiveLongValidator extends LongValidator {
-    private final long max;
+    protected final long max;
 
     public PositiveLongValidator(String name, long max) {
       super(name);
@@ -38,8 +34,8 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       if (v.num_val > max || v.num_val < 1) {
         throw UserException.validationError()
             .message(String.format("Option %s must be between %d and %d.", getOptionName(), 1, max))
@@ -55,8 +51,8 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       if (!isPowerOfTwo(v.num_val)) {
         throw UserException.validationError()
             .message(String.format("Option %s must be a power of two.", getOptionName()))
@@ -70,8 +66,8 @@ public class TypeValidators {
   }
 
   public static class RangeDoubleValidator extends DoubleValidator {
-    private final double min;
-    private final double max;
+    protected final double min;
+    protected final double max;
 
     public RangeDoubleValidator(String name, double min, double max) {
       super(name);
@@ -80,8 +76,8 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       if (v.float_val > max || v.float_val < min) {
         throw UserException.validationError()
             .message(String.format("Option %s must be between %f and %f.", getOptionName(), min, max))
@@ -93,14 +89,14 @@ public class TypeValidators {
   public static class MinRangeDoubleValidator extends RangeDoubleValidator {
     private final String maxValidatorName;
 
-    public MinRangeDoubleValidator(String name, double min, double max, double def, String maxValidatorName) {
+    public MinRangeDoubleValidator(String name, double min, double max, String maxValidatorName) {
       super(name, min, max);
       this.maxValidatorName = maxValidatorName;
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       OptionValue maxValue = manager.getOption(maxValidatorName);
       if (v.float_val > maxValue.float_val) {
         throw UserException.validationError()
@@ -114,14 +110,14 @@ public class TypeValidators {
   public static class MaxRangeDoubleValidator extends RangeDoubleValidator {
     private final String minValidatorName;
 
-    public MaxRangeDoubleValidator(String name, double min, double max, double def, String minValidatorName) {
+    public MaxRangeDoubleValidator(String name, double min, double max, String minValidatorName) {
       super(name, min, max);
       this.minValidatorName = minValidatorName;
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       OptionValue minValue = manager.getOption(minValidatorName);
       if (v.float_val < minValue.float_val) {
         throw UserException.validationError()
@@ -134,60 +130,25 @@ public class TypeValidators {
 
   public static class BooleanValidator extends TypeValidator {
     public BooleanValidator(String name) {
-      this(name, false);
-    }
-
-    public BooleanValidator(String name, boolean isAdminOption) {
-      super(name, Kind.BOOLEAN, isAdminOption);
-    }
-
-    public void loadDefault(DrillConfig bootConfig){
-      OptionValue value = OptionValue.createBoolean(OptionType.SYSTEM, getOptionName(), bootConfig.getBoolean(getConfigProperty()), OptionScope.BOOT);
-      setDefaultValue(value);
+      super(name, Kind.BOOLEAN);
     }
   }
 
   public static class StringValidator extends TypeValidator {
     public StringValidator(String name) {
-      this(name, false);
-    }
-    public StringValidator(String name, boolean isAdminOption) {
-      super(name, Kind.STRING, isAdminOption);
-    }
-
-    public void loadDefault(DrillConfig bootConfig){
-      OptionValue value = OptionValue.createString(OptionType.SYSTEM, getOptionName(), bootConfig.getString(getConfigProperty()), OptionScope.BOOT);
-      setDefaultValue(value);
+      super(name, Kind.STRING);
     }
   }
 
   public static class LongValidator extends TypeValidator {
     public LongValidator(String name) {
-      this(name, false);
-    }
-
-    public LongValidator(String name, boolean isAdminOption) {
-      super(name, Kind.LONG, isAdminOption);
-    }
-
-    public void loadDefault(DrillConfig bootConfig){
-      OptionValue value = OptionValue.createLong(OptionType.SYSTEM, getOptionName(), bootConfig.getLong(getConfigProperty()), OptionScope.BOOT);
-      setDefaultValue(value);
+      super(name, Kind.LONG);
     }
   }
 
   public static class DoubleValidator extends TypeValidator {
     public DoubleValidator(String name) {
-      this(name,false);
-    }
-
-    public DoubleValidator(String name, boolean isAdminOption) {
-      super(name, Kind.DOUBLE, isAdminOption);
-    }
-
-    public void loadDefault(DrillConfig bootConfig){
-      OptionValue value = OptionValue.createDouble(OptionType.SYSTEM, getOptionName(),bootConfig.getDouble(getConfigProperty()), OptionScope.BOOT);
-      setDefaultValue(value);
+      super(name, Kind.DOUBLE);
     }
   }
 
@@ -202,8 +163,8 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       if (v.num_val > max || v.num_val < min) {
         throw UserException.validationError()
             .message(String.format("Option %s must be between %d and %d.", getOptionName(), min, max))
@@ -226,8 +187,8 @@ public class TypeValidators {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      super.validate(v, manager);
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
+      super.validate(v, metaData, manager);
       if (!valuesSet.contains(v.string_val.toLowerCase())) {
         throw UserException.validationError()
             .message(String.format("Option %s must be one of: %s.", getOptionName(), valuesSet))
@@ -242,18 +203,8 @@ public class TypeValidators {
    * the available number of processors and cpu load average
    */
   public static class MaxWidthValidator extends LongValidator{
-
     public MaxWidthValidator(String name) {
-      this(name, false);
-    }
-
-    public MaxWidthValidator(String name, boolean isAdminOption) {
-      super(name, isAdminOption);
-    }
-
-    public void loadDefault(DrillConfig bootConfig) {
-      OptionValue value = OptionValue.createLong(OptionType.SYSTEM, getOptionName(), bootConfig.getLong(getConfigProperty()), OptionScope.BOOT);
-      setDefaultValue(value);
+      super(name);
     }
 
     public int computeMaxWidth(double cpuLoadAverage, long maxWidth) {
@@ -272,33 +223,18 @@ public class TypeValidators {
 
   public static abstract class TypeValidator extends OptionValidator {
     private final Kind kind;
-    private OptionValue defaultValue = null;
 
     public TypeValidator(final String name, final Kind kind) {
-      this(name, kind, false);
-    }
-
-    public TypeValidator(final String name, final Kind kind, final boolean isAdminOption) {
-      super(name, isAdminOption);
+      super(name);
       this.kind = kind;
     }
 
     @Override
-    public OptionValue getDefault() {
-      return defaultValue;
-    }
-
-    @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
       if (v.kind != kind) {
         throw UserException.validationError()
             .message(String.format("Option %s must be of type %s but you tried to set to %s.", getOptionName(),
               kind.name(), v.kind.name()))
-            .build(logger);
-      }
-      if (isAdminOption() && v.type != OptionType.SYSTEM) {
-        throw UserException.validationError()
-            .message("Admin related settings can only be set at SYSTEM level scope. Given scope '%s'.", v.type)
             .build(logger);
       }
     }
@@ -306,14 +242,6 @@ public class TypeValidators {
     @Override
     public Kind getKind() {
       return kind;
-    }
-
-    protected void setDefaultValue(OptionValue defaultValue) {
-      this.defaultValue = defaultValue;
-    }
-
-    public String getConfigProperty() {
-      return OPTION_DEFAULTS_ROOT + getOptionName();
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -33,10 +33,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.drill.exec.server.options.OptionList;
+import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.DrillRestServer.UserAuthEnabled;
 import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.exec.work.WorkManager;
@@ -50,79 +54,128 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class StatusResources {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StatusResources.class);
 
+  public static final String REST_API_SUFFIX = ".json";
+  public static final String PATH_STATUS_JSON = "/status" + REST_API_SUFFIX;
+  public static final String PATH_STATUS = "/status";
+  public static final String PATH_OPTIONS_JSON = "/options" + REST_API_SUFFIX;
+  public static final String PATH_INTERNAL_OPTIONS_JSON = "/internal_options" + REST_API_SUFFIX;
+  public static final String PATH_OPTIONS = "/options";
+  public static final String PATH_INTERNAL_OPTIONS = "/internal_options";
+
   @Inject UserAuthEnabled authEnabled;
   @Inject WorkManager work;
   @Inject SecurityContext sc;
 
   @GET
-  @Path("/status.json")
+  @Path(StatusResources.PATH_STATUS_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public Pair<String, String> getStatusJSON() {
     return new ImmutablePair<>("status", "Running!");
   }
 
   @GET
-  @Path("/status")
+  @Path(StatusResources.PATH_STATUS)
   @Produces(MediaType.TEXT_HTML)
   public Viewable getStatus() {
     return ViewableWithPermissions.create(authEnabled.get(), "/rest/status.ftl", sc, getStatusJSON());
   }
 
-  @GET
-  @Path("/options.json")
-  @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
-  @Produces(MediaType.APPLICATION_JSON)
-  public List<OptionWrapper> getSystemOptionsJSON() {
+  private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)
+  {
     List<OptionWrapper> options = new LinkedList<>();
-    for (OptionValue option : work.getContext().getOptionManager()) {
-      options.add(new OptionWrapper(option.name, option.getValue(), option.type, option.kind));
+    OptionManager optionManager = work.getContext().getOptionManager();
+    OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
+
+    for (OptionValue option : optionList) {
+      options.add(new OptionWrapper(option.name, option.getValue(), option.accessibleScopes, option.kind, option.scope));
     }
+
     return options;
   }
 
   @GET
-  @Path("/options")
+  @Path(StatusResources.PATH_OPTIONS_JSON)
+  @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OptionWrapper> getSystemPublicOptionsJSON() {
+    return getSystemOptionsJSONHelper(false);
+  }
+
+  @GET
+  @Path(StatusResources.PATH_INTERNAL_OPTIONS_JSON)
+  @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OptionWrapper> getSystemInternalOptionsJSON() {
+    return getSystemOptionsJSONHelper(true);
+  }
+
+  private Viewable getSystemOptionsHelper(boolean internal) {
+    return ViewableWithPermissions.create(authEnabled.get(),
+      "/rest/options.ftl",
+      sc,
+      getSystemOptionsJSONHelper(internal));
+  }
+
+  @GET
+  @Path(StatusResources.PATH_OPTIONS)
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.TEXT_HTML)
-  public Viewable getSystemOptions() {
-    return ViewableWithPermissions.create(authEnabled.get(), "/rest/options.ftl", sc, getSystemOptionsJSON());
+  public Viewable getSystemPublicOptions() {
+    return getSystemOptionsHelper(false);
+  }
+
+  @GET
+  @Path(StatusResources.PATH_INTERNAL_OPTIONS)
+  @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
+  @Produces(MediaType.TEXT_HTML)
+  public Viewable getSystemInternalOptions() {
+    return getSystemOptionsHelper(true);
   }
 
   @POST
-  @Path("/option/{optionName}")
+  @Path("option/{optionName}")
   @RolesAllowed(DrillUserPrincipal.ADMIN_ROLE)
   @Consumes("application/x-www-form-urlencoded")
   @Produces(MediaType.TEXT_HTML)
-  public Viewable updateSystemOption(@FormParam("name") String name, @FormParam("value") String value,
+  public Viewable updateSystemOption(@FormParam("name") String name,
+                                   @FormParam("value") String value,
                                    @FormParam("kind") String kind) {
+    SystemOptionManager optionManager = work.getContext()
+      .getOptionManager();
+
     try {
-      work.getContext()
-        .getOptionManager()
-        .setOption(OptionValue.createOption(
-          OptionValue.Kind.valueOf(kind),
-          OptionValue.OptionType.SYSTEM,
-          name,
-          value, OptionValue.OptionScope.SYSTEM));
+      optionManager.setLocalOption(OptionValue.Kind.valueOf(kind), name, value);
     } catch (Exception e) {
       logger.debug("Could not update.", e);
     }
-    return getSystemOptions();
+
+    if (optionManager.getOptionDefinition(name).getMetaData().isInternal()) {
+      return getSystemInternalOptions();
+    } else {
+      return getSystemPublicOptions();
+    }
   }
 
   @XmlRootElement
-  public class OptionWrapper {
+  public static class OptionWrapper {
 
     private String name;
     private Object value;
-    private OptionValue.OptionType type;
+    private OptionValue.AccessibleScopes accessibleScopes;
     private String kind;
+    private String optionScope;
 
     @JsonCreator
-    public OptionWrapper(String name, Object value, OptionValue.OptionType type, Kind kind) {
+    public OptionWrapper(@JsonProperty("name") String name,
+                         @JsonProperty("value") Object value,
+                         @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
+                         @JsonProperty("kind") Kind kind,
+                         @JsonProperty("optionScope") OptionValue.OptionScope scope) {
       this.name = name;
       this.value = value;
-      this.type = type;
+      this.accessibleScopes = type;
       this.kind = kind.name();
+      this.optionScope = scope.name();
     }
 
     public String getName() {
@@ -138,13 +191,21 @@ public class StatusResources {
       return value;
     }
 
-    public OptionValue.OptionType getType() {
-      return type;
+    public OptionValue.AccessibleScopes getAccessibleScopes() {
+      return accessibleScopes;
     }
 
     public String getKind() {
       return kind;
     }
-  }
 
+    public String getOptionScope() {
+      return optionScope;
+    }
+
+    @Override
+    public String toString() {
+      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' +'}';
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/OptionIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/OptionIterator.java
@@ -25,35 +25,41 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.server.options.DrillConfigIterator;
-import org.apache.drill.exec.server.options.FragmentOptionManager;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
-import org.apache.drill.exec.server.options.SystemOptionManager;
+import org.apache.drill.exec.server.options.OptionValue.OptionScope;
+import org.apache.drill.exec.server.options.OptionValue.AccessibleScopes;
 
 public class OptionIterator implements Iterator<Object> {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OptionIterator.class);
 
   enum Mode {
-    BOOT, SYS_SESS, BOTH
+    BOOT,
+    // These represent System/Session options that are public. These are available for everyone to change and are considered safe to change.
+    SYS_SESS_PUBLIC,
+    // These represent System/Session options that are internal. These are segregated from the public options and are not visible in the same tables and rest endpoints as public
+    // options. These are technically available for anyone to change, but users are discouraged from doing so unless they absolutely know what they are doing. The general purpose
+    // for internal options is to enable support to easily debug.
+    SYS_SESS_INTERNAL
   };
 
   private final OptionManager fragmentOptions;
   private final Iterator<OptionValue> mergedOptions;
-  private FragmentContext context;
 
   public OptionIterator(FragmentContext context, Mode mode){
     final DrillConfigIterator configOptions = new DrillConfigIterator(context.getConfig());
     fragmentOptions = context.getOptions();
-    this.context = context;
     final Iterator<OptionValue> optionList;
     switch(mode){
     case BOOT:
       optionList = configOptions.iterator();
       break;
-    case SYS_SESS:
-      optionList = fragmentOptions.iterator();
+    case SYS_SESS_PUBLIC:
+      optionList = fragmentOptions.getPublicOptionList().iterator();
+      break;
+    case SYS_SESS_INTERNAL:
+      optionList = fragmentOptions.getInternalOptionList().iterator();
       break;
     default:
       optionList = Iterators.concat(configOptions.iterator(), fragmentOptions.iterator());
@@ -74,23 +80,22 @@ public class OptionIterator implements Iterator<Object> {
   public OptionValueWrapper next() {
     final OptionValue value = mergedOptions.next();
     final Status status;
-    final FragmentOptionManager fragmentOptionManager = (FragmentOptionManager) fragmentOptions;
-    final SystemOptionManager systemOptionManager = (SystemOptionManager) fragmentOptionManager.getFallback();
-    if (value.type == OptionType.BOOT) {
+
+    if (value.accessibleScopes == AccessibleScopes.BOOT) {
       status = Status.BOOT;
     } else {
-      final OptionValue def = systemOptionManager.getValidator(value.name).getDefault();
+      final OptionValue def = fragmentOptions.getDefault(value.name);
       if (value.equalsIgnoreType(def)) {
         status = Status.DEFAULT;
         } else {
         status = Status.CHANGED;
         }
       }
-    return new OptionValueWrapper(value.name, value.kind, value.type, value.num_val, value.string_val,
+    return new OptionValueWrapper(value.name, value.kind, value.accessibleScopes, value.scope, value.num_val, value.string_val,
         value.bool_val, value.float_val, status);
   }
 
-  public static enum Status {
+  public enum Status {
     BOOT, DEFAULT, CHANGED
   }
 
@@ -101,19 +106,21 @@ public class OptionIterator implements Iterator<Object> {
 
     public final String name;
     public final Kind kind;
-    public final OptionType type;
+    public final AccessibleScopes accessibleScopes;
+    public final OptionScope optionScope;
     public final Status status;
     public final Long num_val;
     public final String string_val;
     public final Boolean bool_val;
     public final Double float_val;
 
-    public OptionValueWrapper(final String name, final Kind kind, final OptionType type, final Long num_val,
-        final String string_val, final Boolean bool_val, final Double float_val,
-        final Status status) {
+    public OptionValueWrapper(final String name, final Kind kind, final OptionValue.AccessibleScopes type, final OptionScope scope, final Long num_val,
+                              final String string_val, final Boolean bool_val, final Double float_val,
+                              final Status status) {
       this.name = name;
       this.kind = kind;
-      this.type = type;
+      this.accessibleScopes = type;
+      this.optionScope = scope;
       this.num_val = num_val;
       this.string_val = string_val;
       this.bool_val = bool_val;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.store.sys.OptionIterator.OptionValueWrapper;
-import org.apache.drill.exec.store.sys.ExtendedOptionIterator.ExtendedOptionValueWrapper;
 
 /**
  * An enumeration of all tables in Drill's system ("sys") schema.
@@ -32,18 +31,31 @@ import org.apache.drill.exec.store.sys.ExtendedOptionIterator.ExtendedOptionValu
  * </p>
  */
 public enum SystemTable {
-
   OPTION("options", false, OptionValueWrapper.class) {
     @Override
     public Iterator<Object> getIterator(final FragmentContext context) {
-      return new OptionIterator(context, OptionIterator.Mode.SYS_SESS);
+      return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_PUBLIC);
     }
   },
 
-  OPTION2("options2", false,ExtendedOptionIterator.ExtendedOptionValueWrapper.class ) {
+  OPTION_VAL("options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
     @Override
     public Iterator<Object> getIterator(final FragmentContext context) {
-      return new ExtendedOptionIterator(context);
+      return new ExtendedOptionIterator(context, false);
+    }
+  },
+
+  INTERNAL_OPTIONS("internal_options", false, OptionValueWrapper.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_INTERNAL);
+    }
+  },
+
+  INTERNAL_OPTIONS_VAL("internal_options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new ExtendedOptionIterator(context, true);
     }
   },
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControls.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControls.java
@@ -22,15 +22,14 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.OptionMetaData;
 import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
 import org.apache.drill.exec.server.options.TypeValidators.TypeValidator;
 import org.apache.drill.exec.testing.InjectionSite.InjectionSiteKeyDeserializer;
 import org.apache.drill.exec.util.AssertionUtil;
@@ -96,12 +95,7 @@ public final class ExecutionControls {
     }
 
     @Override
-    public void validate(final OptionValue v, final OptionSet manager) {
-      if (v.type != OptionType.SESSION) {
-        throw UserException.validationError()
-            .message("Controls can be set only at SESSION level.")
-            .build(logger);
-      }
+    public void validate(final OptionValue v, final OptionMetaData metaData, final OptionSet manager) {
       final String jsonString = v.string_val;
       try {
         validateControlsString(jsonString);
@@ -110,11 +104,6 @@ public final class ExecutionControls {
             .message(String.format("Invalid controls option string (%s) due to %s.", jsonString, e.getMessage()))
             .build(logger);
       }
-    }
-
-    public void loadDefault(DrillConfig bootConfig){
-      OptionValue value = OptionValue.createString(OptionType.SYSTEM, getOptionName(), bootConfig.getString(getConfigProperty()), OptionValue.OptionScope.BOOT);
-      setDefaultValue(value);
     }
   }
 

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -122,6 +122,7 @@ drill.exec: {
   http: {
     enabled: true,
     ssl_enabled: false,
+    porthunt: false,
     port: 8047,
     max_profiles: 100,
     session_max_idle_secs: 3600, # Default value 1hr

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestQuery.java
@@ -460,6 +460,18 @@ public class BaseTestQuery extends ExecTest {
     return file.getPath();
   }
 
+  protected static void setSessionOption(final String option, final boolean value) {
+    setSessionOption(option, Boolean.toString(value));
+  }
+
+  protected static void setSessionOption(final String option, final long value) {
+    setSessionOption(option, Long.toString(value));
+  }
+
+  protected static void setSessionOption(final String option, final double value) {
+    setSessionOption(option, Double.toString(value));
+  }
+
   protected static void setSessionOption(final String option, final String value) {
     try {
       runSQL(String.format("alter session set `%s` = %s", option, value));

--- a/exec/java-exec/src/test/java/org/apache/drill/QueryTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/QueryTestUtil.java
@@ -41,7 +41,7 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionScope;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.util.VectorUtil;
 
 /**
@@ -188,11 +188,9 @@ public class QueryTestUtil {
       final Drillbit drillbit, final ClassTransformer.ScalarReplacementOption srOption) {
     // set the system option
     final DrillbitContext drillbitContext = drillbit.getContext();
-    final OptionManager optionManager = drillbitContext.getOptionManager();
+    final SystemOptionManager optionManager = drillbitContext.getOptionManager();
     final OptionValue originalOptionValue = optionManager.getOption(ClassTransformer.SCALAR_REPLACEMENT_OPTION);
-    final OptionValue newOptionValue = OptionValue.createString(OptionValue.OptionType.SYSTEM,
-        ClassTransformer.SCALAR_REPLACEMENT_OPTION, srOption.name().toLowerCase(), OptionScope.SYSTEM);
-    optionManager.setOption(newOptionValue);
+    optionManager.setLocalOption(ClassTransformer.SCALAR_REPLACEMENT_OPTION, srOption.name().toLowerCase());
 
     // flush the code cache
     drillbitContext.getCompiler().flushCache();
@@ -209,12 +207,12 @@ public class QueryTestUtil {
    * @param drillbit the drillbit
    * @param srOption the scalar replacement option value to use
    */
-  public static void restoreScalarReplacementOption(final Drillbit drillbit, final OptionValue srOption) {
+  public static void restoreScalarReplacementOption(final Drillbit drillbit, final String srOption) {
     @SuppressWarnings("resource")
     final DrillbitContext drillbitContext = drillbit.getContext();
     @SuppressWarnings("resource")
     final OptionManager optionManager = drillbitContext.getOptionManager();
-    optionManager.setOption(srOption);
+    optionManager.setLocalOption(ClassTransformer.SCALAR_REPLACEMENT_OPTION, srOption);
 
     // flush the code cache
     drillbitContext.getCompiler().flushCache();

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -244,7 +244,7 @@ public class TestStarQueries extends BaseTestQuery{
 
   @Test  // select star for a SchemaTable.
   public void testSelStarSubQSchemaTable() throws Exception {
-    test("select name, kind, type from (select * from sys.options);");
+    test("select name, kind, accessibleScopes from (select * from sys.options);");
   }
 
   @Test  // Join a select star of SchemaTable, with a select star of Schema-less table.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSystemTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSystemTestBase.java
@@ -40,7 +40,7 @@ public class DrillSystemTestBase extends TestWithZookeeper {
     try {
       ImmutableList.Builder<Drillbit> servers = ImmutableList.builder();
       for (int i = 0; i < numServers; i++) {
-        servers.add(Drillbit.start(getConfig()));
+        servers.add(Drillbit.start(zkHelper.getConfig()));
       }
       this.servers = servers.build();
     } catch (DrillbitStartupException e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestWithZookeeper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestWithZookeeper.java
@@ -18,26 +18,24 @@
 package org.apache.drill.exec;
 
 import org.apache.drill.common.config.DrillConfig;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 public class TestWithZookeeper extends ExecTest {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestWithZookeeper.class);
 
-  private static ZookeeperHelper zkHelper;
+  protected ZookeeperHelper zkHelper;
 
-  @BeforeClass
-  public static void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     zkHelper = new ZookeeperHelper();
     zkHelper.startZookeeper(1);
   }
 
-  @AfterClass
-  public static void tearDown() throws Exception {
+  @After
+  public void tearDown() throws Exception {
     zkHelper.stopZookeeper();
-  }
-
-  public static DrillConfig getConfig() {
-    return zkHelper.getConfig();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Throwables.propagate;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.util.Properties;
 
 import org.apache.drill.common.config.DrillConfig;
@@ -43,7 +44,7 @@ import org.apache.drill.exec.util.MiniZooKeeperCluster;
 public class ZookeeperHelper {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ZookeeperHelper.class);
 
-  private final File testDir = new File("target/test-data");
+  private final File testDir = new File("target/test-data/" + ManagementFactory.getRuntimeMXBean().getName());
   private final DrillConfig config;
   private String zkUrl;
   private MiniZooKeeperCluster zkCluster;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
@@ -84,6 +84,7 @@ public class ConnectTriesPropertyTestClusterBits {
   @AfterClass
   public static void testCleanUp() throws Exception {
     AutoCloseables.close(drillbits);
+    zkHelper.stopZookeeper();
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
@@ -38,8 +38,8 @@ public class DrillClientSystemTest extends DrillSystemTestBase {
   private static String plan;
 
   @BeforeClass
-  public static void setUp() throws Exception {
-    DrillSystemTestBase.setUp();
+  public void setUp() throws Exception {
+    this.setUp();
     plan = Resources.toString(Resources.getResource("simple_plan.json"), Charsets.UTF_8);
 
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassTransformation.java
@@ -27,9 +27,6 @@ import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.expr.ClassGenerator;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.rpc.user.UserSession;
-import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
-import org.apache.drill.exec.server.options.OptionValue.OptionScope;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.codehaus.commons.compiler.CompileException;
 import org.junit.Assert;
@@ -59,7 +56,7 @@ public class TestClassTransformation extends BaseTestQuery {
   @Test
   public void testJaninoClassCompiler() throws Exception {
     logger.debug("Testing JaninoClassCompiler");
-    sessionOptions.setOption(OptionValue.createString(OptionType.SESSION, ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JANINO.name(), OptionScope.SESSION));
+    sessionOptions.setLocalOption(ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JANINO.name());
     for (int i = 0; i < ITERATION_COUNT; i++) {
       compilationInnerClass(false); // Traditional byte-code manipulation
       compilationInnerClass(true); // Plain-old Java
@@ -69,8 +66,7 @@ public class TestClassTransformation extends BaseTestQuery {
   @Test
   public void testJDKClassCompiler() throws Exception {
     logger.debug("Testing JDKClassCompiler");
-    OptionType type = OptionType.SESSION;
-    sessionOptions.setOption(OptionValue.createString(type, ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JDK.name(), OptionScope.SESSION));
+    sessionOptions.setLocalOption(ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JDK.name());
     for (int i = 0; i < ITERATION_COUNT; i++) {
       compilationInnerClass(false); // Traditional byte-code manipulation
       compilationInnerClass(true); // Plain-old Java
@@ -82,10 +78,9 @@ public class TestClassTransformation extends BaseTestQuery {
     CodeGenerator<ExampleInner> cg = newCodeGenerator(ExampleInner.class, ExampleTemplateWithInner.class);
     ClassSet classSet = new ClassSet(null, cg.getDefinition().getTemplateClassName(), cg.getMaterializedClassName());
     String sourceCode = cg.generateAndGet();
-    OptionType type = OptionType.SESSION;
-    sessionOptions.setOption(OptionValue.createString(type, ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JDK.name(), OptionScope.SESSION));
+    sessionOptions.setLocalOption(ClassCompilerSelector.JAVA_COMPILER_OPTION, ClassCompilerSelector.CompilerPolicy.JDK.name());
 
-    sessionOptions.setOption(OptionValue.createBoolean(type, ClassCompilerSelector.JAVA_COMPILER_DEBUG_OPTION, false, OptionScope.SESSION));
+    sessionOptions.setLocalOption(ClassCompilerSelector.JAVA_COMPILER_DEBUG_OPTION, false);
     @SuppressWarnings("resource")
     QueryClassLoader loader = new QueryClassLoader(config, sessionOptions);
     final byte[][] codeWithoutDebug = loader.getClassByteCode(classSet.generated, sourceCode);
@@ -95,7 +90,7 @@ public class TestClassTransformation extends BaseTestQuery {
       sizeWithoutDebug += bs.length;
     }
 
-    sessionOptions.setOption(OptionValue.createBoolean(type, ClassCompilerSelector.JAVA_COMPILER_DEBUG_OPTION, true, OptionScope.SESSION));
+    sessionOptions.setLocalOption(ClassCompilerSelector.JAVA_COMPILER_DEBUG_OPTION, true);
     loader = new QueryClassLoader(config, sessionOptions);
     final byte[][] codeWithDebug = loader.getClassByteCode(classSet.generated, sourceCode);
     loader.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestInboundImpersonationPrivileges.java
@@ -22,7 +22,9 @@ import com.google.common.io.Files;
 import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.rpc.user.InboundImpersonationManager;
+import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.drill.exec.server.options.OptionValue;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -46,10 +48,11 @@ public class TestInboundImpersonationPrivileges extends BaseTestImpersonation {
   }
 
   private static boolean checkPrivileges(final String proxyName, final String targetName) {
+    OptionDefinition optionDefinition = SystemOptionManager.createDefaultOptionDefinitions().get(ExecConstants.IMPERSONATION_POLICIES_KEY);
     ExecConstants.IMPERSONATION_POLICY_VALIDATOR.validate(
-        OptionValue.createString(OptionValue.OptionType.SYSTEM,
+        OptionValue.create(optionDefinition.getMetaData().getType(),
             ExecConstants.IMPERSONATION_POLICIES_KEY,
-            IMPERSONATION_POLICIES,OptionValue.OptionScope.SYSTEM), null);
+            IMPERSONATION_POLICIES,OptionValue.OptionScope.SYSTEM), optionDefinition.getMetaData(),null);
     try {
       return InboundImpersonationManager.hasImpersonationPrivileges(proxyName, targetName, IMPERSONATION_POLICIES);
     } catch (final Exception e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
@@ -119,7 +119,7 @@ public class TestConvertFunctions extends BaseTestQuery {
           .run();
     } finally {
       // restore the system option
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
       test("alter session set `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
     }
   }
@@ -547,7 +547,7 @@ public class TestConvertFunctions extends BaseTestQuery {
       testBigIntVarCharReturnTripConvertLogical();
     } finally {
       // restore the system option
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
     }
   }
 
@@ -564,7 +564,7 @@ public class TestConvertFunctions extends BaseTestQuery {
     } catch(RpcException e) {
       caughtException = true;
     } finally {
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
     }
 
     // Yes: sometimes this works, sometimes it does not...
@@ -579,7 +579,7 @@ public class TestConvertFunctions extends BaseTestQuery {
       testBigIntVarCharReturnTripConvertLogical();
     } finally {
       // restore the system option
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
     }
   }
 
@@ -650,7 +650,7 @@ public class TestConvertFunctions extends BaseTestQuery {
 
     } finally {
       // restore the system option
-      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption);
+      QueryTestUtil.restoreScalarReplacementOption(bits[0], srOption.string_val);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -19,7 +19,6 @@
 package org.apache.drill.exec.physical.impl.agg;
 
 import ch.qos.logback.classic.Level;
-import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.physical.impl.aggregate.HashAggTemplate;
@@ -42,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 /**
  *  Test spilling for the Hash Aggr operator (using the mock reader)
  */
-public class TestHashAggrSpill extends BaseTestQuery {
+public class TestHashAggrSpill {
 
     private void runAndDump(ClientFixture client, String sql, long expectedRows, long spillCycle, long spilledPartitions) throws Exception {
         String plan = client.queryBuilder().sql(sql).explainJson();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinAdvanced.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinAdvanced.java
@@ -21,6 +21,7 @@ import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.test.OperatorFixture;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -102,10 +103,7 @@ public class TestMergeJoinAdvanced extends BaseTestQuery {
       test("select * from dfs_test.`%s/join/j1` j1 left outer join dfs_test.`%s/join/j2` j2 on (j1.c_varchar = j2.c_varchar)",
         TEST_RES_PATH, TEST_RES_PATH);
     } finally {
-      setSessionOption(PlannerSettings.BROADCAST.getOptionName(), String.valueOf(PlannerSettings.BROADCAST.getDefault().bool_val));
-      setSessionOption(PlannerSettings.HASHJOIN.getOptionName(), String.valueOf(PlannerSettings.HASHJOIN.getDefault().bool_val));
-      setSessionOption(ExecConstants.SLICE_TARGET, String.valueOf(ExecConstants.SLICE_TARGET_DEFAULT));
-      setSessionOption(ExecConstants.MAX_WIDTH_PER_NODE_KEY, String.valueOf(ExecConstants.MAX_WIDTH_PER_NODE.getDefault().num_val));
+      test("ALTER SESSION RESET ALL");
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestLimitWithExchanges.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/limit/TestLimitWithExchanges.java
@@ -22,6 +22,7 @@ import org.apache.drill.PlanTestBase;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.test.OperatorFixture;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -71,7 +72,8 @@ public class TestLimitWithExchanges extends BaseTestQuery {
       final String[] expectedPlan5 = {"(?s)Limit\\(fetch=\\[1\\].*UnionExchange.*Limit\\(fetch=\\[1\\]\\).*Join"};
       testLimitHelper(sql5, expectedPlan5, excludedPlan, 1);
     } finally {
-      test("alter session set `planner.slice_target` = " + ExecConstants.SLICE_TARGET_OPTION.getDefault().getValue());
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `%s` = %s", ExecConstants.SLICE_TARGET, testOptionSet.getDefault(ExecConstants.SLICE_TARGET).getValue());
     }
   }
 
@@ -92,7 +94,8 @@ public class TestLimitWithExchanges extends BaseTestQuery {
 
       testLimitHelper(sql2, expectedPlan, excludedPlan2, 5);
     } finally {
-      test("alter session set `planner.slice_target` = " + ExecConstants.SLICE_TARGET_OPTION.getDefault().getValue());
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `planner.slice_target` = " + testOptionSet.getDefault(ExecConstants.SLICE_TARGET).getValue());
     }
   }
 
@@ -121,7 +124,8 @@ public class TestLimitWithExchanges extends BaseTestQuery {
       testLimitHelper(sql3, expectedPlan2, excludedPlan2, 10);
       testLimitHelper(sql4, expectedPlan2, excludedPlan2, 10);
     } finally {
-      test("alter session set `planner.slice_target` = " + ExecConstants.SLICE_TARGET_OPTION.getDefault().getValue());
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `planner.slice_target` = " + testOptionSet.getDefault(ExecConstants.SLICE_TARGET).getValue());
     }
   }
 
@@ -142,5 +146,4 @@ public class TestLimitWithExchanges extends BaseTestQuery {
     final int actualRecordCount = testSql(sql);
     assertEquals(String.format("Received unexpected number of rows in output: expected=%d, received=%s", expectedRecordCount, actualRecordCount), expectedRecordCount, actualRecordCount);
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.vector.BigIntVector;
 import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.IntVector;
@@ -82,7 +83,7 @@ public class TestOrderedPartitionExchange extends PopUnitTestBase {
           int rows = b.getHeader().getRowCount();
           count += rows;
           DrillConfig config = DrillConfig.create();
-          RecordBatchLoader loader = new RecordBatchLoader(new BootStrapContext(config, ClassPathScanner.fromPrescan(config)).getAllocator());
+          RecordBatchLoader loader = new RecordBatchLoader(new BootStrapContext(config, SystemOptionManager.createDefaultOptionDefinitions(), ClassPathScanner.fromPrescan(config)).getAllocator());
           loader.load(b.getHeader().getDef(), b.getData());
           BigIntVector vv1 = (BigIntVector)loader.getValueAccessorById(BigIntVector.class, loader.getValueVectorId(
                   new SchemaPath("col1", ExpressionPosition.UNKNOWN)).getFieldIds()).getValueVector();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
@@ -62,7 +62,7 @@ import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionList;
 import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionType;
+import org.apache.drill.exec.server.options.OptionValue.AccessibleScopes;
 import org.apache.drill.exec.server.options.OptionValue.OptionScope;
 import org.apache.drill.exec.util.Utilities;
 import org.apache.drill.exec.work.QueryWorkUnit;
@@ -181,20 +181,20 @@ public class TestPartitionSender extends PlanTestBase {
 
     final OptionList options = new OptionList();
     // try multiple scenarios with different set of options
-    options.add(OptionValue.createLong(OptionType.SESSION, "planner.slice_target", 1, OptionScope.SESSION));
+    options.add(OptionValue.create(OptionValue.AccessibleScopes.SESSION, "planner.slice_target", 1, OptionScope.SESSION));
     testThreadsHelper(hashToRandomExchange, drillbitContext, options,
         incoming, registry, planReader, planningSet, rootFragment, 1);
 
     options.clear();
-    options.add(OptionValue.createLong(OptionType.SESSION, "planner.slice_target", 1, OptionScope.SESSION));
-    options.add(OptionValue.createLong(OptionType.SESSION, "planner.partitioner_sender_max_threads", 10, OptionScope.SESSION));
+    options.add(OptionValue.create(AccessibleScopes.SESSION, "planner.slice_target", 1, OptionScope.SESSION));
+    options.add(OptionValue.create(OptionValue.AccessibleScopes.SESSION, "planner.partitioner_sender_max_threads", 10, OptionScope.SESSION));
     hashToRandomExchange.setCost(1000);
     testThreadsHelper(hashToRandomExchange, drillbitContext, options,
         incoming, registry, planReader, planningSet, rootFragment, 10);
 
     options.clear();
-    options.add(OptionValue.createLong(OptionType.SESSION, "planner.slice_target", 1000, OptionScope.SESSION));
-    options.add(OptionValue.createLong(OptionType.SESSION, "planner.partitioner_sender_threads_factor",2, OptionScope.SESSION));
+    options.add(OptionValue.create(AccessibleScopes.SESSION, "planner.slice_target", 1000, OptionScope.SESSION));
+    options.add(OptionValue.create(AccessibleScopes.SESSION, "planner.partitioner_sender_threads_factor",2, OptionScope.SESSION));
     hashToRandomExchange.setCost(14000);
     testThreadsHelper(hashToRandomExchange, drillbitContext, options,
         incoming, registry, planReader, planningSet, rootFragment, 2);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -35,12 +35,14 @@ import java.util.Map;
 
 import com.google.common.base.Joiner;
 import org.apache.drill.BaseTestQuery;
+import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.util.DrillVersionInfo;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.fn.interp.TestConstantFolding;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.test.OperatorFixture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -264,7 +266,9 @@ public class TestParquetWriter extends BaseTestQuery {
       String inputTable = "cp.`tpch/lineitem.parquet`";
       runTestAndValidate(selection, validationSelection, inputTable, "lineitem_parquet_converted");
     } finally {
-      test("alter session set `%s` = %b", ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING, ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING_VALIDATOR.getDefault().bool_val);
+      OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `%s` = %b", ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING,
+        optionSet.getDefault(ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING).bool_val);
     }
   }
 
@@ -318,8 +322,11 @@ public class TestParquetWriter extends BaseTestQuery {
       String inputTable = "cp.`tpch/supplier.parquet`";
       runTestAndValidate("*", "*", inputTable, "supplier_parquet_no_dict_uncompressed");
     } finally {
-      test(String.format("alter session set `%s` = %b", ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING, ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING_VALIDATOR.getDefault().bool_val));
-      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE_VALIDATOR.getDefault().string_val));
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test(String.format("alter session set `%s` = %b", ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING,
+        optionSet.getDefault(ExecConstants.PARQUET_WRITER_ENABLE_DICTIONARY_ENCODING).bool_val));
+      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE,
+        optionSet.getDefault(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE).string_val));
     }
   }
 
@@ -330,7 +337,9 @@ public class TestParquetWriter extends BaseTestQuery {
       String inputTable = "cp.`tpch/supplier.parquet`";
       runTestAndValidate("*", "*", inputTable, "supplier_parquet_dict_gzip");
     } finally {
-      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE_VALIDATOR.getDefault().string_val));
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE,
+        optionSet.getDefault(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE).string_val));
     }
   }
 
@@ -452,8 +461,9 @@ public class TestParquetWriter extends BaseTestQuery {
         .optionSettingQueriesForBaseline("alter system set `store.parquet.use_new_reader` = true")
         .build().run();
     } finally {
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
       test("alter system set `%s` = %b", ExecConstants.PARQUET_NEW_RECORD_READER,
-          ExecConstants.PARQUET_RECORD_READER_IMPLEMENTATION_VALIDATOR.getDefault().bool_val);
+        optionSet.getDefault(ExecConstants.PARQUET_NEW_RECORD_READER).bool_val);
     }
   }
 
@@ -472,10 +482,10 @@ public class TestParquetWriter extends BaseTestQuery {
             "alter system set `store.parquet.use_new_reader` = true")
         .build().run();
     } finally {
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
       test("alter system set `%s` = %b",
           ExecConstants.PARQUET_NEW_RECORD_READER,
-          ExecConstants.PARQUET_RECORD_READER_IMPLEMENTATION_VALIDATOR
-              .getDefault().bool_val);
+          optionSet.getDefault(ExecConstants.PARQUET_NEW_RECORD_READER).bool_val);
     }
   }
 
@@ -947,7 +957,8 @@ public class TestParquetWriter extends BaseTestQuery {
       String inputTable = "cp.`tpch/supplier.parquet`";
         runTestAndValidate("*", "*", inputTable, "suppkey_parquet_dict_gzip");
     } finally {
-      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE_VALIDATOR.getDefault().string_val));
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, optionSet.getDefault(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE).string_val));
     }
   }
 
@@ -958,7 +969,8 @@ public class TestParquetWriter extends BaseTestQuery {
       String inputTable = "cp.`supplier_snappy.parquet`";
       runTestAndValidate("*", "*", inputTable, "suppkey_parquet_dict_snappy");
     } finally {
-      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE_VALIDATOR.getDefault().string_val));
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test(String.format("alter session set `%s` = '%s'", ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE, optionSet.getDefault(ExecConstants.PARQUET_WRITER_COMPRESSION_TYPE).string_val));
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriterEmptyFiles.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriterEmptyFiles.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.writer;
 
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.OperatorFixture;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -92,7 +93,8 @@ public class TestParquetWriterEmptyFiles extends BaseTestQuery {
         .go();
     } finally {
       // restore the session option
-      test("ALTER SESSION SET `store.parquet.block-size` = %d", ExecConstants.PARQUET_BLOCK_SIZE_VALIDATOR.getDefault().num_val);
+      final OperatorFixture.TestOptionSet optionSet = new OperatorFixture.TestOptionSet();
+      test("ALTER SESSION SET `store.parquet.block-size` = %d", optionSet.getDefault(ExecConstants.PARQUET_BLOCK_SIZE).num_val);
       deleteTableIfExists(outputFile);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -51,6 +51,7 @@ import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.rpc.control.WorkEventBus;
 import org.apache.drill.exec.rpc.security.KerberosHelper;
 import org.apache.drill.exec.server.BootStrapContext;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.work.WorkManager.WorkerBee;
@@ -119,7 +120,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
     updateTestCluster(1, newConfig);
 
     ScanResult result = ClassPathScanner.fromPrescan(newConfig);
-    c1 = new BootStrapContext(newConfig, result);
+    c1 = new BootStrapContext(newConfig, SystemOptionManager.createDefaultOptionDefinitions(), result);
     setupFragmentContextAndManager();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
@@ -45,6 +45,7 @@ import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.rpc.control.WorkEventBus;
 import org.apache.drill.exec.server.BootStrapContext;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.vector.Float8Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.work.WorkManager.WorkerBee;
@@ -65,9 +66,9 @@ public class TestBitRpc extends ExecTest {
   public void testConnectionBackpressure(@Injectable WorkerBee bee, @Injectable final WorkEventBus workBus) throws Exception {
 
     DrillConfig config1 = DrillConfig.create();
-    final BootStrapContext c = new BootStrapContext(config1, ClassPathScanner.fromPrescan(config1));
+    final BootStrapContext c = new BootStrapContext(config1, SystemOptionManager.createDefaultOptionDefinitions(), ClassPathScanner.fromPrescan(config1));
     DrillConfig config2 = DrillConfig.create();
-    BootStrapContext c2 = new BootStrapContext(config2, ClassPathScanner.fromPrescan(config2));
+    BootStrapContext c2 = new BootStrapContext(config2, SystemOptionManager.createDefaultOptionDefinitions(), ClassPathScanner.fromPrescan(config2));
 
     final FragmentContext fcon = new MockUp<FragmentContext>(){
       BufferAllocator getAllocator(){

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -186,7 +186,7 @@ public class TestDrillbitResilience extends DrillTest {
     System.setProperty(ExecConstants.HTTP_ENABLE, "false");
 
     // turn on error for failure in cancelled fragments
-    zkHelper = new ZookeeperHelper(true);
+    zkHelper = new ZookeeperHelper(true, true);
     zkHelper.startZookeeper(1);
 
     // use a non-null service set so that the drillbits can use port hunting

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -81,6 +81,7 @@ import org.apache.drill.exec.work.foreman.ForemanException;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.apache.drill.exec.work.fragment.FragmentExecutor;
 import org.apache.drill.test.DrillTest;
+import org.apache.drill.test.OperatorFixture;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -805,8 +806,9 @@ public class TestDrillbitResilience extends DrillTest {
       final String query = "SELECT sales_city, COUNT(*) cnt FROM cp.`region.json` GROUP BY sales_city";
       assertCancelledWithoutException(control, new ListenerThatCancelsQueryAfterFirstBatchOfData(), query);
     } finally {
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
       setSessionOption(SLICE_TARGET, Long.toString(SLICE_TARGET_DEFAULT));
-      setSessionOption(HASHAGG.getOptionName(), HASHAGG.getDefault().bool_val.toString());
+      setSessionOption(HASHAGG.getOptionName(), testOptionSet.getDefault(HASHAGG.getOptionName()).bool_val.toString());
     }
   }
 
@@ -836,10 +838,11 @@ public class TestDrillbitResilience extends DrillTest {
       final long after = countAllocatedMemory();
       assertEquals(String.format("We are leaking %d bytes", after - before), before, after);
     } finally {
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
       setSessionOption(SLICE_TARGET, Long.toString(SLICE_TARGET_DEFAULT));
-      setSessionOption(HASHAGG.getOptionName(), HASHAGG.getDefault().bool_val.toString());
+      setSessionOption(HASHAGG.getOptionName(), testOptionSet.getDefault(HASHAGG.getOptionName()).bool_val.toString());
       setSessionOption(PARTITION_SENDER_SET_THREADS.getOptionName(),
-          Long.toString(PARTITION_SENDER_SET_THREADS.getDefault().num_val));
+          Long.toString(testOptionSet.getDefault(PARTITION_SENDER_SET_THREADS.getOptionName()).num_val));
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptions.java
@@ -26,7 +26,7 @@ import static org.apache.drill.exec.ExecConstants.ENABLE_VERBOSE_ERRORS_KEY;
 import static org.apache.drill.exec.ExecConstants.SLICE_TARGET;
 import static org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType.VALIDATION;
 
-public class TestOptions extends BaseTestQuery{
+public class TestOptions extends BaseTestQuery {
 //  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestOptions.class);
 
   @Test
@@ -56,7 +56,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER session SET `%s` = %d;", SLICE_TARGET,
       ExecConstants.SLICE_TARGET_DEFAULT);
     testBuilder()
-        .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SESSION'", SLICE_TARGET)
+        .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
         .unOrdered()
         .baselineColumns("status")
         .baselineValues("DEFAULT")
@@ -68,7 +68,7 @@ public class TestOptions extends BaseTestQuery{
   public void setAndResetSessionOption() throws Exception {
     // check unchanged
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SESSION'", SLICE_TARGET)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
       .unOrdered()
       .expectsEmptyResultSet()
       .build()
@@ -77,9 +77,9 @@ public class TestOptions extends BaseTestQuery{
     // change option
     test("SET `%s` = %d;", SLICE_TARGET, 10);
     // check changed
-    test("SELECT status, type, name FROM sys.options WHERE type = 'SESSION';");
+    test("SELECT status, accessibleScopes, name FROM sys.options WHERE optionScope = 'SESSION';");
     testBuilder()
-      .sqlQuery("SELECT num_val FROM sys.options WHERE name = '%s' AND type = 'SESSION'", SLICE_TARGET)
+      .sqlQuery("SELECT num_val FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
       .unOrdered()
       .baselineColumns("num_val")
       .baselineValues((long) 10)
@@ -90,7 +90,7 @@ public class TestOptions extends BaseTestQuery{
     test("RESET `%s`;", SLICE_TARGET);
     // check reverted
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SESSION'", SLICE_TARGET)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
       .unOrdered()
       .expectsEmptyResultSet()
       .build()
@@ -101,7 +101,7 @@ public class TestOptions extends BaseTestQuery{
   public void setAndResetSystemOption() throws Exception {
     // check unchanged
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'BOOT'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("status")
       .baselineValues("DEFAULT")
@@ -112,7 +112,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER system SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE name = '%s' AND type = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -123,7 +123,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER system RESET `%s`;", ENABLE_VERBOSE_ERRORS_KEY);
     // check reverted
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'BOOT'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("status")
       .baselineValues("DEFAULT")
@@ -137,7 +137,7 @@ public class TestOptions extends BaseTestQuery{
     test("SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -148,7 +148,7 @@ public class TestOptions extends BaseTestQuery{
     test("RESET ALL;");
     // check no session options changed
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE status <> 'DEFAULT' AND type = 'SESSION'")
+      .sqlQuery("SELECT status FROM sys.options WHERE status <> 'DEFAULT' AND optionScope = 'SESSION'")
       .unOrdered()
       .expectsEmptyResultSet()
       .build()
@@ -162,7 +162,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -170,7 +170,7 @@ public class TestOptions extends BaseTestQuery{
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -181,14 +181,14 @@ public class TestOptions extends BaseTestQuery{
     test("RESET `%s`;", ENABLE_VERBOSE_ERRORS_KEY);
     // check reverted
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SESSION'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .expectsEmptyResultSet()
       .build()
       .run();
     // check unchanged
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -205,7 +205,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -213,7 +213,7 @@ public class TestOptions extends BaseTestQuery{
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -224,14 +224,14 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER SESSION RESET ALL;");
     // check no session options changed
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE status <> 'DEFAULT' AND type = 'SESSION'")
+      .sqlQuery("SELECT status FROM sys.options WHERE status <> 'DEFAULT' AND optionScope = 'SESSION'")
       .unOrdered()
       .expectsEmptyResultSet()
       .build()
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -246,7 +246,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -254,7 +254,7 @@ public class TestOptions extends BaseTestQuery{
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -265,7 +265,7 @@ public class TestOptions extends BaseTestQuery{
     test("ALTER system RESET `%s`;", ENABLE_VERBOSE_ERRORS_KEY);
     // check reverted
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND type = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'BOOT'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("status")
       .baselineValues("DEFAULT")
@@ -273,7 +273,7 @@ public class TestOptions extends BaseTestQuery{
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE type = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
@@ -90,7 +90,7 @@ public class TestOptionsAuthEnabled extends BaseTestQuery {
     updateClient(ADMIN_USER, ADMIN_USER_PASSWORD);
     final String setOptionQuery =
         String.format("ALTER SESSION SET `%s`='%s,%s'", ExecConstants.ADMIN_USERS_KEY, ADMIN_USER, PROCESS_USER);
-    errorMsgTestHelper(setOptionQuery, "Admin related settings can only be set at SYSTEM level scope");
+    errorMsgTestHelper(setOptionQuery, "PERMISSION ERROR: Cannot change option security.admin.users in scope SESSION");
   }
 
   @Test
@@ -98,14 +98,14 @@ public class TestOptionsAuthEnabled extends BaseTestQuery {
     updateClient(TEST_USER_2, TEST_USER_2_PASSWORD);
     final String setOptionQuery =
         String.format("ALTER SESSION SET `%s`='%s,%s'", ExecConstants.ADMIN_USERS_KEY, ADMIN_USER, PROCESS_USER);
-    errorMsgTestHelper(setOptionQuery, "Admin related settings can only be set at SYSTEM level scope");
+    errorMsgTestHelper(setOptionQuery, "PERMISSION ERROR: Cannot change option security.admin.users in scope SESSION");
   }
 
   private void setOptHelper() throws Exception {
     try {
       test(setSysOptionQuery);
       testBuilder()
-          .sqlQuery(String.format("SELECT num_val FROM sys.options WHERE name = '%s' AND type = 'SYSTEM'",
+          .sqlQuery(String.format("SELECT num_val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'",
               ExecConstants.SLICE_TARGET))
           .unOrdered()
           .baselineColumns("num_val")

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.server.rest;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.options.OptionDefinition;
+import org.apache.drill.exec.server.options.OptionValidator;
+import org.apache.drill.test.ClientFixture;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.FixtureBuilder;
+import org.apache.drill.test.RestClientFixture;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.drill.test.TestConfigLinkage.MOCK_PROPERTY;
+import static org.apache.drill.test.TestConfigLinkage.createMockPropOptionDefinition;
+
+public class StatusResourcesTest {
+  @Test
+  public void testRetrieveInternalOption() throws Exception {
+    OptionDefinition optionDefinition = createMockPropOptionDefinition();
+
+    FixtureBuilder builder = ClusterFixture.builder().
+      configProperty(ExecConstants.HTTP_ENABLE, true).
+      configProperty(OptionValidator.OPTION_DEFAULTS_ROOT + MOCK_PROPERTY, "a").
+      putDefinition(optionDefinition);
+
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture();
+         RestClientFixture restClientFixture = cluster.restClientFixture()) {
+      Assert.assertNull(restClientFixture.getStatusOption(MOCK_PROPERTY));
+      StatusResources.OptionWrapper option = restClientFixture.getStatusInternalOption(MOCK_PROPERTY);
+      Assert.assertEquals("a", option.getValueAsString());
+
+      client.alterSystem(MOCK_PROPERTY, "c");
+
+      Assert.assertNull(restClientFixture.getStatusOption(MOCK_PROPERTY));
+      option = restClientFixture.getStatusInternalOption(MOCK_PROPERTY);
+      Assert.assertEquals("c", option.getValueAsString());
+    }
+  }
+
+  @Test
+  public void testRetrievePublicOption() throws Exception {
+    FixtureBuilder builder = ClusterFixture.builder().
+      configProperty(ExecConstants.HTTP_ENABLE, true).
+      systemOption(ExecConstants.SLICE_TARGET, 20);
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture();
+         RestClientFixture restClientFixture = cluster.restClientFixture()) {
+      Assert.assertNull(restClientFixture.getStatusInternalOption(ExecConstants.SLICE_TARGET));
+      StatusResources.OptionWrapper option = restClientFixture.getStatusOption(ExecConstants.SLICE_TARGET);
+      Assert.assertEquals(20, option.getValue());
+
+      client.alterSystem(ExecConstants.SLICE_TARGET, 30);
+
+      Assert.assertNull(restClientFixture.getStatusInternalOption(ExecConstants.SLICE_TARGET));
+      option = restClientFixture.getStatusOption(ExecConstants.SLICE_TARGET);
+      Assert.assertEquals(30, option.getValue());
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
@@ -39,6 +39,7 @@ public class StatusResourcesTest {
     FixtureBuilder builder = ClusterFixture.builder().
       configProperty(ExecConstants.HTTP_ENABLE, true).
       configProperty(OptionValidator.OPTION_DEFAULTS_ROOT + MOCK_PROPERTY, "a").
+      configProperty(ExecConstants.HTTP_PORT_HUNT, true).
       putDefinition(optionDefinition);
 
     try (ClusterFixture cluster = builder.build();
@@ -60,6 +61,7 @@ public class StatusResourcesTest {
   public void testRetrievePublicOption() throws Exception {
     FixtureBuilder builder = ClusterFixture.builder().
       configProperty(ExecConstants.HTTP_ENABLE, true).
+      configProperty(ExecConstants.HTTP_PORT_HUNT, true).
       systemOption(ExecConstants.SLICE_TARGET, 20);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestWithClause.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestWithClause.java
@@ -26,7 +26,7 @@ public class TestWithClause extends BaseTestQuery {
 
   @Test
   public void withClause() throws Exception {
-    test("with alpha as (select * from sys.options where type = 'SYSTEM') \n" +
+    test("with alpha as (select * from sys.options where optionScope = 'SYSTEM') \n" +
         "\n" +
         "select * from alpha");
   }
@@ -34,7 +34,7 @@ public class TestWithClause extends BaseTestQuery {
   @Test
   @Ignore
   public void withClauseWithAliases() throws Exception {
-    test("with alpha (x,y) as (select name, kind from sys.options where type = 'SYSTEM') \n" +
+    test("with alpha (x,y) as (select name, kind from sys.options where optionScope = 'SYSTEM') \n" +
         "\n" +
         "select x, y from alpha");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -23,6 +23,7 @@ import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.BitControl;
+import org.apache.drill.test.OperatorFixture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -291,7 +292,9 @@ public class TestParquetFilterPushDown extends PlanTestBase {
       testParquetFilterPD(query1, 9, 3, false);
 
     } finally {
-      test("alter session set `" + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_KEY  + "` = " + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING.getDefault().bool_val);
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `" + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_KEY  + "` = " +
+        testOptionSet.getDefault(PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_KEY).bool_val);
       deleteTableIfExists(tableName);
     }
   }
@@ -314,7 +317,9 @@ public class TestParquetFilterPushDown extends PlanTestBase {
       testParquetFilterPD(query1, 9, 3, false);
 
     } finally {
-      test("alter session set `" + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD_KEY  + "` = " + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD.getDefault().num_val);
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
+      test("alter session set `" + PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD_KEY + "` = " +
+        testOptionSet.getDefault(PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD_KEY).num_val);
       deleteTableIfExists(tableName);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
@@ -30,8 +30,6 @@ import org.junit.Test;
 public class TestPStoreProviders extends TestWithZookeeper {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestPStoreProviders.class);
 
-  static LocalPersistentStoreProvider provider;
-
   @Test
   public void verifyLocalStore() throws Exception {
     try(LocalPersistentStoreProvider provider = new LocalPersistentStoreProvider(DrillConfig.create())){
@@ -41,10 +39,11 @@ public class TestPStoreProviders extends TestWithZookeeper {
 
   @Test
   public void verifyZkStore() throws Exception {
-    DrillConfig config = getConfig();
-    String connect = config.getString(ExecConstants.ZK_CONNECTION);
+    String connect = zkHelper.getConnectionString();
+    DrillConfig config = zkHelper.getConfig();
+
     CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
-    .namespace(config.getString(ExecConstants.ZK_ROOT))
+    .namespace(zkHelper.getConfig().getString(ExecConstants.ZK_ROOT))
     .retryPolicy(new RetryNTimes(1, 100))
     .connectionTimeoutMs(config.getInt(ExecConstants.ZK_TIMEOUT))
     .connectString(connect);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -34,7 +34,7 @@ public class TestSystemTable extends BaseTestQuery {
   public void alterSessionOption() throws Exception {
 
     newTest() //
-      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by type desc", ExecConstants.JSON_ALL_TEXT_MODE)
+      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by accessibleScopes desc", ExecConstants.JSON_ALL_TEXT_MODE)
       .baselineColumns("bool")
       .ordered()
       .baselineValues(false)
@@ -43,7 +43,7 @@ public class TestSystemTable extends BaseTestQuery {
     test("alter session set `%s` = true", ExecConstants.JSON_ALL_TEXT_MODE);
 
     newTest() //
-      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by type desc ", ExecConstants.JSON_ALL_TEXT_MODE)
+      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by accessibleScopes desc ", ExecConstants.JSON_ALL_TEXT_MODE)
       .baselineColumns("bool")
       .ordered()
       .baselineValues(false)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.testing;
 
-import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROLS_VALIDATOR;
 import static org.apache.drill.exec.ExecConstants.DRILLBIT_CONTROL_INJECTIONS;
 import static org.junit.Assert.fail;
 
@@ -30,9 +29,7 @@ import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.rpc.user.UserSession.QueryCountIncrementer;
-import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.server.options.OptionValue;
-import org.apache.drill.exec.server.options.OptionValue.OptionScope;
+import org.apache.drill.exec.server.options.SessionOptionManager;
 
 /**
  * Static methods for constructing exception and pause injections for testing purposes.
@@ -71,13 +68,10 @@ public class ControlsInjectionUtil {
 
   public static void setControls(final UserSession session, final String controls) {
     validateControlsString(controls);
-    final OptionValue opValue = OptionValue.createString(OptionValue.OptionType.SESSION,
-      DRILLBIT_CONTROL_INJECTIONS, controls, OptionScope.SESSION);
 
-    final OptionManager options = session.getOptions();
+    final SessionOptionManager options = session.getOptions();
     try {
-      DRILLBIT_CONTROLS_VALIDATOR.validate(opValue, null);
-      options.setOption(opValue);
+      options.setLocalOption(DRILLBIT_CONTROL_INJECTIONS, controls);
     } catch (final Exception e) {
       fail("Could not set controls options: " + e.getMessage());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
@@ -231,10 +231,10 @@ public class TestExceptionInjection extends BaseTestQuery {
       final DrillbitContext drillbitContext2 = drillbit2.getContext();
 
       final UserSession session = UserSession.Builder.newBuilder()
-        .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build())
-        .withUserProperties(UserProperties.getDefaultInstance())
-        .withOptionManager(drillbitContext1.getOptionManager())
-        .build();
+          .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build())
+          .withUserProperties(UserProperties.getDefaultInstance())
+          .withOptionManager(drillbitContext1.getOptionManager())
+          .build();
 
       final String passthroughDesc = "<<injected from descPassthrough>>";
       final int nSkip = 7;
@@ -242,7 +242,7 @@ public class TestExceptionInjection extends BaseTestQuery {
       final Class<? extends Throwable> exceptionClass = RuntimeException.class;
       // only drillbit1's (address, port)
       final String controls = Controls.newBuilder()
-        .addExceptionOnBit(DummyClass.class, passthroughDesc, exceptionClass, drillbitContext1.getEndpoint(), nSkip, nFire)
+      .addExceptionOnBit(DummyClass.class, passthroughDesc, exceptionClass, drillbitContext1.getEndpoint(), nSkip, nFire)
         .build();
 
       ControlsInjectionUtil.setControls(session, controls);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestExceptionInjection.java
@@ -216,79 +216,83 @@ public class TestExceptionInjection extends BaseTestQuery {
     final ZookeeperHelper zkHelper = new ZookeeperHelper();
     zkHelper.startZookeeper(1);
 
-    // Creating two drillbits
-    final Drillbit drillbit1, drillbit2;
-    final DrillConfig drillConfig = zkHelper.getConfig();
     try {
-      drillbit1 = Drillbit.start(drillConfig, remoteServiceSet);
-      drillbit2 = Drillbit.start(drillConfig, remoteServiceSet);
-    } catch (DrillbitStartupException e) {
-      throw new RuntimeException("Failed to start drillbits.", e);
-    }
+      // Creating two drillbits
+      final Drillbit drillbit1, drillbit2;
+      final DrillConfig drillConfig = zkHelper.getConfig();
+      try {
+        drillbit1 = Drillbit.start(drillConfig, remoteServiceSet);
+        drillbit2 = Drillbit.start(drillConfig, remoteServiceSet);
+      } catch (DrillbitStartupException e) {
+        throw new RuntimeException("Failed to start drillbits.", e);
+      }
 
-    final DrillbitContext drillbitContext1 = drillbit1.getContext();
-    final DrillbitContext drillbitContext2 = drillbit2.getContext();
+      final DrillbitContext drillbitContext1 = drillbit1.getContext();
+      final DrillbitContext drillbitContext2 = drillbit2.getContext();
 
-    final UserSession session = UserSession.Builder.newBuilder()
+      final UserSession session = UserSession.Builder.newBuilder()
         .withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build())
         .withUserProperties(UserProperties.getDefaultInstance())
         .withOptionManager(drillbitContext1.getOptionManager())
         .build();
 
-    final String passthroughDesc = "<<injected from descPassthrough>>";
-    final int nSkip = 7;
-    final int nFire = 3;
-    final Class<? extends Throwable> exceptionClass = RuntimeException.class;
-    // only drillbit1's (address, port)
-    final String controls = Controls.newBuilder()
-    .addExceptionOnBit(DummyClass.class, passthroughDesc, exceptionClass, drillbitContext1.getEndpoint(), nSkip, nFire)
-      .build();
+      final String passthroughDesc = "<<injected from descPassthrough>>";
+      final int nSkip = 7;
+      final int nFire = 3;
+      final Class<? extends Throwable> exceptionClass = RuntimeException.class;
+      // only drillbit1's (address, port)
+      final String controls = Controls.newBuilder()
+        .addExceptionOnBit(DummyClass.class, passthroughDesc, exceptionClass, drillbitContext1.getEndpoint(), nSkip, nFire)
+        .build();
 
-    ControlsInjectionUtil.setControls(session, controls);
+      ControlsInjectionUtil.setControls(session, controls);
 
-    {
-      final QueryContext queryContext1 = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
-      final DummyClass class1 = new DummyClass(queryContext1);
+      {
+        final QueryContext queryContext1 = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
+        final DummyClass class1 = new DummyClass(queryContext1);
 
-      // these shouldn't throw
-      for (int i = 0; i < nSkip; ++i) {
+        // these shouldn't throw
+        for (int i = 0; i < nSkip; ++i) {
+          class1.descPassthroughMethod(passthroughDesc);
+        }
+
+        // these should throw
+        for (int i = 0; i < nFire; ++i) {
+          assertPassthroughThrows(class1, exceptionClass.getName(), passthroughDesc);
+        }
+
+        // this shouldn't throw
         class1.descPassthroughMethod(passthroughDesc);
+        try {
+          queryContext1.close();
+        } catch (Exception e) {
+          fail();
+        }
       }
+      {
+        final QueryContext queryContext2 = new QueryContext(session, drillbitContext2, QueryId.getDefaultInstance());
+        final DummyClass class2 = new DummyClass(queryContext2);
 
-      // these should throw
-      for (int i = 0; i < nFire; ++i) {
-        assertPassthroughThrows(class1, exceptionClass.getName(), passthroughDesc);
-      }
+        // these shouldn't throw
+        for (int i = 0; i < nSkip; ++i) {
+          class2.descPassthroughMethod(passthroughDesc);
+        }
 
-      // this shouldn't throw
-      class1.descPassthroughMethod(passthroughDesc);
-      try {
-        queryContext1.close();
-      } catch (Exception e) {
-        fail();
-      }
-    }
-    {
-      final QueryContext queryContext2 = new QueryContext(session, drillbitContext2, QueryId.getDefaultInstance());
-      final DummyClass class2 = new DummyClass(queryContext2);
+        // these shouldn't throw
+        for (int i = 0; i < nFire; ++i) {
+          class2.descPassthroughMethod(passthroughDesc);
+        }
 
-      // these shouldn't throw
-      for (int i = 0; i < nSkip; ++i) {
+        // this shouldn't throw
         class2.descPassthroughMethod(passthroughDesc);
+        try {
+          queryContext2.close();
+        } catch (Exception e) {
+          fail();
+        }
       }
-
-      // these shouldn't throw
-      for (int i = 0; i < nFire; ++i) {
-        class2.descPassthroughMethod(passthroughDesc);
-      }
-
-      // this shouldn't throw
-      class2.descPassthroughMethod(passthroughDesc);
-      try {
-        queryContext2.close();
-      } catch (Exception e) {
-        fail();
-      }
+    } finally {
+      zkHelper.stopZookeeper();
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
@@ -150,66 +150,70 @@ public class TestPauseInjection extends BaseTestQuery {
     final ZookeeperHelper zkHelper = new ZookeeperHelper();
     zkHelper.startZookeeper(1);
 
-    // Creating two drillbits
-    final Drillbit drillbit1, drillbit2;
-    final DrillConfig drillConfig = zkHelper.getConfig();
     try {
-      drillbit1 = Drillbit.start(drillConfig, remoteServiceSet);
-      drillbit2 = Drillbit.start(drillConfig, remoteServiceSet);
-    } catch (final DrillbitStartupException e) {
-      throw new RuntimeException("Failed to start two drillbits.", e);
-    }
-
-    final DrillbitContext drillbitContext1 = drillbit1.getContext();
-    final DrillbitContext drillbitContext2 = drillbit2.getContext();
-
-    final UserSession session = UserSession.Builder.newBuilder()
-      .withCredentials(UserCredentials.newBuilder()
-        .setUserName("foo")
-        .build())
-      .withUserProperties(UserProperties.getDefaultInstance())
-      .withOptionManager(drillbitContext1.getOptionManager())
-      .build();
-
-    final DrillbitEndpoint drillbitEndpoint1 = drillbitContext1.getEndpoint();
-    final String controls = Controls.newBuilder()
-      .addPauseOnBit(DummyClass.class, DummyClass.PAUSES, drillbitEndpoint1)
-      .build();
-
-    ControlsInjectionUtil.setControls(session, controls);
-
-    {
-      final long expectedDuration = 1000L;
-      final ExtendedLatch trigger = new ExtendedLatch(1);
-      final Pointer<Exception> ex = new Pointer<>();
-      final QueryContext queryContext = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
-      (new ResumingThread(queryContext, trigger, ex, expectedDuration)).start();
-
-      // test that the pause happens
-      final DummyClass dummyClass = new DummyClass(queryContext, trigger);
-      final long actualDuration = dummyClass.pauses();
-      assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration),
-        expectedDuration <= actualDuration);
-      assertTrue("No exception should be thrown.", ex.value == null);
+      // Creating two drillbits
+      final Drillbit drillbit1, drillbit2;
+      final DrillConfig drillConfig = zkHelper.getConfig();
       try {
-        queryContext.close();
-      } catch (final Exception e) {
-        fail("Failed to close query context: " + e);
+        drillbit1 = Drillbit.start(drillConfig, remoteServiceSet);
+        drillbit2 = Drillbit.start(drillConfig, remoteServiceSet);
+      } catch (final DrillbitStartupException e) {
+        throw new RuntimeException("Failed to start two drillbits.", e);
       }
-    }
 
-    {
-      final ExtendedLatch trigger = new ExtendedLatch(1);
-      final QueryContext queryContext = new QueryContext(session, drillbitContext2, QueryId.getDefaultInstance());
+      final DrillbitContext drillbitContext1 = drillbit1.getContext();
+      final DrillbitContext drillbitContext2 = drillbit2.getContext();
 
-      // if the resume did not happen, the test would hang
-      final DummyClass dummyClass = new DummyClass(queryContext, trigger);
-      dummyClass.pauses();
-      try {
-        queryContext.close();
-      } catch (final Exception e) {
-        fail("Failed to close query context: " + e);
+      final UserSession session = UserSession.Builder.newBuilder()
+        .withCredentials(UserCredentials.newBuilder()
+          .setUserName("foo")
+          .build())
+        .withUserProperties(UserProperties.getDefaultInstance())
+        .withOptionManager(drillbitContext1.getOptionManager())
+        .build();
+
+      final DrillbitEndpoint drillbitEndpoint1 = drillbitContext1.getEndpoint();
+      final String controls = Controls.newBuilder()
+        .addPauseOnBit(DummyClass.class, DummyClass.PAUSES, drillbitEndpoint1)
+        .build();
+
+      ControlsInjectionUtil.setControls(session, controls);
+
+      {
+        final long expectedDuration = 1000L;
+        final ExtendedLatch trigger = new ExtendedLatch(1);
+        final Pointer<Exception> ex = new Pointer<>();
+        final QueryContext queryContext = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
+        (new ResumingThread(queryContext, trigger, ex, expectedDuration)).start();
+
+        // test that the pause happens
+        final DummyClass dummyClass = new DummyClass(queryContext, trigger);
+        final long actualDuration = dummyClass.pauses();
+        assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration),
+          expectedDuration <= actualDuration);
+        assertTrue("No exception should be thrown.", ex.value == null);
+        try {
+          queryContext.close();
+        } catch (final Exception e) {
+          fail("Failed to close query context: " + e);
+        }
       }
+
+      {
+        final ExtendedLatch trigger = new ExtendedLatch(1);
+        final QueryContext queryContext = new QueryContext(session, drillbitContext2, QueryId.getDefaultInstance());
+
+        // if the resume did not happen, the test would hang
+        final DummyClass dummyClass = new DummyClass(queryContext, trigger);
+        dummyClass.pauses();
+        try {
+          queryContext.close();
+        } catch (final Exception e) {
+          fail("Failed to close query context: " + e);
+        }
+      }
+    } finally {
+      zkHelper.stopZookeeper();
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
@@ -189,8 +189,7 @@ public class TestPauseInjection extends BaseTestQuery {
         // test that the pause happens
         final DummyClass dummyClass = new DummyClass(queryContext, trigger);
         final long actualDuration = dummyClass.pauses();
-        assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration),
-          expectedDuration <= actualDuration);
+        assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration), expectedDuration <= actualDuration);
         assertTrue("No exception should be thrown.", ex.value == null);
         try {
           queryContext.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/MiniZooKeeperCluster.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/MiniZooKeeperCluster.java
@@ -47,6 +47,7 @@ public class MiniZooKeeperCluster {
 
   private static final int TICK_TIME = 2000;
   private static final int CONNECTION_TIMEOUT = 10000;
+  public static final int DEFAULT_PORT = 2181;
 
   private boolean started;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/MiniZooKeeperCluster.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/MiniZooKeeperCluster.java
@@ -29,7 +29,9 @@ import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileUtil;
@@ -44,7 +46,7 @@ public class MiniZooKeeperCluster {
   private static final Log LOG = LogFactory.getLog(MiniZooKeeperCluster.class);
 
   private static final int TICK_TIME = 2000;
-  private static final int CONNECTION_TIMEOUT = 30000;
+  private static final int CONNECTION_TIMEOUT = 10000;
 
   private boolean started;
 
@@ -146,27 +148,41 @@ public class MiniZooKeeperCluster {
       } else {
         tickTimeToUse = TICK_TIME;
       }
+
       ZooKeeperServer server = new ZooKeeperServer(dir, dir, tickTimeToUse);
       NIOServerCnxnFactory standaloneServerFactory;
+
       while (true) {
+        System.out.println("Starting zookeeper " + tentativePort);
+
         try {
           standaloneServerFactory = new NIOServerCnxnFactory();
-          standaloneServerFactory.configure(
-            new InetSocketAddress(tentativePort), 1000);
+          standaloneServerFactory.configure(new InetSocketAddress(tentativePort), 1000);
         } catch (BindException e) {
-          LOG.debug("Failed binding ZK Server to client port: " +
-            tentativePort);
+          LOG.debug("Failed binding ZK Server to client port: " + tentativePort);
           // This port is already in use, try to use another.
           tentativePort++;
           continue;
         }
-        break;
-      }
 
-      // Start up this ZK server
-      standaloneServerFactory.startup(server);
-      if (!waitForServerUp(tentativePort, CONNECTION_TIMEOUT)) {
-        throw new IOException("Waiting for startup of standalone server");
+        // Start up this ZK server
+
+        try {
+          standaloneServerFactory.startup(server);
+        } catch (IOException e) {
+          LOG.error("Zookeeper startupt error", e);
+          tentativePort++;
+          continue;
+        }
+
+        if (!waitForServerUp(server, CONNECTION_TIMEOUT)) {
+          server.shutdown();
+          server = new ZooKeeperServer(dir, dir, tickTimeToUse);
+          tentativePort++;
+          continue;
+        }
+
+        break;
       }
 
       // We have selected this port as a client port.
@@ -326,32 +342,13 @@ public class MiniZooKeeperCluster {
   }
 
   // XXX: From o.a.zk.t.ClientBase
-  private static boolean waitForServerUp(int port, long timeout) {
+  private static boolean waitForServerUp(ZooKeeperServer server, long timeout) {
     long start = System.currentTimeMillis();
     while (true) {
-      try {
-        Socket sock = new Socket("localhost", port);
-        BufferedReader reader = null;
-        try {
-          OutputStream outstream = sock.getOutputStream();
-          outstream.write("stat".getBytes());
-          outstream.flush();
+      // Doing it this way instead of openning a connection to zookeeper because of ZOOKEEPER-2383
 
-          Reader isr = new InputStreamReader(sock.getInputStream());
-          reader = new BufferedReader(isr);
-          String line = reader.readLine();
-          if (line != null && line.startsWith("Zookeeper version:")) {
-            return true;
-          }
-        } finally {
-          sock.close();
-          if (reader != null) {
-            reader.close();
-          }
-        }
-      } catch (IOException e) {
-        // ignore as this is expected
-        LOG.info("server localhost:" + port + " not up " + e);
+      if (server.isRunning()) {
+        return true;
       }
 
       if (System.currentTimeMillis() > start + timeout) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestExtendedTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestExtendedTypes.java
@@ -29,6 +29,7 @@ import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.util.TestTools;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
+import org.apache.drill.test.OperatorFixture;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -59,12 +60,13 @@ public class TestExtendedTypes extends BaseTestQuery {
           + "/0_0_0.json"));
       assertEquals(new String(originalData), new String(newData));
     } finally {
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
       testNoResult(String.format("ALTER SESSION SET `%s` = '%s'",
           ExecConstants.OUTPUT_FORMAT_VALIDATOR.getOptionName(),
-          ExecConstants.OUTPUT_FORMAT_VALIDATOR.getDefault().getValue()));
+          testOptionSet.getDefault(ExecConstants.OUTPUT_FORMAT_VALIDATOR.getOptionName()).getValue()));
       testNoResult(String.format("ALTER SESSION SET `%s` = %s",
           ExecConstants.JSON_EXTENDED_TYPES.getOptionName(),
-          ExecConstants.JSON_EXTENDED_TYPES.getDefault().getValue()));
+          testOptionSet.getDefault(ExecConstants.JSON_EXTENDED_TYPES.getOptionName()).getValue()));
     }
   }
 
@@ -89,12 +91,13 @@ public class TestExtendedTypes extends BaseTestQuery {
       String expected = "drill_timestamp_millies,bin,bin1\n2015-07-07T03:59:43.488,drill,drill\n";
       Assert.assertEquals(expected, actual);
     } finally {
+      final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
       testNoResult(String.format("ALTER SESSION SET `%s` = '%s'",
           ExecConstants.OUTPUT_FORMAT_VALIDATOR.getOptionName(),
-          ExecConstants.OUTPUT_FORMAT_VALIDATOR.getDefault().getValue()));
+          testOptionSet.getDefault(ExecConstants.OUTPUT_FORMAT_VALIDATOR.getOptionName()).getValue()));
       testNoResult(String.format("ALTER SESSION SET `%s` = %s",
           ExecConstants.JSON_EXTENDED_TYPES.getOptionName(),
-          ExecConstants.JSON_EXTENDED_TYPES.getDefault().getValue()));
+          testOptionSet.getDefault(ExecConstants.JSON_EXTENDED_TYPES.getOptionName()).getValue()));
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/TestSpoolingBuffer.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.FileUtils;
-import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.server.Drillbit;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -38,6 +38,7 @@ import org.apache.drill.exec.proto.UserProtos.LikeFilter;
 import org.apache.drill.exec.proto.UserProtos.RequestStatus;
 import org.apache.drill.exec.proto.UserProtos.SchemaMetadata;
 import org.apache.drill.exec.proto.UserProtos.TableMetadata;
+import org.apache.drill.exec.store.sys.SystemTable;
 import org.junit.Test;
 
 /**
@@ -152,7 +153,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(12, tables.size());
+    assertEquals(14, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -162,9 +163,12 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "drillbits", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", "options", tables);
+    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
     verifyTable("sys", "threads", tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test
@@ -186,7 +190,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(12, tables.size());
+    assertEquals(14, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -196,9 +200,12 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "drillbits", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", "options", tables);
+    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
     verifyTable("sys", "threads", tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test
@@ -211,12 +218,15 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(5, tables.size());
+    assertEquals(7, tables.size());
 
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", "options", tables);
+    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test
@@ -242,7 +252,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(76, columns.size());
+    assertEquals(92, columns.size());
     // too many records to verify the output.
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -133,6 +133,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
   private RemoteServiceSet serviceSet;
   private File dfsTestTempDir;
   protected List<ClientFixture> clients = new ArrayList<>();
+  protected RestClientFixture restClientFixture;
   private boolean usesZk;
   private boolean preserveLocalFiles;
   private boolean isLocal;
@@ -267,7 +268,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
     Preconditions.checkArgument(builder.bitCount > 0);
     int bitCount = builder.bitCount;
     for (int i = 0; i < bitCount; i++) {
-      Drillbit bit = new Drillbit(config, serviceSet);
+      Drillbit bit = new Drillbit(config, builder.configBuilder.getDefinitions(), serviceSet);
       bit.run();
 
       // Bit name and registration.
@@ -346,11 +347,23 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
     return new ClientFixture.ClientBuilder(this);
   }
 
+  public RestClientFixture.Builder restClientBuilder() {
+    return new RestClientFixture.Builder(this);
+  }
+
   public ClientFixture clientFixture() {
     if (clients.isEmpty()) {
       clientBuilder().build();
     }
     return clients.get(0);
+  }
+
+  public RestClientFixture restClientFixture() {
+    if (restClientFixture == null) {
+      restClientFixture = restClientBuilder().build();
+    }
+
+    return restClientFixture;
   }
 
   public DrillClient client() {
@@ -570,8 +583,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
 
   public static FixtureBuilder builder() {
     FixtureBuilder builder = new FixtureBuilder()
-         .sessionOption(ExecConstants.MAX_WIDTH_PER_NODE_KEY, MAX_WIDTH_PER_NODE)
-         ;
+         .sessionOption(ExecConstants.MAX_WIDTH_PER_NODE_KEY, MAX_WIDTH_PER_NODE);
     Properties props = new Properties();
     props.putAll(ClusterFixture.TEST_CONFIGURATIONS);
     builder.configBuilder.configProps(props);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -188,7 +188,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
     } else if (builder.localZkCount > 0) {
       // Case where we need a local ZK just for this test cluster.
 
-      zkHelper = new ZookeeperHelper("dummy");
+      zkHelper = new ZookeeperHelper();
       zkHelper.startZookeeper(builder.localZkCount);
       ownsZK = true;
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ConfigBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ConfigBuilder.java
@@ -25,6 +25,9 @@ import org.apache.drill.common.config.DrillConfig;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
+import org.apache.drill.common.map.CaseInsensitiveMap;
+import org.apache.drill.exec.server.options.OptionDefinition;
+import org.apache.drill.exec.server.options.SystemOptionManager;
 
 /**
  * Builds a {@link DrillConfig} for use in tests. Use this when a config
@@ -34,12 +37,13 @@ public class ConfigBuilder {
 
   protected String configResource;
   protected Properties configProps;
+  protected CaseInsensitiveMap<OptionDefinition> definitions = SystemOptionManager.createDefaultOptionDefinitions();
 
   /**
    * Use the given configuration properties as overrides.
    * @param configProps a collection of config properties
    * @return this builder
-   * @see {@link #configProperty(String, Object)}
+   * @see {@link #put(String, Object)}
    */
 
   public ConfigBuilder configProps(Properties configProps) {
@@ -64,11 +68,11 @@ public class ConfigBuilder {
    * drill.exec.http.enabled : false
    * </code></pre>
    * It may be more convenient to add your settings to the default
-   * config settings with {@link #configProperty(String, Object)}.
+   * config settings with {@link #put(String, Object)}.
    * @param configResource path to the file that contains the
    * config file to be read
    * @return this builder
-   * @see {@link #configProperty(String, Object)}
+   * @see {@link #put(String, Object)}
    */
 
   public ConfigBuilder resource(String configResource) {
@@ -103,6 +107,15 @@ public class ConfigBuilder {
     }
     configProps.put(key, value.toString());
     return this;
+  }
+
+  public ConfigBuilder putDefinition(OptionDefinition definition) {
+    definitions.put(definition.getValidator().getOptionName(), definition);
+    return this;
+  }
+
+  public CaseInsensitiveMap<OptionDefinition> getDefinitions() {
+    return CaseInsensitiveMap.newImmutableMap(definitions);
   }
 
   public DrillConfig build() {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/FixtureBuilder.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ZookeeperHelper;
+import org.apache.drill.exec.server.options.OptionDefinition;
 
 /**
  * Build a Drillbit and client with the options provided. The simplest
@@ -114,6 +115,11 @@ public class FixtureBuilder {
 
   public FixtureBuilder configProperty(String key, Object value) {
     configBuilder.put(key, value.toString());
+    return this;
+  }
+
+  public FixtureBuilder putDefinition(OptionDefinition definition) {
+    configBuilder.putDefinition(definition);
     return this;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.test;
+
+import com.google.common.base.Preconditions;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.rest.StatusResources;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import java.util.List;
+
+/**
+ * Represents a client for the Drill Rest API.
+ */
+public class RestClientFixture implements AutoCloseable {
+  /**
+   * A builder for the rest client.
+   */
+  public static class Builder {
+    private ClusterFixture cluster;
+
+    public Builder(ClusterFixture cluster) {
+      this.cluster = Preconditions.checkNotNull(cluster);
+    }
+
+    public RestClientFixture build() {
+      return new RestClientFixture(cluster);
+    }
+  }
+
+  private final WebTarget baseTarget;
+  private final Client client;
+
+  private RestClientFixture(ClusterFixture cluster) {
+    int port = cluster.config.getInt(ExecConstants.HTTP_PORT);
+    String address = cluster.drillbits().iterator().next().getContext().getEndpoint().getAddress();
+    String baseURL = "http://" + address + ":" + port;
+
+    client = JerseyClientBuilder.createClient(new ClientConfig());
+    baseTarget = client.target(baseURL);
+  }
+
+  /**
+   * Gets all the external options from the rest api.
+   * @return All the external options
+   */
+  public List<StatusResources.OptionWrapper> getStatusOptions() {
+    return baseTarget.path(StatusResources.PATH_OPTIONS_JSON)
+      .request(MediaType.APPLICATION_JSON)
+      .get(new GenericType<List<StatusResources.OptionWrapper>>() {});
+  }
+
+  public List<StatusResources.OptionWrapper> getStatusInternalOptions() {
+    return baseTarget.path(StatusResources.PATH_INTERNAL_OPTIONS_JSON)
+      .request(MediaType.APPLICATION_JSON)
+      .get(new GenericType<List<StatusResources.OptionWrapper>>() {});
+  }
+
+  /**
+   * Gets the external option corresponding to the given name.
+   * @param name The name of the external option to retrieve.
+   * @return The external option corresponding to the given name.
+   */
+  @Nullable
+  public StatusResources.OptionWrapper getStatusOption(String name) {
+    return getStatusOptionHelper(getStatusOptions(), name);
+  }
+
+  /**
+   * Gets the internal option corresponding to the given name.
+   * @param name The name of the internal option to retrieve.
+   * @return The internal option corresponding to the given name.
+   */
+  @Nullable
+  public StatusResources.OptionWrapper getStatusInternalOption(String name) {
+    return getStatusOptionHelper(getStatusInternalOptions(), name);
+  }
+
+  private StatusResources.OptionWrapper getStatusOptionHelper(List<StatusResources.OptionWrapper> options,
+                                                              String name) {
+    for (StatusResources.OptionWrapper option: options) {
+      if (option.getName().equals(name)) {
+        return option;
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public void close() throws Exception {
+    client.close();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1621,6 +1621,10 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
         </dependencies>


### PR DESCRIPTION
This implements Internal system options that are modifiable at runtime: https://issues.apache.org/jira/browse/DRILL-5723

Internal options do not show up in the **sys.options** table.

Internal options can be queried by:

```
select * from sys.internal_options;
```

or

```
select * from sys.internal_options_val;
```

Internal options can be updated in the same way as normal options:

```
alter system set `my.internal.prop` = 'yay'
```

Internal options do not show up in the following rest endpoints

 - **http://host:8047/options.json**
 - **http://host:8047/options**

Internal options do show up in the following rest endpoints

 - **http://host:8047/internal_options.json**
 - **http://host:8047/internal_options**

Internal options can be set in the same way as other options via the rest api

 - **http://host:8047/option?name=my.internal.prop&value=blah&kind=session**
