### PR TITLE
DRILL-5924: native-client: Support user-specified CXX_FLAGS

### DIFF
--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -101,13 +101,14 @@ find_package(Boost 1.53.0 REQUIRED COMPONENTS regex system date_time chrono thre
 include_directories(${Boost_INCLUDE_DIRS})
 
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_EXE_LINKER_FLAGS "-lrt -lpthread")
-    set(CMAKE_CXX_FLAGS "-fPIC")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lrt -lpthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 endif()
 
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "/EHsc")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif()
 
 if(MSVC)

--- a/contrib/native/client/src/clientlib/CMakeLists.txt
+++ b/contrib/native/client/src/clientlib/CMakeLists.txt
@@ -50,7 +50,6 @@ set_property(
     )
 
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "/EHsc")
     add_definitions(-DDRILL_CLIENT_EXPORTS -D_SCL_SECURE_NO_WARNINGS)
 endif()
 

--- a/contrib/native/client/src/clientlib/y2038/CMakeLists.txt
+++ b/contrib/native/client/src/clientlib/y2038/CMakeLists.txt
@@ -18,14 +18,6 @@
 
 # Y2038 library
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_CXX_FLAGS "-fPIC")
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "-fPIC")
-endif()
-
 set (Y2038_SRC_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/time64.c
     )

--- a/contrib/native/client/src/protobuf/CMakeLists.txt
+++ b/contrib/native/client/src/protobuf/CMakeLists.txt
@@ -103,10 +103,6 @@ add_custom_target(cpProtobufs
 #message("ProtoHeaders =  ${ProtoHeaders}" )
 #message("ProtoIncludes =  ${ProtoIncludes}" )
 
-if(MSVC)
-    set(CMAKE_CXX_FLAGS "/EHsc")
-endif()
-
 add_library(protomsgs STATIC ${ProtoSources} ${ProtoHeaders} ${ProtoIncludes} )
 #set linker properties. The first time around, the protobufs generated files may not exist
 # and CMAKE will not be able to determine the linker type.


### PR DESCRIPTION
Also remove the redundant sets of `CMAKE_CXX_FLAGS`. They are set on a global scope so that there is no need to reset them more locally.