### PR TITLE
DRILL-5964: Do not allow queries to access paths outside the current …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSelection.java
@@ -259,7 +259,7 @@ public class FileSelection {
 
     final Path combined = new Path(parent, removeLeadingSlash(path));
     if (!allowAccessOutsideWorkspace) {
-      checkBackPaths(parent, combined.toString(), path);
+      checkBackPaths(new Path(parent).toUri().getPath(), combined.toUri().getPath(), path);
     }
     final FileStatus[] statuses = fs.globStatus(combined); // note: this would expand wildcards
     if (statuses == null) {
@@ -372,19 +372,23 @@ public class FileSelection {
     }
   }
 
-  // Check if the path is a valid sub path under the parent after removing backpaths. Throw an exception if
-  // it is not
-  // We pass subpath in as a parameter only for the error message
-  public static boolean checkBackPaths(String parent, String combinedPath, String subpath) {
-    Preconditions.checkArgument(!parent.isEmpty());
-    Preconditions.checkArgument(!combinedPath.isEmpty());
+  /**
+   * Check if the path is a valid sub path under the parent after removing backpaths. Throw an exception if
+   * it is not. We pass subpath in as a parameter only for the error message
+   *
+   * @param parent The parent path (the workspace directory).
+   * @param combinedPath The workspace directory and (relative) subpath path combined.
+   * @param subpath For error message only, the subpath
+   */
+  public static void checkBackPaths(String parent, String combinedPath, String subpath) {
+    Preconditions.checkArgument(!parent.isEmpty(), "Invalid root (" + parent + ") in file selection path.");
+    Preconditions.checkArgument(!combinedPath.isEmpty(), "Empty path (" + combinedPath + "( in file selection path.");
 
     if (!combinedPath.startsWith(parent)) {
       StringBuilder msg = new StringBuilder();
       msg.append("Invalid path : ").append(subpath).append(" takes you outside the workspace.");
       throw new IllegalArgumentException(msg.toString());
     }
-    return true;
   }
 
   public List<FileStatus> getFileStatuses() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *  - writable flag to indicate whether the location supports creating new tables.
  *  - default storage format for new tables created in this workspace.
  */
-@JsonIgnoreProperties(value = {"storageformat"})
+@JsonIgnoreProperties(value = {"storageformat"}, ignoreUnknown = true)
+
 public class WorkspaceConfig {
 
   /** Default workspace is a root directory which supports read, but not write. */
@@ -35,20 +36,18 @@ public class WorkspaceConfig {
   private final String location;
   private final boolean writable;
   private final String defaultInputFormat;
-  private final Boolean allowAccessOutsideWorkspace; // allow access outside the workspace by default. This
-                                                     // field is a Boolean (not boolean) so that we can
-                                                     // assign a default value if it is not defined in a
-                                                     // storage plugin config
+  private final boolean allowAccessOutsideWorkspace; // do not allow access outside the workspace by default.
+                                                     // For backward compatibility, the user can turn this
+                                                     // on.
   public WorkspaceConfig(@JsonProperty("location") String location,
                          @JsonProperty("writable") boolean writable,
                          @JsonProperty("defaultInputFormat") String defaultInputFormat,
-                         @JsonProperty("allowAccessOutsideWorkspace") Boolean allowAccessOutsideWorkspace
+                         @JsonProperty("allowAccessOutsideWorkspace") boolean allowAccessOutsideWorkspace
       ) {
     this.location = location;
     this.writable = writable;
     this.defaultInputFormat = defaultInputFormat;
-    //this.allowAccessOutsideWorkspace = allowAccessOutsideWorkspace != null ? allowAccessOutsideWorkspace : false ;
-    this.allowAccessOutsideWorkspace = true;
+    this.allowAccessOutsideWorkspace = allowAccessOutsideWorkspace;
   }
 
   public String getLocation() {
@@ -76,7 +75,7 @@ public class WorkspaceConfig {
     result = prime * result + ((defaultInputFormat == null) ? 0 : defaultInputFormat.hashCode());
     result = prime * result + ((location == null) ? 0 : location.hashCode());
     result = prime * result + (writable ? 1231 : 1237);
-    result = prime * result + ((allowAccessOutsideWorkspace == null) ? 0 : allowAccessOutsideWorkspace.hashCode());
+    result = prime * result + (allowAccessOutsideWorkspace ? 1231 : 1237);
     return result;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
@@ -47,7 +47,8 @@ public class WorkspaceConfig {
     this.location = location;
     this.writable = writable;
     this.defaultInputFormat = defaultInputFormat;
-    this.allowAccessOutsideWorkspace = allowAccessOutsideWorkspace != null ? allowAccessOutsideWorkspace : false ;
+    //this.allowAccessOutsideWorkspace = allowAccessOutsideWorkspace != null ? allowAccessOutsideWorkspace : false ;
+    this.allowAccessOutsideWorkspace = true;
   }
 
   public String getLocation() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceConfig.java
@@ -30,18 +30,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class WorkspaceConfig {
 
   /** Default workspace is a root directory which supports read, but not write. */
-  public static final WorkspaceConfig DEFAULT = new WorkspaceConfig("/", false, null);
+  public static final WorkspaceConfig DEFAULT = new WorkspaceConfig("/", false, null, false);
 
   private final String location;
   private final boolean writable;
   private final String defaultInputFormat;
-
+  private final Boolean allowAccessOutsideWorkspace; // allow access outside the workspace by default. This
+                                                     // field is a Boolean (not boolean) so that we can
+                                                     // assign a default value if it is not defined in a
+                                                     // storage plugin config
   public WorkspaceConfig(@JsonProperty("location") String location,
                          @JsonProperty("writable") boolean writable,
-                         @JsonProperty("defaultInputFormat") String defaultInputFormat) {
+                         @JsonProperty("defaultInputFormat") String defaultInputFormat,
+                         @JsonProperty("allowAccessOutsideWorkspace") Boolean allowAccessOutsideWorkspace
+      ) {
     this.location = location;
     this.writable = writable;
     this.defaultInputFormat = defaultInputFormat;
+    this.allowAccessOutsideWorkspace = allowAccessOutsideWorkspace != null ? allowAccessOutsideWorkspace : false ;
   }
 
   public String getLocation() {
@@ -56,6 +62,12 @@ public class WorkspaceConfig {
     return defaultInputFormat;
   }
 
+  @JsonProperty
+  public Boolean allowAccessOutsideWorkspace() {
+    return allowAccessOutsideWorkspace;
+  }
+
+
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -63,6 +75,7 @@ public class WorkspaceConfig {
     result = prime * result + ((defaultInputFormat == null) ? 0 : defaultInputFormat.hashCode());
     result = prime * result + ((location == null) ? 0 : location.hashCode());
     result = prime * result + (writable ? 1231 : 1237);
+    result = prime * result + ((allowAccessOutsideWorkspace == null) ? 0 : allowAccessOutsideWorkspace.hashCode());
     return result;
   }
 
@@ -93,6 +106,9 @@ public class WorkspaceConfig {
       return false;
     }
     if (writable != other.writable) {
+      return false;
+    }
+    if (allowAccessOutsideWorkspace != other.allowAccessOutsideWorkspace) {
       return false;
     }
     return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
@@ -171,7 +171,7 @@ public class WorkspaceSchemaFactory {
        * In other cases, we use access method since it is cheaper.
        */
       if (SystemUtils.IS_OS_WINDOWS && fs.getUri().getScheme().equalsIgnoreCase(FileSystemSchemaFactory.LOCAL_FS_SCHEME)) {
-        fs.listStatus(wsPath);
+      fs.listStatus(wsPath);
       }
       else {
         fs.access(wsPath, FsAction.READ);
@@ -192,7 +192,7 @@ public class WorkspaceSchemaFactory {
   public WorkspaceSchema createSchema(List<String> parentSchemaPath, SchemaConfig schemaConfig, DrillFileSystem fs) throws IOException {
     if (!accessible(fs)) {
       return null;
-    }
+  }
     return new WorkspaceSchema(parentSchemaPath, schemaName, schemaConfig, fs);
   }
 
@@ -257,7 +257,7 @@ public class WorkspaceSchemaFactory {
             .validationError()
             .message("Unable to find table [%s] in schema [%s]", sig.name, schema.getFullSchemaName())
             .build(logger);
-      }
+    }
       return new DrillTranslatableTable(drillTable);
     }
 
@@ -605,7 +605,8 @@ public class WorkspaceSchemaFactory {
     @Override
     public DrillTable create(TableInstance key) {
       try {
-        final FileSelection fileSelection = FileSelection.create(getFS(), config.getLocation(), key.sig.name);
+        final FileSelection fileSelection = FileSelection
+            .create(getFS(), config.getLocation(), key.sig.name, config.allowAccessOutsideWorkspace());
         if (fileSelection == null) {
           return null;
         }
@@ -684,7 +685,8 @@ public class WorkspaceSchemaFactory {
      * @throws IOException is case of problems accessing table files
      */
     private boolean isHomogeneous(String tableName) throws IOException {
-      FileSelection fileSelection = FileSelection.create(getFS(), config.getLocation(), tableName);
+      FileSelection fileSelection =
+          FileSelection.create(getFS(), config.getLocation(), tableName, config.allowAccessOutsideWorkspace());
 
       if (fileSelection == null) {
         throw UserException

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
@@ -77,7 +77,7 @@ public class StoragePluginTestUtils {
     for (String schema: schemas) {
       WorkspaceConfig workspaceConfig = pluginConfig.workspaces.get(schema);
       String inputFormat = workspaceConfig == null ? null: workspaceConfig.getDefaultInputFormat();
-      WorkspaceConfig newWorkspaceConfig = new WorkspaceConfig(tmpDirPath.getAbsolutePath(), true, inputFormat);
+      WorkspaceConfig newWorkspaceConfig = new WorkspaceConfig(tmpDirPath.getAbsolutePath(), true, inputFormat, false);
       workspaces.put(schema, newWorkspaceConfig);
     }
 

--- a/exec/java-exec/src/main/resources/bootstrap-storage-plugins.json
+++ b/exec/java-exec/src/main/resources/bootstrap-storage-plugins.json
@@ -6,11 +6,13 @@
       workspaces: {
         "root" : {
           location: "/",
-          writable: false
+          writable: false,
+          allowAccessOutsideWorkspace: false
         },
         "tmp" : {
           location: "/tmp",
-          writable: true
+          writable: true,
+          allowAccessOutsideWorkspace: false
         }
       },
       formats: {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -566,8 +566,8 @@ public class TestExampleQueries extends BaseTestQuery {
         expectedRecordCount, actualRecordCount), expectedRecordCount, actualRecordCount);
 
     // source is CSV
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/regions.csv").toURI().toString();
-    String query = String.format("select rid, x.name from (select columns[0] as RID, columns[1] as NAME from dfs.`%s`) X where X.rid = 2", root);
+    String root = "store/text/data/regions.csv";
+    String query = String.format("select rid, x.name from (select columns[0] as RID, columns[1] as NAME from cp.`%s`) X where X.rid = 2", root);
     actualRecordCount = testSql(query);
     expectedRecordCount = 1;
     assertEquals(String.format("Received unexpected number of rows in output: expected=%d, received=%s",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
@@ -513,9 +513,9 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test
   public void testCompoundIdentifierInWindowDefinition() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/multilevel/csv/1994/Q1/orders_94_q1.csv").toURI().toString();
+    String root = "/multilevel/csv/1994/Q1/orders_94_q1.csv";
     String query = String.format("SELECT count(*) OVER w as col1, count(*) OVER w as col2 \n" +
-        "FROM dfs.`%s` \n" +
+        "FROM cp.`%s` \n" +
         "WINDOW w AS (PARTITION BY columns[1] ORDER BY columns[0] DESC)", root);
 
     // Validate the plan
@@ -609,11 +609,11 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test // DRILL-3567
   public void testMultiplePartitions1() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/t.json").toURI().toString();
+    String root = "/store/text/data/t.json";
     String query = String.format("select count(*) over(partition by b1 order by c1) as count1, \n" +
         "sum(a1)  over(partition by b1 order by c1) as sum1, \n" +
         "count(*) over(partition by a1 order by c1) as count2 \n" +
-        "from dfs.`%s`", root);
+        "from cp.`%s`", root);
 
     // Validate the plan
     final String[] expectedPlan = {"Window.*partition \\{2\\} order by \\[1\\].*COUNT\\(\\)",
@@ -642,11 +642,11 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test // DRILL-3567
   public void testMultiplePartitions2() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/t.json").toURI().toString();
+    String root = "/store/text/data/t.json";
     String query = String.format("select count(*) over(partition by b1 order by c1) as count1, \n" +
         "count(*) over(partition by a1 order by c1) as count2, \n" +
         "sum(a1)  over(partition by b1 order by c1) as sum1 \n" +
-        "from dfs.`%s`", root);
+        "from cp.`%s`", root);
 
     // Validate the plan
     final String[] expectedPlan = {"Window.*partition \\{2\\} order by \\[1\\].*COUNT\\(\\)",
@@ -675,9 +675,9 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test // see DRILL-3574
   public void testWithAndWithoutPartitions() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/t.json").toURI().toString();
+    String root = "/store/text/data/t.json";
     String query = String.format("select sum(a1) over(partition by b1, c1) as s1, sum(a1) over() as s2 \n" +
-        "from dfs.`%s` \n" +
+        "from cp.`%s` \n" +
         "order by a1", root);
     test("alter session set `planner.slice_target` = 1");
 
@@ -706,10 +706,10 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test // see DRILL-3657
   public void testConstantsInMultiplePartitions() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/t.json").toURI().toString();
+    String root = "/store/text/data/t.json";
     String query = String.format(
         "select sum(1) over(partition by b1 order by a1) as sum1, sum(1) over(partition by a1) as sum2, rank() over(order by b1) as rank1, rank() over(order by 1) as rank2 \n" +
-        "from dfs.`%s` \n" +
+        "from cp.`%s` \n" +
         "order by 1, 2, 3, 4", root);
 
     // Validate the plan
@@ -740,9 +740,9 @@ public class TestWindowFunctions extends BaseTestQuery {
 
   @Test // DRILL-3580
   public void testExpressionInWindowFunction() throws Exception {
-    String root = DrillFileUtils.getResourceAsFile("/store/text/data/t.json").toURI().toString();
+    String root = "/store/text/data/t.json";
     String query = String.format("select a1, b1, sum(b1) over (partition by a1) as c1, sum(a1 + b1) over (partition by a1) as c2\n" +
-        "from dfs.`%s`", root);
+        "from cp.`%s`", root);
 
     // Validate the plan
     final String[] expectedPlan = {"Window\\(window#0=\\[window\\(partition \\{0\\} order by \\[\\].*\\[SUM\\(\\$1\\), SUM\\(\\$2\\)\\]"};

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/BaseTestImpersonation.java
@@ -146,7 +146,7 @@ public class BaseTestImpersonation extends PlanTestBase {
     final Path dirPath = new Path(path);
     FileSystem.mkdirs(fs, dirPath, new FsPermission(permissions));
     fs.setOwner(dirPath, owner, group);
-    final WorkspaceConfig ws = new WorkspaceConfig(path, true, "parquet");
+    final WorkspaceConfig ws = new WorkspaceConfig(path, true, "parquet", false);
     workspaces.put(name, ws);
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
@@ -75,7 +75,7 @@ public class TestCTTAS extends BaseTestQuery {
 
     StoragePluginRegistry pluginRegistry = getDrillbitContext().getStorage();
     FileSystemConfig pluginConfig = (FileSystemConfig) pluginRegistry.getPlugin(DFS_PLUGIN_NAME).getConfig();
-    pluginConfig.workspaces.put(temp2_wk, new WorkspaceConfig(tmp2.getAbsolutePath(), true, null));
+    pluginConfig.workspaces.put(temp2_wk, new WorkspaceConfig(tmp2.getAbsolutePath(), true, null, false));
     pluginRegistry.createOrUpdate(DFS_PLUGIN_NAME, pluginConfig, true);
 
     fs = getLocalFileSystem();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.dfs;
 
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -26,6 +27,7 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class TestFileSelection extends BaseTestQuery {
@@ -59,4 +61,53 @@ public class TestFileSelection extends BaseTestQuery {
       throw ex;
     }
   }
+
+  @Test
+  public void testBackPath() throws Exception {
+    final String[][] badPaths =
+        {
+            {"/tmp", "../../bad"},   //  goes beyond root and outside parent; resolves to /../bad
+            {"/tmp", "../etc/bad"},  //  goes outside parent; resolves to /etc/bad
+            {"", "/bad"},            //  empty parent
+            {"/", ""},               //  empty path
+        } ;
+
+
+    for (int i = 0; i < badPaths.length; i++) {
+      boolean isPathGood;
+      try {
+        String parent = badPaths[i][0];
+        String subPath = FileSelection.removeLeadingSlash(badPaths[i][1]);
+        String path = new Path(parent, subPath).toString();
+        isPathGood = FileSelection.checkBackPaths(parent, path, subPath);
+      } catch (IllegalArgumentException e) {
+        isPathGood = false;
+      }
+      if (isPathGood) {
+        fail("Failed to catch invalid file selection paths.");
+      }
+    }
+
+    final String[][] goodPaths =
+        {
+            {"/tmp", "../tmp/good"},
+            {"/", "/tmp/good/../../good"},
+            {"/", "etc/tmp/../../good"},   //  no leading slash in path
+            {"/", "../good"},              //  resolves to /../good which is OK
+            {"/", "/good"}
+        } ;
+
+    for (int i = 0; i < goodPaths.length; i++) {
+      try {
+        String parent = goodPaths[i][0];
+        String subPath = FileSelection.removeLeadingSlash(goodPaths[i][1]);
+        String path = new Path(parent, subPath).toString();
+        FileSelection.checkBackPaths(parent, path, subPath);
+      } catch (IllegalArgumentException e) {
+        fail("Valid path not allowed by selection path validation.");
+      }
+    }
+
+  }
+
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -63,7 +63,7 @@ public class TestFileSelection extends BaseTestQuery {
   }
 
   @Test
-  public void testBackPath() throws Exception {
+  public void testBackPathBad() throws Exception {
     final String[][] badPaths =
         {
             {"/tmp", "../../bad"},   //  goes beyond root and outside parent; resolves to /../bad
@@ -74,12 +74,12 @@ public class TestFileSelection extends BaseTestQuery {
 
 
     for (int i = 0; i < badPaths.length; i++) {
-      boolean isPathGood;
+      boolean isPathGood = true;
       try {
         String parent = badPaths[i][0];
         String subPath = FileSelection.removeLeadingSlash(badPaths[i][1]);
         String path = new Path(parent, subPath).toString();
-        isPathGood = FileSelection.checkBackPaths(parent, path, subPath);
+        FileSelection.checkBackPaths(parent, path, subPath);
       } catch (IllegalArgumentException e) {
         isPathGood = false;
       }
@@ -87,7 +87,10 @@ public class TestFileSelection extends BaseTestQuery {
         fail("Failed to catch invalid file selection paths.");
       }
     }
+  }
 
+  @Test
+  public void testBackPathGood() throws Exception {
     final String[][] goodPaths =
         {
             {"/tmp", "../tmp/good"},
@@ -107,7 +110,6 @@ public class TestFileSelection extends BaseTestQuery {
         fail("Valid path not allowed by selection path validation.");
       }
     }
-
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -461,7 +461,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
     @SuppressWarnings("resource")
     final FileSystemPlugin plugin = (FileSystemPlugin) pluginRegistry.getPlugin(pluginName);
     final FileSystemConfig pluginConfig = (FileSystemConfig) plugin.getConfig();
-    final WorkspaceConfig newTmpWSConfig = new WorkspaceConfig(path, true, defaultFormat);
+    final WorkspaceConfig newTmpWSConfig = new WorkspaceConfig(path, true, defaultFormat, false);
 
     pluginConfig.workspaces.remove(schemaName);
     pluginConfig.workspaces.put(schemaName, newTmpWSConfig);


### PR DESCRIPTION
Added check to prevent users from accessing a path outside the current workspace. For backward compatibility this introduces a new parameter 'allowAccessOutsideWorkspace' in the dfs storage plugin configuration that allows the user to override the check and allow access outside the workspace. The default value for the parameter is false. Any existing storage plugin configurations which do not have the parameter specified will no longer be able to access paths outside the workspace. 