### PR TITLE
DRILL-6389: Generate Javadoc for all classes and fix some warnings.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -120,6 +120,11 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Creating a test artifact because javadoc needs to be able to find test classes -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>

--- a/common/src/main/java/org/apache/drill/common/DrillAutoCloseables.java
+++ b/common/src/main/java/org/apache/drill/common/DrillAutoCloseables.java
@@ -28,13 +28,13 @@ public class DrillAutoCloseables {
   }
 
   /**
-   * close() an {@see java.lang.AutoCloseable} without throwing a (checked)
-   * {@see java.lang.Exception}. This wraps the close() call with a
+   * close() an {@link java.lang.AutoCloseable} without throwing a (checked)
+   * {@link java.lang.Exception}. This wraps the close() call with a
    * try-catch that will rethrow an Exception wrapped with a
-   * {@see java.lang.RuntimeException}, providing a way to call close()
+   * {@link java.lang.RuntimeException}, providing a way to call close()
    * without having to do the try-catch everywhere or propagate the Exception.
    *
-   * @param closeable the AutoCloseable to close; may be null
+   * @param autoCloseable the AutoCloseable to close; may be null
    * @throws RuntimeException if an Exception occurs; the Exception is
    *   wrapped by the RuntimeException
    */

--- a/common/src/main/java/org/apache/drill/common/scanner/ClassPathScanner.java
+++ b/common/src/main/java/org/apache/drill/common/scanner/ClassPathScanner.java
@@ -75,13 +75,13 @@ import javassist.bytecode.annotation.StringMemberValue;
 
 /**
  * Classpath scanning utility.
- * The classpath should be scanned once at startup from a DrillConfig instance. {@see ClassPathScanner#fromPrescan(DrillConfig)}
+ * The classpath should be scanned once at startup from a DrillConfig instance. {@link ClassPathScanner#fromPrescan(DrillConfig)}
  * The DrillConfig provides:
- *  - the list of packages to scan. (drill.classpath.scanning.packages) {@see CommonConstants#IMPLEMENTATIONS_SCAN_PACKAGES}
- *  - the list of base classes to scan for implementations. (drill.classpath.scanning.base.classes) {@see CommonConstants#IMPLEMENTATIONS_SCAN_CLASSES}
- *  - the list of annotations to scan for. (drill.classpath.scanning.annotations) {@see CommonConstants#IMPLEMENTATIONS_SCAN_ANNOTATIONS}
+ *  - the list of packages to scan. (drill.classpath.scanning.packages) {@link ClassPathScanner#IMPLEMENTATIONS_SCAN_PACKAGES}
+ *  - the list of base classes to scan for implementations. (drill.classpath.scanning.base.classes) {@link ClassPathScanner#IMPLEMENTATIONS_SCAN_CLASSES}
+ *  - the list of annotations to scan for. (drill.classpath.scanning.annotations) {@link ClassPathScanner#IMPLEMENTATIONS_SCAN_ANNOTATIONS}
  * Only the class directories and jars containing a drill-module.conf will be scanned.
- * Drill core packages are scanned at build time and the result is saved in a JSON file. {@see ClassPathScanner#FUNCTION_REGISTRY_FILE}
+ * Drill core packages are scanned at build time and the result is saved in a JSON file.
  * At runtime only the locations that have not been scanned yet will be scanned.
  */
 public final class ClassPathScanner {

--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>3.3.0</version>
+      <version>${curator.test.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/contrib/storage-kudu/src/main/codegen/templates/KuduRecordWriter.java
+++ b/contrib/storage-kudu/src/main/codegen/templates/KuduRecordWriter.java
@@ -17,23 +17,6 @@
  */
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="org/apache/drill/exec/store/kudu/KuduRecordWriter.java" />
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package org.apache.drill.exec.store.kudu;
 
@@ -101,8 +84,8 @@ public abstract class KuduRecordWriter extends AbstractRecordWriter implements R
   <#list vv.types as type>
     <#list type.minor as minor>
       <#list vv.modes as mode>
-      
-        <#if mode.prefix == "Repeated" || 
+
+        <#if mode.prefix == "Repeated" ||
         minor.class == "TinyInt" ||
         minor.class == "UInt1" ||
         minor.class == "UInt2" ||
@@ -116,31 +99,31 @@ public abstract class KuduRecordWriter extends AbstractRecordWriter implements R
         minor.class == "Decimal38Sparse" ||
         minor.class?contains("Interval")
         >
-        
+
         <#else>
           @Override
           public FieldConverter getNew${mode.prefix}${minor.class}Converter(int fieldId, String fieldName, FieldReader reader) {
             return new ${mode.prefix}${minor.class}KuduConverter(fieldId, fieldName, reader);
           }
-      
+
           public class ${mode.prefix}${minor.class}KuduConverter extends FieldConverter {
             private Nullable${minor.class}Holder holder = new Nullable${minor.class}Holder();
-      
+
             public ${mode.prefix}${minor.class}KuduConverter(int fieldId, String fieldName, FieldReader reader) {
               super(fieldId, fieldName, reader);
             }
-      
+
             @Override
             public void writeField() throws IOException {
-         
+
           <#if mode.prefix == "Nullable" >
             if (!reader.isSet()) {
               return;
             }
           </#if>
-          
+
             reader.read(holder);
-            
+
             <#if minor.class == "Float4">
               row.addFloat(fieldId, holder.value);
             <#elseif minor.class == "TimeStamp">

--- a/contrib/storage-opentsdb/pom.xml
+++ b/contrib/storage-opentsdb/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>2.5.1</version>
+            <version>${wiremock.standalone.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/docs/dev/DevDocs.md
+++ b/docs/dev/DevDocs.md
@@ -11,3 +11,7 @@ For information about how to do integration and unit testing in Drill see [Testi
 ## License Headers
 
 For more information about working with license headers see [LicenseHeaders.md](LicenseHeaders.md)
+
+## Javadocs
+
+For more info about generating and using javadocs see [Javadocs.md](Javadocs.md)

--- a/docs/dev/Javadocs.md
+++ b/docs/dev/Javadocs.md
@@ -1,0 +1,20 @@
+# Javadocs
+
+## Building
+
+ 1. Make sure you are in drill's root project directory.
+ 1. Build the project:
+    ```
+    mvn -T 1C clean install -DskipTests
+    ```
+ 1. Run:
+    ```
+    mvn javadoc:aggregate
+    ```
+ 1. The javadocs are generated and stored in `target/site/apidocs`.
+
+## Viewing In IntelliJ
+
+ 1. Go to `target/set/apidocs/index.html` in IntelliJ's project view.
+ 2. Right click on `target/set/apidocs/index.html`
+ 3. Select **Open in Browser**.

--- a/drill-yarn/pom.xml
+++ b/drill-yarn/pom.xml
@@ -43,7 +43,7 @@
          </configuration>
       </plugin>
         <!-- See http://stackoverflow.com/questions/31173467/maven-cannot-find-git-dotgitdirectory -->
-  <!-- 
+  <!--
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
@@ -65,7 +65,7 @@
      -->
     </plugins>
   </build>
-  
+
   <dependencies>
 
     <!-- For YARN client. -->
@@ -75,7 +75,7 @@
       <artifactId>hadoop-yarn-api</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
     <!--  Included as a reference because this seems to be the only
           way to pick up profile-specific jars. -->
 
@@ -116,7 +116,7 @@
       <version>1.0.13</version>
       <scope>test</scope>
     </dependency>
-    
+
     <!--  Testing -->
     <dependency>
       <groupId>org.apache.drill</groupId>
@@ -132,7 +132,7 @@
 	   <dependency>
 	      <groupId>org.apache.curator</groupId>
 	      <artifactId>curator-test</artifactId>
-	      <version>2.7.1</version>
+	      <version>${curator.test.version}</version>
 	      <scope>test</scope>
 	      <exclusions>
           <exclusion>

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/ClusterController.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/ClusterController.java
@@ -62,7 +62,6 @@ public interface ClusterController extends RegistryHandler {
    *
    * @param containers
    *          the set of containers provided by YARN
-   * @return the set of tasks to launch
    */
 
   void containersAllocated(List<Container> containers);
@@ -146,8 +145,6 @@ public interface ClusterController extends RegistryHandler {
    * Called by the main thread to wait for the normal shutdown of the
    * controller. Such shutdown occurs when the admin sends a sutdown
    * command from the UI or REST API.
-   *
-   * @return
    */
 
   boolean waitForCompletion();
@@ -176,8 +173,6 @@ public interface ClusterController extends RegistryHandler {
   /**
    * Return the target number of tasks that the controller seeks to maintain.
    * This is the sum across all pools.
-   *
-   * @return
    */
 
   int getTargetCount();
@@ -190,14 +185,13 @@ public interface ClusterController extends RegistryHandler {
    * when reducing cluster size.
    *
    * @param id
-   * @return
    */
 
   boolean cancelTask(int id);
 
   /**
    * Whether this distribution of YARN supports disk resources.
-   * @return
+   * @return True if this distribution of YARN supports disk resources. False otherwise.
    */
 
   boolean supportsDiskResource();

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/ClusterControllerImpl.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/ClusterControllerImpl.java
@@ -311,7 +311,7 @@ public class ClusterControllerImpl implements ClusterController {
    * This approximation <b>does not</b> consider whether the node
    * has sufficient resources to run a task; only whether the node
    * itself exists.
-   * @return
+   * @return The approximate number of free YARN nodes.
    */
 
   @Override

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/PersistentTaskScheduler.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/PersistentTaskScheduler.java
@@ -79,7 +79,7 @@ public abstract class PersistentTaskScheduler extends AbstractScheduler {
    * running tasks to target level. Thus, a persistent cluster
    * will normally report 100% progress.
    *
-   * @return
+   * @return The progress of persistent tasks.
    */
 
   @Override

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/Scheduler.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/Scheduler.java
@@ -72,8 +72,6 @@ public interface Scheduler {
   /**
    * Whether tasks from this scheduler should incorporate app startup/shutdown
    * acknowledgements (acks) into the task lifecycle.
-   *
-   * @return
    */
 
   boolean isTracked();
@@ -83,7 +81,7 @@ public interface Scheduler {
   /**
    * Get the desired number of running tasks.
    *
-   * @return
+   * @return The desired number of running tasks
    */
   int getTarget();
 
@@ -119,7 +117,7 @@ public interface Scheduler {
    * Return an estimate of progress given as a ratio of (work completed, total
    * work).
    *
-   * @return
+   * @return Estimate of progress.
    */
   int[] getProgress();
 
@@ -135,7 +133,7 @@ public interface Scheduler {
   /**
    * For reporting, get the YARN resources requested by processes in
    * this pool.
-   * @return
+   * @return The request spec.
    */
 
   ContainerRequestSpec getResource( );

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/SchedulerState.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/SchedulerState.java
@@ -29,7 +29,7 @@ public interface SchedulerState {
   /**
    * The number of tasks in any active (non-ended) lifecycle state.
    *
-   * @return
+   * @return The number of tasks in any active (non-ended) lifecycle state.
    */
 
   int getTaskCount();
@@ -38,7 +38,8 @@ public interface SchedulerState {
    * The number of active tasks that have been cancelled, but have not yet
    * ended.
    *
-   * @return
+   * @returnThe number of active tasks that have been cancelled, but have not yet
+   * ended.
    */
 
   int getCancelledTaskCount();
@@ -50,7 +51,9 @@ public interface SchedulerState {
    * does not contain any tasks in this state which have previously been
    * cancelled.
    *
-   * @return
+   * @return The list of tasks awaiting a container request to be sent to YARN
+   * or for which a container request has been sent to YARN, but no container
+   * allocation has yet been received.
    */
 
   List<Task> getStartingTasks();
@@ -60,7 +63,7 @@ public interface SchedulerState {
    * tasks are any task for which a container has been assigned, but has not yet
    * received a RM container completion event.
    *
-   * @return
+   * @return The list of active tasks that have not yet been cancelled.
    */
 
   List<Task> getActiveTasks();

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/SchedulerStateActions.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/SchedulerStateActions.java
@@ -29,7 +29,7 @@ public interface SchedulerStateActions {
   /**
    * Returns the name of the scheduler associated with this task action group.
    *
-   * @return
+   * @return The name of the scheduler associated with this task action group.
    */
 
   String getName();
@@ -37,7 +37,7 @@ public interface SchedulerStateActions {
   /**
    * Returns the scheduler associated with this task group.
    *
-   * @return
+   * @return The scheduler associated with this task group.
    */
 
   Scheduler getScheduler();
@@ -80,7 +80,7 @@ public interface SchedulerStateActions {
    * differentiates the start state (when no tasks are active) from the end
    * state. The AM will not shut down until all task groups are done.
    *
-   * @return
+   * @return True if this task group is done. False otherwise.
    */
 
   boolean isDone();

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AmRestApi.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AmRestApi.java
@@ -134,9 +134,6 @@ public class AmRestApi extends PageTree
    * set in the Drill-on-YARN configuration file. The purpose is simply to prevent
    * accidental cluster shutdown when experimenting with the REST API; this is
    * not meant to be a security mechanism.
-   *
-   * @param key
-   * @return
    */
 
   @Path("/stop")

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AuthDynamicFeature.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AuthDynamicFeature.java
@@ -44,7 +44,7 @@ import java.net.URLEncoder;
  * login page.
  * <p>
  * Shameless copy of
- * {@link org.apache.drill.exec.server.rest.auth.DynamicFeature}; the two
+ * {@link org.apache.drill.exec.server.rest.auth.AuthDynamicFeature}; the two
  * implementations should be merged at some point. The difference is only the
  * log in/log out constant references.
  */

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKClusterCoordinatorDriver.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKClusterCoordinatorDriver.java
@@ -99,7 +99,7 @@ public class ZKClusterCoordinatorDriver implements AMRegistrar {
    * Specify connect string in the form: host:/zkRoot/clusterId
    *
    * @param connect
-   * @return
+   * @return This {@link ZKClusterCoordinatorDriver}.
    * @throws ZKConfigException
    */
   public ZKClusterCoordinatorDriver setConnect(String connect)
@@ -161,7 +161,7 @@ public class ZKClusterCoordinatorDriver implements AMRegistrar {
    * Builds and starts the ZooKeeper cluster coordinator, translating any errors
    * that occur. After this call, the listener will start receiving messages.
    *
-   * @return
+   * @return This {@link ZKClusterCoordinatorDriver}.
    * @throws ZKRuntimeException
    *           if ZK startup fails
    */
@@ -201,7 +201,8 @@ public class ZKClusterCoordinatorDriver implements AMRegistrar {
    * Returns the set of Drillbits registered at the time of the {@link #build()}
    * call. Should be empty for a cluster managed by YARN.
    *
-   * @return
+   * @return The set of Drillbits registered at the time of the {@link #build()}
+   * call.
    */
 
   public List<DrillbitEndpoint> getInitialEndpoints() {
@@ -213,7 +214,7 @@ public class ZKClusterCoordinatorDriver implements AMRegistrar {
    * advertise the HTTP port, so it does not appear in the generated string.
    *
    * @param bit
-   * @return
+   * @return A string representation of a Drillbit.
    */
 
   public static String asString(DrillbitEndpoint bit) {
@@ -266,7 +267,7 @@ public class ZKClusterCoordinatorDriver implements AMRegistrar {
    * notification, and we received the disconnect notification log enough ago
    * that we assume that a timeout has occurred.
    *
-   * @return
+   * @return True if we think zookeeper has failed. False otherwise.
    */
 
   public boolean hasFailed() {

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKRegistry.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKRegistry.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
@@ -134,7 +135,7 @@ public class ZKRegistry
     /**
      * ZK tracking state.
      *
-     * @see {@link State}
+     * See {@link org.apache.drill.yarn.zk.ZKRegistry.DrillbitTracker.State}
      */
 
     protected State state;
@@ -168,8 +169,6 @@ public class ZKRegistry
      * that the task has come online. Tell the task to update its state to
      * record that the task is, in fact, registered in ZK. This indicates a
      * normal, healthy task.
-     *
-     * @param tracker
      */
 
     private void becomeRegistered() {
@@ -178,8 +177,6 @@ public class ZKRegistry
 
     /**
      * Mark that a YARN-managed Drillbit has dropped out of ZK.
-     *
-     * @param registryHandler
      */
 
     public void becomeUnregistered() {
@@ -492,7 +489,7 @@ public class ZKRegistry
    * cases where tasks hang in this state. This is a potential work-around.
    *
    * @param task
-   * @return
+   * @return True if the given task is regestered. False otherwise.
    */
 
   public synchronized boolean isRegistered(Task task) {
@@ -573,9 +570,9 @@ public class ZKRegistry
    * Get the current registry for testing. Why for testing? Because this is
    * unsynchronized. In production code, the map may change out from under you.
    *
-   * @return
+   * @return The current registry.
    */
-
+  @VisibleForTesting
   protected Map<String, DrillbitTracker> getRegistryForTesting() {
     return registry;
   }

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>2.7.1</version>
+      <version>${curator.test.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -587,7 +587,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>3.5.3</version>
+      <version>${maven.embedder.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -719,6 +719,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <!-- Creating a test artifact because javadoc needs to be able to find test classes -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -520,7 +520,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    *
    * @return the server name, or null if not connected or if the server
    *         doesn't provide the name
-   * @return
+   * @return The server name.
    */
   public String getServerName() {
     return (client != null && client.getServerInfos() != null) ? client.getServerInfos().getName() : null;
@@ -533,7 +533,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    *
    * @return the server version, or null if not connected or if the server
    *         doesn't provide the version
-   * @return
+   * @return The server version.
    */
   public Version getServerVersion() {
     return (client != null && client.getServerInfos() != null) ? UserRpcUtils.getVersion(client.getServerInfos()) : null;
@@ -588,7 +588,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    * @param type
    * @param query
    * @param isSplitPlan - option to tell whether to return single or split plans for a query
-   * @return list of PlanFragments that can be used later on in {@link #runQuery(QueryType, List, UserResultsListener)}
+   * @return list of PlanFragments that can be used later on in {@link #runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType, java.util.List, org.apache.drill.exec.rpc.user.UserResultsListener)}
    * to run a query without additional planning
    */
   public DrillRpcFuture<QueryPlanFragments> planQuery(QueryType type, String query, boolean isSplitPlan) {
@@ -663,7 +663,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    * Get the list of catalogs in <code>INFORMATION_SCHEMA.CATALOGS</code> table satisfying the given filters.
    *
    * @param catalogNameFilter Filter on <code>catalog name</code>. Pass null to apply no filter.
-   * @return
+   * @return The list of catalogs in <code>INFORMATION_SCHEMA.CATALOGS</code> table satisfying the given filters.
    */
   public DrillRpcFuture<GetCatalogsResp> getCatalogs(LikeFilter catalogNameFilter) {
     final GetCatalogsReq.Builder reqBuilder = GetCatalogsReq.newBuilder();
@@ -679,7 +679,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    *
    * @param catalogNameFilter Filter on <code>catalog name</code>. Pass null to apply no filter.
    * @param schemaNameFilter Filter on <code>schema name</code>. Pass null to apply no filter.
-   * @return
+   * @return The list of schemas in <code>INFORMATION_SCHEMA.SCHEMATA</code> table satisfying the given filters.
    */
   public DrillRpcFuture<GetSchemasResp> getSchemas(LikeFilter catalogNameFilter, LikeFilter schemaNameFilter) {
     final GetSchemasReq.Builder reqBuilder = GetSchemasReq.newBuilder();
@@ -701,7 +701,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    * @param schemaNameFilter Filter on <code>schema name</code>. Pass null to apply no filter.
    * @param tableNameFilter Filter in <code>table name</code>. Pass null to apply no filter.
    * @param tableTypeFilter Filter in <code>table type</code>. Pass null to apply no filter
-   * @return
+   * @return The list of tables in <code>INFORMATION_SCHEMA.TABLES</code> table satisfying the given filters.
    */
   public DrillRpcFuture<GetTablesResp> getTables(LikeFilter catalogNameFilter, LikeFilter schemaNameFilter,
       LikeFilter tableNameFilter, List<String> tableTypeFilter) {
@@ -732,7 +732,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
    * @param schemaNameFilter Filter on <code>schema name</code>. Pass null to apply no filter.
    * @param tableNameFilter Filter in <code>table name</code>. Pass null to apply no filter.
    * @param columnNameFilter Filter in <code>column name</code>. Pass null to apply no filter.
-   * @return
+   * @return The list of columns in <code>INFORMATION_SCHEMA.COLUMNS</code> table satisfying the given filters.
    */
   public DrillRpcFuture<GetColumnsResp> getColumns(LikeFilter catalogNameFilter, LikeFilter schemaNameFilter,
       LikeFilter tableNameFilter, LikeFilter columnNameFilter) {
@@ -757,10 +757,10 @@ public class DrillClient implements Closeable, ConnectionThrottle {
   }
 
   /**
-   * Create a prepared statement for given <code>query</code>.
+   * Create a prepared statement for given the <code>query</code>.
    *
    * @param query
-   * @return
+   * @return The prepared statement for given the <code>query</code>.
    */
   public DrillRpcFuture<CreatePreparedStatementResp> createPreparedStatement(final String query) {
     final CreatePreparedStatementReq req =

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CodeGenerator.java
@@ -46,7 +46,7 @@ import com.sun.codemodel.JDefinedClass;
  * class without the normal byte-code manipulations. Plain Java allows
  * the option to persist, and debug, the generated code when building new
  * generated classes or otherwise working with generated code. To turn
- * on debugging, see the explanation in {@link ClassBuilder}.
+ * on debugging, see the explanation in {@link org.apache.drill.exec.compile.ClassBuilder}.
  *
  * @param <T>
  *          The interface that results from compiling and merging the runtime
@@ -149,7 +149,7 @@ public class CodeGenerator<T> {
   /**
    * Debug-time option to persist the code for the generated class to permit debugging.
    * Has effect only when code is generated using the plain Java option. Code
-   * is written to the code directory specified in {@link ClassBuilder}.
+   * is written to the code directory specified in {@link org.apache.drill.exec.compile.ClassBuilder}.
    * To debug code, set this option, then point your IDE to the code directory
    * when the IDE prompts you for the source code location.
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionLookupContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionLookupContext.java
@@ -41,7 +41,7 @@ public interface FunctionLookupContext {
    * implementations found on classpath.
    *
    * @param functionCall - Specifies function name and type of arguments
-   * @return
+   * @return AbstractFuncHolder
    */
   public AbstractFuncHolder findNonDrillFunction(FunctionCall functionCall);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ModifiedUnparseVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/ModifiedUnparseVisitor.java
@@ -43,7 +43,7 @@ public class ModifiedUnparseVisitor extends UnparseVisitor {
   }
 
   /**
-   * Unparse the given {@link Java.CompilationUnit} to the given {@link Writer}.
+   * Unparse the given {@link org.codehaus.janino.Java.CompilationUnit} to the given {@link java.io.Writer}.
    */
   public static void unparse(Java.CompilationUnit cu, Writer w) {
     UnparseVisitor.unparse(cu, w);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -163,10 +163,10 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   }
 
   /**
-   *  Create and return a SchemaTree with given <i>schemaConfig</i> but some schemas (from storage plugins)
+   *  Create and return a {@link org.apache.calcite.schema.SchemaPlus} with given <i>schemaConfig</i> but some schemas (from storage plugins)
    *  could be initialized later.
    * @param schemaConfig
-   * @return
+   * @return A {@link org.apache.calcite.schema.SchemaPlus} with given <i>schemaConfig</i>.
    */
   public SchemaPlus getRootSchema(SchemaConfig schemaConfig) {
     return schemaTreeProvider.createRootSchema(schemaConfig);
@@ -174,7 +174,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   /**
    *  Create and return a fully initialized SchemaTree with given <i>schemaConfig</i>.
    * @param schemaConfig
-   * @return
+   * @return A fully initialized SchemaTree with given <i>schemaConfig</i>.
    */
 
   public SchemaPlus getFullRootSchema(SchemaConfig schemaConfig) {
@@ -182,7 +182,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   }
   /**
    * Get the user name of the user who issued the query that is managed by this QueryContext.
-   * @return
+   * @return The user name of the user who issued the query that is managed by this QueryContext.
    */
   @Override
   public String getQueryUserName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
@@ -55,7 +55,7 @@ public abstract class AbstractExchange extends AbstractSingle implements Exchang
   /**
    * Default sender parallelization width range is [1, Integer.MAX_VALUE] and no endpoint affinity
    * @param receiverFragmentEndpoints Endpoints assigned to receiver fragment if available, otherwise an empty list.
-   * @return
+   * @return Sender {@link org.apache.drill.exec.planner.fragment.ParallelizationInfo}.
    */
   @Override
   public ParallelizationInfo getSenderParallelizationInfo(List<DrillbitEndpoint> receiverFragmentEndpoints) {
@@ -66,7 +66,7 @@ public abstract class AbstractExchange extends AbstractSingle implements Exchang
    * Default receiver parallelization width range is [1, Integer.MAX_VALUE] and affinity to nodes where sender
    * fragments are running.
    * @param senderFragmentEndpoints Endpoints assigned to receiver fragment if available, otherwise an empty list.
-   * @return
+   * @return Receiver {@link org.apache.drill.exec.planner.fragment.ParallelizationInfo}.
    */
   @Override
   public ParallelizationInfo getReceiverParallelizationInfo(List<DrillbitEndpoint> senderFragmentEndpoints) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractSingle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractSingle.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterators;
 
 /**
  * Describes an operator that expects a single child operator as its input.
- * @param <T> The type of Exec model supported.
  */
 public abstract class AbstractSingle extends AbstractBase {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractSingle.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Exchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Exchange.java
@@ -83,7 +83,7 @@ public interface Exchange extends PhysicalOperator {
    * max width and affinity to Drillbits.
    *
    * @param receiverFragmentEndpoints Endpoints assigned to receiver fragment if available, otherwise an empty list.
-   * @return
+   * @return Sender {@link org.apache.drill.exec.planner.fragment.ParallelizationInfo}.
    */
   @JsonIgnore
   ParallelizationInfo getSenderParallelizationInfo(List<DrillbitEndpoint> receiverFragmentEndpoints);
@@ -93,7 +93,7 @@ public interface Exchange extends PhysicalOperator {
    * max width and affinity to Drillbits.
    *
    * @param senderFragmentEndpoints Endpoints assigned to receiver fragment if available, otherwise an empty list
-   * @return
+   * @return Receiver {@link org.apache.drill.exec.planner.fragment.ParallelizationInfo}.
    */
   @JsonIgnore
   ParallelizationInfo getReceiverParallelizationInfo(List<DrillbitEndpoint> senderFragmentEndpoints);
@@ -101,7 +101,7 @@ public interface Exchange extends PhysicalOperator {
   /**
    * Return the feeding child of this operator node.
    *
-   * @return
+   * @return The feeding child of this operator node.
    */
   PhysicalOperator getChild();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/LateralContract.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/LateralContract.java
@@ -27,19 +27,20 @@ import org.apache.drill.exec.record.RecordBatch.IterOutcome;
 public interface LateralContract {
 
   /**
-   * Get reference to left side incoming of LateralJoinRecordBatch
-   * @return
+   * Get reference to left side incoming of {@link org.apache.drill.exec.physical.impl.join.LateralJoinBatch}.
+   * @return The incoming {@link org.apache.drill.exec.record.RecordBatch}
    */
   RecordBatch getIncoming();
 
   /**
-   * Get current record index in incoming to be processed
-   * @return
+   * Get current record index in incoming to be processed.
+   * @return The current record index in incoming to be processed.
    */
   int getRecordIndex();
 
   /**
-   * Get the current outcome of left incoming batch
+   * Get the current outcome of left incoming batch.
+   * @return The current outcome of left incoming batch.
    */
   IterOutcome getLeftOutcome();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
@@ -43,16 +43,13 @@ public interface PhysicalOperator extends GraphValue<PhysicalOperator> {
    * Describes whether or not a particular physical operator can actually be executed. Most physical operators can be
    * executed. However, Exchange nodes cannot be executed. In order to be executed, they must be converted into their
    * Exec sub components.
-   *
-   * @return
    */
   @JsonIgnore
   boolean isExecutable();
 
   /**
    * Describes the SelectionVector Mode for the output steam from this physical op.
-   * This property is used during physical plan creating using {@link PhysicalPlanCreator}.
-   * @return
+   * This property is used during physical plan creating using {@link org.apache.drill.exec.planner.physical.PhysicalPlanCreator}.
    */
   @JsonIgnore
   SelectionVectorMode getSVMode();
@@ -61,14 +58,12 @@ public interface PhysicalOperator extends GraphValue<PhysicalOperator> {
    * Provides capability to build a set of output based on traversing a query graph tree.
    *
    * @param physicalVisitor
-   * @return
    */
   <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E;
 
   /**
    * Regenerate with this node with a new set of children.  This is used in the case of materialization or optimization.
    * @param children
-   * @return
    */
   @JsonIgnore
   PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) throws ExecutionSetupException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Sender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Sender.java
@@ -38,7 +38,7 @@ public interface Sender extends FragmentRoot {
 
   /**
    * Get the receiver major fragment id that is opposite this sender.
-   * @return
+   * @return The receiver major fragment id that is opposite this sender.
    */
   @JsonProperty("receiver-major-fragment")
   public int getOppositeMajorFragmentId();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Store.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Store.java
@@ -61,14 +61,14 @@ public interface Store extends HasAffinity {
    * maxWidth value of 1 will be returned. In the case that there is no limit for parallelization, this method should
    * return Integer.MAX_VALUE.
    *
-   * @return
+   * @return The maximum allowable width for the Store operation.
    */
   @JsonIgnore
   public abstract int getMaxWidth();
 
   /**
    * Get the child of this store operator as this will be needed for parallelization materialization purposes.
-   * @return
+   * @return The child of this store operator.
    */
   public abstract PhysicalOperator getChild();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
@@ -90,7 +90,7 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
    * ExternalSortBatch to make decisions about whether to spill or not.
    *
    * @param recordCount
-   * @return
+   * @return The amount of memory MSorter needs for a given record count.
    */
   public static long memoryNeeded(final int recordCount) {
     // We need 4 bytes (SV4) for each record, power of 2 rounded.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MergeSortWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/MergeSortWrapper.java
@@ -97,9 +97,7 @@ public class MergeSortWrapper extends BaseSortWrapper implements SortResults {
    * destination container, indexed by an SV4.
    *
    * @param batchGroups the complete set of in-memory batches
-   * @param batch the record batch (operator) for the sort operator
-   * @param destContainer the vector container for the sort operator
-   * @return the sv4 for this operator
+   * @param outputBatchSize
    */
 
   public void merge(List<BatchGroup.InputBatch> batchGroups, int outputBatchSize) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/TupleModel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/TupleModel.java
@@ -46,11 +46,11 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
  * <dt>Visitor</dt>
  * <dd>The visitor abstraction (classic Gang-of-Four pattern) allows adding
  * functionality without complicating the structure classes. Allows the same
- * abstraction to be used for the testing {@link RowSet} abstractions and
+ * abstraction to be used for the testing <b>RowSet</b> abstractions and
  * the scan operator "loader" classes.</dd>
  * <dt>Metadata</dt>
  * <dd>Metadata is simply data about data. Here, data about tuples and columns.
- * The column metadata mostly expands on that available in {@link MaterializedField},
+ * The column metadata mostly expands on that available in {@link org.apache.drill.exec.record.MaterializedField},
  * but also adds allocation hints.
  * </dl>
  * <p>
@@ -60,7 +60,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
  * metadata and visitor behavior to allow much easier processing that is
  * possible with the raw container structure.
  * <p>
- * A key value of this abstraction is the extended {@link TupleSchema}
+ * A key value of this abstraction is the extended {@link org.apache.drill.exec.record.metadata.TupleSchema}
  * associated with the structure.  Unlike a
  * {@link VectorContainer}, this abstraction keeps the schema in sync
  * with vectors as columns are added.
@@ -72,7 +72,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
  * <p>
  * Tuples provide access to columns by both index and name. Both the schema and
  * model classes follow this convention. Compared with the VectorContainer and
- * {@link AbstractMapVector} classes, the vector index is a first-class concept:
+ * {@link org.apache.drill.exec.vector.complex.AbstractMapVector} classes, the vector index is a first-class concept:
  * the column model and schema are guaranteed to reside at the same index relative
  * to the enclosing tuple. In addition, name access is efficient using a hash
  * index.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/VectorAllocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/VectorAllocator.java
@@ -36,9 +36,10 @@ import org.apache.drill.exec.vector.complex.RepeatedMapVector;
  * walk the schema tree to allocate new vectors according to a given
  * row count and the size information provided in column metadata.
  * <p>
- * @see {@link AllocationHelper} - the class which this one replaces
- * @see {@link org.apache.drill.exec.record.VectorInitializer} - an earlier cut at implementation
- * based on data from the {@link org.apache.drill.exec.record.RecordBatchSizer}
+ *   {@link org.apache.drill.exec.vector.AllocationHelper} - the class which this one replaces
+ *   {@link org.apache.drill.exec.record.VectorInitializer} - an earlier cut at implementation
+ *   based on data from the {@link org.apache.drill.exec.record.RecordBatchSizer}
+ * </p>
  */
 
 // TODO: Does not yet handle lists; lists are a simple extension

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
@@ -31,7 +31,7 @@ public abstract class AbstractPartitionDescriptor implements PartitionDescriptor
 
   /**
    * A sequence of sublists of partition locations combined into a single super list.
-   * The size of each sublist is at most {@link PartitionDescriptor.PARTITION_BATCH_SIZE}
+   * The size of each sublist is at most {@link PartitionDescriptor#PARTITION_BATCH_SIZE}
    * For example if the size is 3, the complete list could be: {(a, b, c), {d, e, f), (g, h)}
    */
   protected List<List<PartitionLocation>> locationSuperList;
@@ -42,7 +42,7 @@ public abstract class AbstractPartitionDescriptor implements PartitionDescriptor
 
   /**
    * Create sublists of the partition locations, each sublist of size
-   * at most {@link PartitionDescriptor.PARTITION_BATCH_SIZE}
+   * at most {@link PartitionDescriptor#PARTITION_BATCH_SIZE}
    */
   protected abstract void createPartitionSublists() ;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSFilePartitionLocation.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSFilePartitionLocation.java
@@ -51,7 +51,7 @@ public class DFSFilePartitionLocation extends SimplePartitionLocation {
   /**
    * Returns the value for a give partition key
    * @param index - Index of the partition key whose value is to be returned
-   * @return
+   * @return The value for a partition.
    */
   @Override
   public String getPartitionValue(int index) {
@@ -61,7 +61,7 @@ public class DFSFilePartitionLocation extends SimplePartitionLocation {
 
   /**
    * Return the full location of this partition
-   * @return
+   * @return The partition location.
    */
   @Override
   public String getEntirePartitionLocation() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
@@ -70,7 +70,6 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
    * Method returns the Major type associated with the given column
    * @param column - column whose type should be determined
    * @param plannerSettings
-   * @return
    */
   TypeProtos.MajorType getVectorType(SchemaPath column, PlannerSettings plannerSettings);
 
@@ -78,7 +77,6 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
    * Methods create a new TableScan rel node, given the lists of new partitions or new files to SCAN.
    * @param newPartitions
    * @param wasAllPartitionsPruned
-   * @return
    * @throws Exception
    */
   public TableScan createTableScan(List<PartitionLocation> newPartitions,
@@ -91,7 +89,6 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
    * @param cacheFileRoot
    * @param wasAllPartitionsPruned
    * @param metaContext
-   * @return
    * @throws Exception
    */
   public TableScan createTableScan(List<PartitionLocation> newPartitions, String cacheFileRoot,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DistributionAffinity.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DistributionAffinity.java
@@ -55,7 +55,7 @@ public enum DistributionAffinity {
   /**
    * Is the current DistributionAffinity less restrictive than the given DistributionAffinity?
    * @param distributionAffinity
-   * @return
+   * @return True if the current DistributionAffinity less restrictive than the given DistributionAffinity. False otherwise.
    */
   public boolean isLessRestrictiveThan(final DistributionAffinity distributionAffinity) {
     return ordinal() < distributionAffinity.ordinal();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
@@ -140,7 +140,7 @@ public class SimpleParallelizer implements ParallelizationParameters {
    * @param rootFragment
    * @param session
    * @param queryContextInfo
-   * @return
+   * @return The {@link QueryWorkUnit}s.
    * @throws ExecutionSetupException
    */
   public List<QueryWorkUnit> getSplitFragments(OptionList options, DrillbitEndpoint foremanNode, QueryId queryId,
@@ -154,7 +154,7 @@ public class SimpleParallelizer implements ParallelizationParameters {
    * Helper method to reuse the code for QueryWorkUnit(s) generation
    * @param activeEndpoints
    * @param rootFragment
-   * @return
+   * @return A {@link PlanningSet}.
    * @throws ExecutionSetupException
    */
   protected PlanningSet getFragmentsHelper(Collection<DrillbitEndpoint> activeEndpoints, Fragment rootFragment) throws ExecutionSetupException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
@@ -184,15 +184,15 @@ public class Wrapper {
 
   /**
    * Is the endpoints assignment done for this fragment?
-   * @return
+   * @return True if the endpoints assignment done for this fragment. False otherwise.
    */
   public boolean isEndpointsAssignmentDone() {
     return endpointsAssigned;
   }
 
   /**
-   * Get the list of fragements this particular fragment depends for determining its
-   * @return
+   * Get the list of fragements this particular fragment depends on.
+   * @return The list of fragements this particular fragment depends on.
    */
   public List<Wrapper> getFragmentDependencies() {
     return ImmutableList.copyOf(fragmentDependencies);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SqlHandlerUtil.java
@@ -237,7 +237,7 @@ public class SqlHandlerUtil {
   /**
    * Drops table from schema.
    * If drop has failed makes concurrency check: checks if table still exists.
-   * If table exists, throws {@link @UserException} since drop was unsuccessful,
+   * If table exists, throws {@link org.apache.drill.common.exceptions.UserException} since drop was unsuccessful,
    * otherwise assumes that other user had dropped the view and exists without error.
    *
    * @param drillSchema drill schema
@@ -256,7 +256,7 @@ public class SqlHandlerUtil {
   /**
    * Drops view from schema.
    * If drop has failed makes concurrency check: checks if view still exists.
-   * If view exists, throws {@link @UserException} since drop was unsuccessful,
+   * If view exists, throws {@link org.apache.drill.common.exceptions.UserException} since drop was unsuccessful,
    * otherwise assumes that other user had dropped the view and exists without error.
    *
    * @param drillSchema drill schema

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -54,7 +54,7 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
    *
    * @param userName User whom to impersonate when when reading the contents as part of Scan.
    * @param selection The configured storage engine specific selection.
-   * @return
+   * @return The physical scan operator for the particular GroupScan (read) node.
    * @throws IOException
    */
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection) throws IOException;
@@ -65,7 +65,7 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
    * @param userName User whom to impersonate when when reading the contents as part of Scan.
    * @param selection The configured storage engine specific selection.
    * @param columns (optional) The list of column names to scan from the data source.
-   * @return
+   * @return The physical scan operator for the particular GroupScan (read) node.
    * @throws IOException
   */
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/TextParsingSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/TextParsingSettings.java
@@ -209,7 +209,7 @@ public class TextParsingSettings {
 
   /**
    * Configures how to handle unescaped quotes inside quoted values. If set to {@code true}, the parser will parse the quote normally as part of the value.
-   * If set the {@code false}, a {@link TextParsingException} will be thrown. Defaults to {@code true}.
+   * If set the {@code false}, a {@link com.univocity.parsers.common.TextParsingException} will be thrown. Defaults to {@code true}.
    * @param parseUnescapedQuotes indicates whether or not the CSV parser should accept unescaped quotes inside quoted values.
    */
   public void setParseUnescapedQuotes(boolean parseUnescapedQuotes) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataVersion.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataVersion.java
@@ -106,7 +106,7 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
 /**
  * Supported metadata versions.
  * <p>
- * Note: keep them synchronized with {@link Metadata.ParquetTableMetadataBase} versions
+ * Note: keep them synchronized with {@link org.apache.drill.exec.store.parquet.metadata.MetadataBase.ParquetTableMetadataBase} versions
  */
   public static class Constants {
     /**
@@ -134,7 +134,7 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
 
     /**
      * Version 3.2: An array with the components of the field name in
-     * {@link Metadata.ColumnTypeMetadata_v3.Key} class is replaced by the SchemaPath.<br>
+     * {@link org.apache.drill.exec.store.parquet.metadata.Metadata_V3.ColumnTypeMetadata_v3.Key} class is replaced by the {@link org.apache.drill.common.expression.SchemaPath}.<br>
      * See DRILL-4264
      */
     public static final String V3_2 = "3.2";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/ImpersonationUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/ImpersonationUtil.java
@@ -110,7 +110,6 @@ public class ImpersonationUtil {
    * @param opUserName Name of the user whom to impersonate while setting up the operator.
    * @param queryUserName Name of the user who issues the query. If <i>opUserName</i> is invalid,
    *                      then this parameter must be valid user name.
-   * @return
    */
   public static UserGroupInformation createProxyUgi(String opUserName, String queryUserName) {
     if (!Strings.isNullOrEmpty(opUserName)) {
@@ -131,7 +130,6 @@ public class ImpersonationUtil {
    * Create and return proxy user {@link org.apache.hadoop.security.UserGroupInformation} for give user name.
    *
    * @param proxyUserName Proxy user name (must be valid)
-   * @return
    */
   public static UserGroupInformation createProxyUgi(String proxyUserName) {
     try {
@@ -202,7 +200,6 @@ public class ImpersonationUtil {
    *
    * @param proxyUserName Name of the user whom to impersonate while accessing the FileSystem contents.
    * @param fsConf FileSystem configuration.
-   * @return
    */
   public static DrillFileSystem createFileSystem(String proxyUserName, Configuration fsConf) {
     return createFileSystem(createProxyUgi(proxyUserName), fsConf, null);
@@ -234,7 +231,7 @@ public class ImpersonationUtil {
    * @param userName User who is checked for administrative privileges.
    * @param adminUsers Comma separated list of admin usernames,
    * @param adminGroups Comma separated list of admin usergroups
-   * @return
+   * @return True if the user has admin priveleges. False otherwise.
    */
   public static boolean hasAdminPrivileges(final String userName, final String adminUsers, final String adminGroups) {
     // Process user is by default an admin

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/Utilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/Utilities.java
@@ -56,11 +56,11 @@ public class Utilities {
   }
 
   /**
-   * Create QueryContextInformation with given <i>defaultSchemaName</i>. Rest of the members of the
+   * Create {@link org.apache.drill.exec.proto.BitControl.QueryContextInformation} with given <i>defaultSchemaName</i>. Rest of the members of the
    * QueryContextInformation is derived from the current state of the process.
    *
    * @param defaultSchemaName
-   * @return
+   * @return A {@link org.apache.drill.exec.proto.BitControl.QueryContextInformation} with given <i>defaultSchemaName</i>.
    */
   public static QueryContextInformation createQueryContextInfo(final String defaultSchemaName, final String sessionId) {
     final long queryStartTime = System.currentTimeMillis();
@@ -75,7 +75,7 @@ public class Utilities {
 
   /**
    * Read the manifest file and get the Drill version number
-   * @return
+   * @return The Drill version.
    */
   public static String getDrillVersion() {
       String v = Utilities.class.getPackage().getImplementationVersion();
@@ -85,7 +85,7 @@ public class Utilities {
   /**
    * Return true if list of schema path has star column.
    * @param projected
-   * @return
+   * @return True if the list of {@link org.apache.drill.common.expression.SchemaPath}s has star column.
    */
   public static boolean isStarQuery(Collection<SchemaPath> projected) {
     return Iterables.tryFind(Preconditions.checkNotNull(projected, COL_NULL_ERROR), new Predicate<SchemaPath>() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/accessor/SqlAccessor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/accessor/SqlAccessor.java
@@ -43,12 +43,12 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
  * </p>
  * <li>
  *   a get method that return primitive type throws an exception (callers are
- *   responsible for calling {@link isNull} to check for null before calling
+ *   responsible for calling {@link #isNull(int)} to check for null before calling
  *   such methods)
  * </li>
  * <li>
  *   a get method that returns a non-primitive type returns Java {@code null}
- *   (the caller does not need to call {@link isNull} to check for nulls)
+ *   (the caller does not need to call {@link #isNull(int)} to check for nulls)
  * </li>
  */
 public interface SqlAccessor {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/PhysicalOpUnitTestBase.java
@@ -487,12 +487,12 @@ public class PhysicalOpUnitTestBase extends ExecTest {
   }
 
   /**
-   * Create JSONRecordReader from input strings.
+   * Create {@link org.apache.drill.exec.store.easy.json.JSONRecordReader} from input strings.
    * @param jsonBatches : list of input strings, each element represent a batch. Each string could either
    *                    be in the form of "[{...}, {...}, ..., {...}]", or in the form of "{...}".
    * @param fragContext : fragment context
    * @param columnsToRead : list of schema paths to read from JSON reader.
-   * @return
+   * @return The {@link org.apache.drill.exec.store.easy.json.JSONRecordReader} corresponding to each given jsonBatch.
    */
   public static Iterator<RecordReader> getJsonReadersFromBatchString(List<String> jsonBatches, FragmentContext fragContext, List<SchemaPath> columnsToRead) {
     ObjectMapper mapper = new ObjectMapper();
@@ -515,7 +515,7 @@ public class PhysicalOpUnitTestBase extends ExecTest {
    * @param inputPaths : list of .json file paths.
    * @param fragContext
    * @param columnsToRead
-   * @return
+   * @return The {@link org.apache.drill.exec.store.easy.json.JSONRecordReader} corresponding to each given input path.
    */
   public static Iterator<RecordReader> getJsonReadersFromInputFiles(DrillFileSystem fs, List<String> inputPaths, FragmentContext fragContext, List<SchemaPath> columnsToRead) {
     List<RecordReader> readers = new ArrayList<>();

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -185,7 +185,7 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   /**
    * Visible only for memory allocation calculations.
    *
-   * @return
+   * @return The {@link BufferLedger} associated with this {@link DrillBuf}.
    */
   public BufferLedger getLedger() { return ledger; }
 

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
@@ -344,7 +344,7 @@ public class AllocationManager {
      * use.
      *
      * @param allocator
-     * @return
+     * @return The ledger associated with a particular BufferAllocator.
      */
 
     public BufferLedger getLedgerForAllocator(BufferAllocator allocator) {
@@ -375,10 +375,8 @@ public class AllocationManager {
      * @param length
      *          The length in bytes that this DrillBuf will provide access to.
      * @param manager
-     *          An optional BufferManager argument that can be used to manage expansion of this DrillBuf
-     * @param retain
-     *          Whether or not the newly created buffer should get an additional reference count added to it.
-     * @return A new DrillBuf that shares references with all DrillBufs associated with this BufferLedger
+     *          An optional BufferManager argument that can be used to manage expansion of this DrillBuf.
+     * @return A new DrillBuf that shares references with all DrillBufs associated with this BufferLedger.
      */
     public DrillBuf newDrillBuf(int offset, int length, BufferManager manager) {
       allocator.assertOpen();

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BufferAllocator.java
@@ -177,7 +177,7 @@ public interface BufferAllocator extends AutoCloseable {
    * those indexes.
    *
    * @param buf the Drillbuf to write
-   * @param output the output stream
+   * @param out the output stream
    * @throws IOException if a write error occurs
    */
 

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/ops/BufferManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/ops/BufferManager.java
@@ -30,8 +30,8 @@ import io.netty.buffer.DrillBuf;
  * DrillBufs to give UDF writers general purpose buffers we can account for. To prevent the need
  * for UDFs to contain boilerplate to close all of the buffers they request, this list
  * is tracked at a higher level and all of the buffers are freed once we are sure that
- * the code depending on them is done executing (currently {@link FragmentContext}
- * and {@link QueryContext}.
+ * the code depending on them is done executing (currently FragmentContext
+ * and QueryContext.
  */
 public interface BufferManager extends AutoCloseable {
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/NamedThreadFactory.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/NamedThreadFactory.java
@@ -21,14 +21,14 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * {@link ThreadFactory} for {@link ExecutorServices} that names threads sequentially.
+ * {@link ThreadFactory} for {@link java.util.concurrent.ExecutorService}s that names threads sequentially.
  * Creates Threads named with the prefix specified at construction time. Created threads
  * have the daemon bit set and priority Thread.MAX_PRIORITY.
  *
  * <p>An instance creates names with an instance-specific prefix suffixed with sequential
  * integers.</p>
  *
- * <p>Concurrency: See {@link newThread}.</p>
+ * <p>Concurrency: See {@link #newThread}.</p>
  */
 public class NamedThreadFactory implements ThreadFactory {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NamedThreadFactory.class);

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestHandler.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestHandler.java
@@ -41,7 +41,6 @@ public interface RequestHandler<S extends ServerConnection<S>> {
    * @param pBody      message
    * @param dBody      data, maybe null
    * @param sender     used to {@link ResponseSender#send send} the response
-   * @return response to the request
    * @throws RpcException
    */
   void handle(S connection, int rpcType, ByteBuf pBody, ByteBuf dBody, ResponseSender sender)

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
@@ -399,13 +399,13 @@ public class DecimalUtility {
   }
 
   /**
-   * Returns default precision for specified {@link TypeProtos.MinorType}
-   * or returns specified defaultPrecision if {@link TypeProtos.MinorType} isn't
-   * {@link TypeProtos.MinorType#INT} or {@link TypeProtos.MinorType#BIGINT}.
+   * Returns default precision for specified {@link org.apache.drill.common.types.TypeProtos.MinorType}
+   * or returns specified defaultPrecision if {@link org.apache.drill.common.types.TypeProtos.MinorType} isn't
+   * {@link org.apache.drill.common.types.TypeProtos.MinorType#INT} or {@link org.apache.drill.common.types.TypeProtos.MinorType#BIGINT}.
    *
    * @param minorType        type wich precision should be received
    * @param defaultPrecision default value for precision
-   * @return default precision for specified {@link TypeProtos.MinorType}
+   * @return default precision for specified {@link org.apache.drill.common.types.TypeProtos.MinorType}
    */
   public static int getDefaultPrecision(TypeProtos.MinorType minorType, int defaultPrecision) {
     switch (minorType) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayReader.java
@@ -52,7 +52,7 @@ public interface ArrayReader extends ColumnReader {
   /**
    * Return the generic object reader for the array element. This
    * version <i>does not</i> position the reader, the client must
-   * call {@link setPosn()} to set the position. This form allows
+   * call {@link #setPosn(int)} to set the position. This form allows
    * up-front setup of the readers when convenient for the caller.
    */
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
@@ -69,7 +69,7 @@ public interface ColumnWriter extends WriterPosition {
 
   /**
    * Whether this writer allows nulls. This is not as simple as checking
-   * for the {@link DataMode#OPTIONAL} type in the schema. List entries
+   * for the {@link org.apache.drill.common.types.DataMode#OPTIONAL} type in the schema. List entries
    * are nullable, if they are primitive, but not if they are maps or lists.
    * Unions are nullable, regardless of cardinality.
    *

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarReader.java
@@ -41,7 +41,7 @@ import org.joda.time.Period;
  * require another level of reader abstraction to access each value
  * in the structure.
  * <p>
- * {@see ScalarWriter}
+ * See {@link ScalarWriter}
  */
 
 public interface ScalarReader extends ColumnReader {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleReader.java
@@ -39,7 +39,7 @@ public interface TupleReader extends ColumnReader {
    *
    * @param colIndex column index
    * @return reader for the column
-   * @throws IndexOutOfRangeException if the index is invalid
+   * @throws {@link java.lang.IndexOutOfBoundsException} if the index is invalid
    */
 
   ObjectReader column(int colIndex);
@@ -47,7 +47,7 @@ public interface TupleReader extends ColumnReader {
   /**
    * Return a column reader by name.
    *
-   * @param colIndex column name
+   * @param colName column name
    * @return reader for the column, or <tt>null</tt> if no such
    * column exists
    */

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/BaseRepeatedValueVector.java
@@ -177,7 +177,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   /**
    * Returns 1 if inner vector is explicitly set via #addOrGetVector else 0
    *
-   * @see {@link ContainerVectorLike#size}
+   * @see {@link org.apache.drill.exec.vector.complex.ContainerVectorLike#size()}
    */
   @Override
   public int size() {

--- a/logical/src/main/java/org/apache/drill/common/expression/FunctionHolderExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FunctionHolderExpression.java
@@ -54,8 +54,8 @@ public abstract class FunctionHolderExpression extends LogicalExpressionBase {
   }
 
   /**
-   * A function can have multiple names, it returns the function name used in the query
-   * @return
+   * A function can have multiple names, it returns the function name used in the query.
+   * @return The function name used in the query.
    */
   public String getName() {
     return nameUsed;
@@ -64,7 +64,7 @@ public abstract class FunctionHolderExpression extends LogicalExpressionBase {
   /**
    * constant input expected for i'th argument?
    * @param i
-   * @return
+   * @return True if a constant input is expected for the i'th argument. False otherwise.
    */
   public abstract boolean argConstantOnly(int i);
 

--- a/logical/src/main/java/org/apache/drill/common/expression/LogicalExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/LogicalExpression.java
@@ -39,7 +39,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-//@JsonDeserialize(using = LogicalExpression.De.class)  // Excluded as we need to register this with the DrillConfig.
 @JsonSerialize(using = LogicalExpression.Se.class)
 public interface LogicalExpression extends Iterable<LogicalExpression>{
   Logger logger = LoggerFactory.getLogger(LogicalExpression.class);

--- a/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfigBase.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/FormatPluginConfigBase.java
@@ -26,7 +26,7 @@ public abstract class FormatPluginConfigBase implements FormatPluginConfig{
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FormatPluginConfigBase.class);
 
   /**
-   * scan for implementations of {@see FormatPlugin}.
+   * scan for implementations of see <b>FormatPlugin</b>.
    *
    * @param classpathScan - Drill configuration object, used to find the packages to scan
    * @return - list of classes that implement the interface.

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,13 @@
     <commons.io.version>2.4</commons.io.version>
     <junit.version>4.11</junit.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
-
+    <maven.embedder.version>3.5.3</maven.embedder.version>
+    <curator.test.version>2.7.1</curator.test.version>
+    <parquet.hadoop.version>1.8.1</parquet.hadoop.version>
+    <wiremock.standalone.version>2.5.1</wiremock.standalone.version>
+    <jmockit.version>1.39</jmockit.version>
+    <logback.version>1.0.13</logback.version>
+    <mockito.version>2.18.3</mockito.version>
     <!--
       Currently Hive storage plugin only supports Apache Hive 2.3.2 or vendor specific variants of the
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated.
@@ -202,6 +208,117 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <sourcepath>${basedir}</sourcepath>
+          <sourceFileExcludes>
+            <!-- Don't include codegen -->
+            <exclude>**/src/main/codegen/**/*.java</exclude>
+            <!-- Don't include target -->
+            <exclude>**/target/**/*.java</exclude>
+          </sourceFileExcludes>
+          <additionalDependencies>
+            <!-- These dependencies are required for javadoc in order to properly resolve class references in some javadocs. -->
+            <dependency>
+              <groupId>org.apache.hbase</groupId>
+              <artifactId>hbase-server</artifactId>
+              <version>${hbase.version}</version>
+              <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.avro</groupId>
+              <artifactId>avro</artifactId>
+              <version>${avro.version}</version>
+              <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.kerby</groupId>
+              <artifactId>kerb-core</artifactId>
+              <version>${kerby.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.kerby</groupId>
+              <artifactId>kerb-client</artifactId>
+              <version>${kerby.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.kerby</groupId>
+              <artifactId>kerb-simplekdc</artifactId>
+              <version>${kerby.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.maven</groupId>
+              <artifactId>maven-embedder</artifactId>
+              <version>${maven.embedder.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.curator</groupId>
+              <artifactId>curator-test</artifactId>
+              <version>${curator.test.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.hadoop</groupId>
+              <artifactId>hadoop-hdfs</artifactId>
+              <version>${hadoop.version}</version>
+              <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.drill.exec</groupId>
+              <artifactId>drill-java-exec</artifactId>
+              <version>${project.version}</version>
+              <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.drill</groupId>
+              <artifactId>drill-common</artifactId>
+              <version>${project.version}</version>
+              <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+              <groupId>com.github.tomakehurst</groupId>
+              <artifactId>wiremock-standalone</artifactId>
+              <version>${wiremock.standalone.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.kerby</groupId>
+              <artifactId>kerb-client</artifactId>
+              <version>${kerby.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.parquet</groupId>
+              <artifactId>parquet-hadoop</artifactId>
+              <version>${parquet.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.jmockit</groupId>
+              <artifactId>jmockit</artifactId>
+              <version>${jmockit.version}</version>
+            </dependency>
+            <additionalDependency>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-core</artifactId>
+              <version>${hamcrest.core.version}</version>
+            </additionalDependency>
+            <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-core</artifactId>
+              <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>${logback.version}</version>
+            </dependency>
+          </additionalDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
@@ -449,103 +566,114 @@
           </gitDescribe>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>3.0</version>
-        <configuration>
-          <aggregate>true</aggregate>
-          <header>${maven.multiModuleProjectDirectory}/header</header>
-          <excludes>
-            <exclude>**/clientlib/y2038/*.c</exclude> <!-- All the files here should have MIT License -->
-            <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
-            <exclude>**/resources/parquet/**/*</exclude>
-            <exclude>**/*.g</exclude>
-            <exclude>**/*.woff2</exclude>
-            <exclude>**/*.ks</exclude>
-            <exclude>**/*.pcap</exclude>
-            <exclude>**/*.props</exclude>
-            <exclude>**/*.conf</exclude>
-            <exclude>**/*.log</exclude>
-            <exclude>**/*.css</exclude>
-            <exclude>**/*.js</exclude>
-            <exclude>**/*.md</exclude>
-            <exclude>**/*.eps</exclude>
-            <exclude>**/*.json</exclude>
-            <exclude>**/*.seq</exclude>
-            <exclude>**/*.parquet</exclude>
-            <exclude>**/*.sql</exclude>
-            <exclude>**/git.properties</exclude>
-            <exclude>**/*.csv</exclude>
-            <exclude>**/*.csvh</exclude>
-            <exclude>**/*.csvh-test</exclude>
-            <exclude>**/*.tsv</exclude>
-            <exclude>**/*.txt</exclude>
-            <exclude>**/*.ssv</exclude>
-            <exclude>**/drill-*.conf</exclude>
-            <exclude>**/.buildpath</exclude>
-            <exclude>**/*.proto</exclude>
-            <exclude>**/*.fmpp</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>**/.idea/**</exclude>
-            <exclude>**/*.tdd</exclude>
-            <exclude>**/*.project</exclude>
-            <exclude>**/TAGS</exclude>
-            <exclude>**/*.checkstyle</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/.settings/**</exclude>
-            <exclude>.*/**</exclude>
-            <exclude>**/*.patch</exclude>
-            <exclude>**/*.pb.cc</exclude>
-            <exclude>**/*.pb.h</exclude>
-            <exclude>**/*.linux</exclude>
-            <exclude>**/client/*build*/**</exclude>
-            <exclude>**/client/tags</exclude>
-            <exclude>**/cmake_install.cmake</exclude>
-            <exclude>**/ssl/*.csr</exclude>
-            <exclude>**/ssl/*.pem</exclude>
-            <exclude>**/ssl/*.p12</exclude>
-            <exclude>**/*.tbl</exclude>
-            <exclude>**/*.httpd</exclude>
-            <exclude>**/*.autotools</exclude>
-            <exclude>**/*.cproject</exclude>
-            <exclude>**/*.drill</exclude>
-            <exclude>**/*.plist</exclude>
-            <exclude>**/LICENSE</exclude>
-            <exclude>**/NOTICE</exclude>
-            <exclude>KEYS</exclude>
-            <exclude>header</exclude>
-            <!-- TODO DRILL-4336: try to avoid the need to add this -->
-            <exclude>dependency-reduced-pom.xml</exclude>
-          </excludes>
-          <mapping>
-            <java>SLASHSTAR_STYLE</java>
-            <cpp>SLASHSTAR_STYLE</cpp>
-            <hpp>SLASHSTAR_STYLE</hpp>
-            <in>SLASHSTAR_STYLE</in>
-            <ipp>SLASHSTAR_STYLE</ipp>
-            <sasl>SLASHSTAR_STYLE</sasl>
-            <ssl>SLASHSTAR_STYLE</ssl>
-            <txt>SLASHSTAR_STYLE</txt>
-            <macos>SLASHSTAR_STYLE</macos>
-            <linux>SLASHSTAR_STYLE</linux>
-            <boost>SLASHSTAR_STYLE</boost>
-            <cmake>SCRIPT_STYLE</cmake>
-          </mapping>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
     <pluginManagement>
-
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>test-jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>3.0</version>
+          <configuration>
+            <aggregate>true</aggregate>
+            <header>${maven.multiModuleProjectDirectory}/header</header>
+            <excludes>
+              <exclude>**/clientlib/y2038/*.c</exclude> <!-- All the files here should have MIT License -->
+              <exclude>**/clientlib/y2038/*.h</exclude> <!-- All the files here should have MIT License -->
+              <exclude>**/resources/parquet/**/*</exclude>
+              <exclude>**/*.g</exclude>
+              <exclude>**/*.woff2</exclude>
+              <exclude>**/*.ks</exclude>
+              <exclude>**/*.pcap</exclude>
+              <exclude>**/*.props</exclude>
+              <exclude>**/*.conf</exclude>
+              <exclude>**/*.log</exclude>
+              <exclude>**/*.css</exclude>
+              <exclude>**/*.js</exclude>
+              <exclude>**/*.md</exclude>
+              <exclude>**/*.eps</exclude>
+              <exclude>**/*.json</exclude>
+              <exclude>**/*.seq</exclude>
+              <exclude>**/*.parquet</exclude>
+              <exclude>**/*.sql</exclude>
+              <exclude>**/git.properties</exclude>
+              <exclude>**/*.csv</exclude>
+              <exclude>**/*.csvh</exclude>
+              <exclude>**/*.csvh-test</exclude>
+              <exclude>**/*.tsv</exclude>
+              <exclude>**/*.txt</exclude>
+              <exclude>**/*.ssv</exclude>
+              <exclude>**/drill-*.conf</exclude>
+              <exclude>**/.buildpath</exclude>
+              <exclude>**/*.proto</exclude>
+              <exclude>**/*.fmpp</exclude>
+              <exclude>**/target/**</exclude>
+              <exclude>**/*.iml</exclude>
+              <exclude>**/.idea/**</exclude>
+              <exclude>**/*.tdd</exclude>
+              <exclude>**/*.project</exclude>
+              <exclude>**/TAGS</exclude>
+              <exclude>**/*.checkstyle</exclude>
+              <exclude>**/.classpath</exclude>
+              <exclude>**/.settings/**</exclude>
+              <exclude>.*/**</exclude>
+              <exclude>**/*.patch</exclude>
+              <exclude>**/*.pb.cc</exclude>
+              <exclude>**/*.pb.h</exclude>
+              <exclude>**/*.linux</exclude>
+              <exclude>**/client/*build*/**</exclude>
+              <exclude>**/client/tags</exclude>
+              <exclude>**/cmake_install.cmake</exclude>
+              <exclude>**/ssl/*.csr</exclude>
+              <exclude>**/ssl/*.pem</exclude>
+              <exclude>**/ssl/*.p12</exclude>
+              <exclude>**/*.tbl</exclude>
+              <exclude>**/*.httpd</exclude>
+              <exclude>**/*.autotools</exclude>
+              <exclude>**/*.cproject</exclude>
+              <exclude>**/*.drill</exclude>
+              <exclude>**/*.plist</exclude>
+              <exclude>**/LICENSE</exclude>
+              <exclude>**/NOTICE</exclude>
+              <exclude>KEYS</exclude>
+              <exclude>header</exclude>
+              <!-- TODO DRILL-4336: try to avoid the need to add this -->
+              <exclude>dependency-reduced-pom.xml</exclude>
+            </excludes>
+            <mapping>
+              <java>SLASHSTAR_STYLE</java>
+              <cpp>SLASHSTAR_STYLE</cpp>
+              <hpp>SLASHSTAR_STYLE</hpp>
+              <in>SLASHSTAR_STYLE</in>
+              <ipp>SLASHSTAR_STYLE</ipp>
+              <sasl>SLASHSTAR_STYLE</sasl>
+              <ssl>SLASHSTAR_STYLE</ssl>
+              <txt>SLASHSTAR_STYLE</txt>
+              <macos>SLASHSTAR_STYLE</macos>
+              <linux>SLASHSTAR_STYLE</linux>
+              <boost>SLASHSTAR_STYLE</boost>
+              <cmake>SCRIPT_STYLE</cmake>
+            </mapping>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
# Fixes For Javadoc Generation

This patch accomplishes the following:

- Javadoc is generated for all classes (except for a few excluded classes).
- Javadoc warnings about unknown classes and packages are fixed.
- Some (but not all) easy javadoc warnings are fixed.
- Documentation was added on how to add and view javadocs

## Implementation Details

The javadoc plugin can only compile and link all the javadocs if `mvn javadoc:aggregate` is called in the project root directory. The javadoc plugin is also unaware of the test dependencies, so they must be explicitly added to the plugin in order for javadoc to be able to resolve test classes.

Also since test dependencies must be explicitly added to the javadoc plugin, we must also create test jars for drill-common and drill-java-exec which contain common test classes used by other modules, and add these test-jars to the javadoc plugin dependency list.

Some classes were excluded from javadoc generation due to weird package linking issues I could not figure out resulting in javadoc warnings.

There was also a bug with the maven-license-plugin. The plugin definition was included in the plugins section not the pluginManagement section of the pom. This caused a strange issue where an extra license header was being added in storage-kudu/src/main/codegen/templates/KuduRecordWriter.java . This caused the javadoc tool to throw an error.