### PR TITLE
DRILL-5878: TableNotFound exception is being reported for a wrong sto…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -77,6 +77,22 @@ public class SchemaUtilites {
     return findSchema(defaultSchema, schemaPathAsList);
   }
 
+  /**
+   * Utility function to get the commonPrefix schema between two supplied schemas.
+   * @param defaultSchema default schema
+   * @param schemaPath current schema path
+   * @param isCaseSensitive true if caseSensitive comparision is required.
+   * @return common prefix schemaPath
+   */
+  public static String getPrefixSchemaPath(final String defaultSchema, final String schemaPath, final boolean isCaseSensitive) {
+    if (!isCaseSensitive) {
+      return Strings.commonPrefix(defaultSchema.toLowerCase(), schemaPath.toLowerCase());
+    }
+    else {
+      return Strings.commonPrefix(defaultSchema, schemaPath);
+    }
+  }
+
   /** Utility method to search for schema path starting from the given <i>schema</i> reference */
   private static SchemaPlus searchSchemaTree(SchemaPlus schema, final List<String> schemaPath) {
     for (String schemaName : schemaPath) {
@@ -121,6 +137,9 @@ public class SchemaUtilites {
     return SCHEMA_PATH_JOINER.join(schemaPath);
   }
 
+  /** Utility method to get the schema path from one or more strings. */
+  public static String getSchemaPath(String s1, String s2, String... rest) { return SCHEMA_PATH_JOINER.join(s1,s2,rest); }
+
   /** Utility method to get the schema path as list for given schema instance. */
   public static List<String> getSchemaPathAsList(SchemaPlus schema) {
     if (isRootSchema(schema)) {
@@ -146,6 +165,16 @@ public class SchemaUtilites {
             givenSchemaPath)
         .addContext("Current default schema: ",
             isRootSchema(defaultSchema) ? "No default schema selected" : getSchemaPath(defaultSchema))
+        .build(logger);
+  }
+
+  /** Utility method to throw {@link UserException} with context information */
+  public static void throwSchemaNotFoundException(final String defaultSchema, final String givenSchemaPath) {
+    throw UserException.validationError()
+        .message("Schema [%s] is not valid with respect to either root schema or current default schema.",
+            givenSchemaPath)
+        .addContext("Current default schema: ",
+            defaultSchema.equals("") ? "No default schema selected" : defaultSchema)
         .build(logger);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -109,7 +109,7 @@ public class SchemaUtilites {
    * @return true if the given <i>schema</i> is root schema. False otherwise.
    */
   public static boolean isRootSchema(SchemaPlus schema) {
-    return schema.getParentSchema() == null;
+    return schema == null || schema.getParentSchema() == null;
   }
 
   /**
@@ -136,9 +136,6 @@ public class SchemaUtilites {
   public static String getSchemaPath(List<String> schemaPath) {
     return SCHEMA_PATH_JOINER.join(schemaPath);
   }
-
-  /** Utility method to get the schema path from one or more strings. */
-  public static String getSchemaPath(String s1, String s2, String... rest) { return SCHEMA_PATH_JOINER.join(s1,s2,rest); }
 
   /** Utility method to get the schema path as list for given schema instance. */
   public static List<String> getSchemaPathAsList(SchemaPlus schema) {
@@ -169,13 +166,13 @@ public class SchemaUtilites {
   }
 
   /** Utility method to throw {@link UserException} with context information */
-  public static void throwSchemaNotFoundException(final String defaultSchema, final String givenSchemaPath) {
+  public static void throwSchemaNotFoundException(final SchemaPlus defaultSchema, final List<String> givenSchemaPath) {
     throw UserException.validationError()
-        .message("Schema [%s] is not valid with respect to either root schema or current default schema.",
-            givenSchemaPath)
-        .addContext("Current default schema: ",
-            defaultSchema.equals("") ? "No default schema selected" : defaultSchema)
-        .build(logger);
+            .message("Schema [%s] is not valid with respect to either root schema or current default schema.",
+                    givenSchemaPath)
+            .addContext("Current default schema: ",
+                    isRootSchema(defaultSchema) ? "No default schema selected" : getSchemaPath(defaultSchema))
+            .build(logger);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -79,12 +79,19 @@ public class SchemaUtilites {
 
   /**
    * Utility function to get the commonPrefix schema between two supplied schemas.
+   *
+   * Eg: if the defaultSchema: dfs and the schemaPath is dfs.tmp.`cicks.json`
+   *     then this function returns dfs if (caseSensitive is not true
+   *     otherwise it returns empty string.
+   *
    * @param defaultSchema default schema
    * @param schemaPath current schema path
    * @param isCaseSensitive true if caseSensitive comparision is required.
    * @return common prefix schemaPath
    */
-  public static String getPrefixSchemaPath(final String defaultSchema, final String schemaPath, final boolean isCaseSensitive) {
+  public static String getPrefixSchemaPath(final String defaultSchema,
+                                           final String schemaPath,
+                                           final boolean isCaseSensitive) {
     if (!isCaseSensitive) {
       return Strings.commonPrefix(defaultSchema.toLowerCase(), schemaPath.toLowerCase());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -488,23 +488,38 @@ public class SqlConverter {
             .build(logger);
       }
 
+      RelOptTableImpl table = super.getTable(names);
+
       // Check the schema and throw a valid SchemaNotFound exception instead of TableNotFound exception.
+      if (table == null) {
+        isValidSchema(names);
+      }
+
+      return table;
+    }
+
+    /**
+     * check if the schema provided is a valid schema:
+     * <li>schema is not indicated (only one element in the names list)<li/>
+     *
+     * @param names             list of schema and table names, table name is always the last element
+     * @return throws a userexception if the schema is not valid.
+     */
+    private void isValidSchema(final List<String> names) throws UserException {
       SchemaPlus defaultSchema = session.getDefaultSchema(this.rootSchema);
       String defaultSchemaCombinedPath = SchemaUtilites.getSchemaPath(defaultSchema);
       List<String> schemaPath = Util.skipLast(names);
       String schemaPathCombined = SchemaUtilites.getSchemaPath(schemaPath);
       String commonPrefix = SchemaUtilites.getPrefixSchemaPath(defaultSchemaCombinedPath,
-                                                               schemaPathCombined,
-                                                               parserConfig.caseSensitive());
+              schemaPathCombined,
+              parserConfig.caseSensitive());
       boolean isPrefixDefaultPath = commonPrefix.length() == defaultSchemaCombinedPath.length();
       List<String> fullSchemaPath = Strings.isNullOrEmpty(defaultSchemaCombinedPath) ? schemaPath :
               isPrefixDefaultPath ? schemaPath : ListUtils.union(SchemaUtilites.getSchemaPathAsList(defaultSchema), schemaPath);
       if (names.size() > 1 && (SchemaUtilites.findSchema(this.rootSchema, fullSchemaPath) == null &&
-                               SchemaUtilites.findSchema(this.rootSchema, schemaPath) == null)) {
+              SchemaUtilites.findSchema(this.rootSchema, schemaPath) == null)) {
         SchemaUtilites.throwSchemaNotFoundException(defaultSchema, schemaPath);
       }
-
-      return super.getTable(names);
     }
 
     /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -63,4 +63,17 @@ public class TestFileSelection extends BaseTestQuery {
     }
   }
 
+  @Test(expected = Exception.class)
+  public void testWrongSchemaThrowsSchemaNotFound() throws Exception {
+    final String table = String.format("%s/empty", TestTools.getTestResourcesPath());
+    final String query = String.format("select * from dfs1.`%s`", table);
+    try {
+      testNoResult(query);
+    } catch (Exception ex) {
+      final String pattern = String.format("[dfs1] is not valid with respect to either root schema or current default schema").toLowerCase();
+      final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
+      assertTrue(isSchemaNotFound);
+      throw ex;
+    }
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -70,7 +70,7 @@ public class TestFileSelection extends BaseTestQuery {
     try {
       testNoResult(query);
     } catch (Exception ex) {
-      final String pattern = String.format("[dfs1] is not valid with respect to either root schema or current default schema").toLowerCase();
+      final String pattern = String.format("[[dfs1]] is not valid with respect to either root schema or current default schema").toLowerCase();
       final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
       assertTrue(isSchemaNotFound);
       throw ex;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -26,9 +26,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.drill.BaseTestQuery;
 import org.apache.drill.common.util.TestTools;
 import org.apache.hadoop.fs.FileStatus;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TestFileSelection extends BaseTestQuery {
   private static final List<FileStatus> EMPTY_STATUSES = ImmutableList.of();
@@ -59,20 +57,6 @@ public class TestFileSelection extends BaseTestQuery {
       final String pattern = String.format("%s' not found", table).toLowerCase();
       final boolean isTableNotFound = ex.getMessage().toLowerCase().contains(pattern);
       assertTrue(isTableNotFound);
-      throw ex;
-    }
-  }
-
-  @Test(expected = Exception.class)
-  public void testWrongSchemaThrowsSchemaNotFound() throws Exception {
-    final String table = String.format("%s/empty", TestTools.getTestResourcesPath());
-    final String query = String.format("select * from dfs1.`%s`", table);
-    try {
-      testNoResult(query);
-    } catch (Exception ex) {
-      final String pattern = String.format("[[dfs1]] is not valid with respect to either root schema or current default schema").toLowerCase();
-      final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
-      assertTrue(isSchemaNotFound);
       throw ex;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestSchemaNotFoundException.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestSchemaNotFoundException.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.dfs;
+
+import org.apache.drill.BaseTestQuery;
+import org.apache.drill.common.util.TestTools;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestSchemaNotFoundException extends BaseTestQuery {
+
+    @Test(expected = Exception.class)
+    public void testSchemaNotFoundForWrongStoragePlgn() throws Exception {
+        final String table = String.format("%s/empty", TestTools.getTestResourcesPath());
+        final String query = String.format("select * from dfs1.`%s`", table);
+        try {
+            testNoResult(query);
+        } catch (Exception ex) {
+            final String pattern = String.format("[[dfs1]] is not valid with respect to either root schema or current default schema").toLowerCase();
+            final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
+            assertTrue(isSchemaNotFound);
+            throw ex;
+        }
+    }
+
+    @Test(expected = Exception.class)
+    public void testSchemaNotFoundForWrongWorkspace() throws Exception {
+        final String table = String.format("%s/empty", TestTools.getTestResourcesPath());
+        final String query = String.format("select * from dfs.tmp1.`%s`", table);
+        try {
+            testNoResult(query);
+        } catch (Exception ex) {
+            final String pattern = String.format("[[dfs, tmp1]] is not valid with respect to either root schema or current default schema").toLowerCase();
+            final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
+            assertTrue(isSchemaNotFound);
+            throw ex;
+        }
+    }
+
+    @Test(expected = Exception.class)
+    public void testSchemaNotFoundForWrongWorkspaceUsingDefaultWorkspace() throws Exception {
+        final String table = String.format("%s/empty", TestTools.getTestResourcesPath());
+        final String query = String.format("select * from tmp1.`%s`", table);
+        try {
+            testNoResult("use dfs");
+            testNoResult(query);
+        } catch (Exception ex) {
+            final String pattern = String.format("[[tmp1]] is not valid with respect to either root schema or current default schema").toLowerCase();
+            final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
+            assertTrue(isSchemaNotFound);
+            throw ex;
+        }
+    }
+
+    @Test(expected = Exception.class)
+    public void testTableNotFoundException() throws Exception {
+        final String table = String.format("%s/empty1", TestTools.getTestResourcesPath());
+        final String query = String.format("select * from tmp.`%s`", table);
+        try {
+            testNoResult("use dfs");
+            testNoResult(query);
+        } catch (Exception ex) {
+            final String pattern = String.format("[[dfs, tmp1]] is not valid with respect to either root schema or current default schema").toLowerCase();
+            final boolean isSchemaNotFound = ex.getMessage().toLowerCase().contains(pattern);
+            final boolean isTableNotFound = ex.getMessage().toLowerCase().contains(String.format("%s' not found", table).toLowerCase());
+            assertTrue(!isSchemaNotFound && isTableNotFound);
+            throw ex;
+        }
+    }
+}


### PR DESCRIPTION
…rage plugin.

@paul-rogers  @chunhui-shi Please review these changes. These changes are for reporting a meaningful error in case of wrong storage plugin is specified in the query. Currently Drill reports TableNotFound exception for
1) if no storage plugin exists.
2) if no table with the tablename exists.
These changes report SchemaNotFound exception for case 1) and TableNotFound exception for 2).