### PR TITLE
DRILL-6275: Fixed direct memory reporting in sys.memory.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ExecutorFragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ExecutorFragmentContext.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.ops;
 
 import org.apache.drill.exec.coord.ClusterCoordinator;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.impl.OperatorCreatorRegistry;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.proto.CoordinationProtos;
@@ -31,6 +32,11 @@ import java.util.Map;
 import java.util.Set;
 
 public interface ExecutorFragmentContext extends RootFragmentContext {
+  /**
+   * Returns the root allocator for the Drillbit.
+   * @return The root allocator for the Drillbit.
+   */
+  BufferAllocator getRootAllocator();
 
   PhysicalPlanReader getPlanReader();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -336,6 +336,11 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   }
 
   @Override
+  public BufferAllocator getRootAllocator() {
+    return context.getAllocator();
+  }
+
+  @Override
   public BufferAllocator getNewChildAllocator(final String operatorName,
       final int operatorId,
       final long initialReservation,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/MemoryIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/MemoryIterator.java
@@ -61,8 +61,8 @@ public class MemoryIterator implements Iterator<Object> {
     BufferPoolMXBean directBean = getDirectBean();
     memoryInfo.jvm_direct_current = directBean.getMemoryUsed();
 
-
-    memoryInfo.direct_current = context.getAllocator().getAllocatedMemory();
+    // We need the memory used by the root allocator for the Drillbit
+    memoryInfo.direct_current = context.getRootAllocator().getAllocatedMemory();
     memoryInfo.direct_max = DrillConfig.getMaxDirectMemory();
     return memoryInfo;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/PhysicalOpUnitTestBase.java
@@ -26,6 +26,7 @@ import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.RecognitionException;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.drill.exec.coord.ClusterCoordinator;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.AccountingDataTunnel;
 import org.apache.drill.exec.ops.AccountingUserConnection;
 import org.apache.drill.exec.ops.ExecutorFragmentContext;
@@ -342,6 +343,11 @@ public class PhysicalOpUnitTestBase extends ExecTest {
     public MockExecutorFragmentContext(final FragmentContext fragmentContext) {
       super(fragmentContext.getConfig(), fragmentContext.getOptions(), fragmentContext.getAllocator(),
         fragmentContext.getScanExecutor(), fragmentContext.getScanDecodeExecutor());
+    }
+
+    @Override
+    public BufferAllocator getRootAllocator() {
+      return null;
     }
 
     @Override


### PR DESCRIPTION
@kkhatua Thanks for pinpointing the root cause! Please review. 