### PR TITLE
DRILL-5989 Travis Finally Runs Smoke Tests!!!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ cache:
   directories:
   - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
-script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryGb=3.5
+script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryMb=3584

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ cache:
   directories:
   - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
-script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1
--DmemoryGb=3.5
+script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryGb=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ cache:
   directories:
   - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
-script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 
+script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1
+-DmemoryGb=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ language: java
 jdk:
   - openjdk7
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
-script: echo "Done"
+script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ cache:
   - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
 script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1
--DmemoryGb=3
+-DmemoryGb=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,8 @@ before_install: git fetch --unshallow
 language: java
 jdk:
   - openjdk7
+cache:
+  directories:
+  - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
 script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 

--- a/common/src/test/java/org/apache/drill/categories/KafkaStorageTest.java
+++ b/common/src/test/java/org/apache/drill/categories/KafkaStorageTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.categories;
+
+/**
+ * This is a category used to mark unit tests that test the Kafka storage plugin.
+ */
+public interface KafkaStorageTest {
+}

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestColumnListCache.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestColumnListCache.java
@@ -28,7 +28,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestColumnListCache {
 
   @Test

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaQueriesTest.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.drill.categories.KafkaStorageTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
@@ -30,7 +32,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
+import org.junit.experimental.categories.Category;
 
+@Category({KafkaStorageTest.class, SlowTest.class})
 public class KafkaQueriesTest extends KafkaTestBase {
 
   @Test

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/MessageIteratorTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/MessageIteratorTest.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.drill.categories.KafkaStorageTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
 import org.apache.drill.exec.store.kafka.KafkaSubScan.KafkaSubScanSpec;
@@ -32,7 +34,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({KafkaStorageTest.class, SlowTest.class})
 public class MessageIteratorTest extends KafkaTestBase {
 
   private KafkaConsumer<byte[], byte[]> kafkaConsumer;

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.ZkConnection;
+import org.apache.drill.categories.KafkaStorageTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.store.kafka.cluster.EmbeddedKafkaCluster;
 import org.apache.drill.exec.store.kafka.decoders.MessageReaderFactoryTest;
@@ -30,19 +32,19 @@ import org.apache.kafka.common.security.JaasUtils;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
-
 import kafka.admin.AdminUtils;
 import kafka.admin.RackAwareMode;
 import kafka.utils.ZKStringSerializer$;
 import kafka.utils.ZkUtils;
 
+@Category({KafkaStorageTest.class, SlowTest.class})
 @RunWith(Suite.class)
 @SuiteClasses({ KafkaQueriesTest.class, MessageIteratorTest.class, MessageReaderFactoryTest.class })
 public class TestKafkaSuit {

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/decoders/MessageReaderFactoryTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/decoders/MessageReaderFactoryTest.java
@@ -17,11 +17,14 @@
  */
 package org.apache.drill.exec.store.kafka.decoders;
 
+import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({KafkaStorageTest.class})
 public class MessageReaderFactoryTest {
 
   @Test

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -26,8 +26,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kerby</groupId>
@@ -687,35 +685,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>largeTests</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>include-large-tests</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <includes>
-                    <include>**/TestLargeFileCompilation.java</include>
-                  </includes>
-                  <groups>org.apache.drill.categories.SlowTest</groups>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
   <build>
@@ -899,22 +868,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- we override the default test execution to exclude tests
-              that would take unusually long time to run (> 1 minute) and run such tests
-              in a different profile -->
-            <id>default-test</id>
-            <phase>test</phase>
-            <goals><goal>test</goal></goals>
-            <configuration>
-              <!--  Legacy: exclude by file name -->
-              <excludes>
-                <exclude>**/TestLargeFileCompilation.java</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/exec/java-exec/src/test/java/org/apache/drill/TestOutOfMemoryOutcome.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestOutOfMemoryOutcome.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill;
 
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.proto.CoordinationProtos;
@@ -25,11 +26,13 @@ import org.apache.drill.exec.testing.ControlsInjectionUtil;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Run several tpch queries and inject an OutOfMemoryException in ScanBatch that will cause an OUT_OF_MEMORY outcome to
  * be propagated downstream. Make sure the proper "memory error" message is sent to the client.
  */
+@Category({UnlikelyTest.class})
 public class TestOutOfMemoryOutcome extends BaseTestQuery {
 
   private static final String SINGLE_MODE = "ALTER SESSION SET `planner.disable_exchanges` = true";

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributed.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributed.java
@@ -23,10 +23,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestTpchDistributed extends BaseTestQuery {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchDistributed.class);
-
   private static void testDistributed(final String fileName) throws Exception {
     final String query = getFile(fileName);
     test("alter session set `planner.slice_target` = 10; " + query);

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertNull;
  * unstable from running a lot of queries concurrently -- it's not about
  * any particular order of execution. We ignore the results.
  */
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestTpchDistributedConcurrent extends BaseTestQuery {
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(360000); // Longer timeout than usual.
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
@@ -23,7 +23,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestTpchDistributedStreaming extends BaseTestQuery {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchDistributedStreaming.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
@@ -17,10 +17,13 @@
  */
 package org.apache.drill;
 
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class TestTpchDistributedStreaming extends BaseTestQuery {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchDistributedStreaming.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/common/scanner/TestClassPathScanner.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/common/scanner/TestClassPathScanner.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.scanner.persistence.AnnotationDescriptor;
 import org.apache.drill.common.scanner.persistence.FieldDescriptor;
@@ -40,12 +41,13 @@ import org.apache.drill.common.scanner.persistence.AnnotatedClassDescriptor;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.expr.DrillFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
-import org.apache.drill.exec.fn.impl.testing.GeneratorFunctions.IncreasingBigInt;
 import org.apache.drill.exec.fn.impl.testing.GeneratorFunctions.RandomBigIntGauss;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({SlowTest.class})
 public class TestClassPathScanner {
 
   @SafeVarargs
@@ -60,25 +62,6 @@ public class TestClassPathScanner {
   @Test
   public void test() throws Exception {
     ScanResult result = ClassPathScanner.fromPrescan(DrillConfig.create());
-    // if the build has run properly. BuildTimeScan.REGISTRY_FILE was created with a prescan
-//    assertListEqualsUnordered(result.getPrescannedPackages(),
-//      "org.apache.drill.common.logical",
-//      "org.apache.drill.exec.expr",
-//      "org.apache.drill.exec.physical.base",
-//      "org.apache.drill.exec.expr.fn.impl",
-//      "org.apache.drill.exec.physical.impl",
-//      "org.apache.drill.exec.rpc.user.security",
-//      "org.apache.drill.exec.store",
-//      "org.apache.drill.exec.store.mock",
-//      "org.apache.drill.exec.physical.config",
-//      "org.apache.drill.storage"
-//    );
-//    // this is added in the unit test folder that was not scanned so far
-//    assertListEqualsUnordered(result.getScannedPackages(),
-//      "org.apache.drill.exec.testing",
-//      "org.apache.drill.exec.fn.impl.testing",
-//      "org.apache.drill.exec.rpc.user.security.testing"
-//    );
     List<AnnotatedClassDescriptor> functions = result.getAnnotatedClasses();
     Set<String> scanned = new HashSet<>();
     AnnotatedClassDescriptor functionRandomBigIntGauss = null;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
@@ -37,7 +37,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestQueriesOnLargeFile extends BaseTestQuery {
   private static File dataFile = null;
   private static int NUM_RECORDS = 15000;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestQueriesOnLargeFile.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.record.RecordBatchLoader;
@@ -34,7 +35,9 @@ import org.junit.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTest.class)
 public class TestQueriesOnLargeFile extends BaseTestQuery {
   private static File dataFile = null;
   private static int NUM_RECORDS = 15000;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
@@ -21,10 +21,13 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.test.TestTools;
 import org.apache.drill.exec.ExecConstants;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
+
+
 
 @Category({SlowTest.class})
 public class TestLargeFileCompilation extends BaseTestQuery {
@@ -120,6 +123,7 @@ public class TestLargeFileCompilation extends BaseTestQuery {
     return sb.append("full_name\nfrom cp.`employee.json` limit 1)").toString();
   }
 
+  @Ignore // TODO DRILL-5997
   @Test
   public void testTEXT_WRITER() throws Exception {
     testNoResult("alter session set `%s`='JDK'", ClassCompilerSelector.JAVA_COMPILER_OPTION);
@@ -136,6 +140,7 @@ public class TestLargeFileCompilation extends BaseTestQuery {
     testNoResult(ITERATION_COUNT, LARGE_QUERY_WRITER, "wide_table_parquet");
   }
 
+  @Ignore // TODO DRILL-5997
   @Test
   public void testGROUP_BY() throws Exception {
     testNoResult("alter session set `%s`='JDK'", ClassCompilerSelector.JAVA_COMPILER_OPTION);
@@ -154,6 +159,7 @@ public class TestLargeFileCompilation extends BaseTestQuery {
     testNoResult(ITERATION_COUNT, LARGE_QUERY_ORDER_BY_WITH_LIMIT);
   }
 
+  @Ignore // TODO DRILL-5997
   @Test
   public void testFILTER() throws Exception {
     testNoResult("alter session set `%s`='JDK'", ClassCompilerSelector.JAVA_COMPILER_OPTION);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestLargeFileCompilation extends BaseTestQuery {
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(150000); // 150secs
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
-
-
 @Category({SlowTest.class})
 public class TestLargeFileCompilation extends BaseTestQuery {
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(150000); // 150secs

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import mockit.integration.junit4.JMockit;
 import org.apache.commons.io.FileUtils;
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.exec.util.Text;
@@ -36,7 +37,7 @@ import java.io.File;
 import java.io.FileWriter;
 
 @RunWith(JMockit.class)
-@Category(SqlFunctionTest.class)
+@Category({SqlFunctionTest.class, UnlikelyTest.class})
 public class TestStringFunctions extends BaseTestQuery {
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.expr.fn.impl;
 import static org.junit.Assert.assertTrue;
 
 import mockit.integration.junit4.JMockit;
-import org.apache.commons.io.FileUtils;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.SqlFunctionTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.pop.PopUnitTestBase;
@@ -35,7 +36,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
-@Category(OperatorTest.class)
+@Category({OperatorTest.class, SlowTest.class})
 public class TestBroadcastExchange extends PopUnitTestBase {
   @Test
   public void TestSingleBroadcastExchangeWithTwoScans() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
@@ -40,7 +40,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestDecimal extends PopUnitTestBase{
     DrillConfig c = DrillConfig.create();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -35,7 +35,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestDistributedFragmentRun extends PopUnitTestBase{
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestDistributedFragmentRun.class);
 
@@ -54,10 +54,7 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
       }
       assertEquals(100, count);
     }
-
-
   }
-
 
   @Test
   public void oneBitOneExchangeTwoEntryRun() throws Exception{

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -54,7 +54,10 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
       }
       assertEquals(100, count);
     }
+
+
   }
+
 
   @Test
   public void oneBitOneExchangeTwoEntryRun() throws Exception{

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
@@ -42,10 +42,8 @@ import org.junit.experimental.categories.Category;
  * by casting from VarChar, performing basic functions and converting
  * back to VarChar.
  */
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestExtractFunctions extends PopUnitTestBase {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestExtractFunctions.class);
-
   @Test
   public void testFromDate() throws Exception {
     long expectedValues[][] = { {00, 00, 02, 01, 1970}, {00, 00, 28, 12, 2008}, {00, 00, 27, 02, 2000} };

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStringFunctions.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
@@ -39,7 +40,9 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 import mockit.Injectable;
+import org.junit.experimental.categories.Category;
 
+@Category({UnlikelyTest.class})
 public class TestStringFunctions extends ExecTest {
 
   private final DrillConfig c = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestSimpleExternalSort extends DrillTest {
   @Rule
   public final TestRule TIMEOUT = TestTools.getTimeoutRule(160_000);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
 
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.categories.VectorTest;
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
@@ -96,6 +97,7 @@ public class TestValueVector extends ExecTest {
   }
 
   @Test(expected = OversizedAllocationException.class)
+  @Category(UnlikelyTest.class)
   public void testFixedVectorReallocation() {
     final MaterializedField field = MaterializedField.create(EMPTY_SCHEMA_PATH, UInt4Holder.TYPE);
     @SuppressWarnings("resource")
@@ -122,6 +124,7 @@ public class TestValueVector extends ExecTest {
   }
 
   @Test(expected = OversizedAllocationException.class)
+  @Category(UnlikelyTest.class)
   public void testBitVectorReallocation() {
     final MaterializedField field = MaterializedField.create(EMPTY_SCHEMA_PATH, UInt4Holder.TYPE);
     final BitVector vector = new BitVector(field, allocator);
@@ -152,6 +155,7 @@ public class TestValueVector extends ExecTest {
   }
 
   @Test(expected = OversizedAllocationException.class)
+  @Category(UnlikelyTest.class)
   public void testVariableVectorReallocation() {
     final MaterializedField field = MaterializedField.create(EMPTY_SCHEMA_PATH, UInt4Holder.TYPE);
     @SuppressWarnings("resource")

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSSLServer.java
@@ -18,19 +18,21 @@
 package org.apache.drill.exec.rpc.user.security;
 
 import com.typesafe.config.ConfigValueFactory;
+import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.File;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
+@Category({SecurityTest.class})
 public class TestUserBitSSLServer extends BaseTestQuery {
   private static DrillConfig sslConfig;
   private static Properties initProps; // initial client properties

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSaslCompatibility.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitSaslCompatibility.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.rpc.user.security;
 
 import com.google.common.collect.Lists;
 import com.typesafe.config.ConfigValueFactory;
+import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.exec.ExecConstants;
@@ -27,6 +28,7 @@ import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.security.sasl.SaslException;
 import java.util.Properties;
@@ -38,9 +40,8 @@ import static junit.framework.TestCase.fail;
  * Helps to test different scenarios based on security configuration on client and Drillbit side with respect to SASL
  * and specifically using PLAIN mechanism
  */
+@Category({SecurityTest.class})
 public class TestUserBitSaslCompatibility extends BaseTestQuery {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestUserClient.class);
-
   @BeforeClass
   public static void setup() {
     final DrillConfig newConfig = new DrillConfig(DrillConfig.create(cloneDefaultTestConfigProperties())

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -98,7 +98,7 @@ import com.google.common.base.Preconditions;
  * Test how resilient drillbits are to throwing exceptions during various phases of query
  * execution by injecting exceptions at various points, and to cancellations in various phases.
  */
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestDrillbitResilience extends DrillTest {
   private static final Logger logger = org.slf4j.LoggerFactory.getLogger(TestDrillbitResilience.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
@@ -19,6 +19,7 @@
 package org.apache.drill.exec.server.options;
 
 import org.apache.drill.categories.OptionsTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.sys.SystemTable;
 import org.apache.drill.test.BaseDirTestWatcher;
@@ -40,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  * i.e., if the value is not set in system/session.
  * */
 
-@Category(OptionsTest.class)
+@Category({OptionsTest.class, SlowTest.class})
 public class TestConfigLinkage {
   public static final String MOCK_PROPERTY = "mock.prop";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestTimedRunnable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestTimedRunnable.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Unit testing for {@link TimedRunnable}.
  */
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestTimedRunnable extends DrillTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTimedRunnable.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestFixedlenDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestFixedlenDecimal.java
@@ -17,11 +17,14 @@
  */
 package org.apache.drill.exec.store.parquet;
 
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({UnlikelyTest.class})
 public class TestFixedlenDecimal extends BaseTestQuery {
   // enable decimal data type
   @BeforeClass

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
@@ -45,7 +45,7 @@ import org.junit.experimental.categories.Category;
 
 import java.io.File;
 
-@Category(SlowTest.class)
+@Category({SlowTest.class})
 public class TestPStoreProviders extends TestWithZookeeper {
   @Rule
   public BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -56,6 +56,7 @@
           <groupId>javassist</groupId>
         </exclusion>
       </exclusions>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
 
@@ -262,9 +263,8 @@
             -XX:MaxPermSize=256M -XX:MaxDirectMemorySize=3072M
             -XX:+CMSClassUnloadingEnabled -ea</argLine>
           <additionalClasspathElements>
-            <additionalClasspathElement>${settings.localRepository}/org/apache/drill/drill-common/${project.version}/drill-common-${project.version}-tests.jar</additionalClasspathElement>
-            <additionalClasspathElements>${settings.localRepository}/junit/junit/4.11/junit-4.11.jar</additionalClasspathElements>
-            <additionalClasspathElements>${settings.localRepository}/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</additionalClasspathElements>
+            <additionalClasspathElements>${settings.localRepository}/junit/junit/${junit.version}/junit-${junit.version}.jar</additionalClasspathElements>
+            <additionalClasspathElements>${settings.localRepository}/org/hamcrest/hamcrest-core/${hamcrest.core.version}/hamcrest-core-${hamcrest.core.version}.jar</additionalClasspathElements>
             <additionalClasspathElements>${project.build.directory}/test-classes/</additionalClasspathElements>
           </additionalClasspathElements>
           <classpathDependencyExcludes>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -47,20 +47,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.drill</groupId>
-      <artifactId>drill-common</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>javassist</artifactId>
-          <groupId>javassist</groupId>
-        </exclusion>
-      </exclusions>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-java-exec</artifactId>
       <version>${project.version}</version>
@@ -267,9 +253,6 @@
             <additionalClasspathElements>${settings.localRepository}/org/hamcrest/hamcrest-core/${hamcrest.core.version}/hamcrest-core-${hamcrest.core.version}.jar</additionalClasspathElements>
             <additionalClasspathElements>${project.build.directory}/test-classes/</additionalClasspathElements>
           </additionalClasspathElements>
-          <classpathDependencyExcludes>
-            <classpathDependencyExcludes>*:*</classpathDependencyExcludes>
-          </classpathDependencyExcludes>
 
           <systemPropertyVariables>
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -262,6 +262,7 @@
             -XX:MaxPermSize=256M -XX:MaxDirectMemorySize=3072M
             -XX:+CMSClassUnloadingEnabled -ea</argLine>
           <additionalClasspathElements>
+            <additionalClasspathElement>${settings.localRepository}/org/apache/drill/drill-common/${project.version}/drill-common-${project.version}-tests.jar</additionalClasspathElement>
             <additionalClasspathElements>${settings.localRepository}/junit/junit/4.11/junit-4.11.jar</additionalClasspathElements>
             <additionalClasspathElements>${settings.localRepository}/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</additionalClasspathElements>
             <additionalClasspathElements>${project.build.directory}/test-classes/</additionalClasspathElements>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -47,6 +47,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.drill</groupId>
+      <artifactId>drill-common</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>javassist</artifactId>
+          <groupId>javassist</groupId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-java-exec</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <argLine>-Xms512m -Xmx3g -Ddrill.exec.http.enabled=false
+            <argLine>-Xms512m -Xmx4096g -Ddrill.exec.http.enabled=false
               -Ddrill.exec.sys.store.provider.local.write=false
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.8</reflections.version>
     <excludedGroups></excludedGroups>
-    <memoryGb>4</memoryGb>
+    <memoryMb>4096</memoryMb>
   </properties>
 
   <scm>
@@ -461,7 +461,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <argLine>-Xms512m -Xmx${memoryGb}g -Ddrill.exec.http.enabled=false
+            <argLine>-Xms512m -Xmx${memoryMb}m -Ddrill.exec.http.enabled=false
               -Ddrill.exec.sys.store.provider.local.write=false
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.8</reflections.version>
     <excludedGroups></excludedGroups>
+    <memoryGb>4</memoryGb>
   </properties>
 
   <scm>
@@ -460,7 +461,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <argLine>-Xms512m -Xmx4096g -Ddrill.exec.http.enabled=false
+            <argLine>-Xms512m -Xmx${memoryGb}g -Ddrill.exec.http.enabled=false
               -Ddrill.exec.sys.store.provider.local.write=false
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,9 @@
     <kerby.version>1.0.0-RC2</kerby.version>
     <findbugs.version>3.0.0</findbugs.version>
     <netty.tcnative.classifier></netty.tcnative.classifier>
+    <commons.io.version>2.4</commons.io.version>
+    <junit.version>4.11</junit.version>
+    <hamcrest.core.version>1.3</hamcrest.core.version>
 
     <!--
       Currently Hive storage plugin only supports Apache Hive 1.2 or vendor specific variants of the
@@ -439,8 +442,23 @@
           <version>1.3.1</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
+          <executions>
+            <execution>
+              <id>default-test</id>
+              <phase>test</phase>
+              <goals><goal>test</goal></goals>
+            </execution>
+          </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit47</artifactId>
+              <version>2.19.1</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <argLine>-Xms512m -Xmx3g -Ddrill.exec.http.enabled=false
               -Ddrill.exec.sys.store.provider.local.write=false
@@ -621,7 +639,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>${commons.io.version}</version>
     </dependency>
 
     <!-- Test Dependencies -->
@@ -716,6 +734,12 @@
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${javassist.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>${hamcrest.core.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.freemarker</groupId>


### PR DESCRIPTION
## DRILL-5989

Previously Travis would only do a build for each pull request. Now Travis will also run all the smoke tests every time a PR is opened or updated. Smoke Tests are defined as tests which do **not** belong to one of these categories:

- **org.apache.drill.categories.SlowTest**
- **org.apache.drill.categories.SecurityTest**
- **org.apache.drill.categories.UnlikelyTest**

In order to get the smoke tests to run on Travis I had to make the following fixes:

- Categorized Kafka storage plugin tests
- Categorized more long running tests as slow tests in order to avoid timing out on travis
- Fixed a bug with jdbc-all tests which would cause jdbc-all to fail when categories were excluded
- Fixed usage of surefire plugin in java-exec, and fixed a bug which caused **excludedGroups** not to be propagated to the java-exec project.
- Made the heap size of the forked test process configurable via a property. This was necessary because running the whole build requires about 4gb of memory for the test process, but 4gb is too large for the Travis container and the smoke tests only require 3.5gb
- Cached maven dependencies for the Travis build so that it runs faster
