### PR TITLE
DRILL-5270: Improve loading of profiles listing in the WebUI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -223,6 +223,8 @@ public final class ExecConstants {
   public static final String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";
   public static final String PROFILES_STORE_INMEMORY = "drill.exec.profiles.store.inmemory";
   public static final String PROFILES_STORE_CAPACITY = "drill.exec.profiles.store.capacity";
+  public static final String PROFILES_STORE_ARCHIVE_ENABLED = "drill.exec.profiles.store.archive.enabled";
+  public static final String PROFILES_STORE_ARCHIVE_RATE = "drill.exec.profiles.store.archive.rate";
   public static final String IMPERSONATION_ENABLED = "drill.exec.impersonation.enabled";
   public static final String IMPERSONATION_MAX_CHAINED_USER_HOPS = "drill.exec.impersonation.max_chained_user_hops";
   public static final String AUTHENTICATION_MECHANISMS = "drill.exec.security.auth.mechanisms";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.server.rest.profile;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -58,6 +59,7 @@ import org.apache.drill.exec.work.WorkManager;
 import org.apache.drill.exec.work.foreman.Foreman;
 import org.glassfish.jersey.server.mvc.Viewable;
 
+import com.google.common.base.Stopwatch;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @Path("/")
@@ -71,6 +73,7 @@ public class ProfileResources {
   @Inject SecurityContext sc;
 
   public static class ProfileInfo implements Comparable<ProfileInfo> {
+    private static final String TRAILING_DOTS = " ... ";
     private static final int QUERY_SNIPPET_MAX_CHAR = 150;
     private static final int QUERY_SNIPPET_MAX_LINES = 8;
 
@@ -171,13 +174,13 @@ public class ProfileResources {
       //Trimming down based on line-count
       if (QUERY_SNIPPET_MAX_LINES < queryParts.length) {
         int linesConstructed = 0;
-        StringBuilder lineCappedQuerySnippet = new StringBuilder();
+        StringBuilder lineCappedQuerySnippet = new StringBuilder(QUERY_SNIPPET_MAX_CHAR + TRAILING_DOTS.length());
         for (String qPart : queryParts) {
           lineCappedQuerySnippet.append(qPart);
           if (++linesConstructed < QUERY_SNIPPET_MAX_LINES) {
             lineCappedQuerySnippet.append(System.lineSeparator());
           } else {
-            lineCappedQuerySnippet.append(" ... ");
+            lineCappedQuerySnippet.append(TRAILING_DOTS);
             break;
           }
         }
@@ -260,8 +263,6 @@ public class ProfileResources {
 
       Collections.sort(runningQueries, Collections.reverseOrder());
 
-      final List<ProfileInfo> finishedQueries = Lists.newArrayList();
-
       //Defining #Profiles to load
       int maxProfilesToLoad = work.getContext().getConfig().getInt(ExecConstants.HTTP_MAX_PROFILES);
       String maxProfilesParams = uriInfo.getQueryParameters().getFirst(MAX_QPROFILES_PARAM);
@@ -269,8 +270,9 @@ public class ProfileResources {
         maxProfilesToLoad = Integer.valueOf(maxProfilesParams);
       }
 
-      final Iterator<Map.Entry<String, QueryProfile>> range = completed.getRange(0, maxProfilesToLoad);
+      final List<ProfileInfo> finishedQueries = new ArrayList<ProfileResources.ProfileInfo>(maxProfilesToLoad);
 
+      final Iterator<Map.Entry<String, QueryProfile>> range = completed.getRange(0, maxProfilesToLoad);
       while (range.hasNext()) {
         try {
           final Map.Entry<String, QueryProfile> profileEntry = range.next();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
@@ -272,7 +272,7 @@ public class ProfileResources {
 
       final List<ProfileInfo> finishedQueries = new ArrayList<ProfileResources.ProfileInfo>(maxProfilesToLoad);
 
-      final Iterator<Map.Entry<String, QueryProfile>> range = completed.getRange(0, maxProfilesToLoad);
+      final Iterator<Map.Entry<String, QueryProfile>> range = completed.getRange(0, maxProfilesToLoad, true); //Leverage any underlying cache
       while (range.hasNext()) {
         try {
           final Map.Entry<String, QueryProfile> profileEntry = range.next();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/BasePersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/BasePersistentStore.java
@@ -27,4 +27,9 @@ public abstract class BasePersistentStore<V> implements PersistentStore<V> {
     return getRange(0, Integer.MAX_VALUE);
   }
 
+  @Override
+  public Iterator<Map.Entry<String, V>> getRange(int skip, int take, boolean useCache) {
+    //No implicit cache implemented by default
+    return getRange(skip, take, false);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/CaseInsensitivePersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/CaseInsensitivePersistentStore.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.sys;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Wrapper around {@link PersistentStore} to ensure all passed keys are converted to lower case and stored this way.
@@ -70,6 +71,11 @@ public class CaseInsensitivePersistentStore<V> implements PersistentStore<V> {
   @Override
   public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
     return underlyingStore.getRange(skip, take);
+  }
+
+  @Override
+  public Iterator<Entry<String, V>> getRange(int skip, int take, boolean useCache) {
+    return underlyingStore.getRange(skip, take, useCache);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
@@ -54,4 +54,13 @@ public interface PersistentStore<V> extends Store<V> {
    */
   Iterator<Map.Entry<String, V>> getAll();
 
+  /**
+   * Returns, from a possible cache, an iterator of desired number of entries offsetting by the skip value.
+   *
+   * @param skip  number of records to skip from beginning
+   * @param take  max number of records to return
+   * @param useCache  use cache if available
+   */
+  Iterator<Map.Entry<String, V>> getRange(int skip, int take, boolean useCache);
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import static org.apache.drill.exec.ExecConstants.DRILL_SYS_FILE_SUFFIX;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+/**
+ * Filter for Drill System Files
+ */
+public class DrillSysFilePathFilter implements PathFilter {
+
+  //NOTE: The filename is a combination of query ID (which is monotonically
+  //decreasing value derived off epoch timestamp) and a random value. This
+  //filter helps eliminate that list
+  String cutoffFileName = null;
+  public DrillSysFilePathFilter() {}
+
+  public DrillSysFilePathFilter(String cutoffSysFileName) {
+    if (cutoffSysFileName != null) {
+      this.cutoffFileName = cutoffSysFileName + DRILL_SYS_FILE_SUFFIX;
+    }
+  }
+
+  /* (non-Javadoc)
+   * @see org.apache.hadoop.fs.PathFilter#accept(org.apache.hadoop.fs.Path)
+   */
+  @Override
+  public boolean accept(Path file){
+    if (file.getName().endsWith(DRILL_SYS_FILE_SUFFIX)) {
+      if (cutoffFileName != null) {
+        return (file.getName().compareTo(cutoffFileName) <= 0);
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -28,22 +28,33 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.drill.common.collections.ImmutableEntry;
+import org.apache.drill.common.concurrent.AutoCloseableLock;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
-import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreMode;
+import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Stopwatch;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
@@ -55,16 +66,91 @@ import org.slf4j.LoggerFactory;
 public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStore.class);
 
+  //Provides a threshold above which we report an event's time
+  private static final long RESPONSE_TIME_THRESHOLD_MSEC = 2000L;
+  private static final String ARCHIVE_LOCATION = "archived";
+
+  private static final int DRILL_SYS_FILE_EXT_SIZE = DRILL_SYS_FILE_SUFFIX.length();
   private final Path basePath;
   private final PersistentStoreConfig<V> config;
   private final DrillFileSystem fs;
+  private int version = -1;
+  private Function<String, Entry<String, V>> transformer;
 
-  public LocalPersistentStore(DrillFileSystem fs, Path base, PersistentStoreConfig<V> config) {
+  private TreeSet<String> profilesSet;
+  private int profilesSetSize;
+  private PathFilter sysFileSuffixFilter;
+//  private String mostRecentProfile;
+  private long basePathLastModified;
+  private long lastKnownFileCount;
+  private int maxSetCapacity;
+  private Stopwatch listAndBuildWatch;
+  private Stopwatch transformWatch;
+
+  private boolean enableArchiving;
+  private Path archivePath;
+  private TreeSet<String> pendingArchivalSet;
+  private int pendingArchivalSetSize;
+  private int archivalThreshold;
+  private int archivalRate;
+  private Iterable<Entry<String, V>> iterableProfileSet;
+  private Stopwatch archiveWatch;
+
+  public LocalPersistentStore(DrillFileSystem fs, Path base, PersistentStoreConfig<V> config, DrillConfig drillConfig) {
+    super();
     this.basePath = new Path(base, config.getName());
     this.config = config;
     this.fs = fs;
+    //MRU Profile Cache
+    this.profilesSet = new TreeSet<String>();
+    this.profilesSetSize= 0;
+    this.basePathLastModified = 0L;
+    this.lastKnownFileCount = 0L;
+    this.sysFileSuffixFilter = new DrillSysFilePathFilter();
+    //this.mostRecentProfile = null;
+
+    //Initializing for archiving
+    if (drillConfig != null ) {
+      this.enableArchiving = drillConfig.getBoolean(ExecConstants.PROFILES_STORE_ARCHIVE_ENABLED); //(maxStoreCapacity > 0); //Implicitly infer
+      this.archivalThreshold = drillConfig.getInt(ExecConstants.PROFILES_STORE_CAPACITY);
+      this.archivalRate = drillConfig.getInt(ExecConstants.PROFILES_STORE_ARCHIVE_RATE);
+    } else {
+      this.enableArchiving = false;
+    }
+    this.pendingArchivalSet = new TreeSet<String>();
+    this.pendingArchivalSetSize = 0;
+    this.archivePath = new Path(basePath, ARCHIVE_LOCATION);
+
+    // Timing
+    this.listAndBuildWatch = Stopwatch.createUnstarted();
+    this.transformWatch = Stopwatch.createUnstarted();
+    this.archiveWatch = Stopwatch.createUnstarted();
+
+    // One time transformer function instantiation
+    this.transformer = new Function<String, Entry<String, V>>() {
+      @Nullable
+      @Override
+      public Entry<String, V> apply(String key) {
+        return new ImmutableEntry<>(key, get(key));
+      }
+    };
+
+    //Base Dir
     try {
-      mkdirs(getBasePath());
+      if (!fs.mkdirs(basePath)) {
+        version++;
+      }
+      //Creating Archive if required
+      if (enableArchiving) {
+        try {
+          if (!fs.exists(archivePath)) {
+            fs.mkdirs(archivePath);
+          }
+        } catch (IOException e) {
+          logger.warn("Disabling profile archiving due to failure in creating profile archive {} : {}", archivePath, e);
+          this.enableArchiving = false;
+        }
+      }
     } catch (IOException e) {
       throw new RuntimeException("Failure setting pstore configuration path.");
     }
@@ -109,45 +195,177 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
 
   @Override
   public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
+    //Marking currently seen modification time
+    long currBasePathModified = 0L;
     try {
-      // list only files with sys file suffix
-      PathFilter sysFileSuffixFilter = new PathFilter() {
-        @Override
-        public boolean accept(Path path) {
-          return path.getName().endsWith(DRILL_SYS_FILE_SUFFIX);
+      currBasePathModified = fs.getFileStatus(basePath).getModificationTime();
+    } catch (IOException e) {
+      logger.error("Failed to get FileStatus for {}", basePath, e);
+      throw new RuntimeException(e);
+    }
+
+    logger.info("Requesting thread: {}-{}" , Thread.currentThread().getName(), Thread.currentThread().getId());
+    //No need to acquire lock since incoming requests are synchronized
+    try {
+      long expectedFileCount = fs.getFileStatus(basePath).getLen();
+      logger.debug("Current ModTime: {} (Last known ModTime: {})", currBasePathModified, basePathLastModified);
+      logger.debug("Expected {} files (Last known {} files)", expectedFileCount, lastKnownFileCount);
+
+      //Force-read list of profiles based on change of any of the 3 states
+      if (this.basePathLastModified < currBasePathModified  //Has ModificationTime changed?
+          || this.lastKnownFileCount != expectedFileCount   //Has Profile Count changed?
+          || (skip + take) > maxSetCapacity ) {             //Does requestSize exceed current cached size
+
+        if (maxSetCapacity < (skip + take)) {
+          logger.debug("Updating last Max Capacity from {} to {}", maxSetCapacity , (skip + take) );
+          maxSetCapacity = skip + take;
         }
-      };
+        //Mark Start Time
+        listAndBuildWatch.reset().start();
 
-      List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, false, sysFileSuffixFilter);
-      if (fileStatuses.isEmpty()) {
-        return Collections.emptyIterator();
-      }
-
-      List<String> files = Lists.newArrayList();
-      for (FileStatus stat : fileStatuses) {
-        String s = stat.getPath().getName();
-        files.add(s.substring(0, s.length() - DRILL_SYS_FILE_SUFFIX.length()));
-      }
-
-      Collections.sort(files);
-
-      return Iterables.transform(Iterables.limit(Iterables.skip(files, skip), take), new Function<String, Entry<String, V>>() {
-        @Nullable
-        @Override
-        public Entry<String, V> apply(String key) {
-          return new ImmutableEntry<>(key, get(key));
+        //Listing ALL DrillSysFiles
+        //Can apply MostRecentProfile name as filter. Unfortunately, Hadoop (2.7.1) currently doesn't leverage this to speed up
+        List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, false,
+            sysFileSuffixFilter
+            );
+        //Checking if empty
+        if (fileStatuses.isEmpty()) {
+          //WithoutFilter::
+          return Collections.emptyIterator();
         }
-      }).iterator();
+        //Force a reload of the profile.
+        //Note: We shouldn't need to do this if the load is incremental (i.e. using mostRecentProfile)
+        profilesSet.clear();
+        profilesSetSize = 0;
+        int profilesInStoreCount = 0;
+
+        if (enableArchiving) {
+          pendingArchivalSet.clear();
+          pendingArchivalSetSize = 0;
+        }
+
+        //Constructing TreeMap from List
+        for (FileStatus stat : fileStatuses) {
+          String profileName = stat.getPath().getName();
+          profilesSetSize = addToProfileSet(profileName, profilesSetSize, maxSetCapacity);
+          profilesInStoreCount++;
+        }
+
+        //Archive older profiles
+        if (enableArchiving) {
+          archiveProfiles(fs, profilesInStoreCount);
+        }
+
+        //Report Lag
+        if (listAndBuildWatch.stop().elapsed(TimeUnit.MILLISECONDS) >= RESPONSE_TIME_THRESHOLD_MSEC) {
+          logger.warn("Took {} ms to list & map {} profiles (out of {} profiles in store)", listAndBuildWatch.elapsed(TimeUnit.MILLISECONDS)
+              , profilesSetSize, profilesInStoreCount);
+        }
+        //Recording last checked modified time and the most recent profile
+        basePathLastModified = currBasePathModified;
+        /*TODO: mostRecentProfile = profilesSet.first();*/
+        lastKnownFileCount = expectedFileCount;
+
+        //Transform profileSet for consumption
+        transformWatch.start();
+        iterableProfileSet = Iterables.transform(profilesSet, transformer);
+        if (transformWatch.stop().elapsed(TimeUnit.MILLISECONDS) >= RESPONSE_TIME_THRESHOLD_MSEC) {
+          logger.warn("Took {} ms to transform {} profiles", transformWatch.elapsed(TimeUnit.MILLISECONDS), profilesSetSize);
+        }
+      }
+      return iterableProfileSet.iterator();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
+  private void archiveProfiles(DrillFileSystem fs, int profilesInStoreCount) {
+    if (profilesInStoreCount > archivalThreshold) {
+      //We'll attempt to reduce to 90% of threshold, but in batches of archivalRate
+      int pendingArchivalCount = profilesInStoreCount - (int) Math.round(0.9*archivalThreshold);
+      logger.info("Found {} excess profiles. For now, will attempt archiving {} profiles to {}", pendingArchivalCount
+          , Math.min(pendingArchivalCount, archivalRate), archivePath);
+      try {
+        if (fs.isDirectory(archivePath)) {
+          int archivedCount = 0;
+          archiveWatch.reset().start(); //Clocking
+          while (archivedCount < archivalRate) {
+            String toArchive = pendingArchivalSet.pollLast() + DRILL_SYS_FILE_SUFFIX;
+            boolean renameStatus = DrillFileSystemUtil.rename(fs, new Path(basePath, toArchive), new Path(archivePath, toArchive));
+            if (!renameStatus) {
+              //Stop attempting any more archiving since other StoreProviders might be archiving
+              logger.error("Move failed for {} from {} to {}", toArchive, basePath.toString(), archivePath.toString());
+              logger.warn("Skip archiving under the assumption that another Drillbit is archiving");
+              break;
+            }
+            archivedCount++;
+          }
+          logger.info("Archived {} profiles to {} in {} ms", archivedCount, archivePath, archiveWatch.stop().elapsed(TimeUnit.MILLISECONDS));
+        } else {
+          logger.error("Unable to archive {} profiles to {}", pendingArchivalSetSize, archivePath.toString());
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    //Clean up
+    pendingArchivalSet.clear();
+  }
+
+  /**
+   * Add profile name to a TreeSet
+   * @param profileName Name of the profile to add
+   * @param currentSize Provided so as to avoid the need to recount
+   * @param maximumCapacity Maximum number of profiles to maintain
+   * @return Current size of tree after addition
+   */
+  private int addToProfileSet(String profileName, int currentSize, int maximumCapacity) {
+    //Add if not reached max capacity
+    if (currentSize < maximumCapacity) {
+      profilesSet.add(profileName.substring(0, profileName.length() - DRILL_SYS_FILE_EXT_SIZE));
+      currentSize++;
+    } else {
+      boolean addedProfile = profilesSet.add(profileName.substring(0, profileName.length() - DRILL_SYS_FILE_EXT_SIZE));
+      //Remove existing 'oldest' file
+      if (addedProfile) {
+        String oldestProfile = profilesSet.pollLast();
+        if (enableArchiving) {
+          addToArchiveSet(oldestProfile, archivalRate);
+        }
+      }
+    }
+    return currentSize;
+  }
+
+  /**
+   * Add profile name to a TreeSet
+   * @param profileName Name of the profile to add
+   * @param currentSize Provided so as to avoid the need to recount
+   * @param maximumCapacity Maximum number of profiles to maintain
+   * @return Current size of tree after addition
+   */
+  private int addToArchiveSet(String profileName, int maximumCapacity) {
+    //TODO make this global
+    int currentSize = pendingArchivalSet.size();
+    //Add if not reached max capacity
+    if (currentSize < maximumCapacity) {
+      pendingArchivalSet.add(profileName);
+      currentSize++;
+    } else {
+      boolean addedProfile = pendingArchivalSet.add(profileName);
+      //Remove existing 'youngest' file
+      if (addedProfile) {
+        pendingArchivalSet.pollFirst();
+      }
+    }
+    return currentSize;
+  }
+
   private Path makePath(String name) {
     Preconditions.checkArgument(
         !name.contains("/") &&
-            !name.contains(":") &&
-            !name.contains(".."));
+        !name.contains(":") &&
+        !name.contains(".."));
     return new Path(basePath, name + DRILL_SYS_FILE_SUFFIX);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -29,10 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -57,14 +55,11 @@ import org.apache.hadoop.fs.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Stopwatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.hadoop.fs.PathFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStore.class);
@@ -77,8 +72,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   private final PersistentStoreConfig<V> config;
   private final DrillFileSystem fs;
   private int version = -1;
-  private final Lock /*ReadWriteLock*/ lock = new ReentrantLock(true); //new ReentrantReadWriteLock();
-  private final AutoCloseableLock profileStoreLock = new AutoCloseableLock(lock/*.writeLock()*/);
+  private final AutoCloseableLock profileStoreLock;
   private Function<String, Entry<String, V>> stringTransformer;
   private Function<FileStatus, Entry<String, V>> fileStatusTransformer;
 
@@ -99,6 +93,11 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     this.basePath = new Path(base, config.getName());
     this.config = config;
     this.fs = fs;
+
+    //Initialize Lock for profileStore
+    ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    profileStoreLock = new AutoCloseableLock(readWriteLock.writeLock());
+
     //MRU Profile Cache
     this.profilesSet = new ProfileSet(drillConfig.getInt(ExecConstants.HTTP_MAX_PROFILES));
     this.basePathLastModified = 0L;
@@ -190,7 +189,6 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   //Get an iterator based on the current state of the contents on the FileSystem
   @Override
   public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
-    try (Closeable lock = profileStoreLock.open()) {
       try {
         //Recursively look for files (can't apply filename filters, or else sub-directories get excluded)
         List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, true);
@@ -218,11 +216,10 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-    }
   }
 
   /**
-   * Get range of potentially cached profiles (primary usecase is for the WebServer)
+   * Get range of potentially cached list of profiles (primary usecase is for the WebServer that relies on listing cache)
    * @param skip
    * @param take
    * @return iterator of profiles
@@ -254,7 +251,7 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
             || (skip + take) > maxSetCapacity ) {             //Does requestSize exceed current cached size
 
           if (maxSetCapacity < (skip + take)) {
-            logger.debug("Updating last Max Capacity from {} to {}", maxSetCapacity , (skip + take) );
+            logger.debug("Updating last Max Capacity from {} to {}", maxSetCapacity, (skip + take) );
             maxSetCapacity = skip + take;
           }
           //Mark Start Time
@@ -297,8 +294,8 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
 
           //Report Lag
           if (listAndBuildWatch.stop().elapsed(TimeUnit.MILLISECONDS) >= RESPONSE_TIME_THRESHOLD_MSEC) {
-            logger.warn("Took {} ms to list & map {} profiles (out of {} profiles in store)", listAndBuildWatch.elapsed(TimeUnit.MILLISECONDS)
-                , profilesSet.size(), numProfilesInStore);
+            logger.warn("Took {} ms to list & map {} profiles (out of {} profiles in store)", listAndBuildWatch.elapsed(TimeUnit.MILLISECONDS),
+                profilesSet.size(), numProfilesInStore);
           }
           //Recording last checked modified time and the most recent profile
           basePathLastModified = currBasePathModified;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Stopwatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
 
 /**
  * Archive profiles
@@ -72,8 +72,8 @@ public class LocalPersistentStoreArchiver {
       //We'll attempt to reduce to 90% of threshold, but in batches of archivalRate
       int excessCount = profilesInStoreCount - (int) Math.round(0.9*archivalThreshold);
       int numToArchive = Math.min(excessCount, archivalRate);
-      logger.info("Found {} excess profiles. For now, will attempt archiving {} profiles to {}", excessCount
-          , numToArchive, archivePath);
+      logger.info("Found {} excess profiles. For now, will attempt archiving {} profiles to {}", excessCount,
+          numToArchive, archivePath);
       int archivedCount = 0;
       try {
         if (fs.isDirectory(archivePath)) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import static org.apache.drill.exec.ExecConstants.DRILL_SYS_FILE_SUFFIX;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.util.DrillFileSystemUtil;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+
+/**
+ * Archive profiles
+ */
+public class LocalPersistentStoreArchiver {
+  private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStoreArchiver.class);
+
+  private static final String ARCHIVE_LOCATION = "archived";
+
+  private final DrillFileSystem fs;
+  private Path basePath;
+  private Path archivePath;
+  private ProfileSet pendingArchivalSet;
+  private int archivalThreshold;
+  private int archivalRate;
+  private Stopwatch archiveWatch;
+
+  public LocalPersistentStoreArchiver(DrillFileSystem fs, Path base, DrillConfig drillConfig) throws IOException {
+    this.fs = fs;
+    this.basePath = base;
+    this.archivalThreshold = drillConfig.getInt(ExecConstants.PROFILES_STORE_CAPACITY);
+    this.archivalRate = drillConfig.getInt(ExecConstants.PROFILES_STORE_ARCHIVE_RATE);
+    this.pendingArchivalSet = new ProfileSet(archivalRate);
+    this.archivePath = new Path(basePath, ARCHIVE_LOCATION);
+    this.archiveWatch = Stopwatch.createUnstarted();
+
+    try {
+      if (!fs.exists(archivePath)) {
+        fs.mkdirs(archivePath);
+      }
+    } catch (IOException e) {
+      logger.error("Disabling profile archiving due to failure in creating profile archive {} : {}", archivePath, e);
+      throw e;
+    }
+  }
+
+  void archiveProfiles(int profilesInStoreCount) {
+    if (profilesInStoreCount > archivalThreshold) {
+      //We'll attempt to reduce to 90% of threshold, but in batches of archivalRate
+      int excessCount = profilesInStoreCount - (int) Math.round(0.9*archivalThreshold);
+      int numToArchive = Math.min(excessCount, archivalRate);
+      logger.info("Found {} excess profiles. For now, will attempt archiving {} profiles to {}", excessCount
+          , numToArchive, archivePath);
+      try {
+        if (fs.isDirectory(archivePath)) {
+          int archivedCount = 0;
+          archiveWatch.reset().start(); //Clocking
+          while (!pendingArchivalSet.isEmpty()) {
+            String toArchive = pendingArchivalSet.removeOldest() + DRILL_SYS_FILE_SUFFIX;
+            boolean renameStatus = DrillFileSystemUtil.rename(fs, new Path(basePath, toArchive), new Path(archivePath, toArchive));
+            if (!renameStatus) {
+              //Stop attempting any more archiving since other StoreProviders might be archiving
+              logger.error("Move failed for {} from {} to {}", toArchive, basePath.toString(), archivePath.toString());
+              logger.warn("Skip archiving under the assumption that another Drillbit is archiving");
+              break;
+            }
+            archivedCount++;
+          }
+          logger.info("Archived {} profiles to {} in {} ms", archivedCount, archivePath, archiveWatch.stop().elapsed(TimeUnit.MILLISECONDS));
+        } else {
+          logger.error("Unable to archive {} profiles to {}", pendingArchivalSet.size(), archivePath.toString());
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    //Clean up
+    clearPending();
+  }
+
+  /**
+   * Clears the remaining pending profiles
+   */
+  public void clearPending() {
+    this.pendingArchivalSet.clear();
+  }
+
+  /**
+   * Add a profile for archiving
+   * @param profileName
+   * @return youngest profile that will not be archived
+   */
+  public String addProfile(String profileName) {
+    return this.pendingArchivalSet.add(profileName, true);
+  }
+
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStoreArchiver.java
@@ -74,9 +74,9 @@ public class LocalPersistentStoreArchiver {
       int numToArchive = Math.min(excessCount, archivalRate);
       logger.info("Found {} excess profiles. For now, will attempt archiving {} profiles to {}", excessCount
           , numToArchive, archivePath);
+      int archivedCount = 0;
       try {
         if (fs.isDirectory(archivePath)) {
-          int archivedCount = 0;
           archiveWatch.reset().start(); //Clocking
           while (!pendingArchivalSet.isEmpty()) {
             String toArchive = pendingArchivalSet.removeOldest() + DRILL_SYS_FILE_SUFFIX;
@@ -94,7 +94,7 @@ public class LocalPersistentStoreArchiver {
           logger.error("Unable to archive {} profiles to {}", pendingArchivalSet.size(), archivePath.toString());
         }
       } catch (IOException e) {
-        e.printStackTrace();
+        logger.error("Unable to archive profiles to {} ({} successful) due to {}", archivePath.toString(), archivedCount, e.getLocalizedMessage());
       }
     }
     //Clean up

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
@@ -69,7 +69,7 @@ public class ProfileSet implements Iterable<String> {
    */
   public String add(String profile, boolean retainOldest) {
     store.add(profile);
-    if ( size.incrementAndGet() > maxCapacity ) {
+    if (size.incrementAndGet() > maxCapacity) {
       if (retainOldest) {
         return removeYoungest();
       } else {
@@ -136,7 +136,7 @@ public class ProfileSet implements Iterable<String> {
    */
   public void clear(int capacity, boolean forceResize) {
     clear();
-    if (forceResize || capacity > maxCapacity ) {
+    if (forceResize || capacity > maxCapacity) {
       maxCapacity = capacity;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import java.util.Iterator;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Wrapper around TreeSet to mimic a size-bound set ordered by name (implicitly the profiles' age)
+ */
+public class ProfileSet implements Iterable<String> {
+  private TreeSet<String> store;
+  private int maxCapacity;
+  //Using a dedicated counter to avoid
+  private AtomicInteger size;
+
+  @SuppressWarnings("unused")
+  @Deprecated
+  private ProfileSet() {}
+
+  public ProfileSet(int capacity) {
+    this.store = new TreeSet<String>();
+    this.maxCapacity = capacity;
+    this.size = new AtomicInteger();
+  }
+
+  public int size() {
+    return size.get();
+  }
+
+  /**
+   * Get max capacity of the profile set
+   * @return max capacity
+   */
+  public int capacity() {
+    return maxCapacity;
+  }
+
+  /**
+   * Add a profile name to the set, while removing the oldest, if exceeding capacity
+   * @param profile
+   * @return oldest profile
+   */
+  public String add(String profile) {
+    return add(profile, false);
+  }
+
+  /**
+   * Add a profile name to the set, while removing the oldest or youngest, based on flag
+   * @param profile
+   * @param retainOldest indicate retaining policy as oldest
+   * @return youngest/oldest profile
+   */
+  public String add(String profile, boolean retainOldest) {
+    store.add(profile);
+    if ( size.incrementAndGet() > maxCapacity ) {
+      if (retainOldest) {
+        return removeYoungest();
+      } else {
+        return removeOldest();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Remove the oldest profile
+   * @return oldest profile
+   */
+  public String removeOldest() {
+    size.decrementAndGet();
+    return store.pollLast();
+  }
+
+  /**
+   * Remove the youngest profile
+   * @return youngest profile
+   */
+  public String removeYoungest() {
+    size.decrementAndGet();
+    return store.pollFirst();
+  }
+
+  /**
+   * Retrieve the oldest profile without removal
+   * @return oldest profile
+   */
+  public String getOldest() {
+    return store.last();
+  }
+
+  /**
+   * Retrieve the youngest profile without removal
+   * @return youngest profile
+   */
+  public String getYoungest() {
+    return store.first();
+  }
+
+  /**
+   * Clear the set
+   */
+  public void clear() {
+    size.set(0);
+    store.clear();
+  }
+
+  /**
+   * Clear the set with the initial capacity
+   * @param capacity
+   */
+  public void clear(int capacity) {
+    clear(maxCapacity, false);
+  }
+
+  /**
+   * Clear the set with the initial capacity
+   * @param capacity
+   * @param forceResize
+   */
+  public void clear(int capacity, boolean forceResize) {
+    clear();
+    if (forceResize || capacity > maxCapacity ) {
+      maxCapacity = capacity;
+    }
+  }
+
+  public boolean isEmpty() {
+    return store.isEmpty();
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    return store.iterator();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -43,6 +43,8 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
   // This flag is used in testing. Ideally, tests should use a specific PersistentStoreProvider that knows
   // how to handle this flag.
   private final boolean enableWrite;
+  //Config reference for archiving
+  private final DrillConfig drillConfig;
 
   public LocalPersistentStoreProvider(final PersistentStoreRegistry<?> registry) throws StoreException {
     this(registry.getConfig());
@@ -50,6 +52,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
 
   public LocalPersistentStoreProvider(final DrillConfig config) throws StoreException {
     this.path = new Path(config.getString(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH));
+    this.drillConfig = config;
     this.enableWrite = config.getBoolean(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE);
     try {
       this.fs = LocalPersistentStore.getFileSystem(config, path);
@@ -64,7 +67,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
     case BLOB_PERSISTENT:
     case PERSISTENT:
       if (enableWrite) {
-        return new LocalPersistentStore<>(fs, path, storeConfig);
+        return new LocalPersistentStore<>(fs, path, storeConfig, drillConfig);
       }
       return new NoWriteLocalStore<>();
     default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/DrillFileSystemUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/DrillFileSystemUtil.java
@@ -88,4 +88,16 @@ public class DrillFileSystemUtil {
     return FileSystemUtil.listAll(fs, path, recursive, FileSystemUtil.mergeFilters(DRILL_SYSTEM_FILTER, filters));
   }
 
+  /**
+   * Returns the status of a file/directory specified in source path to be renamed/moved to a destination path
+   *
+   * @param fs current file system
+   * @param src path to source
+   * @param dst path to destination
+   * @return status of rename/move
+   */
+  public static boolean rename(FileSystem fs, Path src, Path dst) throws IOException {
+    return FileSystemUtil.rename(fs, src, dst);
+  }
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/FileSystemUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/FileSystemUtil.java
@@ -136,6 +136,18 @@ public class FileSystemUtil {
   }
 
   /**
+   * Helper method that will rename/move file specified in the source path to a destination path
+   *
+   * @param fs current file system
+   * @param src path to source
+   * @param dst path to destination
+   * @return status of rename/move
+   */
+  public static boolean rename(FileSystem fs, Path src, Path dst) throws IOException {
+    return fs.rename(src, dst);
+  }
+
+  /**
    * Helper method that will store in given holder statuses of all directories present in given path applying custom filter.
    * If recursive flag is set to true, will call itself recursively to add statuses of nested directories.
    *

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -185,7 +185,11 @@ drill.exec: {
   },
   profiles.store: {
     inmemory: false,
-    capacity: 1000
+    capacity: 1000,
+    archive: {
+      enabled: false,
+      rate: 1000
+    }
   },
   impersonation: {
     enabled: false,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
@@ -116,7 +116,7 @@ public class TestProfileSet {
       assertEquals(null, poppedProfile);
     }
 
-    assert(testSet.size() == initCapacity);
+    assertEquals(initCapacity, testSet.size());
 
     //Testing No Excess by looking at oldest popped
     for (int i = initCapacity; i < finalCapacity; i++) {
@@ -124,7 +124,7 @@ public class TestProfileSet {
       assertEquals(null, poppedProfile);
     }
 
-    assert(testSet.size() == finalCapacity);
+    assertEquals(finalCapacity, testSet.size());
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.exec.store.sys.store.ProfileSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test the size-constrained ProfileSet for use in the webserver's '/profiles' listing
+ */
+public class TestProfileSet {
+  private final static String PROFILE_PREFIX = "t35t-pr0fil3-";
+  static int initCapacity;
+  static int finalCapacity;
+  static int storeCount;
+  static Random rand;
+  static List<String> masterList;
+
+  @BeforeClass
+  public static void setupProfileSet() {
+    initCapacity = 50;
+    finalCapacity = 70;
+    storeCount = 100;
+    rand = new Random();
+    //Generating source list of storeCount # 'profiles'
+    masterList = new LinkedList<String>();
+    for (int i = 0; i < storeCount; i++) {
+      masterList.add(PROFILE_PREFIX + StringUtils.leftPad(String.valueOf(i), String.valueOf(storeCount).length(), '0'));
+    }
+  }
+
+  @Test
+  public void testProfileOrder() throws Exception {
+    //clone initial # profiles and verify via iterator.
+    ProfileSet testSet = new ProfileSet(initCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assert (poppedProfile == null);
+      assertEquals(null, poppedProfile);
+    }
+
+    //Testing order
+    String prevProfile = null;
+    while (!testSet.isEmpty()) {
+      String currOldestProfile = testSet.removeOldest();
+      if (prevProfile != null) {
+        assertTrue( prevProfile.compareTo(currOldestProfile) > 0 );
+      }
+      prevProfile = currOldestProfile;
+    }
+  }
+
+  //Test if inserts exceeding capacity leads to eviction of oldest
+  @Test
+  public void testExcessInjection() throws Exception {
+    //clone initial # profiles and verify via iterator.
+    ProfileSet testSet = new ProfileSet(initCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    //Testing Excess by looking at oldest popped
+    for (int i = initCapacity; i < finalCapacity; i++) {
+      String toInsert = srcList.remove(rand.nextInt(storeCount - i));
+      String expectedToPop = ( toInsert.compareTo(testSet.getOldest()) > 0 ?
+          toInsert : testSet.getOldest() );
+
+      String oldestPoppedProfile = testSet.add(toInsert);
+      assertEquals(expectedToPop, oldestPoppedProfile);
+    }
+
+    assertEquals(initCapacity, testSet.size());
+  }
+
+  //Test if size internally resizes to final capacity with no evictions
+  @Test
+  public void testSetResize() throws Exception {
+    //clone initial # profiles into a 700-capacity set.
+    ProfileSet testSet = new ProfileSet(finalCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    assert(testSet.size() == initCapacity);
+
+    //Testing No Excess by looking at oldest popped
+    for (int i = initCapacity; i < finalCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    assert(testSet.size() == finalCapacity);
+  }
+
+}


### PR DESCRIPTION
_**Note:** Closed the old PR #755 and opening this._

When Drill is displaying profiles stored on the file system (Local or Distributed), it does so by loading the entire list of `.sys.drill` files in the profile directory, sorting and deserializing. This can get expensive, since only a single CPU thread does this.
As an example, a directory of 120K profiles, the time to just fetch the list of files alone is over 6 seconds. After that, based on the number of profiles being rendered, the time varies. An average of 30ms is needed to deserialize a standard profile, which translates to an additional 3sec for therendering of default 100 profiles.

A user reported issue confirms just that:
DRILL-5028 Opening profiles page from web ui gets very slow when a lot of history files have been stored in HDFS or Local FS

Additional JIRAs filed ask for managing these profiles
DRILL-2362 Drill should manage Query Profiling archiving
DRILL-2861 enhance drill profile file management

This PR brings the following enhancements to achieve that:
1. Mimick the In-memory persistence of profiles (DRILL-5481), by keeping only a predefined `max-capacity` number of profiles in the directory and moving the oldest to an 'archived' sub-directory.
2. Improve loading times by pinning the deserialized list in memory (TreeSet; for maintaining a memory-efficient sortedness of the profiles). That way, if we do not detect any new profiles in the profileStore (i.e. profile directory) since the last time a web-request for rendering the profiles was made, we can re-serve the same listing and skip making a trip to the filesystem to re-fetch all the profiles.

Reload & reconstruction of the profiles in the Tree is done in the event of any of the following states changing:
  i.   Modification Time of profile dir
  ii.  Number of profiles in the profile dir
  iii. Number of profiles requested exceeds existing the currently available list

3. When 2 or more web-requests for rendering arrive, the WebServer code already processes the requests sequentially. As a result, the earliest request will trigger the reconstruction of the in-memory profile-set, and the last-modified timestamp of the profileStore is tracked. This way, the remaining blocked requests can re-use the freshly-reconstructed profile-set for rendering if the underlying profileStore has not been modified. There is an assumption made here that the rate of profiles being added to the profileStore is not too high to trigger a reconstruction for every queued up request. 
4. To prevent frequent archiving, there is a threshold (max-capacity) defined for triggering the archive. However, the number of profiles archived is selected to ensure that the profiles not archived is 90% of the threshold.
5. To prevent the archiving process from taking too long, an archival rate (`drill.exec.profiles.store.archive.rate`) is defined so that upto that many number of profiles are archived in one go, before resumption of re-rendering takes place.
6. On a Distributed FileSystem (e.g. HDFS), multiple Drillbits might attempt to archive. To mitigate that, if a Drillbit detects that it is unable to archive a profile, it will assume that another Drillbit is also archiving, and stop archiving any more.