### PR TITLE
DRILL-5824: Retain original memory limit for 1st phase HashAgg with 1 partition

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -441,8 +441,9 @@ public abstract class HashAggTemplate implements HashAggregator {
 
     // The following initial safety check should be revisited once we can lower the number of rows in a batch
     // In cases of very tight memory -- need at least memory to process one batch, plus overhead (e.g. hash table)
-    if ( numPartitions == 1 ) {
-      // if too little memory - behave like the old code -- no memory limit for hash aggregate
+    if ( numPartitions == 1 && ! canSpill ) {
+      // if too little memory - behave like the old code -- practically no memory limit for hash aggregate
+      // (but 1st phase can still spill, so it will maintain the original memory limit)
       allocator.setLimit(AbstractBase.MAX_ALLOCATION);  // 10_000_000_000L
     }
     // Based on the number of partitions: Set the mask and bit count


### PR DESCRIPTION
 The First Phase Hash Aggr always "fell back" to 1.10 behaviour (i.e. memory limit up to 10GB) when its number of partitions was 1. However the 1st phase can always "spill" (i.e. early return some partition). Hence the code was change for 1st phase (only operator that can spill with 1 partition) to retain its original memory limit and not "fall back".
