### PR TITLE
DRILL-5792: CONVERT_FROM_JSON on an empty file throws runtime exception

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/TypeHelper.java
+++ b/exec/java-exec/src/main/codegen/templates/TypeHelper.java
@@ -61,6 +61,7 @@ public class TypeHelper extends BasicTypeHelper {
     </#list>
     case MAP:
     case LIST:
+    case NULL:
       return new GenericAccessor(vector);
     }
     throw new UnsupportedOperationException(buildErrorMessage("find sql accessor", type));

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -119,6 +119,7 @@
             <exclude>**/.checkstyle</exclude>
             <exclude>**/.buildpath</exclude>
             <exclude>**/*.json</exclude>
+            <exclude>**/*.csv</exclude>
             <exclude>**/*.iml</exclude>
             <exclude>**/git.properties</exclude>
             <exclude>**/donuts-output-data.txt</exclude>

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
@@ -370,7 +370,7 @@ public class TestJdbcQuery extends JdbcTestQueryBase {
 
   @Test // DRILL-1051
   public void testOldDateTimeJulianCalendar() throws Exception {
-    // Should be work with any timezone
+    // Should work with any timezone
     JdbcAssert.withNoDefaultSchema()
         .sql("select cast(to_timestamp('1581-12-01 23:32:01', 'yyyy-MM-dd HH:mm:ss') as date) as `DATE`, " +
             "to_timestamp('1581-12-01 23:32:01', 'yyyy-MM-dd HH:mm:ss') as `TIMESTAMP`, " +
@@ -381,13 +381,20 @@ public class TestJdbcQuery extends JdbcTestQueryBase {
 
   @Test // DRILL-1051
   public void testOldDateTimeLocalMeanTime() throws Exception {
-    // Should be work with any timezone
+    // Should work with any timezone
     JdbcAssert.withNoDefaultSchema()
         .sql("select cast(to_timestamp('1883-11-16 01:32:01', 'yyyy-MM-dd HH:mm:ss') as date) as `DATE`, " +
             "to_timestamp('1883-11-16 01:32:01', 'yyyy-MM-dd HH:mm:ss') as `TIMESTAMP`, " +
             "cast(to_timestamp('1883-11-16 01:32:01', 'yyyy-MM-dd HH:mm:ss') as time) as `TIME` " +
             "from (VALUES(1))")
         .returns("DATE=1883-11-16; TIMESTAMP=1883-11-16 01:32:01.0; TIME=01:32:01");
+  }
+
+  @Test // DRILL-5792
+  public void testConvertFromInEmptyInputSql() throws Exception {
+    JdbcAssert.withNoDefaultSchema()
+        .sql("SELECT CONVERT_FROM(columns[1], 'JSON') as col1 from cp.`empty.csv`")
+        .returns("");
   }
 
 }


### PR DESCRIPTION
Easyfix - using GenericAccessor for UntypedNullVector.