### PR TITLE
DRILL-6254: IllegalArgumentException: the requested size must be non-…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenRecordBatch.java
@@ -237,7 +237,10 @@ public class FlattenRecordBatch extends AbstractSingleRecordBatch<FlattenPOP> {
 
   private void handleRemainder() {
     int remainingRecordCount = flattener.getFlattenField().getAccessor().getInnerValueCount() - remainderIndex;
-    if (!doAlloc(remainingRecordCount)) {
+
+    // remainingRecordCount can be much higher than number of rows we will have in outgoing batch.
+    // Do memory allocation only for number of rows we are going to have in the batch.
+    if (!doAlloc(Math.min(remainingRecordCount, flattenMemoryManager.getOutputRowCount()))) {
       outOfMemory = true;
       return;
     }


### PR DESCRIPTION
…negative

We should limit memory allocation to number of records that are going to be in the next batch, not the total number of records remaining. For very large remaining record count, when multiplied with high cardinality, integer overflows and is becoming negative.