### PR TITLE
DRILL-5873: (C++ Client) Improve SASL error reporting.

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -657,8 +657,11 @@ connectionStatus_t DrillClientImpl::handleAuthentication(const DrillUserProperti
         // Check the negotiated SSF value and change the handlers.
         if(m_encryptionCtxt.isEncryptionReqd()) {
             if(SASL_OK != m_saslAuthenticator->verifyAndUpdateSaslProps()) {
-                logMsg << m_encryptionCtxt << "]. Negotiated Parameter is invalid."
-                       << " Error: " << m_saslResultCode;
+                logMsg << m_encryptionCtxt
+                       << ", Mechanism: " << m_saslAuthenticator->getAuthMechanismName()
+                       << ", Error: " << m_saslResultCode
+                       << ", Cause: " << m_saslAuthenticator->getErrorMessage(m_saslResultCode);
+                logMsg << "]. Negotiated Parameter is invalid.";
                 DRILL_MT_LOG(DRILL_LOG(LOG_DEBUG) << logMsg.str() << std::endl;)
                 return handleConnError(CONN_AUTH_FAILED, logMsg.str().c_str());
             }
@@ -682,10 +685,10 @@ connectionStatus_t DrillClientImpl::handleAuthentication(const DrillUserProperti
                << ", Mechanism: " << m_saslAuthenticator->getAuthMechanismName()
                << ", Error: " << m_saslResultCode
                << ", Cause: " << m_saslAuthenticator->getErrorMessage(m_saslResultCode);
+        logMsg << "]. Check connection parameters?";
         DRILL_MT_LOG(DRILL_LOG(LOG_DEBUG) << logMsg.str() << std::endl;)
 
         // shuts down socket as well
-        logMsg << "]. Check connection parameters?";
         return handleConnError(CONN_AUTH_FAILED, logMsg.str().c_str());
     }
 }

--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -678,7 +678,10 @@ connectionStatus_t DrillClientImpl::handleAuthentication(const DrillUserProperti
         m_io_service.reset();
         return CONN_SUCCESS;
     } else {
-        logMsg << m_encryptionCtxt << ", Error: " << m_saslResultCode;
+        logMsg << m_encryptionCtxt
+               << ", Mechanism: " << m_saslAuthenticator->getAuthMechanismName()
+               << ", Error: " << m_saslResultCode
+               << ", Cause: " << m_saslAuthenticator->getErrorMessage(m_saslResultCode);
         DRILL_MT_LOG(DRILL_LOG(LOG_DEBUG) << logMsg.str() << std::endl;)
 
         // shuts down socket as well

--- a/contrib/native/client/src/clientlib/saslAuthenticatorImpl.cpp
+++ b/contrib/native/client/src/clientlib/saslAuthenticatorImpl.cpp
@@ -145,6 +145,7 @@ int SaslAuthenticatorImpl::init(const std::vector<std::string>& mechanisms, exec
             authMechanismToUse = value;
         }
     }
+    m_authMechanismName = authMechanismToUse;
     if (authMechanismToUse.empty()) return SASL_NOMECH;
 
     // check if requested mechanism is supported by server
@@ -316,5 +317,17 @@ int SaslAuthenticatorImpl::unwrap(const char* dataToUnWrap, const int& dataToUnW
     return sasl_decode(m_pConnection, dataToUnWrap, dataToUnWrapLen, output, &unWrappedLen);
 }
 
+const char* SaslAuthenticatorImpl::getErrorMessage(int errorCode) {
+    switch (errorCode) {
+        case SASL_NOMECH:
+            return "No mechanism found that meets requested properties ";
+        default:
+            return sasl_errdetail(m_pConnection);
+    }
+}
+
+    const std::string &SaslAuthenticatorImpl::getAuthMechanismName() const {
+        return m_authMechanismName;
+    }
 
 } /* namespace Drill */

--- a/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
+++ b/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
@@ -55,6 +55,10 @@ public:
 
     int unwrap(const char* dataToUnWrap, const int& dataToUnWrapLen, const char** output, uint32_t& unWrappedLen);
 
+    const std::string &getAuthMechanismName() const;
+
+    const char *getErrorMessage(int errorCode);
+
 private:
 
     static const std::map<std::string, std::string> MECHANISM_MAPPING;
@@ -67,10 +71,13 @@ private:
     std::string m_username;
     sasl_secret_t *m_ppwdSecret;
     EncryptionContext *m_pEncryptCtxt;
+    std::string m_authMechanismName; // used for debugging/error messages
 
+private:
     static int passwordCallback(sasl_conn_t *conn, void *context, int id, sasl_secret_t **psecret);
 
     static int userNameCallback(void *context, int id, const char **result, unsigned int *len);
+
 
     void setSecurityProps() const;
 };

--- a/contrib/native/client/src/clientlib/utils.cpp
+++ b/contrib/native/client/src/clientlib/utils.cpp
@@ -156,8 +156,8 @@ void EncryptionContext::reset() {
 
 std::ostream& operator<<(std::ostream &contextStream, const EncryptionContext& context) {
     contextStream << " Encryption: " << (context.isEncryptionReqd() ? "enabled" : "disabled");
-    contextStream << " ,MaxWrappedSize: " << context.getMaxWrappedSize();
-    contextStream << " ,WrapSizeLimit: " << context.getWrapSizeLimit();
+    contextStream << ", MaxWrappedSize: " << context.getMaxWrappedSize();
+    contextStream << ", WrapSizeLimit: " << context.getWrapSizeLimit();
     return contextStream;
 }
 


### PR DESCRIPTION
@sohami what do you think? I overrode the SASL_NOMECH error message. The message from the SASL library is very unfriendly.