### PR TITLE
DRILL-6591: Show Exception for failed queries submitted in WebUI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
@@ -55,6 +55,19 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
   }
 
   /**
+   * Wait until the query has completed or timeout is passed. (Used only in case of WebUser)
+   *
+   * @throws Exception
+   */
+  public boolean timedWait(final long timeoutMillis) throws Exception {
+    boolean status = latch.await(timeoutMillis, TimeUnit.MILLISECONDS);
+    if (exception != null) {
+      throw exception;
+    }
+    return status;
+  }
+
+  /**
    * Wait indefinitely until the query is completed. Used only in case of WebUser
    *
    * @throws Exception

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
@@ -55,19 +55,6 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
   }
 
   /**
-   * Wait until the query has completed or timeout is passed. (Used only in case of WebUser)
-   *
-   * @throws Exception
-   */
-  public boolean timedWait(final long timeoutMillis) throws Exception {
-    boolean status = latch.await(timeoutMillis, TimeUnit.MILLISECONDS);
-    if (exception != null) {
-      throw exception;
-    }
-    return status;
-  }
-
-  /**
    * Wait indefinitely until the query is completed. Used only in case of WebUser
    *
    * @throws Exception


### PR DESCRIPTION
When query fails on Web UI result page no error is shown, only "No result found." 
This was because DRILL-6477 (PR #1309) switched to `WebUserConnection.await(long timeoutInMillis)` . Unlike the original `WebUserConnection.await()`, this method did not throw any UserException generated by a query failure.
The fix was to add a new WebUser-only method - `WebUserConnection.timedWait(long timeoutInMillis)` 
This ensures that other callers to the `WebUserConnection.await(timeoutInMillis)` are unaffected by the expected behaviour.

This is what the UI returns after this patch:
_When running query which hits memory limits (DRILL-6477), we get this:_
```
org.apache.drill.common.exceptions.UserException: RESOURCE ERROR: There is not enough heap memory to run this query using the web interface. Please try a query with fewer columns or with a filter or limit condition to limit the data returned. You can also try an ODBC/JDBC client. [Error Id: 702884d0-4e90-46c0-a861-71b7d384084b on kk127.qa.lab:31010]
```

_When querying a non-existent schema:_
```
org.apache.drill.common.exceptions.UserRemoteException: VALIDATION ERROR: Schema [[sys1]] is not valid with respect to either root schema or current default schema. Current default schema: No default schema selected [Error Id: 9fd6041c-b4f1-4f63-912e-d8a44ed318b0 on kk127.qa.lab:31010]
```

_When running an incorrect SQL:_
```
Non-query expression encountered in illegal context (Non-query expression encountered in illegal context) org.apache.drill.common.exceptions.UserException: PARSE ERROR: Non-query expression encountered in illegal context [Error Id: 22238845-2514-4bb0-af8a-be5b6c922a63 on kk127.qa.lab:31010]
```