### PR TITLE
DRILL-5872: Workaround for invalid cost in physical plans

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/PhysicalPlan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/PhysicalPlan.java
@@ -94,6 +94,14 @@ public class PhysicalPlan {
     for (final PhysicalOperator ops : getSortedOperators()) {
       totalCost += ops.getCost();
     }
+
+    // As it turns out, sometimes the total cost can be out of range.
+    // This throws off other code, so clamp the cost at the maximum
+    // double value.
+
+    if (Double.isNaN(totalCost)) {
+      totalCost = Double.MAX_VALUE;
+    }
     return totalCost;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -419,8 +419,9 @@ public class Foreman implements Runnable {
     queryRM.visitAbstractPlan(plan);
     final QueryWorkUnit work = getQueryWorkUnit(plan);
     queryRM.visitPhysicalPlan(work);
-    queryRM.setCost(plan.totalCost());
-    queryManager.setTotalCost(plan.totalCost());
+    final double totalCost = plan.totalCost();
+    queryRM.setCost(totalCost);
+    queryManager.setTotalCost(totalCost);
     work.applyPlan(drillbitContext.getPlanReader());
     logWorkUnit(work);
     admit(work);


### PR DESCRIPTION
See DRILL-5872 for details.

Works around a bug in a storage plugin that produces NaN for a cost estimate, which then leads to profiles that can't be deserialized. This fix simply replaces the NaN in the profile with the maximum double value.

The real fix is that the storage plugin concerned should not produce NaN estimates.