### PR TITLE
DRILL-5877: - Fix travis build. Add *.pem and *.p12 files to rat excl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,8 @@
             <exclude>**/client/tags</exclude>
             <exclude>**/cmake_install.cmake</exclude>
             <exclude>**/ssl/*.csr</exclude>
+            <exclude>**/ssl/*.pem</exclude>
+            <exclude>**/ssl/*.p12</exclude>
             <exclude>**/*.tbl</exclude>
             <exclude>**/*.httpd</exclude>
             <exclude>**/*.autotools</exclude>


### PR DESCRIPTION
…usions. These files are binary files used in ssl tests.