### PR TITLE
DRILL-6472: Prevent using zero precision in CAST function

### DIFF
--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastDecimalVarDecimal.java
@@ -64,17 +64,20 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
   public void eval() {
     java.math.BigDecimal bd =
         <#if type.from == "Decimal9" || type.from == "Decimal18">
-        java.math.BigDecimal.valueOf(in.value)
+        java.math.BigDecimal.valueOf(in.value);
         <#else>
         org.apache.drill.exec.util.DecimalUtility
           <#if type.from.contains("Sparse")>
-            .getBigDecimalFromDrillBuf(in.buffer, in.start, in.nDecimalDigits, in.scale, true)
+            .getBigDecimalFromDrillBuf(in.buffer, in.start, in.nDecimalDigits, in.scale, true);
           <#elseif type.from == "VarDecimal">
-            .getBigDecimalFromDrillBuf(in.buffer, in.start, in.end - in.start, in.scale)
+            .getBigDecimalFromDrillBuf(in.buffer, in.start, in.end - in.start, in.scale);
           </#if>
         </#if>
-                .setScale(scale.value, java.math.RoundingMode.HALF_UP)
-                .round(new java.math.MathContext(precision.value, java.math.RoundingMode.HALF_UP));
+
+    org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);
+
+    bd = bd.setScale(scale.value, java.math.RoundingMode.HALF_UP);
+
     out.scale = scale.value;
     out.precision = precision.value;
     out.start = 0;

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastFloatDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastFloatDecimal.java
@@ -71,12 +71,11 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
 
     out.start = 0;
     java.math.BigDecimal bd =
-        new java.math.BigDecimal(
-            String.valueOf(in.value),
-            new java.math.MathContext(
-                precision.value,
-                java.math.RoundingMode.HALF_UP))
-        .setScale(scale.value, java.math.RoundingMode.HALF_UP);
+        new java.math.BigDecimal(String.valueOf(in.value));
+
+    org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);
+
+    bd = bd.setScale(scale.value, java.math.RoundingMode.HALF_UP);
 
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastIntDecimal.java
@@ -67,9 +67,11 @@ public class Cast${type.from}${type.to} implements DrillSimpleFunc {
 
     out.start = 0;
     out.buffer = buffer;
-    java.math.BigDecimal bd = new java.math.BigDecimal(in.value,
-        new java.math.MathContext(precision.value, java.math.RoundingMode.HALF_UP))
-        .setScale(out.scale, java.math.BigDecimal.ROUND_DOWN);
+    java.math.BigDecimal bd = new java.math.BigDecimal(in.value);
+
+    org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);
+
+    bd = bd.setScale(out.scale, java.math.BigDecimal.ROUND_DOWN);
 
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;

--- a/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/CastVarCharDecimal.java
@@ -93,12 +93,12 @@ public class CastEmptyString${type.from}To${type.to} implements DrillSimpleFunc 
     byte[] buf = new byte[in.end - in.start];
     in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
     String s = new String(buf, com.google.common.base.Charsets.UTF_8);
-    java.math.BigDecimal bd =
-        new java.math.BigDecimal(s,
-            new java.math.MathContext(
-                precision.value,
-                java.math.RoundingMode.HALF_UP))
-        .setScale(scale.value, java.math.RoundingMode.HALF_UP);
+    java.math.BigDecimal bd = new java.math.BigDecimal(s);
+
+    org.apache.drill.exec.util.DecimalUtility.checkValueOverflow(bd, precision.value, scale.value);
+
+    bd = bd.setScale(scale.value, java.math.RoundingMode.HALF_UP);
+
     byte[] bytes = bd.unscaledValue().toByteArray();
     int len = bytes.length;
     out.buffer = buffer.reallocIfNeeded(len);

--- a/exec/java-exec/src/main/codegen/templates/Decimal/DecimalFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/Decimal/DecimalFunctions.java
@@ -193,16 +193,18 @@ public class ${type.name}Functions {
 
 </#list>
 
-<#list ["Abs", "Ceil", "Floor", "Trunc", "Round"] as functionName>
+<#list ["Abs", "Ceil", "Floor", "Trunc", "Round", "Negative"] as functionName>
   <#if functionName == "Ceil">
   @FunctionTemplate(names = {"ceil", "ceiling"},
   <#elseif functionName == "Trunc">
   @FunctionTemplate(names = {"trunc", "truncate"},
+  <#elseif functionName == "Negative">
+  @FunctionTemplate(names = {"negative", "u-", "-"},
   <#else>
   @FunctionTemplate(name = "${functionName?lower_case}",
   </#if>
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
-                  <#if functionName == "Abs">
+                  <#if functionName == "Abs" || functionName == "Negative">
                     returnType = FunctionTemplate.ReturnType.DECIMAL_MAX_SCALE,
                   <#elseif functionName == "Ceil" || functionName == "Floor"
                       || functionName == "Trunc" || functionName == "Round">
@@ -226,6 +228,9 @@ public class ${type.name}Functions {
               .getBigDecimalFromDrillBuf(in.buffer, in.start, in.end - in.start, in.scale)
           <#if functionName == "Abs">
                   .abs();
+      result.scale = in.scale;
+          <#elseif functionName == "Negative">
+                  .negate();
       result.scale = in.scale;
           <#elseif functionName == "Ceil">
                   .setScale(0, java.math.BigDecimal.ROUND_CEILING);

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
@@ -953,7 +953,7 @@ public class TestFunctionsQuery extends BaseTestQuery {
             .sqlQuery(query)
             .unOrdered()
             .baselineColumns("col1")
-            .baselineValues(-1.1)
+            .baselineValues(new BigDecimal("-1.1"))
             .go();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarDecimalFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarDecimalFunctions.java
@@ -113,7 +113,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "/ cast('-1.789' as DECIMAL(4, 3)) as s2,\n" +
             "cast('15.02' as DECIMAL(4, 2)) / cast('15.02' as DECIMAL(4, 2)) as s3,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) / cast('1' as DECIMAL(1, 0)) as s4,\n" +
-            "cast('0' as DECIMAL(0, 0)) / cast('15.02' as DECIMAL(4, 2)) as s5";
+            "cast('0' as DECIMAL(1, 0)) / cast('15.02' as DECIMAL(4, 2)) as s5";
     testBuilder()
         .sqlQuery(query)
         .ordered()
@@ -297,8 +297,8 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "<> cast('1.9999999999999999999999999999234567891' as DECIMAL(38, 37)) as s2,\n" +
             // the same value but different scale and precision
             "cast('1234567.89' as DECIMAL(9, 2)) = cast('1234567.890' as DECIMAL(10, 3)) as s3,\n" +
-            "cast('0' as DECIMAL(4, 2)) = cast('0' as DECIMAL(0, 0)) as s4,\n" +
-            "cast('0' as DECIMAL(4, 2)) <> cast('0' as DECIMAL(0, 0)) as s5,\n" +
+            "cast('0' as DECIMAL(4, 2)) = cast('0' as DECIMAL(1, 0)) as s4,\n" +
+            "cast('0' as DECIMAL(4, 2)) <> cast('0' as DECIMAL(1, 0)) as s5,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) = cast('12.93123456788' as DECIMAL(13, 11)) as s6";
     testBuilder()
         .sqlQuery(query)
@@ -318,7 +318,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "< cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37)) as s2,\n" +
             // the same value but different scale and precision
             "cast('1234567.89' as DECIMAL(9, 2)) < cast('1234567.890' as DECIMAL(10, 3)) as s3,\n" +
-            "cast('0' as DECIMAL(4, 2)) < cast('0' as DECIMAL(0, 0)) as s4,\n" +
+            "cast('0' as DECIMAL(4, 2)) < cast('0' as DECIMAL(1, 0)) as s4,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) < cast('12.93123456788' as DECIMAL(13, 11)) as s5";
     testBuilder()
         .sqlQuery(query)
@@ -338,7 +338,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "<= cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37)) as s2,\n" +
             // the same value but different scale and precision
             "cast('1234567.89' as DECIMAL(9, 2)) <= cast('1234567.890' as DECIMAL(10, 3)) as s3,\n" +
-            "cast('0' as DECIMAL(4, 2)) <= cast('0' as DECIMAL(0, 0)) as s4,\n" +
+            "cast('0' as DECIMAL(4, 2)) <= cast('0' as DECIMAL(1, 0)) as s4,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) <= cast('12.93123456788' as DECIMAL(13, 11)) as s5";
     testBuilder()
         .sqlQuery(query)
@@ -358,7 +358,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "> cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37)) as s2,\n" +
             // the same value but different scale and precision
             "cast('1234567.89' as DECIMAL(9, 2)) > cast('1234567.890' as DECIMAL(10, 3)) as s3,\n" +
-            "cast('0' as DECIMAL(4, 2)) > cast('0' as DECIMAL(0, 0)) as s4,\n" +
+            "cast('0' as DECIMAL(4, 2)) > cast('0' as DECIMAL(1, 0)) as s4,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) > cast('12.93123456788' as DECIMAL(13, 11)) as s5";
     testBuilder()
         .sqlQuery(query)
@@ -378,7 +378,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             ">= cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37)) as s2,\n" +
             // the same value but different scale and precision
             "cast('1234567.89' as DECIMAL(9, 2)) >= cast('1234567.890' as DECIMAL(10, 3)) as s3,\n" +
-            "cast('0' as DECIMAL(4, 2)) >= cast('0' as DECIMAL(0, 0)) as s4,\n" +
+            "cast('0' as DECIMAL(4, 2)) >= cast('0' as DECIMAL(1, 0)) as s4,\n" +
             "cast('12.93123456789' as DECIMAL(13, 11)) >= cast('12.93123456788' as DECIMAL(13, 11)) as s5";
     testBuilder()
         .sqlQuery(query)
@@ -398,8 +398,8 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37))) as s2,\n" +
             // the same value but different scale and precision
             "compare_to_nulls_high(cast('1234567.89' as DECIMAL(9, 2)), cast('1234567.890' as DECIMAL(10, 3))) as s3,\n" +
-            "compare_to_nulls_high(cast('0' as DECIMAL(4, 2)), cast('0' as DECIMAL(0, 0))) as s4,\n" +
-            "compare_to_nulls_high(cast('0' as DECIMAL(4, 2)), cast(null as DECIMAL(0, 0))) as s5,\n" +
+            "compare_to_nulls_high(cast('0' as DECIMAL(4, 2)), cast('0' as DECIMAL(1, 0))) as s4,\n" +
+            "compare_to_nulls_high(cast('0' as DECIMAL(4, 2)), cast(null as DECIMAL(1, 0))) as s5,\n" +
             "compare_to_nulls_high(cast('12.93123456789' as DECIMAL(13, 11)), " +
             "cast('12.93123456788' as DECIMAL(13, 11))) as s6";
     testBuilder()
@@ -420,8 +420,8 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast('1.9999999999999999999999999999234567892' as DECIMAL(38, 37))) as s2,\n" +
             // the same value but different scale and precision
             "compare_to_nulls_low(cast('1234567.89' as DECIMAL(9, 2)), cast('1234567.890' as DECIMAL(10, 3))) as s3,\n" +
-            "compare_to_nulls_low(cast('0' as DECIMAL(4, 2)), cast('0' as DECIMAL(0, 0))) as s4,\n" +
-            "compare_to_nulls_low(cast('0' as DECIMAL(4, 2)), cast(null as DECIMAL(0, 0))) as s5,\n" +
+            "compare_to_nulls_low(cast('0' as DECIMAL(4, 2)), cast('0' as DECIMAL(1, 0))) as s4,\n" +
+            "compare_to_nulls_low(cast('0' as DECIMAL(4, 2)), cast(null as DECIMAL(1, 0))) as s5,\n" +
             "compare_to_nulls_low(cast('12.93123456789' as DECIMAL(13, 11)), " +
             "cast('12.93123456788' as DECIMAL(13, 11))) as s6";
     testBuilder()
@@ -571,8 +571,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast(i3 as DECIMAL(8, 7)) as s3,\n" +
             "cast(i4 as DECIMAL(6, 6)) as s4,\n" +
             "cast(i5 as DECIMAL(7, 0)) as s5,\n" +
-            "cast(i6 as DECIMAL(7, 46)) as s6,\n" +
-            "cast(i7 as DECIMAL(17, 0)) as s7\n" +
+            "cast(i6 as DECIMAL(38, 38)) as s6\n" +
         "from (" +
             "select\n" +
                 "cast(0 as float) as i1,\n" +
@@ -580,17 +579,15 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
                 "cast(-1.5022222 as float) as i3,\n" +
                 "cast(-0.987654 as float) as i4,\n" +
                 "cast(9999999 as float) as i5,\n" +
-                "cast('%s' as float) as i6,\n" +
-                "cast('%s' as float) as i7)";
+                "cast('%s' as float) as i6)";
 
     testBuilder()
-        .sqlQuery(query, Float.MIN_VALUE, Float.MAX_VALUE)
-        .ordered()
-        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6", "s7")
+        .sqlQuery(query, Float.MIN_VALUE)
+        .unOrdered()
+        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6")
         .baselineValues(BigDecimal.valueOf(0), new BigDecimal("1.234567"),
             new BigDecimal("-1.5022222"), new BigDecimal("-0.987654"), BigDecimal.valueOf(9999999),
-            new BigDecimal(String.format("%s", Float.MIN_VALUE)),
-            new BigDecimal("340282350000000000000000000000000000000")) // Float.MAX_VALUE in non-scientific format
+            new BigDecimal(Float.MIN_VALUE).setScale(38, RoundingMode.HALF_UP))
         .go();
   }
 
@@ -603,8 +600,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast(i3 as float) as s3,\n" +
             "cast(i4 as float) as s4,\n" +
             "cast(i5 as float) as s5,\n" +
-            "cast(i6 as float) as s6,\n" +
-            "cast(i7 as float) as s7\n" +
+            "cast(i6 as float) as s6\n" +
         "from (" +
             "select\n" +
                 "cast('999999999999999999999999999.92345678912' as DECIMAL(38, 11)) as i1,\n" +
@@ -612,17 +608,16 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
                 "cast('-1234567891234567891234567891234567.89' as DECIMAL(36, 2)) as i3,\n" +
                 "cast('0' as DECIMAL(36, 3)) as i4,\n" +
                 "cast('15.02' as DECIMAL(4, 2)) as i5,\n" +
-                "cast('%s' as DECIMAL(2, 46)) as i6,\n" +
-                "cast('%s' as DECIMAL(8, 0)) as i7)";
+                "cast('%s' as DECIMAL(38, 38)) as i6)";
 
     testBuilder()
-        .sqlQuery(query, Float.MIN_VALUE, Float.MAX_VALUE)
-        .ordered()
-        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6", "s7")
+        .sqlQuery(query, Float.MIN_VALUE)
+        .unOrdered()
+        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6")
         .baselineValues(new BigDecimal("999999999999999999999999999.92345678912").floatValue(),
             new BigDecimal("0.32345678912345678912345678912345678912").floatValue(),
             new BigDecimal("-1234567891234567891234567891234567.89").floatValue(),
-            0f, 15.02f, Float.MIN_VALUE, Float.MAX_VALUE)
+            0f, 15.02f, 0.0f)
         .go();
   }
 
@@ -635,8 +630,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast(i3 as DECIMAL(8, 7)) as s3,\n" +
             "cast(i4 as DECIMAL(6, 6)) as s4,\n" +
             "cast(i5 as DECIMAL(7, 0)) as s5,\n" +
-            "cast(i6 as DECIMAL(17, 325)) as s6,\n" +
-            "cast(i7 as DECIMAL(17, 0)) as s7\n" +
+            "cast(i6 as DECIMAL(38, 38)) as s6\n" +
         "from (" +
             "select\n" +
                 "cast(0 as double) as i1,\n" +
@@ -644,17 +638,15 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
                 "cast(-1.5022222 as double) as i3,\n" +
                 "cast(-0.987654 as double) as i4,\n" +
                 "cast(9999999 as double) as i5,\n" +
-                "cast('%e' as double) as i6,\n" +
-                "cast('%f' as double) as i7)";
+                "cast('%e' as double) as i6)";
 
     testBuilder()
-        .sqlQuery(query, Double.MIN_VALUE, Double.MAX_VALUE)
-        .ordered()
-        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6", "s7")
+        .sqlQuery(query, Double.MIN_VALUE)
+        .unOrdered()
+        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6")
         .baselineValues(BigDecimal.valueOf(0), new BigDecimal("1.234567"),
             new BigDecimal("-1.5022222"), new BigDecimal("-0.987654"), BigDecimal.valueOf(9999999),
-            new BigDecimal(String.valueOf(Double.MIN_VALUE)),
-            new BigDecimal(String.format("%1.0f", Double.MAX_VALUE))) // non-scientific format
+            new BigDecimal(String.valueOf(Double.MIN_VALUE)).setScale(38, RoundingMode.HALF_UP))
         .go();
   }
 
@@ -667,8 +659,7 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
             "cast(i3 as double) as s3,\n" +
             "cast(i4 as double) as s4,\n" +
             "cast(i5 as double) as s5,\n" +
-            "cast(i6 as double) as s6,\n" +
-            "cast(i7 as double) as s7\n" +
+            "cast(i6 as double) as s6\n" +
         "from (" +
             "select\n" +
                 "cast('999999999999999999999999999.92345678912' as DECIMAL(38, 11)) as i1,\n" +
@@ -676,17 +667,16 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
                 "cast('-1234567891234567891234567891234567.89' as DECIMAL(36, 2)) as i3,\n" +
                 "cast('0' as DECIMAL(36, 3)) as i4,\n" +
                 "cast('15.02' as DECIMAL(4, 2)) as i5,\n" +
-                "cast('%e' as DECIMAL(17, 325)) as i6,\n" +
-                "cast('%f' as DECIMAL(17, 0)) as i7)";
+                "cast('%e' as DECIMAL(38, 38)) as i6)";
 
     testBuilder()
-        .sqlQuery(query, Double.MIN_VALUE, Double.MAX_VALUE)
-        .ordered()
-        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6", "s7")
+        .sqlQuery(query, Double.MIN_VALUE)
+        .unOrdered()
+        .baselineColumns("s1", "s2", "s3", "s4", "s5", "s6")
         .baselineValues(new BigDecimal("999999999999999999999999999.92345678912").doubleValue(),
             new BigDecimal("0.32345678912345678912345678912345678912").doubleValue(),
             new BigDecimal("-1234567891234567891234567891234567.89").doubleValue(),
-            0d, 15.02, Double.MIN_VALUE, Double.MAX_VALUE)
+            0d, 15.02, 0.)
         .go();
   }
 
@@ -738,6 +728,34 @@ public class TestVarDecimalFunctions extends BaseTestQuery {
         .baselineColumns("s1", "s2", "s3", "s4", "s5")
         .baselineValues("999999999999999999999999999.9", "0.3",
             "-1234567891234567891234567891234567.9", "0", "15")
+        .go();
+  }
+
+  @Test
+  public void testDecimalNegate() throws Exception {
+    String query =
+        "select\n" +
+            "negative(i1) as s1,\n" +
+            "-i2 as s2,\n" +
+            "negative(i3) as s3,\n" +
+            "-i4 as s4,\n" +
+            "negative(i5) as s5\n" +
+            "from (" +
+            "select\n" +
+            "cast('999999999999999999999999999.92345678912' as DECIMAL(38, 11)) as i1,\n" +
+            "cast('0.32345678912345678912345678912345678912' as DECIMAL(38, 38)) as i2,\n" +
+            "cast('-1234567891234567891234567891234567.89' as DECIMAL(36, 2)) as i3,\n" +
+            "cast('0' as DECIMAL(36, 3)) as i4,\n" +
+            "cast('15.02' as DECIMAL(4, 2)) as i5)";
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("s1", "s2", "s3", "s4", "s5")
+        .baselineValues(new BigDecimal("-999999999999999999999999999.92345678912"),
+            new BigDecimal("-0.32345678912345678912345678912345678912"),
+            new BigDecimal("1234567891234567891234567891234567.89"),
+            new BigDecimal("0.000"),
+            new BigDecimal("-15.02"))
         .go();
   }
 }

--- a/exec/java-exec/src/test/resources/decimal/cast_decimal_int.json
+++ b/exec/java-exec/src/test/resources/decimal/cast_decimal_int.json
@@ -19,7 +19,7 @@
       "pop" : "project",
       "@id" : 2,
       "exprs" : [
-        { "ref" : "DEC9_COL", "expr": "(cast(cast(INT_COL as int) as vardecimal(9, 0)))" },
+        { "ref" : "DEC9_COL", "expr": "(cast(cast(INT_COL as int) as vardecimal(10, 0)))" },
         { "ref" : "DEC38_COL", "expr": "(cast(BIGINT_COL as vardecimal(38, 0)))" }
       ],
 

--- a/exec/java-exec/src/test/resources/decimal/cast_decimal_vardecimal.json
+++ b/exec/java-exec/src/test/resources/decimal/cast_decimal_vardecimal.json
@@ -21,8 +21,8 @@
       "exprs" : [
         { "ref" : "DEC28", "expr": "(cast(B as vardecimal(38, 20)))" },
         { "ref" : "DEC38", "expr": "(cast(A as vardecimal(28, 16)))" },
-        { "ref" : "DEC18", "expr": "(cast(B as vardecimal(18, 9)))" },
-        { "ref" : "DEC9", "expr": "(cast(A as vardecimal(9, 0)))" }
+        { "ref" : "DEC18", "expr": "(cast(B as vardecimal(19, 0)))" },
+        { "ref" : "DEC9", "expr": "(cast(A as vardecimal(10, 0)))" }
       ],
 
       "child" : 4
@@ -32,8 +32,8 @@
       "exprs" : [
         {"ref": "DEC28_COL", "expr" : "cast(DEC28 as decimal38sparse(38, 20))"},
         {"ref": "DEC38_COL", "expr" : "cast(DEC38 as decimal28sparse(28, 16))"},
-        {"ref": "DEC18_COL", "expr" : "cast(DEC18 as decimal18(18, 0))"},
-        {"ref": "DEC9_COL", "expr" : "cast(DEC9 as decimal9(9, 0))"}
+        {"ref": "DEC18_COL", "expr" : "cast(DEC18 as decimal18(19, 0))"},
+        {"ref": "DEC9_COL", "expr" : "cast(DEC9 as decimal9(10, 0))"}
       ],
 
       "child" : 3

--- a/exec/java-exec/src/test/resources/decimal/cast_int_decimal.json
+++ b/exec/java-exec/src/test/resources/decimal/cast_int_decimal.json
@@ -29,9 +29,9 @@
       "pop" : "project",
       "@id" : 4,
       "exprs" : [
-        {"ref": "DEC9_INT", "expr" : "cast(INT_COL as vardecimal(9, 0))"},
+        {"ref": "DEC9_INT", "expr" : "cast(INT_COL as vardecimal(10, 0))"},
         {"ref": "DEC38_INT", "expr" : "cast(INT_COL as vardecimal(38, 0))"},
-        {"ref": "DEC9_BIGINT", "expr" : "cast(BIGINT_COL as vardecimal(9, 0))"},
+        {"ref": "DEC9_BIGINT", "expr" : "cast(BIGINT_COL as vardecimal(19, 0))"},
         {"ref": "DEC38_BIGINT", "expr" : "cast(BIGINT_COL as vardecimal(38, 0))"}
       ],
 

--- a/exec/java-exec/src/test/resources/decimal/cast_vardecimal_decimal.json
+++ b/exec/java-exec/src/test/resources/decimal/cast_vardecimal_decimal.json
@@ -21,8 +21,8 @@
       "exprs" : [
         { "ref" : "DEC28", "expr": "(cast(B as vardecimal(38, 16)))" },
         { "ref" : "DEC38", "expr": "(cast(A as vardecimal(28, 16)))" },
-        { "ref" : "DEC18", "expr": "(cast(B as vardecimal(18, 9)))" },
-        { "ref" : "DEC9", "expr": "(cast(A as vardecimal(9, 0)))" }
+        { "ref" : "DEC18", "expr": "(cast(B as vardecimal(18, 0)))" },
+        { "ref" : "DEC9", "expr": "(cast(A as vardecimal(10, 0)))" }
       ],
 
       "child" : 1
@@ -34,7 +34,7 @@
         {"ref": "DEC28_COL", "expr" : "cast(DEC28 as decimal38sparse(38, 16))"},
         {"ref": "DEC38_COL", "expr" : "cast(DEC38 as decimal28sparse(28, 16))"},
         {"ref": "DEC18_COL", "expr" : "cast(DEC18 as decimal18(18, 0))"},
-        {"ref": "DEC9_COL", "expr" : "cast(DEC9 as decimal9(9, 0))"}
+        {"ref": "DEC9_COL", "expr" : "cast(DEC9 as decimal9(10, 0))"}
       ],
 
       "child" : 2

--- a/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/util/DecimalUtility.java
@@ -26,7 +26,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("WeakerAccess")
 public class DecimalUtility {
@@ -36,6 +39,8 @@ public class DecimalUtility {
   public final static int MAX_DIGITS_BIGINT = 19;
   public final static int DIGITS_BASE = 1000000000;
   public final static int INTEGER_SIZE = Integer.SIZE / 8;
+
+  private static final Logger logger = LoggerFactory.getLogger(DecimalUtility.class);
 
   /**
    * Given the number of actual digits this function returns the
@@ -415,6 +420,24 @@ public class DecimalUtility {
         return MAX_DIGITS_BIGINT;
       default:
         return defaultPrecision;
+    }
+  }
+
+  /**
+   * Checks that the specified value may be fit into the value with specified
+   * {@code desiredPrecision} precision and {@code desiredScale} scale.
+   * Otherwise, the exception is thrown.
+   *
+   * @param value            BigDecimal value to check
+   * @param desiredPrecision precision for the resulting value
+   * @param desiredScale     scale for the resulting value
+   */
+  public static void checkValueOverflow(BigDecimal value, int desiredPrecision, int desiredScale) {
+    if (value.precision() - value.scale() > desiredPrecision - desiredScale) {
+      throw UserException.validationError()
+          .message("Value %s overflows specified precision %s with scale %s.",
+              value, desiredPrecision, desiredScale)
+          .build(logger);
     }
   }
 }


### PR DESCRIPTION
- Add check for the correctness of scale value;
- Add check for fitting the value to the value with the concrete scale and precision;
- Implement `negative` UDF for VarDecimal;
- Add unit tests for new checks and UDF.