### PR TITLE
DRILL-6339: Add a new option to disable TopN (for testing)

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -55,6 +55,7 @@ public class PlannerSettings implements Context{
   public static final OptionValidator EXCHANGE = new BooleanValidator("planner.disable_exchanges");
   public static final OptionValidator HASHAGG = new BooleanValidator("planner.enable_hashagg");
   public static final OptionValidator STREAMAGG = new BooleanValidator("planner.enable_streamagg");
+  public static final OptionValidator TOPN = new BooleanValidator("planner.enable_topn");
   public static final OptionValidator HASHJOIN = new BooleanValidator("planner.enable_hashjoin");
   public static final OptionValidator MERGEJOIN = new BooleanValidator("planner.enable_mergejoin");
   public static final OptionValidator NESTEDLOOPJOIN = new BooleanValidator("planner.enable_nestedloopjoin");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PushLimitToTopN.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PushLimitToTopN.java
@@ -31,6 +31,12 @@ public class PushLimitToTopN  extends Prule{
   }
 
   @Override
+  public boolean matches(RelOptRuleCall call) {
+    return PrelUtil.getPlannerSettings(call.getPlanner()).getOptions()
+      .getOption(PlannerSettings.TOPN.getOptionName()).bool_val;
+  }
+
+  @Override
   public void onMatch(RelOptRuleCall call) {
     final LimitPrel limit = (LimitPrel) call.rel(0);
     final SingleMergeExchangePrel smex = (SingleMergeExchangePrel) call.rel(1);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -80,6 +80,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(PlannerSettings.EXCHANGE),
       new OptionDefinition(PlannerSettings.HASHAGG),
       new OptionDefinition(PlannerSettings.STREAMAGG),
+      new OptionDefinition(PlannerSettings.TOPN, new OptionMetaData(OptionValue.AccessibleScopes.ALL, false, true)),
       new OptionDefinition(PlannerSettings.HASHJOIN),
       new OptionDefinition(PlannerSettings.MERGEJOIN),
       new OptionDefinition(PlannerSettings.NESTEDLOOPJOIN),

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -483,6 +483,7 @@ drill.exec.options: {
     planner.enable_nestedloopjoin: true,
     planner.enable_nljoin_for_scalar_only: true,
     planner.enable_streamagg: true,
+    planner.enable_topn: true,
     planner.enable_type_inference: true,
     planner.enable_unionall_distribute: false,
     planner.filter.max_selectivity_estimate_factor: 1.0,


### PR DESCRIPTION
To allow simple testing of the External Sort operator (e.g., test spilling), we would like to use a query of the form: ".... ORDER BY ... LIMIT ... "; however the current planner unconditionally selects the TopN operator for such a query.
   Solution: Introduce an internal option that can negate the planner's choice in this case. The implementation overrides the matches() method (default was returning true) in PushLimitToTopN , returning the new boolean option (default true) instead.
  (The last 'true' in SystemOptionManager makes this option 'internal'). This new option was tested manually.

