### PR TITLE
DRILL-6364: Handle Cluster Info in WebUI when existing/new bits restart

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -88,7 +88,7 @@ public class DrillRoot {
     Collection<DrillbitInfo> drillbits = getClusterInfoJSON().getDrillbits();
     Map<String, String> drillStatusMap = new HashMap<String, String>();
     for (DrillbitInfo drillbit : drillbits) {
-      drillStatusMap.put(drillbit.getAddress() + "-" + drillbit.getUserPort(), drillbit.getState());
+      drillStatusMap.put(drillbit.getAddress() + "-" + drillbit.getHttpPort(), drillbit.getState());
     }
     return setResponse(drillStatusMap);
   }
@@ -239,6 +239,7 @@ public class DrillRoot {
   private Response shutdown(String resp) throws Exception {
     Map<String, String> shutdownInfo = new HashMap<String, String>();
     new Thread(new Runnable() {
+        @Override
         public void run() {
           try {
             drillbit.close();

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -478,7 +478,13 @@
                 break;
             }
             let currentRow = $("#row-"+i);
-            let address = currentRow.find("#address").contents().get(0).nodeValue.trim();
+            let address = "";
+            //For 'current' bit, address is referred to by location.hostname instead of FQDN ()
+            if (i == 1) {
+              address = location.hostname;
+            } else {
+              address = currentRow.find("#address").contents().get(0).nodeValue.trim();
+            }
             let httpPort = currentRow.find("#httpPort").contents().get(0).nodeValue.trim();
             updateMetricsHtml(address, httpPort, i);
           }

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -230,7 +230,7 @@
       function setShutdownCtrl() {
         for (i = 1; i <= size; i++) {
           let currentRow = $("#row-"+i);
-          if ( location.protocol == "https" && (currentRow.find("#current").html() != "Current") ) {
+          if ( location.protocol == "https:" && (currentRow.find("#current").html() != "Current") ) {
             //Hide Shutdown Button for remote nodes with HTTPS enabled
             currentRow.find(".shutdownCtrl").css('display','none');
           }
@@ -354,7 +354,7 @@
                 if (status_map[key] == "ONLINE") {
                     currentRow.find("#status").text(status_map[key]).css('font-style','').prop('title','');
                     //EnableShutdown IFF => !isAuthEnabled-&&-!HTTPS OR isAuthEnabled-&&-current
-                    if ( ( !${model.isAuthEnabled()?c} && location.protocol != "https" ) || ( ${model.shouldShowAdminInfo()?c} && currentRow.find("#current").html() == "Current" ) ) {
+                    if ( ( !${model.isAuthEnabled()?c} && location.protocol != "https:" ) || ( ${model.shouldShowAdminInfo()?c} && currentRow.find("#current").html() == "Current" ) ) {
                       currentRow.find("#shutdown").prop('disabled',false).css('opacity',1.0).css('cursor','pointer').attr('title','');
                     }
                 } else {
@@ -474,7 +474,7 @@
       function reloadMetrics() {
           for (i = 1; i <= size; i++) {
             //Skip metrics update for remote bits in HTTPS mode
-            if (i > 1 && location.protocol == "https") {
+            if (i > 1 && location.protocol == "https:") {
                 break;
             }
             let currentRow = $("#row-"+i);

--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -224,6 +224,7 @@
       var size = $("#size").html();
       reloadMetrics();
       setInterval(reloadMetrics, refreshTime);
+      var hideShutdownBtns = setShutdownCtrl();
 
       //Hide Shutdown buttons for remote HTTPS entries
       function setShutdownCtrl() {


### PR DESCRIPTION
As a follow up to DRILL-6289, the following improvements have been done:
1. When loading the page for the first time, the WebUI enables the shutdown button without actually checking the state of the Drillbits.
   The ideal behaviour should be to disable the button till the state is verified. **[Done]**
   _If a Drillbit is confirmed down (i.e. not in `/state` response), it is marked as OFFLINE and button is disabled._
2. When shutting down the current Drillbit, the WebUI no more has access to the cluster state. 
   The ideal behaviour here should be to fetch the state from any of the other Drillbits to update the status. **[Done]**
   _With the current Drillbit down, the other bits are requested for cluster state info and update accordingly._
3. When a new, previously unseen Drillbit comes up, the WebUI will never render it because the table is statically generated during the first page load. 
   The idea behaviour should be to append to the table on discovery of a new node. **[Done]**
   _The new Drillbit info is injected and a prompt appears to refresh the page to re-populate any missing info. This also works with feature (2) mentioned above._

The only Java code change was to have the state response carry the address and http-port as a tuple, instead of the user-port (which seems to be never used).