### PR TITLE
DRILL-6470: Remove defunct repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,18 +166,6 @@
     </repository>
 
     <repository>
-      <id>dremio-releases</id>
-      <name>Dremio Drill Third Party Artifacts</name>
-      <url>http://repo.dremio.com/release/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
       <id>mapr-drill-thirdparty</id>
       <name>MapR Drill Third Party Artifacts</name>
       <url>http://repository.mapr.com/nexus/content/repositories/drill/</url>


### PR DESCRIPTION
When build the Drill source code, Parquet jars from the repository hosted at http://repo.dremio.com/release/  is inaccessible.
These artifacts (parquet libraries) are now available within http://maven.corp.maprtech.com/nexus/content/groups/public/org/apache/parquet/