### PR TITLE
DRILL-6036: Create sys.connections table

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,6 +230,10 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
+  public QueryContext getQueryContext() {
+    return queryContext;
+  }
+
   /**
    * This method is only used to construt InfoSchemaReader, it is for the reader to get full schema, so here we
    * are going to return a fully initialized schema tree.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,8 +230,8 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
-  public QueryContext getQueryContext() {
-    return queryContext;
+  public boolean isUserAuthenticationEnabled() {
+    return queryContext.isUserAuthenticationEnabled();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,10 +230,6 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
-  public boolean isUserAuthenticationEnabled() {
-    return queryContext.isUserAuthenticationEnabled();
-  }
-
   /**
    * This method is only used to construt InfoSchemaReader, it is for the reader to get full schema, so here we
    * are going to return a fully initialized schema tree.
@@ -401,6 +397,16 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     }
 
     return getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
+  }
+
+  public boolean isUserAuthenticationEnabled() {
+    // TODO(DRILL-2097): Until SimpleRootExec tests are removed, we need to consider impersonation disabled if there is
+    // no config
+    if (getConfig() == null) {
+      return false;
+    }
+
+    return getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -35,6 +35,9 @@ import org.apache.drill.exec.rpc.control.Controller;
 import org.apache.drill.exec.rpc.control.WorkEventBus;
 import org.apache.drill.exec.rpc.data.DataConnectionCreator;
 import org.apache.drill.exec.rpc.security.AuthenticatorProvider;
+import org.apache.drill.exec.rpc.user.UserServer;
+import org.apache.drill.exec.rpc.user.UserServer.BitToUserConnection;
+import org.apache.drill.exec.rpc.user.UserServer.BitToUserConnectionConfig;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.store.SchemaFactory;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -43,6 +46,8 @@ import org.apache.drill.exec.work.foreman.rm.ResourceManager;
 import org.apache.drill.exec.work.foreman.rm.ResourceManagerBuilder;
 
 import java.util.Collection;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -277,6 +282,10 @@ public class DrillbitContext implements AutoCloseable {
 
   public AuthenticatorProvider getAuthProvider() {
     return context.getAuthProvider();
+  }
+
+  public Set<Entry<BitToUserConnection, BitToUserConnectionConfig>> getUserConnections() {
+    return UserServer.getUserConnections();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -87,6 +87,13 @@ public enum SystemTable {
     }
   },
 
+  CONNECTIONS("connections", true, BitToUserConnectionIterator.ConnectionInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new BitToUserConnectionIterator(context);
+    }
+  },
+
   THREADS("threads", true, ThreadsIterator.ThreadsInfo.class) {
     @Override
   public Iterator<Object> getIterator(final FragmentContext context) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -69,4 +69,9 @@ public class TestSystemTable extends BaseTestQuery {
   public void memoryTable() throws Exception {
     test("select * from sys.memory");
   }
+
+  @Test
+  public void connectionsTable() throws Exception {
+    test("select * from sys.connections");
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -149,7 +149,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(14, tables.size());
+    assertEquals(15, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -186,7 +186,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(14, tables.size());
+    assertEquals(15, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -214,7 +214,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(7, tables.size());
+    assertEquals(8, tables.size());
 
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "memory", tables);
@@ -248,7 +248,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(93, columns.size());
+    assertEquals(104, columns.size());
     // too many records to verify the output.
   }
 


### PR DESCRIPTION
Introduced a distributed (i.e. each Drillbit executes a fragment) system table to list all the active client connections to all the Drillbits in a cluster. This is achieved by having the UserServer maintain a static (class-level) map of these connections, which is updated as and when connections are established and closed.

The following details are provided by the table:
    user
    targetUser
    client
    drillbit
    established
    duration
    queries
    isAuthenticated
    isEncrypted
    usingSSL
    session

A sample run shows the following:
```
[root@kk190 ~]# /opt/mapr/drill/apache-drill-1.13.0/bin/sqlline -u "jdbc:drill:drillbit=`hostname -i`"
...
apache drill 1.13.0-SNAPSHOT 
"just drill it"
0: jdbc:drill:drillbit=10.10.106.190> select * from sys.connections;
+------------+-------------+----------------+---------------+--------------------------+------------+----------+------------------+--------------+-----------+---------------------------------------+
|    user    | targetUser  |     client     |   drillbit    |       established        |  duration  | queries  | isAuthenticated  | isEncrypted  | usingSSL  |                session                |
+------------+-------------+----------------+---------------+--------------------------+------------+----------+------------------+--------------+-----------+---------------------------------------+
| anonymous  | anonymous   | 10.10.106.190  | kk190.qa.lab  | 2017-12-20 10:27:30.377  | 5.189 sec  | 1        | false            | false        | false     | b95e76ab-be51-4dde-9554-4d31a36e47a5  |
+------------+-------------+----------------+---------------+--------------------------+------------+----------+------------------+--------------+-----------+---------------------------------------+
1 row selected (0.163 seconds)
```