### PR TITLE
DRILL-5879: Improved SQL Pattern Contains Performance

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SqlPatternContainsMatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SqlPatternContainsMatcher.java
@@ -69,7 +69,7 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
     protected abstract int match(int start, int end, DrillBuf drillBuf);
   }
 
-  /** Handles patterns with length one */
+  /** Handles patterns with length zero */
   private final class MatcherZero extends MatcherFcn {
 
     private MatcherZero() {
@@ -84,23 +84,23 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
 
   /** Handles patterns with length one */
   private final class MatcherOne extends MatcherFcn {
+    final byte firstPatternByte;
 
     private MatcherOne() {
-      super();
+      firstPatternByte  = patternArray[0];
     }
 
     /** {@inheritDoc} */
     @Override
     protected final int match(int start, int end, DrillBuf drillBuf) {
       final int lengthToProcess = end - start;
-      final byte firstPattByte  = patternArray[0];
 
       // simplePattern string has meta characters i.e % and _ and escape characters removed.
       // so, we can just directly compare.
       for (int idx = 0; idx < lengthToProcess; idx++) {
         byte inputByte = drillBuf.getByte(start + idx);
 
-        if (firstPattByte != inputByte) {
+        if (firstPatternByte != inputByte) {
           continue;
         }
         return 1;
@@ -111,28 +111,30 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
 
   /** Handles patterns with length two */
   private final class MatcherTwo extends MatcherFcn {
+    final byte firstPatternByte;
+    final byte secondPatternByte;
 
     private MatcherTwo() {
+      firstPatternByte  = patternArray[0];
+      secondPatternByte = patternArray[1];
     }
 
     /** {@inheritDoc} */
     @Override
     protected final int match(int start, int end, DrillBuf drillBuf) {
       final int lengthToProcess = end - start - 1;
-      final byte firstPattByte  = patternArray[0];
-      final byte secondPattByte = patternArray[1];
 
       // simplePattern string has meta characters i.e % and _ and escape characters removed.
       // so, we can just directly compare.
       for (int idx = 0; idx < lengthToProcess; idx++) {
         final byte firstInByte = drillBuf.getByte(start + idx);
 
-        if (firstPattByte != firstInByte) {
+        if (firstPatternByte != firstInByte) {
           continue;
         } else {
-          final byte secondInByte = drillBuf.getByte(start + idx +1);
+          final byte secondInByte = drillBuf.getByte(start + idx + 1);
 
-          if (secondInByte == secondPattByte) {
+          if (secondInByte == secondPatternByte) {
             return 1;
           }
         }
@@ -143,30 +145,33 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
 
   /** Handles patterns with length three */
   private final class MatcherThree extends MatcherFcn {
+    final byte firstPatternByte;
+    final byte secondPatternByte;
+    final byte thirdPatternByte;
 
     private MatcherThree() {
+      firstPatternByte   = patternArray[0];
+      secondPatternByte  = patternArray[1];
+      thirdPatternByte   = patternArray[2];
     }
 
     /** {@inheritDoc} */
     @Override
     protected final int match(int start, int end, DrillBuf drillBuf) {
-      final int lengthToProcess  = end - start -2;
-      final byte firstPattByte   = patternArray[0];
-      final byte secondPattByte  = patternArray[1];
-      final byte thirdPattByte   = patternArray[2];
+      final int lengthToProcess = end - start - 2;
 
       // simplePattern string has meta characters i.e % and _ and escape characters removed.
       // so, we can just directly compare.
       for (int idx = 0; idx < lengthToProcess; idx++) {
         final byte inputByte = drillBuf.getByte(start + idx);
 
-        if (firstPattByte != inputByte) {
+        if (firstPatternByte != inputByte) {
           continue;
         } else {
-          final byte secondInByte = drillBuf.getByte(start + idx +1);
-          final byte thirdInByte  = drillBuf.getByte(start + idx +2);
+          final byte secondInByte = drillBuf.getByte(start + idx + 1);
+          final byte thirdInByte  = drillBuf.getByte(start + idx + 2);
 
-          if (secondInByte == secondPattByte && thirdInByte == thirdPattByte) {
+          if (secondInByte == secondPatternByte && thirdInByte == thirdPatternByte) {
             return 1;
           }
         }
@@ -177,8 +182,10 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
 
   /** Handles patterns with arbitrary length */
   private final class MatcherN extends MatcherFcn {
+    final byte firstPatternByte;
 
     private MatcherN() {
+      firstPatternByte = patternArray[0];
     }
 
     /** {@inheritDoc} */
@@ -186,14 +193,13 @@ public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
     protected final int match(int start, int end, DrillBuf drillBuf) {
       final int lengthToProcess = end - start - patternLength + 1;
       int patternIndex          = 0;
-      final byte firstPattByte  = patternArray[0];
 
       // simplePattern string has meta characters i.e % and _ and escape characters removed.
       // so, we can just directly compare.
       for (int idx = 0; idx < lengthToProcess; idx++) {
         final byte inputByte = drillBuf.getByte(start + idx);
 
-        if (firstPattByte == inputByte) {
+        if (firstPatternByte == inputByte) {
           for (patternIndex = 1; patternIndex < patternLength; ++patternIndex) {
             final byte currInByte   = drillBuf.getByte(start + idx + patternIndex);
             final byte currPattByte = patternArray[patternIndex];

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SqlPatternContainsMatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SqlPatternContainsMatcher.java
@@ -19,44 +19,283 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import io.netty.buffer.DrillBuf;
 
-public class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
+/** SQL Pattern Contains implementation */
+public final class SqlPatternContainsMatcher extends AbstractSqlPatternMatcher {
+  private final MatcherFcn matcherFcn;
 
   public SqlPatternContainsMatcher(String patternString) {
     super(patternString);
+
+    // Pattern matching is 1) a CPU intensive operation and 2) pattern and input dependent. The conclusion is
+    // that there is no single implementation that can do it all well. So, we use multiple implementations
+    // chosen based on the pattern length.
+    if (patternLength == 1) {
+      matcherFcn = new Matcher1();
+    } else if (patternLength == 2) {
+      matcherFcn = new Matcher2();
+    } else if (patternLength == 3) {
+      matcherFcn = new Matcher3();
+    } else if (patternLength < 10) {
+      matcherFcn = new MatcherN();
+    } else {
+      matcherFcn = new BoyerMooreMatcher();
+    }
   }
 
   @Override
   public int match(int start, int end, DrillBuf drillBuf) {
+    return matcherFcn.match(start, end, drillBuf);
+  }
 
-    if (patternLength == 0) { // Everything should match for null pattern string
-      return 1;
+  //--------------------------------------------------------------------------
+  // Inner Data Structure
+  // --------------------------------------------------------------------------
+
+  /** Abstract matcher class to allow us pick the most efficient implementation */
+  private abstract class MatcherFcn {
+    protected final byte[] patternArray;
+
+    protected MatcherFcn() {
+      assert patternByteBuffer.hasArray();
+
+      patternArray = patternByteBuffer.array();
     }
 
-    final int txtLength = end - start;
+    /**
+     * @return 1 if the pattern was matched; 0 otherwise
+     */
+    protected abstract int match(int start, int end, DrillBuf drillBuf);
+  }
 
-    // no match if input string length is less than pattern length
-    if (txtLength < patternLength) {
-      return 0;
+  /** Handles patterns with length one */
+  private final class Matcher1 extends MatcherFcn {
+
+    private Matcher1() {
+      super();
     }
 
-
-    final int outerEnd = txtLength - patternLength;
-
-    outer:
-    for (int txtIndex = 0; txtIndex <= outerEnd; txtIndex++) {
+    /** {@inheritDoc} */
+    @Override
+    protected final int match(int start, int end, DrillBuf drillBuf) {
+      final int lengthToProcess = end - start;
+      final byte firstPattByte  = patternArray[0];
 
       // simplePattern string has meta characters i.e % and _ and escape characters removed.
       // so, we can just directly compare.
-      for (int patternIndex = 0; patternIndex < patternLength; patternIndex++) {
-        if (patternByteBuffer.get(patternIndex) != drillBuf.getByte(start + txtIndex + patternIndex)) {
-          continue outer;
-        }
-      }
+      for (int idx = 0; idx < lengthToProcess; idx++) {
+        byte inputByte = drillBuf.getByte(start + idx);
 
-      return 1;
+        if (firstPattByte != inputByte) {
+          continue;
+        }
+        return 1;
+      }
+      return 0;
+    }
+  }
+
+  /** Handles patterns with length two */
+  private final class Matcher2 extends MatcherFcn {
+
+    private Matcher2() {
+      super();
     }
 
-    return  0;
+    /** {@inheritDoc} */
+    @Override
+    protected final int match(int start, int end, DrillBuf drillBuf) {
+      final int lengthToProcess = end - start - 1;
+      final byte firstPattByte  = patternArray[0];
+      final byte secondPattByte = patternArray[1];
+
+      // simplePattern string has meta characters i.e % and _ and escape characters removed.
+      // so, we can just directly compare.
+      for (int idx = 0; idx < lengthToProcess; idx++) {
+        final byte firstInByte = drillBuf.getByte(start + idx);
+
+        if (firstPattByte != firstInByte) {
+          continue;
+        } else {
+          final byte secondInByte = drillBuf.getByte(start + idx +1);
+
+          if (secondInByte == secondPattByte) {
+            return 1;
+          }
+        }
+      }
+      return 0;
+    }
+  }
+
+  /** Handles patterns with length three */
+  private final class Matcher3 extends MatcherFcn {
+
+    private Matcher3() {
+      super();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected final int match(int start, int end, DrillBuf drillBuf) {
+      final int lengthToProcess  = end - start -2;
+      final byte firstPattByte   = patternArray[0];
+      final byte secondPattByte  = patternArray[1];
+      final byte thirdPattByte   = patternArray[2];
+
+      // simplePattern string has meta characters i.e % and _ and escape characters removed.
+      // so, we can just directly compare.
+      for (int idx = 0; idx < lengthToProcess; idx++) {
+        final byte inputByte = drillBuf.getByte(start + idx);
+
+        if (firstPattByte != inputByte) {
+          continue;
+        } else {
+          final byte secondInByte = drillBuf.getByte(start + idx +1);
+          final byte thirdInByte  = drillBuf.getByte(start + idx +2);
+
+          if (secondInByte == secondPattByte && thirdInByte == thirdPattByte) {
+            return 1;
+          }
+        }
+      }
+      return 0;
+    }
+  }
+
+  /** Handles patterns with arbitrary length */
+  private final class MatcherN extends MatcherFcn {
+
+    private MatcherN() {
+      super();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected final int match(int start, int end, DrillBuf drillBuf) {
+
+      if (patternLength == 0) {
+        return 1;
+      }
+
+      final int lengthToProcess = end - start - patternLength + 1;
+      int patternIndex          = 0;
+      final byte firstPattByte  = patternArray[0];
+
+      // simplePattern string has meta characters i.e % and _ and escape characters removed.
+      // so, we can just directly compare.
+      for (int idx = 0; idx < lengthToProcess; idx++) {
+        final byte inputByte = drillBuf.getByte(start + idx);
+
+        if (firstPattByte == inputByte) {
+          for (patternIndex = 1; patternIndex < patternLength; ++patternIndex) {
+            final byte currInByte   = drillBuf.getByte(start + idx + patternIndex);
+            final byte currPattByte = patternArray[patternIndex];
+
+            if (currInByte != currPattByte) {
+              break;
+            }
+          }
+
+          if (patternIndex == patternLength) {
+            break;
+          }
+        }
+      }
+      return patternIndex == patternLength ? 1 : 0;
+    }
+  }
+
+  /**
+   * Boyer-Moore matcher algorithm; excellent for large patterns and for prefix patterns which appear
+   * frequently in the input.
+   */
+  private final class BoyerMooreMatcher extends MatcherFcn {
+    private final int[] offsetTable;
+    private final int[] characterTable;
+
+    private BoyerMooreMatcher() {
+      super();
+
+      this.offsetTable    = makeOffsetTable();
+      this.characterTable = makeCharTable();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected int match(int start, int end, DrillBuf drillBuf)  {
+      if (patternLength == 0) {
+        return 1;
+      }
+
+      final int inputLength = end - start;
+
+      for (int idx1 = patternLength - 1, idx2; idx1 < inputLength;) {
+        for (idx2 = patternLength - 1; patternArray[idx2] == drillBuf.getByte(start + idx1); --idx1, --idx2) {
+          if (idx2 == 0) {
+            return 1;
+          }
+        }
+        // i += pattern.length - j; // For naive method
+        idx1 += Math.max(offsetTable[patternLength - 1 - idx2], characterTable[drillBuf.getByte(start + idx1) & 0xFF]);
+      }
+      return 0;
+    }
+
+    /** Build the jump table based on the mismatched character information **/
+    private int[] makeCharTable() {
+      final int TABLE_SIZE = 256; // This implementation is based on byte comparison
+      int[] resultTable    = new int[TABLE_SIZE];
+
+      for (int idx = 0; idx < resultTable.length; ++idx) {
+        resultTable[idx] = patternLength;
+      }
+
+      for (int idx = 0; idx < patternLength - 1; ++idx) {
+        final int patternValue    = ((int) patternArray[idx]) & 0xFF;
+        resultTable[patternValue] = patternLength - 1 - idx;
+      }
+
+      return resultTable;
+    }
+
+    /** Builds the scan offset based on which mismatch occurs. **/
+    private int[] makeOffsetTable() {
+      int[] resultTable      = new int[patternLength];
+      int lastPrefixPosition = patternLength;
+
+      for (int idx = patternLength - 1; idx >= 0; --idx) {
+        if (isPrefix(idx + 1)) {
+          lastPrefixPosition = idx + 1;
+        }
+        resultTable[patternLength - 1 - idx] = lastPrefixPosition - idx + patternLength - 1;
+      }
+
+      for (int idx = 0; idx < patternLength - 1; ++idx) {
+        int suffixLen          = suffixLength(idx);
+        resultTable[suffixLen] = patternLength - 1 - idx + suffixLen;
+      }
+
+      return resultTable;
+    }
+
+    /** Checks whether needle[pos:end] is a prefix of pattern **/
+    private boolean isPrefix(int pos) {
+      for (int idx1 = pos, idx2 = 0; idx1 < patternLength; ++idx1, ++idx2) {
+        if (patternArray[idx1] != patternArray[idx2]) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /** Computes the maximum length of the substring ends at "pos" and is a suffix **/
+    private int suffixLength(int pos) {
+      int result = 0;
+      for (int idx1 = pos, idx2 = patternLength - 1; idx1 >= 0 && patternArray[idx1] == patternArray[idx2]; --idx1, --idx2) {
+        result += 1;
+      }
+      return result;
+    }
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
@@ -446,6 +446,61 @@ public class TestSqlPatterns {
     assertEquals(1, sqlPatternComplex.match(0, byteBuffer.limit(), drillBuf)); // should match
   }
 
+  @Test
+  public void testSqlPatternContainsMUltipleMatchers() {
+    final String inputString = "Drill supports a variety of NoSQL databases and file systems, including HBase, MongoDB, MapR-DB, HDFS, MapR-FS, Amazon S3, Azure Blob Storage, Google Cloud Storage, Swift, "
+        + "NAS and local files. A single query can join data from multiple datastores. For example, you can join a user profile collection in MongoDB with a directory of event logs in Hadoop.";
+
+    // Setting the input
+    setDrillBuf(inputString);
+
+    // Matcher with pattern of length I
+    RegexpUtil.SqlPatternInfo patternInfo = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "N");
+    SqlPatternMatcher sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(1, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should match
+
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "&");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(0, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should not match
+
+    // Matcher with pattern of length II
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "SQ");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(1, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should match
+
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "eT");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(0, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should not match
+
+    // Matcher with pattern of length III
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "SQL");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(1, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should match
+
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "cas");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(0, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should not match
+
+    // Matcher with pattern of length 3 < length < 10
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "MongoDB");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(1, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should match
+
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "MongoDz");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(0, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should not match
+
+    // Matcher with pattern of length > 10
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "multiple datastores");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(1, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should match
+
+    patternInfo         = new RegexpUtil.SqlPatternInfo(RegexpUtil.SqlPatternType.CONTAINS, "", "multiple datastorb");
+    sqlPatternContains  = SqlPatternFactory.getSqlPatternMatcher(patternInfo);
+    assertEquals(0, sqlPatternContains.match(0, byteBuffer.limit(), drillBuf)); // should not match
+  }
+
+
   @After
   public void cleanup() {
     drillBuf.close();


### PR DESCRIPTION
**BACKGROUND**
- JIRA [DRILL-5879](https://issues.apache.org/jira/browse/DRILL-5879) goal is to improve the "Contains" pattern performance
- [DRILL-5899](https://issues.apache.org/jira/browse/DRILL-5899) (sub-task) was created subsequently to avoid the ASCII / Unicode pre-processing overhead.
- This pull-request addresses the algorithmic part of this functionality

**ANALYSIS**
- Contains has O(n*m) complexity
- There are two ways to optimize the associated runtime
1) Minimize the number of instructions, pipelining, and CPU stalls
2) Use smarter algorithms (compared to the naive one); for example, the Boyer-Moore algorithm (which is implemented by several popular Open Source tools such as grep)

**IMPLEMENTATION**
Our approach contains both suggestions (listed in the analysis)
- Created five matchers that are chosen based on the pattern length
- The first three, are based on pattern 1) and target patterns with length [1..4[ 
- The forth one, has a similar runtime then the current implementation and targets patterns with length [4..10[
- We use the the Boyer-Moore algorithm for patterns with a length larger than 9 bytes
NOTE - the JDK doesn't use this algorithm because of two main  reasons
- Two extra arrays are necessary with a size relative to the supported character-set and the pattern length (this would be particularly costly for unicode as this would require 64k entries)
- Each Contains (or indexOf) invocation would require memory and initialization overhead
- Drill doesn't have this issue as a) initialization overhead is amortized since the pattern will be matched against many input values and b) our Contains logic is centered around bytes so the memory overhead is around 256 integers per fragment

**PERFORMANCE IMPROVEMENTS**
- We observe at least 25% improvement per Contains operation for matchers with pattern length lower than 4; 100% for negative cases (as the code never accesses a secondary for-loop)
- It was noticed the Boyer-Moor algorithm performs poorly for small patterns as lookup accesses erase the associated optimizations; this algorithm performs extremely well when the pattern length increases as unlike the naive implementation it is able to use the lookup table to jump beyond the next character (since the matching phase has already gained so insight).
- One popular introduction to this algorithm is the following use-case
- Input: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
- Pattern: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax

