### PR TITLE
DRILL-6515: Render a link between the Unnest operator and it's source

### DIFF
--- a/exec/java-exec/src/main/resources/rest/static/js/graph.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/graph.js
@@ -93,7 +93,9 @@ $(window).on('load',(function () {
     }
 
     // parse the short physical plan into a dagreeD3 structure
-    function parseplan (planstring, implicitSrcMap) {
+    function parseplan (planstring) {
+        //Map for implicit links
+        var implicitSrcMap = {};
         var g = new dagreD3.Digraph();
         //Produce 2D array (3 x M): [[0:majorMinor] [1:] [2:opName]] / [[<major>-<minor>, "<indent>", opName]]
         let opPlanArray = planstring.trim().split("\n");
@@ -167,9 +169,7 @@ $(window).on('load',(function () {
     // graph a "planstring" into the d3 svg handle "svg"
     function buildplangraph (svg, planstring) {
         var padding = 20;
-        //Map for implicit links
-        var implicitSrcMap = {}; //Populated by parseplan()
-        var graph = parseplan(planstring, implicitSrcMap);
+        var graph = parseplan(planstring);
 
         var renderer = new dagreD3.Renderer();
         renderer.zoom(function () {return function (graph, root) {}});

--- a/exec/java-exec/src/main/resources/rest/static/js/graph.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/graph.js
@@ -95,7 +95,7 @@ $(window).on('load',(function () {
     // parse the short physical plan into a dagreeD3 structure
     function parseplan (planstring, implicitSrcMap) {
         var g = new dagreD3.Digraph();
-        //Produce 2D array (3 x M): [[0:majorMinor] [1:] [2:opName]]
+        //Produce 2D array (3 x M): [[0:majorMinor] [1:] [2:opName]] / [[<major>-<minor>, "<indent>", opName]]
         let opPlanArray = planstring.trim().split("\n");
         var operatorRegex = new RegExp("^([0-9-]+)( *)([a-zA-Z]*)");
         //Regex to capture source operator 
@@ -128,6 +128,7 @@ $(window).on('load',(function () {
         }
 
         // Define edges by traversing graph from root node (Screen)
+        //NOTE: The indentation value in opTuple which is opTuple[1] represents the relative level of each operator in tree w.r.t root operator
         var nodeStack = [opTuple[0]]; //Add Root
         for (var i = 1; i < opTuple.length; i++) {
             let top = nodeStack.pop();


### PR DESCRIPTION
1. Unnest operator is expected to specify srcOp=##-## to help identify the source of its input.
2. Implicit Source Map is leveraged to capture implicit data flow pipelines between Unnest and Lateral. (Can be expanded to other operators too).
3. In addition, code refactored for more readability.

Sample Screenshot:
![image](https://user-images.githubusercontent.com/4335237/41564557-093ad338-7308-11e8-8659-6fc334295f75.png)
