### PR TITLE
DRILL-5830: Resolve regressions to MapR DB from DRILL-5546

### DIFF
--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,17 +17,22 @@
  */
 package org.apache.drill.exec.store.hbase;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -50,24 +55,18 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.RegionLocator;
-import org.apache.hadoop.hbase.util.Bytes;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableMap;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 @JsonTypeName("hbase-scan")
 public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConstants {
@@ -144,8 +143,8 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
   @Override
   public GroupScan clone(List<SchemaPath> columns) {
     HBaseGroupScan newScan = new HBaseGroupScan(this);
-    newScan.columns = columns == null ? ALL_COLUMNS : columns;;
-    newScan.verifyColumnsAndConvertStar();
+    newScan.columns = columns == null ? ALL_COLUMNS : columns;
+    newScan.verifyColumns();
     return newScan;
   }
 
@@ -177,36 +176,18 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
     } catch (IOException e) {
       throw new DrillRuntimeException("Error getting region info for table: " + hbaseScanSpec.getTableName(), e);
     }
-    verifyColumnsAndConvertStar();
+    verifyColumns();
   }
 
-  private void verifyColumnsAndConvertStar() {
-    boolean hasStarCol = false;
-    LinkedHashSet<SchemaPath> requestedColumns = new LinkedHashSet<>();
-
-    for (SchemaPath column : columns) {
-      // convert * into [row_key, cf1, cf2, ..., cf_n].
-      if (column.equals(Utilities.STAR_COLUMN)) {
-        hasStarCol = true;
-        Set<byte[]> families = hTableDesc.getFamiliesKeys();
-        requestedColumns.add(ROW_KEY_PATH);
-        for (byte[] family : families) {
-          SchemaPath colFamily = SchemaPath.getSimplePath(Bytes.toString(family));
-          requestedColumns.add(colFamily);
-        }
-      } else {
-        if (!(column.equals(ROW_KEY_PATH) ||
-            hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
-          DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
-              column.getRootSegment().getPath(), hTableDesc.getNameAsString());
-        }
-        requestedColumns.add(column);
-      }
+  private void verifyColumns() {
+    if (Utilities.isStarQuery(columns)) {
+      return;
     }
-
-    // since star column has been converted, reset this.cloumns.
-    if (hasStarCol) {
-      this.columns = new ArrayList<>(requestedColumns);
+    for (SchemaPath column : columns) {
+      if (!(column.equals(ROW_KEY_PATH) || hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
+        DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
+            column.getRootSegment().getPath(), hTableDesc.getNameAsString());
+      }
     }
   }
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
@@ -126,11 +126,9 @@ public class HBaseRecordReader extends AbstractRecordReader implements DrillHBas
             HBaseUtils.andFilterAtIndex(hbaseScan.getFilter(), HBaseUtils.LAST_FILTER, new FirstKeyOnlyFilter()));
       }
     } else {
-      throw new IllegalArgumentException("HBaseRecordReader does not allow column *. Column * should have been converted to list of <row_key, column family1, column family2, ..., column family_n");
-//      rowKeyOnly = false;
-//      transformed.add(ROW_KEY_PATH);
+      rowKeyOnly = false;
+      transformed.add(ROW_KEY_PATH);
     }
-
 
     return transformed;
   }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseScanSpec.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseScanSpec.java
@@ -93,5 +93,4 @@ public class HBaseScanSpec {
         + ", filter=" + (filter == null ? null : filter.toString())
         + "]";
   }
-
 }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSchemaFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -94,7 +94,5 @@ public class HBaseSchemaFactory implements SchemaFactory {
     public String getTypeName() {
       return HBaseStoragePluginConfig.NAME;
     }
-
   }
-
 }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePlugin.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseStoragePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -154,7 +154,5 @@ public class HBaseStoragePlugin extends AbstractStoragePlugin {
     private HBaseStoragePlugin getHBaseStoragePlugin() {
       return HBaseStoragePlugin.this;
     }
-
   }
-
 }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -41,7 +41,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 
-// Class containing information for reading a single HBase region
+/**
+ * Contains information for reading a single HBase region
+ */
+
 @JsonTypeName("hbase-region-scan")
 public class HBaseSubScan extends AbstractBase implements SubScan {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HBaseSubScan.class);
@@ -210,12 +213,10 @@ public class HBaseSubScan extends AbstractBase implements SubScan {
           + ", filter=" + (getScanFilter() == null ? null : getScanFilter().toString())
           + ", regionServer=" + regionServer + "]";
     }
-
   }
 
   @Override
   public int getOperatorType() {
     return CoreOperatorType.HBASE_SUB_SCAN_VALUE;
   }
-
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -38,7 +38,7 @@ import com.google.common.io.Files;
 
 public class BaseHBaseTest extends BaseTestQuery {
 
-  private static final String HBASE_STORAGE_PLUGIN_NAME = "hbase";
+  public static final String HBASE_STORAGE_PLUGIN_NAME = "hbase";
 
   protected static Configuration conf = HBaseConfiguration.create();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnionExchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnionExchange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -33,9 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("union-exchange")
-public class UnionExchange extends AbstractExchange{
-
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnionExchange.class);
+public class UnionExchange extends AbstractExchange {
 
   public UnionExchange(@JsonProperty("child") PhysicalOperator child) {
     super(child);
@@ -76,5 +74,4 @@ public class UnionExchange extends AbstractExchange{
   protected PhysicalOperator getNewWithChild(PhysicalOperator child) {
     return new UnionExchange(child);
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -180,9 +180,6 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
       if (context.isOverMemoryLimit()) {
         return IterOutcome.OUT_OF_MEMORY;
       }
-
-
-//      logger.debug("Next received batch {}", batch);
 
       final RecordBatchDef rbd = batch.getHeader().getDef();
       final boolean schemaChanged = batchLoader.load(rbd, batch.getBody());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,8 +28,8 @@ import org.apache.drill.exec.work.batch.IncomingBuffers;
 import org.apache.drill.exec.work.batch.RawBatchBuffer;
 
 public class UnorderedReceiverCreator implements BatchCreator<UnorderedReceiver>{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnorderedReceiverCreator.class);
 
+  @SuppressWarnings("resource")
   @Override
   public UnorderedReceiverBatch getBatch(FragmentContext context, UnorderedReceiver receiver, List<RecordBatch> children)
       throws ExecutionSetupException {
@@ -42,6 +42,4 @@ public class UnorderedReceiverCreator implements BatchCreator<UnorderedReceiver>
     RawBatchBuffer buffer = buffers[0];
     return new UnorderedReceiverBatch(context, buffer, receiver);
   }
-
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjIntoScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushProjIntoScan.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
-import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalProject;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ProjectPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ProjectPrel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
@@ -136,6 +136,21 @@ public class BatchSchema implements Iterable<MaterializedField> {
     return true;
   }
 
+  public boolean isEquivalent(BatchSchema other) {
+    if (fields == null || other.fields == null) {
+      return fields == other.fields;
+    }
+    if (fields.size() != other.fields.size()) {
+      return false;
+    }
+    for (int i = 0; i < fields.size(); i++) {
+      if (! fields.get(i).isEquivalent(other.fields.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * We treat fields with same set of Subtypes as equal, even if they are in a different order
    * @param t1

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -134,7 +134,7 @@ public class VectorContainer implements VectorAccessible {
     return addOrGet(field, null);
   }
 
-  @SuppressWarnings({ "resource", "unchecked" })
+  @SuppressWarnings("unchecked")
   public <T extends ValueVector> T addOrGet(final MaterializedField field, final SchemaChangeCallBack callBack) {
     final TypedFieldId id = getValueVectorId(SchemaPath.getSimplePath(field.getName()));
     final ValueVector vector;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DistributedQueryQueue.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/DistributedQueryQueue.java
@@ -183,6 +183,9 @@ public class DistributedQueryQueue implements QueryQueue {
      */
 
     public boolean isSameAs(ConfigSet otherSet) {
+      if (otherSet == null) {
+        return false;
+      }
       return queueThreshold == otherSet.queueThreshold &&
              queueTimeout == otherSet.queueTimeout &&
              largeQueueSize == otherSet.largeQueueSize &&

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestLoad.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestLoad.java
@@ -18,69 +18,72 @@
 package org.apache.drill.exec.record.vector;
 
 import static org.junit.Assert.assertEquals;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DrillBuf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.categories.VectorTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ExecTest;
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
+import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.RecordBatchLoader;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.vector.AllocationHelper;
-import org.apache.drill.exec.vector.IntVector;
-import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.exec.vector.VarCharVector;
+import org.apache.drill.test.rowSet.SchemaBuilder;
 import org.junit.Test;
-
-import com.google.common.collect.Lists;
 import org.junit.experimental.categories.Category;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DrillBuf;
 
 @Category(VectorTest.class)
 public class TestLoad extends ExecTest {
   private final DrillConfig drillConfig = DrillConfig.create();
 
+  @SuppressWarnings("resource")
   @Test
   public void testLoadValueVector() throws Exception {
     final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
-    final ValueVector fixedV = new IntVector(MaterializedField.create("ints",
-        Types.required(MinorType.INT)), allocator);
-    final ValueVector varlenV = new VarCharVector(MaterializedField.create(
-        "chars", Types.required(MinorType.VARCHAR)), allocator);
-    final ValueVector nullableVarlenV = new NullableVarCharVector(MaterializedField.create("chars",
-        Types.optional(MinorType.VARCHAR)), allocator);
+    BatchSchema schema = new SchemaBuilder()
+        .add("ints", MinorType.INT)
+        .add("chars", MinorType.VARCHAR)
+        .addNullable("chars2", MinorType.VARCHAR)
+        .build();
 
-    final List<ValueVector> vectors = Lists.newArrayList(fixedV, varlenV, nullableVarlenV);
-    for (final ValueVector v : vectors) {
-      AllocationHelper.allocate(v, 100, 50);
-      v.getMutator().generateTestData(100);
-    }
+    // Create vectors
 
-    final WritableBatch writableBatch = WritableBatch.getBatchNoHV(100, vectors, false);
+    final List<ValueVector> vectors = createVectors(allocator, schema, 100);
+
+    // Writeable batch now owns vector buffers
+
+     final WritableBatch writableBatch = WritableBatch.getBatchNoHV(100, vectors, false);
+
+     // Serialize the vectors
+
+    final DrillBuf byteBuf = serializeBatch(allocator, writableBatch);
+
+    // Batch loader does NOT take ownership of the serialized buffer
+
     final RecordBatchLoader batchLoader = new RecordBatchLoader(allocator);
-    final ByteBuf[] byteBufs = writableBatch.getBuffers();
-    int bytes = 0;
-    for (ByteBuf buf : byteBufs) {
-      bytes += buf.writerIndex();
-    }
-    final DrillBuf byteBuf = allocator.buffer(bytes);
-    int index = 0;
-    for (ByteBuf buf : byteBufs) {
-      buf.readBytes(byteBuf, index, buf.writerIndex());
-      index += buf.writerIndex();
-    }
-    byteBuf.writerIndex(bytes);
-
     batchLoader.load(writableBatch.getDef(), byteBuf);
+
+    // Release the serialized buffer.
+
+    byteBuf.release();
+
+    // TODO: Replace this with actual validation, not just dumping to the console.
+
     boolean firstColumn = true;
     int recordCount = 0;
     for (final VectorWrapper<?> v : batchLoader) {
@@ -122,7 +125,294 @@ public class TestLoad extends ExecTest {
       }
     }
     assertEquals(100, recordCount);
-    batchLoader.clear();
+
+    // Free the original vectors
+
     writableBatch.clear();
+
+    // Free the deserialized vectors
+
+    batchLoader.clear();
+
+    // The allocator will verify that the frees were done correctly.
+
+    allocator.close();
+  }
+
+  // TODO: Replace this low-level code with RowSet usage once
+  // DRILL-5657 is committed to master.
+
+  private static List<ValueVector> createVectors(BufferAllocator allocator, BatchSchema schema, int i) {
+    final List<ValueVector> vectors = new ArrayList<>();
+    for (MaterializedField field : schema) {
+      @SuppressWarnings("resource")
+      ValueVector v = TypeHelper.getNewVector(field, allocator);
+      AllocationHelper.allocate(v, 100, 50);
+      v.getMutator().generateTestData(100);
+      vectors.add(v);
+    }
+    return vectors;
+  }
+
+  private static DrillBuf serializeBatch(BufferAllocator allocator, WritableBatch writableBatch) {
+    final ByteBuf[] byteBufs = writableBatch.getBuffers();
+    int bytes = 0;
+    for (ByteBuf buf : byteBufs) {
+      bytes += buf.writerIndex();
+    }
+    final DrillBuf byteBuf = allocator.buffer(bytes);
+    int index = 0;
+    for (ByteBuf buf : byteBufs) {
+      buf.readBytes(byteBuf, index, buf.writerIndex());
+      index += buf.writerIndex();
+    }
+    byteBuf.writerIndex(bytes);
+    return byteBuf;
+  }
+
+  /**
+   * Test function to simulate loading a batch.
+   *
+   * @param allocator a memory allocator
+   * @param batchLoader the batch loader under test
+   * @param schema the schema of the new batch
+   * @return false if the same schema, true if schema changed;
+   * that is, whether the schema changed
+   * @throws SchemaChangeException should not occur
+   */
+
+  @SuppressWarnings("resource")
+  private boolean loadBatch(BufferAllocator allocator,
+      final RecordBatchLoader batchLoader,
+      BatchSchema schema) throws SchemaChangeException {
+    final List<ValueVector> vectors = createVectors(allocator, schema, 100);
+    final WritableBatch writableBatch = WritableBatch.getBatchNoHV(100, vectors, false);
+    final DrillBuf byteBuf = serializeBatch(allocator, writableBatch);
+    boolean result = batchLoader.load(writableBatch.getDef(), byteBuf);
+    byteBuf.release();
+    writableBatch.clear();
+    return result;
+  }
+
+  @Test
+  public void testSchemaChange() throws SchemaChangeException {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
+    final RecordBatchLoader batchLoader = new RecordBatchLoader(allocator);
+
+    // Initial schema: a: INT, b: VARCHAR
+    // Schema change: N/A
+
+    BatchSchema schema1 = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("b", MinorType.VARCHAR)
+        .build();
+    {
+      assertTrue(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Same schema
+    // Schema change: No
+
+    {
+      assertFalse(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Reverse columns: b: VARCHAR, a: INT
+    // Schema change: No
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("b", MinorType.VARCHAR)
+          .add("a", MinorType.INT)
+          .build();
+      assertFalse(loadBatch(allocator, batchLoader, schema));
+
+      // Potential bug: see DRILL-5828
+
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Drop a column: a: INT
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Add a column: a: INT, b: VARCHAR, c: INT
+    // Schema change: Yes
+
+    {
+      assertTrue(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .add("b", MinorType.VARCHAR)
+          .add("c", MinorType.INT)
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Change a column type: a: INT, b: VARCHAR, c: VARCHAR
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .add("b", MinorType.VARCHAR)
+          .add("c", MinorType.VARCHAR)
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Empty schema
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    batchLoader.clear();
+    allocator.close();
+  }
+
+  @Test
+  public void testMapSchemaChange() throws SchemaChangeException {
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
+    final RecordBatchLoader batchLoader = new RecordBatchLoader(allocator);
+
+    // Initial schema: a: INT, m: MAP{}
+
+    BatchSchema schema1 = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addMap("m")
+          .buildMap()
+        .build();
+    {
+      assertTrue(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Same schema
+    // Schema change: No
+
+    {
+      assertFalse(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Add column to map: a: INT, m: MAP{b: VARCHAR}
+    // Schema change: Yes
+
+    BatchSchema schema2 = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addMap("m")
+          .add("b", MinorType.VARCHAR)
+          .buildMap()
+        .build();
+    {
+      assertTrue(loadBatch(allocator, batchLoader, schema2));
+      assertTrue(schema2.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Same schema
+    // Schema change: No
+
+    {
+      assertFalse(loadBatch(allocator, batchLoader, schema2));
+      assertTrue(schema2.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Add column:  a: INT, m: MAP{b: VARCHAR, c: INT}
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .addMap("m")
+            .add("b", MinorType.VARCHAR)
+            .add("c", MinorType.INT)
+            .buildMap()
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Drop a column:  a: INT, m: MAP{b: VARCHAR}
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .addMap("m")
+            .add("b", MinorType.VARCHAR)
+            .buildMap()
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Change type:  a: INT, m: MAP{b: INT}
+    // Schema change: Yes
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .addMap("m")
+            .add("b", MinorType.INT)
+            .buildMap()
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Empty map: a: INT, m: MAP{}
+
+    {
+      assertTrue(loadBatch(allocator, batchLoader, schema1));
+      assertTrue(schema1.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    // Drop map: a: INT
+
+    {
+      BatchSchema schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .build();
+      assertTrue(loadBatch(allocator, batchLoader, schema));
+      assertTrue(schema.isEquivalent(batchLoader.getSchema()));
+      batchLoader.getContainer().zeroVectors();
+    }
+
+    batchLoader.clear();
+    allocator.close();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -345,6 +345,10 @@ public class QueryBuilder {
     }
   }
 
+  public QueryRowSetIterator rowSetIterator( ) {
+    return new QueryRowSetIterator(client.allocator(), withEventListener());
+  }
+
   /**
    * Run the query that is expected to return (at least) one row
    * with the only (or first) column returning a long value.

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.test;
+
+import java.util.Iterator;
+
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.record.RecordBatchLoader;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.rpc.user.QueryDataBatch;
+import org.apache.drill.test.BufferingQueryEventListener.QueryEvent;
+import org.apache.drill.test.rowSet.DirectRowSet;
+
+public class QueryRowSetIterator implements Iterator<DirectRowSet>, Iterable<DirectRowSet> {
+  private final BufferingQueryEventListener listener;
+  private int recordCount = 0;
+  private int batchCount = 0;
+  QueryId queryId = null;
+  private BufferAllocator allocator;
+  private QueryDataBatch batch;
+  private QueryState state;
+
+  QueryRowSetIterator(BufferAllocator allocator, BufferingQueryEventListener listener) {
+    this.allocator = allocator;
+    this.listener = listener;
+  }
+
+  public QueryId queryId() { return queryId; }
+  public String queryIdString() { return QueryIdHelper.getQueryId(queryId); }
+  public QueryState finalState() { return state; }
+  public int batchCount() { return batchCount; }
+  public int rowCount() { return recordCount; }
+
+  @Override
+  public boolean hasNext() {
+    for ( ; ; ) {
+      QueryEvent event = listener.get();
+      state = event.state;
+      batch = null;
+      switch (event.type)
+      {
+      case BATCH:
+        batchCount++;
+        recordCount += event.batch.getHeader().getRowCount();
+        batch = event.batch;
+        return true;
+      case EOF:
+        state = event.state;
+        return false;
+      case ERROR:
+        throw new RuntimeException(event.error);
+      case QUERY_ID:
+        queryId = event.queryId;
+        break;
+      default:
+        throw new IllegalStateException("Unexpected event: " + event.type);
+      }
+    }
+  }
+
+  @Override
+  public DirectRowSet next() {
+
+    if (batch == null) {
+      throw new IllegalStateException();
+    }
+
+    // Unload the batch and convert to a row set.
+
+    final RecordBatchLoader loader = new RecordBatchLoader(allocator);
+    try {
+      loader.load(batch.getHeader().getDef(), batch.getData());
+      batch.release();
+      batch = null;
+      VectorContainer container = loader.getContainer();
+      container.setRecordCount(loader.getRecordCount());
+      return new DirectRowSet(allocator, container);
+    } catch (SchemaChangeException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public void printAll() {
+    for (DirectRowSet rowSet : this) {
+      rowSet.print();
+      rowSet.clear();
+    }
+  }
+
+  @Override
+  public Iterator<DirectRowSet> iterator() {
+    return this;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -52,7 +52,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   private final int offset;
   private final BufferLedger ledger;
   private final BufferManager bufManager;
-  private final ByteBufAllocator alloc;
+//  private final ByteBufAllocator alloc;
   private final boolean isEmpty;
   private volatile int length;
   private final HistoricalLog historicalLog = BaseAllocator.DEBUG ?
@@ -72,7 +72,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     this.udle = byteBuf;
     this.isEmpty = isEmpty;
     this.bufManager = manager;
-    this.alloc = alloc;
+//    this.alloc = alloc;
     this.addr = byteBuf.memoryAddress() + offset;
     this.ledger = ledger;
     this.length = length;

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.expr.BasicTypeHelper;
 import org.apache.drill.exec.proto.UserBitShared.NamePart;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
@@ -86,6 +87,7 @@ public class MaterializedField {
     children.add(field);
   }
 
+  @Override
   public MaterializedField clone() {
     return withPathAndType(name, getType());
   }
@@ -166,6 +168,57 @@ public class MaterializedField {
 
     return this.name.equalsIgnoreCase(other.name) &&
             Objects.equals(this.type, other.type);
+  }
+
+  public boolean isEquivalent(MaterializedField other) {
+    if (! name.equalsIgnoreCase(other.name)) {
+      return false;
+    }
+
+    // Requires full type equality, including fields such as precision and scale.
+    // But, unset fields are equivalent to 0. Can't use the protobuf-provided
+    // isEquals(), that treats set and unset fields as different.
+
+    if (type.getMinorType() != other.type.getMinorType()) {
+      return false;
+    }
+    if (type.getMode() != other.type.getMode()) {
+      return false;
+    }
+    if (type.getScale() != other.type.getScale()) {
+      return false;
+    }
+    if (type.getPrecision() != other.type.getPrecision()) {
+      return false;
+    }
+
+    // Compare children -- but only for maps, not the internal children
+    // for Varchar, repeated or nullable types.
+
+    if (type.getMinorType() != MinorType.MAP) {
+      return true;
+    }
+
+    if (children == null  ||  other.children == null) {
+      return children == other.children;
+    }
+    if (children.size() != other.children.size()) {
+      return false;
+    }
+
+    // Maps are name-based, not position. But, for our
+    // purposes, we insist on identical ordering.
+
+    Iterator<MaterializedField> thisIter = children.iterator();
+    Iterator<MaterializedField> otherIter = other.children.iterator();
+    while (thisIter.hasNext()) {
+      MaterializedField thisChild = thisIter.next();
+      MaterializedField otherChild = otherIter.next();
+      if (! thisChild.isEquivalent(otherChild)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
DRILL-5546 fixed a wide variety of "empty batch" problems. But, it introduced a regression in the HBase and MapR-DB binary storage plugins. This PR refines the fix to resolve those regressions.

Prior to DRILL-5546, HBase provided a project push-down rule to expand wildcard columns. However, a bug in the push-down rule prevented proper function. DRILL-5546 fixed that rule. But, DRILL-5546 also explicitly expanded wildcards for HBase, which turned out to be redundant, and so is backed out in this PR.

Wildcard expansion in the HBase storage plugin was meant to overcome the schema change conflict that occurs with empty regions. In such regions, we get the row key and the column family as an empty map. In regions with data, we get the row key and a non-empty map for the column family. Examples:

* Empty: (row_key, cf{})
* Non-empty: (row_key, cf{col1, col2})

Where cf is a column family and col1, col2 are columns.

It turns out that the receivers were getting confused. The `RecordBatchLoader` class treated empty and non-empty maps as an identical schema. This was mentioned in  DRILL-5546:

> In HBase a column family always has map type, and a non-rowkey column always has nullable varbinary type, this ensures that HBaseRecordReader across different HBase regions will have the same top level schema, even if the region is empty or prune all the rows due to filter pushdown optimization. In other words, we will not see different top level schema from different HBaseRecordReader for the same table.

The problem is, a difference in map content really is a schema change, so we need to detect and report it. This PR makes that change.

Now, as it turns out, changes made by DRILL-5546 to the top-level project operator gracefully removes the empty batches (with empty maps), passing along just the non-empty batches (with non-empty maps.)

In short, this PR:

* Backs out the HBase-specific changes to DRILL-5546,
* Fixes the schema change issue in `RecordBatchLoader`,
* Adds unit tests for the fixes to `RecordBatchLoader`,
* Does a number of minor code cleanups.

The result is that the HBase problems that DRILL-5546 solved are still solved, but the regressions to MapR DB binary are also fixed.

We propose to modify the MapR DB binary storage plugin to do projection push-down the same way as is done in HBase, but that will be a separate PR.