### PR TITLE
DRILL-6346: Create an Official Drill Docker Container

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM centos:7
+
+# Project version defined in pom.xml is passed as an argument
+ARG VERSION
+
+# JDK 8 is a pre-requisite to run Drill ; 'which' package is needed for drill-config.sh
+RUN yum install -y java-1.8.0-openjdk-devel which ; yum clean all ; rm -rf /var/cache/yum
+
+# The drill tarball is generated upon building the Drill project
+COPY target/apache-drill-$VERSION.tar.gz /tmp
+
+# Drill binaries are extracted into the '/opt/drill' directory
+RUN mkdir /opt/drill
+RUN tar -xvzf /tmp/apache-drill-$VERSION.tar.gz --directory=/opt/drill --strip-components 1
+
+# Starts Drill in embedded mode and connects to Sqlline
+ENTRYPOINT /opt/drill/bin/drill-embedded

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -485,6 +485,34 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.3</version>
+            <executions>
+              <execution>
+                <id>docker-image</id>
+                <goals>
+                  <goal>build</goal>
+                  <goal>push</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <repository>${docker.repository}</repository>
+              <tag>${project.version}</tag>
+              <buildArgs>
+                <VERSION>${project.version}</VERSION>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/docs/dev/Docker.md
+++ b/docs/dev/Docker.md
@@ -1,0 +1,97 @@
+# How to build, publish and run a Apache Drill Docker image
+
+## Prerequisites
+
+   To build an Apache Drill docker image, you need to have the following software installed on your system to successfully complete a build. 
+  * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+  * [Maven 3.3.1 or greater](https://maven.apache.org/download.cgi)
+  * [Docker CE](https://store.docker.com/search?type=edition&offering=community)
+  
+   If you are using an older Mac or PC, additionally configure [docker-machine](https://docs.docker.com/machine/overview/#what-is-docker-machine) on your system
+
+## Checkout
+```
+git clone https://github.com/apache/drill.git
+```
+## Build Drill
+```
+$ cd drill
+$ mvn clean install
+```   
+## Build Docker Image
+```
+$ cd distribution
+$ mvn dockerfile:build -Pdocker
+```
+## Push Docker Image
+   
+   By default, the docker image built above is configured to be pushed to [Drill Docker Hub](https://hub.docker.com/r/drill/apache-drill/) to create official Drill Docker images.
+```   
+$ cd distribution
+$ mvn dockerfile:push -Pdocker
+```    
+  You can configure the repository in pom.xml to point to any private or public container registry, or specify it in your mvn command.
+```  
+$ cd distribution
+$ mvn dockerfile:push -Pdocker -Pdocker.repository=<my_repo>
+```
+## Run Docker Container
+   
+   Running the Docker container should start Drill in embedded mode and connect to Sqlline. 
+```    
+$ docker run -i --name drill-1.14.0 -p 8047:8047 -t drill/apache-drill:1.14.0 /bin/bash
+Jun 29, 2018 3:28:21 AM org.glassfish.jersey.server.ApplicationHandler initialize
+INFO: Initiating Jersey application, version Jersey: 2.8 2014-04-29 01:25:26...
+apache drill 1.14.0 
+"json ain't no thang"
+0: jdbc:drill:zk=local> select version from sys.version;
++------------+
+|  version   |
++------------+
+| 1.14.0     |
++------------+
+1 row selected (0.28 seconds)
+```  
+
+   You can also run the container in detached mode and connect to sqlline using drill-localhost. 
+```    
+$ docker run -i --name drill-1.14.0 -p 8047:8047 --detach -t drill/apache-drill:1.14.0 /bin/bash
+<displays container ID>
+
+$ docker exec -it drill-1.14.0 bash
+<connects to container>
+
+$ /opt/drill/bin/drill-localhost
+apache drill 1.14.0 
+"json ain't no thang"
+0: jdbc:drill:drillbit=localhost> select version from sys.version;
++------------+
+|  version   |
++------------+
+| 1.14.0     |
++------------+
+1 row selected (0.28 seconds)
+```
+
+## Querying Data
+
+   By default, you can only query files which are accessible within the container. For example, the sample data which ships with Drill. 
+```
+> select first_name, last_name from cp.`employee.json` limit 1;
++-------------+------------+
+| first_name  | last_name  |
++-------------+------------+
+| Sheri       | Nowmer     |
++-------------+------------+
+1 row selected (0.256 seconds)
+```
+
+   To query files outside of the container, you can configure [docker volumes](https://docs.docker.com/storage/volumes/#start-a-service-with-volumes)
+   
+## Drill Web UI
+
+   Drill web UI can be accessed using http://localhost:8047 once the Drill docker container is up and running. On Windows, you may need to specify the IP address of your system instead of 'localhost'.
+
+## More information 
+
+   For more information including how to run Apache Drill in a Docker container, visit the [Apache Drill Documentation](http://drill.apache.org/docs/)

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <additionalparam>-Xdoclint:none</additionalparam>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
+    <docker.repository>drill/apache-drill</docker.repository>
   </properties>
 
   <scm>


### PR DESCRIPTION
Added apache-release profile in distribution/pom.xml to build a Docker image once the project is built successfully. While the Docker image can be built anytime, I assumed that an official Docker image would only be generated during the release. 

This requires having Docker configured on the environment (works with Docker for Mac). 

Usage: 
Build the project by specifying the apache-release profile
```
$ mvn clean install -Papache-release -DskipTests
```
Pushing image to Docker Hub (or any Container Registry):
```
cd distribution
mvn dockerfile:build -Papache-release
mvn dockerfile:push -Papache-release
```
Run the Docker container -- which should connect and start Drill in embedded mode
```
$ docker run -i -t drill/apache-drill-centos:1.14.0-SNAPSHOT /bin/bash
Jun 29, 2018 3:28:21 AM org.glassfish.jersey.server.ApplicationHandler initialize
INFO: Initiating Jersey application, version Jersey: 2.8 2014-04-29 01:25:26...
apache drill 1.14.0-SNAPSHOT 
"json ain't no thang"
0: jdbc:drill:zk=local> select version from sys.version;
+------------------+
|     version      |
+------------------+
| 1.14.0-SNAPSHOT  |
+------------------+
1 row selected (0.28 seconds)
```