### PR TITLE
DRILL-6089 Removed ordering trait from HashJoin in planner

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPruleBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPruleBase.java
@@ -116,7 +116,6 @@ public abstract class JoinPruleBase extends Prule {
     }
   }
 
-
   // Create join plan with both left and right children hash distributed. If the physical join type
   // is MergeJoin, a collation must be provided for both left and right child and the plan will contain
   // sort converter if necessary to provide the collation.
@@ -126,8 +125,6 @@ public abstract class JoinPruleBase extends Prule {
       RelCollation collationLeft, RelCollation collationRight,
       DrillDistributionTrait hashLeftPartition, DrillDistributionTrait hashRightPartition) throws InvalidRelException {
 
-    //DrillDistributionTrait hashLeftPartition = new DrillDistributionTrait(DrillDistributionTrait.DistributionType.HASH_DISTRIBUTED, ImmutableList.copyOf(getDistributionField(join.getLeftKeys())));
-    //DrillDistributionTrait hashRightPartition = new DrillDistributionTrait(DrillDistributionTrait.DistributionType.HASH_DISTRIBUTED, ImmutableList.copyOf(getDistributionField(join.getRightKeys())));
     RelTraitSet traitsLeft = null;
     RelTraitSet traitsRight = null;
 
@@ -146,7 +143,8 @@ public abstract class JoinPruleBase extends Prule {
     DrillJoinRelBase newJoin = null;
 
     if (physicalJoinType == PhysicalJoinType.HASH_JOIN) {
-      newJoin = new HashJoinPrel(join.getCluster(), traitsLeft,
+      final RelTraitSet traitSet = PrelUtil.removeCollation(traitsLeft, call);
+      newJoin = new HashJoinPrel(join.getCluster(), traitSet,
                                  convertedLeft, convertedRight, join.getCondition(),
                                  join.getJoinType());
 
@@ -236,7 +234,8 @@ public abstract class JoinPruleBase extends Prule {
         call.transformTo(new MergeJoinPrel(join.getCluster(), convertedLeft.getTraitSet(), convertedLeft,
             convertedRight, joinCondition, join.getJoinType()));
       } else if (physicalJoinType == PhysicalJoinType.HASH_JOIN) {
-        call.transformTo(new HashJoinPrel(join.getCluster(), convertedLeft.getTraitSet(), convertedLeft,
+        final RelTraitSet traitSet = PrelUtil.removeCollation(convertedLeft.getTraitSet(), call);
+        call.transformTo(new HashJoinPrel(join.getCluster(), traitSet, convertedLeft,
             convertedRight, joinCondition, join.getJoinType()));
       } else if (physicalJoinType == PhysicalJoinType.NESTEDLOOP_JOIN) {
         call.transformTo(new NestedLoopJoinPrel(join.getCluster(), convertedLeft.getTraitSet(), convertedLeft,
@@ -245,5 +244,4 @@ public abstract class JoinPruleBase extends Prule {
     }
 
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -325,6 +326,20 @@ public class PrelUtil {
     } else {
       return set;
     }
+  }
+
+  // DRILL-6089 make sure no collations are added to HashJoin
+  public static RelTraitSet removeCollation(RelTraitSet traitSet, RelOptRuleCall call)
+  {
+    RelTraitSet newTraitSet = call.getPlanner().emptyTraitSet();
+
+    for (RelTrait trait: traitSet) {
+      if (!trait.getTraitDef().getTraitClass().equals(RelCollation.class)) {
+        newTraitSet = newTraitSet.plus(trait);
+      }
+    }
+
+    return newTraitSet;
   }
 
   public static class InputRefRemap {

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
@@ -80,26 +80,45 @@ public class PlanTestBase extends BaseTestQuery {
    *                     planning process throws an exception
    */
   public static void testPlanMatchingPatterns(String query, String[] expectedPatterns, String[] excludedPatterns)
-      throws Exception {
+    throws Exception {
+    testPlanMatchingPatterns(query, stringsToPatterns(expectedPatterns), stringsToPatterns(excludedPatterns));
+  }
+
+  public static void testPlanMatchingPatterns(String query, Pattern[] expectedPatterns, Pattern[] excludedPatterns)
+    throws Exception {
     final String plan = getPlanInString("EXPLAIN PLAN for " + QueryTestUtil.normalizeQuery(query), OPTIQ_FORMAT);
 
     // Check and make sure all expected patterns are in the plan
     if (expectedPatterns != null) {
-      for (final String s : expectedPatterns) {
-        final Pattern p = Pattern.compile(s);
-        final Matcher m = p.matcher(plan);
-        assertTrue(EXPECTED_NOT_FOUND + s +"\n" + plan, m.find());
+      for (final Pattern expectedPattern: expectedPatterns) {
+        final Matcher m = expectedPattern.matcher(plan);
+        assertTrue(EXPECTED_NOT_FOUND + expectedPattern.pattern() +"\n" + plan, m.find());
       }
     }
 
     // Check and make sure all excluded patterns are not in the plan
     if (excludedPatterns != null) {
-      for (final String s : excludedPatterns) {
-        final Pattern p = Pattern.compile(s);
-        final Matcher m = p.matcher(plan);
-        assertFalse(UNEXPECTED_FOUND + s +"\n" + plan, m.find());
+      for (final Pattern excludedPattern: excludedPatterns) {
+        final Matcher m = excludedPattern.matcher(plan);
+        assertFalse(UNEXPECTED_FOUND + excludedPattern.pattern() +"\n" + plan, m.find());
       }
     }
+  }
+
+  private static Pattern[] stringsToPatterns(String[] strings)
+  {
+    if (strings == null) {
+      return null;
+    }
+
+    final Pattern[] patterns = new Pattern[strings.length];
+
+    for (int index = 0; index < strings.length; index++) {
+      final String string = strings[index];
+      patterns[index] = Pattern.compile(string);
+    }
+
+    return patterns;
   }
 
   /**


### PR DESCRIPTION
HashJoin typically does not preserve ordering in most databases. Drill's HashJoin operator technically preserved ordering up to this point, but after spilling is implemented it will no longer preserve ordering. This change makes sure the planner knows that HashJoin does not preserve ordering.

All unit and functional tests are passing @amansinha100 @Ben-Zvi please review.