### PR TITLE
DRILL-5808: Reduce memory allocator strictness for "managed" operators

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
@@ -97,6 +97,13 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
       // nulls are equal in group by case
       comparators.add(Comparator.IS_NOT_DISTINCT_FROM);
     }
+
+    // This operator manages its memory use. Ask for leniency
+    // from the allocator to allow for slight errors due to the
+    // lumpiness of vector allocations beyond our control.
+
+    boolean allowed = oContext.getAllocator().setLenient();
+    logger.debug("Config: Is allocator lenient? {}", allowed);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortImpl.java
@@ -203,15 +203,16 @@ public class SortImpl {
     metrics = new SortMetrics(opContext.getStats());
     bufferedBatches = new BufferedBatches(opContext);
 
-    // Reset the allocator to allow a 10% safety margin. This is done because
-    // the memory manager will enforce the original limit. Changing the hard
-    // limit will reduce the probability that random chance causes the allocator
+    // Request leniency from the allocator. Leniency
+    // will reduce the probability that random chance causes the allocator
     // to kill the query because of a small, spurious over-allocation.
 
-    long maxMem = memManager.getMemoryLimit();
-    long newMax = (long)(maxMem * 1.10);
-    allocator.setLimit(newMax);
-    logger.debug("Config: Resetting allocator to 10% safety margin: {}", newMax);
+//    long maxMem = memManager.getMemoryLimit();
+//    long newMax = (long)(maxMem * 1.10);
+//    allocator.setLimit(newMax);
+//    logger.debug("Config: Resetting allocator to 10% safety margin: {}", newMax);
+    boolean allowed = allocator.setLenient();
+    logger.debug("Config: Is allocator lenient? {}", allowed);
   }
 
   public void setSchema(BatchSchema schema) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestAllocatorGrace.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestAllocatorGrace.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.xsort.managed;
+
+import static org.junit.Assert.*;
+
+import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.memory.Accountant;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.util.AssertionUtil;
+import org.apache.drill.test.LogFixture;
+import org.apache.drill.test.LogFixture.LogFixtureBuilder;
+import org.apache.drill.test.SubOperatorTest;
+import org.junit.Test;
+
+import ch.qos.logback.classic.Level;
+import io.netty.buffer.DrillBuf;
+
+/**
+ * Test of temporary allocator feature to allow a grace margin
+ * for error in allocations from operators that make a good-faith
+ * effort to stay within their budgets, but are sometimes undone
+ * by unexpected power-of-two buffer sizes and vector doubling.
+ */
+
+public class TestAllocatorGrace extends SubOperatorTest {
+
+  /**
+   * Use a test-time hack to force the allocator to be lenient,
+   * regardless of whether we are in debug mode or not.
+   */
+
+  @Test
+  public void testLenient() {
+    LogFixtureBuilder logBuilder = LogFixture.builder()
+        .logger(Accountant.class, Level.WARN);
+
+    try (LogFixture logFixture = logBuilder.build()) {
+
+      // Test can't run without assertions
+
+      assertTrue(AssertionUtil.isAssertionsEnabled());
+
+      // Create a child allocator
+
+      BufferAllocator allocator = fixture.allocator().newChildAllocator("test", 10 * 1024, 128 * 1024);
+      ((Accountant) allocator).forceLenient();
+
+      // Allocate most of the available memory
+
+      DrillBuf buf1 = allocator.buffer(64 * 1024);
+
+      // Oops, we did our math wrong; allocate too large a buffer.
+
+      DrillBuf buf2 = allocator.buffer(128 * 1024);
+
+      assertEquals(192 * 1024, allocator.getAllocatedMemory());
+
+      // We keep making mistakes.
+
+      DrillBuf buf3 = allocator.buffer(32 * 1024);
+
+      // Right up to the hard limit
+
+      DrillBuf buf4 = allocator.buffer(32 * 1024);
+      assertEquals(256 * 1024, allocator.getAllocatedMemory());
+
+      // Enough of this; we're abusing the system. Next
+      // allocation fails.
+
+      try {
+        allocator.buffer(8);
+        fail();
+      } catch (OutOfMemoryException e) {
+        // Expected
+      }
+
+      // Recover from our excesses
+
+      buf2.close();
+      buf3.close();
+      buf4.close();
+      assertEquals(64 * 1024, allocator.getAllocatedMemory());
+
+      // We're back in the good graces of the allocator,
+      // can allocate more.
+
+      DrillBuf buf5 = allocator.buffer(8);
+
+      // Clean up
+
+      buf1.close();
+      buf5.close();
+      allocator.close();
+    }
+  }
+
+  /**
+   * Test that the allocator is normally strict in debug mode.
+   */
+
+  @Test
+  public void testStrict() {
+    LogFixtureBuilder logBuilder = LogFixture.builder()
+        .logger(Accountant.class, Level.WARN);
+
+    try (LogFixture logFixture = logBuilder.build()) {
+
+      // Test can't run without assertions
+
+      assertTrue(AssertionUtil.isAssertionsEnabled());
+
+      // Create a child allocator
+
+      BufferAllocator allocator = fixture.allocator().newChildAllocator("test", 10 * 1024, 128 * 1024);
+
+      // Allocate most of the available memory
+
+      DrillBuf buf1 = allocator.buffer(64 * 1024);
+
+      // Oops, we did our math wrong; allocate too large a buffer.
+
+      try {
+        allocator.buffer(128 * 1024);
+        fail();
+      } catch (OutOfMemoryException e) {
+        // Expected
+      }
+
+      // Clean up
+
+      buf1.close();
+      allocator.close();
+    }
+  }
+
+  public static final int ONE_MEG = 1024 * 1024;
+
+  @Test
+  public void testLenientLimit() {
+    LogFixtureBuilder logBuilder = LogFixture.builder()
+        .logger(Accountant.class, Level.WARN);
+
+    try (LogFixture logFixture = logBuilder.build()) {
+
+      // Test can't run without assertions
+
+      assertTrue(AssertionUtil.isAssertionsEnabled());
+
+      // Create a child allocator
+
+      BufferAllocator allocator = fixture.allocator().newChildAllocator("test", 10 * ONE_MEG, 128 * ONE_MEG);
+      ((Accountant) allocator).forceLenient();
+
+      // Allocate most of the available memory
+
+      DrillBuf buf1 = allocator.buffer(64 * ONE_MEG);
+
+      // Oops, we did our math wrong; allocate too large a buffer.
+
+      DrillBuf buf2 = allocator.buffer(128 * ONE_MEG);
+
+      // Can't go the full 2x over limit, errors capped at 100 MB.
+
+      try {
+        allocator.buffer(64 * ONE_MEG);
+        fail();
+      } catch (OutOfMemoryException e) {
+        // Expected
+      }
+
+      // Clean up
+
+      buf1.close();
+      buf2.close();
+      allocator.close();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestLenientAllocation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestLenientAllocation.java
@@ -38,7 +38,7 @@ import io.netty.buffer.DrillBuf;
  * by unexpected power-of-two buffer sizes and vector doubling.
  */
 
-public class TestAllocatorGrace extends SubOperatorTest {
+public class TestLenientAllocation extends SubOperatorTest {
 
   /**
    * Use a test-time hack to force the allocator to be lenient,

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -133,9 +133,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   @Override
-  public String getName() {
-    return name;
-  }
+  public String getName() { return name; }
 
   @Override
   public DrillBuf getEmpty() {
@@ -233,7 +231,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     final int actualRequestSize = initialRequestSize < CHUNK_SIZE ?
         nextPowerOfTwo(initialRequestSize)
         : initialRequestSize;
-    AllocationOutcome outcome = this.allocateBytes(actualRequestSize);
+    AllocationOutcome outcome = allocateBytes(actualRequestSize);
     if (!outcome.isOk()) {
       throw new OutOfMemoryException(createErrorMsg(this, actualRequestSize, initialRequestSize));
     }
@@ -828,6 +826,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
   }
 
+  @Override
   public DrillBuf read(int length, InputStream in) throws IOException {
     DrillBuf buf = buffer(length);
     try {

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
@@ -102,6 +102,19 @@ public interface BufferAllocator extends AutoCloseable {
   public void setLimit(long newLimit);
 
   /**
+   * Request lenient enforcement of the allocation limits. Use for
+   * memory-managed operators to prevent minor math errors from killing
+   * queries. This is temporary until Drill manages memory better.
+   * Leniency is allowed only in production code (no assertions),
+   * not in debug mode (assertions enabled).
+   *
+   * @return true if leniency was granted, false if the allocator will
+   * enforce strict limits despite the request
+   */
+
+  public boolean setLenient();
+
+  /**
    * Return the current maximum limit this allocator imposes.
    *
    * @return Limit in number of bytes.

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/ChildAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/ChildAllocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -48,6 +48,4 @@ class ChildAllocator extends BaseAllocator {
       long maxAllocation) {
     super(parentAllocator, name, initReservation, maxAllocation);
   }
-
-
 }


### PR DESCRIPTION
The "managed" external sort and the hash agg operators now actively attempt to stay within a memory "budget." 

Out goals are to:

1. Stay within the budget, and
2. Make full use of the available memory.

Unfortunately, at present, Drill has a number of limitations that work at cross-purposes to the above goal.

* Upstream operators create record batches potentially larger than the memory budget.
* Memory allocations are "lumpy" - power of two rounded.
* Vectors double in size automatically when needed.

The combination of the above means that memory planning must be aware of the size of each and every vector to the byte level in order to predict size doubling and power-of-two rounding.

But, of course, Drill is schema-on-read, meaning that Drill cannot know ahead of time the "shape" of the data it will process. Without that information, memory estimates are, at best, averages, but actual allocations have a wide variance around those averages.

Add to this Drill's memory allocation scheme: each operator is given a strict budget enforced by the memory allocator. Go above the budget by a single byte and the query dies.

How do we resolve this conflict? On the one hand, Drill's internals are rough-and-ready; it is impossible to predict actual memory usage. On the other hand, the allocator requires perfect prediction else the user suffers with failed queries.

Much work is needed in Drill internals to provide for better memory management. (Relational databases have long ago solved the issues, so solutions are available.) Until then, this commit introduces a work-around.

Memory-managed operators can ask for "leniency" from the allocator. In this mode, the allocator:

* Allows actual memory use to spike up to 100% of the limit, or 100 MB, whichever is less,
* Logs each such "excess allocation" as a warning, so we can identify and fix issues, and
* Allows leniency only in production environments, but not during development or test.

That is, we give users a margin for error so that their queries succeed even if Drill's memory calculations don't come out exactly right.

This should be fine because, of course, Drill still has several operators that observe no memory limits at all. Seems silly to have one operator using GBs of memory, while enforcing a typical 30 MB limit on others.

The margins assume that the error in the calcs is normally distributed. For each operator (e.g. minor fragment) that goes over, another is under the limit, meaning that, on average, the aggregate of the set of operators is more-or-less at the limit.

Until all operators are memory managed, and Drill provides better memory management tools, this PR allows queries to succeed even if we get things slightly wrong internally.