### PR TITLE
DRILL-6299: Fixed a filter pushed down issue when a column doesn't ha…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/stat/ParquetIsPredicates.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/stat/ParquetIsPredicates.java
@@ -62,7 +62,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 
@@ -87,8 +87,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null ||
-          exprStat.isEmpty()) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 
@@ -113,8 +112,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null ||
-          exprStat.isEmpty()) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 
@@ -140,8 +138,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null ||
-          exprStat.isEmpty()) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 
@@ -167,8 +164,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null ||
-          exprStat.isEmpty()) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 
@@ -193,8 +189,7 @@ public class ParquetIsPredicates {
     public boolean canDrop(RangeExprEvaluator evaluator) {
       Statistics exprStat = expr.accept(evaluator, null);
 
-      if (exprStat == null ||
-          exprStat.isEmpty()) {
+      if (!ParquetPredicatesHelper.hasStats(exprStat)) {
         return false;
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/stat/ParquetPredicatesHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/stat/ParquetPredicatesHelper.java
@@ -22,7 +22,16 @@ import org.apache.parquet.column.statistics.Statistics;
 /**
  * Parquet predicates class helper for filter pushdown.
  */
+@SuppressWarnings("rawtypes")
 public class ParquetPredicatesHelper {
+
+  /**
+   * @param stat statistics object
+   * @return true if the input stat object has valid statistics; false otherwise
+   */
+  public static boolean hasStats(Statistics stat) {
+    return stat != null && !stat.isEmpty();
+  }
 
   /**
    * Checks that column chunk's statistics has only nulls


### PR DESCRIPTION
This bug happens when the isNull predicate is applied on a column without statistics. @arina-ielchiieva  can you please review this pull request?

Thanks!