### PR TITLE
DRILL-6000: Categorized graceful shutdown unit tests as SlowTests

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -17,12 +17,15 @@
  */
 
 package org.apache.drill.test;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.Drillbit;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,7 +40,7 @@ import java.io.BufferedWriter;
 
 
 
-
+@Category({SlowTest.class})
 public class TestGracefulShutdown extends BaseTestQuery{
 
   @BeforeClass


### PR DESCRIPTION
Graceful shutdown unit tests were failing on Travis, and should not be run as part of the SmokeTests