### PR TITLE
DRILL-6467: Percentage usage of memory is reported as zero by the WebUI

### DIFF
--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -554,7 +554,7 @@
       function computeMemUsage(used, max) {
         let percent = 0;
         if ( max > 0) {
-          let percent = Math.round((100 * used / max), 2);
+          percent = Math.round((100 * used / max), 2);
         }
         let usage   =  bytesInGB(used, 2) + "GB (" + Math.max(0, percent) + "% of "+ bytesInGB(max, 2) +"GB)";
         return usage;


### PR DESCRIPTION
The memory reported as a percentage is incorrectly reported as 0%, irrespective of the actual usage.
![image](https://user-images.githubusercontent.com/4335237/40992450-b568ab6a-68ab-11e8-9c32-d1a6de2f7c91.png)

This is because of a snippet in the Javascript that computes the percentage:
```javascript
      //Compute Usage
      function computeMemUsage(used, max) {
        let percent = 0;
        if ( max > 0) {
          let percent = Math.round((100 * used / max), 2);
        }
        let usage   =  bytesInGB(used, 2) + "GB (" + Math.max(0, percent) + "% of "+ bytesInGB(max, 2) +"GB)";
        return usage;
      }
```

Turns out, the `let` keyword creates a new `percent` variable within the scope of the `if (max > 0) { .. }` block, so the original variable never got updated. The fix was to simply remove the `let` preceding the percentage computation.