### PR TITLE
DRILL-5781: Fix unit test failures to use tests config even if default config is available

### DIFF
--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.drill.exec.coord.zk.PathUtils;
+import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.hbase.test.Drill2130StorageHBaseHamcrestConfigurationTest;
 import org.apache.hadoop.conf.Configuration;
@@ -37,9 +37,6 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import static org.apache.drill.exec.server.TestDrillbitResilience.LOGIN_CONF_RESOURCE_PATHNAME;
-import static org.apache.zookeeper.Environment.JAAS_CONF_KEY;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -99,9 +96,7 @@ public class HBaseTestsSuite {
 
   @BeforeClass
   public static void initCluster() throws Exception {
-    // Specifies JAAS configuration file
-    String configPath = PathUtils.getPathWithProtocol(ClassLoader.getSystemResource(LOGIN_CONF_RESOURCE_PATHNAME));
-    System.setProperty(JAAS_CONF_KEY, configPath);
+    ZookeeperTestUtil.setJaasTestConfigFile();
 
     if (initCount.get() == 0) {
       synchronized (HBaseTestsSuite.class) {

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.drill.exec.coord.zk.PathUtils;
 import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.hbase.test.Drill2130StorageHBaseHamcrestConfigurationTest;
 import org.apache.hadoop.conf.Configuration;
@@ -36,6 +37,9 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import static org.apache.drill.exec.server.TestDrillbitResilience.LOGIN_CONF_RESOURCE_PATHNAME;
+import static org.apache.zookeeper.Environment.JAAS_CONF_KEY;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -95,6 +99,10 @@ public class HBaseTestsSuite {
 
   @BeforeClass
   public static void initCluster() throws Exception {
+    // Specifies JAAS configuration file
+    String configPath = PathUtils.getPathWithProtocol(ClassLoader.getSystemResource(LOGIN_CONF_RESOURCE_PATHNAME));
+    System.setProperty(JAAS_CONF_KEY, configPath);
+
     if (initCount.get() == 0) {
       synchronized (HBaseTestsSuite.class) {
         if (initCount.get() == 0) {

--- a/contrib/storage-hbase/src/test/resources/hbase-site.xml
+++ b/contrib/storage-hbase/src/test/resources/hbase-site.xml
@@ -66,15 +66,13 @@
     Default is 10.
     </description>
   </property>
-<!--
-   <property>
+  <property>
     <name>hbase.master.info.port</name>
     <value>-1</value>
     <description>The port for the hbase master web UI
     Set to -1 if you do not want the info server to run.
     </description>
   </property>
--->
   <property>
     <name>hbase.regionserver.info.port</name>
     <value>-1</value>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
@@ -74,6 +74,9 @@ public final class PathUtils {
 
   /**
    * Creates and returns path with the protocol at the beginning from specified {@code url}.
+   *
+   * @param url the source of path and protocol
+   * @return string with protocol and path divided by colon
    */
   public static String getPathWithProtocol(URL url) {
     if (url.getProtocol() != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/PathUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,8 @@ package org.apache.drill.exec.coord.zk;
 
 import com.google.common.base.Preconditions;
 import org.apache.parquet.Strings;
+
+import java.net.URL;
 
 /**
  * A convenience class used to expedite zookeeper paths manipulations.
@@ -70,4 +72,14 @@ public final class PathUtils {
     return builder.toString();
   }
 
+  /**
+   * Creates and returns path with the protocol at the beginning from specified {@code url}.
+   */
+  public static String getPathWithProtocol(URL url) {
+    if (url.getProtocol() != null) {
+      return url.getProtocol() + ":" + url.getPath();
+    } else {
+      return url.getPath();
+    }
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
@@ -41,13 +41,12 @@ import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.test.DrillTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.zookeeper.client.ZooKeeperSaslClient;
-import org.apache.zookeeper.server.ZooKeeperSaslServer;
 import org.junit.After;
 import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.IOException;
+
 
 public class ExecTest extends DrillTest {
 
@@ -99,14 +98,6 @@ public class ExecTest extends DrillTest {
       }
     });
     return dir.getAbsolutePath() + File.separator + dirName;
-  }
-
-  /**
-   * Sets zookeeper server and client SASL test config properties.
-   */
-  public static void setZookeeperSaslTestConfigProps() {
-    System.setProperty(ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY, "Test_server");
-    System.setProperty(ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY, "Test_client");
   }
 
   protected void mockDrillbitContext(final DrillbitContext bitContext) throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ExecTest.java
@@ -41,12 +41,13 @@ import org.apache.drill.exec.util.GuavaPatcher;
 import org.apache.drill.test.DrillTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.zookeeper.client.ZooKeeperSaslClient;
+import org.apache.zookeeper.server.ZooKeeperSaslServer;
 import org.junit.After;
 import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.IOException;
-
 
 public class ExecTest extends DrillTest {
 
@@ -98,6 +99,14 @@ public class ExecTest extends DrillTest {
       }
     });
     return dir.getAbsolutePath() + File.separator + dirName;
+  }
+
+  /**
+   * Sets zookeeper server and client SASL test config properties.
+   */
+  public static void setZookeeperSaslTestConfigProps() {
+    System.setProperty(ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY, "Test_server");
+    System.setProperty(ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY, "Test_client");
   }
 
   protected void mockDrillbitContext(final DrillbitContext bitContext) throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
@@ -25,9 +25,7 @@ import java.lang.management.ManagementFactory;
 import java.util.Properties;
 
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.util.MiniZooKeeperCluster;
-import org.apache.drill.test.ClusterFixture;
 
 /**
  * Test utility for managing a Zookeeper instance.
@@ -95,7 +93,7 @@ public class ZookeeperHelper {
     }
 
     try {
-      ExecTest.setZookeeperSaslTestConfigProps();
+      ZookeeperTestUtil.setZookeeperSaslTestConfigProps();
 
       zkCluster = new MiniZooKeeperCluster();
       zkCluster.setDefaultClientPort(MiniZooKeeperCluster.DEFAULT_PORT);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.util.FileUtils;
 import org.apache.drill.exec.util.MiniZooKeeperCluster;
+import org.apache.drill.test.ClusterFixture;
 
 /**
  * Test utility for managing a Zookeeper instance.
@@ -94,6 +95,8 @@ public class ZookeeperHelper {
     }
 
     try {
+      ExecTest.setZookeeperSaslTestConfigProps();
+
       zkCluster = new MiniZooKeeperCluster();
       zkCluster.setDefaultClientPort(MiniZooKeeperCluster.DEFAULT_PORT);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperTestUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/ZookeeperTestUtil.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to you under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.drill.exec;
+
+import org.apache.drill.exec.coord.zk.PathUtils;
+import org.apache.zookeeper.client.ZooKeeperSaslClient;
+import org.apache.zookeeper.server.ZooKeeperSaslServer;
+
+import static org.apache.zookeeper.Environment.JAAS_CONF_KEY;
+
+public class ZookeeperTestUtil {
+
+  private static final String LOGIN_CONF_RESOURCE_PATHNAME = "login.conf";
+
+  /**
+   * Sets zookeeper server and client SASL test config properties.
+   */
+  public static void setZookeeperSaslTestConfigProps() {
+    System.setProperty(ZooKeeperSaslServer.LOGIN_CONTEXT_NAME_KEY, "DrillTestServerForUnitTests");
+    System.setProperty(ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY, "DrillTestClientForUnitTests");
+  }
+
+  /**
+   * Specifies JAAS configuration file.
+   */
+  public static void setJaasTestConfigFile() {
+    String configPath = PathUtils.getPathWithProtocol(ClassLoader.getSystemResource(LOGIN_CONF_RESOURCE_PATHNAME));
+    System.setProperty(JAAS_CONF_KEY, configPath);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
+import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
 import org.apache.drill.exec.serialization.InstanceSerializer;
 import org.junit.After;
@@ -61,6 +62,7 @@ public class TestEphemeralStore {
 
   @Before
   public void setUp() throws Exception {
+    ExecTest.setZookeeperSaslTestConfigProps();
     server = new TestingServer();
     final RetryPolicy policy = new RetryNTimes(2, 1000);
     curator = CuratorFrameworkFactory.newClient(server.getConnectString(), policy);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,7 +27,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
-import org.apache.drill.exec.ExecTest;
+import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
 import org.apache.drill.exec.serialization.InstanceSerializer;
 import org.junit.After;
@@ -62,7 +62,8 @@ public class TestEphemeralStore {
 
   @Before
   public void setUp() throws Exception {
-    ExecTest.setZookeeperSaslTestConfigProps();
+    ZookeeperTestUtil.setZookeeperSaslTestConfigProps();
+
     server = new TestingServer();
     final RetryPolicy policy = new RetryNTimes(2, 1000);
     curator = CuratorFrameworkFactory.newClient(server.getConnectString(), policy);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
@@ -31,7 +31,7 @@ import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.drill.common.collections.ImmutableEntry;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.exec.ExecTest;
+import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.exception.VersionMismatchException;
 import org.apache.drill.exec.store.sys.store.DataChangeVersion;
 import org.apache.zookeeper.CreateMode;
@@ -72,7 +72,7 @@ public class TestZookeeperClient {
 
   @Before
   public void setUp() throws Exception {
-    ExecTest.setZookeeperSaslTestConfigProps();
+    ZookeeperTestUtil.setZookeeperSaslTestConfigProps();
 
     server = new TestingServer();
     final RetryPolicy policy = new RetryNTimes(1, 1000);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
@@ -31,6 +31,7 @@ import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.apache.drill.common.collections.ImmutableEntry;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.exception.VersionMismatchException;
 import org.apache.drill.exec.store.sys.store.DataChangeVersion;
 import org.apache.zookeeper.CreateMode;
@@ -71,6 +72,8 @@ public class TestZookeeperClient {
 
   @Before
   public void setUp() throws Exception {
+    ExecTest.setZookeeperSaslTestConfigProps();
+
     server = new TestingServer();
     final RetryPolicy policy = new RetryNTimes(1, 1000);
     curator = CuratorFrameworkFactory.newClient(server.getConnectString(), policy);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -21,7 +21,6 @@ import static org.apache.drill.exec.ExecConstants.SLICE_TARGET;
 import static org.apache.drill.exec.ExecConstants.SLICE_TARGET_DEFAULT;
 import static org.apache.drill.exec.planner.physical.PlannerSettings.HASHAGG;
 import static org.apache.drill.exec.planner.physical.PlannerSettings.PARTITION_SENDER_SET_THREADS;
-import static org.apache.zookeeper.Environment.JAAS_CONF_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,8 +42,8 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.util.RepeatTestRule.Repeat;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ZookeeperHelper;
+import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.client.DrillClient;
-import org.apache.drill.exec.coord.zk.PathUtils;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -99,8 +98,6 @@ import com.google.common.base.Preconditions;
  */
 public class TestDrillbitResilience extends DrillTest {
   private static final Logger logger = org.slf4j.LoggerFactory.getLogger(TestDrillbitResilience.class);
-
-  public static final String LOGIN_CONF_RESOURCE_PATHNAME = "login.conf";
 
   private static ZookeeperHelper zkHelper;
   private static RemoteServiceSet remoteServiceSet;
@@ -189,9 +186,7 @@ public class TestDrillbitResilience extends DrillTest {
     // turn off the HTTP server to avoid port conflicts between the drill bits
     System.setProperty(ExecConstants.HTTP_ENABLE, "false");
 
-    // Specifies JAAS configuration file
-    String configPath = PathUtils.getPathWithProtocol(ClassLoader.getSystemResource(LOGIN_CONF_RESOURCE_PATHNAME));
-    System.setProperty(JAAS_CONF_KEY, configPath);
+    ZookeeperTestUtil.setJaasTestConfigFile();
 
     // turn on error for failure in cancelled fragments
     zkHelper = new ZookeeperHelper(true, true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -21,6 +21,7 @@ import static org.apache.drill.exec.ExecConstants.SLICE_TARGET;
 import static org.apache.drill.exec.ExecConstants.SLICE_TARGET_DEFAULT;
 import static org.apache.drill.exec.planner.physical.PlannerSettings.HASHAGG;
 import static org.apache.drill.exec.planner.physical.PlannerSettings.PARTITION_SENDER_SET_THREADS;
+import static org.apache.zookeeper.Environment.JAAS_CONF_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,6 +44,7 @@ import org.apache.drill.common.util.RepeatTestRule.Repeat;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ZookeeperHelper;
 import org.apache.drill.exec.client.DrillClient;
+import org.apache.drill.exec.coord.zk.PathUtils;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -97,6 +99,8 @@ import com.google.common.base.Preconditions;
  */
 public class TestDrillbitResilience extends DrillTest {
   private static final Logger logger = org.slf4j.LoggerFactory.getLogger(TestDrillbitResilience.class);
+
+  public static final String LOGIN_CONF_RESOURCE_PATHNAME = "login.conf";
 
   private static ZookeeperHelper zkHelper;
   private static RemoteServiceSet remoteServiceSet;
@@ -184,6 +188,10 @@ public class TestDrillbitResilience extends DrillTest {
   public static void startSomeDrillbits() throws Exception {
     // turn off the HTTP server to avoid port conflicts between the drill bits
     System.setProperty(ExecConstants.HTTP_ENABLE, "false");
+
+    // Specifies JAAS configuration file
+    String configPath = PathUtils.getPathWithProtocol(ClassLoader.getSystemResource(LOGIN_CONF_RESOURCE_PATHNAME));
+    System.setProperty(JAAS_CONF_KEY, configPath);
 
     // turn on error for failure in cancelled fragments
     zkHelper = new ZookeeperHelper(true, true);

--- a/exec/java-exec/src/test/resources/core-site.xml
+++ b/exec/java-exec/src/test/resources/core-site.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration>
+  <property>
+    <name>fs.hdfs.impl</name>
+    <value>org.apache.hadoop.hdfs.DistributedFileSystem</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.hdfs.impl</name>
+    <value>org.apache.hadoop.hdfs.DistributedFileSystem</value>
+    <description>The FileSystem for hdfs: uris.</description>
+  </property>
+  <property>
+    <name>dfs.namenode.edits.dir</name>
+    <value>${dfs.namenode.name.dir}</value>
+    <description>Determines where on the local filesystem the DFS name node
+      should store the transaction (edits) file. If this is a comma-delimited list
+      of directories then the transaction file is replicated in all of the
+      directories, for redundancy. Default value is same as dfs.namenode.name.dir
+    </description>
+  </property>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>file:///</value>
+    <description>The name of the default file system.  A URI whose
+      scheme and authority determine the FileSystem implementation.  The
+      uri's scheme determines the config property (fs.SCHEME.impl) naming
+      the FileSystem implementation class.  The uri's authority is used to
+      determine the host, port, etc. for a filesystem.</description>
+  </property>
+  <property>
+    <name>datanucleus.autoCreateTables</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/exec/java-exec/src/test/resources/login.conf
+++ b/exec/java-exec/src/test/resources/login.conf
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * simple login, just get OS creds
+ */
+hadoop_simple {
+  org.apache.hadoop.security.login.GenericOSLoginModule required;
+  org.apache.hadoop.security.login.HadoopLoginModule required;
+};


### PR DESCRIPTION
Please see [DRILL-5781](https://issues.apache.org/jira/browse/DRILL-5781) for details.

