### PR TITLE
DRILL-6289: Cluster view should show more relevant information

### DIFF
--- a/common/src/main/java/org/apache/drill/exec/metrics/CpuGaugeSet.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/CpuGaugeSet.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metrics;
+
+import java.lang.management.OperatingSystemMXBean;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+/**
+ * Creates a Cpu GaugeSet
+ */
+class CpuGaugeSet implements MetricSet {
+
+  private OperatingSystemMXBean osMXBean;
+
+  CpuGaugeSet() {};
+  CpuGaugeSet(OperatingSystemMXBean osBean) {
+    this.osMXBean = osBean;
+  }
+
+  @Override
+  public Map<String, Metric> getMetrics() {
+    final Map<String, Metric> metric = new HashMap<>(1);
+    metric.put("os.load.avg", new OperatingSystemLoad(osMXBean));
+    return metric;
+  }
+}
+
+/**
+ * Creating an AverageSystemLoad Gauge
+ */
+final class OperatingSystemLoad implements Gauge<Double> {
+  private OperatingSystemMXBean osMXBean;
+  public OperatingSystemLoad(OperatingSystemMXBean osBean) {
+    this.osMXBean = osBean;
+  }
+
+  @Override
+  public Double getValue() {
+    return osMXBean.getSystemLoadAverage();
+  }
+
+}

--- a/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
@@ -61,7 +61,7 @@ public final class DrillMetrics {
       REGISTRY.registerAll(new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
       REGISTRY.registerAll(new MemoryUsageGaugeSet());
       REGISTRY.registerAll(new ThreadStatesGaugeSet());
-      REGISTRY.registerAll(new CpuGaugeSet(ManagementFactory.getOperatingSystemMXBean()));
+      REGISTRY.registerAll(new CpuGaugeSet());
       register("fd.usage", new FileDescriptorRatioGauge());
     }
 

--- a/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.metrics;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.JmxReporter;

--- a/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/DrillMetrics.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.metrics;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.JmxReporter;
@@ -60,6 +61,7 @@ public final class DrillMetrics {
       REGISTRY.registerAll(new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
       REGISTRY.registerAll(new MemoryUsageGaugeSet());
       REGISTRY.registerAll(new ThreadStatesGaugeSet());
+      REGISTRY.registerAll(new CpuGaugeSet(ManagementFactory.getOperatingSystemMXBean()));
       register("fd.usage", new FileDescriptorRatioGauge());
     }
 

--- a/contrib/native/client/src/protobuf/Coordination.pb.cc
+++ b/contrib/native/client/src/protobuf/Coordination.pb.cc
@@ -41,7 +41,7 @@ void protobuf_AssignDesc_Coordination_2eproto() {
       "Coordination.proto");
   GOOGLE_CHECK(file != NULL);
   DrillbitEndpoint_descriptor_ = file->message_type(0);
-  static const int DrillbitEndpoint_offsets_[7] = {
+  static const int DrillbitEndpoint_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, address_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, user_port_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, control_port_),
@@ -49,6 +49,7 @@ void protobuf_AssignDesc_Coordination_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, roles_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, version_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, state_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DrillbitEndpoint, http_port_),
   };
   DrillbitEndpoint_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -136,21 +137,22 @@ void protobuf_AddDesc_Coordination_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-    "\n\022Coordination.proto\022\004exec\"\367\001\n\020DrillbitE"
+    "\n\022Coordination.proto\022\004exec\"\212\002\n\020DrillbitE"
     "ndpoint\022\017\n\007address\030\001 \001(\t\022\021\n\tuser_port\030\002 "
     "\001(\005\022\024\n\014control_port\030\003 \001(\005\022\021\n\tdata_port\030\004"
     " \001(\005\022\032\n\005roles\030\005 \001(\0132\013.exec.Roles\022\017\n\007vers"
     "ion\030\006 \001(\t\022+\n\005state\030\007 \001(\0162\034.exec.Drillbit"
-    "Endpoint.State\"<\n\005State\022\013\n\007STARTUP\020\000\022\n\n\006"
-    "ONLINE\020\001\022\r\n\tQUIESCENT\020\002\022\013\n\007OFFLINE\020\003\"i\n\024"
-    "DrillServiceInstance\022\n\n\002id\030\001 \001(\t\022\033\n\023regi"
-    "strationTimeUTC\030\002 \001(\003\022(\n\010endpoint\030\003 \001(\0132"
-    "\026.exec.DrillbitEndpoint\"\227\001\n\005Roles\022\027\n\tsql"
-    "_query\030\001 \001(\010:\004true\022\032\n\014logical_plan\030\002 \001(\010"
-    ":\004true\022\033\n\rphysical_plan\030\003 \001(\010:\004true\022\033\n\rj"
-    "ava_executor\030\004 \001(\010:\004true\022\037\n\021distributed_"
-    "cache\030\005 \001(\010:\004trueB3\n\033org.apache.drill.ex"
-    "ec.protoB\022CoordinationProtosH\001", 590);
+    "Endpoint.State\022\021\n\thttp_port\030\010 \001(\005\"<\n\005Sta"
+    "te\022\013\n\007STARTUP\020\000\022\n\n\006ONLINE\020\001\022\r\n\tQUIESCENT"
+    "\020\002\022\013\n\007OFFLINE\020\003\"i\n\024DrillServiceInstance\022"
+    "\n\n\002id\030\001 \001(\t\022\033\n\023registrationTimeUTC\030\002 \001(\003"
+    "\022(\n\010endpoint\030\003 \001(\0132\026.exec.DrillbitEndpoi"
+    "nt\"\227\001\n\005Roles\022\027\n\tsql_query\030\001 \001(\010:\004true\022\032\n"
+    "\014logical_plan\030\002 \001(\010:\004true\022\033\n\rphysical_pl"
+    "an\030\003 \001(\010:\004true\022\033\n\rjava_executor\030\004 \001(\010:\004t"
+    "rue\022\037\n\021distributed_cache\030\005 \001(\010:\004trueB3\n\033"
+    "org.apache.drill.exec.protoB\022Coordinatio"
+    "nProtosH\001", 609);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "Coordination.proto", &protobuf_RegisterTypes);
   DrillbitEndpoint::default_instance_ = new DrillbitEndpoint();
@@ -204,6 +206,7 @@ const int DrillbitEndpoint::kDataPortFieldNumber;
 const int DrillbitEndpoint::kRolesFieldNumber;
 const int DrillbitEndpoint::kVersionFieldNumber;
 const int DrillbitEndpoint::kStateFieldNumber;
+const int DrillbitEndpoint::kHttpPortFieldNumber;
 #endif  // !_MSC_VER
 
 DrillbitEndpoint::DrillbitEndpoint()
@@ -230,6 +233,7 @@ void DrillbitEndpoint::SharedCtor() {
   roles_ = NULL;
   version_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
   state_ = 0;
+  http_port_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -289,6 +293,7 @@ void DrillbitEndpoint::Clear() {
       }
     }
     state_ = 0;
+    http_port_ = 0;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
@@ -412,6 +417,22 @@ bool DrillbitEndpoint::MergePartialFromCodedStream(
         } else {
           goto handle_uninterpreted;
         }
+        if (input->ExpectTag(64)) goto parse_http_port;
+        break;
+      }
+
+      // optional int32 http_port = 8;
+      case 8: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+         parse_http_port:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &http_port_)));
+          set_has_http_port();
+        } else {
+          goto handle_uninterpreted;
+        }
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -479,6 +500,11 @@ void DrillbitEndpoint::SerializeWithCachedSizes(
       7, this->state(), output);
   }
 
+  // optional int32 http_port = 8;
+  if (has_http_port()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(8, this->http_port(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -533,6 +559,11 @@ void DrillbitEndpoint::SerializeWithCachedSizes(
   if (has_state()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       7, this->state(), target);
+  }
+
+  // optional int32 http_port = 8;
+  if (has_http_port()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(8, this->http_port(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -594,6 +625,13 @@ int DrillbitEndpoint::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->state());
     }
 
+    // optional int32 http_port = 8;
+    if (has_http_port()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->http_port());
+    }
+
   }
   if (!unknown_fields().empty()) {
     total_size +=
@@ -642,6 +680,9 @@ void DrillbitEndpoint::MergeFrom(const DrillbitEndpoint& from) {
     if (from.has_state()) {
       set_state(from.state());
     }
+    if (from.has_http_port()) {
+      set_http_port(from.http_port());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -672,6 +713,7 @@ void DrillbitEndpoint::Swap(DrillbitEndpoint* other) {
     std::swap(roles_, other->roles_);
     std::swap(version_, other->version_);
     std::swap(state_, other->state_);
+    std::swap(http_port_, other->http_port_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/contrib/native/client/src/protobuf/Coordination.pb.h
+++ b/contrib/native/client/src/protobuf/Coordination.pb.h
@@ -202,6 +202,13 @@ class DrillbitEndpoint : public ::google::protobuf::Message {
   inline ::exec::DrillbitEndpoint_State state() const;
   inline void set_state(::exec::DrillbitEndpoint_State value);
 
+  // optional int32 http_port = 8;
+  inline bool has_http_port() const;
+  inline void clear_http_port();
+  static const int kHttpPortFieldNumber = 8;
+  inline ::google::protobuf::int32 http_port() const;
+  inline void set_http_port(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:exec.DrillbitEndpoint)
  private:
   inline void set_has_address();
@@ -218,6 +225,8 @@ class DrillbitEndpoint : public ::google::protobuf::Message {
   inline void clear_has_version();
   inline void set_has_state();
   inline void clear_has_state();
+  inline void set_has_http_port();
+  inline void clear_has_http_port();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -228,9 +237,10 @@ class DrillbitEndpoint : public ::google::protobuf::Message {
   ::google::protobuf::int32 data_port_;
   int state_;
   ::std::string* version_;
+  ::google::protobuf::int32 http_port_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(7 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(8 + 31) / 32];
 
   friend void  protobuf_AddDesc_Coordination_2eproto();
   friend void protobuf_AssignDesc_Coordination_2eproto();
@@ -742,6 +752,28 @@ inline void DrillbitEndpoint::set_state(::exec::DrillbitEndpoint_State value) {
   assert(::exec::DrillbitEndpoint_State_IsValid(value));
   set_has_state();
   state_ = value;
+}
+
+// optional int32 http_port = 8;
+inline bool DrillbitEndpoint::has_http_port() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void DrillbitEndpoint::set_has_http_port() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void DrillbitEndpoint::clear_has_http_port() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void DrillbitEndpoint::clear_http_port() {
+  http_port_ = 0;
+  clear_has_http_port();
+}
+inline ::google::protobuf::int32 DrillbitEndpoint::http_port() const {
+  return http_port_;
+}
+inline void DrillbitEndpoint::set_http_port(::google::protobuf::int32 value) {
+  set_has_http_port();
+  http_port_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -749,7 +749,7 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "agmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALL"
     "OCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\t"
     "CANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_"
-    "REQUESTED\020\006*\244\006\n\020CoreOperatorType\022\021\n\rSING"
+    "REQUESTED\020\006*\302\006\n\020CoreOperatorType\022\021\n\rSING"
     "LE_SENDER\020\000\022\024\n\020BROADCAST_SENDER\020\001\022\n\n\006FIL"
     "TER\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n\tHASH_JOIN\020\004"
     "\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH_PARTITION_SENDE"
@@ -769,11 +769,12 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "ASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOO"
     "P_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_"
     "SCAN\020%\022\022\n\016KAFKA_SUB_SCAN\020&\022\021\n\rKUDU_SUB_S"
-    "CAN\020\'\022\013\n\007FLATTEN\020(*g\n\nSaslStatus\022\020\n\014SASL"
-    "_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_PR"
-    "OGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAILE"
-    "D\020\004B.\n\033org.apache.drill.exec.protoB\rUser"
-    "BitSharedH\001", 5091);
+    "CAN\020\'\022\013\n\007FLATTEN\020(\022\020\n\014LATERAL_JOIN\020)\022\n\n\006"
+    "UNNEST\020**g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000"
+    "\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020"
+    "\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org"
+    ".apache.drill.exec.protoB\rUserBitSharedH"
+    "\001", 5121);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "UserBitShared.proto", &protobuf_RegisterTypes);
   UserCredentials::default_instance_ = new UserCredentials();
@@ -935,6 +936,8 @@ bool CoreOperatorType_IsValid(int value) {
     case 38:
     case 39:
     case 40:
+    case 41:
+    case 42:
       return true;
     default:
       return false;

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -749,7 +749,7 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "agmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALL"
     "OCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\t"
     "CANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_"
-    "REQUESTED\020\006*\227\006\n\020CoreOperatorType\022\021\n\rSING"
+    "REQUESTED\020\006*\244\006\n\020CoreOperatorType\022\021\n\rSING"
     "LE_SENDER\020\000\022\024\n\020BROADCAST_SENDER\020\001\022\n\n\006FIL"
     "TER\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n\tHASH_JOIN\020\004"
     "\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH_PARTITION_SENDE"
@@ -769,10 +769,11 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "ASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOO"
     "P_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_"
     "SCAN\020%\022\022\n\016KAFKA_SUB_SCAN\020&\022\021\n\rKUDU_SUB_S"
-    "CAN\020\'*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n"
-    "\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014S"
-    "ASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.ap"
-    "ache.drill.exec.protoB\rUserBitSharedH\001", 5078);
+    "CAN\020\'\022\013\n\007FLATTEN\020(*g\n\nSaslStatus\022\020\n\014SASL"
+    "_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_PR"
+    "OGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAILE"
+    "D\020\004B.\n\033org.apache.drill.exec.protoB\rUser"
+    "BitSharedH\001", 5091);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "UserBitShared.proto", &protobuf_RegisterTypes);
   UserCredentials::default_instance_ = new UserCredentials();
@@ -933,6 +934,7 @@ bool CoreOperatorType_IsValid(int value) {
     case 37:
     case 38:
     case 39:
+    case 40:
       return true;
     default:
       return false;

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -244,11 +244,13 @@ enum CoreOperatorType {
   PCAP_SUB_SCAN = 37,
   KAFKA_SUB_SCAN = 38,
   KUDU_SUB_SCAN = 39,
-  FLATTEN = 40
+  FLATTEN = 40,
+  LATERAL_JOIN = 41,
+  UNNEST = 42
 };
 bool CoreOperatorType_IsValid(int value);
 const CoreOperatorType CoreOperatorType_MIN = SINGLE_SENDER;
-const CoreOperatorType CoreOperatorType_MAX = FLATTEN;
+const CoreOperatorType CoreOperatorType_MAX = UNNEST;
 const int CoreOperatorType_ARRAYSIZE = CoreOperatorType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* CoreOperatorType_descriptor();

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -243,11 +243,12 @@ enum CoreOperatorType {
   AVRO_SUB_SCAN = 36,
   PCAP_SUB_SCAN = 37,
   KAFKA_SUB_SCAN = 38,
-  KUDU_SUB_SCAN = 39
+  KUDU_SUB_SCAN = 39,
+  FLATTEN = 40
 };
 bool CoreOperatorType_IsValid(int value);
 const CoreOperatorType CoreOperatorType_MIN = SINGLE_SENDER;
-const CoreOperatorType CoreOperatorType_MAX = KUDU_SUB_SCAN;
+const CoreOperatorType CoreOperatorType_MAX = FLATTEN;
 const int CoreOperatorType_ARRAYSIZE = CoreOperatorType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* CoreOperatorType_descriptor();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -191,11 +191,14 @@ public class Drillbit implements AutoCloseable {
     manager.getContext().getRemoteFunctionRegistry().init(context.getConfig(), storeProvider, coord);
     webServer.start();
     //Discovering HTTP port (in case of port hunting)
-    int httpPort = webServer.getPort();
-    // Registering Drillbit with cluster coordinator
-    registrationHandle = coord.register(md.toBuilder().setHttpPort(httpPort).build());
+    if (webServer.isRunning()) {
+      int httpPort = getWebServerPort();
+      registrationHandle = coord.register(md.toBuilder().setHttpPort(httpPort).build());
+    } else {
+      //WebServer is not running
+      registrationHandle = coord.register(md);
+    }
     // Must start the RM after the above since it needs to read system options.
-
     drillbitContext.startRM();
 
     Runtime.getRuntime().addShutdownHook(new ShutdownThread(this, new StackTrace()));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -157,7 +157,7 @@ public class Drillbit implements AutoCloseable {
       profileStoreProvider = storeProvider;
     }
 
-    engine = new ServiceEngine(manager, context, allowPortHunting, isDistributedMode);
+    engine = new ServiceEngine(manager, context, webServer, allowPortHunting, isDistributedMode);
 
     stateManager = new DrillbitStateManager(DrillbitState.STARTUP);
     logger.info("Construction completed ({} ms).", w.elapsed(TimeUnit.MILLISECONDS));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -182,7 +182,8 @@ public class Drillbit implements AutoCloseable {
     }
     DrillbitEndpoint md = engine.start();
     manager.start(md, engine.getController(), engine.getDataConnectionCreator(), coord, storeProvider, profileStoreProvider);
-    DrillbitContext drillbitContext = manager.getContext();
+    @SuppressWarnings("resource")
+    final DrillbitContext drillbitContext = manager.getContext();
     storageRegistry = drillbitContext.getStorage();
     storageRegistry.init();
     drillbitContext.getOptionManager().init();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -182,8 +182,7 @@ public class Drillbit implements AutoCloseable {
     }
     DrillbitEndpoint md = engine.start();
     manager.start(md, engine.getController(), engine.getDataConnectionCreator(), coord, storeProvider, profileStoreProvider);
-    @SuppressWarnings("resource")
-    final DrillbitContext drillbitContext = manager.getContext();
+    DrillbitContext drillbitContext = manager.getContext();
     storageRegistry = drillbitContext.getStorage();
     storageRegistry.init();
     drillbitContext.getOptionManager().init();
@@ -193,11 +192,9 @@ public class Drillbit implements AutoCloseable {
     //Discovering HTTP port (in case of port hunting)
     if (webServer.isRunning()) {
       int httpPort = getWebServerPort();
-      registrationHandle = coord.register(md.toBuilder().setHttpPort(httpPort).build());
-    } else {
-      //WebServer is not running
-      registrationHandle = coord.register(md);
+      md = md.toBuilder().setHttpPort(httpPort).build();
     }
+    registrationHandle = coord.register(md);
     // Must start the RM after the above since it needs to read system options.
     drillbitContext.startRM();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -421,6 +421,7 @@ public static class ClusterInfo {
 
 public static class DrillbitInfo implements Comparable<DrillbitInfo> {
   private final String address;
+  private final String httpPort;
   private final String userPort;
   private final String controlPort;
   private final String dataPort;
@@ -432,6 +433,7 @@ public static class DrillbitInfo implements Comparable<DrillbitInfo> {
   @JsonCreator
   public DrillbitInfo(DrillbitEndpoint drillbit, boolean current, boolean versionMatch) {
     this.address = drillbit.getAddress();
+    this.httpPort = String.valueOf(drillbit.getHttpPort());
     this.userPort = String.valueOf(drillbit.getUserPort());
     this.controlPort = String.valueOf(drillbit.getControlPort());
     this.dataPort = String.valueOf(drillbit.getDataPort());
@@ -442,6 +444,8 @@ public static class DrillbitInfo implements Comparable<DrillbitInfo> {
   }
 
   public String getAddress() { return address; }
+
+  public String getHttpPort() { return httpPort; }
 
   public String getUserPort() { return userPort; }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -158,7 +158,13 @@ public class WebServer implements AutoCloseable {
     final int selectors = config.getInt(ExecConstants.HTTP_JETTY_SERVER_SELECTORS);
     final QueuedThreadPool threadPool = new QueuedThreadPool(2, 2, 60000);
     embeddedJetty = new Server(threadPool);
-    embeddedJetty.setHandler(createServletContextHandler(authEnabled));
+    ServletContextHandler webServerContext = createServletContextHandler(authEnabled);
+    //Allow for Other Drillbits to make REST calls
+    FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
+    filterHolder.setInitParameter("allowedOrigins", "*");
+    webServerContext.addFilter(filterHolder, "/*", null);
+    embeddedJetty.setHandler(webServerContext);
+
     ServerConnector connector = createConnector(port, acceptors, selectors);
     threadPool.setMaxThreads(1 + connector.getAcceptors() + connector.getSelectorManager().getSelectorCount());
     embeddedJetty.addConnector(connector);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -302,10 +302,17 @@ public class WebServer implements AutoCloseable {
   }
 
   public int getPort() {
-    if (embeddedJetty == null || embeddedJetty.getConnectors().length != 1) {
+    if (!isRunning()) {
       throw new UnsupportedOperationException("Http is not enabled");
     }
     return ((ServerConnector)embeddedJetty.getConnectors()[0]).getPort();
+  }
+
+  public boolean isRunning() {
+    if (embeddedJetty == null || embeddedJetty.getConnectors().length != 1) {
+      return false;
+    }
+    return true;
   }
 
   private ServerConnector createConnector(int port, int acceptors, int selectors) throws Exception {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -162,7 +162,8 @@ public class WebServer implements AutoCloseable {
     //Allow for Other Drillbits to make REST calls
     FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
     filterHolder.setInitParameter("allowedOrigins", "*");
-    webServerContext.addFilter(filterHolder, "/*", null);
+    //Allowing CORS for metrics only
+    webServerContext.addFilter(filterHolder, "/status/metrics", null);
     embeddedJetty.setHandler(webServerContext);
 
     ServerConnector connector = createConnector(port, acceptors, selectors);
@@ -309,10 +310,7 @@ public class WebServer implements AutoCloseable {
   }
 
   public boolean isRunning() {
-    if (embeddedJetty == null || embeddedJetty.getConnectors().length != 1) {
-      return false;
-    }
-    return true;
+    return (embeddedJetty != null && embeddedJetty.getConnectors().length == 1);
   }
 
   private ServerConnector createConnector(int port, int acceptors, int selectors) throws Exception {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/service/ServiceEngine.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.rpc.control.ControllerImpl;
 import org.apache.drill.exec.rpc.data.DataConnectionCreator;
 import org.apache.drill.exec.rpc.user.UserServer;
 import org.apache.drill.exec.server.BootStrapContext;
-import org.apache.drill.exec.server.rest.WebServer;
 import org.apache.drill.exec.work.WorkManager;
 
 import com.google.common.base.Stopwatch;
@@ -55,7 +54,6 @@ public class ServiceEngine implements AutoCloseable {
   private final DataConnectionCreator dataPool;
 
   private final String hostName;
-  private final int httpPort;
   private final int intialUserPort;
   private final boolean allowPortHunting;
   private final boolean isDistributedMode;
@@ -66,7 +64,7 @@ public class ServiceEngine implements AutoCloseable {
 
   private int userPort;
 
-  public ServiceEngine(final WorkManager manager, final BootStrapContext context, final WebServer webServer,
+  public ServiceEngine(final WorkManager manager, final BootStrapContext context,
                        final boolean allowPortHunting, final boolean isDistributedMode)
       throws DrillbitStartupException {
     userAllocator = newAllocator(context, "rpc:user", "drill.exec.rpc.user.server.memory.reservation",
@@ -83,7 +81,6 @@ public class ServiceEngine implements AutoCloseable {
     dataPool = new DataConnectionCreator(context, dataAllocator, manager.getWorkBus(), manager.getBee());
 
     hostName = context.getHostName();
-    httpPort = context.getConfig().getInt(ExecConstants.HTTP_PORT);
     intialUserPort = context.getConfig().getInt(ExecConstants.INITIAL_USER_PORT);
     this.allowPortHunting = allowPortHunting;
     this.isDistributedMode = isDistributedMode;
@@ -105,17 +102,12 @@ public class ServiceEngine implements AutoCloseable {
     DrillbitEndpoint partialEndpoint = DrillbitEndpoint.newBuilder()
         .setAddress(hostName)
         .setUserPort(userPort)
-        .setHttpPort(httpPort)
         .setVersion(DrillVersionInfo.getVersion())
         .setState(State.STARTUP)
         .build();
 
     partialEndpoint = controller.start(partialEndpoint, allowPortHunting);
     return dataPool.start(partialEndpoint, allowPortHunting);
-  }
-
-  public int getHttpPort() {
-    return httpPort;
   }
 
   public int getUserPort() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/DrillbitIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/DrillbitIterator.java
@@ -38,6 +38,7 @@ public class DrillbitIterator implements Iterator<Object> {
     public int user_port;
     public int control_port;
     public int data_port;
+    public int http_port;
     public boolean current;
     public String version;
     public String state;
@@ -54,6 +55,7 @@ public class DrillbitIterator implements Iterator<Object> {
     DrillbitInstance i = new DrillbitInstance();
     i.current = isCurrent(ep);
     i.hostname = ep.getAddress();
+    i.http_port = ep.getHttpPort();
     i.user_port = ep.getUserPort();
     i.control_port = ep.getControlPort();
     i.data_port = ep.getDataPort();

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -104,7 +104,7 @@
                 <td id="status" >${drillbit.getState()}</td>
                 <td class="uptime" >Not Available</td>
                   <td>
-                <#if (model.shouldShowAdminInfo() || !model.isAuthEnabled()) && (drillbit.isCurrent() || !model.isUserEncryptionEnabled()) >
+                <#if ( model.shouldShowAdminInfo() &&  ( drillbit.isCurrent() || ( !model.isAuthEnabled() && location.protocol != "https" ))) >
                       <button type="button" id="shutdown" onClick="shutdown($(this), '${drillbit.getAddress()}:${drillbit.getHttpPort()}');">
                 <#else>
                       <button type="button" id="shutdown" title="Drillbit cannot be shutdown remotely" disabled="true" style="opacity:0.5;cursor:not-allowed;">

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -372,7 +372,11 @@
             //DrillbitLoad
             var dbitLoad = metrics['drillbit.load.avg'].value;
             var dbitLoadElem = rowElem.getElementsByClassName("bitload")[0];
-            dbitLoadElem.innerHTML = parseFloat(Math.round(dbitLoad * 10000)/100).toFixed(2) + "%";
+            if (dbitLoad >= 0) {
+              dbitLoadElem.innerHTML = parseFloat(Math.round(dbitLoad * 10000)/100).toFixed(2) + "%";
+            } else {
+              dbitLoadElem.innerHTML = "Not Available";
+            }
             //AvgSysLoad
             var avgSysLoad = metrics['os.load.avg'].value;
             var sysLoadElem = rowElem.getElementsByClassName("avgload")[0];

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -248,7 +248,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(117, columns.size());
+    assertEquals(118, columns.size());
     // too many records to verify the output.
   }
 
@@ -261,7 +261,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(5, columns.size());
+    assertEquals(6, columns.size());
 
     verifyColumn("sys", "drillbits", "user_port", columns);
     verifyColumn("sys", "drillbits", "control_port", columns);
@@ -281,7 +281,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(3, columns.size());
+    assertEquals(4, columns.size());
 
     verifyColumn("sys", "drillbits", "user_port", columns);
     verifyColumn("sys", "drillbits", "control_port", columns);
@@ -302,11 +302,12 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(3, columns.size());
+    assertEquals(4, columns.size());
 
     verifyColumn("sys", "drillbits", "user_port", columns);
     verifyColumn("sys", "drillbits", "control_port", columns);
     verifyColumn("sys", "drillbits", "data_port", columns);
+    verifyColumn("sys", "drillbits", "http_port", columns);
   }
 
   /** Helper method to verify schema contents */

--- a/protocol/readme.txt
+++ b/protocol/readme.txt
@@ -25,3 +25,12 @@ download it from http://code.google.com/p/protobuf/downloads/list.
 2. In protocol dir, run "mvn process-sources -P proto-compile" or "mvn clean install -P proto-compile".
 
 3. Check in the new/updated files.
+
+---------------------------------------------------------------
+If changes are made to the DrillClient's protobuf, you would need to regenerate the sources for the C++ client as well.
+Steps for regenerating the sources are available https://github.com/apache/drill/blob/master/contrib/native/client/
+
+You can use any of the following platforms specified in the above location to regenerate the protobuf sources:
+readme.linux	: Regenerating on Linux
+readme.macos	: Regenerating on MacOS
+readme.win.txt	: Regenerating on Windows

--- a/protocol/src/main/java/org/apache/drill/exec/proto/CoordinationProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/CoordinationProtos.java
@@ -111,6 +111,16 @@ public final class CoordinationProtos {
      * <code>optional .exec.DrillbitEndpoint.State state = 7;</code>
      */
     org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State getState();
+
+    // optional int32 http_port = 8;
+    /**
+     * <code>optional int32 http_port = 8;</code>
+     */
+    boolean hasHttpPort();
+    /**
+     * <code>optional int32 http_port = 8;</code>
+     */
+    int getHttpPort();
   }
   /**
    * Protobuf type {@code exec.DrillbitEndpoint}
@@ -210,6 +220,11 @@ public final class CoordinationProtos {
                 bitField0_ |= 0x00000040;
                 state_ = value;
               }
+              break;
+            }
+            case 64: {
+              bitField0_ |= 0x00000080;
+              httpPort_ = input.readInt32();
               break;
             }
           }
@@ -524,6 +539,22 @@ public final class CoordinationProtos {
       return state_;
     }
 
+    // optional int32 http_port = 8;
+    public static final int HTTP_PORT_FIELD_NUMBER = 8;
+    private int httpPort_;
+    /**
+     * <code>optional int32 http_port = 8;</code>
+     */
+    public boolean hasHttpPort() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional int32 http_port = 8;</code>
+     */
+    public int getHttpPort() {
+      return httpPort_;
+    }
+
     private void initFields() {
       address_ = "";
       userPort_ = 0;
@@ -532,6 +563,7 @@ public final class CoordinationProtos {
       roles_ = org.apache.drill.exec.proto.CoordinationProtos.Roles.getDefaultInstance();
       version_ = "";
       state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
+      httpPort_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -565,6 +597,9 @@ public final class CoordinationProtos {
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeEnum(7, state_.getNumber());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeInt32(8, httpPort_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -602,6 +637,10 @@ public final class CoordinationProtos {
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(7, state_.getNumber());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(8, httpPort_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -738,6 +777,8 @@ public final class CoordinationProtos {
         bitField0_ = (bitField0_ & ~0x00000020);
         state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
         bitField0_ = (bitField0_ & ~0x00000040);
+        httpPort_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
 
@@ -798,6 +839,10 @@ public final class CoordinationProtos {
           to_bitField0_ |= 0x00000040;
         }
         result.state_ = state_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        result.httpPort_ = httpPort_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -838,6 +883,9 @@ public final class CoordinationProtos {
         }
         if (other.hasState()) {
           setState(other.getState());
+        }
+        if (other.hasHttpPort()) {
+          setHttpPort(other.getHttpPort());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1262,6 +1310,39 @@ public final class CoordinationProtos {
       public Builder clearState() {
         bitField0_ = (bitField0_ & ~0x00000040);
         state_ = org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.STARTUP;
+        onChanged();
+        return this;
+      }
+
+      // optional int32 http_port = 8;
+      private int httpPort_ ;
+      /**
+       * <code>optional int32 http_port = 8;</code>
+       */
+      public boolean hasHttpPort() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional int32 http_port = 8;</code>
+       */
+      public int getHttpPort() {
+        return httpPort_;
+      }
+      /**
+       * <code>optional int32 http_port = 8;</code>
+       */
+      public Builder setHttpPort(int value) {
+        bitField0_ |= 0x00000080;
+        httpPort_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 http_port = 8;</code>
+       */
+      public Builder clearHttpPort() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        httpPort_ = 0;
         onChanged();
         return this;
       }
@@ -2765,21 +2846,22 @@ public final class CoordinationProtos {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\022Coordination.proto\022\004exec\"\367\001\n\020DrillbitE" +
+      "\n\022Coordination.proto\022\004exec\"\212\002\n\020DrillbitE" +
       "ndpoint\022\017\n\007address\030\001 \001(\t\022\021\n\tuser_port\030\002 " +
       "\001(\005\022\024\n\014control_port\030\003 \001(\005\022\021\n\tdata_port\030\004" +
       " \001(\005\022\032\n\005roles\030\005 \001(\0132\013.exec.Roles\022\017\n\007vers" +
       "ion\030\006 \001(\t\022+\n\005state\030\007 \001(\0162\034.exec.Drillbit" +
-      "Endpoint.State\"<\n\005State\022\013\n\007STARTUP\020\000\022\n\n\006" +
-      "ONLINE\020\001\022\r\n\tQUIESCENT\020\002\022\013\n\007OFFLINE\020\003\"i\n\024" +
-      "DrillServiceInstance\022\n\n\002id\030\001 \001(\t\022\033\n\023regi" +
-      "strationTimeUTC\030\002 \001(\003\022(\n\010endpoint\030\003 \001(\0132" +
-      "\026.exec.DrillbitEndpoint\"\227\001\n\005Roles\022\027\n\tsql",
-      "_query\030\001 \001(\010:\004true\022\032\n\014logical_plan\030\002 \001(\010" +
-      ":\004true\022\033\n\rphysical_plan\030\003 \001(\010:\004true\022\033\n\rj" +
-      "ava_executor\030\004 \001(\010:\004true\022\037\n\021distributed_" +
-      "cache\030\005 \001(\010:\004trueB3\n\033org.apache.drill.ex" +
-      "ec.protoB\022CoordinationProtosH\001"
+      "Endpoint.State\022\021\n\thttp_port\030\010 \001(\005\"<\n\005Sta" +
+      "te\022\013\n\007STARTUP\020\000\022\n\n\006ONLINE\020\001\022\r\n\tQUIESCENT" +
+      "\020\002\022\013\n\007OFFLINE\020\003\"i\n\024DrillServiceInstance\022" +
+      "\n\n\002id\030\001 \001(\t\022\033\n\023registrationTimeUTC\030\002 \001(\003" +
+      "\022(\n\010endpoint\030\003 \001(\0132\026.exec.DrillbitEndpoi",
+      "nt\"\227\001\n\005Roles\022\027\n\tsql_query\030\001 \001(\010:\004true\022\032\n" +
+      "\014logical_plan\030\002 \001(\010:\004true\022\033\n\rphysical_pl" +
+      "an\030\003 \001(\010:\004true\022\033\n\rjava_executor\030\004 \001(\010:\004t" +
+      "rue\022\037\n\021distributed_cache\030\005 \001(\010:\004trueB3\n\033" +
+      "org.apache.drill.exec.protoB\022Coordinatio" +
+      "nProtosH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -2791,7 +2873,7 @@ public final class CoordinationProtos {
           internal_static_exec_DrillbitEndpoint_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_exec_DrillbitEndpoint_descriptor,
-              new java.lang.String[] { "Address", "UserPort", "ControlPort", "DataPort", "Roles", "Version", "State", });
+              new java.lang.String[] { "Address", "UserPort", "ControlPort", "DataPort", "Roles", "Version", "State", "HttpPort", });
           internal_static_exec_DrillServiceInstance_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_exec_DrillServiceInstance_fieldAccessorTable = new

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaCoordinationProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaCoordinationProtos.java
@@ -50,6 +50,8 @@ public final class SchemaCoordinationProtos
                     output.writeString(6, message.getVersion(), false);
                 if(message.hasState())
                     output.writeEnum(7, message.getState().getNumber(), false);
+                if(message.hasHttpPort())
+                    output.writeInt32(8, message.getHttpPort(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint message)
             {
@@ -111,6 +113,9 @@ public final class SchemaCoordinationProtos
                         case 7:
                             builder.setState(org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint.State.valueOf(input.readEnum()));
                             break;
+                        case 8:
+                            builder.setHttpPort(input.readInt32());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -158,6 +163,7 @@ public final class SchemaCoordinationProtos
                 case 5: return "roles";
                 case 6: return "version";
                 case 7: return "state";
+                case 8: return "httpPort";
                 default: return null;
             }
         }
@@ -176,6 +182,7 @@ public final class SchemaCoordinationProtos
             fieldMap.put("roles", 5);
             fieldMap.put("version", 6);
             fieldMap.put("state", 7);
+            fieldMap.put("httpPort", 8);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/DrillbitEndpoint.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/DrillbitEndpoint.java
@@ -86,6 +86,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
     private Roles roles;
     private String version;
     private State state;
+    private int httpPort;
 
     public DrillbitEndpoint()
     {
@@ -185,6 +186,19 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
         return this;
     }
 
+    // httpPort
+
+    public int getHttpPort()
+    {
+        return httpPort;
+    }
+
+    public DrillbitEndpoint setHttpPort(int httpPort)
+    {
+        this.httpPort = httpPort;
+        return this;
+    }
+
     // java serialization
 
     public void readExternal(ObjectInput in) throws IOException
@@ -261,6 +275,9 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
                 case 7:
                     message.state = State.valueOf(input.readEnum());
                     break;
+                case 8:
+                    message.httpPort = input.readInt32();
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -291,6 +308,9 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
 
         if(message.state != null)
              output.writeEnum(7, message.state.number, false);
+
+        if(message.httpPort != 0)
+            output.writeInt32(8, message.httpPort, false);
     }
 
     public String getFieldName(int number)
@@ -304,6 +324,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
             case 5: return "roles";
             case 6: return "version";
             case 7: return "state";
+            case 8: return "httpPort";
             default: return null;
         }
     }
@@ -324,6 +345,7 @@ public final class DrillbitEndpoint implements Externalizable, Message<DrillbitE
         __fieldMap.put("roles", 5);
         __fieldMap.put("version", 6);
         __fieldMap.put("state", 7);
+        __fieldMap.put("httpPort", 8);
     }
     
 }

--- a/protocol/src/main/protobuf/Coordination.proto
+++ b/protocol/src/main/protobuf/Coordination.proto
@@ -18,6 +18,7 @@ message DrillbitEndpoint{
       OFFLINE = 3;
   }
   optional State state = 7;
+  optional int32 http_port = 8;
 }
 
 message DrillServiceInstance{


### PR DESCRIPTION
The commits make use of AJAX calls by the browser to all the Drillbits for status metrics, which are then displayed here. This works with unsecured Drill sessions, while secure setups will not be able to show the metrics because of certificate authentication.
To achieve this, the HTTP port needed to be discoverable, for which changes to the protobuf were done to provide the HTTP port number. CORS was allowed by the webserver as well.
The Drillbit homepage has been extended to show the following:
* Heap Memory in use
* Direct Memory (actively) in use - Since we're not able to get the total memory held by Netty at the moment, but only what is currently allocated to running queries. The base memory shown is the total peak allocation by Drill for Direct, because the actual Direct memory held is not available. In an active stable system in production, this should be around 90%.
* Average (System) Load Factor reported by the OS for that node.
* Pill indicating the current Drillbit whose WebUI is being viewed (existing UX feature), with an option to load (in a new window) the UI from other Drillbits.

Information such as the User, Data and Control port numbers don't help much during general cluster health, so it might be worth removing this information if more real-estate is needed. For now, we are retaining this. 