### PR TITLE
DRILL-6440: Unnest unit tests and fixes for stats

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestCorrectness.java
@@ -615,7 +615,8 @@ import static org.junit.Assert.assertTrue;
    *    ]
    *  }
    *
-   * @see TestResultSetLoaderMapArray TestResultSetLoaderMapArray for similar schema and data
+   * @see org.apache.drill.exec.physical.rowSet.impl.TestResultSetLoaderMapArray TestResultSetLoaderMapArray for
+   * similar schema and data
    * @return TupleMetadata corresponding to the schema
    */
   private TupleMetadata getRepeatedMapSchema() {


### PR DESCRIPTION
  - Add unit test with mock input, nested lateral and unnest and project.
  - Fix unit test involving batch limits, ignore map tests
  - Fix input row count stats.

@sohami please review