### PR TITLE
DRILL-6438: Remove excess logging form tests.

### DIFF
--- a/common/src/test/java/org/apache/drill/test/Drill2130CommonHamcrestConfigurationTest.java
+++ b/common/src/test/java/org/apache/drill/test/Drill2130CommonHamcrestConfigurationTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class Drill2130CommonHamcrestConfigurationTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130CommonHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")
   private org.hamcrest.MatcherAssert forCompileTimeCheckForNewEnoughHamcrest;
@@ -38,8 +39,7 @@ public class Drill2130CommonHamcrestConfigurationTest {
              + "  Got NoSuchMethodError;  e: " + e );
     }
     catch ( AssertionError e ) {
-      System.out.println( "Class path seems fine re new JUnit vs. old Hamcrest."
-                          + " (Got AssertionError, not NoSuchMethodError.)" );
+      logger.info("Class path seems fine re new JUnit vs. old Hamcrest. (Got AssertionError, not NoSuchMethodError.)");
     }
   }
 

--- a/common/src/test/java/org/apache/drill/test/DrillTest.java
+++ b/common/src/test/java/org/apache/drill/test/DrillTest.java
@@ -17,21 +17,17 @@
  */
 package org.apache.drill.test;
 
-import java.io.PrintStream;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.List;
 
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.drill.common.util.DrillStringUtils;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -67,32 +63,6 @@ public class DrillTest {
    * Tests that do not use this rule are not affected.
    */
   @Rule public final ExpectedException thrownException = ExpectedException.none();
-
-  @Rule public TestName TEST_NAME = new TestName();
-
-  /**
-   * Option to cause tests to produce verbose output. Many tests provide
-   * detailed information to stdout when enabled. To enable:
-   * <p>
-   * <tt>java ... -Dtest.verbose=true ...</tt>
-   */
-  public static final String VERBOSE_OUTPUT = "test.verbose";
-
-  protected static final boolean verbose = Boolean.parseBoolean(System.getProperty(VERBOSE_OUTPUT));
-
-  /**
-   * Output destination for verbose test output. Rather than using
-   * <tt>System.out</tt>, use <tt>DrillTest.out</tt>. Output will
-   * automagically be routed to the bit bucket unless the
-   * {@link #VERBOSE_OUTPUT} flag is set.
-   */
-
-  public static final PrintStream out = verbose ? System.out : new PrintStream(new NullOutputStream());
-
-  @Before
-  public void printID() throws Exception {
-    System.out.printf("Running %s#%s\n", getClass().getName(), TEST_NAME.getMethodName());
-  }
 
   @BeforeClass
   public static void initDrillTest() throws Exception {
@@ -194,17 +164,5 @@ public class DrillTest {
     public long getMemNonHeap() {
       return memoryBean.getNonHeapMemoryUsage().getUsed();
     }
-  }
-
-  /**
-   * Reports whether verbose output has been selected for this test run.
-   *
-   * @return <tt>true</tt> if verbose output is wanted (test is likely running
-   * in a debugger), <tt>false</tt> if verbose output is to be suppressed
-   * (test is likely running in a batch Maven build).
-   */
-
-  public static boolean verbose( ) {
-    return verbose;
   }
 }

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/MaprDBTestsSuite.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/MaprDBTestsSuite.java
@@ -70,7 +70,6 @@ public class MaprDBTestsSuite {
           // Sleep to allow table data to be flushed to tables.
           // Without this, the row count stats to return 0,
           // causing the planner to reject optimized plans.
-          System.out.println("Sleeping for 5 seconds to allow table flushes");
           Thread.sleep(5000);
 
           conf = HBaseTestsSuite.getConf();

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/BaseJsonTest.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/BaseJsonTest.java
@@ -50,7 +50,6 @@ public class BaseJsonTest extends BaseTestQuery {
 
 
   protected List<QueryDataBatch> runHBaseSQLlWithResults(String sql) throws Exception {
-    System.out.println("Running query:\n" + sql);
     return testSqlWithResults(sql);
   }
 
@@ -65,5 +64,4 @@ public class BaseJsonTest extends BaseTestQuery {
       Assert.assertEquals(expectedRowCount, rowCount);
     }
   }
-
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/BaseHBaseTest.java
@@ -84,7 +84,6 @@ public class BaseHBaseTest extends BaseTestQuery {
 
   protected List<QueryDataBatch> runHBaseSQLlWithResults(String sql) throws Exception {
     sql = canonizeHBaseSQL(sql);
-    System.out.println("Running query:\n" + sql);
     return testSqlWithResults(sql);
   }
 

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseTableProvider.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseTableProvider.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Map.Entry;
-
 import com.google.common.collect.Lists;
 import org.apache.drill.categories.HbaseStorageTest;
 import org.apache.drill.common.config.LogicalPlanPersistence;
@@ -66,12 +64,7 @@ public class TestHBaseTableProvider extends BaseHBaseTest {
     assertTrue(hbaseStore.contains(""));
     assertFalse(hbaseStore.contains("unknown_key"));
 
-    int rowCount = 0;
-    for (Entry<String, String> entry : Lists.newArrayList(hbaseStore.getAll())) {
-      rowCount++;
-      System.out.println(entry.getKey() + "=" + entry.getValue());
-    }
-    assertEquals(7, rowCount);
+    assertEquals(7, Lists.newArrayList(hbaseStore.getAll()).size());
 
     PersistentStore<String> hbaseTestStore = provider.getOrCreateStore(PersistentStoreConfig.newJacksonBuilder(lp.getMapper(), String.class).name("hbase.test").build());
     hbaseTestStore.put("", "v0");
@@ -84,12 +77,7 @@ public class TestHBaseTableProvider extends BaseHBaseTest {
     assertEquals("v0", hbaseStore.get(""));
     assertEquals("testValue", hbaseStore.get(".test"));
 
-    rowCount = 0;
-    for (Entry<String, String> entry : Lists.newArrayList(hbaseTestStore.getAll())) {
-      rowCount++;
-      System.out.println(entry.getKey() + "=" + entry.getValue());
-    }
-    assertEquals(6, rowCount);
+    assertEquals(6, Lists.newArrayList(hbaseTestStore.getAll()).size());
   }
 
   @AfterClass

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestHiveUDFs.java
@@ -44,8 +44,6 @@ public class TestHiveUDFs extends BaseTestQuery {
 
   @Test
   public void testGenericUDF() throws Throwable {
-
-    int numRecords = 0;
     String planString = Resources.toString(Resources.getResource("functions/hive/GenericUDF.json"), Charsets.UTF_8);
     List<QueryDataBatch> results = testPhysicalWithResults(planString);
 
@@ -82,10 +80,6 @@ public class TestHiveUDFs extends BaseTestQuery {
         String concat = new String(concatV.getAccessor().get(i), Charsets.UTF_8);
         assertTrue(concat.equals(in+"-"+in));
 
-        float flt1 = flt1V.getAccessor().get(i);
-        String format_number = new String(format_numberV.getAccessor().get(i), Charsets.UTF_8);
-
-
         String nullableStr1 = null;
         if (!nullableStr1V.getAccessor().isNull(i)) {
           nullableStr1 = new String(nullableStr1V.getAccessor().get(i), Charsets.UTF_8);
@@ -100,23 +94,15 @@ public class TestHiveUDFs extends BaseTestQuery {
         if (nullableStr1 != null) {
           assertEquals(nullableStr1.toUpperCase(), upperNullableStr1);
         }
-
-        System.out.println(in + ", " + upper + ", " + concat + ", " +
-          flt1 + ", " + format_number + ", " + nullableStr1 + ", " + upperNullableStr1);
-
-        numRecords++;
       }
 
       result.release();
       batchLoader.clear();
     }
-
-    System.out.println("Processed " + numRecords + " records");
   }
 
   @Test
   public void testUDF() throws Throwable {
-    int numRecords = 0;
     String planString = Resources.toString(Resources.getResource("functions/hive/UDF.json"), Charsets.UTF_8);
     List<QueryDataBatch> results = testPhysicalWithResults(planString);
 
@@ -146,8 +132,6 @@ public class TestHiveUDFs extends BaseTestQuery {
         long str1Length = str1LengthV.getAccessor().get(i);
         assertTrue(str1.length() == str1Length);
 
-        int str1Ascii = str1AsciiV.getAccessor().get(i);
-
         float flt1 = flt1V.getAccessor().get(i);
 
         double pow = 0;
@@ -155,16 +139,10 @@ public class TestHiveUDFs extends BaseTestQuery {
           pow = powV.getAccessor().get(i);
           assertTrue(Math.pow(flt1, 2.0) == pow);
         }
-
-        System.out.println(str1 + ", " + str1Length + ", " + str1Ascii + ", " + flt1 + ", " + pow);
-        numRecords++;
       }
 
       result.release();
       batchLoader.clear();
     }
-
-    System.out.println("Processed " + numRecords + " records");
   }
-
 }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/test/Drill2130StorageHiveCoreHamcrestConfigurationTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/test/Drill2130StorageHiveCoreHamcrestConfigurationTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class Drill2130StorageHiveCoreHamcrestConfigurationTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130StorageHiveCoreHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")
   private org.hamcrest.MatcherAssert forCompileTimeCheckForNewEnoughHamcrest;
@@ -38,9 +39,7 @@ public class Drill2130StorageHiveCoreHamcrestConfigurationTest {
              + "  Got NoSuchMethodError;  e: " + e );
     }
     catch ( AssertionError e ) {
-      System.out.println( "Class path seems fine re new JUnit vs. old Hamcrest."
-                          + " (Got AssertionError, not NoSuchMethodError.)" );
+      logger.info("Class path seems fine re new JUnit vs. old Hamcrest. (Got AssertionError, not NoSuchMethodError.)");
     }
   }
-
 }

--- a/contrib/storage-kudu/src/test/java/org/apache/drill/store/kudu/TestKuduConnect.java
+++ b/contrib/storage-kudu/src/test/java/org/apache/drill/store/kudu/TestKuduConnect.java
@@ -35,7 +35,6 @@ import org.apache.kudu.client.KuduSession;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.ListTablesResponse;
 import org.apache.kudu.client.PartialRow;
-import org.apache.kudu.client.RowResult;
 import org.apache.kudu.client.RowResultIterator;
 import org.apache.kudu.client.SessionConfiguration;
 import org.junit.experimental.categories.Category;
@@ -99,8 +98,7 @@ public class TestKuduConnect {
       while (scanner.hasMoreRows()) {
         RowResultIterator results = scanner.nextRows();
         while (results.hasNext()) {
-          RowResult result = results.next();
-          System.out.println(result.toStringLongFormat());
+          logger.debug(results.next().toString());
         }
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
@@ -36,13 +36,13 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
 public class VectorUtil {
-
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorUtil.class);
   public static final int DEFAULT_COLUMN_WIDTH = 15;
 
   public static void showVectorAccessibleContent(VectorAccessible va, final String delimiter) {
-
+    final StringBuilder sb = new StringBuilder();
     int rows = va.getRecordCount();
-    System.out.println(rows + " row(s):");
+    sb.append(rows).append(" row(s):\n");
     List<String> columns = Lists.newArrayList();
     for (VectorWrapper<?> vw : va) {
       columns.add(formatFieldSchema(vw.getValueVector().getField()));
@@ -50,7 +50,7 @@ public class VectorUtil {
 
     int width = columns.size();
     for (String column : columns) {
-      System.out.printf("%s%s",column, column.equals(columns.get(width - 1)) ? "\n" : delimiter);
+      sb.append(column).append(column.equals(columns.get(width - 1)) ? "\n" : delimiter);
     }
     for (int row = 0; row < rows; row++) {
       int columnCounter = 0;
@@ -65,14 +65,14 @@ public class VectorUtil {
         if (o == null) {
           //null value
           String value = "null";
-          System.out.printf("%s%s", value, lastColumn ? "\n" : delimiter);
+          sb.append(value).append(lastColumn ? "\n" : delimiter);
         }
         else if (o instanceof byte[]) {
           String value = new String((byte[]) o);
-          System.out.printf("%s%s", value, lastColumn ? "\n" : delimiter);
+          sb.append(value).append(lastColumn ? "\n" : delimiter);
         } else {
           String value = o.toString();
-          System.out.printf("%s%s", value, lastColumn ? "\n" : delimiter);
+          sb.append(value).append(lastColumn ? "\n" : delimiter);
         }
         columnCounter++;
       }
@@ -81,6 +81,8 @@ public class VectorUtil {
     for (VectorWrapper<?> vw : va) {
       vw.clear();
     }
+
+    logger.info(sb.toString());
   }
 
   public static String formatFieldSchema(MaterializedField field) {
@@ -140,6 +142,7 @@ public class VectorUtil {
   }
 
   public static void showVectorAccessibleContent(VectorAccessible va, int[] columnWidths) {
+    final StringBuilder sb = new StringBuilder();
     int width = 0;
     int columnIndex = 0;
     List<String> columns = Lists.newArrayList();
@@ -153,19 +156,20 @@ public class VectorUtil {
     }
 
     int rows = va.getRecordCount();
-    System.out.println(rows + " row(s):");
+    sb.append(rows).append(" row(s):\n");
     for (int row = 0; row < rows; row++) {
       // header, every 50 rows.
       if (row%50 == 0) {
-        System.out.println(StringUtils.repeat("-", width + 1));
+        sb.append(StringUtils.repeat("-", width + 1)).append('\n');
         columnIndex = 0;
         for (String column : columns) {
           int columnWidth = getColumnWidth(columnWidths, columnIndex);
-          System.out.printf(formats.get(columnIndex), column.length() <= columnWidth ? column : column.substring(0, columnWidth - 1));
+          sb.append(String.format(formats.get(columnIndex), column.length() <= columnWidth ? column : column.substring(0, columnWidth - 1)));
           columnIndex++;
         }
-        System.out.printf("|\n");
-        System.out.println(StringUtils.repeat("-", width + 1));
+
+        sb.append("|\n");
+        sb.append(StringUtils.repeat("-", width + 1)).append('\n');
       }
       // column values
       columnIndex = 0;
@@ -178,13 +182,13 @@ public class VectorUtil {
         } else {
           cellString = DrillStringUtils.escapeNewLines(String.valueOf(o));
         }
-        System.out.printf(formats.get(columnIndex), cellString.length() <= columnWidth ? cellString : cellString.substring(0, columnWidth - 1));
+        sb.append(String.format(formats.get(columnIndex), cellString.length() <= columnWidth ? cellString : cellString.substring(0, columnWidth - 1)));
         columnIndex++;
       }
-      System.out.printf("|\n");
+      sb.append("|\n");
     }
     if (rows > 0) {
-      System.out.println(StringUtils.repeat("-", width + 1));
+      sb.append(StringUtils.repeat("-", width + 1)).append('\n');
     }
 
     for (VectorWrapper<?> vw : va) {

--- a/exec/java-exec/src/test/java/org/apache/drill/ParquetSchemaMerge.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/ParquetSchemaMerge.java
@@ -24,6 +24,8 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 
 public class ParquetSchemaMerge {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ParquetSchemaMerge.class);
+
   public static void main(String[] args) {
     MessageType message1;
     MessageType message2;
@@ -42,6 +44,6 @@ public class ParquetSchemaMerge {
 
     StringBuilder builder = new StringBuilder();
     message3.writeToStringBuilder(builder, "");
-    System.out.println(builder);
+    logger.info(builder.toString());
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
@@ -39,6 +39,7 @@ import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.test.QueryTestUtil;
 
 public class PlanTestBase extends BaseTestQuery {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlanTestBase.class);
 
   protected static final String OPTIQ_FORMAT = "text";
   protected static final String JSON_FORMAT = "json";
@@ -225,7 +226,6 @@ public class PlanTestBase extends BaseTestQuery {
   public static void testRelLogicalJoinOrder(String sql, String... expectedSubstrs) throws Exception {
     final String planStr = getDrillRelPlanInString(sql, SqlExplainLevel.EXPPLAN_ATTRIBUTES, Depth.LOGICAL);
     final String prefixJoinOrder = getLogicalPrefixJoinOrderFromPlan(planStr);
-    System.out.println(" prefix Join order = \n" + prefixJoinOrder);
     for (final String substr : expectedSubstrs) {
       assertTrue(String.format("Expected string %s is not in the prefixJoinOrder %s!", substr, prefixJoinOrder),
           prefixJoinOrder.contains(substr));
@@ -241,7 +241,6 @@ public class PlanTestBase extends BaseTestQuery {
   public static void testRelPhysicalJoinOrder(String sql, String... expectedSubstrs) throws Exception {
     final String planStr = getDrillRelPlanInString(sql, SqlExplainLevel.EXPPLAN_ATTRIBUTES, Depth.PHYSICAL);
     final String prefixJoinOrder = getPhysicalPrefixJoinOrderFromPlan(planStr);
-    System.out.println(" prefix Join order = \n" + prefixJoinOrder);
     for (final String substr : expectedSubstrs) {
       assertTrue(String.format("Expected string %s is not in the prefixJoinOrder %s!", substr, prefixJoinOrder),
           prefixJoinOrder.contains(substr));
@@ -370,7 +369,6 @@ public class PlanTestBase extends BaseTestQuery {
     final List<QueryDataBatch> results = testSqlWithResults(sql);
     final RecordBatchLoader loader = new RecordBatchLoader(getDrillbitContext().getAllocator());
     final StringBuilder builder = new StringBuilder();
-    final boolean silent = config != null && config.getBoolean(QueryTestUtil.TEST_QUERY_PRINTING_SILENT);
 
     for (final QueryDataBatch b : results) {
       if (!b.hasData()) {
@@ -388,17 +386,14 @@ public class PlanTestBase extends BaseTestQuery {
         throw new Exception("Looks like you did not provide an explain plan query, please add EXPLAIN PLAN FOR to the beginning of your query.");
       }
 
-      if (!silent) {
-        System.out.println(vw.getValueVector().getField().getName());
-      }
+      logger.debug(vw.getValueVector().getField().getName());
       final ValueVector vv = vw.getValueVector();
       for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
         final Object o = vv.getAccessor().getObject(i);
         builder.append(o);
-        if (!silent) {
-          System.out.println(o);
-        }
+        logger.debug(o.toString());
       }
+
       loader.clear();
       b.release();
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedConcurrent.java
@@ -50,6 +50,8 @@ import static org.junit.Assert.assertNull;
  */
 @Category({SlowTest.class})
 public class TestTpchDistributedConcurrent extends BaseTestQuery {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchDistributedConcurrent.class);
+
   @Rule public final TestRule TIMEOUT = TestTools.getTimeoutRule(360000); // Longer timeout than usual.
 
   /*
@@ -151,7 +153,7 @@ public class TestTpchDistributedConcurrent extends BaseTestQuery {
       super.submissionFailed(uex);
 
       completionSemaphore.release();
-      System.out.println("submissionFailed for " + query + "\nwith " + uex);
+      logger.error("submissionFailed for {} \nwith:", query, uex);
       synchronized(TestTpchDistributedConcurrent.this) {
         final Object object = listeners.remove(this);
         assertNotNull("listener not found", object);
@@ -168,7 +170,7 @@ public class TestTpchDistributedConcurrent extends BaseTestQuery {
         try {
           submissionSemaphore.acquire();
         } catch(InterruptedException e) {
-          System.out.println("QuerySubmitter quitting.");
+          logger.error("QuerySubmitter quitting.");
           return;
         }
 
@@ -197,8 +199,7 @@ public class TestTpchDistributedConcurrent extends BaseTestQuery {
 
       // List the failed queries.
       for(final FailedQuery fq : failedQueries) {
-        System.err.println(String.format(
-            "%s failed with %s", fq.queryFile, fq.userEx));
+        logger.error(String.format("%s failed with %s", fq.queryFile, fq.userEx));
       }
     }
 
@@ -212,9 +213,9 @@ public class TestTpchDistributedConcurrent extends BaseTestQuery {
         sb.append(s.toString());
         sb.append('\n');
       }
-      System.out.println("interruptedException: " + interruptedException.getMessage() +
-          " from \n" + sb.toString());
+      logger.error("Interruped Exception ", interruptedException);
     }
+
     assertNull("Query error caused interruption", interruptedException);
 
     final int nListeners = listeners.size();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
@@ -167,12 +167,6 @@ public class DrillSeparatePlanningTest extends ClusterTest {
     client.alterSession("planner.slice_target", 1);
     try {
       QueryPlanFragments planFragments = client.planQuery(QueryType.SQL, query, true);
-
-      // Uncomment for debugging.
-
-//      for (PlanFragment fragment : planFragments.getFragmentsList()) {
-//        System.out.println(fragment.getFragmentJson());
-//      }
       return planFragments;
     }
     finally {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec;
 
-
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
@@ -41,6 +40,8 @@ import com.google.common.base.Stopwatch;
 import com.google.common.io.Files;
 
 public class RunRootExec {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RunRootExec.class);
+
   public static DrillConfig c = DrillConfig.create();
 
   public static void main(String args[]) throws Exception {
@@ -56,7 +57,7 @@ public class RunRootExec {
     SimpleRootExec exec;
     for (int i = 0; i < iterations; i ++) {
       Stopwatch w = Stopwatch.createStarted();
-      System.out.println("STARTITER:" + i);
+      logger.info("STARTITER: {}", i);
       exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
       while (exec.next()) {
@@ -64,8 +65,8 @@ public class RunRootExec {
           v.clear();
         }
       }
-      System.out.println("ENDITER: " + i);
-      System.out.println("TIME: " + w.elapsed(TimeUnit.MILLISECONDS) + "ms");
+      logger.info("ENDITER: {}", i);
+      logger.info("TIME: {}ms", w.elapsed(TimeUnit.MILLISECONDS));
       exec.close();
     }
     context.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/SortTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/SortTest.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.util.IndexedSortable;
 import org.apache.hadoop.util.QuickSort;
 
 public class SortTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SortTest.class);
+
   private static final int RECORD_COUNT = 10*1000*1000;
   private static final int KEY_SIZE = 10;
   private static final int DATA_SIZE = 90;
@@ -35,18 +37,16 @@ public class SortTest {
     for(int i =0; i < 100; i++){
       SortTest st = new SortTest();
       long nanos = st.doSort();
-      System.out.print("Sort Completed in ");
-      System.out.print(nanos);
-      System.out.println(" ns.");
+      logger.info("Sort Completed in {} ns.", nanos);
     }
   }
 
   SortTest(){
-    System.out.print("Generating data... ");
+    logger.info("Generating data... ");
     data = new byte[RECORD_SIZE*RECORD_COUNT];
     Random r = new Random();
     r.nextBytes(data);
-    System.out.print("Data generated. ");
+    logger.info("Data generated. ");
   }
 
   public long doSort(){

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestWriteToDisk.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestWriteToDisk.java
@@ -28,9 +28,7 @@ import org.apache.drill.test.TestTools;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.record.MaterializedField;
-import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
-import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.DrillbitContext;
@@ -108,20 +106,7 @@ public class TestWriteToDisk extends ExecTest {
           }
         }
 
-        final VectorAccessible newContainer = newWrap.get();
-        for (VectorWrapper<?> w : newContainer) {
-          try (ValueVector vv = w.getValueVector()) {
-            int values = vv.getAccessor().getValueCount();
-            for (int i = 0; i < values; i++) {
-              final Object o = vv.getAccessor().getObject(i);
-              if (o instanceof byte[]) {
-                System.out.println(new String((byte[]) o));
-              } else {
-                System.out.println(o);
-              }
-            }
-          }
-        }
+        newWrap.get();
       }
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientSystemTest.java
@@ -56,7 +56,6 @@ public class DrillClientSystemTest extends DrillSystemTestBase {
     client.connect();
     List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, plan);
     for (QueryDataBatch result : results) {
-      System.out.println(result);
       result.release();
     }
     client.close();
@@ -69,7 +68,6 @@ public class DrillClientSystemTest extends DrillSystemTestBase {
     client.connect();
     List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, plan);
     for (QueryDataBatch result : results) {
-      System.out.println(result);
       result.release();
     }
     client.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillClientTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
  */
 
 public class DrillClientTest extends DrillSystemTestBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillClientTest.class);
 
   private final DrillConfig config = DrillConfig.create();
 
@@ -128,7 +129,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 
@@ -142,7 +143,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 
@@ -156,7 +157,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 
@@ -170,7 +171,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 
@@ -237,7 +238,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 
@@ -251,7 +252,7 @@ public class DrillClientTest extends DrillSystemTestBase {
         (drillBitConnection, config.getString(ExecConstants.INITIAL_USER_PORT));
       fail();
     } catch (InvalidConnectionInfoException e) {
-      System.out.println(e.getMessage());
+      logger.error("Exception ", e);
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DumpCatTest.java
@@ -87,12 +87,7 @@ public class DumpCatTest  extends ExecTest {
       final int minorFragmentId = handle.getMinorFragmentId();
 
       final String logLocation = c.getString(ExecConstants.TRACE_DUMP_DIRECTORY);
-
-      System.out.println("Found log location: " + logLocation);
-
       final String filename = String.format("%s//%s_%d_%d_mock-scan", logLocation, qid, majorFragmentId, minorFragmentId);
-
-      System.out.println("File Name: " + filename);
 
       final Configuration conf = new Configuration();
       conf.set(FileSystem.FS_DEFAULT_NAME_KEY, c.getString(ExecConstants.TRACE_DUMP_FILESYSTEM));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassCompilationTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestClassCompilationTypes.java
@@ -36,7 +36,7 @@ public class TestClassCompilationTypes extends ExecTest{
       long n2 = System.nanoTime();
       long janinoT = (n1 - n0)/1000;
       long jdkT = (n2 - n1)/1000;
-      System.out.println("Janino: " + janinoT + "micros.  JDK: " + jdkT + "micros. Val" + r);
+      logger.info("Janino: {} micros.  JDK: {} micros. Val {}", janinoT, jdkT, r);
     }
 
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/EscapeTest1.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/EscapeTest1.java
@@ -23,6 +23,7 @@ import java.nio.IntBuffer;
 import org.apache.drill.exec.ExecTest;
 
 public final class EscapeTest1 extends ExecTest{
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(EscapeTest1.class);
 
   public static class Timer{
     long n1;
@@ -33,7 +34,7 @@ public final class EscapeTest1 extends ExecTest{
     }
 
     public void print(long sum){
-      System.out.println(String.format("Completed %s in %d ms.  Output was %d", name, (System.nanoTime() - n1)/1000/1000, sum));
+      logger.info("Completed {} in {} ms. Output was {}", name, (System.nanoTime() - n1)/1000/1000, sum);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/ExpressionTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/ExpressionTest.java
@@ -51,7 +51,7 @@ public class ExpressionTest extends ExecTest {
 
   @Test
   public void testBasicExpression() throws Exception {
-    System.out.println(getExpressionCode("if(true) then 1 else 0 end"));
+    getExpressionCode("if(true) then 1 else 0 end");
   }
 
   @Test
@@ -76,7 +76,7 @@ public class ExpressionTest extends ExecTest {
     when(batch.getValueVectorId(new SchemaPath("alpha", ExpressionPosition.UNKNOWN))).thenReturn(tfid);
     when(batch.getValueAccessorById(IntVector.class, tfid.getFieldIds())).thenReturn(wrapper);
 
-    System.out.println(getExpressionCode("1 + 1", batch));
+    getExpressionCode("1 + 1", batch);
   }
 
   @Test
@@ -85,7 +85,7 @@ public class ExpressionTest extends ExecTest {
     when(batch.getValueVectorId(new SchemaPath("alpha", ExpressionPosition.UNKNOWN)))
       .thenReturn(new TypedFieldId(Types.optional(MinorType.BIGINT), false, 0));
 
-    System.out.println(getExpressionCode("1 + alpha", batch));
+    getExpressionCode("1 + alpha", batch);
   }
 
   @Test(expected = ExpressionParsingException.class)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateFunctions.java
@@ -65,9 +65,7 @@ public class TestDateFunctions extends PopUnitTestBase {
 
       int i = 0;
       for (VectorWrapper<?> v : batchLoader) {
-
         ValueVector.Accessor accessor = v.getValueVector().getAccessor();
-        System.out.println(accessor.getObject(0));
         assertEquals(expectedResults[i++], accessor.getObject(0).toString());
       }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestNewAggregateFunctions.java
@@ -69,7 +69,6 @@ public class TestNewAggregateFunctions extends PopUnitTestBase {
       int i = 0;
       for (VectorWrapper<?> v : batchLoader) {
         ValueVector.Accessor accessor = v.getValueVector().getAccessor();
-        System.out.println((accessor.getObject(0)));
         assertEquals(expected[i++], (accessor.getObject(0)));
       }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
@@ -235,7 +235,7 @@ public class ExpressionInterpreterTest  extends PopUnitTestBase {
       } else {
         cellString = DrillStringUtils.escapeNewLines(String.valueOf(o));
       }
-      System.out.printf(row + "th value: " + cellString + "\n");
+      logger.info("{}th value: {}", row, cellString);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/opt/BasicOptimizerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/opt/BasicOptimizerTest.java
@@ -32,8 +32,6 @@ public class BasicOptimizerTest extends ExecTest {
         DrillConfig c = DrillConfig.create();
         LogicalPlanPersistence lpp = PhysicalPlanReaderTestFactory.defaultLogicalPlanPersistence(c);
         LogicalPlan plan = LogicalPlan.parse(lpp, DrillFileUtils.getResourceAsString("/scan_screen_logical.json"));
-        String unparse = plan.unparse(lpp);
-//        System.out.println(unparse);
-        //System.out.println( new BasicOptimizer(DrillConfig.create()).convert(plan).unparse(c.getMapper().writer()));
+        plan.unparse(lpp);
     }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/config/TestParsePhysicalPlan.java
@@ -50,7 +50,6 @@ public class TestParsePhysicalPlan extends ExecTest {
     ObjectReader r = lpp.getMapper().reader(PhysicalPlan.class);
     ObjectWriter writer = lpp.getMapper().writer();
     PhysicalPlan plan = reader.readPhysicalPlan(Files.toString(DrillFileUtils.getResourceAsFile("/physical_test1.json"), Charsets.UTF_8));
-    String unparse = plan.unparse(writer);
-//    System.out.println(unparse);
+    plan.unparse(writer);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestBroadcastExchange.java
@@ -88,7 +88,6 @@ public class TestBroadcastExchange extends PopUnitTestBase {
         }
         b.release();
       }
-      System.out.println(count);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestExtractFunctions.java
@@ -126,7 +126,6 @@ public class TestExtractFunctions extends PopUnitTestBase {
         for(int j=0; j<expectedValues[i].length; j++) {
           NullableBigIntVector vv =
               (NullableBigIntVector) batchLoader.getValueAccessorById(NullableBigIntVector.class, j).getValueVector();
-          System.out.println("["+i+"]["+j+"]: Expected: " + expectedValues[i][j] + ", Actual: " + vv.getAccessor().get(i));
           assertEquals(expectedValues[i][j], vv.getAccessor().get(i));
         }
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestLocalExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestLocalExchange.java
@@ -195,7 +195,6 @@ public class TestLocalExchange extends PlanTestBase {
     final int numOccurrances = NUM_EMPLOYEES/NUM_DEPTS;
 
     final String plan = getPlanInString("EXPLAIN PLAN FOR " + groupByMultipleQuery, JSON_FORMAT);
-    System.out.println("Plan: " + plan);
 
     jsonExchangeOrderChecker(plan, false, 1, "hash32asdouble\\(.*, hash32asdouble\\(.*, hash32asdouble\\(.*\\) \\) \\) ");
 
@@ -270,7 +269,6 @@ public class TestLocalExchange extends PlanTestBase {
     setupHelper(isMuxOn, isDeMuxOn);
 
     String plan = getPlanInString("EXPLAIN PLAN FOR " + query, JSON_FORMAT);
-    System.out.println("Plan: " + plan);
 
     if ( isMuxOn ) {
       // # of hash exchanges should be = # of mux exchanges + # of demux exchanges

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestReverseImplicitCast.java
@@ -64,9 +64,7 @@ public class TestReverseImplicitCast extends PopUnitTestBase {
       ValueVector.Accessor varcharAccessor1 = itr.next().getValueVector().getAccessor();
 
       for (int i = 0; i < intAccessor1.getValueCount(); i++) {
-        System.out.println(intAccessor1.getObject(i));
         assertEquals(intAccessor1.getObject(i), 10);
-        System.out.println(varcharAccessor1.getObject(i));
         assertEquals(varcharAccessor1.getObject(i).toString(), "101");
       }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSimpleFragmentRun.java
@@ -52,11 +52,12 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
     bit.run();
     client.connect();
     final String path = "/physical_test2.json";
-//      String path = "/filter/test1.json";
     final List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.toString(DrillFileUtils.getResourceAsFile(path), Charsets.UTF_8));
 
     // look at records
     final RecordBatchLoader batchLoader = new RecordBatchLoader(client.getAllocator());
+    final StringBuilder sb = new StringBuilder();
+
     int recordCount = 0;
     for (final QueryDataBatch batch : results) {
       final boolean schemaChanged = batchLoader.load(batch.getHeader().getDef(), batch.getData());
@@ -64,20 +65,20 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
 
       // print headers.
       if (schemaChanged) {
-        System.out.println("\n\n========NEW SCHEMA=========\n\n");
+        sb.append("\n\n========NEW SCHEMA=========\n\n");
         for (final VectorWrapper<?> value : batchLoader) {
 
           if (firstColumn) {
             firstColumn = false;
           } else {
-            System.out.print("\t");
+            sb.append("\t");
           }
-          System.out.print(value.getField().getName());
-          System.out.print("[");
-          System.out.print(value.getField().getType().getMinorType());
-          System.out.print("]");
+          sb.append(value.getField().getName());
+          sb.append("[");
+          sb.append(value.getField().getType().getMinorType());
+          sb.append("]");
         }
-        System.out.println();
+        sb.append('\n');
       }
 
       for (int i = 0; i < batchLoader.getRecordCount(); i++) {
@@ -87,17 +88,19 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
           if (first) {
             first = false;
           } else {
-            System.out.print("\t");
+            sb.append("\t");
           }
-          System.out.print(value.getValueVector().getAccessor().getObject(i));
+          sb.append(value.getValueVector().getAccessor().getObject(i));
         }
         if (!first) {
-          System.out.println();
+          sb.append('\n');
         }
       }
       batchLoader.clear();
       batch.release();
     }
+
+    logger.debug(sb.toString());
     logger.debug("Received results {}", results);
     assertEquals(recordCount, 200);
     }
@@ -121,10 +124,6 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
       final RecordBatchLoader batchLoader = new RecordBatchLoader(RootAllocatorFactory.newRoot(CONFIG));
       int recordCount = 0;
 
-      //int expectedBatchCount = 2;
-
-      //assertEquals(expectedBatchCount, results.size());
-
       for (int i = 0; i < results.size(); ++i) {
         final QueryDataBatch batch = results.get(i);
         if (i == 0) {
@@ -139,22 +138,23 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
         boolean firstColumn = true;
 
         // print headers.
-        System.out.println("\n\n========NEW SCHEMA=========\n\n");
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append("\n\n========NEW SCHEMA=========\n\n");
         for (final VectorWrapper<?> v : batchLoader) {
 
           if (firstColumn) {
             firstColumn = false;
           } else {
-            System.out.print("\t");
+            sb.append("\t");
           }
-          System.out.print(v.getField().getName());
-          System.out.print("[");
-          System.out.print(v.getField().getType().getMinorType());
-          System.out.print("]");
+          sb.append(v.getField().getName());
+          sb.append("[");
+          sb.append(v.getField().getType().getMinorType());
+          sb.append("]");
         }
 
-        System.out.println();
-
+        sb.append('\n');
 
         for (int r = 0; r < batchLoader.getRecordCount(); r++) {
           boolean first = true;
@@ -163,14 +163,14 @@ public class TestSimpleFragmentRun extends PopUnitTestBase {
             if (first) {
               first = false;
             } else {
-              System.out.print("\t");
+              sb.append("\t");
             }
 
             final ValueVector.Accessor accessor = v.getValueVector().getAccessor();
-            System.out.print(accessor.getObject(r));
+            sb.append(accessor.getObject(r));
           }
           if (!first) {
-            System.out.println();
+            sb.append('\n');
           }
         }
         batchLoader.clear();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.agg;
 
-import ch.qos.logback.classic.Level;
 import org.apache.drill.categories.OperatorTest;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
@@ -29,7 +28,6 @@ import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.DrillTest;
-import org.apache.drill.test.LogFixture;
 import org.apache.drill.test.ProfileParser;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.drill.categories.SlowTest;
@@ -59,10 +57,6 @@ public class TestHashAggrSpill extends DrillTest {
      */
     private void testSpill(long maxMem, long numPartitions, long minBatches, int maxParallel, boolean fallback ,boolean predict,
                            String sql, long expectedRows, int cycle, int fromPart, int toPart) throws Exception {
-        LogFixture.LogFixtureBuilder logBuilder = LogFixture.builder()
-          .toConsole()
-          .logger("org.apache.drill", Level.WARN);
-
         ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
           .sessionOption(ExecConstants.HASHAGG_MAX_MEMORY_KEY,maxMem)
           .sessionOption(ExecConstants.HASHAGG_NUM_PARTITIONS_KEY,numPartitions)
@@ -76,10 +70,9 @@ public class TestHashAggrSpill extends DrillTest {
         String sqlStr = sql != null ? sql :  // if null then use this default query
           "SELECT empid_s17, dept_i, branch_i, AVG(salary_i) FROM `mock`.`employee_1200K` GROUP BY empid_s17, dept_i, branch_i";
 
-        try (LogFixture logs = logBuilder.build();
-             ClusterFixture cluster = builder.build();
+        try (ClusterFixture cluster = builder.build();
              ClientFixture client = cluster.clientFixture()) {
-            runAndDump(client, sqlStr, expectedRows, cycle, fromPart,toPart);
+          runAndDump(client, sqlStr, expectedRows, cycle, fromPart, toPart);
         }
     }
     /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/filter/TestSimpleFilter.java
@@ -83,9 +83,6 @@ public class TestSimpleFilter extends ExecTest {
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
     int recordCount = 0;
     while(exec.next()) {
-      for (int i = 0; i < exec.getSelectionVector4().getCount(); i++) {
-        System.out.println("Got: " + exec.getSelectionVector4().get(i));
-      }
       recordCount += exec.getSelectionVector4().getCount();
     }
     exec.close();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoin.java
@@ -81,7 +81,6 @@ public class TestHashJoin extends PopUnitTestBase {
     }
     exec.close();
     assertEquals(expectedRows, totalRecordCount);
-    System.out.println("Total Record Count: " + totalRecordCount);
     if (context.getExecutorState().getFailureCause() != null) {
       throw context.getExecutorState().getFailureCause();
     }
@@ -168,7 +167,6 @@ public class TestHashJoin extends PopUnitTestBase {
         b.release();
       }
 
-      System.out.println("Total records: " + count);
       assertEquals(25, count);
     }
   }
@@ -238,7 +236,6 @@ public class TestHashJoin extends PopUnitTestBase {
         b.release();
       }
 
-      System.out.println("Total records: " + count);
       assertEquals(272, count);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinSpill.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
-import ch.qos.logback.classic.Level;
 import com.google.common.collect.Lists;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.drill.categories.OperatorTest;
@@ -25,7 +24,6 @@ import org.apache.drill.categories.SlowTest;
 
 import org.apache.drill.exec.physical.config.HashJoinPOP;
 import org.apache.drill.exec.physical.unit.PhysicalOpUnitTestBase;
-import org.apache.drill.test.LogFixture;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -38,11 +36,6 @@ public class TestHashJoinSpill extends PhysicalOpUnitTestBase {
   @Test
   // Should spill, including recursive spill
   public void testSimpleHashJoinSpill() {
-    LogFixture.LogFixtureBuilder logBuilder = LogFixture.builder()
-      .toConsole()
-      .logger("org.apache.drill", Level.WARN);
-
-
     HashJoinPOP joinConf = new HashJoinPOP(null, null,
       Lists.newArrayList(joinCond("lft", "EQUALS", "rgt")), JoinRelType.INNER);
     operatorFixture.getOptionManager().setLocalOption("exec.hashjoin.num_partitions", 4);
@@ -59,7 +52,6 @@ public class TestHashJoinSpill extends PhysicalOpUnitTestBase {
       rightTable.add("[{\"rgt\": " + cnt + ", \"b\" : \"a string\"}]");
     }
 
-    LogFixture logs = logBuilder.build();
     opTestBuilder()
       .physicalOperator(joinConf)
       .inputDataStreamsJson(Lists.newArrayList(leftTable,rightTable))

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoin.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.FragmentRoot;
 import org.apache.drill.exec.physical.impl.ImplCreator;
 import org.apache.drill.exec.physical.impl.SimpleRootExec;
+import org.apache.drill.exec.physical.impl.aggregate.HashAggBatch;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory;
 import org.apache.drill.exec.pop.PopUnitTestBase;
@@ -57,6 +58,7 @@ import org.mockito.Mockito;
 
 @Category({SlowTest.class, OperatorTest.class})
 public class TestMergeJoin extends PopUnitTestBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashAggBatch.class);
   private final DrillConfig c = DrillConfig.create();
 
   @Test
@@ -72,12 +74,13 @@ public class TestMergeJoin extends PopUnitTestBase {
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     int totalRecordCount = 0;
+    final StringBuilder sb = new StringBuilder();
     while (exec.next()) {
       totalRecordCount += exec.getRecordCount();
       for (final ValueVector v : exec) {
-        System.out.print("[" + v.getField().getName() + "]        ");
+        sb.append("[" + v.getField().getName() + "]        ");
       }
-      System.out.println("\n");
+      sb.append("\n\n");
       for (int valueIdx = 0; valueIdx < exec.getRecordCount(); valueIdx++) {
         final List<Object> row = new ArrayList<>();
         for (final ValueVector v : exec) {
@@ -85,21 +88,22 @@ public class TestMergeJoin extends PopUnitTestBase {
         }
         for (final Object cell : row) {
           if (cell == null) {
-            System.out.print("<null>          ");
+            sb.append("<null>          ");
             continue;
           }
           final int len = cell.toString().length();
-          System.out.print(cell);
+          sb.append(cell);
           for (int i = 0; i < (14 - len); ++i) {
-            System.out.print(" ");
+            sb.append(" ");
           }
         }
-        System.out.println();
+        sb.append("\n");
       }
-      System.out.println();
+      sb.append("\n");
     }
+
+    logger.info(sb.toString());
     assertEquals(100, totalRecordCount);
-    System.out.println("Total Record Count: " + totalRecordCount);
     if (context.getExecutorState().getFailureCause() != null) {
       throw context.getExecutorState().getFailureCause();
     }
@@ -124,10 +128,12 @@ public class TestMergeJoin extends PopUnitTestBase {
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     int totalRecordCount = 0;
+    final StringBuilder sb = new StringBuilder();
+
     while (exec.next()) {
       totalRecordCount += exec.getRecordCount();
-      System.out.println("got next with record count: " + exec.getRecordCount() + " (total: " + totalRecordCount + "):");
-      System.out.println("       t1                 t2");
+      sb.append(String.format("got next with record count: %d (total: %d):\n", exec.getRecordCount(), totalRecordCount));
+      sb.append("       t1                 t2\n");
 
       for (int valueIdx = 0; valueIdx < exec.getRecordCount(); valueIdx++) {
         final List<Object> row = Lists.newArrayList();
@@ -136,19 +142,20 @@ public class TestMergeJoin extends PopUnitTestBase {
         }
         for (final Object cell : row) {
           if (cell == null) {
-            System.out.print("<null>    ");
+            sb.append("<null>    ");
             continue;
           }
           final int len = cell.toString().length();
-          System.out.print(cell + " ");
+          sb.append(cell + " ");
           for (int i = 0; i < (10 - len); ++i) {
-            System.out.print(" ");
+            sb.append(" ");
           }
         }
-        System.out.println();
+        sb.append('\n');
       }
     }
-    System.out.println("Total Record Count: " + totalRecordCount);
+
+    logger.info(sb.toString());
     assertEquals(25, totalRecordCount);
 
     if (context.getExecutorState().getFailureCause() != null) {
@@ -175,10 +182,12 @@ public class TestMergeJoin extends PopUnitTestBase {
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     int totalRecordCount = 0;
+    final StringBuilder sb = new StringBuilder();
+
     while (exec.next()) {
       totalRecordCount += exec.getRecordCount();
-      System.out.println("got next with record count: " + exec.getRecordCount() + " (total: " + totalRecordCount + "):");
-      System.out.println("       t1                 t2");
+      sb.append(String.format("got next with record count: %d (total: %d):\n", exec.getRecordCount(), totalRecordCount));
+      sb.append("       t1                 t2\n");
 
       for (int valueIdx = 0; valueIdx < exec.getRecordCount(); valueIdx++) {
         final List<Object> row = Lists.newArrayList();
@@ -187,19 +196,18 @@ public class TestMergeJoin extends PopUnitTestBase {
         }
         for (final Object cell : row) {
           if (cell == null) {
-            System.out.print("<null>    ");
+            sb.append("<null>    ");
             continue;
           }
           final int len = cell.toString().length();
-          System.out.print(cell + " ");
+          sb.append(cell + " ");
           for (int i = 0; i < (10 - len); ++i) {
-            System.out.print(" ");
+            sb.append(" ");
           }
         }
-        System.out.println();
+        sb.append('\n');
       }
     }
-    System.out.println("Total Record Count: " + totalRecordCount);
     assertEquals(23, totalRecordCount);
 
     if (context.getExecutorState().getFailureCause() != null) {
@@ -226,9 +234,11 @@ public class TestMergeJoin extends PopUnitTestBase {
     final SimpleRootExec exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));
 
     int totalRecordCount = 0;
+    final StringBuilder sb = new StringBuilder();
+
     while (exec.next()) {
       totalRecordCount += exec.getRecordCount();
-      System.out.println("got next with record count: " + exec.getRecordCount() + " (total: " + totalRecordCount + "):");
+      sb.append(String.format("got next with record count: %d (total: %d):\n", exec.getRecordCount(), totalRecordCount));
 
       for (int valueIdx = 0; valueIdx < exec.getRecordCount(); valueIdx++) {
         final List<Object> row = Lists.newArrayList();
@@ -237,19 +247,18 @@ public class TestMergeJoin extends PopUnitTestBase {
         }
         for (final Object cell : row) {
           if (cell == null) {
-            System.out.print("<null>    ");
+            sb.append("<null>    ");
             continue;
           }
           int len = cell.toString().length();
-          System.out.print(cell + " ");
+          sb.append(cell + " ");
           for (int i = 0; i < (10 - len); ++i) {
-            System.out.print(" ");
+            sb.append(" ");
           }
         }
-        System.out.println();
+        sb.append('\n');
       }
     }
-    System.out.println("Total Record Count: " + totalRecordCount);
     assertEquals(25, totalRecordCount);
 
     if (context.getExecutorState().getFailureCause() != null) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/orderedpartitioner/TestOrderedPartitionExchange.java
@@ -134,8 +134,6 @@ public class TestOrderedPartitionExchange extends PopUnitTestBase {
       Mean mean = new Mean();
       double std = stdDev.evaluate(values);
       double m = mean.evaluate(values);
-      System.out.println("mean: " + m + " std dev: " + std);
-      //Assert.assertTrue(std < 0.1 * m);
       assertEquals(31000, count);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
@@ -147,7 +147,6 @@ public class TestPartitionSender extends PlanTestBase {
 
     test("ALTER SESSION SET `planner.slice_target`=1");
     String plan = getPlanInString("EXPLAIN PLAN FOR " + groupByQuery, JSON_FORMAT);
-    System.out.println("Plan: " + plan);
 
     final DrillbitContext drillbitContext = getDrillbitContext();
     final PhysicalPlanReader planReader = drillbitContext.getPlanReader();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/sort/TestSimpleSort.java
@@ -84,8 +84,6 @@ public class TestSimpleSort extends ExecTest {
       }
     }
 
-    System.out.println(String.format("Sorted %,d records in %d batches.", recordCount, batchCount));
-
     if(context.getExecutorState().getFailureCause() != null) {
       throw context.getExecutorState().getFailureCause();
     }
@@ -129,8 +127,6 @@ public class TestSimpleSort extends ExecTest {
         assertTrue(previousLong >= a2.get(i));
       }
     }
-
-    System.out.println(String.format("Sorted %,d records in %d batches.", recordCount, batchCount));
 
     if(context.getExecutorState().getFailureCause() != null) {
       throw context.getExecutorState().getFailureCause();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/trace/TestTraceOutputDump.java
@@ -98,11 +98,8 @@ public class TestTraceOutputDump extends ExecTest {
     final int minorFragmentId = handle.getMinorFragmentId();
 
     final String logLocation = c.getString(ExecConstants.TRACE_DUMP_DIRECTORY);
-    System.out.println("Found log location: " + logLocation);
 
     final String filename = String.format("%s//%s_%d_%d_mock-scan", logLocation, qid, majorFragmentId, minorFragmentId);
-    System.out.println("File Name: " + filename);
-
     final Configuration conf = new Configuration();
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, c.getString(ExecConstants.TRACE_DUMP_FILESYSTEM));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/union/TestSimpleUnion.java
@@ -62,7 +62,6 @@ public class TestSimpleUnion extends ExecTest {
     final int[] counts = new int[]{0, 100,50}; // first batch : 0-row schema-only batch.
     int i = 0;
     while(exec.next()) {
-      System.out.println("iteration count:" + exec.getRecordCount());
       assertEquals(counts[i++], exec.getRecordCount());
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/GenerateTestData.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/GenerateTestData.java
@@ -30,6 +30,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class GenerateTestData {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(GenerateTestData.class);
+
   private static final int BATCH_SIZE = 20;
 
   private static class Builder {
@@ -306,7 +308,6 @@ public class GenerateTestData {
       }
       emp_idx++;
       if ((emp_idx % BATCH_SIZE)==0 && emp_idx < total) {
-        System.out.printf("total: %d, emp_idx: %d, fileID: %d%n", total, emp_idx, fileId);
         dataStream.close();
         fileId++;
         dataStream = new PrintStream(path + "/" + fileId + ".data.json");
@@ -364,7 +365,7 @@ public class GenerateTestData {
 
     if (!pathFolder.exists()) {
       if (!pathFolder.mkdirs()) {
-        System.err.printf("Couldn't create folder %s, exiting%n", path);
+        logger.error("Couldn't create folder {}, exiting", path);
       }
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -963,9 +963,6 @@ public class TestParquetWriter extends BaseTestQuery {
   @Test
   public void testTPCHReadWriteRunRepeated() throws Exception {
     for (int i = 1; i <= repeat; i++) {
-      if(i%100 == 0) {
-        System.out.println("\n\n Iteration : "+i +"\n");
-      }
       testTPCHReadWriteGzip();
       testTPCHReadWriteSnappy();
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
@@ -36,7 +36,6 @@ import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.DrillTest;
-import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.categories.SlowTest;
 import org.junit.Rule;
 import org.junit.Test;
@@ -134,8 +133,6 @@ public class TestSimpleExternalSort extends DrillTest {
       loader.clear();
       b.release();
     }
-
-    System.out.println(String.format("Sorted %,d records in %d batches.", recordCount, batchCount));
   }
 
   @Test
@@ -211,7 +208,6 @@ public class TestSimpleExternalSort extends DrillTest {
         loader.clear();
         b.release();
       }
-      System.out.println(String.format("Sorted %,d records in %d batches.", recordCount, batchCount));
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
@@ -577,14 +577,12 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     // empty offsets for the missing rows.
 
     actual = fixture.wrap(rsLoader.harvest());
-//    System.out.println(actual.schema().toString());
     expected = fixture.rowSetBuilder(actual.schema())
         .addRow(40, mapValue(intArray(410, 420), strArray("d4.1", "d4.2"), strArray()))
         .addRow(50, mapValue(intArray(510), strArray("d5.1"), strArray()))
         .addRow(60, mapValue(intArray(610, 620), strArray("d6.1", "d6.2"), strArray("e6.1", "e6.2")))
         .addRow(70, mapValue(intArray(710), strArray(), strArray("e7.1", "e7.2")))
         .build();
-//    expected.print();
 
     new RowSetComparison(expected).verifyAndClearAll(actual);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTorture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTorture.java
@@ -65,6 +65,7 @@ import com.google.common.base.Charsets;
  */
 
 public class TestResultSetLoaderTorture extends SubOperatorTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestResultSetLoaderTorture.class);
 
   private static class TestSetup {
     int n1Cycle = 5;
@@ -130,15 +131,11 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
       // Write until overflow
 
       writeRowCount = rootWriter.rowCount();
-      //System.out.println("Start count: " + writeRowCount);
       while (! rootWriter.isFull()) {
         lastRowDiscarded = false;
         writeRow();
         rowId++;
       }
-//      System.out.println("End of batch: rowId: " + rowId +
-//          ", count: " + writeRowCount +
-//          ", writer count:" + rootWriter.rowCount());
     }
 
     private void writeRow() {
@@ -166,12 +163,6 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
         writeRowCount++;
       } else {
         lastRowDiscarded = true;
-//        System.out.println("Skip row ID: " + rowId +
-//            ", count: " + writeRowCount +
-//            ", row set: " + rootWriter.rowCount());
-      }
-      if (rowId >= startPrint &&  rowId <= endPrint) {
-        System.out.println();
       }
     }
 
@@ -228,10 +219,7 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
 
     public void print(String label, Object value) {
       if (rowId >= startPrint &&  rowId <= endPrint) {
-        System.out.print(label);
-        System.out.print(" = ");
-        System.out.print(value);
-        System.out.print(" ");
+        logger.info("{} = {}", label, value);
       }
     }
 
@@ -278,7 +266,6 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
 
     public void verify() {
       while (rootReader.next()) {
-//        System.out.println(readState.rowId);
         verifyRow();
         readState.rowId++;
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestFragmentChecker.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/pop/TestFragmentChecker.java
@@ -24,7 +24,6 @@ import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory;
 import org.apache.drill.exec.planner.fragment.Fragment;
 import org.apache.drill.exec.planner.fragment.SimpleParallelizer;
-import org.apache.drill.exec.proto.BitControl.PlanFragment;
 import org.apache.drill.exec.proto.BitControl.QueryContextInformation;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.proto.UserBitShared;
@@ -50,8 +49,7 @@ public class TestFragmentChecker extends PopUnitTestBase{
 
   }
 
-  private void print(String fragmentFile, int bitCount, int expectedFragmentCount) throws Exception{
-    System.out.println(String.format("=================Building plan fragments for [%s].  Allowing %d total Drillbits.==================", fragmentFile, bitCount));
+  private void print(String fragmentFile, int bitCount, int expectedFragmentCount) throws Exception {
     PhysicalPlanReader ppr = PhysicalPlanReaderTestFactory.defaultPhysicalPlanReader(CONFIG);
     Fragment fragmentRoot = getRootFragment(ppr, fragmentFile);
     SimpleParallelizer par = new SimpleParallelizer(1000*1000, 5, 10, 1.2);
@@ -70,14 +68,6 @@ public class TestFragmentChecker extends PopUnitTestBase{
         UserSession.Builder.newBuilder().withCredentials(UserBitShared.UserCredentials.newBuilder().setUserName("foo").build()).build(),
         queryContextInfo);
     qwu.applyPlan(ppr);
-    System.out.println(String.format("=========ROOT FRAGMENT [%d:%d] =========", qwu.getRootFragment().getHandle().getMajorFragmentId(), qwu.getRootFragment().getHandle().getMinorFragmentId()));
-
-    System.out.print(qwu.getRootFragment().getFragmentJson());
-
-    for(PlanFragment f : qwu.getFragments()) {
-      System.out.println(String.format("=========Fragment [%d:%d]=====", f.getHandle().getMajorFragmentId(), f.getHandle().getMinorFragmentId()));
-      System.out.print(f.getFragmentJson());
-    }
 
     assertEquals(expectedFragmentCount,
         qwu.getFragments().size() + 1 /* root fragment is not part of the getFragments() list*/);
@@ -86,7 +76,5 @@ public class TestFragmentChecker extends PopUnitTestBase{
   @Test
   public void validateSingleExchangeFragment() throws Exception{
     print("/physical_single_exchange.json", 1, 2);
-
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/ExpressionTreeMaterializerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/ExpressionTreeMaterializerTest.java
@@ -114,9 +114,6 @@ public class ExpressionTreeMaterializerTest extends ExecTest {
     assertTrue(newIfExpr.elseExpression instanceof IfExpression);
     assertEquals(bigIntType, ifCondition.expression.getMajorType());
     assertEquals(true, ((ValueExpressions.BooleanExpression) ((IfExpression)(newIfExpr.elseExpression)).ifCondition.condition).value);
-    if (ec.hasErrors()) {
-      System.out.println(ec.toErrorString());
-    }
     assertFalse(ec.hasErrors());
   }
 
@@ -188,6 +185,5 @@ public class ExpressionTreeMaterializerTest extends ExecTest {
     LogicalExpression newExpr = ExpressionTreeMaterializer.materialize(functionCallExpr, batch, ec, registry);
     assertTrue(newExpr instanceof TypedNullConstant);
     assertEquals(1, ec.getErrorCount());
-    System.out.println(ec.toErrorString());
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
@@ -55,6 +55,7 @@ import java.util.List;
 
 @Category(VectorTest.class)
 public class TestRecordIterator extends PopUnitTestBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRecordIterator.class);
   DrillConfig c = DrillConfig.create();
 
   @Test
@@ -318,7 +319,7 @@ public class TestRecordIterator extends PopUnitTestBase {
         final Integer v = (Integer)o;
         result &= (v == expected);
       } else {
-        System.out.println(String.format("Found wrong type %s at position %d", o.getClass(), position));
+        logger.error("Found wrong type {} at position {}", o.getClass(), position);
         result = false;
         break;
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestLoad.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestLoad.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.drill.categories.VectorTest;
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ExecTest;
 import org.apache.drill.exec.exception.SchemaChangeException;
@@ -36,7 +35,6 @@ import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.RecordBatchLoader;
-import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.ValueVector;
@@ -82,49 +80,9 @@ public class TestLoad extends ExecTest {
 
     byteBuf.release();
 
-    // TODO: Replace this with actual validation, not just dumping to the console.
+    // TODO: Do actual validation
 
-    boolean firstColumn = true;
-    int recordCount = 0;
-    for (final VectorWrapper<?> v : batchLoader) {
-      if (firstColumn) {
-        firstColumn = false;
-      } else {
-        System.out.print("\t");
-      }
-      System.out.print(v.getField().getName());
-      System.out.print("[");
-      System.out.print(v.getField().getType().getMinorType());
-      System.out.print("]");
-    }
-
-    System.out.println();
-    for (int r = 0; r < batchLoader.getRecordCount(); r++) {
-      boolean first = true;
-      recordCount++;
-      for (final VectorWrapper<?> v : batchLoader) {
-        if (first) {
-          first = false;
-        } else {
-          System.out.print("\t");
-        }
-        final ValueVector.Accessor accessor = v.getValueVector().getAccessor();
-        if (v.getField().getType().getMinorType() == TypeProtos.MinorType.VARCHAR) {
-          final Object obj = accessor.getObject(r);
-          if (obj != null) {
-            System.out.print(accessor.getObject(r));
-          } else {
-            System.out.print("NULL");
-          }
-        } else {
-          System.out.print(accessor.getObject(r));
-        }
-      }
-      if (!first) {
-        System.out.println();
-      }
-    }
-    assertEquals(100, recordCount);
+    assertEquals(100, batchLoader.getRecordCount());
 
     // Free the original vectors
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitBitKerberos.java
@@ -163,8 +163,6 @@ public class TestBitBitKerberos extends BaseTestQuery {
     @Override
     public void success(Ack value, ByteBuf buffer) {
       long micros = watch.elapsed(TimeUnit.MILLISECONDS);
-      System.out.println(String.format("Total time to send: %d, start time %d", micros,
-          System.currentTimeMillis() - micros));
       while (true) {
         long nowMax = max.get();
         if (nowMax < micros) {
@@ -225,9 +223,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
         tunnel.sendRecordBatch(new TimingOutcome(max),
           new FragmentWritableBatch(false, QueryId.getDefaultInstance(), 1, 1, 1, 1,
             getRandomBatch(c1.getAllocator(), 5000)));
-        System.out.println(System.currentTimeMillis() - t1);
       }
-      System.out.println(String.format("Max time: %d", max.get()));
       assertTrue(max.get() > 2700);
       Thread.sleep(5000);
     } catch (Exception | AssertionError e) {
@@ -282,9 +278,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
         tunnel.sendRecordBatch(new TimingOutcome(max),
           new FragmentWritableBatch(false, QueryId.getDefaultInstance(), 1, 1, 1, 1,
             getRandomBatch(c2.getAllocator(), 5000)));
-        System.out.println(System.currentTimeMillis() - t1);
       }
-      System.out.println(String.format("Max time: %d", max.get()));
       assertTrue(max.get() > 2700);
       Thread.sleep(5000);
     } finally {
@@ -342,9 +336,7 @@ public class TestBitBitKerberos extends BaseTestQuery {
         tunnel.sendRecordBatch(new TimingOutcome(max),
           new FragmentWritableBatch(false, QueryId.getDefaultInstance(), 1, 1, 1, 1,
             getRandomBatch(c2.getAllocator(), 5000)));
-        System.out.println(System.currentTimeMillis() - t1);
       }
-      System.out.println(String.format("Max time: %d", max.get()));
       assertTrue(max.get() > 2700);
       Thread.sleep(5000);
     } catch (Exception | AssertionError ex) {
@@ -492,7 +484,6 @@ public class TestBitBitKerberos extends BaseTestQuery {
       try {
         v++;
         if (v % 10 == 0) {
-          System.out.println("sleeping.");
           Thread.sleep(3000);
         }
       } catch (InterruptedException e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/data/TestBitRpc.java
@@ -89,9 +89,7 @@ public class TestBitRpc extends ExecTest {
       long t1 = System.currentTimeMillis();
       tunnel.sendRecordBatch(new TimingOutcome(max), new FragmentWritableBatch(false, QueryId.getDefaultInstance(), 1,
           1, 1, 1, getRandomBatch(c.getAllocator(), 5000)));
-      System.out.println(System.currentTimeMillis() - t1);
     }
-    System.out.println(String.format("Max time: %d", max.get()));
     assertTrue(max.get() > 2700);
     Thread.sleep(5000);
   }
@@ -126,7 +124,6 @@ public class TestBitRpc extends ExecTest {
     @Override
     public void success(Ack value, ByteBuf buffer) {
       long micros = watch.elapsed(TimeUnit.MILLISECONDS);
-      System.out.println(String.format("Total time to send: %d, start time %d", micros, System.currentTimeMillis() - micros));
       while (true) {
         long nowMax = max.get();
         if (nowMax < micros) {
@@ -160,7 +157,6 @@ public class TestBitRpc extends ExecTest {
       try {
         v++;
         if (v % 10 == 0) {
-          System.out.println("sleeping.");
           Thread.sleep(3000);
         }
       } catch (InterruptedException e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/user/security/TestUserBitKerberosEncryption.java
@@ -512,8 +512,7 @@ public class TestUserBitKerberosEncryption extends BaseTestQuery {
       fail();
     } catch (Exception ex) {
       assert (ex.getCause() instanceof NonTransientRpcException);
-      System.out.println("Caught exception: " + ex.getMessage());
-      logger.info("Caught exception: " + ex.getMessage());
+      logger.error("Caught exception: ", ex);
     }
   }
 
@@ -543,8 +542,7 @@ public class TestUserBitKerberosEncryption extends BaseTestQuery {
       fail();
     } catch (Exception ex) {
       assert (ex.getCause() instanceof NonTransientRpcException);
-      System.out.println("Caught exception: " + ex.getMessage());
-      logger.info("Caught exception: " + ex.getMessage());
+      logger.error("Caught exception: ", ex);
     }
   }
 
@@ -579,8 +577,7 @@ public class TestUserBitKerberosEncryption extends BaseTestQuery {
       fail();
     } catch (Exception ex) {
       assert (ex.getCause() instanceof RpcException);
-      System.out.println("Caught exception: " + ex.getMessage());
-      logger.info("Caught exception: " + ex.getMessage());
+      logger.error("Caught exception: ", ex);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -148,7 +148,6 @@ public class TestDrillbitResilience extends DrillTest {
       drillbit.close();
     } catch (final Exception e) {
       final String message = "Error shutting down Drillbit \"" + name + "\"";
-      System.err.println(message + '.');
       logger.warn(message, e);
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestTpcdsSf1Leaks.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestTpcdsSf1Leaks.java
@@ -59,8 +59,6 @@ public class TestTpcdsSf1Leaks extends BaseTestQuery {
     try {
       final String query = getFile("tpcds-sf1/q73.sql");
       for (int i = 0; i < 20; i++) {
-        System.out.printf("%nRun #%d%n", i+1);
-
         try {
           runSQL(query);
         } catch (final Exception e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/CachedSingleFileSystem.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/CachedSingleFileSystem.java
@@ -50,7 +50,6 @@ public class CachedSingleFileSystem extends FileSystem {
     if (length > Integer.MAX_VALUE) {
       throw new UnsupportedOperationException("Cached file system only supports files of less than 2GB.");
     }
-    System.out.println(length);
     try (InputStream is = new BufferedInputStream(new FileInputStream(path))) {
       byte[] buffer = new byte[64*1024];
       this.file = UnpooledByteBufAllocator.DEFAULT.directBuffer((int) length);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestAffinityCalculator.java
@@ -17,10 +17,7 @@
  */
 package org.apache.drill.exec.store;
 
-import java.util.LinkedList;
-
 import org.apache.drill.exec.ExecTest;
-import org.apache.drill.exec.proto.CoordinationProtos;
 import org.apache.hadoop.fs.BlockLocation;
 import org.junit.Test;
 
@@ -28,6 +25,8 @@ import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 
 public class TestAffinityCalculator extends ExecTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestAffinityCalculator.class);
+
   private final String port = "1234";
 
   public BlockLocation[] buildBlockLocations(String[] hosts, long blockSize) {
@@ -46,15 +45,6 @@ public class TestAffinityCalculator extends ExecTest {
     return blockLocations;
   }
 
-  public LinkedList<CoordinationProtos.DrillbitEndpoint> buildEndpoints(int numberOfEndpoints) {
-    LinkedList<CoordinationProtos.DrillbitEndpoint> endPoints = new LinkedList<>();
-
-    for (int i = 0; i < numberOfEndpoints; i++) {
-      endPoints.add(CoordinationProtos.DrillbitEndpoint.newBuilder().setAddress("host" + i).build());
-    }
-    return endPoints;
-  }
-
   @Test
   public void testBuildRangeMap() {
     BlockLocation[] blocks = buildBlockLocations(new String[4], 256*1024*1024);
@@ -68,6 +58,6 @@ public class TestAffinityCalculator extends ExecTest {
     }
     ImmutableRangeMap<Long,BlockLocation> map = blockMapBuilder.build();
     long tB = System.nanoTime();
-    System.out.println(String.format("Took %f ms to build range map", (tB - tA) / 1e6));
+    logger.info(String.format("Took %f ms to build range map", (tB - tA) / 1e6));
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetRecordReaderTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.drill.exec.ops.FragmentContextImpl;
 import org.apache.drill.test.BaseTestQuery;
@@ -292,8 +291,6 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     final Stopwatch watch = Stopwatch.createStarted();
     testWithListener(type, planText, resultListener);
     resultListener.getResults();
-    // batchLoader.clear();
-    System.out.println(String.format("Took %d ms to run query", watch.elapsed(TimeUnit.MILLISECONDS)));
   }
 
   //use this method to submit physical plan
@@ -641,12 +638,10 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
       while ((rowCount = rr.next()) > 0) {
         totalRowCount += rowCount;
       }
-      System.out.println(String.format("Time completed: %s. ", watch.elapsed(TimeUnit.MILLISECONDS)));
       rr.close();
     }
 
     allocator.close();
-    System.out.println(String.format("Total row count %s", totalRowCount));
   }
 
   // specific tests should call this method, but it is not marked as a test itself intentionally
@@ -681,8 +676,6 @@ public class ParquetRecordReaderTest extends BaseTestQuery {
     }
     testWithListener(queryType, planText, resultListener);
     resultListener.getResults();
-    final long D = System.nanoTime();
-    System.out.println(String.format("Took %f s to run query", (float)(D-C) / 1E9));
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetResultListener.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetResultListener.java
@@ -183,11 +183,11 @@ public class ParquetResultListener implements UserResultsListener {
   }
 
   public void printColumnMajor(ValueVector vv) {
-    if (ParquetRecordReaderTest.VERBOSE_DEBUG){
-      System.out.println("\n" + vv.getField().getName());
-    }
+    logger.debug("\n{}", vv.getField().getName());
+    final StringBuilder sb = new StringBuilder();
+
     for (int j = 0; j < vv.getAccessor().getValueCount(); j++) {
-      if (ParquetRecordReaderTest.VERBOSE_DEBUG){
+      if (logger.isDebugEnabled()) {
         Object o = vv.getAccessor().getObject(j);
         if (o instanceof byte[]) {
           try {
@@ -196,27 +196,29 @@ public class ParquetResultListener implements UserResultsListener {
             throw new RuntimeException(e);
           }
         }
-        System.out.print(Strings.padStart(o + "", 20, ' ') + " ");
-        System.out.print(", " + (j % 25 == 0 ? "\n batch:" + batchCounter + " v:" + j + " - " : ""));
+        sb.append(Strings.padStart(o + "", 20, ' ') + " ");
+        sb.append(", " + (j % 25 == 0 ? "\n batch:" + batchCounter + " v:" + j + " - " : ""));
       }
     }
-    if (ParquetRecordReaderTest.VERBOSE_DEBUG) {
-      System.out.println("\n" + vv.getAccessor().getValueCount());
-    }
+
+    logger.debug(sb.toString());
+    logger.debug(Integer.toString(vv.getAccessor().getValueCount()));
   }
 
   public void printRowMajor(RecordBatchLoader batchLoader) {
     for (int i = 0; i < batchLoader.getRecordCount(); i++) {
       if (i % 50 == 0) {
-        System.out.println();
+        final StringBuilder sb = new StringBuilder();
+
         for (VectorWrapper vw : batchLoader) {
           ValueVector v = vw.getValueVector();
-          System.out.print(Strings.padStart(v.getField().getName(), 20, ' ') + " ");
-
+          sb.append(Strings.padStart(v.getField().getName(), 20, ' ') + " ");
         }
-        System.out.println();
-        System.out.println();
+
+        logger.debug(sb.toString());
       }
+
+      final StringBuilder sb = new StringBuilder();
 
       for (final VectorWrapper vw : batchLoader) {
         final ValueVector v = vw.getValueVector();
@@ -232,7 +234,6 @@ public class ParquetResultListener implements UserResultsListener {
 //                // check that the value at each position is a valid single character ascii value.
 //
 //                if (((byte[])o)[k] > 128) {
-//                  System.out.println("batch: " + batchCounter + " record: " + recordCount);
 //                }
 //              }
             o = new String((byte[])o, "UTF-8");
@@ -240,9 +241,11 @@ public class ParquetResultListener implements UserResultsListener {
             throw new RuntimeException(e);
           }
         }
-        System.out.print(Strings.padStart(o + "", 20, ' ') + " ");
+
+        sb.append(Strings.padStart(o + "", 20, ' ') + " ");
       }
-      System.out.println();
+
+      logger.debug(sb.toString());
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestFileGenerator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestFileGenerator.java
@@ -220,7 +220,6 @@ public class TestFileGenerator {
           for (int i = 0; i < valsPerPage; i++) {
             repLevels.writeInteger(0);
             defLevels.writeInteger(1);
-            //System.out.print(i + ", " + (i % 25 == 0 ? "\n gen " + fieldInfo.name + ": " : ""));
             if (fieldInfo.values[0] instanceof Boolean) {
 
               bytes[currentBooleanByte] |= bitFields[booleanBitCounter.val]

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.store.parquet;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.drill.common.config.DrillConfig;
@@ -51,6 +50,7 @@ public class TestParquetPhysicalPlan extends ExecTest {
   @Test
   @Ignore
   public void testParseParquetPhysicalPlan() throws Exception {
+    final StringBuilder sb = new StringBuilder();
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
     DrillConfig config = DrillConfig.create();
 
@@ -61,29 +61,30 @@ public class TestParquetPhysicalPlan extends ExecTest {
       RecordBatchLoader loader = new RecordBatchLoader(bit1.getContext().getAllocator());
       int count = 0;
       for (QueryDataBatch b : results) {
-        System.out.println(String.format("Got %d results", b.getHeader().getRowCount()));
+        sb.append(String.format("Got %d results\n", b.getHeader().getRowCount()));
         count += b.getHeader().getRowCount();
         loader.load(b.getHeader().getDef(), b.getData());
         for (VectorWrapper vw : loader) {
-          System.out.print(vw.getValueVector().getField().getName() + ": ");
+          sb.append(vw.getValueVector().getField().getName() + ": ");
           ValueVector vv = vw.getValueVector();
           for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
             Object o = vv.getAccessor().getObject(i);
             if (o instanceof byte[]) {
-              System.out.print(" [" + new String((byte[]) o) + "]");
+              sb.append(" [" + new String((byte[]) o) + "]");
             } else {
-              System.out.print(" [" + vv.getAccessor().getObject(i) + "]");
+              sb.append(" [" + vv.getAccessor().getObject(i) + "]");
             }
-//            break;
           }
-          System.out.println();
+          sb.append('\n');
         }
         loader.clear();
         b.release();
       }
       client.close();
-      System.out.println(String.format("Got %d total results", count));
+      sb.append(String.format("Got %d total results\n", count));
     }
+
+    logger.debug(sb.toString());
   }
 
   private class ParquetResultsListener implements UserResultsListener {
@@ -104,7 +105,6 @@ public class TestParquetPhysicalPlan extends ExecTest {
     @Override
     public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
       int rows = result.getHeader().getRowCount();
-      System.out.println(String.format("Result batch arrived. Number of records: %d", rows));
       count.addAndGet(rows);
       result.release();
     }
@@ -129,7 +129,6 @@ public class TestParquetPhysicalPlan extends ExecTest {
       ParquetResultsListener listener = new ParquetResultsListener();
       Stopwatch watch = Stopwatch.createStarted();
       client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(Resources.getResource(fileName),Charsets.UTF_8), listener);
-      System.out.println(String.format("Got %d total records in %d seconds", listener.await(), watch.elapsed(TimeUnit.SECONDS)));
       client.close();
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestPcapDecoder extends BaseTestQuery {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestPcapDecoder.class);
+
   private static File bigFile;
 
   @Test
@@ -148,10 +150,10 @@ public class TestPcapDecoder extends BaseTestQuery {
       p = pd.nextPacket();
     }
     long t1 = System.nanoTime();
-    System.out.printf("\nSpeed test for per packet object%s\n", msg);
-    System.out.printf("    Read %.1f MB in %.2f s for %.1f MB/s\n", total / 1e6, (t1 - t0) / 1e9, (double) total * 1e3 / (t1 - t0));
-    System.out.printf("    %d packets, %d TCP packets, %d UDP\n", allCount, tcpCount, udpCount);
-    System.out.printf("\n\n\n");
+    logger.info("Speed test for per packet object {}", msg);
+    logger.info(String.format("    Read %.1f MB in %.2f s for %.1f MB/s\n", total / 1e6, (t1 - t0) / 1e9, (double) total * 1e3 / (t1 - t0)));
+    logger.info(String.format("    %d packets, %d TCP packets, %d UDP\n", allCount, tcpCount, udpCount));
+    logger.info("\n\n\n");
   }
 
   /**
@@ -200,10 +202,10 @@ public class TestPcapDecoder extends BaseTestQuery {
       }
     }
     long t1 = System.nanoTime();
-    System.out.printf("\nSpeed test for in-place packet decoding\n");
-    System.out.printf("    Read %.1f MB in %.2f s for %.1f MB/s\n", total / 1e6, (t1 - t0) / 1e9, (double) total * 1e3 / (t1 - t0));
-    System.out.printf("    %d packets, %d TCP packets, %d UDP\n", allCount, tcpCount, udpCount);
-    System.out.printf("\n\n\n");
+    logger.info("Speed test for in-place packet decoding");
+    logger.info(String.format("    Read %.1f MB in %.2f s for %.1f MB/s\n", total / 1e6, (t1 - t0) / 1e9, (double) total * 1e3 / (t1 - t0)));
+    logger.info(String.format("    %d packets, %d TCP packets, %d UDP\n", allCount, tcpCount, udpCount));
+    logger.info("\n\n\n");
   }
 
 
@@ -216,7 +218,7 @@ public class TestPcapDecoder extends BaseTestQuery {
     bigFile = File.createTempFile("tcp", ".pcap");
     bigFile.deleteOnExit();
     boolean first = true;
-    System.out.printf("Building large test file\n");
+    logger.info("Building large test file");
     try (DataOutputStream out = new DataOutputStream(new FileOutputStream(bigFile))) {
       for (int i = 0; i < 1000e6 / (29208 - 24) + 1; i++) {
         // might be faster to keep this open and rewind each time, but
@@ -231,7 +233,7 @@ public class TestPcapDecoder extends BaseTestQuery {
   }
 
   public static void main(String[] args) throws IOException {
-    System.out.printf("Checking speeds for various approaches\n\n");
+    logger.info("Checking speeds for various approaches");
     buildBigTcpFile();
     checkConventionalApproach();
     checkBufferedApproach();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/store/TestAssignment.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/store/TestAssignment.java
@@ -78,7 +78,6 @@ public class TestAssignment {
     }
 
     ListMultimap<Integer, CompleteFileWork> mappings = AssignmentCreator.getMappings(incomingEndpoints, chunks);
-    System.out.println(mappings.keySet().size());
 
     // Verify that all fragments have chunks assigned.
     for (int i = 0; i < width; i++) {
@@ -118,7 +117,6 @@ public class TestAssignment {
     }
 
     ListMultimap<Integer, CompleteFileWork> mappings = AssignmentCreator.getMappings(incomingEndpoints, chunks);
-    System.out.println(mappings.keySet().size());
     for (int i = 0; i < width; i++) {
       Assert.assertTrue("no mapping for entry " + i, mappings.get(i) != null && mappings.get(i).size() > 0);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
@@ -56,7 +56,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 public class TestJsonReader extends BaseTestQuery {
-  private static final boolean VERBOSE_DEBUG = false;
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestJsonReader.class);
 
   @BeforeClass
   public static void setupTestFiles() {
@@ -154,27 +154,24 @@ public class TestJsonReader extends BaseTestQuery {
   }
 
   public void runTestsOnFile(String filename, UserBitShared.QueryType queryType, String[] queries, long[] rowCounts) throws Exception {
-    if (VERBOSE_DEBUG) {
-      System.out.println("===================");
-      System.out.println("source data in json");
-      System.out.println("===================");
-      System.out.println(Files.toString(DrillFileUtils.getResourceAsFile(filename), Charsets.UTF_8));
-    }
+    logger.debug("===================");
+    logger.debug("source data in json");
+    logger.debug("===================");
+    logger.debug(Files.toString(DrillFileUtils.getResourceAsFile(filename), Charsets.UTF_8));
 
     int i = 0;
     for (String query : queries) {
-      if (VERBOSE_DEBUG) {
-        System.out.println("=====");
-        System.out.println("query");
-        System.out.println("=====");
-        System.out.println(query);
-        System.out.println("======");
-        System.out.println("result");
-        System.out.println("======");
-      }
+      logger.debug("=====");
+      logger.debug("query");
+      logger.debug("=====");
+      logger.debug(query);
+      logger.debug("======");
+      logger.debug("result");
+      logger.debug("======");
       int rowCount = testRunAndPrint(queryType, query);
       assertEquals(rowCounts[i], rowCount);
-      System.out.println();
+
+      logger.debug("\n");
       i++;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.base.Charsets;
 
 public class TestRepeated {
   // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRepeated.class);
@@ -108,8 +107,6 @@ public class TestRepeated {
 //
 //
 //    assertTrue(writer.ok());
-//
-//    System.out.println(v.getAccessor().getObject(0));
 //
 //  }
 
@@ -242,9 +239,6 @@ public class TestRepeated {
 
     final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
 
-    System.out.println("Map of Object[0]: " + ow.writeValueAsString(mapVector.getAccessor().getObject(0)));
-    System.out.println("Map of Object[1]: " + ow.writeValueAsString(mapVector.getAccessor().getObject(1)));
-
     final ByteArrayOutputStream stream = new ByteArrayOutputStream();
     final JsonWriter jsonWriter = new JsonWriter(stream, true, true);
     final FieldReader reader = mapVector.getChild("col", MapVector.class).getReader();
@@ -252,8 +246,6 @@ public class TestRepeated {
     jsonWriter.write(reader);
     reader.setPosition(1);
     jsonWriter.write(reader);
-    System.out.print("Json Read: ");
-    System.out.println(new String(stream.toByteArray(), Charsets.UTF_8));
 
     writer.close();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/FileTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/batch/FileTest.java
@@ -32,29 +32,29 @@ import org.apache.hadoop.fs.Path;
 import com.google.common.base.Stopwatch;
 
 public class FileTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FileTest.class);
+
   public static void main(String[] args) throws IOException {
     Configuration conf = new Configuration();
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, "sync:///");
-    System.out.println(FileSystem.getDefaultUri(conf));
+    logger.info(FileSystem.getDefaultUri(conf).toString());
     FileSystem fs = FileSystem.get(conf);
-//    FileSystem fs = new LocalSyncableFileSystem(conf);
     Path path = new Path("/tmp/testFile");
     FSDataOutputStream out = fs.create(path);
     byte[] s = "hello world".getBytes();
     out.write(s);
     out.sync();
-//    out.close();
     FSDataInputStream in = fs.open(path);
     byte[] bytes = new byte[s.length];
     in.read(bytes);
-    System.out.println(new String(bytes));
+    logger.info(new String(bytes));
     File file = new File("/tmp/testFile");
     FileOutputStream fos = new FileOutputStream(file);
     FileInputStream fis = new FileInputStream(file);
     fos.write(s);
     fos.getFD().sync();
     fis.read(bytes);
-    System.out.println(new String(bytes));
+    logger.info(new String(bytes));
     out = fs.create(new Path("/tmp/file"));
     for (int i = 0; i < 100; i++) {
       bytes = new byte[256*1024];
@@ -62,7 +62,7 @@ public class FileTest {
       out.write(bytes);
       out.sync();
       long t = watch.elapsed(TimeUnit.MILLISECONDS);
-      System.out.printf("Elapsed: %d. Rate %d.\n", t, (long) ((long) bytes.length * 1000L / t));
+      logger.info(String.format("Elapsed: %d. Rate %d.\n", t, (long) ((long) bytes.length * 1000L / t)));
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseTestQuery.java
@@ -525,7 +525,6 @@ public class BaseTestQuery extends ExecTest {
       loader.clear();
       result.release();
     }
-    System.out.println("Total record count: " + rowCount);
     return rowCount;
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClientFixture.java
@@ -51,6 +51,7 @@ import org.apache.drill.test.rowSet.RowSetBuilder;
  */
 
 public class ClientFixture implements AutoCloseable {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ClientFixture.class);
 
   public static class ClientBuilder {
 
@@ -334,30 +335,21 @@ public class ClientFixture implements AutoCloseable {
     }
   }
 
-  private boolean trace = false;
-
-  public void enableTrace(boolean flag) {
-    this.trace = flag;
-  }
-
   public int exec(Reader in) throws IOException {
     StatementParser parser = new StatementParser(in);
     int count = 0;
     for (;;) {
       String stmt = parser.parseNext();
       if (stmt == null) {
-        if (trace) {
-          System.out.println("----");
-        }
+        logger.debug("----");
         return count;
       }
       if (stmt.isEmpty()) {
         continue;
       }
-      if (trace) {
-        System.out.println("----");
-        System.out.println(stmt);
-      }
+
+      logger.debug("----");
+      logger.debug(stmt);
       runSqlSilently(stmt);
       count++;
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
@@ -144,7 +144,6 @@ public class ClusterTest extends DrillTest {
         }
         rowSet.clear();
       }
-      System.out.println(results.recordCount());
     } catch (Exception e) {
       throw new IllegalStateException(e);
     } finally {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
@@ -67,6 +67,7 @@ import ch.qos.logback.classic.Level;
 
 @Ignore
 public class ExampleTest {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExampleTest.class);
 
   /**
    * This test watcher creates all the temp directories that are required for an integration test with a Drillbit. The
@@ -135,9 +136,9 @@ public class ExampleTest {
 
       try (ClusterFixture cluster = builder.build(); ClientFixture client = cluster.clientFixture()) {
         String sql = "SELECT * FROM `dfs`.`test/employee.json`";
-        System.out.println(client.queryBuilder().sql(sql).explainJson());
+        logger.info(client.queryBuilder().sql(sql).explainJson());
         QuerySummary results = client.queryBuilder().sql(sql).run();
-        System.out.println(String.format("Read %d rows", results.recordCount()));
+        logger.info(String.format("Read %d rows", results.recordCount()));
         // Usually we want to test something. Here, just test that we got
         // the 2 records.
         assertEquals(2, results.recordCount());
@@ -251,9 +252,9 @@ public class ExampleTest {
       String sql = "SELECT id_i, name_s10 FROM `mock`.`employees_10K` ORDER BY id_i";
 
       QuerySummary summary = client.queryBuilder().sql(sql).run();
-      System.out.println(String.format("Results: %,d records, %d batches, %,d ms", summary.recordCount(), summary.batchCount(), summary.runTimeMs() ) );
+      logger.info(String.format("Results: %,d records, %d batches, %,d ms", summary.recordCount(), summary.batchCount(), summary.runTimeMs() ) );
 
-      System.out.println("Query ID: " + summary.queryIdString());
+      logger.info("Query ID: " + summary.queryIdString());
       ProfileParser profile = client.parseProfile(summary.queryIdString());
       profile.print();
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -511,8 +511,8 @@ public class QueryBuilder {
   public long print() throws Exception {
     DrillConfig config = client.cluster().config( );
 
-    boolean verbose = ! config.getBoolean(QueryTestUtil.TEST_QUERY_PRINTING_SILENT) ||
-                      DrillTest.verbose();
+    boolean verbose = !config.getBoolean(QueryTestUtil.TEST_QUERY_PRINTING_SILENT);
+
     if (verbose) {
       return print(Format.TSV, VectorUtil.DEFAULT_COLUMN_WIDTH);
     } else {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/PerformanceTool.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/PerformanceTool.java
@@ -73,6 +73,7 @@ import com.google.common.base.Stopwatch;
  */
 
 public class PerformanceTool {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PerformanceTool.class);
 
   public static final int ROW_COUNT = 16 * 1024 * 1024 / 4;
   public static final int ITERATIONS = 300;
@@ -97,7 +98,8 @@ public class PerformanceTool {
       for (int i = 0; i < ITERATIONS; i++) {
         doTest();
       }
-      System.out.println(label + ": " + timer.elapsed(TimeUnit.MILLISECONDS));
+
+      logger.info("{}: {}", label, timer.elapsed(TimeUnit.MILLISECONDS));
     }
 
     public abstract void doTest();
@@ -273,7 +275,7 @@ public class PerformanceTool {
   public static void main(String args[]) {
     try (OperatorFixture fixture = OperatorFixture.standardFixture(null);) {
       for (int i = 0; i < 2; i++) {
-        System.out.println((i==0) ? "Warmup" : "Test run");
+        logger.info((i==0) ? "Warmup" : "Test run");
         new RequiredVectorTester(fixture).runTest();
         new RequiredWriterTester(fixture).runTest();
         new NullableVectorTester(fixture).runTest();
@@ -283,7 +285,7 @@ public class PerformanceTool {
       }
     } catch (Exception e) {
       // TODO Auto-generated catch block
-      e.printStackTrace();
+      logger.error("Exception", e);
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/RowSetTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/RowSetTest.java
@@ -73,6 +73,7 @@ import org.junit.Test;
  */
 
 public class RowSetTest extends SubOperatorTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RowSetTest.class);
 
   /**
    * Test the simplest constructs: a row with top-level scalar
@@ -809,15 +810,16 @@ public class RowSetTest extends SubOperatorTest {
     // values.
 
     while (reader.next()) {
-      print(reader.scalar("a").getString());
+      final StringBuilder sb = new StringBuilder();
+      sb.append(print(reader.scalar("a").getString()));
       ArrayReader bReader = reader.array("b");
       while (bReader.next()) {
-        print(bReader.scalar().getInt());
+        sb.append(print(bReader.scalar().getInt()));
       }
       TupleReader cReader = reader.tuple("c");
-      print(cReader.scalar("c1").getInt());
-      print(cReader.scalar("c2").getString());
-      endRow();
+      sb.append(print(cReader.scalar("c1").getInt()));
+      sb.append(print(cReader.scalar("c2").getString()));
+      logger.debug(sb.toString());
     }
 
     // Step 7: Free memory.
@@ -825,18 +827,17 @@ public class RowSetTest extends SubOperatorTest {
     rowSet.clear();
   }
 
-  public void print(Object obj) {
-    if (obj instanceof String) {
-      System.out.print("\"");
-      System.out.print(obj);
-      System.out.print("\"");
-    } else {
-      System.out.print(obj);
-    }
-    System.out.print(" ");
-  }
+  public String print(Object obj) {
+    final StringBuilder sb = new StringBuilder();
 
-  public void endRow() {
-    System.out.println();
+    if (obj instanceof String) {
+      sb.append("\"");
+      sb.append(obj);
+      sb.append("\"");
+    } else {
+      sb.append(obj);
+    }
+    sb.append(" ");
+    return sb.toString();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestFixedWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestFixedWidthWriter.java
@@ -395,7 +395,6 @@ public class TestFixedWidthWriter extends SubOperatorTest {
 
         @Override
         public boolean canExpand(ScalarWriter writer, int delta) {
-//          System.out.println("Delta: " + delta);
           totalAlloc += delta;
           return totalAlloc < 16_384 * 4;
         }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestOffsetVectorWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestOffsetVectorWriter.java
@@ -378,7 +378,6 @@ public class TestOffsetVectorWriter extends SubOperatorTest {
 
         @Override
         public boolean canExpand(ScalarWriter writer, int delta) {
-//          System.out.println("Delta: " + delta);
           totalAlloc += delta;
           return totalAlloc < 16_384 * 4;
         }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
@@ -373,7 +373,6 @@ public class TestVariableWidthWriter extends SubOperatorTest {
 
         @Override
         public boolean canExpand(ScalarWriter writer, int delta) {
-//          System.out.println("Delta: " + delta);
           totalAlloc += delta;
           return totalAlloc < 1024 * 1024;
         }

--- a/exec/java-exec/src/test/java/org/apache/drill/vector/TestFillEmpties.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/vector/TestFillEmpties.java
@@ -37,6 +37,7 @@ import org.junit.experimental.categories.Category;
 
 @Category(VectorTest.class)
 public class TestFillEmpties extends SubOperatorTest {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestFillEmpties.class);
 
   @Test
   public void testNullableVarChar() {
@@ -136,13 +137,15 @@ public class TestFillEmpties extends SubOperatorTest {
   }
 
   private void visualize(IntVector vector, int valueCount) {
-    System.out.print("Values: [");
+    final StringBuilder sb = new StringBuilder();
+    sb.append("Values: [");
     IntVector.Accessor accessor = vector.getAccessor();
     for (int i = 0; i < valueCount; i++) {
-      if (i > 0) { System.out.print(" "); }
-      System.out.print(accessor.get(i));
+      if (i > 0) { sb.append(" "); }
+      sb.append(accessor.get(i));
     }
-    System.out.println("]");
+    sb.append("]");
+    logger.info(sb.toString());
   }
 
   private void visualize(NullableVarCharVector vector, int valueCount) {
@@ -157,31 +160,37 @@ public class TestFillEmpties extends SubOperatorTest {
 
   private void visualize(String label, UInt4Vector offsetVector,
       int valueCount) {
-    System.out.print(label + ": [");
+    final StringBuilder sb = new StringBuilder();
+    sb.append(label + ": [");
     UInt4Vector.Accessor accessor = offsetVector.getAccessor();
     for (int i = 0; i < valueCount; i++) {
-      if (i > 0) { System.out.print(" "); }
-      System.out.print(accessor.get(i));
+      if (i > 0) { sb.append(" "); }
+      sb.append(accessor.get(i));
     }
-    System.out.println("]");
+    sb.append("]");
+    logger.info(sb.toString());
   }
 
   private void visualize(String label, DrillBuf buffer, int valueCount) {
-    System.out.print(label + ": [");
+    final StringBuilder sb = new StringBuilder();
+    sb.append(label + ": [");
     for (int i = 0; i < valueCount; i++) {
-      if (i > 0) { System.out.print(" "); }
-      System.out.print((char) buffer.getByte(i));
+      if (i > 0) { sb.append(" "); }
+      sb.append((char) buffer.getByte(i));
     }
-    System.out.println("]");
+    sb.append("]");
+    logger.info(sb.toString());
   }
 
   private void visualize(String label, BaseDataValueVector.BaseAccessor accessor, int valueCount) {
-    System.out.print(label + ": [");
+    final StringBuilder sb = new StringBuilder();
+    sb.append(label + ": [");
     for (int i = 0; i < valueCount; i++) {
-      if (i > 0) { System.out.print(" "); }
-      System.out.print(accessor.isNull(i) ? 0 : 1);
+      if (i > 0) { sb.append(" "); }
+      sb.append(accessor.isNull(i) ? 0 : 1);
     }
-    System.out.println("]");
+    sb.append("]");
+    logger.info(sb.toString());
   }
 
   private void verifyOffsets(UInt4Vector offsetVector, int[] expected) {

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataGetColumnsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataGetColumnsTest.java
@@ -169,8 +169,6 @@ public class DatabaseMetaDataGetColumnsTest extends JdbcTestBase {
                                      final String tableOrViewName,
                                      final String columnName ) throws SQLException
   {
-    System.out.println( "(Setting up row for " + tableOrViewName + "."
-                        + columnName + ".)");
     assertNotNull( "dbMetadata is null; must be set before calling setUpRow(...)",
                    dbMetadata );
     final ResultSet testRow =
@@ -204,16 +202,10 @@ public class DatabaseMetaDataGetColumnsTest extends JdbcTestBase {
                               + "WHERE TABLE_SCHEMA = 'hive_test.default' "
                               + "  AND TABLE_NAME = 'infoschematest'" );
 
-    System.out.println( "(Hive infoschematest columns: " );
     int hiveTestColumnRowCount = 0;
     while ( util.next() ) {
       hiveTestColumnRowCount++;
-      System.out.println(
-          " Hive test column: "
-          + util.getString( 1 ) + " - " + util.getString( 2 ) + " - "
-          + util.getString( 3 ) + " - " + util.getString( 4 ) );
     }
-    System.out.println( " Hive test column count: " + hiveTestColumnRowCount + ")" );
     if ( 0 == hiveTestColumnRowCount ) {
       // No Hive test data--create it.
       new HiveTestDataGenerator().generateTestData();

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/JdbcTestBase.java
@@ -397,7 +397,7 @@ public class JdbcTestBase extends ExecTest {
         connection = adapter.createConnection();
         statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(sql);
-        System.out.println(JdbcTestBase.toString(resultSet, recordCount));
+        logger.debug(JdbcTestBase.toString(resultSet, recordCount));
         resultSet.close();
         return this;
       } finally {

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Bug1735ConnectionCloseTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Bug1735ConnectionCloseTest.java
@@ -77,8 +77,6 @@ public class Bug1735ConnectionCloseTest extends JdbcTestQueryBase {
   @Test
   public void testCloseDoesntLeakResourcesBasic() throws Exception {
     for ( int i = 1; i <= SMALL_ITERATION_COUNT; i++ ) {
-      logger.info( "iteration " + i + ":" );
-      System.out.println( "iteration " + i + ":" );
       Connection connection = new Driver().connect("jdbc:drill:zk=local", getDefaultProperties());
       connection.close();
     }
@@ -94,9 +92,6 @@ public class Bug1735ConnectionCloseTest extends JdbcTestQueryBase {
   @Test
   public void testCloseDoesntLeakResourcesMany() throws Exception {
     for ( int i = 1; i <= LARGE_ITERATION_COUNT; i++ ) {
-      logger.info( "iteration " + i + ":" );
-      System.out.println( "iteration " + i + ":" );
-
       // (Note: Can't use JdbcTest's connect(...) because it returns connection
       // that doesn't really close.
       Connection connection = new Driver().connect("jdbc:drill:zk=local", getDefaultProperties());

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2130JavaJdbcHamcrestConfigurationTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2130JavaJdbcHamcrestConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 @Category(JdbcTest.class)
 public class Drill2130JavaJdbcHamcrestConfigurationTest {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130JavaJdbcHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")
   private org.hamcrest.MatcherAssert forCompileTimeCheckForNewEnoughHamcrest;
@@ -41,8 +42,7 @@ public class Drill2130JavaJdbcHamcrestConfigurationTest {
              + "  Got NoSuchMethodError;  e: " + e );
     }
     catch ( AssertionError e ) {
-      System.out.println( "Class path seems fine re new JUnit vs. old Hamcrest."
-                          + " (Got AssertionError, not NoSuchMethodError.)" );
+      logger.info("Class path seems fine re new JUnit vs. old Hamcrest. (Got AssertionError, not NoSuchMethodError.)");
     }
   }
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestActionBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestActionBase.java
@@ -36,6 +36,8 @@ import org.junit.rules.TestRule;
 import com.google.common.base.Stopwatch;
 
 public class JdbcTestActionBase extends JdbcTestBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestActionBase.class);
+
   // Set a timeout unless we're debugging.
   static Connection connection;
 
@@ -61,6 +63,8 @@ public class JdbcTestActionBase extends JdbcTestBase {
   }
 
   protected void testAction(JdbcAction action, long rowcount) throws Exception {
+    final StringBuilder sb = new StringBuilder();
+
     int rows = 0;
     Stopwatch watch = Stopwatch.createStarted();
     ResultSet r = action.getResult(connection);
@@ -70,28 +74,28 @@ public class JdbcTestActionBase extends JdbcTestBase {
       ResultSetMetaData md = r.getMetaData();
       if (first == true) {
         for (int i = 1; i <= md.getColumnCount(); i++) {
-          System.out.print(md.getColumnName(i));
-          System.out.print('\t');
+          sb.append(md.getColumnName(i));
+          sb.append('\t');
         }
-        System.out.println();
+        sb.append('\n');
         first = false;
       }
 
       for (int i = 1; i <= md.getColumnCount(); i++) {
-        System.out.print(r.getObject(i));
-        System.out.print('\t');
+        sb.append(r.getObject(i));
+        sb.append('\t');
       }
-      System.out.println();
+      sb.append('\n');
     }
 
-    System.out.println(String.format("Query completed in %d millis.", watch.elapsed(TimeUnit.MILLISECONDS)));
+    sb.append(String.format("Query completed in %d millis.\n", watch.elapsed(TimeUnit.MILLISECONDS)));
 
     if (rowcount != -1) {
       Assert.assertEquals((long) rowcount, (long) rows);
     }
 
-    System.out.println("\n\n\n");
-
+    sb.append("\n\n\n");
+    logger.info(sb.toString());
   }
 
   public interface JdbcAction {

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestQueryBase.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/JdbcTestQueryBase.java
@@ -33,6 +33,8 @@ import org.junit.rules.TestRule;
 import com.google.common.base.Stopwatch;
 
 public class JdbcTestQueryBase extends JdbcTestBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JdbcTestQueryBase.class);
+
   // Set a timeout unless we're debugging.
   @Rule
   public TestRule TIMEOUT = TestTools.getTimeoutRule(40000);
@@ -41,42 +43,46 @@ public class JdbcTestQueryBase extends JdbcTestBase {
     Driver.load();
   }
 
-  protected static void testQuery(String sql) throws Exception{
+  protected static void testQuery(String sql) throws Exception {
+    final StringBuilder sb = new StringBuilder();
+
     boolean success = false;
     try (Connection conn = connect()) {
       for (int x = 0; x < 1; x++) {
         Stopwatch watch = Stopwatch.createStarted();
         Statement s = conn.createStatement();
         ResultSet r = s.executeQuery(sql);
-        System.out.println(String.format("QueryId: %s", r.unwrap(DrillResultSet.class).getQueryId()));
+        sb.append(String.format("QueryId: %s\n", r.unwrap(DrillResultSet.class).getQueryId()));
         boolean first = true;
         while (r.next()) {
           ResultSetMetaData md = r.getMetaData();
           if (first == true) {
             for (int i = 1; i <= md.getColumnCount(); i++) {
-              System.out.print(md.getColumnName(i));
-              System.out.print('\t');
+              sb.append(md.getColumnName(i));
+              sb.append('\t');
             }
-            System.out.println();
+            sb.append('\b');
             first = false;
           }
 
           for (int i = 1; i <= md.getColumnCount(); i++) {
-            System.out.print(r.getObject(i));
-            System.out.print('\t');
+            sb.append(r.getObject(i));
+            sb.append('\t');
           }
-          System.out.println();
+          sb.append('\n');
         }
 
-        System.out.println(String.format("Query completed in %d millis.", watch.elapsed(TimeUnit.MILLISECONDS)));
+        sb.append(String.format("Query completed in %d millis.\n", watch.elapsed(TimeUnit.MILLISECONDS)));
       }
 
-      System.out.println("\n\n\n");
+      sb.append("\n\n\n");
       success = true;
     } finally {
       if (!success) {
         Thread.sleep(2000);
       }
     }
+
+    logger.info(sb.toString());
   }
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestInformationSchemaColumns.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestInformationSchemaColumns.java
@@ -151,7 +151,6 @@ public class TestInformationSchemaColumns extends JdbcTestBase {
                                      final String tableOrViewName,
                                      final String columnName ) throws SQLException
   {
-    System.out.println( "(Setting up row for " + tableOrViewName + "." + columnName + ".)");
     final Statement stmt = connection.createStatement();
     final ResultSet mdrUnk =
         stmt.executeQuery(
@@ -184,16 +183,10 @@ public class TestInformationSchemaColumns extends JdbcTestBase {
                               + "WHERE TABLE_SCHEMA = 'hive_test.default' "
                               + "  AND TABLE_NAME = 'infoschematest'" );
 
-    System.out.println( "(Hive infoschematest columns: " );
     int hiveTestColumnRowCount = 0;
     while ( util.next() ) {
       hiveTestColumnRowCount++;
-      System.out.println(
-          " Hive test column: "
-          + util.getString( 1 ) + " - " + util.getString( 2 ) + " - "
-          + util.getString( 3 ) + " - " + util.getString( 4 ) );
     }
-    System.out.println( " Hive test column count: " + hiveTestColumnRowCount + ")" );
     if ( 0 == hiveTestColumnRowCount ) {
       // No Hive test data--create it.
       new HiveTestDataGenerator().generateTestData();

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
@@ -36,6 +36,7 @@ import org.junit.experimental.categories.Category;
 
 @Category(JdbcTest.class)
 public class TestJdbcQuery extends JdbcTestQueryBase {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestJdbcQuery.class);
 
   // TODO:  Purge nextUntilEnd(...) and calls when remaining fragment race
   // conditions are fixed (not just DRILL-2245 fixes).
@@ -247,10 +248,6 @@ public class TestJdbcQuery extends JdbcTestQueryBase {
           assertEquals(ts1, result);
           assertEquals(date1, result1);
 
-          System.out.println("Date: " + date.toString() + " time: " + time.toString() + " timestamp: " + ts.toString() +
-                             "\ninterval year: " + intervalYear + " intervalDay: " + intervalDay +
-                             " date_interval_add: " + ts1.toString() + "date_int_add: " + date1.toString());
-
           // TODO:  Purge nextUntilEnd(...) and calls when remaining fragment
           // race conditions are fixed (not just DRILL-2245 fixes).
           // nextUntilEnd(resultSet);
@@ -277,7 +274,7 @@ public class TestJdbcQuery extends JdbcTestQueryBase {
           assertEquals( Types.TIMESTAMP, resultSet.getMetaData().getColumnType(1) );
           assertEquals( Types.DATE, resultSet.getMetaData().getColumnType(2) );
 
-          System.out.println(JdbcTestBase.toString(resultSet));
+          logger.debug(JdbcTestBase.toString(resultSet));
           resultSet.close();
           statement.close();
           return null;

--- a/logical/src/test/java/org/apache/drill/common/expression/parser/TreeTest.java
+++ b/logical/src/test/java/org/apache/drill/common/expression/parser/TreeTest.java
@@ -88,17 +88,10 @@ public class TreeTest extends DrillTest {
     ExprLexer lexer = new ExprLexer(new ANTLRStringStream(expr));
     CommonTokenStream tokens = new CommonTokenStream(lexer);
 
-//    tokens.fill();
-//    for(Token t : (List<Token>) tokens.getTokens()){
-//      System.out.println(t + "" + t.getType());
-//    }
-//    tokens.rewind();
-
     ExprParser parser = new ExprParser(tokens);
     parse_return ret = parser.parse();
 
     return ret.e;
-
   }
 
   private String serializeExpression(LogicalExpression expr){
@@ -122,10 +115,5 @@ public class TreeTest extends DrillTest {
     String newStringExpr = serializeExpression(e);
     logger.debug(newStringExpr);
     LogicalExpression e2 = parseExpression(newStringExpr);
-    //Assert.assertEquals(e, e2);
-
   }
-
-
-
 }


### PR DESCRIPTION
## Changes

 - Removed excess print statements from tests
 - Switched all System.out and System.err statements in the tests to loggers
