### PR TITLE
DRILL-5864: Handled projection of non-existent field in MapRDB JSON

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/MaprDBJsonRecordReader.java
@@ -157,6 +157,10 @@ public class MaprDBJsonRecordReader extends AbstractRecordReader {
       transformed.add(column);
     }
 
+    if (!transformed.contains(ID_PATH)) {
+      transformed.add(ID_PATH);
+    }
+
     if (projectedFieldsSet.size() > 0) {
       projectedFields = projectedFieldsSet.toArray(new FieldPath[projectedFieldsSet.size()]);
     }


### PR DESCRIPTION
When atleast one of the projected fields exists in the MapRDB JSON table, we don't have problem handling the non-existing fields.
Taking cue from this observation, I included _id field in the projected columns list if it is not already present. This way we don't have to worry about NPE.

@paul-rogers Please review