### PR TITLE
DRILL-5812: Restore the minor fragment Gantt chart canvas

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -226,6 +226,7 @@
       </div>
       <div id="fragment-overview" class="panel-collapse collapse">
         <div class="panel-body">
+          <svg id="fragment-overview-canvas" class="center-block"></svg>
           ${model.getFragmentsOverview()?no_esc}
         </div>
       </div>


### PR DESCRIPTION
Minor update to restore the fragment Gantt chart
https://issues.apache.org/jira/browse/DRILL-5766?focusedCommentId=16176955&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16176955