### PR TITLE
DRILL-5911: Upgrade esri-geometry-api version to 2.0.0 to avoid depen…

### DIFF
--- a/contrib/gis/pom.xml
+++ b/contrib/gis/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.esri.geometry</groupId>
 			<artifactId>esri-geometry-api</artifactId>
-			<version>1.2.1</version>
+			<version>2.0.0</version>
 		</dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
…dency on org.json library

Please see [DRILL-5911](https://issues.apache.org/jira/browse/DRILL-5911) for details.