### PR TITLE
DRILL-6570: Fixed IndexOutofBoundException in Parquet Reader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkEntry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/VarLenColumnBulkEntry.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.store.parquet.columnreaders;
 
 import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionInfo;
-import org.apache.drill.exec.store.parquet.columnreaders.VarLenColumnBulkInput.ColumnPrecisionType;
+import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.VarLenBulkEntry;
 
 import io.netty.buffer.DrillBuf;
@@ -55,25 +55,17 @@ final class VarLenColumnBulkEntry implements VarLenBulkEntry {
   }
 
   VarLenColumnBulkEntry(ColumnPrecisionInfo columnPrecInfo, int buffSz) {
-    int lengthSz = -1;
-    int dataSz = -1;
 
-    if (ColumnPrecisionType.isPrecTypeFixed(columnPrecInfo.columnPrecisionType)) {
-      final int expectedDataLen = columnPrecInfo.precision;
-      final int maxNumValues = buffSz / (4 + expectedDataLen);
-      lengthSz = maxNumValues;
-      dataSz = maxNumValues * expectedDataLen + PADDING;
+    // For variable length data, we need to handle a) maximum number of entries
+    // and b) max entry length. Note that we don't optimize for fixed length
+    // columns as the reader can notice a false-positive (that is, the first
+    // values were fixed but not the rest).
+    final int largestDataLen = buffSz - UInt4Vector.VALUE_WIDTH;
+    final int maxNumValues = buffSz / UInt4Vector.VALUE_WIDTH;
+    final int lengthSz = maxNumValues;
+    final int dataSz = largestDataLen + PADDING;
 
-    } else {
-      // For variable length data, we need to handle a) maximum number of entries and b) max entry length
-      final int smallestDataLen = 1;
-      final int largestDataLen = buffSz - 4;
-      final int maxNumValues = buffSz / (4 + smallestDataLen);
-      lengthSz = maxNumValues;
-      dataSz = largestDataLen + PADDING;
-    }
-
-    this.lengths       = new int[lengthSz];
+    this.lengths = new int[lengthSz];
     this.internalArray = new byte[dataSz];
   }
 


### PR DESCRIPTION
Reserving same size intermediary buffers to handle the case of false-positive; that is, a column is first thought to be fixed length (after sampling), then reverted to variable length as we read more values.