### PR TITLE
DRILL-5700: Adding nohup support for SQLLine script

### DIFF
--- a/distribution/src/resources/sqlline
+++ b/distribution/src/resources/sqlline
@@ -76,6 +76,7 @@ if ! $is_cygwin; then
   DRILL_SHELL_OPTS="$DRILL_SHELL_OPTS --color=true"
 fi
 
+# To add nohup support for SQLline script
 if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
     export SQLLINE_JAVA_OPTS="$SQLLINE_JAVA_OPTS -Djline.terminal=jline.UnsupportedTerminal"
 fi

--- a/distribution/src/resources/sqlline
+++ b/distribution/src/resources/sqlline
@@ -76,6 +76,10 @@ if ! $is_cygwin; then
   DRILL_SHELL_OPTS="$DRILL_SHELL_OPTS --color=true"
 fi
 
+if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
+    export SQLLINE_JAVA_OPTS="$SQLLINE_JAVA_OPTS -Djline.terminal=jline.UnsupportedTerminal"
+fi
+
 SHELL_OPTS="$DRILL_SHELL_JAVA_OPTS $SQLLINE_JAVA_OPTS $DRILL_SHELL_LOG_OPTS $CLIENT_GC_OPTS"
 CMD="$JAVA $SHELL_OPTS -cp $CP sqlline.SqlLine -d org.apache.drill.jdbc.Driver --maxWidth=10000"
 


### PR DESCRIPTION
Changes to support nohup mode of execution for the SQLLine script.