### PR TITLE
DRILL-5758: Fix for repeated columns; enable managed sort by default

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BatchGroup.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BatchGroup.java
@@ -75,9 +75,9 @@ public abstract class BatchGroup implements VectorAccessible, AutoCloseable {
 
   public static class InputBatch extends BatchGroup {
     private final SelectionVector2 sv2;
-    private final int dataSize;
+    private final long dataSize;
 
-    public InputBatch(VectorContainer container, SelectionVector2 sv2, BufferAllocator allocator, int dataSize) {
+    public InputBatch(VectorContainer container, SelectionVector2 sv2, BufferAllocator allocator, long dataSize) {
       super(container, allocator);
       this.sv2 = sv2;
       this.dataSize = dataSize;
@@ -85,7 +85,7 @@ public abstract class BatchGroup implements VectorAccessible, AutoCloseable {
 
     public SelectionVector2 getSv2() { return sv2; }
 
-    public int getDataSize() { return dataSize; }
+    public long getDataSize() { return dataSize; }
 
     @Override
     public int getRecordCount() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BufferedBatches.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/BufferedBatches.java
@@ -79,7 +79,7 @@ public class BufferedBatches {
   public int size() { return bufferedBatches.size(); }
 
   @SuppressWarnings("resource")
-  public void add(VectorAccessible incoming, int batchSize) {
+  public void add(VectorAccessible incoming, long batchSize) {
     // Convert the incoming batch to the agreed-upon schema.
     // No converted batch means we got an empty input batch.
     // Converting the batch transfers memory ownership to our
@@ -165,7 +165,7 @@ public class BufferedBatches {
   }
 
   @SuppressWarnings("resource")
-  private void bufferBatch(VectorContainer convertedBatch, SelectionVector2 sv2, int netSize) {
+  private void bufferBatch(VectorContainer convertedBatch, SelectionVector2 sv2, long netSize) {
     BufferAllocator allocator = context.getAllocator();
     RecordBatchData rbd = new RecordBatchData(convertedBatch, allocator);
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MergeSortWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MergeSortWrapper.java
@@ -37,7 +37,6 @@ import org.apache.drill.exec.physical.config.Sort;
 import org.apache.drill.exec.physical.impl.sort.RecordBatchData;
 import org.apache.drill.exec.physical.impl.sort.SortRecordBatchBuilder;
 import org.apache.drill.exec.physical.impl.xsort.managed.SortImpl.SortResults;
-import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/PriorityQueueCopierWrapper.java
@@ -140,6 +140,7 @@ public class PriorityQueueCopierWrapper extends BaseSortWrapper {
             .message("Unexpected schema change - likely code error.")
             .build(logger);
     }
+    logger.debug("Copier setup complete");
   }
 
   public BufferAllocator getAllocator() { return context.getAllocator(); }
@@ -261,8 +262,9 @@ public class PriorityQueueCopierWrapper extends BaseSortWrapper {
       } else {
         allocHelper.allocateBatch(outputContainer, targetRecordCount);
       }
-      logger.trace("Initial output batch allocation: {} bytes",
-                   holder.getAllocator().getAllocatedMemory() - start);
+      logger.trace("Initial output batch allocation: {} bytes, {} records",
+                   holder.getAllocator().getAllocatedMemory() - start,
+                   targetRecordCount);
       Stopwatch w = Stopwatch.createStarted();
       int count = holder.copier.next(targetRecordCount);
       if (count > 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortImpl.java
@@ -310,7 +310,7 @@ public class SortImpl {
    * @return true if spilling is needed (and possible), false otherwise
    */
 
-  private boolean isSpillNeeded(int incomingSize) {
+  private boolean isSpillNeeded(long incomingSize) {
 
     if (bufferedBatches.size() >= config.getBufferedBatchLimit()) {
       return true;
@@ -407,6 +407,9 @@ public class SortImpl {
    * @return results iterator over the single input batch
    */
 
+  // Disabled temporarily
+
+  @SuppressWarnings("unused")
   private SortResults singleBatchResult() {
     List<InputBatch> batches = bufferedBatches.removeAll();
     return new SingleBatchResults(batches.get(0), outputBatch);
@@ -499,9 +502,11 @@ public class SortImpl {
           spilledRuns.size());
       switch (task.action) {
       case SPILL:
+        logger.debug("Consolidate: spill");
         spillFromMemory();
         break;
       case MERGE:
+        logger.debug("Consolidate: merge {} batches", task.count);
         mergeRuns(task.count);
         break;
       case NONE:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
@@ -680,9 +680,11 @@ public class SortMemoryManager {
     // spilled run.
 
     // Maximum spill batches that fit into available memory.
+    // Use the maximum buffer size since spill batches seem to
+    // be read with almost 50% internal fragmentation.
 
     int memMergeLimit = (int) ((mergeMemoryLimit - allocMemory) /
-                                spillBatchSize.expectedBufferSize);
+                                spillBatchSize.maxBufferSize);
     memMergeLimit = Math.max(0, memMergeLimit);
 
     // If batches are in memory, and we need more memory to merge
@@ -751,7 +753,7 @@ public class SortMemoryManager {
   // Must spill if we are below the spill point (the amount of memory
   // needed to do the minimal spill.)
 
-  public boolean isSpillNeeded(long allocatedBytes, int incomingSize) {
+  public boolean isSpillNeeded(long allocatedBytes, long incomingSize) {
     return allocatedBytes + incomingSize >= bufferMemoryLimit;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMetrics.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMetrics.java
@@ -47,7 +47,7 @@ public class SortMetrics {
     this.stats = stats;
   }
 
-  public void updateInputMetrics(int rowCount, int batchSize) {
+  public void updateInputMetrics(int rowCount, long batchSize) {
     inputRecordCount += rowCount;
     inputBatchCount++;
     totalInputBytes += batchSize;

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -242,9 +242,6 @@ drill.exec: {
   sort: {
     purge.threshold : 1000,
     external: {
-      // Drill uses the managed External Sort Batch by default.
-      // Set this to true to use the legacy, unmanaged version.
-      disable_managed: true,
       // Limit on the number of batches buffered in memory.
       // Primarily for testing.
       // 0 = unlimited

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
@@ -102,7 +102,6 @@ public class SortTestUtilities {
       }
       int rowCount = outputRowCount();
       VectorContainer dest = new VectorContainer();
-      @SuppressWarnings("resource")
       BatchMerger merger = copier.startMerge(schema.toBatchSchema(SelectionVectorMode.NONE),
                                              batches, dest, rowCount, null);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestShortArrays.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestShortArrays.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.xsort.managed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.spill.RecordBatchSizer;
+import org.apache.drill.exec.physical.impl.spill.RecordBatchSizer.ColumnSize;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.VectorInitializer;
+import org.apache.drill.exec.record.VectorInitializer.AllocationHint;
+import org.apache.drill.exec.vector.IntVector;
+import org.apache.drill.exec.vector.RepeatedIntVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSet;
+import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.RowSetBuilder;
+import org.apache.drill.test.rowSet.SchemaBuilder;
+import org.junit.Test;
+
+/**
+ * DRILL-5804.
+ * Code had a bug that if an array had low cardinality, the average,
+ * expressed as an int, was zero. We then allocated a zero length
+ * buffer, tried to double it, got another zero length buffer, and
+ * looped forever. This test verifies the fixes to avoid that case.
+ * @throws Exception
+ */
+
+
+public class TestShortArrays extends SubOperatorTest {
+
+  @Test
+  public void testSizer() {
+
+    // Create a row set with less than one item, on
+    // average, per array.
+
+    BatchSchema schema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addArray("b", MinorType.INT)
+        .build();
+    RowSetBuilder builder = fixture.rowSetBuilder(schema)
+        .add(1, new int[] {10});
+    for (int i = 2; i <= 10; i++) {
+      builder.add(i, new int[] {});
+    }
+    RowSet rows = builder.build();
+
+    // Run the record batch sizer on the resulting batch.
+
+    RecordBatchSizer sizer = new RecordBatchSizer(rows.container());
+    assertEquals(2, sizer.columns().size());
+    ColumnSize bCol = sizer.columns().get(1);
+    assertEquals(0.1, bCol.estElementCountPerArray, 0.01);
+    assertEquals(1, bCol.elementCount);
+
+    // Create a vector initializer using the sizer info.
+
+    VectorInitializer vi = sizer.buildVectorInitializer();
+    AllocationHint bHint = vi.hint("b");
+    assertNotNull(bHint);
+    assertEquals(bHint.elementCount, bCol.estElementCountPerArray, 0.001);
+
+    // Create a new batch, and new vector, using the sizer and
+    // intializer inferred from the previoius batch.
+
+    SingleRowSet empty = fixture.rowSet(schema);
+    vi.allocateBatch(empty.container(), 100);
+    assertEquals(2, empty.vectors().length);
+    @SuppressWarnings("resource")
+    ValueVector bVector = empty.vectors()[1];
+    assertTrue(bVector instanceof RepeatedIntVector);
+    assertEquals(16, ((RepeatedIntVector) bVector).getDataVector().getValueCapacity());
+
+    rows.clear();
+    empty.clear();
+  }
+
+  /**
+   * Test that a zero-length vector, on reAlloc, will default
+   * to 256 bytes. (Previously the code just doubled zero
+   * forever.)
+   */
+
+  @Test
+  public void testReAllocZeroSize() {
+    try (IntVector vector = new IntVector(
+            SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.REQUIRED),
+            fixture.allocator())) {
+      vector.allocateNew(0);
+      vector.reAlloc();
+      assertEquals(256 / 4, vector.getValueCapacity());
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/AbstractRowSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/AbstractRowSet.java
@@ -153,7 +153,7 @@ public abstract class AbstractRowSet implements RowSet {
   }
 
   @Override
-  public int size() {
+  public long size() {
     throw new UnsupportedOperationException("getSize");
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/AbstractSingleRowSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/AbstractSingleRowSet.java
@@ -184,7 +184,7 @@ public abstract class AbstractSingleRowSet extends AbstractRowSet implements Sin
   public ValueVector[] vectors() { return valueVectors; }
 
   @Override
-  public int size() {
+  public long size() {
     RecordBatchSizer sizer = new RecordBatchSizer(container);
     return sizer.actualSize();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/IndirectRowSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/IndirectRowSet.java
@@ -118,7 +118,7 @@ public class IndirectRowSet extends AbstractSingleRowSet {
   public SingleRowSet toIndirect() { return this; }
 
   @Override
-  public int size() {
+  public long size() {
     RecordBatchSizer sizer = new RecordBatchSizer(container, sv2);
     return sizer.actualSize();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSet.java
@@ -160,7 +160,7 @@ public interface RowSet {
    * @return memory size in bytes
    */
 
-  int size();
+  long size();
 
   RowSet merge(RowSet other);
 

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -207,6 +207,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     accessor.reset();
   }
 
+  @Override
   public void reset() {
     bits.zeroVector();
     mutator.reset();

--- a/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
@@ -183,6 +183,7 @@ public final class Repeated${minor.class}Vector extends BaseRepeatedValueVector 
     copyFromSafe(fromIndex, toIndex, (Repeated${minor.class}Vector) from);
   }
 
+  @Override
   public boolean allocateNewSafe() {
     /* boolean to keep track if all the memory allocations were successful.
      * Used in the case of composite vectors when we need to allocate multiple
@@ -224,6 +225,7 @@ public final class Repeated${minor.class}Vector extends BaseRepeatedValueVector 
             .setVarByteLength(values.getVarByteLength());
   }
 
+  @Override
   public void allocateNew(int totalBytes, int valueCount, int innerValueCount) {
     try {
       offsets.allocateNew(valueCount + 1);
@@ -236,6 +238,7 @@ public final class Repeated${minor.class}Vector extends BaseRepeatedValueVector 
     mutator.reset();
   }
 
+  @Override
   public int getByteCapacity(){
     return values.getByteCapacity();
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/AllocationHelper.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/AllocationHelper.java
@@ -27,6 +27,12 @@ public class AllocationHelper {
   }
 
   public static void allocatePrecomputedChildCount(ValueVector vector, int valueCount, int bytesPerValue, int childValCount) {
+
+    // Don't fail if given a 0-sized array. Assume at least one value.
+    childValCount = Math.max(1, childValCount);
+    valueCount = Math.max(1, valueCount);
+    bytesPerValue = Math.max(1, bytesPerValue);
+
     if (vector instanceof FixedWidthVector) {
       ((FixedWidthVector) vector).allocateNew(valueCount);
     } else if (vector instanceof VariableWidthVector) {
@@ -44,6 +50,21 @@ public class AllocationHelper {
 
   public static void allocate(ValueVector vector, int valueCount, int bytesPerValue, int repeatedPerTop){
     allocatePrecomputedChildCount(vector, valueCount, bytesPerValue, repeatedPerTop * valueCount);
+  }
+
+  /**
+   * Allocate an array, but with a fractional value for the number of elements
+   * per array. This form is useful when the number comes from observations and
+   * represents an average.
+   *
+   * @param vector the vector to allocate
+   * @param valueCount the number of top-level values
+   * @param bytesPerValue the width of each value
+   * @param repeatedPerTop the number of array elements per value.
+   */
+  public static void allocate(ValueVector vector, int valueCount, int bytesPerValue, float repeatedPerTop){
+    allocatePrecomputedChildCount(vector, valueCount, bytesPerValue,
+        (int) Math.ceil(repeatedPerTop * valueCount));
   }
 
   /**


### PR DESCRIPTION
Fix for DRILL-5443. Basically, the “record batch sizer” did not handle repeated columns correctly.

Enabled managed sort by default.