### PR TITLE
DRILL-6443: Enable Search for both running AND completed queries

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/list.ftl
@@ -23,26 +23,28 @@
 <script src="/static/js/jquery.dataTables-1.10.16.min.js"></script>
 <script>
     $(document).ready(function() {
-      $("#profileList").DataTable( {
-        //Preserve order
-        "ordering": false,
-        "searching": true,
-        "paging": true,
-        "pagingType": "first_last_numbers",
-        "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
-        "lengthChange": true,
-        "info": true,
-        //Ref: https://legacy.datatables.net/ref#sDom
-        "sDom": '<"top"lftip><"bottom"><"clear">',
-        //Customized info labels
-        "language": {
-            "lengthMenu": "Display _MENU_ profiles per page",
-            "zeroRecords": "No matching profiles found!",
-            "info": "Showing page _PAGE_ of _PAGES_ ",
-            "infoEmpty": "No profiles available",
-            "infoFiltered": "(filtered _TOTAL_ from _MAX_)",
-            "search": "Search Profiles  "
-        }
+      $.each(["running","completed"], function(i, key) {
+        $("#profileList_"+key).DataTable( {
+          //Preserve order
+          "ordering": false,
+          "searching": true,
+          "paging": true,
+          "pagingType": "full_numbers",
+          "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
+          "lengthChange": true,
+          "info": true,
+          //Ref: https://legacy.datatables.net/ref#sDom
+          "sDom": '<"top"lftip><"bottom"><"clear">',
+          //Customized info labels
+          "language": {
+              "lengthMenu": "Display _MENU_ profiles per page",
+              "zeroRecords": "No matching profiles found!",
+              "info": "Showing page _PAGE_ of _PAGES_ ",
+              "infoEmpty": "No profiles available",
+              "infoFiltered": "(filtered _TOTAL_ from _MAX_)",
+              "search": "Search Profiles  "
+          }
+        } );
       } );
     } );
 </script>
@@ -94,7 +96,7 @@
   </#if>
   <#if (model.getRunningQueries()?size > 0) >
     <h3>Running Queries</h3>
-    <@list_queries queries=model.getRunningQueries()/>
+    <@list_queries queries=model.getRunningQueries() stateList="running" />
     <div class="page-header">
     </div>
   <#else>
@@ -139,12 +141,12 @@
             $("#fetchMax").val(maxFetched);
     });
     </script>
-  <@list_queries queries=model.getFinishedQueries()/>
+  <@list_queries queries=model.getFinishedQueries() stateList="completed" />
 </#macro>
 
-<#macro list_queries queries>
+<#macro list_queries queries stateList>
     <div class="table-responsive">
-        <table id="profileList" class="table table-hover dataTable" role="grid">
+        <table id="profileList_${stateList}" class="table table-hover dataTable" role="grid">
             <thead>
             <tr role="row">
                 <th>Time</th>


### PR DESCRIPTION
When running a query in Drill, the `/profiles` page will show the search (and pagination) capabilities only for the top most visible table (i.e. Running Queries ).

The _Completed Queries_ table will show the search feature only when there are no _Running Queries_. This is because the backend uses a generalized freemarker macro to define the seach capabilities for the tables being rendered. With running queries, both, _Running_ and _Completed_ queries tables have the same element ID, resulting in the search capability only being applied to the first table.

This modifies the Freemarker macro to take an additional argument for distinguishing between _Running_ and _Completed_ _Queries_ tables.