### PR TITLE
DRILL-6290: Refactor TestInfoSchemaFilterPushDown tests to use PlanTestBase utility methods

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/ischema/TestInfoSchemaFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/ischema/TestInfoSchemaFilterPushDown.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,9 +17,6 @@
  */
 package org.apache.drill.exec.store.ischema;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.drill.PlanTestBase;
 import org.junit.Test;
 
@@ -28,7 +25,7 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
   @Test
   public void testFilterPushdown_Equal() throws Exception {
     final String query = "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_SCHEMA='INFORMATION_SCHEMA'";
-    final String scan = "Scan(groupscan=[TABLES, filter=equal(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA)])";
+    final String scan = "Scan.*groupscan=\\[TABLES, filter=equal\\(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -36,7 +33,7 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
   @Test
   public void testFilterPushdown_NonEqual() throws Exception {
     final String query = "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_SCHEMA <> 'INFORMATION_SCHEMA'";
-    final String scan = "Scan(groupscan=[TABLES, filter=not_equal(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA)])";
+    final String scan = "Scan.*groupscan=\\[TABLES, filter=not_equal\\(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -44,7 +41,7 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
   @Test
   public void testFilterPushdown_Like() throws Exception {
     final String query = "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_SCHEMA LIKE '%SCH%'";
-    final String scan = "Scan(groupscan=[TABLES, filter=like(Field=TABLE_SCHEMA,Literal=%SCH%)])";
+    final String scan = "Scan.*groupscan=\\[TABLES, filter=like\\(Field=TABLE_SCHEMA,Literal=%SCH%\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -52,7 +49,7 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
   @Test
   public void testFilterPushdown_LikeWithEscape() throws Exception {
     final String query = "SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_SCHEMA LIKE '%\\\\SCH%' ESCAPE '\\'";
-    final String scan = "Scan(groupscan=[TABLES, filter=like(Field=TABLE_SCHEMA,Literal=%\\\\SCH%,Literal=\\)])";
+    final String scan = "Scan.*groupscan=\\[TABLES, filter=like\\(Field=TABLE_SCHEMA,Literal=%\\\\\\\\SCH%,Literal=\\\\\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -62,8 +59,8 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
     final String query = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE " +
         "TABLE_SCHEMA = 'sys' AND " +
         "TABLE_NAME <> 'version'";
-    final String scan = "Scan(groupscan=[COLUMNS, filter=booleanand(equal(Field=TABLE_SCHEMA,Literal=sys)," +
-        "not_equal(Field=TABLE_NAME,Literal=version))])";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, filter=booleanand\\(equal\\(Field=TABLE_SCHEMA,Literal=sys\\)," +
+        "not_equal\\(Field=TABLE_NAME,Literal=version\\)\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -74,8 +71,8 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
         "TABLE_SCHEMA = 'sys' OR " +
         "TABLE_NAME <> 'version' OR " +
         "TABLE_SCHEMA like '%sdfgjk%'";
-    final String scan = "Scan(groupscan=[COLUMNS, filter=booleanor(equal(Field=TABLE_SCHEMA,Literal=sys)," +
-        "not_equal(Field=TABLE_NAME,Literal=version),like(Field=TABLE_SCHEMA,Literal=%sdfgjk%))])";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, filter=booleanor\\(equal\\(Field=TABLE_SCHEMA,Literal=sys\\)," +
+        "not_equal\\(Field=TABLE_NAME,Literal=version\\),like\\(Field=TABLE_SCHEMA,Literal=%sdfgjk%\\)\\)\\]";
 
     testHelper(query, scan, false);
   }
@@ -83,21 +80,21 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
   @Test
   public void testFilterPushDownWithProject_Equal() throws Exception {
     final String query = "SELECT COLUMN_NAME from INFORMATION_SCHEMA.`COLUMNS` WHERE TABLE_SCHEMA = 'INFORMATION_SCHEMA'";
-    final String scan = "Scan(groupscan=[COLUMNS, filter=equal(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA)])";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, filter=equal\\(Field=TABLE_SCHEMA,Literal=INFORMATION_SCHEMA\\)\\]";
     testHelper(query, scan, false);
   }
 
   @Test
   public void testFilterPushDownWithProject_NotEqual() throws Exception {
     final String query = "SELECT COLUMN_NAME from INFORMATION_SCHEMA.`COLUMNS` WHERE TABLE_NAME <> 'TABLES'";
-    final String scan = "Scan(groupscan=[COLUMNS, filter=not_equal(Field=TABLE_NAME,Literal=TABLES)])";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, filter=not_equal\\(Field=TABLE_NAME,Literal=TABLES\\)\\]";
     testHelper(query, scan, false);
   }
 
   @Test
   public void testFilterPushDownWithProject_Like() throws Exception {
     final String query = "SELECT COLUMN_NAME from INFORMATION_SCHEMA.`COLUMNS` WHERE TABLE_NAME LIKE '%BL%'";
-    final String scan = "Scan(groupscan=[COLUMNS, filter=like(Field=TABLE_NAME,Literal=%BL%)])";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, filter=like\\(Field=TABLE_NAME,Literal=%BL%\\)\\]";
     testHelper(query, scan, false);
   }
 
@@ -108,25 +105,26 @@ public class TestInfoSchemaFilterPushDown extends PlanTestBase {
         "TABLE_NAME = 'version' AND " +
         "COLUMN_NAME like 'commit%s' AND " +
         "IS_NULLABLE = 'YES'"; // this is not expected to pushdown into scan
-    final String scan = "Scan(groupscan=[COLUMNS, " +
-        "filter=booleanand(equal(Field=TABLE_SCHEMA,Literal=sys),equal(Field=TABLE_NAME,Literal=version)," +
-        "like(Field=COLUMN_NAME,Literal=commit%s))]";
+    final String scan = "Scan.*groupscan=\\[COLUMNS, " +
+        "filter=booleanand\\(equal\\(Field=TABLE_SCHEMA,Literal=sys\\),equal\\(Field=TABLE_NAME,Literal=version\\)," +
+        "like\\(Field=COLUMN_NAME,Literal=commit%s\\)\\)\\]";
 
     testHelper(query, scan, true);
   }
 
   private void testHelper(final String query, String filterInScan, boolean filterPrelExpected) throws Exception {
-    final String plan = getPlanInString("EXPLAIN PLAN FOR " + query, OPTIQ_FORMAT);
-
-    if (!filterPrelExpected) {
-      // If filter prel is not expected, make sure it is not in plan
-      assertFalse(plan.contains("Filter("));
+    String[] expectedPatterns;
+    String[] excludedPatterns;
+    if (filterPrelExpected) {
+      expectedPatterns = new String[] {filterInScan, "Filter"};
+      excludedPatterns = new String[] {};
     } else {
-      assertTrue(plan.contains("Filter("));
+      expectedPatterns = new String[] {filterInScan};
+      excludedPatterns = new String[] {"Filter"};
     }
 
-    // Check for filter pushed into scan.
-    assertTrue(plan.contains(filterInScan));
+    // check plan
+    testPlanMatchingPatterns(query, expectedPatterns, excludedPatterns);
 
     // run the query
     test(query);


### PR DESCRIPTION
Details in [DRILL-6290](https://issues.apache.org/jira/browse/DRILL-6290).