### PR TITLE
DRILL-6185: Fixed error while displaying system profiles via the Web-UI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -25,13 +25,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.drill.exec.ops.OperatorMetricRegistry;
 import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.proto.UserBitShared.MetricValue;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
 import org.apache.drill.exec.proto.UserBitShared.StreamProfile;
+
+import com.google.common.base.Preconditions;
 
 /**
  * Wrapper class for profiles of ALL operator instances of the same operator type within a major fragment.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -331,7 +331,7 @@ public class ProfileWrapper {
 
   //Generates operator names inferred from physical plan
   private void generateOpMap(String plan) {
-    this.physicalOperatorMap = new HashMap<String,String>();
+    this.physicalOperatorMap = new HashMap<>();
     if (plan.isEmpty()) {
       return;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -17,15 +17,14 @@
  */
 package org.apache.drill.exec.server.rest.profile;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.CaseFormat;
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
@@ -39,7 +38,9 @@ import org.apache.drill.exec.server.options.OptionList;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.server.rest.WebServer;
 
-import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.Maps;
 
 /**
  * Wrapper class for a {@link #profile query profile}, so it to be presented through web UI.
@@ -64,7 +65,8 @@ public class ProfileWrapper {
     this.profile = profile;
     this.id = QueryIdHelper.getQueryId(profile.getId());
     //Generating Operator Name map (DRILL-6140)
-    generateOpMap(profile.getPlan());
+    String profileTextPlan = profile.hasPlan() ? profile.getPlan() : "" ;
+    generateOpMap(profileTextPlan);
 
     final List<FragmentWrapper> fragmentProfiles = new ArrayList<>();
 
@@ -330,10 +332,16 @@ public class ProfileWrapper {
   //Generates operator names inferred from physical plan
   private void generateOpMap(String plan) {
     this.physicalOperatorMap = new HashMap<String,String>();
+    if (plan.isEmpty()) {
+      return;
+    }
     //[e.g ] operatorLine = "01-03 Flatten(flattenField=[$1]) : rowType = RecordType(ANY rfsSpecCode, ..."
     String[] operatorLine = plan.split("\\n");
     for (String line : operatorLine) {
       String[] lineToken = line.split("\\s+", 3);
+      if (lineToken.length < 2) {
+        continue; //Skip due to possible invalid entry
+      }
       //[e.g ] operatorPath = "01-xx-03"
       String operatorPath = lineToken[0].trim().replaceFirst("-", "-xx-"); //Required format for lookup
       //[e.g ] extractedOperatorName = "FLATTEN"


### PR DESCRIPTION
The bug lies in the absence of a text plan for profiles related to system queries:
e.g.
```
use dfs.tmp;
show tables;
alter session reset all;
```
This addresses that by ensuring an empty string is substituted and the tokenization is done correctly.