### PR TITLE
DRILL-4580: Support for exporting storage plugin configurations

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -35,6 +35,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -132,6 +133,15 @@ public class StorageResources {
       logger.debug("Error in enabling storage name: " + name + " flag: " + enable);
       return message("error (unable to enable/ disable storage)");
     }
+  }
+
+  @GET
+  @Path("/storage/{name}/export")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response exportPlugin(@PathParam("name") String name) {
+    Response.ResponseBuilder response = Response.ok(getStoragePluginJSON(name));
+    response.header("Content-Disposition", String.format("attachment;filename=\"%s.json\"", name));
+    return response.build();
   }
 
   @DELETE

--- a/exec/java-exec/src/main/resources/rest/storage/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/list.ftl
@@ -38,6 +38,7 @@
               <td style="border:none;">
                 <a class="btn btn-primary" href="/storage/${plugin.getName()}">Update</a>
                 <a class="btn btn-default" onclick="doEnable('${plugin.getName()}', false)">Disable</a>
+                <a class="btn btn-default" href="/storage/${plugin.getName()}/export"">Export</a>
               </td>
             </tr>
           </#if>

--- a/exec/java-exec/src/main/resources/rest/storage/update.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/update.ftl
@@ -48,6 +48,7 @@
       <#else>
         <a id="enabled" class="btn btn-primary">Enable</a>
       </#if>
+      <a class="btn btn-default" href="/storage/${model.getName()}/export"">Export</a>
       <a id="del" class="btn btn-danger" onclick="deleteFunction()">Delete</a>
     </#if>
   </form>


### PR DESCRIPTION
Added an "Export" button to enabled storage plugins to support exporting the configuration into a JSON file. This can be useful to backup storage plugin configurations for Upgrade or other purposes. 