### PR TITLE
DRILL-5775: Expand * into list of column/column family for  MapR-DB b…

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.hbase.DrillHBaseConstants;
 import org.apache.drill.exec.store.hbase.HBaseScanSpec;
+import org.apache.drill.exec.store.hbase.HBaseUtils;
 import org.apache.drill.exec.store.mapr.db.MapRDBFormatPlugin;
 import org.apache.drill.exec.store.mapr.db.MapRDBFormatPluginConfig;
 import org.apache.drill.exec.store.mapr.db.MapRDBGroupScan;
@@ -113,8 +114,7 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
   @Override
   public GroupScan clone(List<SchemaPath> columns) {
     BinaryTableGroupScan newScan = new BinaryTableGroupScan(this);
-    newScan.columns = columns;
-    newScan.verifyColumns();
+    newScan.columns = HBaseUtils.verifyColumnsAndConvertStar(columns, hTableDesc);
     return newScan;
   }
 
@@ -145,20 +145,7 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
     } catch (Exception e) {
       throw new DrillRuntimeException("Error getting region info for table: " + hbaseScanSpec.getTableName(), e);
     }
-    verifyColumns();
-  }
-
-  private void verifyColumns() {
-    /*
-    if (columns != null) {
-      for (SchemaPath column : columns) {
-        if (!(column.equals(ROW_KEY_PATH) || hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
-          DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
-              column.getRootSegment().getPath(), hTableDesc.getNameAsString());
-        }
-      }
-    }
-    */
+    columns = HBaseUtils.verifyColumnsAndConvertStar(columns, hTableDesc);
   }
 
   protected MapRDBSubScanSpec getSubScanSpec(TabletFragmentInfo tfi) {

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
@@ -126,7 +126,7 @@ public class HBaseRecordReader extends AbstractRecordReader implements DrillHBas
             HBaseUtils.andFilterAtIndex(hbaseScan.getFilter(), HBaseUtils.LAST_FILTER, new FirstKeyOnlyFilter()));
       }
     } else {
-      throw new IllegalArgumentException("HBaseRecordReader does not allow column *. Column * should have been converted to list of <row_key, column family1, column family2, ..., column family_n");
+      throw new IllegalArgumentException("HBaseRecordReader does not allow column *. Column * should have been converted to list of <row_key, column family1, column family2, ..., column family_n>");
 //      rowKeyOnly = false;
 //      transformed.add(ROW_KEY_PATH);
     }


### PR DESCRIPTION
…inary table groupscan.

 Move common code to HBaseUtils, so it's shared by both HBaseGroupScan and BinaryTableGroupScan
 The issue was exposed by existing unit tests in contrib/format-maprdb; no new unit tests added.