### PR TITLE
DRILL-5972: Slow performance for query on INFORMATION_SCHEMA.TABLE

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -202,14 +202,19 @@ public class InfoSchemaFilter {
         // If at least one arg returns FALSE, then the AND function value is FALSE
         // If at least one arg returns INCONCLUSIVE, then the AND function value is INCONCLUSIVE
         // If all args return TRUE, then the AND function value is TRUE
+        Result result = Result.TRUE;
+
         for(ExprNode arg : exprNode.args) {
           Result exprResult = evaluateHelper(recordValues, arg);
-          if (exprResult != Result.TRUE) {
+          if (exprResult == Result.FALSE) {
             return exprResult;
+          }
+          if (exprResult == Result.INCONCLUSIVE) {
+            result = Result.INCONCLUSIVE;
           }
         }
 
-        return Result.TRUE;
+        return result;
       }
 
       case "in": {


### PR DESCRIPTION
Please see DRILL-5972.
Problem is while evaluating "boolean and", we are returning as soon as expression result is not TRUE. We should go through all the expressions and if any of them is FALSE, return FALSE. If any of them is INCONCLUSIVE, return INCONCLUSIVE. 
Tested the fix with lot of hive tables and verified that it fixes the performance problem.

