### PR TITLE
DRILL-6080: Sort incorrectly limits batch size to 65535 records

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
@@ -105,7 +105,7 @@ public class SortRecordBatchBuilder implements AutoCloseable {
       return;
     }
 
-    if(runningBatches >= Character.MAX_VALUE) {
+    if (runningBatches >= Character.MAX_VALUE) {
       final String errMsg = String.format("Tried to add more than %d number of batches.", (int) Character.MAX_VALUE);
       logger.error(errMsg);
       throw new DrillRuntimeException(errMsg);
@@ -152,7 +152,7 @@ public class SortRecordBatchBuilder implements AutoCloseable {
     if (svBuffer == null) {
       throw new OutOfMemoryError("Failed to allocate direct memory for SV4 vector in SortRecordBatchBuilder.");
     }
-    sv4 = new SelectionVector4(svBuffer, recordCount, Character.MAX_VALUE);
+    sv4 = new SelectionVector4(svBuffer, recordCount, ValueVector.MAX_ROW_COUNT);
     BatchSchema schema = batches.keySet().iterator().next();
     List<RecordBatchData> data = batches.get(schema);
 
@@ -174,7 +174,7 @@ public class SortRecordBatchBuilder implements AutoCloseable {
       int recordBatchId = 0;
       for (RecordBatchData d : data) {
         for (int i = 0; i < d.getRecordCount(); i++, index++) {
-          sv4.set(index, recordBatchId, (int) d.getSv2().getIndex(i));
+          sv4.set(index, recordBatchId, d.getSv2().getIndex(i));
         }
         // might as well drop the selection vector since we'll stop using it now.
         d.getSv2().clear();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector4.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector4.java
@@ -112,8 +112,8 @@ public class SelectionVector4 implements AutoCloseable {
       return false;
     }
 
-    start = start+length;
-    int newEnd = Math.min(start+length, recordCount);
+    start = start + length;
+    int newEnd = Math.min(start + length, recordCount);
     length = newEnd - start;
 //    logger.debug("New start {}, new length {}", start, length);
     return true;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/PerformanceTool.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/PerformanceTool.java
@@ -47,6 +47,16 @@ import com.google.common.base.Stopwatch;
  * <p>
  * Current results:
  * <ul>
+ * <li>Required and nullable writers are slightly faster than the
+ * corresponding vector mutator methods.</li>
+ * <li>Writer is 230% faster than a repeated mutator.</li>
+ * </ul>
+ *
+ * The key reason for the converged performance (now compared to earlier
+ * results below) is that both paths now use bounds-checking optimizations.
+ * <p>
+ * Prior results before the common bounds-check optimizations:
+ * <ul>
  * <li>Writer is 42% faster than a required mutator.</li>
  * <li>Writer is 73% faster than a nullable mutator.</li>
  * <li>Writer is 407% faster than a repeated mutator.</li>

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
@@ -373,7 +373,7 @@ public class TestVariableWidthWriter extends SubOperatorTest {
 
         @Override
         public boolean canExpand(ScalarWriter writer, int delta) {
-          System.out.println("Delta: " + delta);
+//          System.out.println("Delta: " + delta);
           totalAlloc += delta;
           return totalAlloc < 1024 * 1024;
         }

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -712,25 +712,6 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
-  // Clone of UDLE's setBytes(), but with bounds checking done as a boolean,
-  // not assertion.
-
-  public boolean setBytesBounded(int index, byte[] src, int srcIndex, int length) {
-    // Must do here because Drill's UDLE is not ref counted.
-    // Done as an assert to avoid production overhead: if this is going
-    // to fail, it will do so spectacularly in tests, due to a programming error.
-    assert refCnt() > 0;
-    return udle.setBytesBounded(index, src, srcIndex, length);
-  }
-
-  // As above, but for direct memory.
-
-  public boolean setBytesBounded(int index, DrillBuf src, int srcIndex, int length) {
-    // See above.
-    assert refCnt() > 0;
-    return udle.setBytesBounded(index, src.udle, srcIndex, length);
-  }
-
   @Override
   public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
     udle.setBytes(index + offset, src, srcIndex, length);
@@ -841,72 +822,5 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
       sb.append("\n");
       historicalLog.buildHistory(sb, indent + 1, verbosity.includeStackTraces);
     }
-  }
-
-  // The "unsafe" methods are for use ONLY by code that does its own
-  // bounds checking. They are called "unsafe" for a reason: they will crash
-  // the JVM if values are addressed out of bounds.
-
-  /**
-   * Write an integer to the buffer at the given byte index, without
-   * bounds checks.
-   *
-   * @param offset byte (not int) offset of the location to write
-   * @param value the value to write
-   */
-
-  public void unsafePutInt(int offset, int value) {
-    PlatformDependent.putInt(addr + offset, value);
-  }
-
-  /**
-   * Write a long to the buffer at the given byte index, without
-   * bounds checks.
-   *
-   * @param index byte (not long) offset of the location to write
-   * @param value the value to write
-   */
-
-  public void unsafePutLong(int index, long value) {
-    PlatformDependent.putLong(addr + index, value);
-  }
-
-  /**
-   * Write a short to the buffer at the given byte index, without
-   * bounds checks.
-   *
-   * @param offset byte (not short) offset of the location to write
-   * @param value the value to write
-   */
-
-  public void unsafePutShort(int offset, short value) {
-    PlatformDependent.putShort(addr + offset, value);
-  }
-
-  /**
-   * Write a byte to the buffer at the given byte index, without
-   * bounds checks.
-   *
-   * @param offset byte offset of the location to write
-   * @param value the value to write
-   */
-
-  public void unsafePutByte(int offset, byte value) {
-    PlatformDependent.putByte(addr + offset, value);
-  }
-
-  /**
-   * Copy a buffer of heap data to the buffer memory.
-   *
-   * @param srce source byte buffer
-   * @param srcOffset offset within the byte buffer of the start of data
-   * @param destOffset byte offset into this buffer to which to write the
-   * data
-   * @param length length of the data, which must be within the
-   * bounds of this buffer
-   */
-
-  public void unsafeCopyMemory(byte[] srce, int srcOffset, int destOffset, int length) {
-    PlatformDependent.copyMemory(srce, srcOffset, addr + destOffset, length);
   }
 }

--- a/exec/vector/src/main/codegen/templates/ColumnAccessors.java
+++ b/exec/vector/src/main/codegen/templates/ColumnAccessors.java
@@ -276,14 +276,14 @@ public class ColumnAccessors {
       <#assign putAddr = "writeIndex * VALUE_WIDTH">
       </#if>
       <#if varWidth>
-      drillBuf.unsafeCopyMemory(value, 0, offset, len);
+      drillBuf.setBytes(offset, value, 0, len);
       offsetsWriter.setNextOffset(offset + len);
       <#elseif drillType == "Decimal9">
-      drillBuf.unsafePutInt(${putAddr},
+      drillBuf.setInt(${putAddr},
           DecimalUtility.getDecimal9FromBigDecimal(value,
                 type.getScale(), type.getPrecision()));
       <#elseif drillType == "Decimal18">
-      drillBuf.unsafePutLong(${putAddr},
+      drillBuf.setLong(${putAddr},
           DecimalUtility.getDecimal18FromBigDecimal(value,
                 type.getScale(), type.getPrecision()));
       <#elseif drillType == "Decimal38Sparse">
@@ -295,23 +295,23 @@ public class ColumnAccessors {
       DecimalUtility.getSparseFromBigDecimal(value, vector.getBuffer(), writeIndex * VALUE_WIDTH,
                type.getScale(), type.getPrecision(), 5);
       <#elseif drillType == "IntervalYear">
-      drillBuf.unsafePutInt(${putAddr},
+      drillBuf.setInt(${putAddr},
                 value.getYears() * 12 + value.getMonths());
       <#elseif drillType == "IntervalDay">
       final int offset = ${putAddr};
-      drillBuf.unsafePutInt(offset,     value.getDays());
-      drillBuf.unsafePutInt(offset + 4, periodToMillis(value));
+      drillBuf.setInt(offset,     value.getDays());
+      drillBuf.setInt(offset + 4, periodToMillis(value));
       <#elseif drillType == "Interval">
       final int offset = ${putAddr};
-      drillBuf.unsafePutInt(offset,     value.getYears() * 12 + value.getMonths());
-      drillBuf.unsafePutInt(offset + 4, value.getDays());
-      drillBuf.unsafePutInt(offset + 8, periodToMillis(value));
+      drillBuf.setInt(offset,     value.getYears() * 12 + value.getMonths());
+      drillBuf.setInt(offset + 4, value.getDays());
+      drillBuf.setInt(offset + 8, periodToMillis(value));
       <#elseif drillType == "Float4">
-      drillBuf.unsafePutInt(${putAddr}, Float.floatToRawIntBits((float) value));
+      drillBuf.setInt(${putAddr}, Float.floatToRawIntBits((float) value));
       <#elseif drillType == "Float8">
-      drillBuf.unsafePutLong(${putAddr}, Double.doubleToRawLongBits(value));
+      drillBuf.setLong(${putAddr}, Double.doubleToRawLongBits(value));
       <#else>
-      drillBuf.unsafePut${putType?cap_first}(${putAddr}, <#if doCast>(${putType}) </#if>value);
+      drillBuf.set${putType?cap_first}(${putAddr}, <#if doCast>(${putType}) </#if>value);
       </#if>
       vectorIndex.nextElement();
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractFixedWidthWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractFixedWidthWriter.java
@@ -98,7 +98,7 @@ public abstract class AbstractFixedWidthWriter extends BaseScalarWriter {
       while (dest < writeIndex) {
         int length = writeIndex - dest;
         length = Math.min(length, stride);
-        drillBuf.unsafeCopyMemory(ZERO_BUF, 0, dest * width, length * width);
+        drillBuf.setBytes(dest * width, ZERO_BUF, 0, length * width);
         dest += length;
       }
     }


### PR DESCRIPTION
Sort incorrectly limits batch size to 65535 records rather than 65536.

This PR also includes a few code cleanup items.

Also fixes DRILL-6086: Overflow in offset vector in row set writer

@vrozov, please review.