### PR TITLE
DRILL-5854: IllegalStateException when empty batch with valid schema …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
@@ -224,6 +224,7 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
         if (rawBatch == null) {
           createDummyBatch = true;
           rawBatches.add(rawBatch);
+          p++; // move to next sender
           continue;
         }
 


### PR DESCRIPTION
…is received

Problem is that merge receiver is reading from the wrong sender when first batch is empty from one of the senders.
When first batch is empty, we are continuing without moving to the next sender.