### PR TITLE
DRILL-6553: Fix TopN for unnest operator

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLateralJoinRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLateralJoinRelBase.java
@@ -50,15 +50,15 @@ public abstract class DrillLateralJoinRelBase extends Correlate implements Drill
     this.excludeCorrelateColumn = excludeCorrelateCol;
   }
 
-  @Override public RelOptCost computeSelfCost(RelOptPlanner planner,
-                                              RelMetadataQuery mq) {
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
     DrillCostBase.DrillCostFactory costFactory = (DrillCostBase.DrillCostFactory) planner.getCostFactory();
 
-    double rowCount = mq.getRowCount(this.getLeft());
+    double rowCount = estimateRowCount(mq);
     long fieldWidth = PrelUtil.getPlannerSettings(planner).getOptions()
-        .getOption(ExecConstants.AVERAGE_FIELD_WIDTH_KEY).num_val;
+        .getLong(ExecConstants.AVERAGE_FIELD_WIDTH_KEY);
 
-    double rowSize = (this.getLeft().getRowType().getFieldList().size()) * fieldWidth;
+    double rowSize = left.getRowType().getFieldList().size() * fieldWidth;
 
     double cpuCost = rowCount * rowSize * DrillCostBase.BASE_CPU_COST;
     double memCost = !excludeCorrelateColumn ? CORRELATE_MEM_COPY_COST : 0.0;
@@ -109,5 +109,10 @@ public abstract class DrillLateralJoinRelBase extends Correlate implements Drill
       return getCluster().getTypeFactory().createStructType(fields, fieldNames);
     }
     return inputRowType;
+  }
+
+  @Override
+  public double estimateRowCount(RelMetadataQuery mq) {
+    return mq.getRowCount(left);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestE2EUnnestAndLateral.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestE2EUnnestAndLateral.java
@@ -18,8 +18,10 @@
 package org.apache.drill.exec.physical.impl.lateraljoin;
 
 import org.apache.drill.categories.OperatorTest;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,8 +44,10 @@ public class TestE2EUnnestAndLateral extends ClusterTest {
   public static void setupTestFiles() throws Exception {
     dirTestWatcher.copyResourceToRoot(Paths.get("lateraljoin", "multipleFiles", regularTestFile_1));
     dirTestWatcher.copyResourceToRoot(Paths.get("lateraljoin", "multipleFiles", regularTestFile_2));
-    startCluster(ClusterFixture.builder(dirTestWatcher).maxParallelization(1));
-    test("alter session set `planner.enable_unnest_lateral`=%s", true);
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
+        .sessionOption(ExecConstants.ENABLE_UNNEST_LATERAL_KEY, true)
+        .maxParallelization(1);
+    startCluster(builder);
   }
 
   /***********************************************************************************************
@@ -96,7 +100,6 @@ public class TestE2EUnnestAndLateral extends ClusterTest {
   /**
    * Test which disables the TopN operator from planner settings before running query using SORT and LIMIT in
    * subquery. The same query as in above test is executed and same result is expected.
-   * @throws Exception
    */
   @Test
   public void testLateral_WithSortAndLimitInSubQuery() throws Exception {


### PR DESCRIPTION
`estimateRowCount()` method for DrillLateralJoinRelBase rel node wasn't overridden, so was used method from `AbstractRelNode` class, which just returns 1. It caused problems with choosing better plans.

For more details please see [DRILL-6553](https://issues.apache.org/jira/browse/DRILL-6553).