### PR TITLE
DRILL-5765: Json query profile is not shown on Web UI

### DIFF
--- a/exec/java-exec/src/main/resources/rest/static/js/graph.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/graph.js
@@ -11,7 +11,7 @@
  *  language governing permissions and limitations under the License.
  */
 
-$(window).load(function () {
+$(window).on('load',(function () {
     // for each record, unroll the array pointed to by "fieldpath" into a new
     // record for each element of the array
     function unnest (table, fieldpath, dest) {
@@ -310,4 +310,4 @@ $(window).load(function () {
         //            .append("tbody"), extractminortimes(profile),
         //            ["name", "start", "end"]);
     });
-});
+}));


### PR DESCRIPTION
The "graph.js", used in the profiles page of Drill Web UI, uses $(window).load(function () {}). The ".load" function is deprecated from the Jquery after 1.8. In this change, I have changed the function to onload. 