### PR TITLE
DRILL-6129: Fixed query failure due to nested column data type change

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
@@ -204,6 +204,17 @@ public class RecordBatchLoader implements VectorAccessible, Iterable<VectorWrapp
       if (! currentChild.getType().equals(newChild.getMajorType())) {
         return false;
       }
+
+      // Perform schema diff for child column(s)
+      if (currentChild.getChildren().size() != newChild.getChildCount()) {
+        return false;
+      }
+
+      if (!currentChild.getChildren().isEmpty()) {
+        if (!isSameSchema(currentChild.getChildren(), newChild.getChildList())) {
+          return false;
+        }
+      }
     }
 
     // Everything matches.


### PR DESCRIPTION
Problem Description -
- The Drillbit was able to successfully send batches containing different metadata (for nested columns)
- This was the case when one or multiple scanners were involved
- The issue happened within the client where value vectors are cached across batches
- The load(...) API is responsible for updating values vectors when a new batch arrives
- The RecordBatchLoader class is used to detect schema changes ; if this is the case, then previous value vectors are discarded and new ones created
- There is a bug with the current implementation where only first level columns are compared

Fix -
- The fix is to improve the schema diff logic by including nested columns