### PR TITLE
DRILL-6601 LageFileCompilation testProject times out

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestLargeFileCompilation.java
@@ -51,7 +51,7 @@ public class TestLargeFileCompilation extends BaseTestQuery {
 
   private static final int NUM_PROJECT_COLUMNS = 2500;
 
-  private static final int NUM_PROJECT_TEST_COLUMNS = 10000;
+  private static final int NUM_PROJECT_TEST_COLUMNS = 5000;
 
   private static final int NUM_ORDERBY_COLUMNS = 500;
 


### PR DESCRIPTION
Changing NUM_PROJECT_TEST_COLUMNS to the original 5K value. This number will still stress the constant pool constraints that have to be honored in code-gen, without stressing the total execution time. 