### PR TITLE
DRILL-5888: Remove dependency of SSLConfig on hadoop.security package…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
@@ -128,7 +128,7 @@ public class UserClient
     this.allocator = allocator;
     this.supportComplexTypes = supportComplexTypes;
     try {
-      this.sslConfig = new SSLConfigBuilder().properties(properties).mode(SSLFactory.Mode.CLIENT)
+      this.sslConfig = new SSLConfigBuilder().properties(properties).mode(SSLConfig.Mode.CLIENT)
           .initializeSSLContext(true).validateKeyStore(false).build();
     } catch (DrillException e) {
       throw new InvalidConnectionInfoException(e.getMessage());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
@@ -83,7 +83,6 @@ import org.apache.drill.exec.rpc.security.plain.PlainFactory;
 import org.apache.drill.exec.rpc.security.SaslProperties;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.ssl.SSLFactory;
 import org.slf4j.Logger;
 
 import com.google.common.base.Strings;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -93,7 +93,7 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
     try {
       this.sslConfig = new SSLConfigBuilder()
           .config(context.getConfig())
-          .mode(SSLFactory.Mode.SERVER)
+          .mode(SSLConfig.Mode.SERVER)
           .initializeSSLContext(true)
           .validateKeyStore(true)
           .build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -62,7 +62,6 @@ import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
 import org.apache.drill.exec.work.user.UserWorker;
 import org.apache.hadoop.security.HadoopKerberosName;
-import org.apache.hadoop.security.ssl.SSLFactory;
 import org.slf4j.Logger;
 
 import com.google.protobuf.MessageLite;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -335,7 +335,7 @@ public class WebServer implements AutoCloseable {
     final SslContextFactory sslContextFactory = new SslContextFactory();
     SSLConfig ssl = new SSLConfigBuilder()
         .config(config)
-        .mode(SSLFactory.Mode.SERVER)
+        .mode(SSLConfig.Mode.SERVER)
         .initializeSSLContext(false)
         .validateKeyStore(true)
         .build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.server.rest.auth.DrillRestLoginService;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
 import org.apache.drill.exec.work.WorkManager;
-import org.apache.hadoop.security.ssl.SSLFactory;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.cert.X509v3CertificateBuilder;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
@@ -58,6 +58,12 @@ public abstract class SSLConfig {
   public static final String HADOOP_SSL_TRUSTSTORE_PASSWORD_TPL_KEY = "ssl.{0}.truststore.password";
   public static final String HADOOP_SSL_TRUSTSTORE_TYPE_TPL_KEY = "ssl.{0}.truststore.type";
 
+  // copy of Hadoop's SSLFactory.Mode. Done so that we do not
+  // need to include hadoop-common as a dependency in
+  // jdbc-all-jar.
+  public enum Mode { CLIENT, SERVER };
+
+
   public SSLConfig() {
   }
 
@@ -101,7 +107,7 @@ public abstract class SSLConfig {
 
   public abstract int getHandshakeTimeout();
 
-  public abstract SSLFactory.Mode getMode();
+  public abstract Mode getMode();
 
   public abstract boolean disableHostVerification();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
@@ -22,7 +22,6 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.hadoop.security.ssl.SSLFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigBuilder.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillConfigurationException;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.ssl.SSLFactory;
 
 import java.util.Properties;
 
@@ -34,7 +33,7 @@ public class SSLConfigBuilder {
   private DrillConfig config = null;
   private Configuration hadoopConfig = null;
   private Properties properties;
-  private SSLFactory.Mode mode = SSLFactory.Mode.SERVER;
+  private SSLConfig.Mode mode = SSLConfig.Mode.SERVER;
   private boolean initializeSSLContext = false;
   private boolean validateKeyStore = false;
 
@@ -43,12 +42,12 @@ public class SSLConfigBuilder {
   }
 
   public SSLConfig build() throws DrillException {
-    if (mode == SSLFactory.Mode.SERVER && config == null) {
+    if (mode == SSLConfig.Mode.SERVER && config == null) {
       throw new DrillConfigurationException(
           "Cannot create SSL configuration from null Drill configuration.");
     }
     SSLConfig sslConfig;
-    if (mode == SSLFactory.Mode.SERVER) {
+    if (mode == SSLConfig.Mode.SERVER) {
       sslConfig = new SSLConfigServer(config, hadoopConfig);
     } else {
       sslConfig = new SSLConfigClient(properties);
@@ -77,7 +76,7 @@ public class SSLConfigBuilder {
     return this;
   }
 
-  public SSLConfigBuilder mode(SSLFactory.Mode mode) {
+  public SSLConfigBuilder mode(SSLConfig.Mode mode) {
     this.mode = mode;
     return this;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -20,12 +20,9 @@ package org.apache.drill.exec.ssl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.ssl.SSLFactory;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -247,8 +247,8 @@ public class SSLConfigClient extends SSLConfig {
   }
 
   @Override
-  public SSLFactory.Mode getMode() {
-    return SSLFactory.Mode.CLIENT;
+  public Mode getMode() {
+    return Mode.CLIENT;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -26,7 +26,6 @@ import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.ssl.SSLFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -54,7 +53,7 @@ public class SSLConfigServer extends SSLConfig {
 
   public SSLConfigServer(DrillConfig config, Configuration hadoopConfig) throws DrillException {
     this.config = config;
-    SSLFactory.Mode mode = SSLFactory.Mode.SERVER;
+    Mode mode = Mode.SERVER;
     httpsEnabled =
         config.hasPath(ExecConstants.HTTP_ENABLE_SSL) && config.getBoolean(ExecConstants.HTTP_ENABLE_SSL);
     // For testing we will mock up a hadoop configuration, however for regular use, we find the actual hadoop config.
@@ -227,7 +226,7 @@ public class SSLConfigServer extends SSLConfig {
     return value;
   }
 
-  private String resolveHadoopPropertyName(String nameTemplate, SSLFactory.Mode mode) {
+  private String resolveHadoopPropertyName(String nameTemplate, Mode mode) {
     return MessageFormat.format(nameTemplate, mode.toString().toLowerCase());
   }
 
@@ -304,8 +303,8 @@ public class SSLConfigServer extends SSLConfig {
   }
 
   @Override
-  public SSLFactory.Mode getMode() {
-    return SSLFactory.Mode.SERVER;
+  public Mode getMode() {
+    return Mode.SERVER;
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.ssl.SSLConfig;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
 import org.apache.drill.test.ConfigBuilder;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.ssl.SSLFactory;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -144,7 +143,7 @@ public class TestSSLConfig {
   public void testInvalidHadoopKeystore() throws Exception {
     Configuration hadoopConfig = new Configuration();
     String hadoopSSLFileProp = MessageFormat
-        .format(HADOOP_SSL_CONF_TPL_KEY, SSLFactory.Mode.SERVER.toString().toLowerCase());
+        .format(HADOOP_SSL_CONF_TPL_KEY, SSLConfig.Mode.SERVER.toString().toLowerCase());
     hadoopConfig.set(hadoopSSLFileProp, "ssl-server-invalid.xml");
     ConfigBuilder config = new ConfigBuilder();
     config.put(ExecConstants.USER_SSL_ENABLED, true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -51,7 +51,7 @@ public class TestSSLConfig {
     try {
       SSLConfig sslv = new SSLConfigBuilder()
           .config(config.build())
-          .mode(SSLFactory.Mode.SERVER)
+          .mode(SSLConfig.Mode.SERVER)
           .initializeSSLContext(false)
           .validateKeyStore(true)
           .build();
@@ -73,7 +73,7 @@ public class TestSSLConfig {
     try {
       SSLConfig sslv = new SSLConfigBuilder()
           .config(config.build())
-          .mode(SSLFactory.Mode.SERVER)
+          .mode(SSLConfig.Mode.SERVER)
           .initializeSSLContext(false)
           .validateKeyStore(true)
           .build();
@@ -93,7 +93,7 @@ public class TestSSLConfig {
     try {
       SSLConfig sslv = new SSLConfigBuilder()
           .config(config.build())
-          .mode(SSLFactory.Mode.SERVER)
+          .mode(SSLConfig.Mode.SERVER)
           .initializeSSLContext(false)
           .validateKeyStore(true)
           .build();
@@ -113,7 +113,7 @@ public class TestSSLConfig {
     config.put("javax.net.ssl.keyStorePassword", "root");
     SSLConfig sslv = new SSLConfigBuilder()
         .config(config.build())
-        .mode(SSLFactory.Mode.SERVER)
+        .mode(SSLConfig.Mode.SERVER)
         .initializeSSLContext(false)
         .validateKeyStore(true)
         .build();
@@ -130,7 +130,7 @@ public class TestSSLConfig {
     config.put(ExecConstants.SSL_USE_HADOOP_CONF, false);
     SSLConfig sslv = new SSLConfigBuilder()
         .config(config.build())
-        .mode(SSLFactory.Mode.SERVER)
+        .mode(SSLConfig.Mode.SERVER)
         .initializeSSLContext(false)
         .validateKeyStore(true)
         .build();
@@ -153,7 +153,7 @@ public class TestSSLConfig {
     try {
       sslv = new SSLConfigBuilder()
           .config(config.build())
-          .mode(SSLFactory.Mode.SERVER)
+          .mode(SSLConfig.Mode.SERVER)
           .initializeSSLContext(false)
           .validateKeyStore(true)
           .hadoopConfig(hadoopConfig)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
@@ -24,7 +24,6 @@ import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.ssl.SSLFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;


### PR DESCRIPTION
…. This allows jdbc-all-jar to be built without hadoop dependencies.

The original  code used Hadoop's SSLFactory.Mode enum. The same enum is now replicated in 
the SSLConfig class. 

@arina-ielchiieva  please review 

