### PR TITLE
DRILL-5876: Remove netty-tcnative dependency from java-exec/pom.xml

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>kr.motd.maven</groupId>
+    <artifactId>os-maven-plugin</artifactId>
+    <version>1.5.0.Final</version>
+  </extension>
+</extensions>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -699,6 +699,19 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>openssl</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative</artifactId>
+          <version>2.0.1.Final</version>
+          <classifier>${os.detected.classifier}</classifier>
+        </dependency>
+      </dependencies>
+      <build>
+      </build>
+    </profile>
   </profiles>
 
   <build>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -22,7 +22,10 @@
     <libpam4j.version>1.8-rev1</libpam4j.version>
     <!-- Configure the os-maven-plugin extension to expand the classifier on -->
     <!-- Fedora-"like" systems. Used for netty-tcnative inclusion -->
+    <!-- Uncomment the following to get a debug build that allows openssl support -->
+    <!--
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    -->
   </properties>
 
   <dependencies>
@@ -587,6 +590,8 @@
       <artifactId>libpam4j</artifactId>
       <version>${libpam4j.version}</version>
     </dependency>
+    <!-- Uncomment the following to get a debug build that allows openssl support -->
+    <!--
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
@@ -594,6 +599,7 @@
       <scope>provided</scope>
       <classifier>${os.detected.classifier}</classifier>
     </dependency>
+    -->
 
   </dependencies>
 
@@ -701,18 +707,21 @@
       <!--
       Include the os-maven-plugin to get os.detected.classifier
       -->
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
-      </extension>
-    </extensions>
+      <!-- Uncomment the following to get a debug build that allows openssl support -->
+      <!--
+        <extension>
+          <groupId>kr.motd.maven</groupId>
+          <artifactId>os-maven-plugin</artifactId>
+          <version>1.5.0.Final</version>
+        </extension>
+      -->
+      </extensions>
 
-    <plugins>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution> <!-- copy all templates/data in the same location to compile them at once -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <executions>
+            <execution> <!-- copy all templates/data in the same location to compile them at once -->
             <id>copy-fmpp-resources</id>
             <phase>initialize</phase>
             <goals><goal>copy-resources</goal></goals>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -66,6 +66,12 @@ public class SSLConfigClient extends SSLConfig {
       hsTimeout = DEFAULT_SSL_HANDSHAKE_TIMEOUT_MS;
     }
     handshakeTimeout = hsTimeout;
+    // If provider is OPENSSL then to debug or run this code in an IDE, you will need to enable
+    // the dependency on netty-tcnative. In exec/java-exec/pom.xml search for 'openssl support'
+    // and uncomment the required lines
+    // If the IDE is Eclipse, you will require an additional Eclipse plugin available here:
+    // http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.jar
+    // Note that this plugin requires you to start with a new workspace
     provider = getStringProperty(DrillProperties.TLS_PROVIDER, DEFAULT_SSL_PROVIDER);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -67,8 +67,8 @@ public class SSLConfigClient extends SSLConfig {
     }
     handshakeTimeout = hsTimeout;
     // If provider is OPENSSL then to debug or run this code in an IDE, you will need to enable
-    // the dependency on netty-tcnative. In exec/java-exec/pom.xml search for 'openssl support'
-    // and uncomment the required lines
+    // the dependency on netty-tcnative.
+    // Enable the openssl profile in the java-exec project
     // If the IDE is Eclipse, you will require an additional Eclipse plugin available here:
     // http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.jar
     // Note that this plugin requires you to start with a new workspace

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -92,6 +92,12 @@ public class SSLConfigServer extends SSLConfig {
         resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_KEYPASSWORD_TPL_KEY, mode));
     keyPassword = keyPass.isEmpty() ? keyStorePassword : keyPass;
     protocol = getConfigParamWithDefault(ExecConstants.SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL);
+    // If provider is OPENSSL then to debug or run this code in an IDE, you will need to enable
+    // the dependency on netty-tcnative. In exec/java-exec/pom.xml search for 'openssl support'
+    // and uncomment the required lines
+    // If the IDE is Eclipse, you will require an additional Eclipse plugin available here:
+    // http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.jar
+    // Note that this plugin requires you to start with a new workspace
     provider = getConfigParamWithDefault(ExecConstants.SSL_PROVIDER, DEFAULT_SSL_PROVIDER);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -93,8 +93,8 @@ public class SSLConfigServer extends SSLConfig {
     keyPassword = keyPass.isEmpty() ? keyStorePassword : keyPass;
     protocol = getConfigParamWithDefault(ExecConstants.SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL);
     // If provider is OPENSSL then to debug or run this code in an IDE, you will need to enable
-    // the dependency on netty-tcnative. In exec/java-exec/pom.xml search for 'openssl support'
-    // and uncomment the required lines
+    // the dependency on netty-tcnative.
+    // Enable the openssl profile in the java-exec project
     // If the IDE is Eclipse, you will require an additional Eclipse plugin available here:
     // http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.jar
     // Note that this plugin requires you to start with a new workspace


### PR DESCRIPTION
Commented out the netty-tcnative dependency. Tested build on command line, intellij. Ran unit tests.
@paul-rogers, @vrozov  Can you guys please review?
