### PR TITLE
DRILL-6476: Generate explain plan which shows relation between Latera…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PhysicalPlanCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PhysicalPlanCreator.java
@@ -52,11 +52,6 @@ public class PhysicalPlanCreator {
     return context;
   }
 
-//  public int getOperatorId(Prel prel){
-//    OpId id = opIdMap.get(prel);
-//    return id.getAsSingleInt();
-//  }
-
   public PhysicalOperator addMetadata(Prel originalPrel, PhysicalOperator op){
     op.setOperatorId(opIdMap.get(originalPrel).getAsSingleInt());
     op.setCost(originalPrel.estimateRowCount(originalPrel.getCluster().getMetadataQuery()));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnnestPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnnestPrel.java
@@ -75,4 +75,7 @@ public class UnnestPrel extends DrillUnnestRelBase implements Prel {
     return true;
   }
 
+  public Class<?> getParentClass() {
+    return CorrelatePrel.class;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.physical.explain;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,8 +32,10 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.util.Pair;
+import org.apache.drill.exec.planner.physical.CorrelatePrel;
 import org.apache.drill.exec.planner.physical.HashJoinPrel;
 import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.physical.UnnestPrel;
 import org.apache.drill.exec.planner.physical.explain.PrelSequencer.OpId;
 
 import com.google.common.collect.ImmutableList;
@@ -47,6 +50,7 @@ class NumberingRelWriter implements RelWriter {
   private final SqlExplainLevel detailLevel;
   protected final Spacer spacer = new Spacer();
   private final List<Pair<String, Object>> values = new ArrayList<>();
+  private final Map<String, Prel> registry;
 
   private final Map<Prel, OpId> ids;
   //~ Constructors -----------------------------------------------------------
@@ -55,6 +59,7 @@ class NumberingRelWriter implements RelWriter {
     this.pw = pw;
     this.ids = ids;
     this.detailLevel = detailLevel;
+    this.registry = new HashMap<>();
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -71,7 +76,7 @@ class NumberingRelWriter implements RelWriter {
     RelMetadataQuery mq = RelMetadataQuery.instance();
     if (!mq.isVisibleInExplain(rel, detailLevel)) {
       // render children in place of this, at same level
-      explainInputs(inputs);
+      explainInputs(rel);
       return;
     }
 
@@ -95,6 +100,7 @@ class NumberingRelWriter implements RelWriter {
     s.append(rel.getRelTypeName().replace("Prel", ""));
     if (detailLevel != SqlExplainLevel.NO_ATTRIBUTES) {
       int j = 0;
+      s.append(getDependentSrcOp(rel));
       for (Pair<String, Object> value : values) {
         if (value.right instanceof RelNode) {
           continue;
@@ -125,14 +131,56 @@ class NumberingRelWriter implements RelWriter {
     }
     pw.println(s);
     spacer.add(2);
-    explainInputs(inputs);
+    explainInputs(rel);
     spacer.subtract(2);
   }
 
-  private void explainInputs(List<RelNode> inputs) {
-    for (RelNode input : inputs) {
-      input.explain(this);
+  private String getDependentSrcOp(RelNode rel) {
+    if (rel instanceof UnnestPrel) {
+      return this.getDependentSrcOp((UnnestPrel) rel);
     }
+    return "";
+  }
+
+  private String getDependentSrcOp(UnnestPrel unnest) {
+    Prel parent = this.getRegisteredPrel(unnest.getParentClass());
+    if (parent != null && parent instanceof CorrelatePrel) {
+      OpId id = ids.get(parent);
+      return String.format(" [SrcOp: (%02d-%02d)] ", id.fragmentId, id.opId);
+    }
+    return "";
+  }
+
+  public void register(Prel toRegister) {
+    this.registry.put(toRegister.getClass().getSimpleName(), toRegister);
+  }
+
+  public Prel getRegisteredPrel(Class<?> classname) {
+    return this.registry.get(classname.getSimpleName());
+  }
+
+  public void unRegister(Prel unregister) {
+    this.registry.remove(unregister.getClass().getSimpleName());
+  }
+
+
+  private void explainInputs(RelNode rel) {
+    if (rel instanceof CorrelatePrel) {
+      this.explainInputs((CorrelatePrel) rel);
+    } else {
+      for (RelNode input : rel.getInputs()) {
+        input.explain(this);
+      }
+    }
+  }
+
+  //Correlate is handled differently because explain plan
+  //needs to show relation between Lateral and Unnest operators.
+  private void explainInputs(CorrelatePrel correlate) {
+    correlate.getInput(0).explain(this);
+    this.register(correlate);
+    correlate.getInput(1).explain(this);
+    this.unRegister(correlate);
   }
 
   public final void explain(RelNode rel, List<Pair<String, Object>> valueList) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestLateralPlans.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestLateralPlans.java
@@ -448,9 +448,9 @@ public class TestLateralPlans extends BaseTestQuery {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String explain = client.queryBuilder().sql(Sql).explainText();
-      String srcOp = explain.substring(explain.indexOf("SrcOp"));
+      String srcOp = explain.substring(explain.indexOf("srcOp"));
       assertTrue(srcOp != null && srcOp.length() > 0);
-      String correlateFragmentPattern = srcOp.substring(srcOp.indexOf("(")+1, srcOp.indexOf(")"));
+      String correlateFragmentPattern = srcOp.substring(srcOp.indexOf("=")+1, srcOp.indexOf("]"));
       assertTrue(correlateFragmentPattern != null && correlateFragmentPattern.length() > 0);
       Matcher matcher = Pattern.compile(correlateFragmentPattern + ".*Correlate", Pattern.MULTILINE | Pattern.DOTALL).matcher(explain);
       assertTrue(matcher.find());


### PR DESCRIPTION
…l and the corresponding Unnest.

@amansinha100 Please help review this PR.

This PR includes changes to the explain plan generation to generate a SrcOp: (majorfrag:minorFrag) for unnest operator so that it can be used for visual depiction of the relation.

Here is the plan which shows this relation.

explain plan for select * from (select customer.orders as c_orders from  dfs.`/home/mapr/LATERAL/drill/exec/java-exec/src/test/resources/lateraljoin/nested-customer.parquet` customer ) t1,  lateral ( select t.ord.o_lineitems as items from unnest(t1.c_orders) t(ord) ) t2, lateral (select count(*)  from unnest(t2.items) t3(item)) d1;

 

| 00-00 Screen : rowType = RecordType(ANY c_orders, ANY items, BIGINT EXPR$0): rowcount = 1.0, cumulative cost = \{15.1 rows, 74.1 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6223
00-01 Project(c_orders=[$0], items=[$1], EXPR$0=[$2]) : rowType = RecordType(ANY c_orders, ANY items, BIGINT EXPR$0): rowcount = 1.0, cumulative cost = \{15.0 rows, 74.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6222
00-02 Correlate(correlation=[$cor1], joinType=[inner], requiredColumns=[\{1}]) : rowType = RecordType(ANY orders, ANY items, BIGINT EXPR$0): rowcount = 1.0, cumulative cost = \{14.0 rows, 71.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6221
00-04 Correlate(correlation=[$cor0], joinType=[inner], requiredColumns=[\{0}]) : rowType = RecordType(ANY orders, ANY items): rowcount = 1.0, cumulative cost = \{10.0 rows, 38.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6218
00-07 Scan(groupscan=[ParquetGroupScan [entries=[ReadEntryWithPath [path=file:/home/mapr/LATERAL/drill/exec/java-exec/src/test/resources/lateraljoin/nested-customer.parquet]], selectionRoot=file:/home/mapr/LATERAL/drill/exec/java-exec/src/test/resources/lateraljoin/nested-customer.parquet, numFiles=1, numRowGroups=1, usedMetadataFile=false, columns=[`orders`]]]) : rowType = RecordType(ANY orders): rowcount = 4.0, cumulative cost = \{4.0 rows, 4.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6216
00-06 Project(items=[ITEM($0, 'o_lineitems')]) : rowType = RecordType(ANY items): rowcount = 1.0, cumulative cost = \{2.0 rows, 2.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6217
00-09 Unnest **[SrcOp: (00-04)]** : rowType = RecordType(ANY c_orders): rowcount = 1.0, cumulative cost = \{1.0 rows, 1.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6055
00-03 StreamAgg(group=[{}], EXPR$0=[COUNT()]) : rowType = RecordType(BIGINT EXPR$0): rowcount = 1.0, cumulative cost = \{3.0 rows, 17.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6220
00-05 Project($f0=[0]) : rowType = RecordType(INTEGER $f0): rowcount = 1.0, cumulative cost = \{2.0 rows, 5.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6219
00-08 Unnest **[SrcOp: (00-02)]**: rowType = RecordType(ANY items): rowcount = 1.0, cumulative cost = \{1.0 rows, 1.0 cpu, 0.0 io, 0.0 network, 0.0 memory}, id = 6058