### PR TITLE
DRILL-6224: Publish current memory usage for Drillbits in webpages

### DIFF
--- a/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
+++ b/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
@@ -43,6 +43,11 @@
         <div id="totalUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
+      Direct (Estimate)
+      <div class="progress">
+        <div id="estDirectUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
+        </div>
+      </div>
     </div>
 
     <div id="mainDiv" class="col-md-9" role="main">
@@ -109,18 +114,23 @@
     };
 
     function updateBars(gauges) {
-      $.each(["heap","non-heap","total"], function(i, key) {
+      $.each(["heap","non-heap","total","drill.allocator.root"], function(i, key) {
         var used    = gauges[key + ".used"].value;
-        var max     = gauges[key + ".max"].value;
-        var usage   = round((used / 1073741824), 2) + "GB";
-        var percent = round((used / max), 2);
+        var max;
+        if (key.startsWith("drill.allocator")) {
+          max       = gauges[key + ".peak"].value;
+        } else {
+          max       = gauges[key + ".max"].value;
+        }
+        var percent = round((100 * used / max), 2);
+        var usage   = round((used / 1073741824), 2) + "GB (" + Math.max(0, percent) + "%)";
 
-        var styleVal = "width: " + percent + "%;"
-        $("#" + key + "Usage").attr({
+        var styleVal = "width: " + percent + "%;color: #202020;white-space: nowrap"
+        $("#" + (key.startsWith("drill.allocator") ? "estDirect" : key) + "Usage").attr({
           "aria-valuenow" : percent,
           "style" : styleVal
         });
-        $("#" + key + "Usage").html(usage);
+        $("#" + (key.startsWith("drill.allocator") ? "estDirect" : key) + "Usage").html(usage);
       });
     };
 
@@ -159,7 +169,7 @@
     };
 
     update();
-    setInterval(update, 2000);
+    setInterval(update, 3000);
   </script>
 </#macro>
 

--- a/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
+++ b/exec/java-exec/src/main/resources/rest/metrics/metrics.ftl
@@ -43,7 +43,7 @@
         <div id="totalUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
       </div>
-      Direct (Estimate)
+      Actively Used Direct (Estimate)
       <div class="progress">
         <div id="estDirectUsage" class="progress-bar" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
         </div>
@@ -82,6 +82,15 @@
     var round = function(val, n) {
       return Math.round(val * Math.pow(10, n)) / Math.pow(10, n);
     };
+    var isAllocator = function(metricName) {
+      return (metricName.startsWith("drill.allocator"));
+    };
+    function getGBUsageText(val, perc) {
+      if (isNaN(perc)) {
+        perc = 0;
+      }
+      return round((val / 1073741824), 2) + "GB (" + Math.max(0, perc) + "%)";
+    }
 
     function updateGauges(gauges) {
       $("#gaugesTable").html(function() {
@@ -115,22 +124,22 @@
 
     function updateBars(gauges) {
       $.each(["heap","non-heap","total","drill.allocator.root"], function(i, key) {
-        var used    = gauges[key + ".used"].value;
+        var used = gauges[key + ".used"].value;
         var max;
-        if (key.startsWith("drill.allocator")) {
-          max       = gauges[key + ".peak"].value;
+        if (isAllocator(key)) {
+          max = gauges[key + ".peak"].value;
         } else {
-          max       = gauges[key + ".max"].value;
+          max = gauges[key + ".max"].value;
         }
         var percent = round((100 * used / max), 2);
-        var usage   = round((used / 1073741824), 2) + "GB (" + Math.max(0, percent) + "%)";
+        var usage = getGBUsageText(used, percent);
 
         var styleVal = "width: " + percent + "%;color: #202020;white-space: nowrap"
-        $("#" + (key.startsWith("drill.allocator") ? "estDirect" : key) + "Usage").attr({
+        $("#" + (isAllocator(key) ? "estDirect" : key) + "Usage").attr({
           "aria-valuenow" : percent,
           "style" : styleVal
         });
-        $("#" + (key.startsWith("drill.allocator") ? "estDirect" : key) + "Usage").html(usage);
+        $("#" + (isAllocator(key) ? "estDirect" : key) + "Usage").html(usage);
       });
     };
 


### PR DESCRIPTION
The `metrics.ftl` page had gauges incorrectly set to near zero values. The commit for metrics.ftl fixes that, and also provides an estimate of the current direct memory actively in use (based on the `drill.allocator.root.used` value reported by the Drillbit)
The `index.ftl` page expands this by additionally providing the active heap and direct memory usage for all Drillbits. This is done by the JavaScript actively pinging all the Drillbits on their current memory usage in 10 second intervals.
The percentages in both cases indicate the % usage in terms of the max (heap) or the peak (direct) observed.