### PR TITLE
DRILL-6248: Added limit push down support for system tables

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -30,10 +30,8 @@ import org.apache.drill.exec.planner.fragment.DistributionAffinity;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Iterators;
 
 public abstract class AbstractGroupScan extends AbstractBase implements GroupScan {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractGroupScan.class);
 
   public AbstractGroupScan(String userName) {
     super(userName);
@@ -45,7 +43,7 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
 
   @Override
   public Iterator<PhysicalOperator> iterator() {
-    return Iterators.emptyIterator();
+    return Collections.emptyIterator();
   }
 
   @Override
@@ -135,7 +133,6 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
 
   /**
    * Default is not to support limit pushdown.
-   * @return
    */
   @Override
   @JsonIgnore
@@ -144,12 +141,12 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
   }
 
   /**
-   * By default, return null to indicate rowcount based prune is not supported.
-   * Each groupscan subclass should override, if it supports rowcount based prune.
+   * By default, return null to indicate row count based prune is not supported.
+   * Each group scan subclass should override, if it supports row count based prune.
    */
   @Override
   @JsonIgnore
-  public GroupScan applyLimit(long maxRecords) {
+  public GroupScan applyLimit(int maxRecords) {
     return null;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -40,16 +40,16 @@ public interface GroupScan extends Scan, HasAffinity{
    *                             2) NULL is interpreted as ALL_COLUMNS.
    *  How to handle skipAll query is up to each storage plugin, with different policy in corresponding RecordReader.
    */
-  public static final List<SchemaPath> ALL_COLUMNS = ImmutableList.of(SchemaPath.STAR_COLUMN);
+  List<SchemaPath> ALL_COLUMNS = ImmutableList.of(SchemaPath.STAR_COLUMN);
 
-  public static final long NO_COLUMN_STATS = -1;
+  long NO_COLUMN_STATS = -1;
 
-  public abstract void applyAssignments(List<DrillbitEndpoint> endpoints) throws PhysicalOperatorSetupException;
+  void applyAssignments(List<DrillbitEndpoint> endpoints) throws PhysicalOperatorSetupException;
 
-  public abstract SubScan getSpecificScan(int minorFragmentId) throws ExecutionSetupException;
+  SubScan getSpecificScan(int minorFragmentId) throws ExecutionSetupException;
 
   @JsonIgnore
-  public int getMaxParallelizationWidth();
+  int getMaxParallelizationWidth();
 
   /**
    * At minimum, the GroupScan requires these many fragments to run.
@@ -57,7 +57,7 @@ public interface GroupScan extends Scan, HasAffinity{
    * @return the minimum number of fragments that should run
    */
   @JsonIgnore
-  public int getMinParallelizationWidth();
+  int getMinParallelizationWidth();
 
   /**
    * Check if GroupScan enforces width to be maximum parallelization width.
@@ -69,50 +69,50 @@ public interface GroupScan extends Scan, HasAffinity{
    */
   @JsonIgnore
   @Deprecated
-  public boolean enforceWidth();
+  boolean enforceWidth();
 
   /**
    * Returns a signature of the {@link GroupScan} which should usually be composed of
    * all its attributes which could describe it uniquely.
    */
   @JsonIgnore
-  public abstract String getDigest();
+  String getDigest();
 
   @JsonIgnore
-  public ScanStats getScanStats(PlannerSettings settings);
+  ScanStats getScanStats(PlannerSettings settings);
 
   /**
    * Returns a clone of GroupScan instance, except that the new GroupScan will use the provided list of columns .
    */
-  public GroupScan clone(List<SchemaPath> columns);
+  GroupScan clone(List<SchemaPath> columns);
 
   /**
    * GroupScan should check the list of columns, and see if it could support all the columns in the list.
    */
-  public boolean canPushdownProjects(List<SchemaPath> columns);
+  boolean canPushdownProjects(List<SchemaPath> columns);
 
   /**
    * Return the number of non-null value in the specified column. Raise exception, if groupscan does not
    * have exact column row count.
    */
-  public long getColumnValueCount(SchemaPath column);
+  long getColumnValueCount(SchemaPath column);
 
   /**
    * Whether or not this GroupScan supports pushdown of partition filters (directories for filesystems)
    */
-  public boolean supportsPartitionFilterPushdown();
+  boolean supportsPartitionFilterPushdown();
 
   /**
    * Returns a list of columns that can be used for partition pruning
    *
    */
   @JsonIgnore
-  public List<SchemaPath> getPartitionColumns();
+  List<SchemaPath> getPartitionColumns();
 
   /**
    * Whether or not this GroupScan supports limit pushdown
    */
-  public boolean supportsLimitPushdown();
+  boolean supportsLimitPushdown();
 
   /**
    * Apply rowcount based prune for "LIMIT n" query.
@@ -120,18 +120,18 @@ public interface GroupScan extends Scan, HasAffinity{
    * @return  a new instance of group scan if the prune is successful.
    *          null when either if row-based prune is not supported, or if prune is not successful.
    */
-  public GroupScan applyLimit(long maxRecords);
+  GroupScan applyLimit(int maxRecords);
 
   /**
    * Return true if this GroupScan can return its selection as a list of file names (retrieved by getFiles()).
    */
   @JsonIgnore
-  public boolean hasFiles();
+  boolean hasFiles();
 
   /**
    * Returns a collection of file names associated with this GroupScan. This should be called after checking
    * hasFiles().  If this GroupScan cannot provide file names, it returns null.
    */
-  public Collection<String> getFiles();
+  Collection<String> getFiles();
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetGroupScan.java
@@ -1189,7 +1189,7 @@ public class ParquetGroupScan extends AbstractFileGroupScan {
   }
 
   @Override
-  public GroupScan applyLimit(long maxRecords) {
+  public GroupScan applyLimit(int maxRecords) {
     Preconditions.checkArgument(rowGroupInfos.size() >= 0);
 
     maxRecords = Math.max(maxRecords, 1); // Make sure it request at least 1 row -> 1 rowGroup.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pojo/PojoRecordReader.java
@@ -43,6 +43,12 @@ public class PojoRecordReader<T> extends AbstractPojoRecordReader<T> {
     this.fields = new ArrayList<>();
   }
 
+  public PojoRecordReader(Class<T> pojoClass, List<T> records, int maxRecordToRead) {
+    super(records, maxRecordToRead);
+    this.pojoClass = pojoClass;
+    this.fields = new ArrayList<>();
+  }
+
   /**
    * Creates writers based on pojo field class types. Ignores static fields.
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -26,91 +26,91 @@ import org.apache.drill.exec.store.sys.OptionIterator.OptionValueWrapper;
  * An enumeration of all tables in Drill's system ("sys") schema.
  * <p>
  *   OPTION, DRILLBITS and VERSION are local tables available on every Drillbit.
- *   MEMORY and THREADS are distributed tables with one record on every
- *   Drillbit.
+ *   MEMORY and THREADS are distributed tables with one record on every Drillbit.
+ *   PROFILES and PROFILES_JSON are stored in local / distributed storage.
  * </p>
  */
 public enum SystemTable {
   OPTION("options", false, OptionValueWrapper.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_PUBLIC);
     }
   },
 
   OPTION_VAL("options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ExtendedOptionIterator(context, false);
     }
   },
 
   INTERNAL_OPTIONS("internal_options", false, OptionValueWrapper.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_INTERNAL);
     }
   },
 
   INTERNAL_OPTIONS_VAL("internal_options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ExtendedOptionIterator(context, true);
     }
   },
 
   BOOT("boot", false, OptionValueWrapper.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new OptionIterator(context, OptionIterator.Mode.BOOT);
     }
   },
 
   DRILLBITS("drillbits", false,DrillbitIterator.DrillbitInstance.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new DrillbitIterator(context);
     }
   },
 
   VERSION("version", false, VersionIterator.VersionInfo.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new VersionIterator();
     }
   },
 
   MEMORY("memory", true, MemoryIterator.MemoryInfo.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new MemoryIterator(context);
     }
   },
 
   CONNECTIONS("connections", true, BitToUserConnectionIterator.ConnectionInfo.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new BitToUserConnectionIterator(context);
     }
   },
 
   PROFILES("profiles", false, ProfileInfoIterator.ProfileInfo.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
-      return new ProfileInfoIterator(context);
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
+      return new ProfileInfoIterator(context, maxRecords);
     }
   },
 
   PROFILES_JSON("profiles_json", false, ProfileJsonIterator.ProfileJson.class) {
     @Override
-    public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
-      return new ProfileJsonIterator(context);
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
+      return new ProfileJsonIterator(context, maxRecords);
     }
   },
 
   THREADS("threads", true, ThreadsIterator.ThreadsInfo.class) {
     @Override
-  public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+  public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ThreadsIterator(context);
     }
   };
@@ -125,7 +125,7 @@ public enum SystemTable {
     this.pojoClass = pojoClass;
   }
 
-  public Iterator<Object> getIterator(final ExecutorFragmentContext context) {
+  public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
     throw new UnsupportedOperationException(tableName + " must override this method.");
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTableBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTableBatchCreator.java
@@ -43,8 +43,8 @@ public class SystemTableBatchCreator implements BatchCreator<SystemTableScan> {
                             final List<RecordBatch> children)
     throws ExecutionSetupException {
     final SystemTable table = scan.getTable();
-    final Iterator<Object> iterator = table.getIterator(context);
-    final RecordReader reader = new PojoRecordReader(table.getPojoClass(), ImmutableList.copyOf(iterator));
+    final Iterator<Object> iterator = table.getIterator(context, scan.getMaxRecordsToRead());
+    final RecordReader reader = new PojoRecordReader(table.getPojoClass(), ImmutableList.copyOf(iterator), scan.getMaxRecordsToRead());
 
     return new ScanBatch(scan, context, Collections.singletonList(reader));
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTablePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTablePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.sys;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -68,13 +67,12 @@ public class SystemTablePlugin extends AbstractStoragePlugin {
   }
 
   @Override
-  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) throws IOException {
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent) {
     parent.add(schema.getName(), schema);
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns)
-      throws IOException {
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns) {
     SystemTable table = selection.getWith(context.getLpPersistence(), SystemTable.class);
     return new SystemTableScan(table, this);
   }
@@ -87,7 +85,7 @@ public class SystemTablePlugin extends AbstractStoragePlugin {
     private final Set<String> tableNames;
 
     public SystemSchema() {
-      super(ImmutableList.<String>of(), SYS_SCHEMA_NAME);
+      super(ImmutableList.of(), SYS_SCHEMA_NAME);
       Set<String> names = Sets.newHashSet();
       for (SystemTable t : SystemTable.values()) {
         names.add(t.getTableName());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,18 +17,17 @@
  */
 package org.apache.drill.exec.store.sys;
 
-import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.exec.ExecConstants;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-public class TestSystemTable extends BaseTestQuery {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSystemTable.class);
+public class TestSystemTable extends PlanTestBase {
 
   @BeforeClass
-  public static void setupMultiNodeCluster() throws Exception {
+  public static void setupMultiNodeCluster() {
     updateTestCluster(3, null);
   }
 
@@ -83,5 +82,12 @@ public class TestSystemTable extends BaseTestQuery {
   @Test
   public void profilesJsonTable() throws Exception {
     test("select * from sys.profiles_json");
+  }
+
+  @Test
+  public void testProfilesLimitPushDown() throws Exception {
+    String query = "select * from sys.profiles limit 10";
+    String numFilesPattern = "maxRecordsToRead=10";
+    testPlanMatchingPatterns(query, new String[] {numFilesPattern}, new String[] {});
   }
 }


### PR DESCRIPTION
1. PojoRecordReader started returning data in batches instead of returing all in one batch. Default batch size is 4000.
2. SystemTableScan supports limit push down while extrating data in record reader based on given max records to read.
3. Profiles and profiles_json tables apply limit push down while extracting data from store accessing profiles by range.

Details in [DRILL-6248](https://issues.apache.org/jira/browse/DRILL-6248).