### PR TITLE
DRILL-6144: Make directMemory amount configurable in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ cache:
   directories:
   - "$HOME/.m2"
 install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
-script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryMb=3584
+script: mvn install -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryMb=2560 -DdirectMemoryMb=4608

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <reflections.version>0.9.8</reflections.version>
     <excludedGroups></excludedGroups>
     <memoryMb>4096</memoryMb>
+    <directMemoryMb>4096</directMemoryMb>
   </properties>
 
   <scm>
@@ -468,7 +469,7 @@
               -Dorg.apache.drill.exec.server.Drillbit.system_options="org.apache.drill.exec.compile.ClassTransformer.scalar_replacement=on"
               -Ddrill.test.query.printing.silent=true
               -Ddrill.catastrophic_to_standard_out=true
-              -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=4096M
+              -XX:MaxPermSize=512M -XX:MaxDirectMemorySize=${directMemoryMb}M
               -Djava.net.preferIPv4Stack=true
               -Djava.awt.headless=true
               -XX:+CMSClassUnloadingEnabled -ea


### PR DESCRIPTION
Travis builds have been hanging as well as unit tests on our Jenkins server. It is not clear what the underlying cause is but increasing direct memory resolves the issue. 

One possible root cause is that some unit tests leak direct memory by creating allocators which allocate memory and are then never closed. It will take a while to find a true fix for the issue and resolve it, so to unblock our work for now I would like to increase direct memory available for the build.

**Update:** For now we will not change the default amount of direct memory allocated until we find the root cause. If you need to you can pass the -DdirectMemoryMb property to override the amount of memory in your build.