### PR TITLE
DRILL-5702: Jdbc Driver Class not found

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/security/SecurityConfiguration.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/security/SecurityConfiguration.java
@@ -54,14 +54,13 @@ public class SecurityConfiguration extends Configuration {
    * Update the GroupMapping class name to add namespace prefix retrieved from System Property. This is needed since
    * in drill-jdbc-all jar we are packaging hadoop dependencies under that namespace. This will help application
    * using this jar as driver to avoid conflict with it's own hadoop dependency if any. The property is needed only
-   * when Hadoop classes are relocated to different namespace which is done inside jdbc-all package. For normal build
-   * this property is not required as Hadoop classes will be used normally.
+   * when Hadoop classes are relocated to different namespace which is done inside jdbc-all package.
    */
   private void updateGroupMapping() {
     final String originalClassName = get(CommonConfigurationKeys.HADOOP_SECURITY_GROUP_MAPPING);
     final String profilePrefix = System.getProperty("drill.security.namespacePrefix");
 
-    if (!Strings.isNullOrEmpty(profilePrefix)) {
+    if (originalClassName != null && !Strings.isNullOrEmpty(profilePrefix) && !originalClassName.startsWith(profilePrefix)) {
       set(CommonConfigurationKeys.HADOOP_SECURITY_GROUP_MAPPING, profilePrefix + originalClassName);
     }
   }

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -26,6 +26,12 @@
   <artifactId>drill-jdbc-all</artifactId>
   <name>JDBC JAR with all dependencies</name>
 
+  <!-- Since we are packaging hadoop dependencies under the namespace with "oadd." prefix by default,
+       "package.namespace.prefix" equals to "oadd.". It can be overridden if necessary within any profile -->
+  <properties>
+    <package.namespace.prefix>oadd.</package.namespace.prefix>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -535,19 +541,10 @@
   </pluginRepositories>
 
   <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <package.namespace.prefix>oadd.</package.namespace.prefix>
-      </properties>
-    </profile>
       <profile>
         <id>mapr</id>
         <properties>
-          <package.namespace.prefix></package.namespace.prefix>
+          <package.namespace.prefix />
         </properties>
 
         <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1918,10 +1918,6 @@
                 <groupId>commons-logging</groupId>
               </exclusion>
               <exclusion>
-                <artifactId>commons-logging</artifactId>
-                <groupId>commons-logging</groupId>
-              </exclusion>
-              <exclusion>
                 <artifactId>core</artifactId>
                 <groupId>org.eclipse.jdt</groupId>
               </exclusion>
@@ -2002,10 +1998,6 @@
               </exclusion>
               <exclusion>
                 <artifactId>commons-logging-api</artifactId>
-                <groupId>commons-logging</groupId>
-              </exclusion>
-              <exclusion>
-                <artifactId>commons-logging</artifactId>
                 <groupId>commons-logging</groupId>
               </exclusion>
               <exclusion>


### PR DESCRIPTION
- Setting "package.namespace.prefix" to "oadd." by default for all profiles. It can be overridden if necessary within any profile.
- Removing duplicated and redundant excluding of commons-logging packages.