### PR TITLE
DRILL-5740: Ensure spill directories are unique

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/SpillSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/SpillSet.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.directory.api.util.Strings;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
@@ -427,7 +426,7 @@ public class SpillSet {
 
     String nodeDir = "";
     if (ep != null  &&  ep.getAddress() != null) {
-      nodeDir = ep.getAddress() + "-" + ep.getUserPort() + "/";
+      nodeDir = ep.getAddress() + "-" + ep.getUserPort() + "_";
     }
     spillDirName = String.format("%s%s_%s_%s-%s-%s",
         nodeDir,


### PR DESCRIPTION
A recent change added the node name and port to make the spill path
unique. Turns out we need to add this information to the single spill
directory name. The previous change use the node ID as a parent
directory, which turns out not to work well in practice.