### PR TITLE
DRILL-5922 Fixed Child Allocator Leak. DRILL-5926 Stabalize TestValueVector tests.

### DIFF
--- a/common/src/test/java/org/apache/drill/test/DrillTest.java
+++ b/common/src/test/java/org/apache/drill/test/DrillTest.java
@@ -54,7 +54,7 @@ public class DrillTest {
   static MemWatcher memWatcher;
   static String className;
 
-  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(100000);
+  @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(100_000);
 
   @Rule public final TestLogReporter logOutcome = LOG_OUTCOME;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
@@ -115,7 +115,6 @@ public class SimpleParallelizer implements ParallelizationParameters {
    * @param foremanNode     The driving/foreman node for this query.  (this node)
    * @param queryId         The queryId for this query.
    * @param activeEndpoints The list of endpoints to consider for inclusion in planning this query.
-   * @param reader          Tool used to read JSON plans
    * @param rootFragment    The root node of the PhysicalPlan that we will be parallelizing.
    * @param session         UserSession of user who launched this query.
    * @param queryContextInfo Info related to the context when query has started.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -230,7 +230,7 @@ public class Drillbit implements AutoCloseable {
     waitForGracePeriod();
     stateManager.setState(DrillbitState.DRAINING);
     // wait for all the in-flight queries to finish
-    manager.waitToExit(this, forcefulShutdown);
+    manager.waitToExit(forcefulShutdown);
     //safe to exit
     registrationHandle = coord.update(registrationHandle, State.OFFLINE);
     stateManager.setState(DrillbitState.OFFLINE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -802,11 +802,16 @@ public class Foreman implements Runnable {
       fragmentsRunner.getBee().retireForeman(Foreman.this);
 
       try {
+        queryContext.close();
+      } catch (Exception e) {
+        logger.error("Unable to close query context for query {}", QueryIdHelper.getQueryId(queryId), e);
+      }
+
+      try {
         queryManager.close();
       } catch (final Exception e) {
         logger.warn("unable to close query manager", e);
       }
-
 
       queryStateProcessor.close();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/PlanSplitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/PlanSplitter.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
 import org.apache.drill.exec.proto.UserProtos.GetQueryPlanFragments;
 import org.apache.drill.exec.proto.UserProtos.QueryPlanFragments;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.util.Pointer;
@@ -64,7 +65,7 @@ public class PlanSplitter {
   public QueryPlanFragments planFragments(DrillbitContext dContext, QueryId queryId,
       GetQueryPlanFragments req, UserClientConnection connection) {
     QueryPlanFragments.Builder responseBuilder = QueryPlanFragments.newBuilder();
-    QueryContext queryContext = new QueryContext(connection.getSession(), dContext, queryId);
+    final QueryContext queryContext = new QueryContext(connection.getSession(), dContext, queryId);
 
     responseBuilder.setQueryId(queryId);
 
@@ -79,6 +80,14 @@ public class PlanSplitter {
       responseBuilder.setStatus(QueryState.FAILED);
       responseBuilder.setError(error);
     }
+
+    try {
+      queryContext.close();
+    } catch (Exception e) {
+      logger.error("Error closing QueryContext when getting plan fragments for query {}.",
+        QueryIdHelper.getQueryId(queryId), e);
+    }
+
     return responseBuilder.build();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestDynamicUDFSupport.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestDynamicUDFSupport.java
@@ -118,7 +118,6 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
         closeClient();
         FileUtils.cleanDirectory(udfDir);
         dirTestWatcher.clear();
-        setupDefaultTestCluster();
         setup();
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true
               -Ddrill.catastrophic_to_standard_out=true
-              -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=3072M
+              -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=4096M
               -Djava.net.preferIPv4Stack=true
               -Djava.awt.headless=true
               -XX:+CMSClassUnloadingEnabled -ea


### PR DESCRIPTION
## DRILL-5922

 - QueryContext was never closed when the Foreman finished. So the query child allocator was never closed.
 - The PlanSplitter created a QueryContext temporarily to construct an RPC message but never closed it.
 - The waitForExit method was error prone. Changed it to use the standard condition variable pattern.

## DRILL-5926

The TestValueVector tests would run out of memory. I simple increased the MaxDirectMemorySize for the forked test processes in the pom to avoid this.

