### PR TITLE
DRILL-6485: Fix typo in drill-env.sh

### DIFF
--- a/distribution/src/resources/drill-env.sh
+++ b/distribution/src/resources/drill-env.sh
@@ -80,7 +80,7 @@
 
 # Location to place Drill logs. Set to $DRILL_HOME/log by default.
 
-#export DRILL_LOG_DIR=${DRILL_LOG_DIR:-$DRILL_HOME/conf}
+#export DRILL_LOG_DIR=${DRILL_LOG_DIR:-$DRILL_HOME/log}
 
 # Location to place the Drillbit pid file when running as a daemon using
 # drillbit.sh start.


### PR DESCRIPTION
Fixed typo in example for `DRILL_LOG_DIR`