### PR TITLE
DRILL-6459: Unable to view profile of a running query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/proto/helper/QueryIdHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/proto/helper/QueryIdHelper.java
@@ -33,7 +33,7 @@ public class QueryIdHelper {
 
   public static QueryId getQueryIdFromString(final String queryId) {
     final UUID uuid = UUID.fromString(queryId);
-    return QueryId.newBuilder().setPart1(uuid.getMostSignificantBits()).setPart2(uuid.getLeastSignificantBits()).build();
+    return QueryId.newBuilder().setPart1(uuid.getMostSignificantBits()).setPart2(uuid.getLeastSignificantBits()).setText(queryId).build();
   }
 
   public static String getQueryIdentifier(final FragmentHandle h) {


### PR DESCRIPTION
Fixes the missing text component of the QueryId that causes lookups to fail in `WorkManager.queries` map.
This got introduced with the fix (#1265) for DRILL-5305