### PR TITLE
DRILL-6028: Allow splitting generated code in ChainedHashTable into b…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/ConstantExpressionIdentifier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/ConstantExpressionIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -225,5 +225,10 @@ public class ConstantExpressionIdentifier implements ExprVisitor<Boolean, Identi
   public Boolean visitConvertExpression(ConvertExpression e,
       IdentityHashMap<LogicalExpression, Object> value) throws RuntimeException {
     return e.getInput().accept(this, value);
+  }
+
+  @Override
+  public Boolean visitParameter(ValueExpressions.ParameterExpression e, IdentityHashMap<LogicalExpression, Object> value) throws RuntimeException {
+    return false;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
@@ -225,7 +225,7 @@ public class ClassGenerator<T>{
   }
 
   public JLabel getEvalBlockLabel (String prefix) {
-    return getEvalBlock().label(prefix + labelIndex ++);
+    return getEvalBlock().label(prefix + labelIndex++);
   }
 
   /**
@@ -543,12 +543,24 @@ public class ClassGenerator<T>{
   }
 
   public HoldingContainer declare(MajorType t, boolean includeNewInstance) {
+    return declare(t, "out", includeNewInstance);
+  }
+
+  /**
+   * Adds local variable declaration based on given name and type.
+   *
+   * @param t major type
+   * @param name variable name
+   * @param includeNewInstance whether to create new instance
+   * @return holder instance
+   */
+  public HoldingContainer declare(MajorType t, String name, boolean includeNewInstance) {
     JType holderType = getHolderType(t);
     JVar var;
     if (includeNewInstance) {
-      var = getEvalBlock().decl(holderType, "out" + index, JExpr._new(holderType));
+      var = getEvalBlock().decl(holderType, name + index, JExpr._new(holderType));
     } else {
-      var = getEvalBlock().decl(holderType, "out" + index);
+      var = getEvalBlock().decl(holderType, name + index);
     }
     JFieldRef outputSet = null;
     if (t.getMode() == DataMode.OPTIONAL) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -37,6 +37,7 @@ import org.apache.drill.common.expression.NullExpression;
 import org.apache.drill.common.expression.PathSegment;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.expression.TypedNullConstant;
+import org.apache.drill.common.expression.ValueExpressions;
 import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
 import org.apache.drill.common.expression.ValueExpressions.DateExpression;
 import org.apache.drill.common.expression.ValueExpressions.Decimal18Expression;
@@ -348,6 +349,28 @@ public class EvaluationVisitor {
         return super.visitUnknown(e, generator);
       }
 
+    }
+
+    /**
+     * <p>
+     * Creates local variable based on given parameter type and name and assigns parameter to this local instance.
+     * </p>
+     *
+     * <p>
+     * Example: <br/>
+     * IntHolder seedValue0 = new IntHolder();<br/>
+     * seedValue0 .value = seedValue;
+     * </p>
+     *
+     * @param e parameter expression
+     * @param generator class generator
+     * @return holder instance
+     */
+    @Override
+    public HoldingContainer visitParameter(ValueExpressions.ParameterExpression e, ClassGenerator<?> generator) {
+      HoldingContainer out = generator.declare(e.getMajorType(), e.getName(), true);
+      generator.getEvalBlock().assign(out.getValue(), JExpr.ref(e.getName()));
+      return out;
     }
 
     private HoldingContainer visitValueVectorWriteExpression(ValueVectorWriteExpression e, ClassGenerator<?> generator) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
@@ -18,13 +18,14 @@
 package org.apache.drill.exec.physical.impl.common;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.ValueExpressions;
 import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.compile.sig.GeneratorMapping;
 import org.apache.drill.exec.compile.sig.MappingSet;
@@ -154,7 +155,6 @@ public class ChainedHashTable {
 
     ErrorCollector collector = new ErrorCollectorImpl();
     VectorContainer htContainerOrig = new VectorContainer(); // original ht container from which others may be cloned
-    LogicalExpression[] htKeyExprs = new LogicalExpression[htConfig.getKeyExprsBuild().size()];
     TypedFieldId[] htKeyFieldIds = new TypedFieldId[htConfig.getKeyExprsBuild().size()];
 
     int i = 0;
@@ -241,10 +241,10 @@ public class ChainedHashTable {
       return;
     }
 
-    for (int i=0; i<keyExprs.length; i++) {
+    for (int i = 0; i < keyExprs.length; i++) {
       final LogicalExpression expr = keyExprs[i];
       cg.setMappingSet(incomingMapping);
-      HoldingContainer left = cg.addExpr(expr, ClassGenerator.BlkCreateMode.FALSE);
+      HoldingContainer left = cg.addExpr(expr, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
 
       cg.setMappingSet(htableMapping);
       ValueVectorReadExpression vvrExpr = new ValueVectorReadExpression(htKeyFieldIds[i]);
@@ -286,7 +286,7 @@ public class ChainedHashTable {
       boolean useSetSafe = !Types.isFixedWidthType(expr.getMajorType()) || Types.isRepeated(expr.getMajorType());
       ValueVectorWriteExpression vvwExpr = new ValueVectorWriteExpression(htKeyFieldIds[i++], expr, useSetSafe);
 
-      cg.addExpr(vvwExpr, ClassGenerator.BlkCreateMode.FALSE); // this will write to the htContainer at htRowIdx
+      cg.addExpr(vvwExpr, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
     }
   }
 
@@ -320,11 +320,22 @@ public class ChainedHashTable {
      * aggregate. For join we need to hash everything as double (both for distribution and for comparison) but
      * for aggregation we can avoid the penalty of casting to double
      */
-    LogicalExpression hashExpression = HashPrelUtil.getHashExpression(Arrays.asList(keyExprs), incomingProbe != null);
-    final LogicalExpression materializedExpr = ExpressionTreeMaterializer.materializeAndCheckErrors(hashExpression, batch, context.getFunctionRegistry());
-    HoldingContainer hash = cg.addExpr(materializedExpr);
-    cg.getEvalBlock()._return(hash.getValue());
 
 
+    /*
+      Generate logical expression for each key so expression can be split into blocks if number of expressions in method exceeds upper limit.
+      `seedValue` is used as holder to pass generated seed value for the new methods.
+    */
+    String seedValue = "seedValue";
+    LogicalExpression seed = ValueExpressions.getParameterExpression(seedValue, Types.required(TypeProtos.MinorType.INT));
+
+    for (LogicalExpression expr : keyExprs) {
+      LogicalExpression hashExpression = HashPrelUtil.getHashExpression(expr, seed, incomingProbe != null);
+      LogicalExpression materializedExpr = ExpressionTreeMaterializer.materializeAndCheckErrors(hashExpression, batch, context.getFunctionRegistry());
+      HoldingContainer hash = cg.addExpr(materializedExpr, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
+      cg.getEvalBlock().assign(JExpr.ref(seedValue), hash.getValue());
+    }
+
+    cg.getEvalBlock()._return(JExpr.ref(seedValue));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
@@ -578,7 +578,7 @@ public abstract class HashTableTemplate implements HashTable {
   }
 
   public int getHashCode(int incomingRowIdx) throws SchemaChangeException {
-    return getHashBuild(incomingRowIdx);
+    return getHashBuild(incomingRowIdx, 0);
   }
 
   /** put() uses the hash code (from gethashCode() above) to insert the key(s) from the incoming
@@ -667,7 +667,8 @@ public abstract class HashTableTemplate implements HashTable {
   // Return -1 if key is not found in the hash table. Otherwise, return the global index of the key
   @Override
   public int containsKey(int incomingRowIdx, boolean isProbe) throws SchemaChangeException {
-    int hash = isProbe ? getHashProbe(incomingRowIdx) : getHashBuild(incomingRowIdx);
+    int seedValue = 0;
+    int hash = isProbe ? getHashProbe(incomingRowIdx, seedValue) : getHashBuild(incomingRowIdx, seedValue);
     int bucketIndex = getBucketIndex(hash, numBuckets());
 
     for ( currentIdxHolder.value = startIndices.getAccessor().get(bucketIndex);
@@ -814,8 +815,8 @@ public abstract class HashTableTemplate implements HashTable {
   // These methods will be code-generated in the context of the outer class
   protected abstract void doSetup(@Named("incomingBuild") RecordBatch incomingBuild, @Named("incomingProbe") RecordBatch incomingProbe) throws SchemaChangeException;
 
-  protected abstract int getHashBuild(@Named("incomingRowIdx") int incomingRowIdx) throws SchemaChangeException;
+  protected abstract int getHashBuild(@Named("incomingRowIdx") int incomingRowIdx, @Named("seedValue") int seedValue) throws SchemaChangeException;
 
-  protected abstract int getHashProbe(@Named("incomingRowIdx") int incomingRowIdx) throws SchemaChangeException;
+  protected abstract int getHashProbe(@Named("incomingRowIdx") int incomingRowIdx, @Named("seedValue") int seedValue) throws SchemaChangeException;
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashPrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashPrelUtil.java
@@ -25,7 +25,13 @@ import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.ValueExpressions;
+import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.expr.DirectExpression;
+import org.apache.drill.exec.expr.ValueVectorReadExpression;
 import org.apache.drill.exec.planner.physical.DrillDistributionTrait.DistributionField;
+import org.apache.drill.exec.record.TypedFieldId;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +106,7 @@ public class HashPrelUtil {
 
     final String functionName = hashAsDouble ? HASH32_DOUBLE_FUNCTION_NAME : HASH32_FUNCTION_NAME;
 
-    T func = helper.createCall(functionName,  ImmutableList.of(inputExprs.get(0), seed ));
+    T func = helper.createCall(functionName,  ImmutableList.of(inputExprs.get(0), seed));
     for (int i = 1; i<inputExprs.size(); i++) {
       func = helper.createCall(functionName, ImmutableList.of(inputExprs.get(i), func));
     }
@@ -109,11 +115,15 @@ public class HashPrelUtil {
   }
 
   /**
-   * Return a hash expression :  hash32(field1, hash32(field2, hash32(field3, 0)));
+   * Creates hash expression for input field and seed.
+   *
+   * @param field field expression
+   * @param seed seed expression
+   * @param hashAsDouble whether to use the hash as double function or regular hash64 function
+   * @return hash expression
    */
-  public static LogicalExpression getHashExpression(List<LogicalExpression> fields, boolean hashAsDouble){
-    final LogicalExpression seed = ValueExpressions.getInt(0); // Hash Table seed
-    return createHashExpression(fields, seed, HASH_HELPER_LOGICALEXPRESSION, hashAsDouble);
+  public static LogicalExpression getHashExpression(LogicalExpression field, LogicalExpression seed, boolean hashAsDouble) {
+    return createHashExpression(ImmutableList.of(field), seed, HASH_HELPER_LOGICALEXPRESSION, hashAsDouble);
   }
 
 

--- a/logical/src/main/java/org/apache/drill/common/expression/ValueExpressions.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/ValueExpressions.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
@@ -133,6 +134,10 @@ public class ValueExpressions {
     throw new IllegalArgumentException(String.format("Unable to parse string %s as integer or floating point number.",
         numStr));
 
+  }
+
+  public static LogicalExpression getParameterExpression(String name, MajorType type) {
+    return new ParameterExpression(name, type, ExpressionPosition.UNKNOWN);
   }
 
   protected static abstract class ValueExpression<V> extends LogicalExpressionBase {
@@ -676,6 +681,40 @@ public class ValueExpressions {
     @Override
     public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
       return visitor.visitQuotedStringConstant(this, value);
+    }
+  }
+
+  /**
+   * Is used to identify method parameter based on given name and type.
+   */
+  public static class ParameterExpression extends LogicalExpressionBase {
+
+    private final String name;
+    private final MajorType type;
+
+    protected ParameterExpression(String name, MajorType type, ExpressionPosition pos) {
+      super(pos);
+      this.name = name;
+      this.type = type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public MajorType getMajorType() {
+      return type;
+    }
+
+    @Override
+    public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
+      return visitor.visitParameter(this, value);
+    }
+
+    @Override
+    public Iterator<LogicalExpression> iterator() {
+      return ImmutableList.<LogicalExpression>of().iterator();
     }
   }
 

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/AbstractExprVisitor.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/AbstractExprVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -39,6 +39,7 @@ import org.apache.drill.common.expression.ValueExpressions.IntExpression;
 import org.apache.drill.common.expression.ValueExpressions.IntervalDayExpression;
 import org.apache.drill.common.expression.ValueExpressions.IntervalYearExpression;
 import org.apache.drill.common.expression.ValueExpressions.LongExpression;
+import org.apache.drill.common.expression.ValueExpressions.ParameterExpression;
 import org.apache.drill.common.expression.ValueExpressions.QuotedString;
 import org.apache.drill.common.expression.ValueExpressions.TimeExpression;
 import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
@@ -172,5 +173,9 @@ public abstract class AbstractExprVisitor<T, VAL, EXCEP extends Exception> imple
     throw new UnsupportedOperationException(String.format("Expression of type %s not handled by visitor type %s.", e.getClass().getCanonicalName(), this.getClass().getCanonicalName()));
   }
 
+  @Override
+  public T visitParameter(ParameterExpression e, VAL value) throws EXCEP {
+    return visitUnknown(e, value);
+  }
 
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/AggregateChecker.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/AggregateChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -29,6 +29,7 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.NullExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.expression.TypedNullConstant;
+import org.apache.drill.common.expression.ValueExpressions;
 import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
 import org.apache.drill.common.expression.ValueExpressions.DateExpression;
 import org.apache.drill.common.expression.ValueExpressions.Decimal18Expression;
@@ -200,6 +201,11 @@ public final class AggregateChecker implements ExprVisitor<Boolean, ErrorCollect
 
   @Override
   public Boolean visitNullExpression(NullExpression e, ErrorCollector value) throws RuntimeException {
+    return false;
+  }
+
+  @Override
+  public Boolean visitParameter(ValueExpressions.ParameterExpression e, ErrorCollector value) throws RuntimeException {
     return false;
   }
 

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ConstantChecker.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ConstantChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -29,6 +29,7 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.NullExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.expression.TypedNullConstant;
+import org.apache.drill.common.expression.ValueExpressions;
 import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
 import org.apache.drill.common.expression.ValueExpressions.DateExpression;
 import org.apache.drill.common.expression.ValueExpressions.Decimal18Expression;
@@ -205,6 +206,11 @@ final class ConstantChecker implements ExprVisitor<Boolean, ErrorCollector, Runt
   @Override
   public Boolean visitNullExpression(NullExpression e, ErrorCollector value) throws RuntimeException {
     return true;
+  }
+
+  @Override
+  public Boolean visitParameter(ValueExpressions.ParameterExpression e, ErrorCollector value) throws RuntimeException {
+    return false;
   }
 
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ExprVisitor.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ExprVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -39,6 +39,7 @@ import org.apache.drill.common.expression.ValueExpressions.IntExpression;
 import org.apache.drill.common.expression.ValueExpressions.IntervalDayExpression;
 import org.apache.drill.common.expression.ValueExpressions.IntervalYearExpression;
 import org.apache.drill.common.expression.ValueExpressions.LongExpression;
+import org.apache.drill.common.expression.ValueExpressions.ParameterExpression;
 import org.apache.drill.common.expression.ValueExpressions.QuotedString;
 import org.apache.drill.common.expression.ValueExpressions.TimeExpression;
 import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
@@ -69,4 +70,5 @@ public interface ExprVisitor<T, VAL, EXCEP extends Exception> {
   public T visitUnknown(LogicalExpression e, VAL value) throws EXCEP;
   public T visitCastExpression(CastExpression e, VAL value) throws EXCEP;
   public T visitConvertExpression(ConvertExpression e, VAL value) throws EXCEP;
+  public T visitParameter(ParameterExpression e, VAL value) throws EXCEP;
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ExpressionValidator.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ExpressionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -229,6 +229,11 @@ public class ExpressionValidator implements ExprVisitor<Void, ErrorCollector, Ru
   public Void visitConvertExpression(ConvertExpression e, ErrorCollector value)
       throws RuntimeException {
     return e.getInput().accept(this, value);
+  }
+
+  @Override
+  public Void visitParameter(ValueExpressions.ParameterExpression e, ErrorCollector value) throws RuntimeException {
+    return null;
   }
 
 }


### PR DESCRIPTION
…locks to avoid "code too large" error

1. Added new parameter seedValue to getHashBuild and getHashProbe methods in HashTableTemplate.
2. Generate logical expression for each key so its  can be split into blocks if number of expressions in method exceeds upper limit.
3. ParameterExpression was added to generate reference to method parameter during code generation.

Details in [DRILL-6028](https://issues.apache.org/jira/browse/DRILL-6028)