### PR TITLE
DRILL-5973 : Support injection of time-bound pauses in server

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/CountDownLatchInjectionImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/CountDownLatchInjectionImpl.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.drill.common.concurrent.ExtendedLatch;
 
-import java.util.concurrent.CountDownLatch;
-
 /**
  * See {@link org.apache.drill.exec.testing.CountDownLatchInjection} Degenerates to
  * {@link org.apache.drill.exec.testing.PauseInjection#pause}, if initialized to zero count. In any case, this injection
@@ -42,7 +40,7 @@ public class CountDownLatchInjectionImpl extends Injection implements CountDownL
                                       @JsonProperty("port") final int port,
                                       @JsonProperty("siteClass") final String siteClass,
                                       @JsonProperty("desc") final String desc) throws InjectionConfigurationException {
-    super(address, port, siteClass, desc, 0, 1);
+    super(address, port, siteClass, desc, 0, 1, 0L);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExceptionInjection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExceptionInjection.java
@@ -44,7 +44,7 @@ public class ExceptionInjection extends Injection {
                              @JsonProperty("nSkip") final int nSkip,
                              @JsonProperty("nFire") final int nFire,
                              @JsonProperty("exceptionClass") String classString) throws InjectionConfigurationException {
-    super(address, port, siteClass, desc, nSkip, nFire);
+    super(address, port, siteClass, desc, nSkip, nFire, 0L);
     final Class<?> clazz;
     try {
       clazz = Class.forName(classString);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControlsInjector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/ExecutionControlsInjector.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.testing;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.drill.exec.ops.FragmentContext;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -81,7 +83,12 @@ public class ExecutionControlsInjector implements ControlsInjector {
       executionControls.lookupPauseInjection(this, desc);
 
     if (pauseInjection != null) {
-      logger.debug("Pausing at {}", desc);
+      long pauseDuration = pauseInjection.getMsPause();
+      if ( pauseDuration > 0L) {
+        logger.debug("Pausing at {} for {} sec", desc, TimeUnit.MILLISECONDS.toSeconds(pauseDuration) );
+      } else {
+        logger.debug("Pausing at {}", desc);
+      }
       pauseInjection.pause();
       logger.debug("Resuming at {}", desc);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/testing/Injection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/testing/Injection.java
@@ -32,9 +32,10 @@ public abstract class Injection {
   protected final String desc; // description of the injection site; useful for multiple exception injections in a single class
   private final AtomicInteger nSkip; // the number of times to skip the injection; starts >= 0
   private final AtomicInteger nFire;  // the number of times to do the injection, after any skips; starts > 0
+  private final long msPause; // duration of the injection (only applies to pause injections)
 
   protected Injection(final String address, final int port, final String siteClass, final String desc,
-                      final int nSkip, final int nFire) throws InjectionConfigurationException {
+                      final int nSkip, final int nFire, final long msPause) throws InjectionConfigurationException {
     if (desc == null || desc.isEmpty()) {
       throw new InjectionConfigurationException("Injection desc is null or empty.");
     }
@@ -57,6 +58,7 @@ public abstract class Injection {
     this.desc = desc;
     this.nSkip = new AtomicInteger(nSkip);
     this.nFire = new AtomicInteger(nFire);
+    this.msPause = msPause;
   }
 
   /**
@@ -80,5 +82,9 @@ public abstract class Injection {
   public final boolean isValidForBit(final DrillbitEndpoint endpoint) {
     return address == null ||
       (address.equals(endpoint.getAddress()) && port == endpoint.getUserPort());
+  }
+
+  public long getMsPause() {
+    return msPause;
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/Controls.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/Controls.java
@@ -138,6 +138,20 @@ public class Controls {
     }
 
     /**
+     * Adds a time-bound pause injection to the controls builder with the given parameters.
+     *
+     * @param siteClass class where the pause should happen
+     * @param desc      descriptor for the pause site in the site class
+     * @param nSkip     number of times to skip before firing
+     * @param msPause     duration of the pause in millisec
+     * @return this builder
+     */
+    public Builder addTimedPause(final Class<?> siteClass, final String desc, final int nSkip, final long msPause) {
+      injections.add(ControlsInjectionUtil.createTimedPause(siteClass, desc, nSkip, msPause));
+      return this;
+    }
+
+    /**
      * Adds a pause injection to the controls builder with the given parameters. The pause is not skipped i.e. the pause
      * happens when execution reaches the site.
      *
@@ -160,6 +174,21 @@ public class Controls {
     public Builder addPauseOnBit(final Class<?> siteClass, final String desc,
                                  final DrillbitEndpoint endpoint, final int nSkip) {
       injections.add(ControlsInjectionUtil.createPauseOnBit(siteClass, desc, nSkip, endpoint));
+      return this;
+    }
+
+    /**
+     * Adds a time-bound pause injection (for the specified drillbit) to the controls builder with the given parameters.
+     *
+     * @param siteClass class where the pause should happen
+     * @param desc      descriptor for the pause site in the site class
+     * @param nSkip     number of times to skip before firing
+     * @param msPause     duration of the pause in millisec
+     * @return this builder
+     */
+    public Builder addTimedPauseOnBit(final Class<?> siteClass, final String desc,
+                                 final DrillbitEndpoint endpoint, final int nSkip, final long msPause) {
+      injections.add(ControlsInjectionUtil.createTimedPauseOnBit(siteClass, desc, nSkip, endpoint, msPause));
       return this;
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/ControlsInjectionUtil.java
@@ -133,6 +133,18 @@ public class ControlsInjectionUtil {
   }
 
   /**
+   * Create a time-bound pause injection. Note this format is not directly accepted by the injection mechanism. Use the
+   * {@link Controls} to build exceptions.
+   */
+  public static String createTimedPause(final Class<?> siteClass, final String desc, final int nSkip, final long msPause) {
+    return "{ \"type\" : \"pause\"," +
+      "\"siteClass\" : \"" + siteClass.getName() + "\","
+      + "\"desc\" : \"" + desc + "\","
+      + "\"nSkip\" : " + nSkip + ","
+      + "\"msPause\" : " + msPause + "}";
+  }
+
+  /**
    * Create a pause injection on a specific bit. Note this format is not directly accepted by the injection
    * mechanism. Use the {@link Controls} to build exceptions.
    */
@@ -142,6 +154,21 @@ public class ControlsInjectionUtil {
       "\"siteClass\" : \"" + siteClass.getName() + "\","
       + "\"desc\" : \"" + desc + "\","
       + "\"nSkip\" : " + nSkip + ","
+      + "\"address\":\"" + endpoint.getAddress() + "\","
+      + "\"port\":\"" + endpoint.getUserPort() + "\"}";
+  }
+
+  /**
+   * Create a pause injection on a specific bit. Note this format is not directly accepted by the injection
+   * mechanism. Use the {@link Controls} to build exceptions.
+   */
+  public static String createTimedPauseOnBit(final Class<?> siteClass, final String desc, final int nSkip,
+                                        final DrillbitEndpoint endpoint, final long msPause) {
+    return "{ \"type\" : \"pause\"," +
+      "\"siteClass\" : \"" + siteClass.getName() + "\","
+      + "\"desc\" : \"" + desc + "\","
+      + "\"nSkip\" : " + nSkip + ","
+      + "\"msPause\" : " + msPause + ","
       + "\"address\":\"" + endpoint.getAddress() + "\","
       + "\"port\":\"" + endpoint.getUserPort() + "\"}";
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/testing/TestPauseInjection.java
@@ -145,6 +145,34 @@ public class TestPauseInjection extends BaseTestQuery {
   }
 
   @Test
+  public void timedPauseInjected() {
+    final long pauseDuration = 2000L;
+    final long expectedDuration = pauseDuration;
+    final ExtendedLatch trigger = new ExtendedLatch(1);
+    final Pointer<Exception> ex = new Pointer<>();
+    final String controls = Controls.newBuilder()
+      .addTimedPause(DummyClass.class, DummyClass.PAUSES, 0, pauseDuration)
+      .build();
+
+    ControlsInjectionUtil.setControls(session, controls);
+
+    final QueryContext queryContext = new QueryContext(session, bits[0].getContext(), QueryId.getDefaultInstance());
+    //We don't need a ResumingThread because this should automatically resume
+
+    // test that the pause happens
+    final DummyClass dummyClass = new DummyClass(queryContext, trigger);
+    final long actualDuration = dummyClass.pauses();
+    assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration),
+      expectedDuration <= actualDuration);
+    assertTrue("No exception should be thrown.", ex.value == null);
+    try {
+      queryContext.close();
+    } catch (final Exception e) {
+      fail("Failed to close query context: " + e);
+    }
+  }
+
+  @Test
   public void pauseOnSpecificBit() {
     final RemoteServiceSet remoteServiceSet = RemoteServiceSet.getLocalServiceSet();
     final ZookeeperHelper zkHelper = new ZookeeperHelper();
@@ -185,6 +213,79 @@ public class TestPauseInjection extends BaseTestQuery {
         final Pointer<Exception> ex = new Pointer<>();
         final QueryContext queryContext = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
         (new ResumingThread(queryContext, trigger, ex, expectedDuration)).start();
+
+        // test that the pause happens
+        final DummyClass dummyClass = new DummyClass(queryContext, trigger);
+        final long actualDuration = dummyClass.pauses();
+        assertTrue(String.format("Test should stop for at least %d milliseconds.", expectedDuration), expectedDuration <= actualDuration);
+        assertTrue("No exception should be thrown.", ex.value == null);
+        try {
+          queryContext.close();
+        } catch (final Exception e) {
+          fail("Failed to close query context: " + e);
+        }
+      }
+
+      {
+        final ExtendedLatch trigger = new ExtendedLatch(1);
+        final QueryContext queryContext = new QueryContext(session, drillbitContext2, QueryId.getDefaultInstance());
+
+        // if the resume did not happen, the test would hang
+        final DummyClass dummyClass = new DummyClass(queryContext, trigger);
+        dummyClass.pauses();
+        try {
+          queryContext.close();
+        } catch (final Exception e) {
+          fail("Failed to close query context: " + e);
+        }
+      }
+    } finally {
+      zkHelper.stopZookeeper();
+    }
+  }
+
+
+  @Test
+  public void timedPauseOnSpecificBit() {
+    final RemoteServiceSet remoteServiceSet = RemoteServiceSet.getLocalServiceSet();
+    final ZookeeperHelper zkHelper = new ZookeeperHelper();
+    zkHelper.startZookeeper(1);
+
+    final long pauseDuration = 2000L;
+    final long expectedDuration = pauseDuration;
+
+    try {
+      // Creating two drillbits
+      final Drillbit drillbit1, drillbit2;
+      final DrillConfig drillConfig = zkHelper.getConfig();
+      try {
+        drillbit1 = Drillbit.start(drillConfig, remoteServiceSet);
+        drillbit2 = Drillbit.start(drillConfig, remoteServiceSet);
+      } catch (final DrillbitStartupException e) {
+        throw new RuntimeException("Failed to start two drillbits.", e);
+      }
+
+      final DrillbitContext drillbitContext1 = drillbit1.getContext();
+      final DrillbitContext drillbitContext2 = drillbit2.getContext();
+
+      final UserSession session = UserSession.Builder.newBuilder()
+        .withCredentials(UserCredentials.newBuilder()
+          .setUserName("foo")
+          .build())
+        .withUserProperties(UserProperties.getDefaultInstance())
+        .withOptionManager(drillbitContext1.getOptionManager())
+        .build();
+
+      final DrillbitEndpoint drillbitEndpoint1 = drillbitContext1.getEndpoint();
+      final String controls = Controls.newBuilder()
+        .addTimedPauseOnBit(DummyClass.class, DummyClass.PAUSES, drillbitEndpoint1, 0, pauseDuration)
+        .build();
+
+      ControlsInjectionUtil.setControls(session, controls);
+      {
+        final ExtendedLatch trigger = new ExtendedLatch(1);
+        final Pointer<Exception> ex = new Pointer<>();
+        final QueryContext queryContext = new QueryContext(session, drillbitContext1, QueryId.getDefaultInstance());
 
         // test that the pause happens
         final DummyClass dummyClass = new DummyClass(queryContext, trigger);


### PR DESCRIPTION
Support pause injections in the test framework that are time-bound, to allow for testing high latency scenarios.
e.g. delayed server response to the Drill client allows for test a server-induced timeout
This would allow for testing of DRILL-3640 