### PR TITLE
DRILL-6583: Add space between pagination links in Profiles (WebUI) list

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/list.ftl
@@ -54,9 +54,12 @@
   /* Control Padding for length and filter as a pair */
   div.dataTables_length {
     float: right;
+    font-weight: normal;
   }
   div.dataTables_filter {
     float: left;
+    font-weight: normal;
+    padding-left: 0.45em;
   }
   div.dataTables_info {
     padding-right: 2em;
@@ -64,19 +67,10 @@
   }
 
   /* Add spaces between pagination links */
-  #profileList_paginate * {
-    padding-right: 0.55em;
-    float:left
+  #profileList_completed_paginate *, #profileList_running_paginate * { 
+    padding-right: 0.35em; 
+    float:left 
   }
-  /* Normal wt for search text */
-  #profileList_filter input {
-    font-weight: normal;
-    padding-left: 0.45em;
-  }
-  #profileList_length * {
-    font-weight: normal;
-  }
-
 </style>
 
 </#macro>


### PR DESCRIPTION
Inject a small space to improve readability of the pagination links (CSS).
Before fix:
![image](https://user-images.githubusercontent.com/4335237/42470422-3b3255d8-836f-11e8-9dc6-bb9479d2e51b.png)

After fix:
![image](https://user-images.githubusercontent.com/4335237/42470284-d836448a-836e-11e8-91c6-23e2c98a1399.png)


@sohami can you review this minor change for the bug filed by @Khurram?