### PR TITLE
DRILL-6585: PartitionSender clones vectors, but shares field metdata

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerTemplate.java
@@ -376,9 +376,8 @@ public abstract class PartitionerTemplate implements Partitioner {
      */
     public void initializeBatch() {
       for (VectorWrapper<?> v : incoming) {
-        // create new vector
-        @SuppressWarnings("resource")
-        ValueVector outgoingVector = TypeHelper.getNewVector(v.getField(), allocator);
+        // create new vector by cloning the incoming vector's type
+        ValueVector outgoingVector = TypeHelper.getNewVector(v.getField().clone(), allocator);
         outgoingVector.setInitialCapacity(outgoingRecordBatchSize);
         vectorContainer.add(outgoingVector);
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerTemplate.java
@@ -377,7 +377,7 @@ public abstract class PartitionerTemplate implements Partitioner {
     public void initializeBatch() {
       for (VectorWrapper<?> v : incoming) {
         // create new vector by cloning the incoming vector's type
-        ValueVector outgoingVector = TypeHelper.getNewVector(v.getField().clone(), allocator);
+        ValueVector outgoingVector = TypeHelper.getNewVector(v.getField().cloneEmpty(), allocator);
         outgoingVector.setInitialCapacity(outgoingRecordBatchSize);
         vectorContainer.add(outgoingVector);
       }


### PR DESCRIPTION
See the discussion for [PR #1244 for DRILL-6373](https://github.com/apache/drill/pull/1244).

The PartitionSender clones vectors. But, it does so by reusing the MaterializedField from the original vector. Though the original authors of MaterializedField apparently meant it to be immutable, later changes for maps and unions ended up changing it to add members.

When cloning a map, we get the original map materialized field, then start doctoring it up as we add the cloned map members. This screws up the original map vector's metadata.

The solution is to clone an empty version of the materialized field when creating a new vector.
But, since much code creates vectors by giving a perfectly valid, unique materialized field, we want to add a new method for use by the ill-behaved uses, such as PartitionSender, that ask to create a new vector without cloning the materialized field.

The solution is to add a new method, `TypeHelper.getClonedVector()`, which handles the "new vector from the materialized field of an existing vector" case. Modified the partition sender to use this version.

Moved an existing method to group the "new vector" functions.

My IDE is set up to mark variables as final when possible; so the edited files also have these changes.