### PR TITLE
DRILL-5846: Improve parquet performance for Flat Data Types

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -311,6 +311,10 @@ public final class ExecConstants {
 
   public static final OptionValidator COMPILE_SCALAR_REPLACEMENT = new BooleanValidator("exec.compile.scalar_replacement");
 
+  // Controls whether to enable bulk parquet reader processing
+  public static final String PARQUET_FLAT_READER_BULK = "store.parquet.flat.reader.bulk";
+  public static final OptionValidator PARQUET_FLAT_READER_BULK_VALIDATOR = new BooleanValidator(PARQUET_FLAT_READER_BULK);
+
   public static final String JSON_ALL_TEXT_MODE = "store.json.all_text_mode";
   public static final BooleanValidator JSON_READER_ALL_TEXT_MODE_VALIDATOR = new BooleanValidator(JSON_ALL_TEXT_MODE);
   public static final BooleanValidator JSON_EXTENDED_TYPES = new BooleanValidator("store.json.extended_types");
@@ -321,6 +325,7 @@ public final class ExecConstants {
   public static final String JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG = "store.json.reader.print_skipped_invalid_record_number";
   public static final BooleanValidator JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG_VALIDATOR = new BooleanValidator(JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
   public static final DoubleValidator TEXT_ESTIMATED_ROW_SIZE = new RangeDoubleValidator("store.text.estimated_row_size_bytes", 1, Long.MAX_VALUE);
+
 
   /**
    * Json writer option for writing `NaN` and `Infinity` tokens as numbers (not enclosed with double quotes)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -148,6 +148,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.PARQUET_PAGEREADER_BUFFER_SIZE_VALIDATOR),
       new OptionDefinition(ExecConstants.PARQUET_PAGEREADER_USE_FADVISE_VALIDATOR),
       new OptionDefinition(ExecConstants.PARQUET_READER_INT96_AS_TIMESTAMP_VALIDATOR),
+      new OptionDefinition(ExecConstants.PARQUET_FLAT_READER_BULK_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_WRITER_NAN_INF_NUMBERS_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
@@ -207,6 +207,10 @@ public abstract class ColumnReader<V extends ValueVector> {
     pageReader.valuesRead += recordsToRead;
   }
 
+  protected int readRecordsInBulk(int recordsToReadInThisPass) throws IOException {
+      throw new UnsupportedOperationException();
+  }
+
   protected boolean processPageData(int recordsToReadInThisPass) throws IOException {
     readValues(recordsToReadInThisPass);
     return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/NullableColumnReader.java
@@ -20,10 +20,10 @@ package org.apache.drill.exec.store.parquet.columnreaders;
 import java.io.IOException;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.DefLevelReaderWrapper;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.NullableVectorDefinitionSetter;
 import org.apache.drill.exec.vector.ValueVector;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -32,17 +32,33 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NullableColumnReader.class);
   protected BaseDataValueVector castedBaseVector;
   protected NullableVectorDefinitionSetter castedVectorMutator;
-  private long definitionLevelsRead = 0;
+
+  /** The number of values we have processed thus far */
+  private int currPageValuesProcessed = 0;
+  /** Definition level wrapper to handle {@link ValueVector} limitations */
+  private final DefLevelReaderWrapper definitionLevelWrapper = new DefLevelReaderWrapper();
 
   NullableColumnReader(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor, ColumnChunkMetaData columnChunkMetaData,
                boolean fixedLength, V v, SchemaElement schemaElement) throws ExecutionSetupException {
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
+
     castedBaseVector = (BaseDataValueVector) v;
     castedVectorMutator = (NullableVectorDefinitionSetter) v.getMutator();
   }
 
-  @Override public void processPages(long recordsToReadInThisPass)
-      throws IOException {
+  /** {@inheritDoc} */
+  @Override
+  public void processPages(long recordsToReadInThisPass) throws IOException {
+
+    if (!parentReader.useBulkReader()) {
+      processPagesOrig(recordsToReadInThisPass);
+
+    } else {
+      processPagesBulk(recordsToReadInThisPass);
+    }
+  }
+
+  private final void processPagesOrig(long recordsToReadInThisPass) throws IOException {
     readStartInBytes = 0;
     readLength = 0;
     readLengthInBits = 0;
@@ -65,13 +81,13 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
     while (readCount < recordsToReadInThisPass && writeCount < valueVec.getValueCapacity()) {
       // read a page if needed
       if (!pageReader.hasPage()
-          || (definitionLevelsRead >= pageReader.currentPageCount)) {
+          || (currPageValuesProcessed >= pageReader.currentPageCount)) {
         if (!pageReader.next()) {
           break;
         }
         //New page. Reset the definition level.
         currentDefinitionLevel = -1;
-        definitionLevelsRead = 0;
+        currPageValuesProcessed = 0;
         recordsReadInThisIteration = 0;
         readStartInBytes = 0;
       }
@@ -89,15 +105,15 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
       }
       haveMoreData = readCount < recordsToReadInThisPass
           && writeCount + nullRunLength < valueVec.getValueCapacity()
-          && definitionLevelsRead < pageReader.currentPageCount;
+          && currPageValuesProcessed < pageReader.currentPageCount;
       while (haveMoreData && currentDefinitionLevel < columnDescriptor
           .getMaxDefinitionLevel()) {
         readCount++;
         nullRunLength++;
-        definitionLevelsRead++;
+        currPageValuesProcessed++;
         haveMoreData = readCount < recordsToReadInThisPass
             && writeCount + nullRunLength < valueVec.getValueCapacity()
-            && definitionLevelsRead < pageReader.currentPageCount;
+            && currPageValuesProcessed < pageReader.currentPageCount;
         if (haveMoreData) {
           currentDefinitionLevel = pageReader.definitionLevels.readInteger();
         }
@@ -121,17 +137,17 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
       haveMoreData = readCount < recordsToReadInThisPass
           && writeCount + runLength < valueVec.getValueCapacity()
           // note: writeCount+runLength
-          && definitionLevelsRead < pageReader.currentPageCount;
+          && currPageValuesProcessed < pageReader.currentPageCount;
       while (haveMoreData && currentDefinitionLevel >= columnDescriptor
           .getMaxDefinitionLevel()) {
         readCount++;
         runLength++;
-        definitionLevelsRead++;
+        currPageValuesProcessed++;
         castedVectorMutator.setIndexDefined(writeCount + runLength
             - 1); //set the nullable bit to indicate a non-null value
         haveMoreData = readCount < recordsToReadInThisPass
             && writeCount + runLength < valueVec.getValueCapacity()
-            && definitionLevelsRead < pageReader.currentPageCount;
+            && currPageValuesProcessed < pageReader.currentPageCount;
         if (haveMoreData) {
           currentDefinitionLevel = pageReader.definitionLevels.readInteger();
         }
@@ -165,13 +181,129 @@ abstract class NullableColumnReader<V extends ValueVector> extends ColumnReader<
               + "Run Length: {} \t Null Run Length: {} \t readCount: {} \t writeCount: {} \t "
               + "recordsReadInThisIteration: {} \t valuesReadInCurrentPass: {} \t "
               + "totalValuesRead: {} \t readStartInBytes: {} \t readLength: {} \t pageReader.byteLength: {} \t "
-              + "definitionLevelsRead: {} \t pageReader.currentPageCount: {}",
+              + "currPageValuesProcessed: {} \t pageReader.currentPageCount: {}",
           recordsToReadInThisPass, runLength, nullRunLength, readCount,
           writeCount, recordsReadInThisIteration, valuesReadInCurrentPass,
           totalValuesRead, readStartInBytes, readLength, pageReader.byteLength,
-          definitionLevelsRead, pageReader.currentPageCount);
+          currPageValuesProcessed, pageReader.currentPageCount);
 
     }
+
+    valueVec.getMutator().setValueCount(valuesReadInCurrentPass);
+  }
+
+  private final void processPagesBulk(long recordsToReadInThisPass) throws IOException {
+    readStartInBytes = 0;
+    readLength = 0;
+    readLengthInBits = 0;
+    recordsReadInThisIteration = 0;
+    vectorData = castedBaseVector.getBuffer();
+
+    // values need to be spaced out where nulls appear in the column
+    // leaving blank space for nulls allows for random access to values
+    // to optimize copying data out of the buffered disk stream, runs of defined values
+    // are located and copied together, rather than copying individual values
+
+    int valueCount = 0;
+    final int maxValuesToProcess = Math.min((int) recordsToReadInThisPass, valueVec.getValueCapacity());
+
+    // To handle the case where the page has been already loaded
+    if (pageReader.definitionLevels != null && currPageValuesProcessed == 0) {
+      definitionLevelWrapper.set(pageReader.definitionLevels, pageReader.currentPageCount);
+    }
+
+    while (valueCount < maxValuesToProcess) {
+
+      // read a page if needed
+      if (!pageReader.hasPage() || (currPageValuesProcessed == pageReader.currentPageCount)) {
+        if (!pageReader.next()) {
+          break;
+        }
+
+        //New page. Reset the definition level.
+        currPageValuesProcessed = 0;
+        recordsReadInThisIteration = 0;
+        readStartInBytes = 0;
+
+        // Update the Definition Level reader
+        definitionLevelWrapper.set(pageReader.definitionLevels, pageReader.currentPageCount);
+      }
+
+      definitionLevelWrapper.readFirstIntegerIfNeeded();
+
+      int numNullValues = 0;
+      int numNonNullValues = 0;
+      final int remaining = maxValuesToProcess - valueCount;
+      int currBatchSz = Math.min(remaining, (pageReader.currentPageCount - currPageValuesProcessed));
+      assert currBatchSz > 0;
+
+      // Let's skip the next run of nulls if any ...
+      int idx;
+      for (idx = 0; idx < currBatchSz; ++idx) {
+        if (definitionLevelWrapper.readCurrInteger() == 1) {
+          break; // non-value encountered
+        }
+        definitionLevelWrapper.nextIntegerIfNotEOF();
+      }
+      numNullValues += idx;
+
+      // Write the nulls if any
+      if (numNullValues > 0) {
+        int writerIndex = ((BaseDataValueVector) valueVec).getBuffer().writerIndex();
+        castedBaseVector.getBuffer().setIndex(0, writerIndex + (int) Math.ceil(numNullValues * dataTypeLengthInBits / 8.0));
+
+        // let's update the counters
+        currBatchSz -= numNullValues;
+        valuesReadInCurrentPass += numNullValues;
+        recordsReadInThisIteration += numNullValues;
+      }
+
+      // Let's figure out the number of contiguous non-null values
+      for (idx = 0; idx < currBatchSz; ++idx) {
+        if (definitionLevelWrapper.readCurrInteger() == 0) {
+          break;
+        }
+        definitionLevelWrapper.nextIntegerIfNotEOF();
+      }
+      numNonNullValues += idx;
+
+      //
+      // Write the non-null values
+      //
+      if (numNonNullValues > 0) {
+        // Set the non-values nullable state
+        castedVectorMutator.setIndexDefined(valueCount + numNullValues, numNonNullValues);
+
+        // This _must_ be set so that the call to readField works correctly for all datatypes
+        this.recordsReadInThisIteration += numNonNullValues;
+
+        this.readStartInBytes = pageReader.readPosInBytes;
+        this.readLengthInBits = numNonNullValues * dataTypeLengthInBits;
+        this.readLength = (int) Math.ceil(readLengthInBits / 8.0);
+
+        readField(numNonNullValues);
+
+        valuesReadInCurrentPass  += numNonNullValues;
+        pageReader.readPosInBytes = readStartInBytes + readLength;
+      }
+
+      pageReader.valuesRead += recordsReadInThisIteration;
+      totalValuesRead += numNonNullValues + numNullValues;
+      currPageValuesProcessed += numNonNullValues + numNullValues;
+      valueCount += numNonNullValues + numNullValues;
+
+      if (logger.isTraceEnabled()) {
+        logger.trace("" + "recordsToReadInThisPass: {} \t "
+          + "Run Length: {} \t Null Run Length: {} \t valueCount: {} \t "
+          + "recordsReadInThisIteration: {} \t valuesReadInCurrentPass: {} \t "
+          + "totalValuesRead: {} \t readStartInBytes: {} \t readLength: {} \t pageReader.byteLength: {} \t "
+          + "currPageValuesProcessed: {} \t pageReader.currentPageCount: {}",
+          recordsToReadInThisPass, numNonNullValues, numNullValues, valueCount,
+          recordsReadInThisIteration, valuesReadInCurrentPass,
+          totalValuesRead, readStartInBytes, readLength, pageReader.byteLength,
+          currPageValuesProcessed, pageReader.currentPageCount);
+      }
+    } // loop-end
 
     valueVec.getMutator().setValueCount(valuesReadInCurrentPass);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ParquetRecordReader.java
@@ -90,6 +90,7 @@ public class ParquetRecordReader extends AbstractRecordReader {
   public boolean useFadvise;
   public boolean enforceTotalSize;
   public long readQueueSize;
+  public boolean useBulkReader;
 
   @SuppressWarnings("unused")
   private String name;
@@ -161,6 +162,7 @@ public class ParquetRecordReader extends AbstractRecordReader {
       ParquetMetadata footer,
       List<SchemaPath> columns,
       ParquetReaderUtility.DateCorruptionStatus dateCorruptionStatus) throws ExecutionSetupException {
+
     this.name = path;
     this.hadoopPath = new Path(path);
     this.fileSystem = fs;
@@ -171,20 +173,14 @@ public class ParquetRecordReader extends AbstractRecordReader {
     this.dateCorruptionStatus = dateCorruptionStatus;
     this.fragmentContext = fragmentContext;
     this.numRecordsToRead = numRecordsToRead;
-    useAsyncColReader =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_COLUMNREADER_ASYNC).bool_val;
-    useAsyncPageReader =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_ASYNC).bool_val;
-    useBufferedReader =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_USE_BUFFERED_READ).bool_val;
-    bufferedReadSize =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_BUFFER_SIZE).num_val.intValue();
-    useFadvise =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_USE_FADVISE).bool_val;
-    readQueueSize =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_QUEUE_SIZE).num_val;
-    enforceTotalSize =
-        fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_ENFORCETOTALSIZE).bool_val;
+    this.useAsyncColReader = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_COLUMNREADER_ASYNC).bool_val;
+    this.useAsyncPageReader = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_ASYNC).bool_val;
+    this.useBufferedReader = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_USE_BUFFERED_READ).bool_val;
+    this.bufferedReadSize = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_BUFFER_SIZE).num_val.intValue();
+    this.useFadvise = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_USE_FADVISE).bool_val;
+    this.readQueueSize = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_QUEUE_SIZE).num_val;
+    this.enforceTotalSize = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_PAGEREADER_ENFORCETOTALSIZE).bool_val;
+    this.useBulkReader = fragmentContext.getOptions().getOption(ExecConstants.PARQUET_FLAT_READER_BULK).bool_val;
 
     setColumns(columns);
   }
@@ -229,6 +225,13 @@ public class ParquetRecordReader extends AbstractRecordReader {
 
   public FragmentContext getFragmentContext() {
     return fragmentContext;
+  }
+
+  /**
+   * @return true if Parquet reader Bulk processing is enabled; false otherwise
+   */
+  public boolean useBulkReader() {
+    return useBulkReader;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenAbstractEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenAbstractEntryReader.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+
+import io.netty.buffer.DrillBuf;
+
+/** Abstract class for sub-classes implementing several algorithms for loading a Bulk Entry */
+abstract class VarLenAbstractEntryReader {
+
+  /** byte buffer used for buffering page data */
+  protected final ByteBuffer buffer;
+  /** Page Data Information */
+  protected final PageDataInfo pageInfo;
+  /** expected precision type: fixed or variable length */
+  protected final ColumnPrecisionInfo columnPrecInfo;
+  /** Bulk entry */
+  protected final VarLenColumnBulkEntry entry;
+
+  /**
+   * CTOR.
+   * @param buffer byte buffer for data buffering (within CPU cache)
+   * @param pageInfo page being processed information
+   * @param columnPrecInfo column precision information
+   * @param entry reusable bulk entry object
+   */
+  VarLenAbstractEntryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    this.buffer = buffer;
+    this.pageInfo = pageInfo;
+    this.columnPrecInfo = columnPrecInfo;
+    this.entry = entry;
+  }
+
+  /**
+   * @param valuesToRead maximum values to read within the current page
+   * @return a bulk entry object
+   */
+  abstract VarLenColumnBulkEntry getEntry(int valsToReadWithinPage);
+
+  /**
+   * Indicates whether to use bulk processing
+   */
+  protected final boolean bulkProcess() {
+    return columnPrecInfo.bulkProcess;
+  }
+
+  /**
+   * Loads new data into the buffer if empty or the force flag is set.
+   *
+   * @param force flag to force loading new data into the buffer
+   */
+  protected final boolean load(boolean force) {
+
+    if (!force && buffer.hasRemaining()) {
+      return true; // NOOP
+    }
+
+    // We're here either because the buffer is empty or we want to force a new load operation.
+    // In the case of force, there might be unprocessed data (still in the buffer) which is fine
+    // since the caller updates the page data buffer's offset only for the data it has consumed; this
+    // means unread data will be loaded again but this time will be positioned in the beginning of the
+    // buffer. This can happen only for the last entry in the buffer when either of its length or value
+    // is incomplete.
+    buffer.clear();
+
+    final int bufferCapacity = VarLenBulkPageReader.BUFF_SZ;
+    final int remaining = remainingPageData();
+    final int toCopy = remaining > bufferCapacity ? bufferCapacity : remaining;
+
+    if (toCopy == 0) {
+      return false;
+    }
+
+    pageInfo.pageData.getBytes(pageInfo.pageDataOff, buffer.array(), buffer.position(), toCopy);
+
+    buffer.limit(toCopy);
+
+    // At this point the buffer position is 0 and its limit set to the number of bytes copied.
+
+    return true;
+  }
+
+  /**
+   * @return remaining data in current page
+   */
+  protected final int remainingPageData() {
+    return pageInfo.pageDataLen - pageInfo.pageDataOff;
+  }
+
+  /**
+   * @param buff source buffer
+   * @param pos start position
+   * @return an integer encoded as a low endian
+   */
+  protected final int getInt(final byte[] buff, final int pos) {
+    return DrillBuf.getInt(buff, pos);
+  }
+
+  /**
+   * Copy data; expects 8bytes PADDING for source and target
+   *
+   * @param src source buffer
+   * @param srcIndex source index
+   * @param dest destination buffer
+   * @param destIndex destination buffer
+   * @param length length to copy (in bytes)
+   */
+  static void vlCopy(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    if (length <= 8) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+    } else {
+      vlCopyGTLongWithPadding(src, srcIndex, dest, destIndex, length);
+    }
+  }
+
+  /**
+   * Copy data; no PADDING needed for source and target (though less efficient than the copy with
+   * padding as more comparisons need to be made).
+   *
+   * @param src source buffer
+   * @param srcIndex source index
+   * @param dest destination buffer
+   * @param destIndex destination buffer
+   * @param length length to copy (in bytes)
+   */
+  static void vlCopyNoPadding(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    if (length <= 8) {
+      vlCopyLELongNoPadding(src, srcIndex, dest, destIndex, length);
+    } else {
+      vlCopyGTLongNoPadding(src, srcIndex, dest, destIndex, length);
+    }
+  }
+
+  private static void vlCopyGTLongWithPadding(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    final int bulkCopyThreshold = 24;
+    if (length < bulkCopyThreshold) {
+      _vlCopyGTLongWithPadding(src, srcIndex, dest, destIndex, length);
+
+    } else {
+      System.arraycopy(src, srcIndex, dest, destIndex, length);
+    }
+  }
+
+  private static void _vlCopyGTLongWithPadding(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    final int numLongEntries = length >> 3;
+    assert numLongEntries < 3;
+
+    final int remaining = length & 0x7;
+    int prevCopied      = 0;
+
+    if (numLongEntries == 1) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+      prevCopied = 1 << 3;
+
+    } else {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+      DrillBuf.putLong(src, srcIndex + DrillBuf.LONG_NUM_BYTES, dest, destIndex + DrillBuf.LONG_NUM_BYTES);
+      prevCopied = 1 << 4;
+    }
+
+    if (remaining > 0) {
+      final int srcPos  = srcIndex  + prevCopied;
+      final int destPos = destIndex + prevCopied;
+
+      DrillBuf.putLong(src, srcPos, dest, destPos);
+    }
+  }
+
+  private static final void vlCopyLELongNoPadding(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    if (length == 1) {
+      dest[destIndex] = src[srcIndex];
+
+    } else if (length == 2) {
+      DrillBuf.putShort(src, srcIndex, dest, destIndex);
+
+    } else if (length == 3) {
+      dest[destIndex] = src[srcIndex];
+      DrillBuf.putShort(src, srcIndex+1, dest, destIndex+1);
+
+    } else if (length == 4) {
+      DrillBuf.putInt(src, srcIndex, dest, destIndex);
+
+    } else if (length == 5) {
+      dest[destIndex] = src[srcIndex];
+      DrillBuf.putInt(src, srcIndex+1, dest, destIndex+1);
+
+    } else if (length == 6) {
+      DrillBuf.putShort(src, srcIndex, dest, destIndex);
+      DrillBuf.putInt(src, srcIndex+2, dest, destIndex+2);
+
+    } else if (length == 7) {
+      dest[destIndex] = src[srcIndex];
+      DrillBuf.putShort(src, srcIndex+1, dest, destIndex+1);
+      DrillBuf.putInt(src, srcIndex+3, dest, destIndex+3);
+
+    } else {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+    }
+  }
+
+  private static final void vlCopyGTLongNoPadding(byte[] src, int srcIndex, byte[] dest, int destIndex, int length) {
+    final int numLongEntries = length >> 3;
+    final int remaining      = length & 0x7;
+
+    if (numLongEntries == 1) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+
+    } else if (numLongEntries == 2) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+      DrillBuf.putLong(src, srcIndex + DrillBuf.LONG_NUM_BYTES, dest, destIndex + DrillBuf.LONG_NUM_BYTES);
+
+    } else if (numLongEntries == 3) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+      DrillBuf.putLong(src, srcIndex + DrillBuf.LONG_NUM_BYTES, dest, destIndex + DrillBuf.LONG_NUM_BYTES);
+      DrillBuf.putLong(src, srcIndex + 2 * DrillBuf.LONG_NUM_BYTES, dest, destIndex + 2 * DrillBuf.LONG_NUM_BYTES);
+
+    } else if (numLongEntries == 4) {
+      DrillBuf.putLong(src, srcIndex, dest, destIndex);
+      DrillBuf.putLong(src, srcIndex + DrillBuf.LONG_NUM_BYTES, dest, destIndex + DrillBuf.LONG_NUM_BYTES);
+      DrillBuf.putLong(src, srcIndex + 2 * DrillBuf.LONG_NUM_BYTES, dest, destIndex + 2 * DrillBuf.LONG_NUM_BYTES);
+      DrillBuf.putLong(src, srcIndex + 3 * DrillBuf.LONG_NUM_BYTES, dest, destIndex + 3 * DrillBuf.LONG_NUM_BYTES);
+
+    } else {
+      for (int idx = 0; idx < numLongEntries; ++idx) {
+        DrillBuf.putLong(src, srcIndex + idx * DrillBuf.LONG_NUM_BYTES, dest, destIndex + idx * DrillBuf.LONG_NUM_BYTES);
+      }
+    }
+
+    if (remaining > 0) {
+      final int srcPos  = srcIndex  + numLongEntries * DrillBuf.LONG_NUM_BYTES;
+      final int destPos = destIndex + numLongEntries * DrillBuf.LONG_NUM_BYTES;
+
+      if (srcPos + 7 < src.length) {
+        DrillBuf.putLong(src, srcPos, dest, destPos);
+
+      } else {
+        vlCopyLELongNoPadding(src, srcPos, dest, destPos, remaining);
+      }
+    }
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBulkPageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBulkPageReader.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionType;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.VLColumnBulkInputCallback;
+
+/** Provides bulk reads when accessing Parquet's page payload for variable length columns */
+final class VarLenBulkPageReader {
+
+  /**
+   * Using small buffers so that they could fit in the L1 cache
+   * NOTE - This buffer size is used in several places of the bulk processing implementation; please analyze
+   *        the impact of changing this buffer size.
+   */
+  static final int BUFF_SZ = 1 << 12; // 4k
+  static final int PADDING = 1 << 6; // 128bytes padding to allow for access optimizations
+
+  /** byte buffer used for buffering page data */
+  private final ByteBuffer buffer = ByteBuffer.allocate(BUFF_SZ + PADDING);
+  /** Page Data Information */
+  private final PageDataInfo pageInfo = new PageDataInfo();
+  /** expected precision type: fixed or variable length */
+  private final ColumnPrecisionInfo columnPrecInfo;
+  /** Bulk entry */
+  private final VarLenColumnBulkEntry entry;
+  /** A callback to allow bulk readers interact with their container */
+  private final VLColumnBulkInputCallback containerCallback;
+
+  // Various BulkEntry readers
+  final VarLenAbstractEntryReader fixedReader;
+  final VarLenAbstractEntryReader nullableFixedReader;
+  final VarLenAbstractEntryReader variableLengthReader;
+  final VarLenAbstractEntryReader nullableVLReader;
+  final VarLenAbstractEntryReader dictionaryReader;
+  final VarLenAbstractEntryReader nullableDictionaryReader;
+
+  VarLenBulkPageReader(
+    PageDataInfo pageInfoInput,
+    ColumnPrecisionInfo columnPrecInfoInput,
+    VLColumnBulkInputCallback containerCallbackInput) {
+
+    // Set the buffer to the native byte order
+    this.buffer.order(ByteOrder.nativeOrder());
+
+    if (pageInfoInput != null) {
+      this.pageInfo.pageData = pageInfoInput.pageData;
+      this.pageInfo.pageDataOff = pageInfoInput.pageDataOff;
+      this.pageInfo.pageDataLen = pageInfoInput.pageDataLen;
+      this.pageInfo.numPageFieldsRead = pageInfoInput.numPageFieldsRead;
+      this.pageInfo.definitionLevels = pageInfoInput.definitionLevels;
+      this.pageInfo.dictionaryValueReader = pageInfoInput.dictionaryValueReader;
+    }
+
+    this.columnPrecInfo = columnPrecInfoInput;
+    this.entry = new VarLenColumnBulkEntry(this.columnPrecInfo);
+    this.containerCallback = containerCallbackInput;
+
+    // Initialize the Variable Length Entry Readers
+    fixedReader = new VarLenFixedEntryReader(buffer, pageInfo, columnPrecInfo, entry);
+    nullableFixedReader = new VarLenNullableFixedEntryReader(buffer, pageInfo, columnPrecInfo, entry);
+    variableLengthReader = new VarLenEntryReader(buffer, pageInfo, columnPrecInfo, entry);
+    nullableVLReader = new VarLenNullableEntryReader(buffer, pageInfo, columnPrecInfo, entry);
+    dictionaryReader = new VarLenEntryDictionaryReader(buffer, pageInfo, columnPrecInfo, entry);
+    nullableDictionaryReader = new VarLenNullableDictionaryReader(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  final void set(PageDataInfo pageInfoInput) {
+    pageInfo.pageData = pageInfoInput.pageData;
+    pageInfo.pageDataOff = pageInfoInput.pageDataOff;
+    pageInfo.pageDataLen = pageInfoInput.pageDataLen;
+    pageInfo.numPageFieldsRead = pageInfoInput.numPageFieldsRead;
+    pageInfo.definitionLevels = pageInfoInput.definitionLevels;
+    pageInfo.dictionaryValueReader = pageInfoInput.dictionaryValueReader;
+
+    buffer.clear();
+  }
+
+  final VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    VarLenColumnBulkEntry entry = null;
+
+    if (ColumnPrecisionType.isPrecTypeFixed(columnPrecInfo.columnPrecisionType)) {
+      if ((entry = getFixedEntry(valuesToRead)) == null) {
+        // The only reason for a null to be returned is when the "getFixedEntry" method discovers
+        // the column is not fixed length; this false positive happens if the sample data was not
+        // representative of all the column values.
+
+        // If this is an optional column, then we need to reset the definition-level reader
+        if (pageInfo.definitionLevels.hasDefinitionLevels()) {
+          try {
+            containerCallback.resetDefinitionLevelReader(pageInfo.numPageFieldsRead);
+            // Update the definition level object reference
+            pageInfo.definitionLevels.set(containerCallback.getDefinitionLevelsReader(),
+              pageInfo.numPageValues - pageInfo.numPageFieldsRead);
+
+          } catch (IOException ie) {
+            throw new DrillRuntimeException(ie);
+          }
+        }
+
+        columnPrecInfo.columnPrecisionType = ColumnPrecisionType.DT_PRECISION_IS_VARIABLE;
+        entry = getVLEntry(valuesToRead);
+      }
+
+    } else {
+      entry = getVLEntry(valuesToRead);
+    }
+
+    if (entry != null) {
+      pageInfo.numPageFieldsRead += entry.getNumValues();
+    }
+    return entry;
+  }
+
+  private final VarLenColumnBulkEntry getFixedEntry(int valuesToRead) {
+    if (pageInfo.definitionLevels.hasDefinitionLevels()) {
+      return nullableFixedReader.getEntry(valuesToRead);
+    } else {
+      return fixedReader.getEntry(valuesToRead);
+    }
+  }
+
+  private final VarLenColumnBulkEntry getVLEntry(int valuesToRead) {
+    if (pageInfo.dictionaryValueReader == null
+     || !pageInfo.dictionaryValueReader.isDefined()) {
+
+      if (pageInfo.definitionLevels.hasDefinitionLevels()) {
+        return nullableVLReader.getEntry(valuesToRead);
+      } else {
+        return variableLengthReader.getEntry(valuesToRead);
+      }
+    } else {
+      if (pageInfo.definitionLevels.hasDefinitionLevels()) {
+        return nullableDictionaryReader.getEntry(valuesToRead);
+      } else {
+        return dictionaryReader.getEntry(valuesToRead);
+      }
+    }
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkEntry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkEntry.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionType;
+import org.apache.drill.exec.vector.VarLenBulkEntry;
+
+import io.netty.buffer.DrillBuf;
+
+/** Implements the {@link VarLenBulkEntry} interface to optimize data copy */
+final class VarLenColumnBulkEntry implements VarLenBulkEntry {
+  private static final int PADDING = 1 << 6; // 128bytes padding to allow for access optimizations
+
+  /** start data offset */
+  private int startOffset;
+  /** aggregate data length */
+  private int totalLength;
+  /** number of values contained within this bulk entry object */
+  private int numValues;
+  /** number of non-null values contained within this bulk entry object */
+  private int numNonValues;
+  /** a fixed length array that hosts value lengths */
+  private final int[] lengths;
+  /** internal byte array for data caching (small precision values) */
+  private final byte[] internalArray;
+  /** external byte array for data caching */
+  private byte[] externalArray;
+  /** reference to page reader drill buffer (larger precision values) */
+  private DrillBuf externalDrillBuf;
+  /** indicator on whether the current entry is array backed */
+  private boolean arrayBacked;
+  /** indicator on whether the current data buffer is externally or internally owned */
+  private boolean internalDataBuf;
+
+  VarLenColumnBulkEntry(ColumnPrecisionInfo columnPrecInfo) {
+    this(columnPrecInfo, VarLenBulkPageReader.BUFF_SZ);
+  }
+
+  VarLenColumnBulkEntry(ColumnPrecisionInfo columnPrecInfo, int buffSz) {
+    int lengthSz = -1;
+    int dataSz = -1;
+
+    if (ColumnPrecisionType.isPrecTypeFixed(columnPrecInfo.columnPrecisionType)) {
+      final int expectedDataLen = columnPrecInfo.precision;
+      final int maxNumValues = buffSz / (4 + expectedDataLen);
+      lengthSz = maxNumValues;
+      dataSz = maxNumValues * expectedDataLen + PADDING;
+
+    } else {
+      // For variable length data, we need to handle a) maximum number of entries and b) max entry length
+      final int smallestDataLen = 1;
+      final int largestDataLen = buffSz - 4;
+      final int maxNumValues = buffSz / (4 + smallestDataLen);
+      lengthSz = maxNumValues;
+      dataSz = largestDataLen + PADDING;
+    }
+
+    this.lengths       = new int[lengthSz];
+    this.internalArray = new byte[dataSz];
+  }
+
+  /** @inheritDoc */
+  @Override
+  public int getTotalLength() {
+    return totalLength;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public boolean arrayBacked() {
+    return arrayBacked;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public byte[] getArrayData() {
+    return internalDataBuf ? internalArray : externalArray;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public DrillBuf getData() {
+    return externalDrillBuf;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public int getDataStartOffset() {
+    return startOffset;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public int[] getValuesLength() {
+    return lengths;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public int getNumValues() {
+    return numValues;
+  }
+
+  /** @inheritDoc */
+  @Override
+  public int getNumNonNullValues() {
+    return numNonValues;
+  }
+
+  @Override
+  public boolean hasNulls() {
+    return numNonValues < numValues;
+  }
+
+  public byte[] getInternalDataArray() {
+    return internalArray;
+  }
+
+  void set(int startOffset, int totalLength, int numValues, int nonNullValues) {
+    this.startOffset = startOffset;
+    this.totalLength = totalLength;
+    this.numValues = numValues;
+    this.numNonValues = nonNullValues;
+    this.arrayBacked = true;
+    this.internalDataBuf = true;
+    this.externalArray = null;
+    this.externalDrillBuf = null;
+  }
+
+  void set(int startOffset, int totalLength, int numValues, int nonNullValues, byte[] externalArray) {
+    this.startOffset = startOffset;
+    this.totalLength = totalLength;
+    this.numValues = numValues;
+    this.numNonValues = nonNullValues;
+    this.arrayBacked = true;
+    this.internalDataBuf = false;
+    this.externalArray = externalArray;
+    this.externalDrillBuf = null;
+  }
+
+  void set(int startOffset, int totalLength, int numValues, int nonNullValues, DrillBuf externalDrillBuf) {
+    this.startOffset = startOffset;
+    this.totalLength = totalLength;
+    this.numValues = numValues;
+    this.numNonValues = nonNullValues;
+    this.arrayBacked = false;
+    this.internalDataBuf = false;
+    this.externalArray = null;
+    this.externalDrillBuf = externalDrillBuf;
+  }
+
+  int getMaxEntries() {
+    return lengths.length;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkInput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkInput.java
@@ -1,0 +1,570 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import io.netty.buffer.DrillBuf;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.VarLenBulkEntry;
+import org.apache.drill.exec.vector.VarLenBulkInput;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.api.Binary;
+
+/** Implements the {@link VarLenBulkInput} interface to optimize data copy */
+final class VarLenColumnBulkInput<V extends ValueVector> implements VarLenBulkInput<VarLenBulkEntry> {
+  /** A cut off number for bulk processing */
+  private static final int BULK_PROCESSING_MAX_PREC_LEN = 1 << 10;
+
+  /** parent object */
+  private final VarLengthValuesColumn<V> parentInst;
+  /** Column precision type information (owner by caller) */
+  private final ColumnPrecisionInfo columnPrecInfo;
+  /** Custom definition level reader */
+  private final DefLevelReaderWrapper custDefLevelReader;
+  /** Custom dictionary reader */
+  private final DictionaryReaderWrapper custDictionaryReader;
+
+  /** The records to read */
+  private final int recordsToRead;
+  /** Current operation bulk reader state */
+  private final OprBulkReadState oprReadState;
+  /** Container class for holding page data information */
+  private final PageDataInfo pageInfo = new PageDataInfo();
+  /** Buffered page payload */
+  private VarLenBulkPageReader buffPagePayload;
+  /** A callback to allow child readers interact with this class */
+  private final VLColumnBulkInputCallback callback;
+
+  /**
+   * CTOR.
+   * @param parentInst parent object instance
+   * @param recordsToRead number of records to read
+   * @param columnPrecInfo column precision information
+   * @throws IOException runtime exception in case of processing error
+   */
+  VarLenColumnBulkInput(VarLengthValuesColumn<V> parentInst,
+    int recordsToRead, BulkReaderState bulkReaderState) throws IOException {
+
+    this.parentInst = parentInst;
+    this.recordsToRead = recordsToRead;
+    this.callback = new VLColumnBulkInputCallback(parentInst.pageReader);
+    this.columnPrecInfo = bulkReaderState.columnPrecInfo;
+    this.custDefLevelReader = bulkReaderState.definitionLevelReader;
+    this.custDictionaryReader = bulkReaderState.dictionaryReader;
+
+    // Load page if none have been read
+    loadPageIfNeeed();
+
+    // Create the internal READ_STATE object based on the current page-reader state
+    this.oprReadState = new OprBulkReadState(parentInst.pageReader.readyToReadPosInBytes, parentInst.pageReader.valuesRead, 0);
+
+    // Let's try to figure out whether this columns is fixed or variable length; this information
+    // is not always accurate within the Parquet schema metadata.
+    if (ColumnPrecisionType.isPrecTypeUnknown(columnPrecInfo.columnPrecisionType)) {
+      guessColumnPrecision(columnPrecInfo);
+    }
+
+    // Initialize the buffered-page-payload object
+    setBufferedPagePayload();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean hasNext() {
+    try {
+      if (oprReadState.batchFieldIndex < recordsToRead) {
+        // We need to ensure there is a page of data to be read
+        if (!parentInst.pageReader.hasPage() || parentInst.pageReader.currentPageCount == oprReadState.numPageFieldsProcessed) {
+          long totalValueCount = parentInst.columnChunkMetaData.getValueCount();
+
+          if (totalValueCount == (parentInst.totalValuesRead + oprReadState.batchFieldIndex) || !parentInst.pageReader.next()) {
+            parentInst.hitRowGroupEnd();
+            return false;
+          }
+
+          // Reset the state object page read metadata
+          oprReadState.numPageFieldsProcessed = 0;
+          oprReadState.pageReadPos = parentInst.pageReader.readyToReadPosInBytes;
+
+          // Update the value readers information
+          setValuesReadersOnNewPage();
+
+          // Update the buffered-page-payload since we've read a new page
+          setBufferedPagePayload();
+        }
+        return true;
+      } else {
+        return false;
+      }
+    } catch (IOException ie) {
+      throw new DrillRuntimeException(ie);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final VarLenBulkEntry next() {
+    final int toReadRemaining = recordsToRead - oprReadState.batchFieldIndex;
+    final int pageRemaining = parentInst.pageReader.currentPageCount - oprReadState.numPageFieldsProcessed;
+    final int remaining = Math.min(toReadRemaining, pageRemaining);
+    final VarLenBulkEntry result = buffPagePayload.getEntry(remaining);
+
+    // Update position for next read
+    if (result != null) {
+      // Page read position is meaningful only when dictionary mode is off
+      if (pageInfo.dictionaryValueReader == null
+       || !pageInfo.dictionaryValueReader.isDefined()) {
+        oprReadState.pageReadPos += (result.getTotalLength() + 4 * result.getNumNonNullValues());
+      }
+      oprReadState.numPageFieldsProcessed += result.getNumValues();
+      oprReadState.batchFieldIndex += result.getNumValues();
+    }
+    return result;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final int getStartIndex() {
+    return oprReadState.batchFieldIndex;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final void done() {
+    // Update the page reader state so that a future call to this method resumes
+    // where we left off.
+
+    // Page read position is meaningful only when dictionary mode is off
+    if (pageInfo.dictionaryValueReader == null
+     || !pageInfo.dictionaryValueReader.isDefined()) {
+      parentInst.pageReader.readyToReadPosInBytes = oprReadState.pageReadPos;
+    }
+    parentInst.pageReader.valuesRead = oprReadState.numPageFieldsProcessed;
+    parentInst.totalValuesRead += oprReadState.batchFieldIndex;
+  }
+
+  final int getReadBatchFields() {
+    return oprReadState.batchFieldIndex;
+  }
+
+  private final void setValuesReadersOnNewPage() {
+    if (parentInst.pageReader.currentPageCount > 0) {
+      custDefLevelReader.set(parentInst.pageReader.definitionLevels, parentInst.pageReader.currentPageCount);
+      if (parentInst.usingDictionary) {
+        assert parentInst.pageReader.dictionaryValueReader != null : "Dictionary reader should not be null";
+        custDictionaryReader.set(parentInst.pageReader.dictionaryValueReader);
+      } else {
+        custDictionaryReader.set(null);
+      }
+    } else {
+      custDefLevelReader.set(null, 0);
+      custDictionaryReader.set(null);
+    }
+  }
+
+  private final void setBufferedPagePayload() {
+
+    if (parentInst.pageReader.hasPage() && oprReadState.numPageFieldsProcessed < parentInst.pageReader.currentPageCount) {
+      if (!parentInst.usingDictionary) {
+        pageInfo.pageData  = parentInst.pageReader.pageData;
+        pageInfo.pageDataOff = (int) oprReadState.pageReadPos;
+        pageInfo.pageDataLen = (int) parentInst.pageReader.byteLength;
+      }
+
+      pageInfo.numPageValues = parentInst.pageReader.currentPageCount;
+      pageInfo.definitionLevels = custDefLevelReader;
+      pageInfo.dictionaryValueReader = custDictionaryReader;
+      pageInfo.numPageFieldsRead = oprReadState.numPageFieldsProcessed;
+
+      if (buffPagePayload == null) {
+        buffPagePayload = new VarLenBulkPageReader(pageInfo, columnPrecInfo, callback);
+
+      } else {
+        buffPagePayload.set(pageInfo);
+      }
+    } else {
+      if (buffPagePayload == null) {
+        buffPagePayload = new VarLenBulkPageReader(null, columnPrecInfo, callback);
+      }
+    }
+  }
+
+  final ColumnPrecisionInfo getColumnPrecisionInfo() {
+    return columnPrecInfo;
+  }
+
+  /** Reads a data sample to evaluate this column's precision (variable or fixed); this is best effort, caller
+   * should be ready to handle false positives.
+   *
+   * @param columnPrecInfo input/output precision info container
+   * @throws IOException
+   */
+  private final void guessColumnPrecision(ColumnPrecisionInfo columnPrecInfo) throws IOException {
+    columnPrecInfo.columnPrecisionType = ColumnPrecisionType.DT_PRECISION_IS_VARIABLE;
+
+    loadPageIfNeeed();
+
+    // Minimum number of values within a data size to consider bulk processing
+    final int minNumVals = VarLenBulkPageReader.BUFF_SZ / BULK_PROCESSING_MAX_PREC_LEN;
+    final int maxDataToProcess =
+      Math.min(VarLenBulkPageReader.BUFF_SZ + 4 * minNumVals,
+        (int) (parentInst.pageReader.byteLength-parentInst.pageReader.readyToReadPosInBytes));
+
+    if (parentInst.usingDictionary || maxDataToProcess == 0) {
+      // The number of values is small, there are lot of null values, or dictionary encoding is used. Bulk
+      // processing should work fine for these use-cases
+      columnPrecInfo.bulkProcess = true;
+      return;
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(maxDataToProcess);
+    buffer.order(ByteOrder.nativeOrder());
+
+    parentInst.pageReader.pageData.getBytes((int) parentInst.pageReader.readyToReadPosInBytes, buffer.array(), 0, maxDataToProcess);
+    buffer.limit(maxDataToProcess);
+
+    int numValues = 0;
+    int fixedDataLen = -1;
+    boolean isFixedPrecision = false;
+
+    do {
+      if (buffer.remaining() < 4) {
+        break;
+      }
+
+      int data_len = buffer.getInt();
+
+      if (fixedDataLen < 0) {
+        fixedDataLen = data_len;
+        isFixedPrecision = true;
+      }
+
+      if (isFixedPrecision && fixedDataLen != data_len) {
+        isFixedPrecision = false;
+      }
+
+      if (buffer.remaining() < data_len) {
+        break;
+      }
+      buffer.position(buffer.position() + data_len);
+
+      ++numValues;
+
+    } while (true);
+
+    // We need to have encountered at least a couple of values with the same length; if the values
+    // have long length, then fixed vs VL is not a big deal with regard to performance.
+    if (isFixedPrecision && fixedDataLen >= 0) {
+      columnPrecInfo.columnPrecisionType = ColumnPrecisionType.DT_PRECISION_IS_FIXED;
+      columnPrecInfo.precision = fixedDataLen;
+
+      if (fixedDataLen <= BULK_PROCESSING_MAX_PREC_LEN) {
+        columnPrecInfo.bulkProcess = true;
+
+      } else {
+        columnPrecInfo.columnPrecisionType = ColumnPrecisionType.DT_PRECISION_IS_VARIABLE;
+        columnPrecInfo.bulkProcess = false;
+
+      }
+    } else {
+      // At this point we know this column is variable length; we need to figure out whether it is worth
+      // processing it in a bulk-manner or not.
+
+      if (numValues >= minNumVals) {
+        columnPrecInfo.bulkProcess = true;
+      } else {
+        columnPrecInfo.bulkProcess = false;
+      }
+    }
+  }
+
+  private void loadPageIfNeeed() throws IOException {
+    if (!parentInst.pageReader.hasPage()) {
+      // load a page
+      parentInst.pageReader.next();
+      // update the definition level information
+      setValuesReadersOnNewPage();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Inner Classes
+  // --------------------------------------------------------------------------
+
+  /** Enumeration which indicates whether a column's type precision is unknown, variable, or fixed. */
+  enum ColumnPrecisionType {
+    DT_PRECISION_UNKNOWN,
+    DT_PRECISION_IS_FIXED,
+    DT_PRECISION_IS_VARIABLE;
+
+    static boolean isPrecTypeUnknown(ColumnPrecisionType type) {
+      return DT_PRECISION_UNKNOWN.equals(type);
+    }
+
+    static boolean isPrecTypeFixed(ColumnPrecisionType type) {
+      return DT_PRECISION_IS_FIXED.equals(type);
+    }
+
+    static boolean isPrecTypeVariable(ColumnPrecisionType type) {
+      return DT_PRECISION_IS_VARIABLE.equals(type);
+    }
+  }
+
+  /** this class enables us to cache state across bulk reader operations */
+  final static class BulkReaderState {
+
+    /** Column Precision Type: variable or fixed length; used to overcome unreliable meta-data information  */
+    final ColumnPrecisionInfo columnPrecInfo = new ColumnPrecisionInfo();
+    /**
+     * A custom definition level reader which overcomes Parquet's ValueReader limitations (that is,
+     * no ability to peek)
+     */
+    final DefLevelReaderWrapper definitionLevelReader = new DefLevelReaderWrapper();
+    /**
+     * A custom dictionary reader which overcomes Parquet's ValueReader limitations (that is,
+     * no ability to peek)
+     */
+    final DictionaryReaderWrapper dictionaryReader = new DictionaryReaderWrapper();
+  }
+
+  /** Container class to hold a column precision information */
+  final static class ColumnPrecisionInfo {
+    /** column precision type */
+    ColumnPrecisionType columnPrecisionType = ColumnPrecisionType.DT_PRECISION_UNKNOWN;
+    /** column precision; set only for fixed length precision */
+    int precision;
+    /** indicator on whether this column should be bulk processed */
+    boolean bulkProcess;
+
+    /** Copies source content into this object */
+    void clone(final ColumnPrecisionInfo src) {
+      columnPrecisionType = src.columnPrecisionType;
+      precision = src.precision;
+      bulkProcess = src.bulkProcess;
+    }
+
+  }
+
+  /** Contains information about current bulk read operation */
+  private final static class OprBulkReadState {
+    /** reader position within current page */
+    long pageReadPos;
+    /** number of fields processed within the current page */
+    int numPageFieldsProcessed;
+    /** field index within current batch */
+    int batchFieldIndex;
+
+      OprBulkReadState(long pageReadPos, int numPageFieldsRead, int batchFieldIndex) {
+        this.pageReadPos = pageReadPos;
+        this.numPageFieldsProcessed = numPageFieldsRead;
+        this.batchFieldIndex = batchFieldIndex;
+      }
+  }
+
+  /** Container class for holding page data information */
+  final static class PageDataInfo {
+    /** Number of values within the current page */
+    int numPageValues;
+    /** Page data buffer */
+    DrillBuf pageData;
+    /** Offset within the page data */
+    int pageDataOff;
+    /** Page data length */
+    int pageDataLen;
+    /** number of fields read within current page */
+    int numPageFieldsRead;
+    /** Definition Level */
+    DefLevelReaderWrapper definitionLevels;
+    /** Dictionary value reader */
+    DictionaryReaderWrapper dictionaryValueReader;
+  }
+
+  /** Callback to allow a bulk reader interact with its parent */
+  final static class VLColumnBulkInputCallback {
+    /** Page reader object */
+    PageReader pageReader;
+
+    VLColumnBulkInputCallback(PageReader _pageReader) {
+      this.pageReader = _pageReader;
+    }
+
+    /**
+     * Enables Parquet column readers to reset the definition level reader to a specific state.
+     * @param skipCount the number of rows to skip (optional)
+     *
+     * @throws IOException An IO related condition
+     */
+    void resetDefinitionLevelReader(int skipCount) throws IOException {
+      pageReader.resetDefinitionLevelReader(skipCount);
+    }
+
+    /**
+     * @return current page definition level
+     */
+    ValuesReader getDefinitionLevelsReader() {
+      return pageReader.definitionLevels;
+    }
+  }
+
+  /** A wrapper value reader with the ability to control when to read the next value */
+  final static class DefLevelReaderWrapper {
+    /** Definition Level */
+    private ValuesReader definitionLevels;
+    /** Peeked value     */
+    private int currValue;
+    /** Remaining values */
+    private int remaining;
+
+    /**
+     * @return true if the current page has definition levels to be read
+     */
+    public boolean hasDefinitionLevels() {
+      return definitionLevels != null;
+    }
+
+    /**
+     * Consume the first integer if not done; we want to empower the caller so to avoid extra checks
+     * during access methods (e.g., some consumers will not invoke this method as they rather access
+     * the raw reader..)
+     */
+    public void readFirstIntegerIfNeeded() {
+      assert definitionLevels != null;
+      if (currValue == -1) {
+        setNextInteger();
+      }
+    }
+
+    /**
+     * Set the {@link PageReader#definitionLevels} object; if a null value is passed, then it is understood
+     * the current page doesn't have definition levels to be processed
+     * @param definitionLevels {@link ValuesReader} object
+     * @param numValues total number of values that can be read from the stream
+     */
+    void set(ValuesReader definitionLevels, int numValues) {
+      this.definitionLevels = definitionLevels;
+      this.currValue = -1;
+      this.remaining = numValues;
+    }
+
+    /**
+     * @return the current integer from the page; this method has no side-effects (the underlying
+     *         {@link ValuesReader} is not affected)
+     */
+    public int readCurrInteger() {
+      assert currValue >= 0;
+      return currValue;
+    }
+
+    /**
+     * @return internally reads the next integer from the underlying {@link ValuesReader}; false if the stream
+     *         reached EOF
+     */
+    public boolean nextIntegerIfNotEOF() {
+      return setNextInteger();
+    }
+
+    /**
+     * @return underlying reader object; this object is now unusable
+     *         note that you have to invoke the {@link #set(ValuesReader, int)} method
+     *         to update this object state in case a) you have used the {@link ValuesReader} object and b)
+     *         want to resume using this {@link DefinitionLevelReader} object instance
+     */
+    public ValuesReader getUnderlyingReader() {
+      currValue = -1; // to make this object unusable
+      return definitionLevels;
+    }
+
+    private boolean setNextInteger() {
+      if (remaining > 0) {
+        --remaining;
+        try {
+          currValue = definitionLevels.readInteger();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+        return true;
+      }
+      currValue = -1;
+      return false;
+    }
+  }
+
+  /** A wrapper value reader with the ability to control when to read the next value */
+  final static class DictionaryReaderWrapper {
+    /** Dictionary Reader */
+    private ValuesReader valuesReader;
+    /** Pushed back value     */
+    private Binary pushedBackValue;
+
+    /**
+     * @return true if the current page uses dictionary encoding for the data
+     */
+    public boolean isDefined() {
+      return valuesReader != null;
+    }
+
+    /**
+     * Set the {@link PageReader#dictionaryValueReader} object; if a null value is passed, then it is understood
+     * the current page doesn't use dictionary encoding
+     * @param valuesReader {@link ValuesReader} object
+     * @param numValues total number of values that can be read from the stream
+     */
+    void set(ValuesReader _rawReader) {
+      this.valuesReader    = _rawReader;
+      this.pushedBackValue = null;
+    }
+
+    /**
+     * @return the current entry from the page
+     */
+    public Binary getEntry() {
+      Binary entry = null;
+      if (pushedBackValue == null) {
+        entry = getNextEntry();
+
+      } else {
+        entry           = pushedBackValue;
+        pushedBackValue = null;
+      }
+      return entry;
+    }
+
+    public void pushBack(Binary entry) {
+      pushedBackValue = entry;
+    }
+
+    private Binary getNextEntry() {
+      try {
+        return valuesReader.readBytes();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryDictionaryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryDictionaryReader.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.DictionaryReaderWrapper;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+import org.apache.parquet.io.api.Binary;
+
+/** Handles variable data types using a dictionary */
+final class VarLenEntryDictionaryReader extends VarLenAbstractEntryReader {
+
+  VarLenEntryDictionaryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  final VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    // Bulk processing is in effect for smaller precisions
+    if (bulkProcess()) {
+      return getEntryBulk(valuesToRead);
+    }
+    return getEntrySingle(valuesToRead);
+  }
+
+  private final VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
+    final DictionaryReaderWrapper valueReader = pageInfo.dictionaryValueReader;
+    final int[] valueLengths = entry.getValuesLength();
+    final int readBatch = Math.min(entry.getMaxEntries(), valuesToRead);
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final int tgtLen = tgtBuff.length;
+
+    // Counters
+    int numValues = 0;
+    int tgtPos = 0;
+
+    for (int idx = 0; idx < readBatch; ++idx ) {
+      final Binary currEntry = valueReader.getEntry();
+      final int dataLen = currEntry.length();
+
+      if (tgtLen < (tgtPos + dataLen)) {
+        valueReader.pushBack(currEntry); // push back this value since we're exiting from the loop
+        break;
+      }
+
+      valueLengths[numValues++] = dataLen;
+
+      if (dataLen > 0) {
+        vlCopyNoPadding(currEntry.getBytes(), 0, tgtBuff, tgtPos, dataLen);
+
+        // Update the counters
+        tgtPos += dataLen;
+      }
+    }
+
+    // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
+    // or the first value being processed ended up to be too long for the buffer.
+    if (numValues == 0) {
+      return getEntrySingle(valuesToRead);
+    }
+
+    // Now set the bulk entry
+    entry.set(0, tgtPos, numValues, numValues);
+
+    return entry;
+  }
+
+  private final VarLenColumnBulkEntry getEntrySingle(int valsToReadWithinPage) {
+    final DictionaryReaderWrapper valueReader = pageInfo.dictionaryValueReader;
+    final int[] valueLengths = entry.getValuesLength();
+    final Binary currEntry = valueReader.getEntry();
+    final int dataLen = currEntry.length();
+
+    // Set the value length
+    valueLengths[0] = dataLen;
+
+    // Now set the bulk entry
+    entry.set(0, dataLen, 1, 1, currEntry.getBytes());
+
+    return entry;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenEntryReader.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+
+/** Handles variable data types. */
+final class VarLenEntryReader extends VarLenAbstractEntryReader {
+
+  VarLenEntryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    // Bulk processing is effecting for smaller precisions
+    if (bulkProcess()) {
+      return getEntryBulk(valuesToRead);
+    }
+    return getEntrySingle(valuesToRead);
+  }
+
+  private final VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
+
+    load(true); // load new data to process
+
+    final int[] valueLengths = entry.getValuesLength();
+    final int readBatch = Math.min(entry.getMaxEntries(), valuesToRead);
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final byte[] srcBuff = buffer.array();
+    final int srcLen = buffer.remaining();
+    final int tgtLen = tgtBuff.length;
+
+    // Counters
+    int numValues = 0;
+    int tgtPos = 0;
+    int srcPos = 0;
+
+    for (; numValues < readBatch; ) {
+      if (srcPos > srcLen -4) {
+        break;
+      }
+
+      final int data_len = getInt(srcBuff, srcPos);
+      srcPos += 4;
+
+      if (srcLen < (srcPos + data_len)
+       || tgtLen < (tgtPos + data_len)) {
+
+        break;
+      }
+
+      valueLengths[numValues++] = data_len;
+
+      if (data_len > 0) {
+        vlCopy(srcBuff, srcPos, tgtBuff, tgtPos, data_len);
+
+        // Update the counters
+        srcPos += data_len;
+        tgtPos += data_len;
+      }
+    }
+
+    // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
+    // or the first value being processed ended up to be too long for the buffer.
+    if (numValues == 0) {
+      return getEntrySingle(valuesToRead);
+    }
+
+    // Update the page data buffer offset
+    pageInfo.pageDataOff += (numValues * 4 + tgtPos);
+
+    if (remainingPageData() < 0) {
+      final String message = String.format("Invalid Parquet page data offset [%d]..", pageInfo.pageDataOff);
+      throw new DrillRuntimeException(message);
+    }
+
+    // Now set the bulk entry
+    entry.set(0, tgtPos, numValues, numValues);
+
+    return entry;
+  }
+
+  private final VarLenColumnBulkEntry getEntrySingle(int valuesToRead) {
+
+    if (remainingPageData() < 4) {
+      final String message = String.format("Invalid Parquet page metadata; cannot process advertised page count..");
+      throw new DrillRuntimeException(message);
+    }
+
+    final int[] valueLengths = entry.getValuesLength();
+    final int dataLen = pageInfo.pageData.getInt(pageInfo.pageDataOff);
+
+    if (remainingPageData() < (4 + dataLen)) {
+      final String message = String.format("Invalid Parquet page metadata; cannot process advertised page count..");
+      throw new DrillRuntimeException(message);
+    }
+
+    // Register the length
+    valueLengths[0] = dataLen;
+
+    // Now set the bulk entry
+    entry.set(pageInfo.pageDataOff + 4, dataLen, 1, 1, pageInfo.pageData);
+
+    // Update the page data buffer offset
+    pageInfo.pageDataOff += (dataLen + 4);
+
+    return entry;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenFixedEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenFixedEntryReader.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+
+/** Handles fixed data types that have been erroneously tagged as Variable Length. */
+final class VarLenFixedEntryReader extends VarLenAbstractEntryReader {
+
+  VarLenFixedEntryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  final VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    assert columnPrecInfo.precision >= 0 : "Fixed length precision cannot be lower than zero";
+
+    load(true); // load new data to process
+
+    final int expectedDataLen = columnPrecInfo.precision;
+    final int entrySz = 4 + columnPrecInfo.precision;
+    final int maxValues = Math.min(entry.getMaxEntries(), (pageInfo.pageDataLen - pageInfo.pageDataOff) / entrySz);
+    final int readBatch = Math.min(maxValues, valuesToRead);
+    final int[] valueLengths = entry.getValuesLength();
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final byte[] srcBuff = buffer.array();
+    int idx = 0;
+
+    for ( ; idx < readBatch; ++idx) {
+      final int currPos = idx * entrySz;
+      final int dataLen = getInt(srcBuff, currPos);
+
+      if (dataLen != expectedDataLen) {
+        return null; // this is a soft error; caller needs to revert to variable length processing
+      }
+
+      valueLengths[idx] = dataLen;
+      final int tgt_pos = idx * expectedDataLen;
+
+      if (expectedDataLen > 0) {
+        vlCopy(srcBuff, currPos + 4, tgtBuff, tgt_pos, dataLen);
+      }
+    }
+
+    // Update the page data buffer offset
+    pageInfo.pageDataOff += idx * entrySz;
+
+    // Now set the bulk entry
+    entry.set(0, idx * expectedDataLen, idx, idx);
+
+    return entry;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableDictionaryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableDictionaryReader.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.DictionaryReaderWrapper;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+import org.apache.parquet.io.api.Binary;
+
+/** Handles nullable variable data types using a dictionary */
+final class VarLenNullableDictionaryReader extends VarLenAbstractEntryReader {
+
+  VarLenNullableDictionaryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  final VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    assert valuesToRead > 0;
+
+    // Bulk processing is effecting for smaller precisions
+    if (bulkProcess()) {
+      return getEntryBulk(valuesToRead);
+    }
+    return getEntrySingle(valuesToRead);
+  }
+
+  private final VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
+    final DictionaryReaderWrapper valueReader = pageInfo.dictionaryValueReader;
+    final int[] valueLengths = entry.getValuesLength();
+    final int readBatch = Math.min(entry.getMaxEntries(), valuesToRead);
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final int tgtLen = tgtBuff.length;
+
+    // Counters
+    int numValues = 0;
+    int numNulls = 0;
+    int tgtPos = 0;
+
+    // Initialize the reader if needed
+    pageInfo.definitionLevels.readFirstIntegerIfNeeded();
+
+    for (int idx = 0; idx < readBatch; ++idx ) {
+      if (pageInfo.definitionLevels.readCurrInteger() == 1) {
+        final Binary currEntry = valueReader.getEntry();
+        final int dataLen = currEntry.length();
+
+        if (tgtLen < (tgtPos + dataLen)) {
+          valueReader.pushBack(currEntry); // push back this value since we're exiting from the loop
+          break;
+        }
+
+        valueLengths[numValues++] = dataLen;
+
+        if (dataLen > 0) {
+          vlCopyNoPadding(currEntry.getBytes(), 0, tgtBuff, tgtPos, dataLen);
+
+          // Update the counters
+          tgtPos += dataLen;
+        }
+
+      } else {
+        valueLengths[numValues++] = -1;
+        ++numNulls;
+      }
+
+      // read the next definition-level value since we know the current entry has been processed
+      pageInfo.definitionLevels.nextIntegerIfNotEOF();
+    }
+
+    // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
+    // or the first value being processed ended up to be too long for the buffer.
+    if (numValues == 0) {
+      return getEntrySingle(valuesToRead);
+    }
+
+    entry.set(0, tgtPos, numValues, numValues - numNulls);
+
+    return entry;
+  }
+
+  private final VarLenColumnBulkEntry getEntrySingle(int valsToReadWithinPage) {
+    final int[] valueLengths = entry.getValuesLength();
+
+    // Initialize the reader if needed
+    pageInfo.definitionLevels.readFirstIntegerIfNeeded();
+
+    if (pageInfo.definitionLevels.readCurrInteger() == 1) {
+      final DictionaryReaderWrapper valueReader = pageInfo.dictionaryValueReader;
+      final Binary currEntry = valueReader.getEntry();
+      final int dataLen = currEntry.length();
+
+      // Set the value length
+      valueLengths[0] = dataLen;
+
+      // Now set the bulk entry
+      entry.set(0, dataLen, 1, 1, currEntry.getBytes());
+
+    } else {
+      valueLengths[0] = -1;
+
+      // Now set the bulk entry
+      entry.set(0, 0, 1, 0);
+    }
+
+    // read the next definition-level value since we know the current entry has been processed
+    pageInfo.definitionLevels.nextIntegerIfNotEOF();
+
+    return entry;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableEntryReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+
+/** Handles variable data types. */
+final class VarLenNullableEntryReader extends VarLenAbstractEntryReader {
+
+  VarLenNullableEntryReader(ByteBuffer buffer,
+      PageDataInfo pageInfo,
+      ColumnPrecisionInfo columnPrecInfo,
+      VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    assert valuesToRead > 0;
+
+    // Bulk processing is effective for smaller precisions
+    if (bulkProcess()) {
+      return getEntryBulk(valuesToRead);
+    }
+    return getEntrySingle(valuesToRead);
+  }
+
+  VarLenColumnBulkEntry getEntryBulk(int valuesToRead) {
+
+    load(true); // load new data to process
+
+    final int[] valueLengths = entry.getValuesLength();
+    final int readBatch = Math.min(entry.getMaxEntries(), valuesToRead);
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final byte[] srcBuff = buffer.array();
+    final int srcLen = buffer.remaining();
+    final int tgtLen = tgtBuff.length;
+
+    // Counters
+    int numValues = 0;
+    int numNulls = 0;
+    int tgtPos = 0;
+    int srcPos = 0;
+
+    // Initialize the reader if needed
+    pageInfo.definitionLevels.readFirstIntegerIfNeeded();
+
+    for (; numValues < readBatch; ) {
+      // Non-null entry
+      if (pageInfo.definitionLevels.readCurrInteger() == 1) {
+        if (srcPos > srcLen - 4) {
+          break;
+        }
+
+        final int dataLen = getInt(srcBuff, srcPos);
+        srcPos += 4;
+
+        if (srcLen < (srcPos + dataLen)
+         || tgtLen < (tgtPos + dataLen)) {
+
+          break;
+        }
+
+        valueLengths[numValues++] = dataLen;
+
+        if (dataLen > 0) {
+          vlCopy(srcBuff, srcPos, tgtBuff, tgtPos, dataLen);
+
+          // Update the counters
+          srcPos += dataLen;
+          tgtPos += dataLen;
+        }
+
+      } else { // Null value
+        valueLengths[numValues++] = -1;
+        ++numNulls;
+      }
+
+      // read the next definition-level value since we know the current entry has been processed
+      pageInfo.definitionLevels.nextIntegerIfNotEOF();
+    }
+
+    // We're here either because a) the Parquet metadata is wrong (advertises more values than the real count)
+    // or the first value being processed ended up to be too long for the buffer.
+    if (numValues == 0) {
+      return getEntrySingle(valuesToRead);
+    }
+
+    // Update the page data buffer offset
+    final int numNonNullValues = numValues - numNulls;
+    pageInfo.pageDataOff += (numNonNullValues * 4 + tgtPos);
+
+    if (remainingPageData() < 0) {
+      final String message = String.format("Invalid Parquet page data offset [%d]..", pageInfo.pageDataOff);
+      throw new DrillRuntimeException(message);
+    }
+
+    // Now set the bulk entry
+    entry.set(0, tgtPos, numValues, numNonNullValues);
+
+    return entry;
+  }
+
+  VarLenColumnBulkEntry getEntrySingle(int valuesToRead) {
+
+    // Initialize the reader if needed
+    pageInfo.definitionLevels.readFirstIntegerIfNeeded();
+
+    final int[] valueLengths = entry.getValuesLength();
+
+    if (pageInfo.definitionLevels.readCurrInteger() == 1) {
+
+      if (remainingPageData() < 4) {
+        final String message = String.format("Invalid Parquet page metadata; cannot process advertised page count..");
+        throw new DrillRuntimeException(message);
+      }
+
+      final int dataLen = pageInfo.pageData.getInt(pageInfo.pageDataOff);
+
+      if (remainingPageData() < (4 + dataLen)) {
+        final String message = String.format("Invalid Parquet page metadata; cannot process advertised page count..");
+        throw new DrillRuntimeException(message);
+      }
+
+      // Register the length
+      valueLengths[0] = dataLen;
+
+      // Now set the bulk entry
+      entry.set(pageInfo.pageDataOff + 4, dataLen, 1, 1, pageInfo.pageData);
+
+      // Update the page data buffer offset
+      pageInfo.pageDataOff += (dataLen + 4);
+
+    } else { // Null value
+      valueLengths[0] = -1;
+
+      // Now set the bulk entry
+      entry.set(0, 0, 1, 0);
+    }
+
+    // read the next definition-level value since we know the current entry has been processed
+    pageInfo.definitionLevels.nextIntegerIfNotEOF();
+
+    return entry;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableFixedEntryReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenNullableFixedEntryReader.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.columnreaders;
+
+import java.nio.ByteBuffer;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.PageDataInfo;
+import org.apache.parquet.column.values.ValuesReader;
+
+/** Handles nullable fixed data types that have been erroneously tagged as Variable Length. */
+final class VarLenNullableFixedEntryReader extends VarLenAbstractEntryReader {
+
+  VarLenNullableFixedEntryReader(ByteBuffer buffer,
+    PageDataInfo pageInfo,
+    ColumnPrecisionInfo columnPrecInfo,
+    VarLenColumnBulkEntry entry) {
+
+    super(buffer, pageInfo, columnPrecInfo, entry);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  final VarLenColumnBulkEntry getEntry(int valuesToRead) {
+    assert columnPrecInfo.precision >= 0 : "Fixed length precision cannot be lower than zero";
+
+    // TODO - We should not use force reload for sparse columns (values with lot of nulls)
+    load(true); // load new data to process
+
+    final int expectedDataLen = columnPrecInfo.precision;
+    final int entrySz = 4 + columnPrecInfo.precision;
+    final int readBatch = Math.min(entry.getMaxEntries(), valuesToRead);
+    final int[] valueLengths = entry.getValuesLength();
+    final byte[] tgtBuff = entry.getInternalDataArray();
+    final byte[] srcBuff = buffer.array();
+    int nonNullValues = 0;
+    int idx = 0;
+
+    // Fixed precision processing can directly operate on the raw definition-level reader as no peeking
+    // is needed.
+    final ValuesReader definitionLevels = pageInfo.definitionLevels.getUnderlyingReader();
+
+    for ( ; idx < readBatch; ++idx) {
+      if (definitionLevels.readInteger() == 1) {
+
+        final int currPos = nonNullValues * entrySz;
+        final int dataLen = getInt(srcBuff, currPos);
+
+        if (dataLen != expectedDataLen) {
+          return null; // this is a soft error; caller needs to revert to variable length processing
+        }
+
+        valueLengths[idx] = dataLen;
+        final int tgt_pos = nonNullValues * expectedDataLen;
+
+        if (expectedDataLen > 0) {
+          vlCopy(srcBuff, currPos + 4, tgtBuff, tgt_pos, dataLen);
+        }
+
+        // Increase the non null values counter
+        ++nonNullValues;
+
+      } else { // Null value
+        valueLengths[idx] = -1; // to mark a null value
+      }
+    }
+
+    // Update the page data buffer offset
+    pageInfo.pageDataOff += nonNullValues * entrySz;
+
+    // Now set the bulk entry
+    entry.set(0, nonNullValues * expectedDataLen, idx, nonNullValues);
+
+    return entry;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLengthValuesColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLengthValuesColumn.java
@@ -17,40 +17,92 @@
  */
 package org.apache.drill.exec.store.parquet.columnreaders;
 
-import io.netty.buffer.DrillBuf;
-
 import java.io.IOException;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.BulkReaderState;
+import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionType;
+import org.apache.drill.exec.vector.VarLenBulkEntry;
+import org.apache.drill.exec.vector.VarLenBulkInput;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VariableWidthVector;
-
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.Encoding;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.io.api.Binary;
 
+import io.netty.buffer.DrillBuf;
+
+@SuppressWarnings("unchecked")
 public abstract class VarLengthValuesColumn<V extends ValueVector> extends VarLengthColumn {
 
   Binary currLengthDeterminingDictVal;
   Binary currDictValToWrite;
   VariableWidthVector variableWidthVector;
 
+  /** Bulk read operation state that needs to be maintained across batch calls */
+  protected final BulkReaderState bulkReaderState = new BulkReaderState();
+
   VarLengthValuesColumn(ParquetRecordReader parentReader, int allocateSize, ColumnDescriptor descriptor,
                         ColumnChunkMetaData columnChunkMetaData, boolean fixedLength, V v,
                         SchemaElement schemaElement) throws ExecutionSetupException {
+
     super(parentReader, allocateSize, descriptor, columnChunkMetaData, fixedLength, v, schemaElement);
     variableWidthVector = (VariableWidthVector) valueVec;
+
     if (columnChunkMetaData.getEncodings().contains(Encoding.PLAIN_DICTIONARY)) {
       usingDictionary = true;
+      // We didn't implement the fixed length optimization when a Parquet Dictionary is used; as there are
+      // no data point about this use-case. Will also enable bulk processing by default since early data
+      // profiling (for detecting the best processing strategy to use) is disabled when the column precision
+      // is already set.
+      bulkReaderState.columnPrecInfo.columnPrecisionType = ColumnPrecisionType.DT_PRECISION_IS_VARIABLE;
+      bulkReaderState.columnPrecInfo.bulkProcess         = true;
     }
     else {
       usingDictionary = false;
     }
   }
 
+  /**
+   * Store a variable length entry if there is enough memory.
+   *
+   * @param index entry's index
+   * @param bytes byte array container
+   * @param start start offset
+   * @param length entry's length
+   * @return true if the entry was successfully inserted; false otherwise
+   */
   public abstract boolean setSafe(int index, DrillBuf bytes, int start, int length);
+
+  /**
+   * Store a set of variable entries in bulk; this method will automatically extend the underlying
+   * value vector if needed.
+   *
+   * @param bulkInput set of variable length entries
+   */
+  protected abstract void setSafe(VarLenBulkInput<VarLenBulkEntry> bulkInput);
+
+  /**
+   * @return new variable bulk input object
+   */
+  protected abstract VarLenColumnBulkInput<V> newVLBulkInput(int recordsToRead) throws IOException;
+
+  /** {@inheritDoc} */
+  @Override
+  protected final int readRecordsInBulk(int recordsToRead) throws IOException {
+    final VarLenColumnBulkInput<V> bulkInput = newVLBulkInput(recordsToRead);
+
+    // Process this batch
+    setSafe(bulkInput);
+
+    // Somehow the Batch Reader uses this variable to propagate the batch-size (picks the first column and
+    // then reads the "valuesReadInCurrentPass" variable value).
+    valuesReadInCurrentPass = bulkInput.getReadBatchFields();
+
+    return valuesReadInCurrentPass;
+  }
 
   @Override
   protected void readField(long recordToRead) {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -578,6 +578,7 @@ drill.exec.options: {
     store.parquet.writer.use_primitive_types_for_decimals: true,
     store.parquet.writer.logical_type_for_decimals: "fixed_len_byte_array",
     store.parquet.writer.use_single_fs_block: false,
+    store.parquet.flat.reader.bulk: true,
     store.partition.hash_distribute: false,
     store.text.estimated_row_size_bytes: 100.0,
     store.kafka.all_text_mode: false,

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVectorDefinitionSetter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVectorDefinitionSetter.java
@@ -19,5 +19,17 @@ package org.apache.drill.exec.vector;
 
 public interface NullableVectorDefinitionSetter {
 
+  /**
+   * Set value at position "index" to be defined.
+   * @param index value position
+   */
   public void setIndexDefined(int index);
+
+  /**
+   * Set a contiguous set of values starting at position "index" to be defined.
+   * @param index value position
+   * @param number of contiguous values
+   */
+  public void setIndexDefined(int index, int numValues);
+
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkEntry.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkEntry.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector;
+
+import io.netty.buffer.DrillBuf;
+
+/**
+ * A bulk input entry enables us to process potentially multiple VL values in one shot (especially for very
+ * small values); please refer to {@link org.apache.drill.exec.vector.VarBinaryVector.BulkInput}.
+ *
+ * <p><b>Format -</b>
+ * <ul>
+ * <li>data: [&lt;val1&gt;&lt;val2&gt;&lt;val3&gt;..]
+ * <li>value lengths: [&lt;val1-len&gt;&lt;val2-len&gt;&lt;val3-len&gt;..]
+ * </ul>
+ *
+ * <p><b>NOTE - </b>Bulk entries are immutable
+ */
+public interface VarLenBulkEntry {
+  /**
+   * @return total length of this bulk entry data
+   */
+  int getTotalLength();
+  /**
+   * @return data start offset
+   */
+  int getDataStartOffset();
+  /**
+   * @return true if this entry's data is backed by an array
+   */
+  boolean arrayBacked();
+  /**
+   * @return byte buffer containing the data; the data is located within buffer[start-offset, length-1] where
+   * buffer is the byte array returned by this method
+   */
+  byte[] getArrayData();
+  /**
+   * @return {@link DrillBuf} containing the data; the data is located within [start-offset, length-1]
+   */
+   DrillBuf getData();
+  /**
+   * @return length table (one per VL value)
+   */
+  int[] getValuesLength();
+  /**
+   * @return number of values (including null values)
+   */
+  int getNumValues();
+  /**
+   * @return number of non-null values
+   */
+  int getNumNonNullValues();
+  /**
+   * @return true if this bulk entry has nulls; false otherwise
+   */
+  boolean hasNulls();
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkInput.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/VarLenBulkInput.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector;
+
+import java.util.Iterator;
+
+/**
+ * Allows caller to provide input in a bulk manner while abstracting the underlying data structure
+ * to provide performance optimizations opportunities.
+ */
+public interface VarLenBulkInput<T extends VarLenBulkEntry> extends Iterator<T> {
+  /**
+   * @return start index of this bulk input (relative to this VL container)
+   */
+  int getStartIndex();
+
+  /**
+   * Indicates we're done processing (processor might stop processing when memory buffers
+   * are depleted); this allows caller to re-submit any unprocessed data.
+   *
+   * @param numCommitted number of processed entries
+   */
+  void done();
+
+  /**
+   * Enables caller (such as wrapper vector objects) to include more processing logic as the data is being
+   * streamed.
+   */
+  public interface BulkInputCallback<T extends VarLenBulkEntry> {
+    /**
+     * Invoked when a new bulk entry is read (entry is immutable)
+     * @param entry bulk entry
+     */
+    void onNewBulkEntry(final T entry);
+
+    /**
+     * Indicates the bulk input is done
+     */
+    void onEndBulkInput();
+  }
+}


### PR DESCRIPTION
Performance improvements for the Parquet Scanner (Flat Data Types). The are two flags to control this performance enhancement (disabled by default):
Option I -
Config Name: store.parquet.flat.reader.bulk
Config Type  : boolean
Description   : Enables bulk processing to minimize memory checks and improve JVM HotSpot optimizations

Option II -
Config Name: scan.optimized.implicit.columns 
Config Type  : boolean
Description   : Memory optimization when storing duplicate value (implicit columns have duplicate values within a batch). Code profiling indicated this step represented one third of Parquet processing (when implicit columns are processed).  
