### PR TITLE
DRILL-6188: Fix C++ client build on Centos7, OS X

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.hpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.hpp
@@ -182,7 +182,6 @@ class DrillClientBaseHandle: public DrillClientQueryHandle {
     virtual status_t notifyListener(ListenerValue v, DrillClientError* pErr);
 
     virtual void signalError(DrillClientError* pErr);
-    void setHasError(bool hasError) { m_bHasError = hasError; }
 
     private:
     Listener m_pApplicationListener;

--- a/contrib/native/client/src/clientlib/logger.hpp
+++ b/contrib/native/client/src/clientlib/logger.hpp
@@ -19,6 +19,7 @@
 #ifndef __LOGGER_H
 #define __LOGGER_H
 
+#include <iostream>
 #include <sstream>
 #include <ostream>
 #include <iostream>


### PR DESCRIPTION
Removed unused method that didn't compile. 
Included iostream for declaration of std::cout