### PR TITLE
DRILL-5797: Choose parquet reader from read columns

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetScanBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetScanBatchCreator.java
@@ -168,9 +168,8 @@ public class ParquetScanBatchCreator implements BatchCreator<ParquetRowGroupScan
     If it is a wildcard query, we check every columns in the metadata.
     If not, we only check the projected columns.
     */
+    MessageType schema = footer.getFileMetaData().getSchema();
     if (Utilities.isStarQuery(columns)) {
-      MessageType schema = footer.getFileMetaData().getSchema();
-
       for (Type type : schema.getFields()) {
         if (!type.isPrimitive()) {
           return true;
@@ -184,7 +183,7 @@ public class ParquetScanBatchCreator implements BatchCreator<ParquetRowGroupScan
       return false;
     } else {
       for (SchemaPath column : columns) {
-        if (isColumnComplex(footer.getFileMetaData().getSchema(), column)) {
+        if (isColumnComplex(schema, column)) {
           return true;
         }
       }


### PR DESCRIPTION
ParquetRecordReader is not able to read complex columns. However it is
able to read simple columns in a file containing complex
columns. Instead of looking at the file to choose the reader, we
now choose which reader to use based on what columns is asked and if
they are simple or not.