### PR TITLE
DRILL-6140: Correctly list Operators in a Query Profile

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -56,10 +56,10 @@ public class OperatorWrapper {
     String extractedOpName = phyOperMap.get(path);
     String inferredOpName = operatorType == null ? UNKNOWN_OPERATOR : operatorType.toString();
     //Revert to inferred names for exceptional cases
-    if (extractedOpName == null || inferredOpName.contains(extractedOpName)
-        || inferredOpName.endsWith("_RECEIVER") || inferredOpName.endsWith("_RECEIVER")) {
-      //e.g. Inf:PARQUET_ROW_GROUP_SCAN ; Ext:SCAN
-      //e.g. UNORDERED_RECEIVER instead of UNION_EXCHANGE
+    // 1. Extracted 'FLATTEN' operator is NULL
+    // 2. Extracted 'SCAN' could be a PARQUET_ROW_GROUP_SCAN, or KAFKA_SUB_SCAN, or etc.
+    // 3. Extracted 'UNION_EXCHANGE' could be a SINGLE_SENDER or UNORDERED_RECEIVER
+    if (extractedOpName == null || inferredOpName.contains(extractedOpName) || extractedOpName.endsWith("_EXCHANGE")) {
       operatorName =  inferredOpName;
     } else {
       operatorName =  extractedOpName;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -151,10 +151,6 @@ public class ProfileWrapper {
     return profile;
   }
 
-  public Map<String, String> getPhysicalOperatorMap() {
-    return this.physicalOperatorMap;
-  }
-
   public String getProfileDuration() {
     return (new SimpleDurationFormat(profile.getStart(), profile.getEnd())).verbose();
   }
@@ -334,10 +330,13 @@ public class ProfileWrapper {
   //Generates operator names inferred from physical plan
   private void generateOpMap(String plan) {
     this.physicalOperatorMap = new HashMap<String,String>();
+    //[e.g ] operatorLine = "01-03 Flatten(flattenField=[$1]) : rowType = RecordType(ANY rfsSpecCode, ..."
     String[] operatorLine = plan.split("\\n");
     for (String line : operatorLine) {
       String[] lineToken = line.split("\\s+", 3);
+      //[e.g ] operatorPath = "01-xx-03"
       String operatorPath = lineToken[0].trim().replaceFirst("-", "-xx-"); //Required format for lookup
+      //[e.g ] extractedOperatorName = "FLATTEN"
       String extractedOperatorName = CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, lineToken[1].split("\\(", 2)[0].trim());
       physicalOperatorMap.put(operatorPath, extractedOperatorName);
     }


### PR DESCRIPTION
Operators listed in Profiles Page don't always correspond with operator specified in Physical Plan.
This commit fixes that by using the PhysicalPlan as a reference, but reverts to the inferred names in the event of an Exchange-based operator.
This is trying to address the example in the JIRA, where we need to show up a `FLATTEN` operator correctly, but there is no such operator type defined in `org.apache.drill.exec.proto.UserBitShared.CoreOperatorType`. So, the operator shown instead is `SINGLE_SENDER`