### PR TITLE
DRILL-6148: TestSortSpillWithException is sometimes failing.

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSortSpillWithException.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSortSpillWithException.java
@@ -59,6 +59,11 @@ public class TestSortSpillWithException extends ClusterTest {
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
         .configProperty(ExecConstants.EXTERNAL_SORT_SPILL_THRESHOLD, 1) // Unmanaged
         .configProperty(ExecConstants.EXTERNAL_SORT_SPILL_GROUP_SIZE, 1) // Unmanaged
+        // Using EXTERNAL_SORT_MAX_MEMORY to set low values of memory for SORT instead
+        // of lowering MAX_QUERY_MEMORY_PER_NODE_KEY because computation of operator memory
+        // cannot go lower than MIN_MEMORY_PER_BUFFERED_OP (the default value of this parameter
+        // is 40MB). The 40MB memory is sufficient for this testcase to run sort without spilling.
+        .configProperty(ExecConstants.EXTERNAL_SORT_MAX_MEMORY, 10 * 1024 * 1024)
         .sessionOption(ExecConstants.MAX_QUERY_MEMORY_PER_NODE_KEY, 60 * 1024 * 1024) // Spill early
         // Prevent the percent-based memory rule from second-guessing the above.
         .sessionOption(ExecConstants.PERCENT_MEMORY_PER_QUERY_KEY, 0.0)


### PR DESCRIPTION
I have changed the test case to use the EXTERNAL_SORT_MAX_MEMORY to configure the sort operator to use less memory instead of relying on MAX_QUERY_MEMORY_PER_NODE_KEY.

This way the test case passes all the time (it is failing intermittently in my branch).

@paul-rogers  can you please review this change.