### PR TITLE
DRILL-6197: Skip duplicate entry for OperatorStats

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
@@ -17,13 +17,14 @@
  */
 package org.apache.drill.exec.ops;
 
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
-
-import com.google.common.collect.Lists;
 
 /**
  * Holds statistics of a particular (minor) fragment.
@@ -31,7 +32,7 @@ import com.google.common.collect.Lists;
 public class FragmentStats {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentStats.class);
 
-  private List<OperatorStats> operators = Lists.newArrayList();
+  private Map<ImmutablePair<Integer, Integer>, OperatorStats> operators = new LinkedHashMap<>();
   private final long startTime;
   private final DrillbitEndpoint endpoint;
   private final BufferAllocator allocator;
@@ -47,8 +48,8 @@ public class FragmentStats {
     prfB.setMaxMemoryUsed(allocator.getPeakMemoryAllocation());
     prfB.setEndTime(System.currentTimeMillis());
     prfB.setEndpoint(endpoint);
-    for(OperatorStats o : operators){
-      prfB.addOperatorProfile(o.getProfile());
+    for(Entry<ImmutablePair<Integer, Integer>, OperatorStats> o : operators.entrySet()){
+      prfB.addOperatorProfile(o.getValue().getProfile());
     }
   }
 
@@ -62,30 +63,14 @@ public class FragmentStats {
   public OperatorStats newOperatorStats(final OpProfileDef profileDef, final BufferAllocator allocator) {
     final OperatorStats stats = new OperatorStats(profileDef, allocator);
     if(profileDef.operatorType != -1) {
-      operators.add(stats);
+      @SuppressWarnings("unused")
+      OperatorStats existingStatsHolder = addOperatorStats(stats);
     }
     return stats;
   }
 
-  public void addOperatorStats(OperatorStats stats) {
-    operators.add(stats);
+  public OperatorStats addOperatorStats(OperatorStats stats) {
+    return operators.put(new ImmutablePair<>(stats.operatorId, stats.operatorType), stats);
   }
 
-  //DRILL-6197
-  public OperatorStats addOrReplaceOperatorStats(OperatorStats stats) {
-    //Remove existing stat
-    OperatorStats replacedStat = null;
-    int index = 0;
-    for (OperatorStats opStat : operators) {
-      if (opStat.operatorId == stats.operatorId && opStat.operatorType == stats.operatorType) {
-        replacedStat = operators.remove(index);
-        break; //Expecting only one entry
-      }
-      index++;
-    }
-    //Add new stat
-    operators.add(stats);
-    //Return replaced Stat to caller
-    return replacedStat;
-  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
+import org.apache.drill.exec.proto.beans.CoreOperatorType;
 
 import com.google.common.collect.Lists;
 
@@ -31,6 +32,13 @@ import com.google.common.collect.Lists;
 public class FragmentStats {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentStats.class);
 
+  //Skip operators that already have stats reported by org.apache.drill.exec.physical.impl.BaseRootExec
+  private static final List<Integer> operatorStatsInitToSkip = Lists.newArrayList(
+      CoreOperatorType.SCREEN.getNumber(),
+      CoreOperatorType.SINGLE_SENDER.getNumber(),
+      CoreOperatorType.BROADCAST_SENDER.getNumber(),
+      CoreOperatorType.HASH_PARTITION_SENDER.getNumber()
+      );
   private List<OperatorStats> operators = Lists.newArrayList();
   private final long startTime;
   private final DrillbitEndpoint endpoint;
@@ -61,7 +69,7 @@ public class FragmentStats {
    */
   public OperatorStats newOperatorStats(final OpProfileDef profileDef, final BufferAllocator allocator) {
     final OperatorStats stats = new OperatorStats(profileDef, allocator);
-    if(profileDef.operatorType != -1) {
+    if(profileDef.operatorType != -1 && !operatorStatsInitToSkip.contains(profileDef.operatorType)) {
       operators.add(stats);
     }
     return stats;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
@@ -57,7 +57,7 @@ public abstract class BaseRootExec implements RootExec {
     stats = new OperatorStats(new OpProfileDef(config.getOperatorId(),
         config.getOperatorType(), OperatorUtilities.getChildCount(config)),
       this.oContext.getAllocator());
-    fragmentContext.getStats().addOrReplaceOperatorStats(this.stats);
+    fragmentContext.getStats().addOperatorStats(this.stats);
     this.fragmentContext = fragmentContext;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
@@ -43,21 +43,21 @@ public abstract class BaseRootExec implements RootExec {
   private List<CloseableRecordBatch> operators;
 
   public BaseRootExec(final RootFragmentContext fragmentContext, final PhysicalOperator config) throws OutOfMemoryException {
-    this.oContext = fragmentContext.newOperatorContext(config, stats);
-    stats = new OperatorStats(new OpProfileDef(config.getOperatorId(),
-        config.getOperatorType(), OperatorUtilities.getChildCount(config)),
-        oContext.getAllocator());
-    fragmentContext.getStats().addOperatorStats(this.stats);
-    this.fragmentContext = fragmentContext;
+    this(fragmentContext, null, config);
   }
 
   public BaseRootExec(final RootFragmentContext fragmentContext, final OperatorContext oContext,
                       final PhysicalOperator config) throws OutOfMemoryException {
-    this.oContext = oContext;
+    if (oContext == null) {
+      this.oContext = fragmentContext.newOperatorContext(config, stats);
+    } else {
+      this.oContext = oContext;
+    }
+    //Creating new stat for appending to list
     stats = new OperatorStats(new OpProfileDef(config.getOperatorId(),
         config.getOperatorType(), OperatorUtilities.getChildCount(config)),
-      oContext.getAllocator());
-    fragmentContext.getStats().addOperatorStats(this.stats);
+      this.oContext.getAllocator());
+    fragmentContext.getStats().addOrReplaceOperatorStats(this.stats);
     this.fragmentContext = fragmentContext;
   }
 


### PR DESCRIPTION
`org.apache.drill.exec.ops.FragmentStats` should skip injecting the `org.apache.drill.exec.ops.OperatorStats` instance for these operators:
```
org.apache.drill.exec.proto.beans.CoreOperatorType.SCREEN
org.apache.drill.exec.proto.beans.CoreOperatorType.SINGLE_SENDER
org.apache.drill.exec.proto.beans.CoreOperatorType.BROADCAST_SENDER
org.apache.drill.exec.proto.beans.CoreOperatorType.HASH_PARTITION_SENDER
```
They all use the `org.apache.drill.exec.physical.impl.BaseRootExec` to inject the correct statistics.
**NOTE:**
To avoid going out of sync for new operators' `...Exec` , the BaseRootExec does the swapping of the matching `OperatorStats` instead of having `FragmentStats` perform skipping.