### PR TITLE
DRILL-6076: Reduce the default memory from a total of 13GB to 5GB

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -295,9 +295,9 @@ fi
 # DEFAULT memory settings if none provided by the environment or
 # above config files.
 # The Drillbit needs a large code cache.
-export DRILL_MAX_DIRECT_MEMORY=${DRILL_MAX_DIRECT_MEMORY:-"8G"}
-export DRILL_HEAP=${DRILL_HEAP:-"4G"}
-export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"1G"}
+export DRILL_MAX_DIRECT_MEMORY=${DRILL_MAX_DIRECT_MEMORY:-"3G"}
+export DRILL_HEAP=${DRILL_HEAP:-"1G"}
+export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"512M"}
 
 export DRILLBIT_OPTS="-Xms$DRILL_HEAP -Xmx$DRILL_HEAP -XX:MaxDirectMemorySize=$DRILL_MAX_DIRECT_MEMORY"
 export DRILLBIT_OPTS="$DRILLBIT_OPTS -XX:ReservedCodeCacheSize=$DRILLBIT_CODE_CACHE_SIZE -Ddrill.exec.enable-epoll=false"

--- a/distribution/src/resources/drill-env.sh
+++ b/distribution/src/resources/drill-env.sh
@@ -50,12 +50,12 @@
 #export DRILLBIT_MAX_PROC_MEM=${DRILLBIT_MAX_PROC_MEM:-"13G"}
 
 # Amount of heap memory for the Drillbit process. Values are those supported by
-# the Java -Xms option. The default is 4G.
+# the Java -Xms option. The recommended minimum is 4G.
 
 #export DRILL_HEAP=${DRILL_HEAP:-"4G"}
 
 # Maximum amount of direct memory to allocate to the Drillbit in the format
-# supported by -XX:MaxDirectMemorySize. Default is 8G.
+# supported by -XX:MaxDirectMemorySize. The recommended minimum is 8G.
 
 #export DRILL_MAX_DIRECT_MEMORY=${DRILL_MAX_DIRECT_MEMORY:-"8G"}
 


### PR DESCRIPTION
Reduce minimum memory requirements from 13GB to <= 5GB
For this, the default need to be changed as follows:

Allocation | Current | New 
------------|--------|------
 Heap | 4GB | 1GB 
 Direct | 8GB | 3GB 
 CodeCache | 1GB | 512MB 
 MaxPermSize | 512MB | 512MB (Ignored if JDK8+) 
 **Total** | 13.5GB | 5GB 
 **Total (JDK8+)** | 13GB | 4.5GB 
