### PR TITLE
 DRILL-5775: Select * query on a maprdb binary table fails

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPlugin.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBFormatPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -73,9 +73,7 @@ public class MapRDBFormatPlugin extends TableFormatPlugin {
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection,
       List<SchemaPath> columns) throws IOException {
-    List<String> files = selection.getFiles();
-    assert (files.size() == 1);
-    String tableName = files.get(0);
+    String tableName = getTableName(selection);
     TableProperties props = getMaprFS().getTableProperties(new Path(tableName));
 
     if (props.getAttr().getJson()) {
@@ -95,6 +93,19 @@ public class MapRDBFormatPlugin extends TableFormatPlugin {
   @JsonIgnore
   public Connection getConnection() {
     return connection;
+  }
+
+  /**
+   * Allows to get a table name from FileSelection object
+   *
+   * @param selection File selection object
+   * @return string table name
+   */
+  @JsonIgnore
+  public String getTableName(FileSelection selection) {
+    List<String> files = selection.getFiles();
+    assert (files.size() == 1);
+    return files.get(0);
   }
 
 }

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.exec.store.dfs.FileSystemPlugin;
 import org.apache.drill.exec.store.hbase.DrillHBaseConstants;
 import org.apache.drill.exec.store.hbase.HBaseScanSpec;
+import org.apache.drill.exec.store.hbase.HBaseUtils;
 import org.apache.drill.exec.store.mapr.db.MapRDBFormatPlugin;
 import org.apache.drill.exec.store.mapr.db.MapRDBFormatPluginConfig;
 import org.apache.drill.exec.store.mapr.db.MapRDBGroupScan;
@@ -113,8 +114,8 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
   @Override
   public GroupScan clone(List<SchemaPath> columns) {
     BinaryTableGroupScan newScan = new BinaryTableGroupScan(this);
-    newScan.columns = columns;
-    newScan.verifyColumns();
+    newScan.columns = columns == null ? ALL_COLUMNS : columns;
+    HBaseUtils.verifyColumns(columns, hTableDesc);
     return newScan;
   }
 
@@ -145,21 +146,9 @@ public class BinaryTableGroupScan extends MapRDBGroupScan implements DrillHBaseC
     } catch (Exception e) {
       throw new DrillRuntimeException("Error getting region info for table: " + hbaseScanSpec.getTableName(), e);
     }
-    verifyColumns();
+    HBaseUtils.verifyColumns(columns, hTableDesc);
   }
 
-  private void verifyColumns() {
-    /*
-    if (columns != null) {
-      for (SchemaPath column : columns) {
-        if (!(column.equals(ROW_KEY_PATH) || hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
-          DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
-              column.getRootSegment().getPath(), hTableDesc.getNameAsString());
-        }
-      }
-    }
-    */
-  }
 
   protected MapRDBSubScanSpec getSubScanSpec(TabletFragmentInfo tfi) {
     HBaseScanSpec spec = hbaseScanSpec;

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBBinaryTable.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBBinaryTable.java
@@ -15,15 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.hbase;
+package org.apache.drill.exec.store.mapr.db.binary;
 
 
+import org.apache.drill.exec.store.dfs.FileSystemPlugin;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.exec.store.hbase.AbstractHBaseDrillTable;
+import org.apache.drill.exec.store.mapr.db.MapRDBFormatPlugin;
 
-public class DrillHBaseTable extends AbstractHBaseDrillTable {
+public class MapRDBBinaryTable extends AbstractHBaseDrillTable {
 
-  public DrillHBaseTable(String storageEngineName, HBaseStoragePlugin plugin, HBaseScanSpec scanSpec) {
-    super(storageEngineName, plugin, scanSpec);
-    setTableDesc(plugin.getConnection(), scanSpec.getTableName());
+  public MapRDBBinaryTable(String storageEngineName, FileSystemPlugin storagePlugin, MapRDBFormatPlugin formatPlugin,
+      FormatSelection selection) {
+    super(storageEngineName, storagePlugin, selection);
+    setTableDesc(formatPlugin.getConnection(), formatPlugin.getTableName(selection.getSelection()));
   }
 
 }

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/AbstractHBaseDrillTable.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/AbstractHBaseDrillTable.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hbase;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.store.StoragePlugin;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+
+import static org.apache.drill.exec.store.hbase.DrillHBaseConstants.ROW_KEY;
+
+public abstract class AbstractHBaseDrillTable extends DrillTable {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractHBaseDrillTable.class);
+
+  protected HTableDescriptor tableDesc;
+
+  public AbstractHBaseDrillTable(String storageEngineName, StoragePlugin plugin, Object selection) {
+    super(storageEngineName, plugin, selection);
+  }
+
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    ArrayList<RelDataType> typeList = new ArrayList<>();
+    ArrayList<String> fieldNameList = new ArrayList<>();
+
+    fieldNameList.add(ROW_KEY);
+    typeList.add(typeFactory.createSqlType(SqlTypeName.ANY));
+
+    Set<byte[]> families = tableDesc.getFamiliesKeys();
+    for (byte[] family : families) {
+      fieldNameList.add(Bytes.toString(family));
+      typeList.add(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), typeFactory.createSqlType(SqlTypeName.ANY)));
+    }
+    return typeFactory.createStructType(typeList, fieldNameList);
+  }
+
+  /**
+   * Allows to set HTableDescriptor
+   *
+   * @param connection with a server
+   * @param tableName the name of table
+   */
+  protected void setTableDesc(Connection connection, String tableName) {
+    try {
+      tableDesc = connection.getAdmin().getTableDescriptor(TableName.valueOf(tableName));
+    } catch (IOException e) {
+      throw UserException.dataReadError()
+          .message("Failure while loading table %s in database %s.", tableName, getStorageEngineName())
+          .addContext("Message: ", e.getMessage())
+          .build(logger);
+    }
+  }
+
+}

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
@@ -145,7 +145,7 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
   public GroupScan clone(List<SchemaPath> columns) {
     HBaseGroupScan newScan = new HBaseGroupScan(this);
     newScan.columns = columns == null ? ALL_COLUMNS : columns;;
-    newScan.verifyColumnsAndConvertStar();
+    newScan.verifyColumns();
     return newScan;
   }
 
@@ -177,36 +177,18 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
     } catch (IOException e) {
       throw new DrillRuntimeException("Error getting region info for table: " + hbaseScanSpec.getTableName(), e);
     }
-    verifyColumnsAndConvertStar();
+    verifyColumns();
   }
 
-  private void verifyColumnsAndConvertStar() {
-    boolean hasStarCol = false;
-    LinkedHashSet<SchemaPath> requestedColumns = new LinkedHashSet<>();
-
-    for (SchemaPath column : columns) {
-      // convert * into [row_key, cf1, cf2, ..., cf_n].
-      if (column.equals(Utilities.STAR_COLUMN)) {
-        hasStarCol = true;
-        Set<byte[]> families = hTableDesc.getFamiliesKeys();
-        requestedColumns.add(ROW_KEY_PATH);
-        for (byte[] family : families) {
-          SchemaPath colFamily = SchemaPath.getSimplePath(Bytes.toString(family));
-          requestedColumns.add(colFamily);
-        }
-      } else {
-        if (!(column.equals(ROW_KEY_PATH) ||
-            hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
-          DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
-              column.getRootSegment().getPath(), hTableDesc.getNameAsString());
-        }
-        requestedColumns.add(column);
-      }
+  private void verifyColumns() {
+    if (Utilities.isStarQuery(columns)) {
+      return;
     }
-
-    // since star column has been converted, reset this.cloumns.
-    if (hasStarCol) {
-      this.columns = new ArrayList<>(requestedColumns);
+    for (SchemaPath column : columns) {
+      if (!(column.equals(ROW_KEY_PATH) || hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
+        DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
+            column.getRootSegment().getPath(), hTableDesc.getNameAsString());
+      }
     }
   }
 

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseGroupScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -144,8 +144,8 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
   @Override
   public GroupScan clone(List<SchemaPath> columns) {
     HBaseGroupScan newScan = new HBaseGroupScan(this);
-    newScan.columns = columns == null ? ALL_COLUMNS : columns;;
-    newScan.verifyColumns();
+    newScan.columns = columns == null ? ALL_COLUMNS : columns;
+    HBaseUtils.verifyColumns(columns, hTableDesc);
     return newScan;
   }
 
@@ -177,19 +177,7 @@ public class HBaseGroupScan extends AbstractGroupScan implements DrillHBaseConst
     } catch (IOException e) {
       throw new DrillRuntimeException("Error getting region info for table: " + hbaseScanSpec.getTableName(), e);
     }
-    verifyColumns();
-  }
-
-  private void verifyColumns() {
-    if (Utilities.isStarQuery(columns)) {
-      return;
-    }
-    for (SchemaPath column : columns) {
-      if (!(column.equals(ROW_KEY_PATH) || hTableDesc.hasFamily(HBaseUtils.getBytes(column.getRootSegment().getPath())))) {
-        DrillRuntimeException.format("The column family '%s' does not exist in HBase table: %s .",
-            column.getRootSegment().getPath(), hTableDesc.getNameAsString());
-      }
-    }
+    HBaseUtils.verifyColumns(columns, hTableDesc);
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRecordReader.java
@@ -126,11 +126,9 @@ public class HBaseRecordReader extends AbstractRecordReader implements DrillHBas
             HBaseUtils.andFilterAtIndex(hbaseScan.getFilter(), HBaseUtils.LAST_FILTER, new FirstKeyOnlyFilter()));
       }
     } else {
-      throw new IllegalArgumentException("HBaseRecordReader does not allow column *. Column * should have been converted to list of <row_key, column family1, column family2, ..., column family_n");
-//      rowKeyOnly = false;
-//      transformed.add(ROW_KEY_PATH);
+      rowKeyOnly = false;
+      transformed.add(ROW_KEY_PATH);
     }
-
 
     return transformed;
   }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -38,7 +38,7 @@ import com.google.common.io.Files;
 
 public class BaseHBaseTest extends BaseTestQuery {
 
-  private static final String HBASE_STORAGE_PLUGIN_NAME = "hbase";
+  public static final String HBASE_STORAGE_PLUGIN_NAME = "hbase";
 
   protected static Configuration conf = HBaseConfiguration.create();
 


### PR DESCRIPTION
- Back out HBase changes introduced in DRILL-5546;
- The common HBase/MapR-DB_binary verifyColumns() method;
- MapRDBBinaryTable is introduced for the purpose of expanding the wildcard on the planning stage;
- AbstractHBaseDrillTable class for MapRDBBinaryTable and DrillHBaseTable.