### PR TITLE
DRILL-6103: lsb_release: command not found

### DIFF
--- a/distribution/src/resources/drill-config.sh
+++ b/distribution/src/resources/drill-config.sh
@@ -422,8 +422,7 @@ CP="$CP:$DRILL_HOME/jars/classb/*"
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   # Linux
   # check for Fedora. netty-tcnative has a Fedora variant
-  linuxvariant=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
-  if [[ "$linuxvariant" == "Fedora" ]]; then
+  if [[ -f "/etc/fedora-release" ]]; then
     CP="$CP:$DRILL_HOME/jars/3rdparty/fedora/*"
   else
     CP="$CP:$DRILL_HOME/jars/3rdparty/linux/*"


### PR DESCRIPTION
Thanks to Sanel Zukan for providing a small patch that checks for /etc/fedora-release path. This is more common, than lsb_release command on Linux distros.