### PR TITLE
DRILL-6486: BitVector split and transfer does not work correctly for non byte-multiple transfer lengths

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -573,8 +573,7 @@ the interface to load has changed
       assertEquals(1, accessor.get(1));
 
       // Ensure unallocated space returns 0
-      // Not a valid check since bounds checking is enabled
-     //assertEquals(0, accessor.get(3));
+      assertEquals(0, accessor.get(3));
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestValueVector.java
@@ -548,6 +548,7 @@ the interface to load has changed
       m.set(1, 0);
       m.set(100, 0);
       m.set(1022, 1);
+      m.setValueCount(1023);
 
       final BitVector.Accessor accessor = vector.getAccessor();
       assertEquals(1, accessor.get(0));
@@ -560,17 +561,20 @@ the interface to load has changed
       m.set(0, 1);
       m.set(1, 0);
       m.set(1, 0);
+      m.setValueCount(2);
       assertEquals(1, accessor.get(0));
       assertEquals(0, accessor.get(1));
 
       // test toggling the values
       m.set(0, 0);
       m.set(1, 1);
+      m.setValueCount(2);
       assertEquals(0, accessor.get(0));
       assertEquals(1, accessor.get(1));
 
       // Ensure unallocated space returns 0
-      assertEquals(0, accessor.get(3));
+      // Not a valid check since bounds checking is enabled
+     //assertEquals(0, accessor.get(3));
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -119,8 +119,7 @@ public class TestSplitAndTransfer {
 
   int getBit(TestBitPattern pattern, int index) {
     if (pattern == TestBitPattern.RANDOM) {
-      final int randomBit = (int) (Math.random() * 2);
-      return randomBit;
+      return (int) (Math.random() * 2);
     }
     return (pattern == TestBitPattern.ALTERNATING) ? (index % 2) : ((pattern == TestBitPattern.ONE) ? 1 : 0);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -167,7 +167,7 @@ public class TestSplitAndTransfer {
       final int start = startLength[0];
       final int length = startLength[1];
       tp.splitAndTransfer(start, length);
-      newBitVector.getMutator().setValueCount(length);
+      assertEquals(newBitVector.getAccessor().getValueCount(), length);
       for (int i = 0; i < length; i++) {
         final int expectedValue = compareArray[start + i];
         assertEquals(expectedValue, accessor.get(i));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -17,10 +17,6 @@
  */
 package org.apache.drill.exec.vector;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -30,6 +26,12 @@ import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.NullableVarCharVector.Accessor;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+
 
 public class TestSplitAndTransfer {
   @Test
@@ -75,6 +77,86 @@ public class TestSplitAndTransfer {
     }
 
     varCharVector.close();
+    allocator.close();
+  }
+
+  /**
+   *  BitVector tests
+   */
+
+  enum TestBitPattern {
+    ZERO,
+    ONE,
+    ALTERNATING,
+    RANDOM
+  }
+
+  @Test
+  public void testBitVectorUnalignedStart() throws Exception {
+    testBitVectorImpl(3443, new int[][] {{0, 2047}, {2047, 1396}}, TestBitPattern.ZERO);
+    testBitVectorImpl(3443, new int[][] {{0, 2047}, {2047, 1396}}, TestBitPattern.ONE);
+    testBitVectorImpl(3443, new int[][] {{0, 2047}, {2047, 1396}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(3443, new int[][] {{0, 2047}, {2047, 1396}}, TestBitPattern.RANDOM);
+
+    testBitVectorImpl(3447, new int[][] {{0, 2047}, {2047, 1400}}, TestBitPattern.ZERO);
+    testBitVectorImpl(3447, new int[][] {{0, 2047}, {2047, 1400}}, TestBitPattern.ONE);
+    testBitVectorImpl(3447, new int[][] {{0, 2047}, {2047, 1400}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(3447, new int[][] {{0, 2047}, {2047, 1400}}, TestBitPattern.RANDOM);
+  }
+
+  @Test
+  public void testBitVectorAlignedStart() throws Exception {
+    testBitVectorImpl(3444, new int[][] {{0, 2048}, {2048, 1396}}, TestBitPattern.ZERO);
+    testBitVectorImpl(3444, new int[][] {{0, 2048}, {2048, 1396}}, TestBitPattern.ONE);
+    testBitVectorImpl(3444, new int[][] {{0, 2048}, {2048, 1396}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(3444, new int[][] {{0, 2048}, {2048, 1396}}, TestBitPattern.RANDOM);
+
+    testBitVectorImpl(3448, new int[][] {{0, 2048}, {2048, 1400}}, TestBitPattern.ZERO);
+    testBitVectorImpl(3448, new int[][] {{0, 2048}, {2048, 1400}}, TestBitPattern.ONE);
+    testBitVectorImpl(3448, new int[][] {{0, 2048}, {2048, 1400}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(3448, new int[][] {{0, 2048}, {2048, 1400}}, TestBitPattern.RANDOM);
+  }
+
+  int getBit(TestBitPattern pattern, int index) {
+    if (pattern == TestBitPattern.RANDOM) {
+      final int randomBit = (int) (Math.random() * 2);
+      return randomBit;
+    }
+    return (pattern == TestBitPattern.ALTERNATING) ? (index % 2) : ((pattern == TestBitPattern.ONE) ? 1 : 0);
+  }
+
+  public void testBitVectorImpl(int valueCount, final int[][] startLengths, TestBitPattern pattern) throws Exception {
+    final DrillConfig drillConfig = DrillConfig.create();
+    final BufferAllocator allocator = RootAllocatorFactory.newRoot(drillConfig);
+    final MaterializedField field = MaterializedField.create("field", Types.optional(MinorType.BIT));
+    final BitVector bitVector = new BitVector(field, allocator);
+    bitVector.allocateNew(valueCount);
+    final int[] compareArray = new int[valueCount];
+
+    final BitVector.Mutator mutator = bitVector.getMutator();
+    for (int i = 0; i < valueCount; i ++) {
+      int testBitValue = getBit(pattern, i);
+      mutator.set(i, testBitValue);
+      compareArray[i] = testBitValue;
+    }
+    mutator.setValueCount(valueCount);
+
+    final TransferPair tp = bitVector.getTransferPair(allocator);
+    final BitVector newBitVector = (BitVector) tp.getTo();
+    final BitVector.Accessor accessor = newBitVector.getAccessor();
+
+    for (final int[] startLength : startLengths) {
+      final int start = startLength[0];
+      final int length = startLength[1];
+      tp.splitAndTransfer(start, length);
+      newBitVector.getMutator().setValueCount(length);
+      for (int i = 0; i < length; i++) {
+        final int expectedValue = compareArray[start + i];
+        assertEquals(expectedValue, accessor.get(i));
+      }
+      newBitVector.clear();
+    }
+    bitVector.close();
     allocator.close();
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -323,17 +323,17 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
       if (length % 8 != 0) {
         byte lastButOneByte = 0;
         byte bitsFromLastButOneByte = 0;
-        // if start is not byte aligned then we have to copy some bits from the last full byte read in the
+        // start is not byte aligned so we have to copy some bits from the last full byte read in the
         // previous loop
-        if (firstBitOffset != 0) {
-          lastButOneByte = byteIPlus1;
-          bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
-        }
+        lastButOneByte = byteIPlus1;
+        bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
+
         final int lastByte = this.data.getByte(firstByteIndex + numBytesHoldingSourceBits);
         target.data.setByte(numBytesHoldingSourceBits - 1, bitsFromLastButOneByte + (lastByte << (8 - firstBitOffset)));
       } else {
         target.data.setByte(numBytesHoldingSourceBits - 1,
-            (((this.data.getByte(firstByteIndex + numBytesHoldingSourceBits - 1) & 0xFF) >>> firstBitOffset) + (this.data.getByte(firstByteIndex + numBytesHoldingSourceBits) <<  (8 - firstBitOffset))));
+            (((this.data.getByte(firstByteIndex + numBytesHoldingSourceBits - 1) & 0xFF) >>> firstBitOffset) +
+                     (this.data.getByte(firstByteIndex + numBytesHoldingSourceBits) <<  (8 - firstBitOffset))));
       }
     }
     target.getMutator().setValueCount(length);
@@ -392,6 +392,7 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
      * @return 1 if set, otherwise 0
      */
     public final int get(int index) {
+      Preconditions.checkElementIndex(index, valueCount);
       int byteIndex = index >> 3;
       byte b = data.getByte(byteIndex);
       int bitIndex = index & 7;

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -394,7 +394,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
      * @return 1 if set, otherwise 0
      */
     public final int get(int index) {
-      Preconditions.checkElementIndex(index, valueCount);
       int byteIndex = index >> 3;
       byte b = data.getByte(byteIndex);
       int bitIndex = index & 7;

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -321,14 +321,15 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
 
       //Copy length is not a byte-multiple
       if (length % 8 != 0) {
-        byte lastButOneByte = 0;
-        byte bitsFromLastButOneByte = 0;
         // start is not byte aligned so we have to copy some bits from the last full byte read in the
         // previous loop
-        lastButOneByte = byteIPlus1;
-        bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
+        byte lastButOneByte = byteIPlus1;
+        byte bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
 
-
+        // If we have to read more bits than what we have already read, read it into lastByte otherwise set lastByte to 0.
+        // (length % 8) is num of remaining bits to be read.
+        // (8 - firstBitOffset) is the number of bits already read into lastButOneByte but not used in the previous write.
+        // We do not have to read more bits if (8 - firstBitOffset >= length % 8)
         final int lastByte = (8 - firstBitOffset >= length % 8) ?
                 0 : this.data.getByte(firstByteIndex + numBytesHoldingSourceBits);
         target.data.setByte(numBytesHoldingSourceBits - 1, bitsFromLastButOneByte + (lastByte << (8 - firstBitOffset)));

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -328,7 +328,9 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
         lastButOneByte = byteIPlus1;
         bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
 
-        final int lastByte = this.data.getByte(firstByteIndex + numBytesHoldingSourceBits);
+
+        final int lastByte = (8 - firstBitOffset >= length % 8) ?
+                0 : this.data.getByte(firstByteIndex + numBytesHoldingSourceBits);
         target.data.setByte(numBytesHoldingSourceBits - 1, bitsFromLastButOneByte + (lastByte << (8 - firstBitOffset)));
       } else {
         target.data.setByte(numBytesHoldingSourceBits - 1,


### PR DESCRIPTION
Fix for the bug in BitVector splitAndTransfer. The logic for handling copy of last-n bits was incorrect for none byte-multiple transfer lengths. This PR fixes this problem and adds new tests which simulate the failing condition and also exercise other changes in this PR.


