### PR TITLE
DRILL-6336: Inconsistent method name.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ClassGenerator.java
@@ -835,18 +835,18 @@ public class ClassGenerator<T>{
     public String toString() {
       DebugStringBuilder buf = new DebugStringBuilder(this);
       if (isConstant()) {
-        buf.append("const ");
+        buf.print("const ");
       }
-      buf.append(holder.type().fullName())
-        .append(" ")
-        .append(holder.name())
-        .append(", ")
-        .append(type.getMode().name())
-        .append(" ")
-        .append(type.getMinorType().name())
-        .append(", ");
+      buf.print(holder.type().fullName())
+        .print(" ")
+        .print(holder.name())
+        .print(", ")
+        .print(type.getMode().name())
+        .print(" ")
+        .print(type.getMinorType().name())
+        .print(", ");
       holder.generate(buf.formatter());
-      buf.append(", ");
+      buf.print(", ");
       value.generate(buf.formatter());
       return buf.toString();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/DebugStringBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/DebugStringBuilder.java
@@ -44,7 +44,7 @@ public class DebugStringBuilder {
     fmt = new JFormatter( writer );
   }
 
-  public DebugStringBuilder append( String s ) {
+  public DebugStringBuilder print( String s ) {
     writer.print( s );
     return this;
   }


### PR DESCRIPTION
Change the method name "append" to "print" since its body code is an method invocation "writer.print( s )". The method named "print" should be more clear.
The method name "append" is labeled as "@Deprecated" in case of breaking backward compatibility.