### PR TITLE
DRILL-5980: Making queryType param for REST client case-insensitive

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -43,7 +43,7 @@ public class QueryWrapper {
   @JsonCreator
   public QueryWrapper(@JsonProperty("query") String query, @JsonProperty("queryType") String queryType) {
     this.query = query;
-    this.queryType = queryType;
+    this.queryType = queryType.toUpperCase();
   }
 
   public String getQuery() {


### PR DESCRIPTION
Fixes #5980