### PR TITLE
DRILL-6303: Provide a button to copy the Drillbit's JStack shown in /threads

### DIFF
--- a/exec/java-exec/src/main/resources/rest/threads/threads.ftl
+++ b/exec/java-exec/src/main/resources/rest/threads/threads.ftl
@@ -17,17 +17,21 @@
   <a href="/queries">back</a><br/>
   <div class="page-header">
   </div>
-  <p>Auto refreshes every 2 seconds
-    <button id="clippy" type="button" class="btn btn-default btn-sm" onClick="copyThreads();" title="Use this to copy the thread stack before it auto-refreshes"> 
-      <span class="glyphicon glyphicon-copy"/> Copy To Clipboard  
-    </button> 
+  <p align="right">Auto Refresh <span class="badge badge-pill badge-info" id="refreshTimeLabel"></span>
+    <button id="clippy" type="button" class="btn btn-default btn-sm" onClick="copyThreads();" title="Copy To Clipboard"> 
+      <!-- Refer: https://glyphicons.bootstrapcheatsheets.com/# for correct rendering -->
+      <span class="glyphicon glyphicon-copy" style="font-size:180%">&#xe205;</span>
+    </button>
   </p>
   <div id="mainDiv" role="main">
   </div>
   </div>
   <script>
+    var statusUrl = location.protocol + "//" + location.host + "/status/threads";
+    var refreshInterval = 3;
+    document.getElementById('refreshTimeLabel').innerHTML = refreshInterval+" sec"; 
     var update = function() {
-      $.get("/status/threads", function(data) {
+      $.get(statusUrl, function(data) {
         $("#mainDiv").html("<pre>" + data + "</pre>");
       });
     };
@@ -39,17 +43,15 @@
         range.moveToElementText(document.getElementById("mainDiv"));
         range.select().createTextRange();
         document.execCommand("copy");
-        alert("Copied thread stack to clipboard");
       } else if (window.getSelection) {
         var range = document.createRange();
         range.selectNode(document.getElementById("mainDiv"));
         window.getSelection().addRange(range);
         document.execCommand("copy");
-        alert("Copied thread stack to clipboard");
       }
     }
     update();
-    setInterval(update, 2000);
+    setInterval(update, refreshInterval*1000);
   </script>
 </#macro>
 

--- a/exec/java-exec/src/main/resources/rest/threads/threads.ftl
+++ b/exec/java-exec/src/main/resources/rest/threads/threads.ftl
@@ -17,6 +17,11 @@
   <a href="/queries">back</a><br/>
   <div class="page-header">
   </div>
+  <p>Auto refreshes every 2 seconds
+    <button id="clippy" type="button" class="btn btn-default btn-sm" onClick="copyThreads();" title="Use this to copy the thread stack before it auto-refreshes"> 
+      <span class="glyphicon glyphicon-copy"/> Copy To Clipboard  
+    </button> 
+  </p>
   <div id="mainDiv" role="main">
   </div>
   </div>
@@ -27,6 +32,22 @@
       });
     };
 
+    //Ref: https://stackoverflow.com/a/36640126/8323038
+    function copyThreads() {
+      if (document.selection) { 
+        var range = document.body.createTextRange();
+        range.moveToElementText(document.getElementById("mainDiv"));
+        range.select().createTextRange();
+        document.execCommand("copy");
+        alert("Copied thread stack to clipboard");
+      } else if (window.getSelection) {
+        var range = document.createRange();
+        range.selectNode(document.getElementById("mainDiv"));
+        window.getSelection().addRange(range);
+        document.execCommand("copy");
+        alert("Copied thread stack to clipboard");
+      }
+    }
     update();
     setInterval(update, 2000);
   </script>


### PR DESCRIPTION
Provides a button in the web UI to copy the thread stack to the user's clipboard.