### PR TITLE
DRILL-5857: Fix NumberFormatException in Hive unit tests

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -194,8 +194,9 @@ public class HiveMetadataProvider {
    * Get the stats from table properties. If not found -1 is returned for each stats field.
    * CAUTION: stats may not be up-to-date with the underlying data. It is always good to run the ANALYZE command on
    * Hive table to have up-to-date stats.
-   * @param properties
-   * @return
+   *
+   * @param properties the source of table stats
+   * @return {@link HiveStats} instance with rows number and size in bytes from specified properties
    */
   private HiveStats getStatsFromProps(final Properties properties) {
     long numRows = -1;
@@ -208,7 +209,7 @@ public class HiveMetadataProvider {
 
       final String sizeInBytesProp = properties.getProperty(StatsSetupConst.TOTAL_SIZE);
       if (sizeInBytesProp != null) {
-        sizeInBytes = Long.valueOf(numRowsProp);
+        sizeInBytes = Long.valueOf(sizeInBytesProp);
       }
     } catch (final NumberFormatException e) {
       logger.error("Failed to parse Hive stats in metastore.", e);


### PR DESCRIPTION
There is no unit test since with or without this change tests are passes and query plan does not change. 

The exception that has been appeared caught and wrote into the logs.
After the check on [this line](https://github.com/apache/drill/blob/3e8b01d5b0d3013e3811913f0fd6028b22c1ac3f/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java#L90), correct stats was created calling [getStatsEstimateFromInputSplits()](https://github.com/apache/drill/blob/3e8b01d5b0d3013e3811913f0fd6028b22c1ac3f/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java#L95) method.