### PR TITLE
DRILL-6192: Drill is vulnerable to CVE-2017-12197

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -19,7 +19,7 @@
   <artifactId>drill-java-exec</artifactId>
   <name>exec/Java Execution Engine</name>
   <properties>
-    <libpam4j.version>1.8-rev1</libpam4j.version>
+    <libpam4j.version>1.8-rev2</libpam4j.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Changed libpam4j version from 1.8-rev1 to 1.9-mapr