### PR TITLE
DRILL-5906: java.lang.NullPointerException while quering Hive ORC tables on MapR cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1747,7 +1747,7 @@
       <properties>
         <alt-hadoop>mapr</alt-hadoop>
         <rat.excludeSubprojects>true</rat.excludeSubprojects>
-        <hive.version>1.2.0-mapr-1608</hive.version>
+        <hive.version>1.2.0-mapr-1707</hive.version>
         <hbase.version>1.1.1-mapr-1602-m7-5.2.0</hbase.version>
         <hadoop.version>2.7.0-mapr-1607</hadoop.version>
       </properties>


### PR DESCRIPTION
- Upgrade drill to 1.2.0-mapr-1707 hive.version.