### PR TITLE
DRILL-3958: Return a valid error message when storage plugin fails

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -162,8 +162,8 @@ public class StorageResources {
       plugin.createOrUpdateInStorage(storage);
       return message("success");
     } catch (ExecutionSetupException e) {
-      logger.debug("Unable to create/ update plugin: " + plugin.getName());
-      return message("error (unable to create/ update storage)");
+      logger.error("Unable to create/ update plugin: " + plugin.getName(), e);
+      return message("Error while creating/ updating storage : " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
     }
   }
 


### PR DESCRIPTION
Currently when the Storage Configuration fails(due to an invalid configuration/missing driver) the error message is too generic and says "Please retry: error (unable to create/ update storage)"

This patch adds a line of detail to the error response like: 
Please retry: Error while creating/ updating storage : org.apache.commons.dbcp.SQLNestedException: Cannot load JDBC driver class 'com.microsoft.sqlserver.jdbc.SQLServerDriver'