### PR TITLE
DRILL-5068: Create sys.profiles and sys.profiles_json tables

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,6 +230,10 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
+  public QueryContext getQueryContext() {
+    return queryContext;
+  }
+
   /**
    * This method is only used to construt InfoSchemaReader, it is for the reader to get full schema, so here we
    * are going to return a fully initialized schema tree.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,8 +230,8 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
-  public QueryContext getQueryContext() {
-    return queryContext;
+  public boolean isUserAuthenticationEnabled() {
+    return queryContext.isUserAuthenticationEnabled();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -230,10 +230,6 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     return context;
   }
 
-  public boolean isUserAuthenticationEnabled() {
-    return queryContext.isUserAuthenticationEnabled();
-  }
-
   /**
    * This method is only used to construt InfoSchemaReader, it is for the reader to get full schema, so here we
    * are going to return a fully initialized schema tree.
@@ -401,6 +397,16 @@ public class FragmentContext extends BaseFragmentContext implements AutoCloseabl
     }
 
     return getConfig().getBoolean(ExecConstants.IMPERSONATION_ENABLED);
+  }
+
+  public boolean isUserAuthenticationEnabled() {
+    // TODO(DRILL-2097): Until SimpleRootExec tests are removed, we need to consider impersonation disabled if there is
+    // no config
+    if (getConfig() == null) {
+      return false;
+    }
+
+    return getConfig().getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/QueryProfileStoreContext.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.server;
 
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.coord.store.TransientStore;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
@@ -30,7 +29,6 @@ import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
-import org.apache.drill.exec.store.sys.PersistentStoreConfig.StoreConfigBuilder;
 
 public class QueryProfileStoreContext {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryProfileStoreContext.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileInfoIterator.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
+
+import javax.annotation.Nullable;
+import java.sql.Timestamp;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+/**
+ * System table listing completed profiles
+ */
+public class ProfileInfoIterator extends ProfileIterator {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileInfoIterator.class);
+
+  private final Iterator<ProfileInfo> itr;
+
+  public ProfileInfoIterator(FragmentContext context) {
+    super(context);
+    itr = iterateProfileInfo();
+  }
+
+  //Returns an iterator for authorized profiles
+  private Iterator<ProfileInfo> iterateProfileInfo() {
+    try {
+      //Transform authorized profiles to iterator for ProfileInfo
+      return transform(
+          getAuthorizedProfiles(
+            profileStoreContext
+              .getCompletedProfileStore()
+              .getAll(),
+            queryingUsername, isAdmin));
+
+    } catch (Exception e) {
+      logger.error(e.getMessage());
+      return Iterators.singletonIterator(ProfileInfo.getDefault());
+    }
+  }
+
+  /**
+   * Iterating persistentStore as a iterator of {@link org.apache.drill.exec.store.sys.ProfileInfoIterator.ProfileInfo}.
+   */
+  private Iterator<ProfileInfo> transform(Iterator<Entry<String, UserBitShared.QueryProfile>> all) {
+    return Iterators.transform(all, new Function<Entry<String, UserBitShared.QueryProfile>, ProfileInfo>() {
+      @Nullable
+      @Override
+      public ProfileInfo apply(@Nullable Entry<String, UserBitShared.QueryProfile> input) {
+        if (input == null || input.getValue() == null) {
+          return ProfileInfo.getDefault();
+        }
+
+        //Constructing ProfileInfo
+        final String queryID = input.getKey();
+        final QueryProfile profile = input.getValue();
+        //For cases where query was never queued
+        final long assumedQueueEndTime = profile.getQueueWaitEnd()> 0 ? profile.getQueueWaitEnd() : profile.getPlanEnd();
+        return new ProfileInfo(
+            queryID,
+            new Timestamp(profile.getStart()),
+            profile.getForeman().getAddress(),
+            profile.getTotalFragments(),
+            profile.getUser(),
+            profile.getQueueName(),
+            computeDuration(profile.getStart(), profile.getPlanEnd()),
+            computeDuration(profile.getPlanEnd(), assumedQueueEndTime),
+            computeDuration(assumedQueueEndTime, profile.getEnd()),
+            profile.getState().name(),
+            profile.getQuery()
+         );
+      }
+    });
+  }
+
+  @Override
+  public boolean hasNext() {
+    return itr.hasNext();
+  }
+
+  @Override
+  public Object next() {
+    return itr.next();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class ProfileInfo {
+    private static final String UnknownValue = "N/A";
+
+    private static final ProfileInfo DEFAULT = new ProfileInfo();
+
+    public final String queryId;
+    public final Timestamp startTime;
+    public final String foreman;
+    public final long fragments;
+    public final String user;
+    public final String queue;
+    public final long planTime;
+    public final long queueTime;
+    public final long executeTime;
+    public final long totalTime;
+    public final String state;
+    public final String query;
+
+    public ProfileInfo(String query_id, Timestamp time, String foreman, long fragmentCount, String username,
+        String queueName, long planDuration, long queueWaitDuration, long executeDuration,
+        String state, String query) {
+      this.queryId = query_id;
+      this.startTime = time;
+      this.foreman = foreman;
+      this.fragments = fragmentCount;
+      this.user = username;
+      this.queue = queueName;
+      this.planTime = planDuration;
+      this.queueTime = queueWaitDuration;
+      this.executeTime = executeDuration;
+      this.totalTime = this.planTime + this.queueTime + this.executeTime;
+      this.query = query;
+      this.state = state;
+    }
+
+    private ProfileInfo() {
+      this(UnknownValue, new Timestamp(0), UnknownValue, 0L, UnknownValue, UnknownValue, 0L, 0L, 0L, UnknownValue, UnknownValue);
+    }
+
+    /**
+     * If unable to get ProfileInfo, use this default instance instead.
+     * @return the default instance
+     */
+    public static final ProfileInfo getDefault() {
+      return DEFAULT;
+    }
+  }
+}
+
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileIterator.java
@@ -32,7 +32,7 @@ import org.apache.drill.exec.util.ImpersonationUtil;
 /**
  * Base class for Profile Iterators
  */
-public class ProfileIterator implements Iterator<Object> {
+public abstract class ProfileIterator implements Iterator<Object> {
   protected final QueryProfileStoreContext profileStoreContext;
   protected final String queryingUsername;
   protected final boolean isAdmin;
@@ -85,20 +85,5 @@ public class ProfileIterator implements Iterator<Object> {
     } else {
       return 0;
     }
-  }
-
-  @Override
-  public boolean hasNext() {
-    return false;
-  }
-
-  @Override
-  public Object next() {
-    return null;
-  }
-
-  @Override
-  public void remove() {
-    throw new UnsupportedOperationException();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileIterator.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.work.foreman.QueryManager;
+
+import javax.annotation.Nullable;
+import java.sql.Timestamp;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * DRILL-5068: Add a new system table for completed profiles
+ */
+public class ProfileIterator implements Iterator<Object> {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileIterator.class);
+
+  private final Iterator<ProfileInfo> itr;
+
+  public ProfileIterator(FragmentContext context) {
+    itr = iterateProfileInfo(context);
+  }
+
+  private Iterator<ProfileInfo> iterateProfileInfo(FragmentContext context) {
+    try {
+      PersistentStore<UserBitShared.QueryProfile> profiles = context
+        .getDrillbitContext()
+        .getStoreProvider()
+        .getOrCreateStore(QueryManager.QUERY_PROFILE);
+
+      return transform(profiles.getAll());
+
+    } catch (Exception e) {
+      logger.error(String.format("Unable to get persistence store: %s, ", QueryManager.QUERY_PROFILE.getName()), e);
+      return Iterators.singletonIterator(ProfileInfo.getDefault());
+    }
+  }
+
+  /**
+   * Iterating persistentStore as a iterator of {@link org.apache.drill.exec.store.sys.ProfileIterator.ProfileInfo}.
+   */
+  private Iterator<ProfileInfo> transform(Iterator<Map.Entry<String, UserBitShared.QueryProfile>> all) {
+    return Iterators.transform(all, new Function<Map.Entry<String, UserBitShared.QueryProfile>, ProfileInfo>() {
+      @Nullable
+      @Override
+      public ProfileInfo apply(@Nullable Map.Entry<String, UserBitShared.QueryProfile> input) {
+        if (input == null || input.getValue() == null) {
+          return ProfileInfo.getDefault();
+        }
+
+        final String queryID = input.getKey();
+
+        return new ProfileInfo(queryID,
+          mkHref(queryID),
+          new Timestamp(input.getValue().getStart()),
+          input.getValue().getEnd() - input.getValue().getStart(),
+          input.getValue().getUser(),
+          input.getValue().getQuery(),
+          input.getValue().getState().name()
+        );
+      }
+
+      /**
+       * Generate a link to detailed profile page using queryID. this makes user be able to jump to that page directly from query result.
+       * @param queryID query ID
+       * @return html href link of the input query ID
+       */
+      private String mkHref(String queryID) {
+        return String.format("<a href=\"/profiles/%s\">%s</a>", queryID, queryID);
+      }
+    });
+  }
+
+  @Override
+  public boolean hasNext() {
+    return itr.hasNext();
+  }
+
+  @Override
+  public Object next() {
+    return itr.next();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class ProfileInfo {
+    private static final ProfileInfo DEFAULT = new ProfileInfo();
+
+    public final String query_id;
+    public final String link;
+    public final Timestamp time;
+    public final long latency;
+    public final String user;
+    public final String query;
+    public final String state;
+
+    public ProfileInfo(String query_id, String link, Timestamp time, long latency, String user, String query, String state) {
+      this.query_id = query_id;
+      this.link = link;
+      this.time = time;
+      this.latency = latency;
+      this.user = user;
+      this.query = query;
+      this.state = state;
+    }
+
+    private ProfileInfo() {
+      this("UNKNOWN", "UNKNOWN", new Timestamp(0L), 0L, "UNKNOWN", "UNKNOWN", "UNKNOWN");
+    }
+
+    /**
+     * If unable to get ProfileInfo, use this default instance instead.
+     * @return the default instance
+     */
+    public static final ProfileInfo getDefault() {
+      return DEFAULT;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
+import org.apache.drill.exec.serialization.InstanceSerializer;
+import org.apache.drill.exec.server.QueryProfileStoreContext;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * DRILL-5068: Add a new system table for completed profiles
+ */
+public class ProfileJsonIterator implements Iterator<Object> {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileJsonIterator.class);
+
+  private final QueryProfileStoreContext profileStoreContext;
+  private final InstanceSerializer<QueryProfile> profileSerializer;
+  private final Iterator<ProfileInfoJson> itr;
+
+  public ProfileJsonIterator(FragmentContext context) {
+    //Grab profile Store Context
+    profileStoreContext = context
+        .getDrillbitContext()
+        .getProfileStoreContext();
+
+    //Holding a serializer (for JSON extract)
+    profileSerializer = profileStoreContext.
+        getProfileStoreConfig().getSerializer();
+
+    itr = iterateProfileInfoJson(context);
+  }
+
+  private Iterator<ProfileInfoJson> iterateProfileInfoJson(FragmentContext context) {
+    try {
+      PersistentStore<UserBitShared.QueryProfile> profiles = profileStoreContext.getCompletedProfileStore();
+
+      return transformJson(profiles.getAll());
+
+    } catch (Exception e) {
+      logger.error(String.format("Unable to get persistence store: %s, ", profileStoreContext.getProfileStoreConfig().getName(), e));
+      return Iterators.singletonIterator(ProfileInfoJson.getDefault());
+    }
+  }
+
+  /**
+   * Iterating persistentStore as a iterator of {@link org.apache.drill.exec.store.sys.ProfileJsonIterator.ProfileInfoJson}.
+   */
+  private Iterator<ProfileInfoJson> transformJson(Iterator<Map.Entry<String, UserBitShared.QueryProfile>> all) {
+    return Iterators.transform(all, new Function<Map.Entry<String, UserBitShared.QueryProfile>, ProfileInfoJson>() {
+      @Nullable
+      @Override
+      public ProfileInfoJson apply(@Nullable Map.Entry<String, UserBitShared.QueryProfile> input) {
+        if (input == null || input.getValue() == null) {
+          return ProfileInfoJson.getDefault();
+        }
+
+        //Constructing ProfileInfo
+        final String queryID = input.getKey();
+        String profileJson = null;
+        try {
+          profileJson = new String(profileSerializer.serialize(input.getValue()));
+        } catch (IOException e) {
+          logger.debug("Failed to serialize profile for: " + queryID);
+          profileJson = "{ 'message' : 'error (unable to serialize profile: "+ queryID +")' }";
+        }
+
+        return new ProfileInfoJson(
+            queryID,
+            profileJson
+         );
+      }
+    });
+  }
+
+  @Override
+  public boolean hasNext() {
+    return itr.hasNext();
+  }
+
+  @Override
+  public Object next() {
+    return itr.next();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class ProfileInfoJson {
+    private static final String UnknownValue = "UNKNOWN";
+
+    private static final ProfileInfoJson DEFAULT = new ProfileInfoJson();
+
+    public final String queryId;
+    public final String json;
+
+    public ProfileInfoJson(String query_id, String profileJson) {
+      this.queryId = query_id;
+      this.json = profileJson;
+    }
+
+    private ProfileInfoJson() {
+      this(UnknownValue, UnknownValue);
+    }
+
+    /**
+     * If unable to get ProfileInfo, use this default instance instead.
+     * @return the default instance
+     */
+    public static final ProfileInfoJson getDefault() {
+      return DEFAULT;
+    }
+  }
+}
+
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
@@ -19,19 +19,27 @@ package org.apache.drill.exec.store.sys;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
+
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.QueryProfile;
 import org.apache.drill.exec.serialization.InstanceSerializer;
 import org.apache.drill.exec.server.QueryProfileStoreContext;
+import org.apache.drill.exec.server.options.QueryOptionManager;
+import org.apache.drill.exec.util.ImpersonationUtil;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
- * DRILL-5068: Add a new system table for completed profiles
+ * DRILL-5068: Add a new system table for completed profiles (JSON)
  */
 public class ProfileJsonIterator implements Iterator<Object> {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileJsonIterator.class);
@@ -39,6 +47,8 @@ public class ProfileJsonIterator implements Iterator<Object> {
   private final QueryProfileStoreContext profileStoreContext;
   private final InstanceSerializer<QueryProfile> profileSerializer;
   private final Iterator<ProfileInfoJson> itr;
+  private final String queryingUsername;
+  private final boolean isAdmin;
 
   public ProfileJsonIterator(FragmentContext context) {
     //Grab profile Store Context
@@ -50,19 +60,57 @@ public class ProfileJsonIterator implements Iterator<Object> {
     profileSerializer = profileStoreContext.
         getProfileStoreConfig().getSerializer();
 
+    queryingUsername = context.getQueryUserName();
+    isAdmin = hasAdminPrivileges(context.getQueryContext());
+
     itr = iterateProfileInfoJson(context);
+  }
+
+  private boolean hasAdminPrivileges(QueryContext queryContext) {
+    if (queryContext == null) {
+      return false;
+    }
+    QueryOptionManager options = queryContext.getOptions();
+    if (queryContext.isUserAuthenticationEnabled() &&
+        !ImpersonationUtil.hasAdminPrivileges(
+          queryContext.getQueryUserName(),
+          ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(options),
+          ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(options))) {
+      return false;
+    }
+
+    //Passed checks
+    return true;
   }
 
   private Iterator<ProfileInfoJson> iterateProfileInfoJson(FragmentContext context) {
     try {
       PersistentStore<UserBitShared.QueryProfile> profiles = profileStoreContext.getCompletedProfileStore();
 
-      return transformJson(profiles.getAll());
+      return transformJson(getAuthorizedProfiles(profiles.getAll(), queryingUsername, isAdmin));
 
     } catch (Exception e) {
       logger.error(String.format("Unable to get persistence store: %s, ", profileStoreContext.getProfileStoreConfig().getName(), e));
       return Iterators.singletonIterator(ProfileInfoJson.getDefault());
     }
+  }
+
+  //Returns an iterator for authorized profiles
+  private Iterator<Entry<String, QueryProfile>> getAuthorizedProfiles (
+      Iterator<Entry<String, QueryProfile>> allProfiles, String username, boolean isAdministrator) {
+    if (isAdministrator) {
+      return allProfiles;
+    }
+
+    List<Entry<String, QueryProfile>> authorizedProfiles = new LinkedList<Entry<String, QueryProfile>>();
+    while (allProfiles.hasNext()) {
+      Entry<String, QueryProfile> profileKVPair = allProfiles.next();
+      //Check if user matches
+      if (profileKVPair.getValue().getUser().equals(username)) {
+        authorizedProfiles.add(profileKVPair);
+      }
+    }
+    return authorizedProfiles.iterator();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/ProfileJsonIterator.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.store.sys;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
@@ -70,11 +69,11 @@ public class ProfileJsonIterator extends ProfileIterator {
   /**
    * Iterating persistentStore as a iterator of {@link org.apache.drill.exec.store.sys.ProfileJsonIterator.ProfileJson}.
    */
-  private Iterator<ProfileJson> transformJson(Iterator<Map.Entry<String, UserBitShared.QueryProfile>> all) {
-    return Iterators.transform(all, new Function<Map.Entry<String, UserBitShared.QueryProfile>, ProfileJson>() {
+  private Iterator<ProfileJson> transformJson(Iterator<Entry<String, UserBitShared.QueryProfile>> all) {
+    return Iterators.transform(all, new Function<Entry<String, UserBitShared.QueryProfile>, ProfileJson>() {
       @Nullable
       @Override
-      public ProfileJson apply(@Nullable Map.Entry<String, UserBitShared.QueryProfile> input) {
+      public ProfileJson apply(@Nullable Entry<String, UserBitShared.QueryProfile> input) {
         if (input == null || input.getValue() == null) {
           return ProfileJson.getDefault();
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -87,17 +87,24 @@ public enum SystemTable {
     }
   },
 
+  PROFILES("profiles", false, ProfileIterator.ProfileInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new ProfileIterator(context);
+    }
+  },
+
+  PROFILES_JSON("profiles_json", false, ProfileJsonIterator.ProfileInfoJson.class) {
+    @Override
+    public Iterator<Object> getIterator(final FragmentContext context) {
+      return new ProfileJsonIterator(context);
+    }
+  },
+
   THREADS("threads", true, ThreadsIterator.ThreadsInfo.class) {
     @Override
   public Iterator<Object> getIterator(final FragmentContext context) {
       return new ThreadsIterator(context);
-    }
-  },
-
-  PROFILES("profiles", false, ProfileIterator.ProfileInfo.class) {
-    @Override
-    public Iterator<Object> getIterator(FragmentContext context) {
-      return new ProfileIterator(context);
     }
   };
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -87,14 +87,14 @@ public enum SystemTable {
     }
   },
 
-  PROFILES("profiles", false, ProfileIterator.ProfileInfo.class) {
+  PROFILES("profiles", false, ProfileInfoIterator.ProfileInfo.class) {
     @Override
     public Iterator<Object> getIterator(final FragmentContext context) {
-      return new ProfileIterator(context);
+      return new ProfileInfoIterator(context);
     }
   },
 
-  PROFILES_JSON("profiles_json", false, ProfileJsonIterator.ProfileInfoJson.class) {
+  PROFILES_JSON("profiles_json", false, ProfileJsonIterator.ProfileJson.class) {
     @Override
     public Iterator<Object> getIterator(final FragmentContext context) {
       return new ProfileJsonIterator(context);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -92,6 +92,13 @@ public enum SystemTable {
   public Iterator<Object> getIterator(final FragmentContext context) {
       return new ThreadsIterator(context);
     }
+  },
+
+  PROFILES("profiles", false, ProfileIterator.ProfileInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(FragmentContext context) {
+      return new ProfileIterator(context);
+    }
   };
 
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SystemTable.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -123,6 +123,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
             return path.getName().endsWith(DRILL_SYS_FILE_SUFFIX);
           }
         };
+
         List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, false, sysFileSuffixFilter);
         if (fileStatuses.isEmpty()) {
           return Collections.emptyIterator();
@@ -135,6 +136,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
         }
 
         Collections.sort(files);
+
         return Iterables.transform(Iterables.limit(Iterables.skip(files, skip), take), new Function<String, Entry<String, V>>() {
           @Nullable
           @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -74,4 +74,9 @@ public class TestSystemTable extends BaseTestQuery {
   public void profilesTable() throws Exception {
     test("select * from sys.profiles");
   }
+
+  @Test
+  public void profilesJsonTable() throws Exception {
+    test("select * from sys.profiles_json");
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -69,4 +69,9 @@ public class TestSystemTable extends BaseTestQuery {
   public void memoryTable() throws Exception {
     test("select * from sys.memory");
   }
+
+  @Test
+  public void profilesTable() throws Exception {
+    test("select * from sys.profiles");
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -149,7 +149,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(14, tables.size());
+    assertEquals(16, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -186,7 +186,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(14, tables.size());
+    assertEquals(16, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -214,7 +214,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(7, tables.size());
+    assertEquals(9, tables.size());
 
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "memory", tables);
@@ -248,7 +248,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(93, columns.size());
+    assertEquals(107, columns.size());
     // too many records to verify the output.
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -149,7 +149,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(16, tables.size());
+    assertEquals(17, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -186,7 +186,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(16, tables.size());
+    assertEquals(17, tables.size());
 
     verifyTable("INFORMATION_SCHEMA", "CATALOGS", tables);
     verifyTable("INFORMATION_SCHEMA", "COLUMNS", tables);
@@ -214,7 +214,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(9, tables.size());
+    assertEquals(10, tables.size());
 
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "memory", tables);
@@ -248,7 +248,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(107, columns.size());
+    assertEquals(118, columns.size());
     // too many records to verify the output.
   }
 


### PR DESCRIPTION
(Thanks to Hongze Zhang for the initial work)
Introduced a non-distributed (i.e. the foreman Drillbit executes a single fragment query) system table to list the completed profiles that are visible to it in the persistent store. This allows for querying the profiles on the following common metrics:
    queryId
    startTime
    foreman
    fragments
    user
    queue
    planTime
    queueTime
    executeTime
    totalTime
    state
    query

An additional system table - `sys.profiles_json` has also been introduced. This only has the following fields:
    queryId
    json
This allows for more detail metrics to be queried on the profile as a JSON document. Users are expected to use `sys.profiles` to identify profiles on the available metrics (such as long executeTime or fragments), and use the queryId to find the corresponding JSON document representation for further drill down into the profiles.

Here is what a sample output looks like:
```
[root@kk127 ~]# /opt/drill/apache-drill-1.13.0/bin/sqlline -u "jdbc:drill:drillbit=`hostname -i`"
...
apache drill 1.13.0-SNAPSHOT 
"just drill it"
0: jdbc:drill:drillbit=10.10.100.127> select * from sys.profiles where startTime < date '2017-12-18' limit 10;
+---------------------------------------+--------------------------+---------------+------------+------------+--------+-----------+------------+--------------+------------+------------+--------------------------------------------------------+
|                queryId                |        startTime         |    foreman    | fragments  |    user    | queue  | planTime  | queueTime  | executeTime  | totalTime  |   state    |                         query                          |
+---------------------------------------+--------------------------+---------------+------------+------------+--------+-----------+------------+--------------+------------+------------+--------------------------------------------------------+
| 25cdcede-410d-6399-97f9-00ec2048f247  | 2017-12-14 08:06:57.062  | kk127.qa.lab  | 1          | anonymous  | -      | 35        | 0          | 7718         | 7753       | COMPLETED  | select queryId from profiles limit 1                   |
| 25cdd1a2-7928-bcf9-a8cd-8e0fa653e2ce  | 2017-12-14 07:55:09.551  | kk127.qa.lab  | 1          | anonymous  | -      | 41        | 0          | 7580         | 7621       | COMPLETED  | select queryId from profiles limit 1                   |
| 25cdd1b6-3a56-e2b3-a6a1-4d1006ec8fac  | 2017-12-14 07:54:49.403  | kk127.qa.lab  | 1          | anonymous  | -      | 77        | 0          | 7452         | 7529       | COMPLETED  | select queryId from profiles limit 1                   |
| 25cdd1bd-963f-7a57-6a2d-cf7a3eac3f00  | 2017-12-14 07:54:41.065  | kk127.qa.lab  | 0          | anonymous  | -      | 0         | 0          | 0            | 0          | FAILED     | select profileJson from profiles limit 1               |
| 25cdd1e5-de23-0cfe-5c01-86621b31d8d5  | 2017-12-14 07:54:01.576  | kk127.qa.lab  | 1          | anonymous  | -      | 1184      | 0          | 10860        | 12044      | COMPLETED  | select profileJson from profiles_json limit 1          |
| 25cdd1e7-7c3a-5a25-0860-a86246bbc9ed  | 2017-12-14 07:54:00.186  | kk127.qa.lab  | 1          | anonymous  | -      | 102       | 0          | 231          | 333        | COMPLETED  | use sys                                                |
| 25cdd1f0-4473-55aa-a5eb-c85194321118  | 2017-12-14 07:53:51.966  | kk127.qa.lab  | 0          | anonymous  | -      | 0         | 0          | 0            | 0          | FAILED     | select profileJson from profiles_json limit 1          |
| 25cdd442-04cc-65fe-7a25-ac075fa22467  | 2017-12-14 07:43:57.251  | kk127.qa.lab  | 1          | anonymous  | -      | 40        | 0          | 10553        | 10593      | COMPLETED  | select profileJson from profiles_json limit 1          |
| 25cdd7c8-614d-8bcc-3b89-08df12761a3a  | 2017-12-14 07:28:55.359  | kk127.qa.lab  | 1          | anonymous  | -      | 170       | 0          | 10508        | 10678      | COMPLETED  | select count(*) from (select * from profiles_json)     |
| 25cdd7e0-34ea-9040-ab2a-ef8c6a136440  | 2017-12-14 07:28:31.464  | kk127.qa.lab  | 0          | anonymous  | -      | 0         | 0          | 0            | 0          | FAILED     | select count(*) from (pwdselect * from profiles_json)  |
+---------------------------------------+--------------------------+---------------+------------+------------+--------+-----------+------------+--------------+------------+------------+--------------------------------------------------------+
10 rows selected (8.336 seconds)
0: jdbc:drill:drillbit=10.10.100.127> select * from sys.profiles_json where queryId = '25cdd1e7-7c3a-5a25-0860-a86246bbc9ed';
+---------+------+
| queryId | json |
+---------+------+
| 25cdd1e7-7c3a-5a25-0860-a86246bbc9ed | {"id":{"part1":2724064141780867621,"part2":603667490114619885},"type":1,"start":1513238040186,"end":1513238040519,"query":"use sys","foreman":{"address":"kk127.qa.lab","userPort":31010,"controlPort":31011,"dataPort":31012,"version":"1.12.0-SNAPSHOT","state":0},"state":2,"totalFragments":1,"finishedFragments":0,"fragmentProfile":[{"majorFragmentId":0,"minorFragmentProfile":[{"state":3,"minorFragmentId":0,"operatorProfile":[{"inputProfile":[{"records":1,"batches":2,"schemas":1}],"operatorId":0,"operatorType":26,"setupNanos":0,"processNanos":67070036,"peakLocalMemoryAllocated":4530688,"waitNanos":0},{"inputProfile":[{"records":0,"batches":0,"schemas":0}],"operatorId":0,"operatorType":13,"setupNanos":0,"processNanos":0,"peakLocalMemoryAllocated":4530176,"waitNanos":0},{"inputProfile":[{"records":1,"batches":1,"schemas":1}],"operatorId":0,"operatorType":13,"setupNanos":0,"processNanos":15787437,"peakLocalMemoryAllocated":4530176,"metric":[{"metricId":0,"longValue":41}],"waitNanos":18796208}],"startTime":1513238040329,"endTime":1513238040482,"memoryUsed":0,"maxMemoryUsed":9060864,"endpoint":{"address":"kk127.qa.lab","userPort":31010,"controlPort":31011,"dataPort":31012,"version":"1.12.0-SNAPSHOT","state":0},"lastUpdate":1513238040487,"lastProgress":1513238040487}]}],"user":"anonymous","optionsJson":"[ ]","planEnd":1513238040288,"queueWaitEnd":1513238040288,"totalCost":0.0,"queueName":"-"} |
+---------+------+
1 row selected (11.667 seconds)
```