### PR TITLE
 DRILL-5188: Expand sub-queries using rules

### DIFF
--- a/exec/java-exec/src/main/codegen/config.fmpp
+++ b/exec/java-exec/src/main/codegen/config.fmpp
@@ -43,6 +43,7 @@ data: {
     intervalNumericTypes:     tdd(../data/IntervalNumericTypes.tdd),
     extract:                  tdd(../data/ExtractTypes.tdd),
     sumzero:                  tdd(../data/SumZero.tdd),
+    singleValue:              tdd(../data/SingleValue.tdd),
     numericTypes:             tdd(../data/NumericTypes.tdd),
     casthigh:                 tdd(../data/CastHigh.tdd),
     countAggrTypes:           tdd(../data/CountAggrTypes.tdd)

--- a/exec/java-exec/src/main/codegen/data/SingleValue.tdd
+++ b/exec/java-exec/src/main/codegen/data/SingleValue.tdd
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http:# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+types: [
+    {inputType: "Bit", outputType: "NullableBit", runningType: "Bit", major: "primitive"},
+    {inputType: "TinyInt", outputType: "NullableTinyInt", runningType: "TinyInt", major: "primitive"},
+    {inputType: "NullableTinyInt", outputType: "NullableTinyInt", runningType: "TinyInt", major: "primitive"},
+    {inputType: "UInt1", outputType: "NullableUInt1", runningType: "UInt1", major: "primitive"},
+    {inputType: "NullableUInt1", outputType: "NullableUInt1", runningType: "UInt1", major: "primitive"},
+    {inputType: "UInt2", outputType: "NullableUInt2", runningType: "UInt2", major: "primitive"},
+    {inputType: "NullableUInt2", outputType: "NullableUInt2", runningType: "UInt2", major: "primitive"},
+    {inputType: "SmallInt", outputType: "NullableSmallInt", runningType: "SmallInt", major: "primitive"},
+    {inputType: "NullableSmallInt", outputType: "NullableSmallInt", runningType: "SmallInt", major: "primitive"},
+    {inputType: "UInt4", outputType: "NullableUInt4", runningType: "UInt4", major: "primitive"},
+    {inputType: "NullableUInt4", outputType: "NullableUInt4", runningType: "UInt4", major: "primitive"},
+    {inputType: "UInt8", outputType: "NullableUInt8", runningType: "UInt8", major: "primitive"},
+    {inputType: "NullableUInt8", outputType: "NullableUInt8", runningType: "UInt8", major: "primitive"},
+    {inputType: "Int", outputType: "NullableInt", runningType: "Int", major: "primitive"},
+    {inputType: "BigInt", outputType: "NullableBigInt", runningType: "BigInt", major: "primitive"},
+    {inputType: "NullableBit", outputType: "NullableBit", runningType: "Bit", major: "primitive"},
+    {inputType: "NullableInt", outputType: "NullableInt", runningType: "Int", major: "primitive"},
+    {inputType: "NullableBigInt", outputType: "NullableBigInt", runningType: "BigInt", major: "primitive"},
+    {inputType: "Float4", outputType: "NullableFloat4", runningType: "Float4", major: "primitive"},
+    {inputType: "Float8", outputType: "NullableFloat8", runningType: "Float8", major: "primitive"},
+    {inputType: "NullableFloat4", outputType: "NullableFloat4", runningType: "Float4", major: "primitive"},
+    {inputType: "NullableFloat8", outputType: "NullableFloat8", runningType: "Float8", major: "primitive"},
+    {inputType: "Date", outputType: "NullableDate", runningType: "Date", major: "primitive"},
+    {inputType: "NullableDate", outputType: "NullableDate", runningType: "Date", major: "primitive"},
+    {inputType: "TimeStamp", outputType: "NullableTimeStamp", runningType: "TimeStamp", major: "primitive"},
+    {inputType: "NullableTimeStamp", outputType: "NullableTimeStamp", runningType: "TimeStamp", major: "primitive"},
+    {inputType: "Time", outputType: "NullableTime", runningType: "Time", major: "primitive"},
+    {inputType: "NullableTime", outputType: "NullableTime", runningType: "Time", major: "primitive"},
+    {inputType: "IntervalDay", outputType: "NullableIntervalDay", runningType: "IntervalDay", major: "IntervalDay"},
+    {inputType: "NullableIntervalDay", outputType: "NullableIntervalDay", runningType: "IntervalDay", major: "IntervalDay"},
+    {inputType: "IntervalYear", outputType: "NullableIntervalYear", runningType: "IntervalYear", major: "primitive"},
+    {inputType: "NullableIntervalYear", outputType: "NullableIntervalYear", runningType: "IntervalYear", major: "primitive"},
+    {inputType: "Interval", outputType: "NullableInterval", runningType: "Interval", major: "Interval"},
+    {inputType: "NullableInterval", outputType: "NullableInterval", runningType: "Interval", major: "Interval"},
+    {inputType: "VarDecimal", outputType: "NullableVarDecimal", runningType: "VarDecimal", major: "VarDecimal"},
+    {inputType: "NullableVarDecimal", outputType: "NullableVarDecimal", runningType: "VarDecimal", major: "VarDecimal"},
+    {inputType: "VarChar", outputType: "NullableVarChar", runningType: "VarChar", major: "bytes"},
+    {inputType: "NullableVarChar", outputType: "NullableVarChar", runningType: "VarChar", major: "bytes"},
+    {inputType: "Var16Char", outputType: "NullableVar16Char", runningType: "Var16Char", major: "bytes"},
+    {inputType: "NullableVar16Char", outputType: "NullableVar16Char", runningType: "Var16Char", major: "bytes"},
+    {inputType: "VarBinary", outputType: "NullableVarBinary", runningType: "VarBinary", major: "bytes"},
+    {inputType: "NullableVarBinary", outputType: "NullableVarBinary", runningType: "VarBinary", major: "bytes"}
+   ]
+}

--- a/exec/java-exec/src/main/codegen/templates/SingleValueAgg.java
+++ b/exec/java-exec/src/main/codegen/templates/SingleValueAgg.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+<@pp.dropOutputFile />
+
+<@pp.changeOutputFile name="/org/apache/drill/exec/expr/fn/impl/gaggr/SingleValueFunctions.java" />
+
+<#include "/@includes/license.ftl" />
+
+package org.apache.drill.exec.expr.fn.impl.gaggr;
+
+import org.apache.drill.exec.expr.DrillAggFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.*;
+
+import javax.inject.Inject;
+import io.netty.buffer.DrillBuf;
+
+/*
+ * This class is generated using freemarker and the ${.template_name} template.
+ */
+@SuppressWarnings("unused")
+public class SingleValueFunctions {
+<#list singleValue.types as type>
+
+  @FunctionTemplate(name = "single_value",
+                  <#if type.major == "VarDecimal">
+                    returnType = FunctionTemplate.ReturnType.DECIMAL_AVG_AGGREGATE,
+                  </#if>
+                    scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+  public static class ${type.inputType}SingleValue implements DrillAggFunc {
+    @Param ${type.inputType}Holder in;
+    @Workspace ${type.runningType}Holder value;
+    @Output ${type.outputType}Holder out;
+    @Workspace BigIntHolder nonNullCount;
+    <#if type.major == "VarDecimal" || type.major == "bytes">
+    @Inject DrillBuf buffer;
+    </#if>
+
+    public void setup() {
+      nonNullCount = new BigIntHolder();
+      nonNullCount.value = 0;
+      value = new ${type.runningType}Holder();
+    }
+
+    @Override
+    public void add() {
+    <#if type.inputType?starts_with("Nullable")>
+      sout: {
+        if (in.isSet == 0) {
+          // processing nullable input and the value is null, so don't do anything...
+          break sout;
+        }
+	  </#if>
+      if (nonNullCount.value == 0) {
+        nonNullCount.value = 1;
+      } else {
+        throw org.apache.drill.common.exceptions.UserException.functionError()
+            .message("Input for single_value function has more than one row")
+            .build();
+      }
+    <#if type.major == "primitive">
+      value.value = in.value;
+    <#elseif type.major == "IntervalDay">
+      value.days = in.days;
+      value.milliseconds = in.milliseconds;
+    <#elseif type.major == "Interval">
+      value.days = in.days;
+      value.milliseconds = in.milliseconds;
+      value.months = in.months;
+    <#elseif type.major == "VarDecimal">
+      value.start = in.start;
+      value.end = in.end;
+      value.buffer = in.buffer;
+      value.scale = in.scale;
+      value.precision = in.precision;
+    <#elseif type.major == "bytes">
+      value.start = in.start;
+      value.end = in.end;
+      value.buffer = in.buffer;
+    </#if>
+    <#if type.inputType?starts_with("Nullable")>
+      } // end of sout block
+	  </#if>
+    }
+
+    @Override
+    public void output() {
+      if (nonNullCount.value > 0) {
+        out.isSet = 1;
+      <#if type.major == "primitive">
+        out.value = value.value;
+      <#elseif type.major == "IntervalDay">
+        out.days = value.days;
+        out.milliseconds = value.milliseconds;
+      <#elseif type.major == "Interval">
+        out.days = value.days;
+        out.milliseconds = value.milliseconds;
+        out.months = value.months;
+      <#elseif type.major == "VarDecimal">
+        out.start = value.start;
+        out.end = value.end;
+        out.buffer = buffer.reallocIfNeeded(value.end - value.start);
+        out.buffer.writeBytes(value.buffer, value.start, value.end - value.start);
+        out.scale = value.scale;
+        out.precision = value.precision;
+      <#elseif type.major == "bytes">
+        out.start = value.start;
+        out.end = value.end;
+        out.buffer = buffer.reallocIfNeeded(value.end - value.start);
+        out.buffer.writeBytes(value.buffer, value.start, value.end - value.start);
+      </#if>
+      } else {
+        out.isSet = 0;
+      }
+    }
+
+    @Override
+    public void reset() {
+      value = new ${type.runningType}Holder();
+      nonNullCount.value = 0;
+    }
+  }
+</#list>
+}
+

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -113,6 +113,16 @@ public enum PlannerPhase {
     }
   },
 
+  SUBQUERY_REWRITE("Sub-queries rewrites") {
+    public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
+      return RuleSets.ofList(
+          RuleInstance.SUB_QUERY_FILTER_REMOVE_RULE,
+          RuleInstance.SUB_QUERY_PROJECT_REMOVE_RULE,
+          RuleInstance.SUB_QUERY_JOIN_REMOVE_RULE
+      );
+    }
+  },
+
   LOGICAL_PRUNE("Logical Planning (with partition pruning)") {
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/RuleInstance.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/RuleInstance.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rel.rules.ProjectToWindowRule;
 import org.apache.calcite.rel.rules.ProjectWindowTransposeRule;
 import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.rel.rules.SortRemoveRule;
+import org.apache.calcite.rel.rules.SubQueryRemoveRule;
 import org.apache.calcite.rel.rules.UnionToDistinctRule;
 import org.apache.drill.exec.planner.logical.DrillConditions;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
@@ -130,4 +131,13 @@ public interface RuleInstance {
 
   FilterRemoveIsNotDistinctFromRule REMOVE_IS_NOT_DISTINCT_FROM_RULE =
       new FilterRemoveIsNotDistinctFromRule(DrillRelBuilder.proto(DrillRelFactories.DRILL_LOGICAL_FILTER_FACTORY));
+
+  SubQueryRemoveRule SUB_QUERY_FILTER_REMOVE_RULE =
+      new SubQueryRemoveRule.SubQueryFilterRemoveRule(DrillRelFactories.LOGICAL_BUILDER);
+
+  SubQueryRemoveRule SUB_QUERY_PROJECT_REMOVE_RULE =
+      new SubQueryRemoveRule.SubQueryProjectRemoveRule(DrillRelFactories.LOGICAL_BUILDER);
+
+  SubQueryRemoveRule SUB_QUERY_JOIN_REMOVE_RULE =
+      new SubQueryRemoveRule.SubQueryJoinRemoveRule(DrillRelFactories.LOGICAL_BUILDER);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -64,7 +64,6 @@ import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
-import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Util;
@@ -384,10 +383,7 @@ public class SqlConverter {
     //To avoid unexpected column errors set a value of top to false
     final RelRoot rel = sqlToRelConverter.convertQuery(validatedNode, false, false);
     final RelRoot rel2 = rel.withRel(sqlToRelConverter.flattenTypes(rel.rel, true));
-    final RelRoot rel3 = rel2.withRel(
-        RelDecorrelator.decorrelateQuery(rel2.rel,
-            sqlToRelConverterConfig.getRelBuilderFactory().create(cluster, null)));
-    return rel3;
+    return rel2;
   }
 
   private class Expander implements RelOptTable.ViewExpander {
@@ -478,7 +474,7 @@ public class SqlConverter {
 
     @Override
     public boolean isExpand() {
-      return SqlToRelConverterConfig.DEFAULT.isExpand();
+      return false;
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/TestCorrelation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestCorrelation.java
@@ -58,4 +58,50 @@ public class TestCorrelation extends PlanTestBase {
       .run();
   }
 
+  @Test
+  public void testExistsScalarSubquery() throws Exception {
+    String query =
+        "SELECT employee_id\n" +
+        "FROM cp.`employee.json`\n" +
+        "WHERE EXISTS\n" +
+        "    (SELECT *\n" +
+        "     FROM cp.`employee.json` cs2\n" +
+        "     )\n" +
+        "limit 1";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("employee_id")
+        .baselineValues(1L)
+        .go();
+  }
+
+  @Test
+  public void testSeveralExistsCorrelateSubquery() throws Exception {
+    String query =
+        "SELECT cs1.employee_id\n" +
+        "FROM cp.`employee.json` cs1,\n" +
+        "     cp.`employee.json` cs3\n" +
+        "WHERE cs1.hire_date = cs3.hire_date\n" +
+        "  AND EXISTS\n" +
+        "    (SELECT *\n" +
+        "     FROM cp.`employee.json` cs2\n" +
+        "     WHERE " +
+        "       cs1.position_id > cs2.position_id\n" +
+        "       AND" +
+        "       cs1.epmloyee_id = cs2.epmloyee_id" +
+        "       )\n" +
+        "  AND EXISTS\n" +
+        "    (SELECT *\n" +
+        "     FROM cp.`employee.json` cr1\n" +
+        "     WHERE cs1.position_id = cr1.position_id)\n" +
+        "LIMIT 1";
+
+    testBuilder()
+      .sqlQuery(query)
+      .unOrdered()
+      .expectsEmptyResultSet()
+      .go();
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestDisabledFunctionality.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestDisabledFunctionality.java
@@ -47,23 +47,6 @@ public class TestDisabledFunctionality extends BaseTestQuery {
     throw ex;
   }
 
-  @Test
-  public void testComparisonWithSingleValueSubQuery() throws Exception {
-    String query = "select n_name from cp.`tpch/nation.parquet` " +
-        "where n_nationkey = " +
-        "(select r_regionkey from cp.`tpch/region.parquet` " +
-        "where r_regionkey = 1)";
-    PlanTestBase.testPlanMatchingPatterns(query,
-        new String[]{"agg.*SINGLE_VALUE", "Filter.*=\\(\\$0, 1\\)"});
-
-    testBuilder()
-        .sqlQuery(query)
-        .unOrdered()
-        .baselineColumns("n_name")
-        .baselineValues("ARGENTINA")
-        .go();
-  }
-
   @Test(expected = UnsupportedRelOperatorException.class) // see DRILL-1921
   public void testDisabledIntersect() throws Exception {
     try {
@@ -206,22 +189,6 @@ public class TestDisabledFunctionality extends BaseTestQuery {
     } catch(UserException ex) {
       throwAsUnsupportedException(ex);
     }
-  }
-
-  @Test
-  public void testMultipleComparisonWithSingleValueSubQuery() throws Exception {
-    String query = "select a.last_name, b.n_name " +
-          "from cp.`employee.json` a, cp.`tpch/nation.parquet` b " +
-          "where b.n_nationkey = " +
-          "(select r_regionkey from cp.`tpch/region.parquet` " +
-          "where r_regionkey = 1) limit 1";
-
-    testBuilder()
-        .sqlQuery(query)
-        .unOrdered()
-        .baselineColumns("last_name", "n_name")
-        .baselineValues("Nowmer", "ARGENTINA")
-        .go();
   }
 
   @Test(expected = UnsupportedRelOperatorException.class) // see DRILL-2068, DRILL-1325

--- a/exec/java-exec/src/test/java/org/apache/drill/TestDisabledFunctionality.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestDisabledFunctionality.java
@@ -47,28 +47,21 @@ public class TestDisabledFunctionality extends BaseTestQuery {
     throw ex;
   }
 
-  @Test(expected = UnsupportedFunctionException.class)  // see DRILL-1937
-  public void testDisabledExplainplanForComparisonWithNonscalarSubquery() throws Exception {
-    try {
-      test("explain plan for select n_name from cp.`tpch/nation.parquet` " +
-           "where n_nationkey = " +
-           "(select r_regionkey from cp.`tpch/region.parquet` " +
-           "where r_regionkey = 1)");
-    } catch(UserException ex) {
-      throwAsUnsupportedException(ex);
-    }
-  }
+  @Test
+  public void testComparisonWithSingleValueSubQuery() throws Exception {
+    String query = "select n_name from cp.`tpch/nation.parquet` " +
+        "where n_nationkey = " +
+        "(select r_regionkey from cp.`tpch/region.parquet` " +
+        "where r_regionkey = 1)";
+    PlanTestBase.testPlanMatchingPatterns(query,
+        new String[]{"agg.*SINGLE_VALUE", "Filter.*=\\(\\$0, 1\\)"});
 
-  @Test(expected = UnsupportedFunctionException.class)  // see DRILL-1937
-  public void testDisabledComparisonWithNonscalarSubquery() throws Exception {
-    try {
-      test("select n_name from cp.`tpch/nation.parquet` " +
-           "where n_nationkey = " +
-           "(select r_regionkey from cp.`tpch/region.parquet` " +
-           "where r_regionkey = 1)");
-    } catch(UserException ex) {
-      throwAsUnsupportedException(ex);
-    }
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("n_name")
+        .baselineValues("ARGENTINA")
+        .go();
   }
 
   @Test(expected = UnsupportedRelOperatorException.class) // see DRILL-1921
@@ -215,17 +208,20 @@ public class TestDisabledFunctionality extends BaseTestQuery {
     }
   }
 
-  @Test(expected = UnsupportedFunctionException.class) // see DRILL-1325, DRILL-2155, see DRILL-1937
-  public void testMultipleUnsupportedOperatorations() throws Exception {
-    try {
-      test("select a.lastname, b.n_name " +
+  @Test
+  public void testMultipleComparisonWithSingleValueSubQuery() throws Exception {
+    String query = "select a.last_name, b.n_name " +
           "from cp.`employee.json` a, cp.`tpch/nation.parquet` b " +
           "where b.n_nationkey = " +
           "(select r_regionkey from cp.`tpch/region.parquet` " +
-          "where r_regionkey = 1)");
-    } catch(UserException ex) {
-      throwAsUnsupportedException(ex);
-    }
+          "where r_regionkey = 1) limit 1";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("last_name", "n_name")
+        .baselineValues("Nowmer", "ARGENTINA")
+        .go();
   }
 
   @Test(expected = UnsupportedRelOperatorException.class) // see DRILL-2068, DRILL-1325

--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -1165,4 +1165,37 @@ public class TestExampleQueries extends BaseTestQuery {
         .build()
         .run();
   }
+
+  @Test
+  public void testComparisonWithSingleValueSubQuery() throws Exception {
+    String query = "select n_name from cp.`tpch/nation.parquet` " +
+        "where n_nationkey = " +
+        "(select r_regionkey from cp.`tpch/region.parquet` " +
+        "where r_regionkey = 1)";
+    PlanTestBase.testPlanMatchingPatterns(query,
+        new String[]{"agg.*SINGLE_VALUE", "Filter.*=\\(\\$0, 1\\)"});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("n_name")
+        .baselineValues("ARGENTINA")
+        .go();
+  }
+
+  @Test
+  public void testMultipleComparisonWithSingleValueSubQuery() throws Exception {
+    String query = "select a.last_name, b.n_name " +
+        "from cp.`employee.json` a, cp.`tpch/nation.parquet` b " +
+        "where b.n_nationkey = " +
+        "(select r_regionkey from cp.`tpch/region.parquet` " +
+        "where r_regionkey = 1) limit 1";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("last_name", "n_name")
+        .baselineValues("Nowmer", "ARGENTINA")
+        .go();
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributed.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributed.java
@@ -138,7 +138,6 @@ public class TestTpchDistributed extends BaseTestQuery {
   }
 
   @Test
-  @Ignore
   public void tpch21() throws Exception{
     testDistributed("queries/tpch/21.sql");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
@@ -145,7 +145,6 @@ public class TestTpchDistributedStreaming extends BaseTestQuery {
   }
 
   @Test
-  @Ignore
   public void tpch21() throws Exception{
     testDistributed("queries/tpch/21.sql");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchExplain.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchExplain.java
@@ -148,7 +148,6 @@ public class TestTpchExplain extends BaseTestQuery {
   }
 
   @Test
-  @Ignore
   public void tpch21() throws Exception{
     doExplain("queries/tpch/21.sql");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchLimit0.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchLimit0.java
@@ -140,7 +140,6 @@ public class TestTpchLimit0 extends BaseTestQuery {
   }
 
   @Test
-  @Ignore
   public void tpch21() throws Exception{
     testLimitZero("queries/tpch/21.sql");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchPlanning.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchPlanning.java
@@ -141,7 +141,6 @@ public class TestTpchPlanning extends PlanningBase {
   }
 
   @Test
-  @Ignore // DRILL-519
   public void tpch21() throws Exception {
     testSqlPlanFromFile("queries/tpch/21.sql");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchSingleMode.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchSingleMode.java
@@ -139,7 +139,6 @@ public class TestTpchSingleMode extends BaseTestQuery {
   }
 
   @Test
-  @Ignore
   public void tpch21() throws Exception{
     testSingleMode("queries/tpch/21.sql");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dep.guava.version>18.0</dep.guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.10.0</parquet.version>
-    <calcite.version>1.16.0-drill-r3</calcite.version>
+    <calcite.version>1.16.0-drill-r4</calcite.version>
     <avatica.version>1.11.0</avatica.version>
     <janino.version>2.7.6</janino.version>
     <sqlline.version>1.1.9-drill-r7</sqlline.version>


### PR DESCRIPTION
Before this change, sub-queries were rewritten in `SqlToRelConverter`. During such expansion, excessive aggregate calls were created. Due to these excessive aggregate calls, some rel nodes weren't able to transpose to Aggregate rel node and the resulting plan was inefficient and in the most cases with joins with true in condition. As discussed in [CALCITE-2158](https://issues.apache.org/jira/browse/CALCITE-2158), a better approach to expand sub-queries is to use `SubQueryRemoveRule` rules.

This PR contains two commits:
- the first one contains changes to use `SubQueryRemoveRule` rules instead of expanding in `SqlToRelConverter`.
- the second commit contains introducing single_value aggregate function which is used when filter contains a comparison of value and subquery and in some `SubQueryRemoveRule` rules.