### PR TITLE
DRILL-5365: Enforce Immutability of DrillFileSystem

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
@@ -161,7 +161,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
     this.incoming = incoming;
     DrillConfig config = context.getConfig();
     Configuration conf = new Configuration();
-    conf.set("fs.default.name", config.getString(ExecConstants.EXTERNAL_SORT_SPILL_FILESYSTEM));
+    conf.set(FileSystem.FS_DEFAULT_NAME_KEY, config.getString(ExecConstants.EXTERNAL_SORT_SPILL_FILESYSTEM));
     try {
       this.fs = FileSystem.get(conf);
     } catch (IOException e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -212,6 +212,6 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
   }
 
   public Configuration getFsConf() {
-    return fsConf;
+    return new Configuration(fsConf);
   }
 }


### PR DESCRIPTION
Continuing the PR that was opened here https://github.com/apache/drill/pull/796

## The Issue

If a user specifies **fs.defualt.name** in the hive storage plugin configuration, it can override the default file system defined in the FileSystemPlugin when CTAS statements are executed. This issue was occurring on a user's Drill cluster.

Chun's steps for reproducing the issue:

 1. Two or more nodes cluster. 
 2. Enable impersonation.
 3. Set **fs.default.name**: "file:///" in hive storage plugin.
 4. Restart drillbits. 
 5. As a regular user, on node A, drop the table/file. 
 6. Ctas from a large enough hive table as source to recreate the table/file. 
 7. Query the table from node A should work. 
 8. Query from node B as same user should reproduce the issue.

## The Cause

The root cause is unclear, somehow hive store plugin settings are finding their way into the Configuration object passed to the DrillFileSystem. I'm not sure if this is by design or not. If it is not by design then we should investigate the root cause.

## The Solution (Pending QA Verification)

- Force the correct value of **fs.default.name** in the FileSystemPlugin.
- Enforce immutability of the DrillFileSystem.
- Add further logging to assist in debugging similar issues in the future.
