### PR TITLE
DRILL-6102: Fix ConcurrentModificationException in the BaseAllocator

### DIFF
--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -742,21 +742,23 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         .append('\n');
 
     if (DEBUG) {
-      indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));
-      for (BaseAllocator child : childAllocators.keySet()) {
-        child.print(sb, level + 2, verbosity);
-      }
+      synchronized (DEBUG_LOCK) {
+        indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));
+        for (BaseAllocator child : childAllocators.keySet()) {
+          child.print(sb, level + 2, verbosity);
+        }
 
-      indent(sb, level + 1).append(String.format("ledgers: %d\n", childLedgers.size()));
-      for (BufferLedger ledger : childLedgers.keySet()) {
-        ledger.print(sb, level + 2, verbosity);
-      }
+        indent(sb, level + 1).append(String.format("ledgers: %d\n", childLedgers.size()));
+        for (BufferLedger ledger : childLedgers.keySet()) {
+          ledger.print(sb, level + 2, verbosity);
+        }
 
-      final Set<Reservation> reservations = this.reservations.keySet();
-      indent(sb, level + 1).append(String.format("reservations: %d\n", reservations.size()));
-      for (final Reservation reservation : reservations) {
-        if (verbosity.includeHistoricalLog) {
-          reservation.historicalLog.buildHistory(sb, level + 3, true);
+        final Set<Reservation> reservations = this.reservations.keySet();
+        indent(sb, level + 1).append(String.format("reservations: %d\n", reservations.size()));
+        for (final Reservation reservation : reservations) {
+          if (verbosity.includeHistoricalLog) {
+            reservation.historicalLog.buildHistory(sb, level + 3, true);
+          }
         }
       }
     }


### PR DESCRIPTION
When a unit test fails and calls the BaseAllocators print method, the following exception can be thrown:

```
Running org.apache.drill.TestTpchDistributed#tpch19_1
11:45:47.482 [main] ERROR o.a.d.exec.server.BootStrapContext - Pool did not terminate
11:45:47.486 [main] ERROR o.a.d.exec.server.BootStrapContext - Error while closing
java.util.ConcurrentModificationException: null
at java.util.IdentityHashMap$IdentityHashMapIterator.nextIndex(IdentityHashMap.java:732) ~[na:1.7.0_141]
at java.util.IdentityHashMap$KeyIterator.next(IdentityHashMap.java:822) ~[na:1.7.0_141]
at org.apache.drill.exec.memory.BaseAllocator.print(BaseAllocator.java:751) ~[drill-memory-base-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.memory.BaseAllocator.print(BaseAllocator.java:747) ~[drill-memory-base-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.memory.BaseAllocator.print(BaseAllocator.java:747) ~[drill-memory-base-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.memory.BaseAllocator.toString(BaseAllocator.java:542) ~[drill-memory-base-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.memory.BaseAllocator.close(BaseAllocator.java:495) ~[drill-memory-base-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.common.AutoCloseables.close(AutoCloseables.java:76) [drill-common-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.common.AutoCloseables.close(AutoCloseables.java:64) [drill-common-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.server.BootStrapContext.close(BootStrapContext.java:256) ~[classes/:na]
at org.apache.drill.common.AutoCloseables.close(AutoCloseables.java:76) [drill-common-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.common.AutoCloseables.close(AutoCloseables.java:64) [drill-common-1.13.0-SNAPSHOT.jar:1.13.0-SNAPSHOT]
at org.apache.drill.exec.server.Drillbit.close(Drillbit.java:254) [classes/:na]
at org.apache.drill.test.BaseTestQuery.closeClient(BaseTestQuery.java:311) [test-classes/:1.13.0-SNAPSHOT]
at sun.reflect.GeneratedMethodAccessor262.invoke(Unknown Source) ~[na:na]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_141]
at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_141]
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) [junit-4.11.jar:na]
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.11.jar:na]
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) [junit-4.11.jar:na]
at mockit.integration.junit4.internal.JUnit4TestRunnerDecorator.invokeExplosively(JUnit4TestRunnerDecorator.java:44) [jmockit-1.3.jar:na]
at mockit.integration.junit4.internal.MockFrameworkMethod.invokeExplosively(MockFrameworkMethod.java:29) [jmockit-1.3.jar:na]
at sun.reflect.GeneratedMethodAccessor17.invoke(Unknown Source) ~[na:na]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_141]
at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_141]
at mockit.internal.util.MethodReflection.invokeWithCheckedThrows(MethodReflection.java:95) [jmockit-1.3.jar:na]
at mockit.internal.annotations.MockMethodBridge.callMock(MockMethodBridge.java:76) [jmockit-1.3.jar:na]
at mockit.internal.annotations.MockMethodBridge.invoke(MockMethodBridge.java:41) [jmockit-1.3.jar:na]
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java) [junit-4.11.jar:na]
at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33) [junit-4.11.jar:na]
at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55) [junit-4.11.jar:na]
at org.junit.rules.RunRules.evaluate(RunRules.java:20) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:na]
at org.junit.runners.Suite.runChild(Suite.java:127) [junit-4.11.jar:na]
at org.junit.runners.Suite.runChild(Suite.java:26) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229) [junit-4.11.jar:na]
at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:na]
at org.junit.runner.JUnitCore.run(JUnitCore.java:160) [junit-4.11.jar:na]
at org.junit.runner.JUnitCore.run(JUnitCore.java:138) [junit-4.11.jar:na]
at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:113) [surefire-junit47-2.17.jar:2.17]
at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeLazy(JUnitCoreWrapper.java:94) [surefire-junit47-2.17.jar:2.17]
at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:58) [surefire-junit47-2.17.jar:2.17]
at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:134) [surefire-junit47-2.17.jar:2.17]
at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200) [surefire-booter-2.17.jar:2.17]
at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153) [surefire-booter-2.17.jar:2.17]
at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103) [surefire-booter-2.17.jar:2.17]
```
This was fixed by synchronizing on the DEBUG_LOCK