### PR TITLE
DRILL-6410: Fixed memory leak in flat Parquet reader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -17,17 +17,15 @@
  */
 package org.apache.drill.exec.server;
 
-import com.codahale.metrics.MetricRegistry;
-import io.netty.channel.EventLoopGroup;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.SynchronousQueue;
+
 import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.KerberosUtil;
 import org.apache.drill.common.config.DrillConfig;
@@ -43,9 +41,14 @@ import org.apache.drill.exec.rpc.TransportCheck;
 import org.apache.drill.exec.rpc.security.AuthenticatorProvider;
 import org.apache.drill.exec.rpc.security.AuthenticatorProviderImpl;
 import org.apache.drill.exec.server.options.OptionDefinition;
+import org.apache.drill.exec.util.ExecutorServiceUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import com.codahale.metrics.MetricRegistry;
+
+import io.netty.channel.EventLoopGroup;
 
 public class BootStrapContext implements AutoCloseable {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BootStrapContext.class);
@@ -109,9 +112,9 @@ public class BootStrapContext implements AutoCloseable {
         MIN_SCAN_THREADPOOL_SIZE > numScanThreads ? MIN_SCAN_THREADPOOL_SIZE : numScanThreads;
     final int scanDecodeThreadPoolSize =
         (numCores + 1) / 2 > numScanDecodeThreads ? (numCores + 1) / 2 : numScanDecodeThreads;
-    this.scanExecutor = Executors.newFixedThreadPool(scanThreadPoolSize, new NamedThreadFactory("scan-"));
+    this.scanExecutor = ExecutorServiceUtil.newFixedThreadPool(scanThreadPoolSize, new NamedThreadFactory("scan-"));
     this.scanDecodeExecutor =
-        Executors.newFixedThreadPool(scanDecodeThreadPoolSize, new NamedThreadFactory("scan-decode-"));
+      ExecutorServiceUtil.newFixedThreadPool(scanDecodeThreadPoolSize, new NamedThreadFactory("scan-decode-"));
   }
 
   private void login(final DrillConfig config) throws DrillbitStartupException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/AsyncPageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/AsyncPageReader.java
@@ -297,11 +297,11 @@ class AsyncPageReader extends PageReader {
     while (asyncPageRead != null && !asyncPageRead.isEmpty()) {
       try {
         Future<Void> f = asyncPageRead.poll();
-        if(!f.isDone() && !f.isCancelled()){
+        if(!f.isDone() && !f.isCancelled()) {
           f.cancel(true);
-        } else {
-          f.get(1, TimeUnit.MILLISECONDS);
         }
+        // The framework guarantees a blocking version of FutureTask cancellation. At this time we are
+        // guaranteed the task is not running (or will not be able to run).
       } catch (RuntimeException e) {
         // Do Nothing
       } catch (Exception e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/ExecutorServiceUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/ExecutorServiceUtil.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.util;
+
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.util.ConcurrentHashSet;
+
+/** Utility class to enhance the Java {@link ExecutorService} class functionality */
+public final class ExecutorServiceUtil {
+
+  /**
+   * Instantiate an {@link java.util.concurrent.ExecutorService} instance with the ability to block
+   * when the {@link FutureTask#cancel(boolean)} method is called with the "mayInterruptIfRunning" parameter
+   * set to true.
+   *
+   * @see {@link java.util.concurrent.Executors#newFixedThreadPool(int)}
+   */
+  public static ExecutorService newFixedThreadPool(int nThreads) {
+
+    return new CustomThreadPoolExecutor(nThreads,
+      nThreads,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<Runnable>());
+  }
+
+  /**
+   * Instantiate an {@link java.util.concurrent.ExecutorService} instance with the ability to block
+   * when the {@link FutureTask#cancel(boolean)} method is called with the "mayInterruptIfRunning" parameter
+   * set to true.
+   *
+   * @see {@link java.util.concurrent.Executors#newFixedThreadPool(int, ThreadFactory)}
+   */
+  public static ExecutorService newFixedThreadPool(int nThreads, ThreadFactory threadFactory) {
+
+    return new CustomThreadPoolExecutor(nThreads,
+      nThreads,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<Runnable>(),
+      threadFactory);
+  }
+
+
+// ----------------------------------------------------------------------------
+// Local Implementation
+// ----------------------------------------------------------------------------
+
+  /** Disabling object instantiation */
+  private ExecutorServiceUtil() {
+  }
+
+
+// ----------------------------------------------------------------------------
+// Inner classes
+// ----------------------------------------------------------------------------
+
+  /** Customizing the {@link ThreadPoolExecutor} class to expose a blocking version of task cancellation */
+  private static final class CustomThreadPoolExecutor extends ThreadPoolExecutor {
+
+    private CustomThreadPoolExecutor(int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue) {
+
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    private CustomThreadPoolExecutor(int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      ThreadFactory threadFactory) {
+
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+
+    private CustomThreadPoolExecutor(int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      RejectedExecutionHandler handler) {
+
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    private CustomThreadPoolExecutor(int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      ThreadFactory threadFactory,
+      RejectedExecutionHandler handler) {
+
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+      return new CustomFutureTask<T>(runnable, value);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
+      return new CustomFutureTask<T>(callable);
+    }
+  }
+
+  /**
+   * Extends the {@link FutureTask#cancel(boolean)} method behavior by blocking the cancel call
+   * when the "mayInterruptIfRunning" parameter is set.
+   */
+  private static final class CustomFutureTask<V> extends FutureTask<V> {
+    // Captures task's execution state
+    private enum STATE {
+      NOT_RUNNING,
+      RUNNING,
+      DONE
+    };
+
+    /** Enables us to figure out the true running state of this task */
+    private volatile STATE state                       = STATE.NOT_RUNNING;
+    private final AtomicReference<Thread> runnerThread = new AtomicReference<>(null);
+    private final Object monitor                       = new Object();
+    private final Set<Thread> interruptingThreads      = new ConcurrentHashSet<>();
+
+
+    private CustomFutureTask(Callable<V> callable) {
+      super(callable);
+    }
+
+    private CustomFutureTask(Runnable runnable, V result) {
+      super(runnable, result);
+    }
+
+    @Override
+    public void run() {
+      // Prevents concurrent invocation of the run method
+      if (!runnerThread.compareAndSet(null, Thread.currentThread())) {
+        return;
+      }
+
+      state = STATE.RUNNING;
+
+      try {
+        super.run();
+      } finally {
+        state = STATE.DONE;
+
+        // Optimization: no need to notify if the state is not "cancelled"
+        if (isCancelled()) {
+          synchronized (monitor) {
+            monitor.notifyAll();
+          }
+        }
+        runnerThread.set(null);
+      }
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      if (mayInterruptIfRunning) {
+        interruptingThreads.add(Thread.currentThread());
+      }
+      return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    protected void done() {
+
+      // ALGORITHM - referring to the parent state unless otherwise noted
+      //
+      // - done() is called implies that the parent's state is different than NEW
+      // - If the state is not cancelled, implies the task is done from running; note that cancellation is
+      //   not possible anymore (can only happen if the state was NEW)
+      // - Otherwise, the state is cancelled and only the cancel thread can invoke this method
+      // - The cancel thread will check whether it needs to block waiting:
+      //   a) In case it has requested interruption of the future task
+      //   b) The task is still running
+      // - If wait is granted, then it will block as long as the task is running
+
+      // Note: the cancel thread interrupt flag is preserved
+
+      if (!isCancelled()) {
+        return; // NOOP
+      }
+
+      // At this point we know we are dealing with the cancel thread
+
+      if (shouldWait()) {
+        // Save the current interrupted flag and clear it to allow wait operations
+        boolean interrupted = Thread.interrupted();
+
+        try {
+          synchronized (monitor) {
+            while (isRunning()) {
+              try {
+                monitor.wait();
+              } catch (InterruptedException e) {
+                interrupted = true;
+              }
+            }
+          }
+        } finally {
+          if (interrupted) {
+            Thread.currentThread().interrupt();
+          }
+        }
+      }
+    }
+
+    private boolean shouldWait() {
+      return isRunning()                                         // The task is currently executing
+        && interruptingThreads.contains(Thread.currentThread()); // the cancel thread wishes to interrupt this task
+    }
+
+    private boolean isRunning() {
+      return state == STATE.RUNNING;
+    }
+
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestCustomExecutorService.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestCustomExecutorService.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.drill.test.DrillTest;
+import org.junit.Test;
+
+public class TestCustomExecutorService extends DrillTest {
+
+  @Test
+  public void testSuccessfulExecution() throws Exception {
+    final int numThreads            = 2;
+    final int numTasks              = 20;
+    ExecutorService service         = ExecutorServiceUtil.newFixedThreadPool(numThreads);
+    List<RequestContainer> requests = new ArrayList<>(numTasks);
+
+    // Set the test parameters (using the default values)
+    TestParams params = new TestParams();
+
+    // Launch the tasks
+    for (int idx = 0; idx < numTasks; idx++) {
+      CallableTask task         = new CallableTask(params);
+      Future<TaskResult> future = service.submit(task);
+
+      requests.add(new RequestContainer(future, task));
+    }
+
+    int numSuccess  = 0;
+
+    // Wait for the tasks to finish
+    for (int idx = 0; idx < numTasks; idx++) {
+      RequestContainer request = requests.get(idx);
+
+      try {
+        TaskResult result = request.future.get();
+        assertNotNull(result);
+
+        if (result.isSuccess()) {
+          ++numSuccess;
+        }
+      } catch (Exception e) {
+        // NOOP
+      }
+    }
+
+    assertEquals(numTasks, numSuccess);
+  }
+
+  @Test
+  public void testFailedExecution() throws Exception {
+    final int numThreads            = 2;
+    final int numTasks              = 20;
+    ExecutorService service         = ExecutorServiceUtil.newFixedThreadPool(numThreads);
+    List<RequestContainer> requests = new ArrayList<>(numTasks);
+
+    // Set the test parameters
+    TestParams params        = new TestParams();
+    params.generateException = true;
+
+    // Launch the tasks
+    for (int idx = 0; idx < numTasks; idx++) {
+      CallableTask task         = new CallableTask(params);
+      Future<TaskResult> future = service.submit(task);
+
+      requests.add(new RequestContainer(future, task));
+    }
+
+    int numSuccess  = 0;
+    int numFailures = 0;
+
+    // Wait for the tasks to finish
+    for (int idx = 0; idx < numTasks; idx++) {
+      RequestContainer request = requests.get(idx);
+
+      try {
+        TaskResult result = request.future.get();
+        assertNotNull(result);
+
+        if (result.isSuccess()) {
+          ++numSuccess;
+        }
+      } catch (Exception e) {
+        assertTrue(request.task.result.isFailed());
+        ++numFailures;
+      }
+    }
+
+    assertEquals(0, numSuccess);
+    assertEquals(numTasks, numFailures);
+  }
+
+  @Test
+  public void testMixedExecution() throws Exception {
+    final int numThreads            = 2;
+    final int numTasks              = 20;
+    ExecutorService service         = ExecutorServiceUtil.newFixedThreadPool(numThreads);
+    List<RequestContainer> requests = new ArrayList<>(numTasks);
+
+    // Set the test parameters
+    TestParams successParams = new TestParams();
+    TestParams failedParams  = new TestParams();
+    failedParams.generateException = true;
+
+    int expNumFailedTasks  = 0;
+    int expNumSuccessTasks = 0;
+
+    // Launch the tasks
+    for (int idx = 0; idx < numTasks; idx++) {
+      CallableTask task = null;
+
+      if (idx % 2 == 0) {
+        task = new CallableTask(successParams);
+        ++expNumSuccessTasks;
+      } else {
+        task = new CallableTask(failedParams);
+        ++expNumFailedTasks;
+      }
+
+      Future<TaskResult> future = service.submit(task);
+      requests.add(new RequestContainer(future, task));
+    }
+
+    int numSuccess  = 0;
+    int numFailures = 0;
+
+    // Wait for the tasks to finish
+    for (int idx = 0; idx < numTasks; idx++) {
+      RequestContainer request = requests.get(idx);
+
+      try {
+        TaskResult result = request.future.get();
+        assertNotNull(result);
+
+        if (result.isSuccess()) {
+          ++numSuccess;
+        }
+      } catch (Exception e) {
+        assertTrue(request.task.result.isFailed());
+        ++numFailures;
+      }
+    }
+
+    assertEquals(expNumSuccessTasks, numSuccess);
+    assertEquals(expNumFailedTasks, numFailures);
+  }
+
+  @Test
+  public void testCancelExecution() throws Exception {
+    final int numThreads     = 2;
+    ExecutorService service  = ExecutorServiceUtil.newFixedThreadPool(numThreads);
+    RequestContainer request = null;
+
+    // Set the test parameters
+    TestParams params = new TestParams();
+    params.controller = new TaskExecutionController();
+
+    // Launch the task
+    CallableTask task         = new CallableTask(params);
+    Future<TaskResult> future = service.submit(task);
+    request                   = new RequestContainer(future, task);
+
+    // Allow the task to start
+    params.controller.start();
+    params.controller.hasStarted();
+
+    // Allow the task to exit but with a delay so that we can test the blocking nature of "cancel"
+    params.controller.delayMillisOnExit = 50;
+    params.controller.exit();
+
+    // Cancel the task
+    boolean result = request.future.cancel(true);
+
+    if (result) {
+      // We were able to cancel this task; let's make sure that it is done now that are
+      // unblocked
+      assertTrue(task.result.isCancelled());
+
+    } else {
+      // Cancellation could't happen most probably because this thread got context switched for
+      // for a long time (should be rare); let's make sure the task is done and successful
+      assertTrue(task.result.isSuccess());
+    }
+  }
+
+
+
+// ----------------------------------------------------------------------------
+// Internal Classes
+// ----------------------------------------------------------------------------
+
+  @SuppressWarnings("unused")
+  private static final class TaskResult {
+
+    private enum ExecutionStatus {
+      NOT_STARTED,
+      RUNNING,
+      SUCCEEDED,
+      FAILED,
+      CANCELLED
+    };
+
+    private ExecutionStatus status;
+
+    TaskResult() {
+      status = ExecutionStatus.NOT_STARTED;
+    }
+
+    private boolean isSuccess() {
+      return status.equals(ExecutionStatus.SUCCEEDED);
+    }
+
+    private boolean isFailed() {
+      return status.equals(ExecutionStatus.FAILED);
+    }
+
+    private boolean isCancelled() {
+      return status.equals(ExecutionStatus.CANCELLED);
+    }
+
+    private boolean isFailedOrCancelled() {
+      return status.equals(ExecutionStatus.CANCELLED)
+        || status.equals(ExecutionStatus.FAILED);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static final class TaskExecutionController {
+    private boolean canStart      = false;
+    private boolean canExit       = false;
+    private boolean started       = false;
+    private boolean exited        = false;
+    private int delayMillisOnExit = 0;
+    private Object monitor   = new Object();
+
+    private void canStart() {
+      synchronized(monitor) {
+        while (!canStart) {
+          try {
+            monitor.wait();
+          } catch (InterruptedException ie) {
+            // NOOP
+          }
+        }
+        started = true;
+        monitor.notify();
+      }
+    }
+
+    private void canExit() {
+      synchronized(monitor) {
+        while (!canExit) {
+          try {
+            monitor.wait();
+          } catch (InterruptedException ie) {
+            // NOOP
+          }
+        }
+      }
+
+      // Wait requested delay time before exiting
+      for (int i = 0; i < delayMillisOnExit; i++) {
+        try {
+          Thread.sleep(1); // sleep 1 ms
+        } catch (InterruptedException ie) {
+          // NOOP
+        }
+      }
+
+      synchronized(monitor) {
+        exited = true;
+        monitor.notify();
+      }
+    }
+
+    private void start() {
+      synchronized(monitor) {
+        canStart = true;
+        monitor.notify();
+      }
+    }
+
+    private void exit() {
+      synchronized(monitor) {
+        canExit = true;
+        monitor.notify();
+      }
+    }
+
+    private void hasStarted() {
+      synchronized(monitor) {
+        while (!started) {
+          try {
+            monitor.wait();
+          } catch (InterruptedException ie) {
+            // NOOP
+          }
+        }
+      }
+    }
+
+    private void hasExited() {
+      synchronized(monitor) {
+        while (!exited) {
+          try {
+            monitor.wait();
+          } catch (InterruptedException ie) {
+            // NOOP
+          }
+        }
+      }
+    }
+
+  }
+
+  private static final class TestParams {
+    private int waitTimeMillis                 = 2;
+    private boolean generateException          = false;
+    private TaskExecutionController controller = null;
+  }
+
+  private static final class CallableTask implements Callable<TaskResult> {
+    private volatile TaskResult result = new TaskResult();
+    private final TestParams params;
+
+    private CallableTask(TestParams params) {
+      this.params = params;
+    }
+
+    @Override
+    public TaskResult call() throws Exception {
+
+      beforeStart();
+
+      result.status       = TaskResult.ExecutionStatus.RUNNING;
+      boolean interrupted = false;
+      Exception exc       = null;
+
+      try {
+        for (int i = 0; i < params.waitTimeMillis; i++) {
+          try {
+            Thread.sleep(1); // sleep 1 ms
+          } catch (InterruptedException ie) {
+            interrupted = true;
+          }
+        }
+
+        if (params.generateException) {
+          throw new RuntimeException("Test emulated exception..");
+        }
+
+      } catch (Exception e) {
+        exc = e;
+        throw e;
+
+      } finally {
+        beforeExit();
+
+        if (interrupted) {
+          result.status = TaskResult.ExecutionStatus.CANCELLED;
+        } else if (exc != null) {
+          result.status = TaskResult.ExecutionStatus.FAILED;
+        } else {
+          result.status = TaskResult.ExecutionStatus.SUCCEEDED;
+        }
+      }
+      return result;
+    }
+
+    private void beforeStart() {
+      if (params.controller != null) {
+        params.controller.canStart();
+      }
+    }
+
+    private void beforeExit() {
+      if (params.controller != null) {
+        params.controller.canExit();
+      }
+    }
+  }
+
+  private static final class RequestContainer {
+    private final Future<TaskResult> future;
+    private final CallableTask task;
+
+    private RequestContainer(Future<TaskResult> future, CallableTask task) {
+      this.future = future;
+      this.task   = task;
+    }
+  }
+
+}


### PR DESCRIPTION
**Problem Description**
- Occasionally, a memory leak is observed within the Parquet reader (flat) when query cancellation is invoked
- I tried to fix this leak in a previous attempt but it seems it is still happening
- Thus far, only QA have been able to observe this issue (and only occasionally)

**Analysis**
- There was a recent breakthrough which gives me hope for addressing this issue 
- The leak logged two piece of information: leak size and state of the child allocator
- The state of the child allocator indicated no leak (all allocated bytes were released)
- After code examination, it occurred to me this was happening because the Asynchronous Page Reader task was releasing the Drill buffer while the scan thread was closing the allocator
- The code attempts to cancel asynchronous tasks and then release allocated buffers, though there is one big caveat: the Java FutureTask.cancel(true) doesn't block during the cancellation process; this method **merely interrupts the asynchronous task** and proceeds
- This means if the asynchronous thread was context switched or doing computation (not blocked waiting), then the fragment cleanup logic can close the allocator before all resources have been released

**Fix**
- The Java ThreadPoolExecutor and FutureTask have few extension points to enhance the task termination process
- Created a new utility class which can create an ExecutorService with the ability to block during future cancellation
- Blocking will happen only when the cancel method is allowed to interrupt the asynchronous task
- Note that there shouldn't be any performance degradation as synchronization code was added only to cover the cancel path
- Also added a new test-suite to test the correctness of this new utility


