### PR TITLE
DRILL-5801: Gantt chart (fragment timeline) enhancements

### DIFF
--- a/exec/java-exec/src/main/resources/rest/static/js/graph.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/graph.js
@@ -166,14 +166,15 @@ $(window).on('load',(function () {
             .attr("height", result.graph().height + 2 * padding);
     }
 
+    // Fragment Gantt Chart
     function buildtimingchart (svgdest, timetable) {
         var chartprops = {
-            "w" : 800,
-            "h" : -1,
+            "w" : 850,
+            "h" : 70,
             "svg" : svgdest,
             "bheight" : 2,
             "bpad" : 0,
-            "margin" : 50,
+            "margin" : 35,
             "scaler" : null,
             "colorer" : null,
         };
@@ -193,10 +194,15 @@ $(window).on('load',(function () {
 
         // backdrop
         chartprops.svg.append("g")
-            .selectAll("rect")
+          .selectAll("rect")
             .data(timetable)
             .enter()
-            .append("rect")
+          // TODO: Prototype to jump to related Major Fragment
+          //.append("a")
+          //  .attr("xlink:href", function(d) {
+          //     return "#fragment-" + parseInt(d.category);
+          //   })
+          .append("rect")
             .attr("x", 0)
             .attr("y", function(d, i) {return i * (chartprops.bheight + 2 * chartprops.bpad);})
             .attr("width", chartprops.w)
@@ -205,14 +211,25 @@ $(window).on('load',(function () {
             .attr("fill", function(d) {return d3.rgb(chartprops.colorer(d.category));})
             .attr("opacity", 0.1)
             .attr("transform", "translate(" + chartprops.margin + "," +
-                  chartprops.margin + ")");
+                  chartprops.margin + ")")
+            .attr("style", "cursor: pointer;")
+          .append("title")
+            .text(function(d) {
+                var id = parseInt(d.category);
+                return ((id < 10) ? ("0" + id) : id) + "-XX-XX";
+             });
 
         // bars
         chartprops.svg.append('g')
-            .selectAll("rect")
+          .selectAll("rect")
             .data(timetable)
             .enter()
-            .append("rect")
+          // TODO: Prototype to jump to related Major Fragment
+          //.append("a")
+          //  .attr("xlink:href", function(d) {
+          //     return "#fragment-" + parseInt(d.category);
+          //   })
+          .append("rect")
              //.attr("rx", 3)
              //.attr("ry", 3)
             .attr("x", function(d) {return chartprops.scaler(d.start) + chartprops.bpad;})
@@ -222,7 +239,13 @@ $(window).on('load',(function () {
             .attr("stroke", "none")
             .attr("fill", function(d) {return d3.rgb(chartprops.colorer(d.category));})
             .attr("transform", "translate(" + chartprops.margin + "," +
-                  chartprops.margin + ")");
+                  chartprops.margin + ")")
+            .attr("style", "cursor: pointer;")
+          .append("title")
+            .text(function(d) {
+                var id = parseInt(d.category);
+                return ((id < 10) ? ("0" + id) : id) + "-XX-XX";
+            });
 
         // grid lines
         chartprops.svg.append("g")
@@ -248,6 +271,25 @@ $(window).on('load',(function () {
                   .orient('bottom')
                   .tickSize(0, 0)
                   .tickFormat(d3.format(".2f")));
+
+        // X Axis Label (Centered above graph)
+        chartprops.svg.append("text")
+            .attr("transform", "rotate(0)")
+            .attr("y", 0)
+            .attr("x", chartprops.w/2 + chartprops.margin)
+            .attr("dy", "1.5em")
+            .style("text-anchor", "middle")
+            .text("Elapsed Timeline");
+
+        //Y Axis (center of y axis)
+        chartprops.svg.append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", 0)
+            // Aligning to center of Y-axis with minimum Svg height
+            .attr("x",0 - Math.max(chartprops.h/2 + chartprops.margin, 36))
+            .attr("dy", "1.5em")
+            .style("text-anchor", "middle")
+            .html("Fragments"); 
     }
 
     function loadprofile (queryid, callback) {


### PR DESCRIPTION
1. Labelled X and Y axes on the Gantt Chart that expresses the fragments' timelines
2. Support mouse hover to reveal major fragment ID

* With 104 minor fragments / 5 major fragments : _You can see the tooltip (mouse pointer was not captured in screenshot)_
![image](https://user-images.githubusercontent.com/4335237/32798813-b55b6f52-c92a-11e7-80b0-205f95e35081.png)

* With 14 minor fragments / 4 major fragments : _Check for label alignment_
![image](https://user-images.githubusercontent.com/4335237/32798883-e57f4f1e-c92a-11e7-9ce0-b2522f42c584.png)

* With 1 minor fragment / 1 major fragment : _Check for label alignment_
![image](https://user-images.githubusercontent.com/4335237/32798928-07a5f21e-c92b-11e7-9f14-9ee2e2605719.png)
