### PR TITLE
DRILL-6455: Add missing JDBC Scan Operator for profiles

### DIFF
--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -750,7 +750,7 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "TATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020"
     "\000\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022"
     "\014\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005"
-    "\022\032\n\026CANCELLATION_REQUESTED\020\006*\360\006\n\020CoreOpe"
+    "\022\032\n\026CANCELLATION_REQUESTED\020\006*\377\006\n\020CoreOpe"
     "ratorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAS"
     "T_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE"
     "\020\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HAS"
@@ -772,11 +772,11 @@ void protobuf_AddDesc_UserBitShared_2eproto() {
     "AN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFKA_SUB_SCA"
     "N\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATTEN\020(\022\020\n\014L"
     "ATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HIVE_DRILL_"
-    "NATIVE_PARQUET_ROW_GROUP_SCAN\020+*g\n\nSaslS"
-    "tatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022"
-    "\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022"
-    "\017\n\013SASL_FAILED\020\004B.\n\033org.apache.drill.exe"
-    "c.protoB\rUserBitSharedH\001", 5184);
+    "NATIVE_PARQUET_ROW_GROUP_SCAN\020+\022\r\n\tJDBC_"
+    "SCAN\020,*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016"
+    "\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014"
+    "SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.a"
+    "pache.drill.exec.protoB\rUserBitSharedH\001", 5199);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "UserBitShared.proto", &protobuf_RegisterTypes);
   UserCredentials::default_instance_ = new UserCredentials();
@@ -941,6 +941,7 @@ bool CoreOperatorType_IsValid(int value) {
     case 41:
     case 42:
     case 43:
+    case 44:
       return true;
     default:
       return false;

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -247,11 +247,12 @@ enum CoreOperatorType {
   FLATTEN = 40,
   LATERAL_JOIN = 41,
   UNNEST = 42,
-  HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43
+  HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43,
+  JDBC_SCAN = 44
 };
 bool CoreOperatorType_IsValid(int value);
 const CoreOperatorType CoreOperatorType_MIN = SINGLE_SENDER;
-const CoreOperatorType CoreOperatorType_MAX = HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN;
+const CoreOperatorType CoreOperatorType_MAX = JDBC_SCAN;
 const int CoreOperatorType_ARRAYSIZE = CoreOperatorType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* CoreOperatorType_descriptor();

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.jdbc;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractSubScan;
+import org.apache.drill.exec.proto.beans.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -52,7 +53,7 @@ public class JdbcSubScan extends AbstractSubScan {
 
   @Override
   public int getOperatorType() {
-    return -1;
+    return CoreOperatorType.JDBC_SCAN.getNumber();
   }
 
   public String getSql() {

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -541,6 +541,10 @@ public final class UserBitShared {
      * <code>HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;</code>
      */
     HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN(43, 43),
+    /**
+     * <code>JDBC_SCAN = 44;</code>
+     */
+    JDBC_SCAN(44, 44),
     ;
 
     /**
@@ -719,6 +723,10 @@ public final class UserBitShared {
      * <code>HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;</code>
      */
     public static final int HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN_VALUE = 43;
+    /**
+     * <code>JDBC_SCAN = 44;</code>
+     */
+    public static final int JDBC_SCAN_VALUE = 44;
 
 
     public final int getNumber() { return value; }
@@ -769,6 +777,7 @@ public final class UserBitShared {
         case 41: return LATERAL_JOIN;
         case 42: return UNNEST;
         case 43: return HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN;
+        case 44: return JDBC_SCAN;
         default: return null;
       }
     }
@@ -24305,7 +24314,7 @@ public final class UserBitShared {
       "TATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020" +
       "\000\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022" +
       "\014\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005" +
-      "\022\032\n\026CANCELLATION_REQUESTED\020\006*\360\006\n\020CoreOpe" +
+      "\022\032\n\026CANCELLATION_REQUESTED\020\006*\377\006\n\020CoreOpe" +
       "ratorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAS" +
       "T_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE" +
       "\020\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HAS" +
@@ -24327,11 +24336,11 @@ public final class UserBitShared {
       "AN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFKA_SUB_SCA" +
       "N\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATTEN\020(\022\020\n\014L" +
       "ATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HIVE_DRILL_" +
-      "NATIVE_PARQUET_ROW_GROUP_SCAN\020+*g\n\nSaslS" +
-      "tatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022" +
-      "\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022" +
-      "\017\n\013SASL_FAILED\020\004B.\n\033org.apache.drill.exe" +
-      "c.protoB\rUserBitSharedH\001"
+      "NATIVE_PARQUET_ROW_GROUP_SCAN\020+\022\r\n\tJDBC_" +
+      "SCAN\020,*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016" +
+      "\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014" +
+      "SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.a" +
+      "pache.drill.exec.protoB\rUserBitSharedH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/CoreOperatorType.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/CoreOperatorType.java
@@ -65,7 +65,8 @@ public enum CoreOperatorType implements com.dyuproject.protostuff.EnumLite<CoreO
     FLATTEN(40),
     LATERAL_JOIN(41),
     UNNEST(42),
-    HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN(43);
+    HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN(43),
+    JDBC_SCAN(44);
     
     public final int number;
     
@@ -127,6 +128,7 @@ public enum CoreOperatorType implements com.dyuproject.protostuff.EnumLite<CoreO
             case 41: return LATERAL_JOIN;
             case 42: return UNNEST;
             case 43: return HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN;
+            case 44: return JDBC_SCAN;
             default: return null;
         }
     }

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -332,6 +332,7 @@ enum CoreOperatorType {
   LATERAL_JOIN = 41;
   UNNEST = 42;
   HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;
+  JDBC_SCAN = 44;
 }
 
 /* Registry that contains list of jars, each jar contains its name and list of function signatures.


### PR DESCRIPTION
The operator is missing in the profile protobuf. This commit introduces that.
1. Added protobuf files
2. Updated JdbcSubScan's getOperatorType API