### PR TITLE
DRILL-6341: Fixed failing tests for mongodb storage plugin

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>1.50.5</version>
+      <version>2.0.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -21,7 +21,9 @@ public interface MongoTestConstants {
 
   public static final String LOCALHOST = "localhost";
   // TODO: DRILL-3934: add some randomization to this as it fails when running concurrent builds
-  public static final int CONFIG_SERVER_PORT = 27019;
+  int CONFIG_SERVER_1_PORT = 61114;
+  int CONFIG_SERVER_2_PORT = 61215;
+  int CONFIG_SERVER_3_PORT = 61316;
   public static final int MONGOD_1_PORT = 27020;
   public static final int MONGOD_2_PORT = 27021;
   public static final int MONGOD_3_PORT = 27022;
@@ -44,10 +46,12 @@ public interface MongoTestConstants {
   public static final String EMP_DATA = "emp.json";
   public static final String SCHEMA_CHANGE_DATA = "schema_change_int_to_string.json";
 
+  String STORAGE_ENGINE = "wiredTiger";
   String DATATYPE_DB = "datatype";
   String DATATYPE_COLLECTION = "types";
   String DATATYPE_DATA = "datatype-oid.json";
 
+  String CONFIG_REPLICA_SET = "config_replicas";
   public static final String REPLICA_SET_1_NAME = "shard_1_replicas";
   public static final String REPLICA_SET_2_NAME = "shard_2_replicas";
 

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestTableGenerator.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestTableGenerator.java
@@ -53,7 +53,7 @@ public class TestTableGenerator implements MongoTestConstants {
     logger.info("Started importing file {} into collection {} ", jsonFile,
         collection);
     IMongoImportConfig mongoImportConfig = new MongoImportConfigBuilder()
-        .version(Version.Main.PRODUCTION)
+        .version(Version.Main.V3_4)
         .net(new Net(MONGOS_PORT, Network.localhostIsIPv6())).db(dbName)
         .collection(collection).upsert(upsert).dropCollection(drop)
         .jsonArray(jsonArray).importFile(jsonFile).build();


### PR DESCRIPTION
## Issue

The Mongodb storage plugin tests fail on osx 10.13.x because MongoDB 3.2 itself has a bug on osx 10.13.x  . This is a known and documented issue here https://github.com/github/hub/issues/1405 . The issue occurs consistently on my laptop.

## Fix

 - The version of MongDB used for tests needs to be updated to 3.4. Why 3.4 and not 3.6? There is some discussion here that people are experiencing issues with 3.6 on Windows and that 3.4 is the safest option. 
 - The **de.flapdoodle.embed.mongo** plugin needs to be updated to the latest 2.x version which supports mongo 3.4. Currently we are using 1.x which doesn't support Mongo 3.4.
 - In Mongo db 3.4 Config servers need to be part of a replica set. Also **de.flapdoodle.embed.mongo** 2.x requires a replica set for config servers. And the minimum number of servers in a replica set is 3, so I launch 3 config servers now.
 - There is a bug with **de.flapdoodle.embed.mongo** where config servers need to be initialized as replica sets so you need to add them to your complete list of replica sets to be initialized. But if you provide the configServers to MongosSystemForTestFactory it will try to start the config servers again! To work around this bug I pass an empty list of config servers to MongosSystemForTestFactory. This ensures each config server is only started once.
 - The **wiredTiger** storage engine is required to run replica sets. To ensure we don't revert back to **mmapv1** storage engine I explicitly configure **wiredTiger** on all the configs.
 - **useNoPrealloc** and ** useSmallFiles** default to true and must be set to false since they are configs for **mmapv1** and  **de.flapdoodle.embed.mongo** passes these options to MongoDB if they are true. When MongoDB sees **mmapv1** options it throws an error. To prevent all this I have to explicitly set these two options to false.
 - The config server and shard server flags need to be set correctly on the configs, so I do that now.