### PR TITLE
DRILL-6246: Reduced the size of the jdbc-all jar file

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -485,6 +485,8 @@
                <exclude>org/yaml/**</exclude>
                <exclude>hello/**</exclude>
                <exclude>webapps/**</exclude>
+               <exclude>**/org/apache/calcite/avatica/metrics/**</exclude>
+               <exclude>**/org/apache/calcite/avatica/org/**</exclude>
              </excludes>
            </filter>
          </filters>
@@ -511,7 +513,7 @@
                   This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                   </message>
-                  <maxsize>39000000</maxsize>
+                  <maxsize>38000000</maxsize>
                   <minsize>15000000</minsize>
                   <files>
                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
@@ -571,7 +573,7 @@
                           This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                         </message>
-                        <maxsize>37000000</maxsize>
+                        <maxsize>35000000</maxsize>
                         <minsize>15000000</minsize>
                         <files>
                           <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
@@ -788,6 +790,8 @@
                       <exclude>org/yaml/**</exclude>
                       <exclude>hello/**</exclude>
                       <exclude>webapps/**</exclude>
+                      <exclude>**/org/apache/calcite/avatica/metrics/**</exclude>
+                      <exclude>**/org/apache/calcite/avatica/org/**</exclude>
                     </excludes>
                   </filter>
                 </filters>


### PR DESCRIPTION
- The jdbc-all client jar has been growing in size from version to the next (~20MB in version 1.10, ~27MB in version 1.12, and 34MB in version 1.13
- Note the exact size of the size depends on the maven profile used during compilation (e.g., "mapr" which have more excludes)
- Originally, I tried to exclude the following calcite/avatica packages (responsible for the recent size increase): metrics, proto, org/apache/, com/fasterxml, com/google but some tests failed as the calcite code was referencing some of them
- In this pull request, I have excluded the following packages: calcite/avatica/org and calcite/avatica/metrics