### PR TITLE
DRILL-5755 Reduced default number of batches kept in memory by TopN

### DIFF
--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -248,7 +248,7 @@ drill.exec: {
     }
   },
   sort: {
-    purge.threshold : 1000,
+    purge.threshold : 10,
     external: {
       // Drill uses the managed External Sort Batch by default.
       // Set this to true to use the legacy, unmanaged version.


### PR DESCRIPTION
This change prevents the TopN operator from consuming large amounts of memory by default. This is important since the TopN operator doesn't obey memory limits currently. This is not a true fix for the issue, but it will reduce the number of issues seen until a true fix is developed.