### PR TITLE
DRILL-5941: Skip header / footer improvements for Hive storage plugin

### DIFF
--- a/contrib/storage-hive/core/src/main/codegen/includes/license.ftl
+++ b/contrib/storage-hive/core/src/main/codegen/includes/license.ftl
@@ -1,5 +1,4 @@
-/*******************************************************************************
-
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,4 +14,4 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+*/

--- a/contrib/storage-hive/core/src/main/codegen/templates/HiveRecordReaders.java
+++ b/contrib/storage-hive/core/src/main/codegen/templates/HiveRecordReaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-/**
+/*
  * This template is used to generate different Hive record reader classes for different data formats
  * to avoid JIT profile pullusion. These readers are derived from HiveAbstractReader which implements
  * codes for init and setup stage, but the repeated - and performance critical part - next() method is
@@ -32,15 +32,17 @@
 <@pp.changeOutputFile name="/org/apache/drill/exec/store/hive/Hive${entry.hiveReader}Reader.java" />
 <#include "/@includes/license.ftl" />
 
-package org.apache.drill.exec.store.hive;
+package org.apache.drill.exec.store.hive.readers;
 
-import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.hive.HivePartition;
+import org.apache.drill.exec.store.hive.HiveTableWithColumnCache;
 import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.hadoop.io.Writable;
@@ -51,31 +53,26 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.serde2.SerDeException;
 
 import org.apache.hadoop.mapred.RecordReader;
+
 <#if entry.hasHeaderFooter == true>
-import org.apache.hadoop.hive.serde2.SerDe;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Queue;
-import java.util.Set;
-import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.drill.exec.store.hive.readers.inspectors.AbstractRecordsInspector;
+import org.apache.drill.exec.store.hive.readers.inspectors.DefaultRecordsInspector;
+import org.apache.drill.exec.store.hive.readers.inspectors.SkipFooterRecordsInspector;
+import org.apache.drill.exec.store.hive.HiveUtilities;
 import org.apache.hadoop.hive.serde.serdeConstants;
 </#if>
 
 public class Hive${entry.hiveReader}Reader extends HiveAbstractReader {
 
-  Object key;
 <#if entry.hasHeaderFooter == true>
-  SkipRecordsInspector skipRecordsInspector;
+  AbstractRecordsInspector recordsInspector;
 <#else>
   Object value;
 </#if>
 
-  public Hive${entry.hiveReader}Reader(HiveTableWithColumnCache table, HivePartition partition, InputSplit inputSplit, List<SchemaPath> projectedColumns,
-                       FragmentContext context, final HiveConf hiveConf,
-                       UserGroupInformation proxyUgi) throws ExecutionSetupException {
+  public Hive${entry.hiveReader}Reader(HiveTableWithColumnCache table, HivePartition partition, Collection<InputSplit> inputSplit, List<SchemaPath> projectedColumns,
+                      FragmentContext context, final HiveConf hiveConf,
+                      UserGroupInformation proxyUgi) throws ExecutionSetupException {
     super(table, partition, inputSplit, projectedColumns, context, hiveConf, proxyUgi);
   }
 
@@ -83,186 +80,70 @@ public class Hive${entry.hiveReader}Reader extends HiveAbstractReader {
 
     key = reader.createKey();
 <#if entry.hasHeaderFooter == true>
-    skipRecordsInspector = new SkipRecordsInspector(tableProperties, reader);
+    int skipHeaderCount = HiveUtilities.retrieveIntProperty(tableProperties, serdeConstants.HEADER_COUNT, -1);
+
+    // skip first N records to apply skip header policy
+    Object value = reader.createValue();
+    for (int i = 0; i < skipHeaderCount; i++) {
+      if (!hasNextValue(value)) {
+        // no more records to skip, we drained the table
+        empty = true;
+        break;
+      }
+    }
+
+    // if table was drained while skipping first N records, there is no need to check for skip footer logic
+    if (!empty) {
+      int skipFooterCount = HiveUtilities.retrieveIntProperty(tableProperties, serdeConstants.FOOTER_COUNT, -1);
+
+      // if we need to skip N last records, use records inspector which will buffer records while reading
+      if (skipFooterCount > 0) {
+        recordsInspector = new SkipFooterRecordsInspector(reader, skipFooterCount);
+      } else {
+        recordsInspector = new DefaultRecordsInspector(reader.createValue());
+      }
+    }
 <#else>
     value = reader.createValue();
 </#if>
 
   }
-  private void readHiveRecordAndInsertIntoRecordBatch(Object deSerializedValue, int outputRecordIndex) {
-    for (int i = 0; i < selectedStructFieldRefs.size(); i++) {
-      Object hiveValue = finalOI.getStructFieldData(deSerializedValue, selectedStructFieldRefs.get(i));
-      if (hiveValue != null) {
-        selectedColumnFieldConverters.get(i).setSafeValue(selectedColumnObjInspectors.get(i), hiveValue,
-          vectors.get(i), outputRecordIndex);
-      }
-    }
-  }
 
 <#if entry.hasHeaderFooter == true>
+
   @Override
   public int next() {
     for (ValueVector vv : vectors) {
       AllocationHelper.allocateNew(vv, TARGET_RECORD_COUNT);
     }
+
     if (empty) {
       setValueCountAndPopulatePartitionVectors(0);
       return 0;
     }
 
     try {
-      skipRecordsInspector.reset();
-      Object value;
+      // starting new batch, reset processed records count
+      recordsInspector.reset();
 
-      int recordCount = 0;
-
-      while (recordCount < TARGET_RECORD_COUNT && reader.next(key, value = skipRecordsInspector.getNextValue())) {
-        if (skipRecordsInspector.doSkipHeader(recordCount++)) {
-          continue;
-        }
-        Object bufferedValue = skipRecordsInspector.bufferAdd(value);
-        if (bufferedValue != null) {
-          Object deSerializedValue = partitionSerDe.deserialize((Writable) bufferedValue);
+      // process records till batch is full or all records were processed
+      while (!recordsInspector.isBatchFull() && hasNextValue(recordsInspector.getValueHolder())) {
+        Object value = recordsInspector.getNextValue();
+        if (value != null) {
+          Object deSerializedValue = partitionSerDe.deserialize((Writable) value);
           if (partTblObjectInspectorConverter != null) {
             deSerializedValue = partTblObjectInspectorConverter.convert(deSerializedValue);
           }
-          readHiveRecordAndInsertIntoRecordBatch(deSerializedValue, skipRecordsInspector.getActualCount());
-          skipRecordsInspector.incrementActualCount();
+          readHiveRecordAndInsertIntoRecordBatch(deSerializedValue, recordsInspector.getProcessedRecordCount());
+          recordsInspector.incrementProcessedRecordCount();
         }
-        skipRecordsInspector.incrementTempCount();
       }
-
-      setValueCountAndPopulatePartitionVectors(skipRecordsInspector.getActualCount());
-      skipRecordsInspector.updateContinuance();
-      return skipRecordsInspector.getActualCount();
-    } catch (IOException | SerDeException e) {
+      setValueCountAndPopulatePartitionVectors(recordsInspector.getProcessedRecordCount());
+      return recordsInspector.getProcessedRecordCount();
+    } catch (SerDeException e) {
       throw new DrillRuntimeException(e);
     }
   }
-
-/**
- * SkipRecordsInspector encapsulates logic to skip header and footer from file.
- * Logic is applicable only for predefined in constructor file formats.
- */
-protected class SkipRecordsInspector {
-
-  private final Set<Object> fileFormats;
-  private int headerCount;
-  private int footerCount;
-  private Queue<Object> footerBuffer;
-  // indicates if we continue reading the same file
-  private boolean continuance;
-  private int holderIndex;
-  private List<Object> valueHolder;
-  private int actualCount;
-  // actualCount without headerCount, used to determine holderIndex
-  private int tempCount;
-
-  protected SkipRecordsInspector(Properties tableProperties, RecordReader reader) {
-    this.fileFormats = new HashSet<Object>(Arrays.asList(org.apache.hadoop.mapred.TextInputFormat.class.getName()));
-    this.headerCount = retrievePositiveIntProperty(tableProperties, serdeConstants.HEADER_COUNT, 0);
-    this.footerCount = retrievePositiveIntProperty(tableProperties, serdeConstants.FOOTER_COUNT, 0);
-    logger.debug("skipRecordInspector: fileFormat {}, headerCount {}, footerCount {}",
-        this.fileFormats, this.headerCount, this.footerCount);
-    this.footerBuffer = Lists.newLinkedList();
-    this.continuance = false;
-    this.holderIndex = -1;
-    this.valueHolder = initializeValueHolder(reader, footerCount);
-    this.actualCount = 0;
-    this.tempCount = 0;
-  }
-
-  protected boolean doSkipHeader(int recordCount) {
-    return !continuance && recordCount < headerCount;
-  }
-
-  protected void reset() {
-    tempCount = holderIndex + 1;
-    actualCount = 0;
-    if (!continuance) {
-      footerBuffer.clear();
-    }
-  }
-
-  protected Object bufferAdd(Object value) throws SerDeException {
-    footerBuffer.add(value);
-    if (footerBuffer.size() <= footerCount) {
-      return null;
-    }
-    return footerBuffer.poll();
-  }
-
-  protected Object getNextValue() {
-    holderIndex = tempCount % getHolderSize();
-    return valueHolder.get(holderIndex);
-  }
-
-  private int getHolderSize() {
-    return valueHolder.size();
-  }
-
-  protected void updateContinuance() {
-    this.continuance = actualCount != 0;
-  }
-
-  protected int incrementTempCount() {
-    return ++tempCount;
-  }
-
-  protected int getActualCount() {
-    return actualCount;
-  }
-
-  protected int incrementActualCount() {
-    return ++actualCount;
-  }
-
-  /**
-   * Retrieves positive numeric property from Properties object by name.
-   * Return default value if
-   * 1. file format is absent in predefined file formats list
-   * 2. property doesn't exist in table properties
-   * 3. property value is negative
-   * otherwise casts value to int.
-   *
-   * @param tableProperties property holder
-   * @param propertyName    name of the property
-   * @param defaultValue    default value
-   * @return property numeric value
-   * @throws NumberFormatException if property value is non-numeric
-   */
-  protected int retrievePositiveIntProperty(Properties tableProperties, String propertyName, int defaultValue) {
-    int propertyIntValue = defaultValue;
-    if (!fileFormats.contains(tableProperties.get(hive_metastoreConstants.FILE_INPUT_FORMAT))) {
-      return propertyIntValue;
-    }
-    Object propertyObject = tableProperties.get(propertyName);
-    if (propertyObject != null) {
-      try {
-        propertyIntValue = Integer.valueOf((String) propertyObject);
-      } catch (NumberFormatException e) {
-        throw new NumberFormatException(String.format("Hive table property %s value '%s' is non-numeric", propertyName, propertyObject.toString()));
-      }
-    }
-    return propertyIntValue < 0 ? defaultValue : propertyIntValue;
-  }
-
-  /**
-   * Creates buffer of objects to be used as values, so these values can be re-used.
-   * Objects number depends on number of lines to skip in the end of the file plus one object.
-   *
-   * @param reader          RecordReader to return value object
-   * @param skipFooterLines number of lines to skip at the end of the file
-   * @return list of objects to be used as values
-   */
-  private List<Object> initializeValueHolder(RecordReader reader, int skipFooterLines) {
-    List<Object> valueHolder = new ArrayList<>(skipFooterLines + 1);
-    for (int i = 0; i <= skipFooterLines; i++) {
-      valueHolder.add(reader.createValue());
-    }
-    return valueHolder;
-  }
- }
 
 <#else>
   @Override
@@ -277,7 +158,7 @@ protected class SkipRecordsInspector {
 
     try {
       int recordCount = 0;
-      while (recordCount < TARGET_RECORD_COUNT && reader.next(key, value)) {
+      while (recordCount < TARGET_RECORD_COUNT && hasNextValue(value)) {
         Object deSerializedValue = partitionSerDe.deserialize((Writable) value);
         if (partTblObjectInspectorConverter != null) {
           deSerializedValue = partTblObjectInspectorConverter.convert(deSerializedValue);
@@ -288,7 +169,7 @@ protected class SkipRecordsInspector {
 
       setValueCountAndPopulatePartitionVectors(recordCount);
       return recordCount;
-    } catch (IOException | SerDeException e) {
+    } catch (SerDeException e) {
       throw new DrillRuntimeException(e);
     }
   }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetSubScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetSubScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -38,7 +38,7 @@ public class HiveDrillNativeParquetSubScan extends HiveSubScan {
   @JsonCreator
   public HiveDrillNativeParquetSubScan(@JacksonInject StoragePluginRegistry registry,
                                        @JsonProperty("userName") String userName,
-                                       @JsonProperty("splits") List<String> splits,
+                                       @JsonProperty("splits") List<List<String>> splits,
                                        @JsonProperty("hiveReadEntry") HiveReadEntry hiveReadEntry,
                                        @JsonProperty("splitClasses") List<String> splitClasses,
                                        @JsonProperty("columns") List<SchemaPath> columns,

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/AbstractReadersInitializer.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/AbstractReadersInitializer.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.initilializers;
+
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.RecordReader;
+import org.apache.drill.exec.store.hive.HivePartition;
+import org.apache.drill.exec.store.hive.HiveSubScan;
+import org.apache.drill.exec.store.hive.HiveTableWithColumnCache;
+import org.apache.drill.exec.store.hive.readers.HiveAbstractReader;
+import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Parent class for reader initializers which create reader based on reader class.
+ * Holds common logic how to create reader constructor and reader instance.
+ * Is responsible to ensure each child class implements logic for initializing record reader.
+ */
+public abstract class AbstractReadersInitializer {
+
+  protected final HiveSubScan config;
+
+  private final FragmentContext context;
+  private final Class<? extends HiveAbstractReader> readerClass;
+  private final UserGroupInformation proxyUgi;
+
+  public AbstractReadersInitializer(FragmentContext context, HiveSubScan config, Class<? extends HiveAbstractReader> readerClass) {
+    this.config = config;
+    this.context = context;
+    this.readerClass = readerClass;
+    this.proxyUgi = ImpersonationUtil.createProxyUgi(config.getUserName(), context.getQueryUserName());
+  }
+
+  protected Constructor<? extends HiveAbstractReader> createReaderConstructor() {
+    try {
+      return readerClass.getConstructor(HiveTableWithColumnCache.class, HivePartition.class,
+          Collection.class,
+          List.class, FragmentContext.class, HiveConf.class, UserGroupInformation.class);
+    } catch (ReflectiveOperationException e) {
+      throw new DrillRuntimeException(String.format("Unable to retrieve constructor for Hive reader class [%s]", readerClass), e);
+    }
+  }
+
+  protected HiveAbstractReader createReader(Constructor<? extends HiveAbstractReader> readerConstructor, Partition partition, Object split) {
+    try {
+      return readerConstructor.newInstance(config.getTable(), partition, split, config.getColumns(), context, config.getHiveConf(), proxyUgi);
+    } catch (ReflectiveOperationException e) {
+      throw new DrillRuntimeException(String.format("Unable to create instance for Hive reader [%s]", readerConstructor), e);
+    }
+  }
+
+  /**
+   * @return list of initialized records readers
+   */
+  public abstract List<RecordReader> init();
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/DefaultReadersInitializer.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/DefaultReadersInitializer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.initilializers;
+
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.RecordReader;
+import org.apache.drill.exec.store.hive.HivePartition;
+import org.apache.drill.exec.store.hive.HiveSubScan;
+import org.apache.drill.exec.store.hive.readers.HiveAbstractReader;
+import org.apache.drill.exec.store.hive.readers.initilializers.AbstractReadersInitializer;
+import org.apache.hadoop.mapred.InputSplit;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Creates separate record reader for each given input split group.
+ */
+public class DefaultReadersInitializer extends AbstractReadersInitializer {
+
+  public DefaultReadersInitializer(FragmentContext context, HiveSubScan config, Class<? extends HiveAbstractReader> readerClass) {
+    super(context, config, readerClass);
+  }
+
+  @Override
+  public List<RecordReader> init() {
+    List<List<InputSplit>> inputSplits = config.getInputSplits();
+    List<HivePartition> partitions = config.getPartitions();
+    boolean hasPartitions = partitions != null && !partitions.isEmpty();
+
+    List<RecordReader> readers = new ArrayList<>(inputSplits.size());
+    Constructor<? extends HiveAbstractReader> readerConstructor = createReaderConstructor();
+    for (int i = 0 ; i < inputSplits.size(); i++) {
+      readers.add(createReader(readerConstructor, hasPartitions ? partitions.get(i) : null, inputSplits.get(i)));
+    }
+    return readers;
+  }
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/EmptyReadersInitializer.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/EmptyReadersInitializer.java
@@ -15,26 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.hive;
+package org.apache.drill.exec.store.hive.readers.initilializers;
 
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.RecordReader;
+import org.apache.drill.exec.store.hive.HiveSubScan;
+import org.apache.drill.exec.store.hive.readers.HiveAbstractReader;
+import org.apache.drill.exec.store.hive.readers.initilializers.AbstractReadersInitializer;
+import org.apache.hadoop.mapred.InputSplit;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.drill.common.exceptions.ExecutionSetupException;
-import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.physical.impl.BatchCreator;
-import org.apache.drill.exec.physical.impl.ScanBatch;
-import org.apache.drill.exec.record.RecordBatch;
-import org.apache.drill.exec.store.hive.readers.initilializers.AbstractReadersInitializer;
-import org.apache.drill.exec.store.hive.readers.initilializers.ReadersInitializer;
+/**
+ * If table is empty creates an empty record reader to output the schema.
+ */
+public class EmptyReadersInitializer extends AbstractReadersInitializer {
 
-@SuppressWarnings("unused")
-public class HiveScanBatchCreator implements BatchCreator<HiveSubScan> {
+  public EmptyReadersInitializer(FragmentContext context, HiveSubScan config, Class<? extends HiveAbstractReader> readerClass) {
+    super(context, config, readerClass);
+  }
 
   @Override
-  public ScanBatch getBatch(FragmentContext context, HiveSubScan config, List<RecordBatch> children)
-      throws ExecutionSetupException {
-    AbstractReadersInitializer readersInitializer = ReadersInitializer.getInitializer(context, config);
-    return new ScanBatch(config, context, readersInitializer.init());
+  public List<RecordReader> init() {
+    List<RecordReader> readers = new ArrayList<>(1);
+    Constructor<? extends HiveAbstractReader> readerConstructor = createReaderConstructor();
+    readers.add(createReader(readerConstructor, null, null));
+    return readers;
   }
 
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/ReadersInitializer.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/ReadersInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.initilializers;
+
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.store.hive.HiveSubScan;
+import org.apache.drill.exec.store.hive.readers.HiveAbstractReader;
+import org.apache.drill.exec.store.hive.readers.HiveAvroReader;
+import org.apache.drill.exec.store.hive.readers.HiveDefaultReader;
+import org.apache.drill.exec.store.hive.readers.HiveOrcReader;
+import org.apache.drill.exec.store.hive.readers.HiveParquetReader;
+import org.apache.drill.exec.store.hive.readers.HiveRCFileReader;
+import org.apache.drill.exec.store.hive.readers.HiveTextReader;
+import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.mapred.TextInputFormat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReadersInitializer {
+
+  /**
+   * List of all available readers classes for a different Hive nativ formats:
+   * ORC, AVRO, RCFFile, Text and Parquet.
+   */
+  private static final Map<String, Class<? extends HiveAbstractReader>> READER_MAP = new HashMap<>();
+
+  static {
+    READER_MAP.put(OrcInputFormat.class.getCanonicalName(), HiveOrcReader.class);
+    READER_MAP.put(AvroContainerInputFormat.class.getCanonicalName(), HiveAvroReader.class);
+    READER_MAP.put(RCFileInputFormat.class.getCanonicalName(), HiveRCFileReader.class);
+    READER_MAP.put(MapredParquetInputFormat.class.getCanonicalName(), HiveParquetReader.class);
+    READER_MAP.put(TextInputFormat.class.getCanonicalName(), HiveTextReader.class);
+  }
+
+  /**
+   * Determines which reader initializer should be used got given table configuration.
+   * Decision is made based on table content and skip header / footer logic usage.
+   *
+   * @param context fragment context
+   * @param config Hive table config
+   * @return reader initializer
+   */
+  public static AbstractReadersInitializer getInitializer(FragmentContext context, HiveSubScan config) {
+    Class<? extends HiveAbstractReader> readerClass = getReaderClass(config);
+    if (config.getInputSplits().isEmpty()) {
+      return new EmptyReadersInitializer(context, config, readerClass);
+    } else {
+      return new DefaultReadersInitializer(context, config, readerClass);
+    }
+  }
+
+  /**
+   * Will try to find reader class based on Hive table input format.
+   * If reader class was not find, will use default reader class.
+   *
+   * @param config Hive table config
+   * @return reader class
+   */
+  private static Class<? extends HiveAbstractReader> getReaderClass(HiveSubScan config) {
+    final String formatName = config.getTable().getSd().getInputFormat();
+    Class<? extends HiveAbstractReader> readerClass = HiveDefaultReader.class;
+    if (READER_MAP.containsKey(formatName)) {
+      readerClass = READER_MAP.get(formatName);
+    }
+    return readerClass;
+  }
+
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/AbstractRecordsInspector.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/AbstractRecordsInspector.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.inspectors;
+
+import org.apache.drill.exec.store.hive.readers.HiveAbstractReader;
+
+/**
+ * Parent class for records inspectors which responsible for counting of processed records
+ * and managing free and used value holders.
+ */
+public abstract class AbstractRecordsInspector {
+
+  private int processedRecordCount;
+
+  /**
+   * Checks if current number of processed records does not exceed max batch size.
+   *
+   * @return true if reached max number of records in batch
+   */
+  public boolean isBatchFull() {
+    return processedRecordCount >= HiveAbstractReader.TARGET_RECORD_COUNT;
+  }
+
+  /**
+   * @return number of processed records
+   */
+  public int getProcessedRecordCount() {
+    return processedRecordCount;
+  }
+
+  /**
+   * Increments current number of processed records.
+   */
+  public void incrementProcessedRecordCount() {
+    processedRecordCount++;
+  }
+
+  /**
+   * When batch of data was sent, number of processed records should be reset.
+   */
+  public void reset() {
+    processedRecordCount = 0;
+  }
+
+  /**
+   * Returns value holder where next value will be written.
+   *
+   * @return value holder
+   */
+  public abstract Object getValueHolder();
+
+  /**
+   * @return value holder with written value
+   */
+  public abstract Object getNextValue();
+
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/DefaultRecordsInspector.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/DefaultRecordsInspector.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.inspectors;
+
+/**
+ * Default records inspector that uses the same value holder for each record.
+ * Each value once written is immediately processed thus value holder can be re-used.
+ */
+public class DefaultRecordsInspector extends AbstractRecordsInspector {
+
+  private final Object value;
+
+  public DefaultRecordsInspector(Object value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object getValueHolder() {
+    return value;
+  }
+
+  @Override
+  public Object getNextValue() {
+    return value;
+  }
+
+}

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/SkipFooterRecordsInspector.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/inspectors/SkipFooterRecordsInspector.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.hive.readers.inspectors;
+
+import org.apache.hadoop.mapred.RecordReader;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * To implement skip footer logic this records inspector will buffer N number of incoming read records in queue
+ * and make sure they are skipped when input is fully processed. FIFO method of queuing is used for these purposes.
+ */
+public class SkipFooterRecordsInspector extends AbstractRecordsInspector {
+
+  private final int footerCount;
+  private Queue<Object> footerBuffer;
+  private final List<Object> valueHolders;
+  private long readRecordsCount;
+
+  public SkipFooterRecordsInspector(RecordReader<Object, Object> reader, int footerCount) {
+    this.footerCount = footerCount;
+    this.footerBuffer = new LinkedList<>();
+    this.valueHolders = initializeValueHolders(reader, footerCount);
+  }
+
+  /**
+   * Returns next available value holder where value should be written from the cached value holders.
+   * Current available holder is determined by getting mod for actually read records.
+   *
+   * @return value holder
+   */
+  @Override
+  public Object getValueHolder() {
+    int availableHolderIndex = (int) readRecordsCount % valueHolders.size();
+    return valueHolders.get(availableHolderIndex);
+  }
+
+  /**
+   * Buffers current value holder with written value
+   * and returns last buffered value if number of buffered values exceeds N records to skip.
+   *
+   * @return next available value holder with written value, null otherwise
+   */
+  @Override
+  public Object getNextValue() {
+    footerBuffer.add(getValueHolder());
+    readRecordsCount++;
+    if (footerBuffer.size() <= footerCount) {
+      return null;
+    }
+    return footerBuffer.poll();
+  }
+
+  /**
+   * Creates buffer of value holders, so these holders can be re-used.
+   * Holders quantity depends on number of lines to skip in the end of the file plus one.
+   *
+   * @param reader record reader
+   * @param footerCount number of lines to skip at the end of the file
+   * @return list of value holders
+   */
+  private List<Object> initializeValueHolders(RecordReader<Object, Object> reader, int footerCount) {
+    List<Object> valueHolder = new ArrayList<>(footerCount + 1);
+    for (int i = 0; i <= footerCount; i++) {
+      valueHolder.add(reader.createValue());
+    }
+    return valueHolder;
+  }
+
+}

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestHiveStorage.java
@@ -493,33 +493,43 @@ public class TestHiveStorage extends HiveTestBase {
     }
   }
 
-  @Test // DRILL-3688
-  public void testIgnoreSkipHeaderFooterForRcfile() throws Exception {
+  @Test
+  public void testTableWithHeaderOnly() throws Exception {
     testBuilder()
-        .sqlQuery("select count(1) as cnt from hive.skipper.kv_rcfile_large")
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_header_only")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5000L)
+        .baselineValues(0L)
         .go();
   }
 
-  @Test // DRILL-3688
-  public void testIgnoreSkipHeaderFooterForParquet() throws Exception {
+  @Test
+  public void testTableWithFooterOnly() throws Exception {
     testBuilder()
-        .sqlQuery("select count(1) as cnt from hive.skipper.kv_parquet_large")
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_footer_only")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5000L)
+        .baselineValues(0L)
         .go();
   }
 
-  @Test // DRILL-3688
-  public void testIgnoreSkipHeaderFooterForSequencefile() throws Exception {
+  @Test
+  public void testTableWithHeaderFooterOnly() throws Exception {
     testBuilder()
-        .sqlQuery("select count(1) as cnt from hive.skipper.kv_sequencefile_large")
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_header_footer_only")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5000L)
+        .baselineValues(0L)
+        .go();
+  }
+
+  @Test
+  public void testSkipHeaderFooterForPartitionedTable() throws Exception {
+    testBuilder()
+        .sqlQuery("select count(1) as cnt from hive.skipper.kv_text_with_part")
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(4980L)
         .go();
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/TestInfoSchemaOnHiveStorage.java
@@ -67,9 +67,10 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineValues("hive.skipper", "kv_text_large")
         .baselineValues("hive.skipper", "kv_incorrect_skip_header")
         .baselineValues("hive.skipper", "kv_incorrect_skip_footer")
-        .baselineValues("hive.skipper", "kv_rcfile_large")
-        .baselineValues("hive.skipper", "kv_parquet_large")
-        .baselineValues("hive.skipper", "kv_sequencefile_large")
+        .baselineValues("hive.skipper", "kv_text_header_only")
+        .baselineValues("hive.skipper", "kv_text_footer_only")
+        .baselineValues("hive.skipper", "kv_text_header_footer_only")
+        .baselineValues("hive.skipper", "kv_text_with_part")
         .go();
   }
 
@@ -258,9 +259,10 @@ public class TestInfoSchemaOnHiveStorage extends HiveTestBase {
         .baselineValues("DRILL", "hive.skipper", "kv_text_large", "TABLE")
         .baselineValues("DRILL", "hive.skipper", "kv_incorrect_skip_header", "TABLE")
         .baselineValues("DRILL", "hive.skipper", "kv_incorrect_skip_footer", "TABLE")
-        .baselineValues("DRILL", "hive.skipper", "kv_rcfile_large", "TABLE")
-        .baselineValues("DRILL", "hive.skipper", "kv_parquet_large", "TABLE")
-        .baselineValues("DRILL", "hive.skipper", "kv_sequencefile_large", "TABLE")
+        .baselineValues("DRILL", "hive.skipper", "kv_text_header_only", "TABLE")
+        .baselineValues("DRILL", "hive.skipper", "kv_text_footer_only", "TABLE")
+        .baselineValues("DRILL", "hive.skipper", "kv_text_header_footer_only", "TABLE")
+        .baselineValues("DRILL", "hive.skipper", "kv_text_with_part", "TABLE")
         .go();
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/inspectors/SkipFooterRecordsInspectorTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/inspectors/SkipFooterRecordsInspectorTest.java
@@ -1,0 +1,84 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to you under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.drill.exec.store.hive.inspectors;
+
+import org.apache.drill.exec.store.hive.readers.inspectors.SkipFooterRecordsInspector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SkipFooterRecordsInspectorTest {
+
+  private static RecordReader<Object, Object> recordReader;
+
+  @BeforeClass
+  @SuppressWarnings("unchecked")
+  public static void init() {
+    recordReader = mock(RecordReader.class);
+    when(recordReader.createValue()).thenReturn(new Object());
+  }
+
+  @Test
+  public void testHolderReUsage() {
+    SkipFooterRecordsInspector inspector = new SkipFooterRecordsInspector(recordReader, 1);
+    // store first value holder
+    Object firstHolder = inspector.getValueHolder();
+
+    // return null since one record was buffered as footer
+    assertNull(inspector.getNextValue());
+
+    // store first value holder
+    Object secondHolder = inspector.getValueHolder();
+
+    // return value stored in first holder  now second holder is buffering the footer
+    assertEquals(secondHolder, inspector.getValueHolder());
+    assertEquals(firstHolder, inspector.getNextValue());
+
+    // return value stored in second holder, as now first holder is buffering the footer
+    assertEquals(firstHolder, inspector.getValueHolder());
+    assertEquals(secondHolder, inspector.getNextValue());
+  }
+
+  @Test
+  public void testReset() {
+    SkipFooterRecordsInspector inspector = new SkipFooterRecordsInspector(recordReader, 2);
+    assertEquals(0, inspector.getProcessedRecordCount());
+
+    // store second holder
+    inspector.getNextValue();
+    Object secondHolder = inspector.getValueHolder();
+    inspector.getNextValue();
+
+    // process n records and increment count, so we stop at second holder
+    for (int i = 0; i < 4; i++) {
+      inspector.getNextValue();
+      inspector.incrementProcessedRecordCount();
+    }
+    assertEquals(4, inspector.getProcessedRecordCount());
+    assertEquals(secondHolder, inspector.getValueHolder());
+
+    // reset and make sure we start from the last available holder
+    inspector.reset();
+    assertEquals(0, inspector.getProcessedRecordCount());
+    assertEquals(secondHolder, inspector.getValueHolder());
+  }
+}


### PR DESCRIPTION
Overview:
1. When table has header / footer process input splits fo the same file in one reader (bug fix for DRILL-5941).
2. Apply skip header logic during reader initialization only once to avoid checks during reading the data (DRILL-5106).
3. Apply skip footer logic only when footer is more then 0, otherwise default processing will be done without buffering data in queue (DRILL-5106).

Code changes:
1. AbstractReadersInitializer was introduced to factor out common logic during readers intialization.
It will have two implementations:
a. Default (each input split group gets its own reader);
b. Empty (for empty tables);

2. AbstractRecordsInspector was introduced to improve performance when table has footer is less or equals to 0.
It will have two implementations:
a. Default (records will be processed one by one without buffering);
b. SkipFooter (queue will be used to buffer N records that should be skipped in the end of file processing).

3. When text table has header / footer each table file should be read as one unit. When file is being read as several input splits, they should be grouped.
For this purpose LogicalInputSplit class was introduced which replaced InputSplitWrapper class. New class stores list of grouped input splits and returns information about splits on group level.
Please note, during planning input splits are grouped only when data is being read from text table has header / footer each table, otherwise each input split is treated separately.

4. Allow HiveAbstractReader to have multiple input splits instead of one.