### PR TITLE
DRILL-6241: Saffron properties config has the excessive permissions

### DIFF
--- a/distribution/src/assemble/bin.xml
+++ b/distribution/src/assemble/bin.xml
@@ -411,6 +411,7 @@
     <file>
       <source>src/resources/saffron.properties</source>
       <outputDirectory>conf</outputDirectory>
+      <fileMode>0640</fileMode>
     </file>
     <file>
       <source>src/resources/drill-on-yarn-example.conf</source>


### PR DESCRIPTION
changed saffron.properties permission to 640