### PR TITLE
DRILL-143: Support CGROUPs resource management

### DIFF
--- a/distribution/src/resources/drill-env.sh
+++ b/distribution/src/resources/drill-env.sh
@@ -86,10 +86,14 @@
 
 #export DRILL_PID_DIR=${DRILL_PID_DIR:-$DRILL_HOME}
 
-# CGroup to which the Drillbit belong when running as a daemon using
-# drillbit.sh start.
-# Unset $DRILLBIT_CGROUP by default.
+# Default (Standard) CGroup Location: /sys/fs/cgroup
+# Specify the cgroup location if it is different from the default
+#export SYS_CGROUP_DIR=${SYS_CGROUP_DIR:-"/sys/fs/cgroup"}
 
+# CGroup to which the Drillbit belongs when running as a daemon using drillbit.sh start .
+# Drill will use CGroup for CPU enforcement only.
+
+# Unset $DRILLBIT_CGROUP by default
 #export DRILLBIT_CGROUP=${DRILLBIT_CGROUP:-"drillcpu"}
 
 # Custom JVM arguments to pass to the both the Drillbit and sqlline. Typically

--- a/distribution/src/resources/drill-env.sh
+++ b/distribution/src/resources/drill-env.sh
@@ -86,6 +86,12 @@
 
 #export DRILL_PID_DIR=${DRILL_PID_DIR:-$DRILL_HOME}
 
+# CGroup to which the Drillbit belong when running as a daemon using
+# drillbit.sh start.
+# Unset $DRILLBIT_CGROUP by default.
+
+#export DRILLBIT_CGROUP=${DRILLBIT_CGROUP:-"drillcpu"}
+
 # Custom JVM arguments to pass to the both the Drillbit and sqlline. Typically
 # used to override system properties as shown below. Empty by default.
 


### PR DESCRIPTION
Introduces the `DRILLBIT_CGROUP` option in defined in `drill-env.sh`
The startup script checks if the specified CGroup (ver 2) is available and tries to apply it to the launched Drillbit JVM.
This would benefit not just Drill-on-YARN usecases, but  any setup that would like CGroups for enforcement of (cpu) resources management.

e.g when Drillbit is configured to use `drillcpu` cgroup
```
[root@maprlabs ~]# /opt/mapr/drill/apache-drill-1.14.0-SNAPSHOT/bin/drillbit.sh restart
Stopping drillbit
..
Starting drillbit, logging to /var/log/drill/drillbit.out
WARN: Drillbit's CPU resource usage will be managed under the CGroup : drillcpu (up to 4.00 cores allowed)
```

e.g. Non-existent CGroup `droolcpu` is used
```
[root@maprlabs ~]# /opt/mapr/drill/apache-drill-1.14.0-SNAPSHOT/bin/drillbit.sh restart
Stopping drillbit
..
Starting drillbit, logging to /var/log/drill/drillbit.out
ERROR: cgroup droolcpu does not found. Ensure that daemon is running and cgroup exists
```