### PR TITLE
DRILL-5803: Show the hostname for each minor fragment in operator table

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.server.rest.profile;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,20 +38,20 @@ import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
 public class OperatorWrapper {
   private static final String UNKNOWN_OPERATOR = "UNKNOWN_OPERATOR";
   private final int major;
-  private final List<ImmutablePair<OperatorProfile, Integer>> ops; // operator profile --> minor fragment number
+  private final List<ImmutablePair<ImmutablePair<OperatorProfile, Integer>, String>> opsAndHosts; // [(operatorProfile --> minorFragment number,host), ...]
   private final OperatorProfile firstProfile;
   private final CoreOperatorType operatorType;
   private final String operatorName;
   private final int size;
 
-  public OperatorWrapper(int major, List<ImmutablePair<OperatorProfile, Integer>> ops) {
-    Preconditions.checkArgument(ops.size() > 0);
+  public OperatorWrapper(int major, List<ImmutablePair<ImmutablePair<OperatorProfile, Integer>, String>> opsAndHostsList) {
+    Preconditions.checkArgument(opsAndHostsList.size() > 0);
     this.major = major;
-    firstProfile = ops.get(0).getLeft();
+    firstProfile = opsAndHostsList.get(0).getLeft().getLeft();
     operatorType = CoreOperatorType.valueOf(firstProfile.getOperatorType());
     operatorName = operatorType == null ? UNKNOWN_OPERATOR : operatorType.toString();
-    this.ops = ops;
-    size = ops.size();
+    this.opsAndHosts = opsAndHostsList;
+    size = opsAndHostsList.size();
   }
 
   public String getDisplayName() {
@@ -59,21 +60,22 @@ public class OperatorWrapper {
   }
 
   public String getId() {
-    return String.format("operator-%d-%d", major, ops.get(0).getLeft().getOperatorId());
+    return String.format("operator-%d-%d", major, opsAndHosts.get(0).getLeft().getLeft().getOperatorId());
   }
 
-  public static final String [] OPERATOR_COLUMNS = {"Minor Fragment", "Setup Time", "Process Time", "Wait Time",
+  public static final String [] OPERATOR_COLUMNS = {"Minor Fragment", "Host Name", "Setup Time", "Process Time", "Wait Time",
       "Max Batches", "Max Records", "Peak Memory"};
 
   public String getContent() {
     TableBuilder builder = new TableBuilder(OPERATOR_COLUMNS, null);
 
-    for (ImmutablePair<OperatorProfile, Integer> ip : ops) {
-      int minor = ip.getRight();
-      OperatorProfile op = ip.getLeft();
+    for (ImmutablePair<ImmutablePair<OperatorProfile, Integer>, String> ip : opsAndHosts) {
+      int minor = ip.getLeft().getRight();
+      OperatorProfile op = ip.getLeft().getLeft();
 
       String path = new OperatorPathBuilder().setMajor(major).setMinor(minor).setOperator(op).build();
       builder.appendCell(path);
+      builder.appendCell(ip.getRight());
       builder.appendNanos(op.getSetupNanos());
       builder.appendNanos(op.getProcessNanos());
       builder.appendNanos(op.getWaitNanos());
@@ -128,8 +130,12 @@ public class OperatorWrapper {
     double waitSum = 0.0;
     double memSum = 0.0;
     long recordSum = 0L;
-    for (ImmutablePair<OperatorProfile, Integer> ip : ops) {
-      OperatorProfile profile = ip.getLeft();
+
+    //Construct list for sorting purposes (using legacy Comparators)
+    final List<ImmutablePair<OperatorProfile, Integer>> opList = new ArrayList<>();
+
+    for (ImmutablePair<ImmutablePair<OperatorProfile, Integer>,String> ip : opsAndHosts) {
+      OperatorProfile profile = ip.getLeft().getLeft();
       setupSum += profile.getSetupNanos();
       processSum += profile.getProcessNanos();
       waitSum += profile.getWaitNanos();
@@ -137,18 +143,19 @@ public class OperatorWrapper {
       for (final StreamProfile sp : profile.getInputProfileList()) {
         recordSum += sp.getRecords();
       }
+      opList.add(ip.getLeft());
     }
 
-    final ImmutablePair<OperatorProfile, Integer> longSetup = Collections.max(ops, Comparators.setupTime);
+    final ImmutablePair<OperatorProfile, Integer> longSetup = Collections.max(opList, Comparators.setupTime);
     tb.appendNanos(Math.round(setupSum / size));
     tb.appendNanos(longSetup.getLeft().getSetupNanos());
 
-    final ImmutablePair<OperatorProfile, Integer> longProcess = Collections.max(ops, Comparators.processTime);
+    final ImmutablePair<OperatorProfile, Integer> longProcess = Collections.max(opList, Comparators.processTime);
     tb.appendNanos(Math.round(processSum / size));
     tb.appendNanos(longProcess.getLeft().getProcessNanos());
 
-    final ImmutablePair<OperatorProfile, Integer> shortWait = Collections.min(ops, Comparators.waitTime);
-    final ImmutablePair<OperatorProfile, Integer> longWait = Collections.max(ops, Comparators.waitTime);
+    final ImmutablePair<OperatorProfile, Integer> shortWait = Collections.min(opList, Comparators.waitTime);
+    final ImmutablePair<OperatorProfile, Integer> longWait = Collections.max(opList, Comparators.waitTime);
     tb.appendNanos(shortWait.getLeft().getWaitNanos());
     tb.appendNanos(Math.round(waitSum / size));
     tb.appendNanos(longWait.getLeft().getWaitNanos());
@@ -158,7 +165,7 @@ public class OperatorWrapper {
 
     tb.appendFormattedInteger(recordSum);
 
-    final ImmutablePair<OperatorProfile, Integer> peakMem = Collections.max(ops, Comparators.operatorPeakMemory);
+    final ImmutablePair<OperatorProfile, Integer> peakMem = Collections.max(opList, Comparators.operatorPeakMemory);
     tb.appendBytes(Math.round(memSum / size));
     tb.appendBytes(peakMem.getLeft().getPeakLocalMemoryAllocated());
   }
@@ -180,13 +187,13 @@ public class OperatorWrapper {
     }
     final TableBuilder builder = new TableBuilder(metricsTableColumnNames, null);
 
-    for (final ImmutablePair<OperatorProfile, Integer> ip : ops) {
-      final OperatorProfile op = ip.getLeft();
+    for (final ImmutablePair<ImmutablePair<OperatorProfile, Integer>,String> ip : opsAndHosts) {
+      final OperatorProfile op = ip.getLeft().getLeft();
 
       builder.appendCell(
           new OperatorPathBuilder()
           .setMajor(major)
-          .setMinor(ip.getRight())
+          .setMinor(ip.getLeft().getRight())
           .setOperator(op)
           .build());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -73,8 +73,8 @@ public class ProfileWrapper {
     this.majorFragmentTallyTotal = tallyMajorFragmentCost(majors);
 
     final List<OperatorWrapper> ows = new ArrayList<>();
-    // temporary map to store (major_id, operator_id) -> [(op_profile, minor_id)]
-    final Map<ImmutablePair<Integer, Integer>, List<ImmutablePair<OperatorProfile, Integer>>> opmap = new HashMap<>();
+    // temporary map to store (major_id, operator_id) -> [((op_profile, minor_id),minorFragHostname)]
+    final Map<ImmutablePair<Integer, Integer>, List<ImmutablePair<ImmutablePair<OperatorProfile, Integer>, String>>> opmap = new HashMap<>();
 
     Collections.sort(majors, Comparators.majorId);
     for (final MajorFragmentProfile major : majors) {
@@ -82,18 +82,21 @@ public class ProfileWrapper {
       final List<MinorFragmentProfile> minors = new ArrayList<>(major.getMinorFragmentProfileList());
       Collections.sort(minors, Comparators.minorId);
       for (final MinorFragmentProfile minor : minors) {
-
+        String fragmentHostName = minor.getEndpoint().getAddress();
         final List<OperatorProfile> ops = new ArrayList<>(minor.getOperatorProfileList());
         Collections.sort(ops, Comparators.operatorId);
+
         for (final OperatorProfile op : ops) {
 
           final ImmutablePair<Integer, Integer> ip = new ImmutablePair<>(
               major.getMajorFragmentId(), op.getOperatorId());
           if (!opmap.containsKey(ip)) {
-            final List<ImmutablePair<OperatorProfile, Integer>> l = new ArrayList<>();
+            final List<ImmutablePair<ImmutablePair<OperatorProfile, Integer>, String>> l = new ArrayList<>();
             opmap.put(ip, l);
           }
-          opmap.get(ip).add(new ImmutablePair<>(op, minor.getMinorFragmentId()));
+          opmap.get(ip).add(new ImmutablePair<>(
+              new ImmutablePair<>(op, minor.getMinorFragmentId()),
+              fragmentHostName));
         }
       }
     }


### PR DESCRIPTION
Based on DRILL-4909, list hostnames for each minor fragment within an operator table to identify any problematic host