### PR TITLE
DRILL-6577: Change Hash-Join fallback default to false

### DIFF
--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -424,7 +424,7 @@ drill.exec.options: {
     # Setting to control if HashJoin should fallback to older behavior of consuming
     # unbounded memory. By default it's set to false such that the
     # query will fail if there is not enough memory
-    drill.exec.hashjoin.fallback.enabled: true, # should soon be changed to false !!
+    drill.exec.hashjoin.fallback.enabled: false
     # Setting to control if HashAgg should fallback to older behavior of consuming
     # unbounded memory. In case of 2 phase Agg when available memory is not enough
     # to start at least 2 partitions then HashAgg fallbacks to this case. It can be


### PR DESCRIPTION
Option's default setting changed to *false*. 
