### PR TITLE
DRILL-5893: Reverted the number of forked test processes back to 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.version>4.11</dep.junit.version>
     <dep.slf4j.version>1.7.6</dep.slf4j.version>
     <dep.guava.version>18.0</dep.guava.version>
-    <forkCount>1C</forkCount>
+    <forkCount>2</forkCount>
     <parquet.version>1.8.1-drill-r0</parquet.version>
     <calcite.version>1.4.0-drill-r22</calcite.version>
     <janino.version>2.7.6</janino.version>


### PR DESCRIPTION
Reverting the number of forked test process back to a safe number, since the current default I added in  DRILL-5752 was too aggressive for build machines with a large number of cores. If you want to speed up the build you can do:

```
mvn clean install -DforkCount=1C
```