### PR TITLE
DRILL-6085: Fixed spontaneous vm exits on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 before_install: git fetch --unshallow
+sudo: required
 language: java
 jdk:
   - openjdk7


### PR DESCRIPTION
This error occurs sporadically on Travis.

```
Failed to execute goal [32morg.apache.maven.plugins:maven-surefire-plugin:2.17:test[m [1m(default-test)[m on project [36mdrill-java-exec[m: [1;31mExecution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?[m
```

I believe the issue is caused by the fact that our travis containers only have 4gb of memory and our test vms are given up to 4 gb of direct memory and heap memory (for a total of up to 8gb). Because we are promising more memory than we have it seems we occasionally hit the limit of our 4gb vm. I have added the ```sudo: "required"``` option to travis.yml which increases the amount of memory in the container to 7gb.

The vm exits occurred about 30% of the time lately before this change for me. With this change I ran 5 consecutive builds without a vm exit.