### PR TITLE
DRILL-5772: Enable UTF-8 support in query string by default 

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -17,13 +17,9 @@
  */
 package org.apache.drill.exec.hive;
 
-import mockit.Mock;
-import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import org.apache.calcite.util.Util;
-import org.apache.calcite.util.ConversionUtil;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.UserRemoteException;
@@ -41,7 +37,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
-import java.nio.charset.Charset;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
@@ -75,7 +70,7 @@ public class TestHiveStorage extends HiveTestBase {
           .sqlQuery(query)
           .unOrdered()
           .baselineColumns("col")
-          .baselineValues(200l)
+          .baselineValues(200L)
           .go();
     } finally {
       final OperatorFixture.TestOptionSet testOptionSet = new OperatorFixture.TestOptionSet();
@@ -554,15 +549,6 @@ public class TestHiveStorage extends HiveTestBase {
 
   @Test // DRILL-3250
   public void testNonAsciiStringLiterals() throws Exception {
-    // mock calcite util method to return utf charset
-    // instead of setting saffron.default.charset at system level
-    new MockUp<Util>() {
-      @Mock
-      Charset getDefaultCharset() {
-        return Charset.forName(ConversionUtil.NATIVE_UTF16_CHARSET_NAME);
-      }
-    };
-
     testBuilder()
         .sqlQuery("select * from hive.empty_table where b = 'Абвгде谢谢'")
         .expectsEmptyResultSet()

--- a/distribution/src/assemble/bin.xml
+++ b/distribution/src/assemble/bin.xml
@@ -352,5 +352,9 @@
       <source>src/resources/core-site-example.xml</source>
       <outputDirectory>conf</outputDirectory>
     </file>
+    <file>
+      <source>src/resources/saffron.properties</source>
+      <outputDirectory>conf</outputDirectory>
+    </file>
   </files>
 </assembly>

--- a/distribution/src/resources/saffron.properties
+++ b/distribution/src/resources/saffron.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This properties file is used by Apache Calcite to define allowed charset in string literals,
+# which is by default ISO-8859-1.
+# Current configuration allows parsing UTF-8 by default, i.e. queries that contain utf-8 string literal.
+# To take affect this file should be present in classpath.
+
+saffron.default.charset=UTF-16LE
+saffron.default.nationalcharset=UTF-16LE
+saffron.default.collation.name=UTF-16LE$en_US

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUtf8SupportInQueryString.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUtf8SupportInQueryString.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill;
+
+import mockit.Deencapsulation;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+import org.apache.calcite.util.SaffronProperties;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JMockit.class)
+public class TestUtf8SupportInQueryString extends BaseTestQuery {
+
+  @Test
+  public void testUtf8SupportInQueryStringByDefault() throws Exception {
+    // can be defined in saffron.properties file present in classpath or system property
+    testBuilder()
+        .sqlQuery("select 'привет' as hello from (values(1))")
+        .unOrdered()
+        .baselineColumns("hello")
+        .baselineValues("привет")
+        .go();
+  }
+
+  @Test(expected = UserRemoteException.class)
+  public void testDisableUtf8SupportInQueryString() throws Exception {
+    Deencapsulation.setField(SaffronProperties.class, "properties", null);
+    final Properties properties = System.getProperties();
+    final String charset = "ISO-8859-1";
+    new MockUp<System>()
+    {
+      @Mock
+      Properties getProperties() {
+        Properties newProperties = new Properties();
+        newProperties.putAll(properties);
+        newProperties.put("saffron.default.charset", charset);
+        newProperties.put("saffron.default.nationalcharset", charset);
+        newProperties.put("saffron.default.collation.name", charset + "$en_US");
+        return newProperties;
+      }
+    };
+
+    final String hello = "привет";
+    try {
+      test("values('%s')", hello);
+    } catch (UserRemoteException e) {
+      assertThat(e.getMessage(), containsString(
+          String.format("Failed to encode '%s' in character set '%s'", hello, charset)));
+      throw e;
+    } finally {
+      Deencapsulation.setField(SaffronProperties.class, "properties", null);
+    }
+  }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -19,11 +19,7 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import static org.junit.Assert.assertTrue;
 
-import mockit.Mock;
-import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
-import org.apache.calcite.util.ConversionUtil;
-import org.apache.calcite.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.categories.SqlFunctionTest;
@@ -38,7 +34,6 @@ import org.junit.runner.RunWith;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.nio.charset.Charset;
 
 @RunWith(JMockit.class)
 @Category(SqlFunctionTest.class)
@@ -1339,16 +1334,6 @@ public class TestStringFunctions extends BaseTestQuery {
   @Ignore("DRILL-5477")
   @Test
   public void testMultiByteEncoding() throws Exception {
-    // mock calcite util method to return utf charset
-    // instead of setting saffron.default.charset at system level
-    new MockUp<Util>()
-    {
-      @Mock
-      Charset getDefaultCharset() {
-        return Charset.forName(ConversionUtil.NATIVE_UTF16_CHARSET_NAME);
-      }
-    };
-
     testBuilder()
         .sqlQuery("select\n" +
             "upper('привет')as col_upper,\n" +

--- a/exec/java-exec/src/test/resources/saffron.properties
+++ b/exec/java-exec/src/test/resources/saffron.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This properties file is used by Apache Calcite to define allowed charset in string literals,
+# which is by default ISO-8859-1.
+# Current configuration allows parsing UTF-8 by default, i.e. queries that contain utf-8 string literal.
+# To take affect this file should be present in classpath.
+
+saffron.default.charset=UTF-16LE
+saffron.default.nationalcharset=UTF-16LE
+saffron.default.collation.name=UTF-16LE$en_US

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dep.guava.version>18.0</dep.guava.version>
     <forkCount>1C</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
-    <calcite.version>1.4.0-drill-r22</calcite.version>
+    <calcite.version>1.4.0-drill-r23</calcite.version>
     <janino.version>2.7.6</janino.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>
     <jackson.version>2.7.8</jackson.version>


### PR DESCRIPTION
Details in [DRILL-5772](https://issues.apache.org/jira/browse/DRILL-5772).