### PR TITLE
DRILL-6447: Fixed a sanity check condition

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/PageReader.java
@@ -445,8 +445,8 @@ class PageReader {
    * @throws IOException An IO related condition
    */
   void resetDefinitionLevelReader(int skipCount) throws IOException {
-    if (parentColumnReader.columnDescriptor.getMaxDefinitionLevel() != 0) {
-      throw new UnsupportedOperationException("Unsupoorted Operation");
+    if (parentColumnReader.columnDescriptor.getMaxDefinitionLevel() > 1) {
+      throw new UnsupportedOperationException("Unsupported Operation");
     }
 
     final Encoding dlEncoding = METADATA_CONVERTER.getEncoding(pageHeader.data_page_header.definition_level_encoding);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBulkPageReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenBulkPageReader.java
@@ -72,6 +72,7 @@ final class VarLenBulkPageReader {
       this.pageInfo.numPageFieldsRead = pageInfoInput.numPageFieldsRead;
       this.pageInfo.definitionLevels = pageInfoInput.definitionLevels;
       this.pageInfo.dictionaryValueReader = pageInfoInput.dictionaryValueReader;
+      this.pageInfo.numPageValues = pageInfoInput.numPageValues;
     }
 
     this.columnPrecInfo = columnPrecInfoInput;
@@ -94,6 +95,7 @@ final class VarLenBulkPageReader {
     pageInfo.numPageFieldsRead = pageInfoInput.numPageFieldsRead;
     pageInfo.definitionLevels = pageInfoInput.definitionLevels;
     pageInfo.dictionaryValueReader = pageInfoInput.dictionaryValueReader;
+    pageInfo.numPageValues = pageInfoInput.numPageValues;
 
     buffer.clear();
   }


### PR DESCRIPTION
The Parquet bulk reader asserted that resetting a Page Definition Level should be performed only for a Flat Schema; the check should have tested for a value of zero or one.