### PR TITLE
DRILL-6578: Handle query cancellation in Parquet reader

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
@@ -48,4 +48,22 @@ public class DrillRuntimeException extends RuntimeException {
   public static void format(Throwable cause, String format, Object...args) {
     throw new DrillRuntimeException(String.format(format, args), cause);
   }
+
+  /**
+   * This method can be called within loops to check whether the current thread has been
+   * interrupted; it ensures that operator implementation can respond to query cancellation
+   * in a timely manner.
+   *
+   * <p>Calling this method will result in the following behavior:
+   * <ul>
+   * <li>Throws a runtime exception if current thread interrupt flag has been set
+   * <li>Clears current thread interrupt flag
+   * </ul>
+   */
+  public static void checkInterrupted() {
+    if (Thread.interrupted()) {
+      // This exception will ensure the control layer will immediately get back control
+      throw new DrillRuntimeException("Interrupt received; aborting current operation");
+    }
+  }
 }

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -19,7 +19,7 @@ import java.lang.Override;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Set;
-
+import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.vector.BaseDataValueVector;
@@ -641,6 +641,8 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
         if (callback != null) {
           callback.onNewBulkEntry(entry);
         }
+
+        DrillRuntimeException.checkInterrupted(); // Ensures fast handling of query cancellation
       }
 
       // Flush any data not yet copied to this VL container


### PR DESCRIPTION
Goal -
- The optimized Parquet reader uses an iterator style to load column data 
- We need to ensure the code can properly handle query cancellation even in the presence of bugs within the hasNext() .. next() calls

Fix Details -
- Added a check within the hasNext() and next() to detect a thread interrupt
- If this is the case, these methods will throw a runtime exception and keep the thread's interrupted state set
- This will ensure that any blocking call will get the InterruptedException to be thrown 