### PR TITLE
DRILL-6437: Removed excess maven logging when downloading dependencies. This fixed Travis failures due to log overflow.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ jdk:
 cache:
   directories:
   - "$HOME/.m2"
-install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+install: MAVEN_OPTS="-Xms1G -Xmx1G" mvn install --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
 script: mvn install -Drat.skip=false -Dlicense.skip=false -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest,org.apache.drill.categories.SecurityTest" -DforkCount=1 -DmemoryMb=2560 -DdirectMemoryMb=4608


### PR DESCRIPTION
The fix was to change the log level maven when downloading artifacts.