### PR TITLE
DRILL-6622: Fixed a NullPointerException in a query with Union

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
@@ -114,8 +114,13 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
 
     @Override
     public void update() {
+      update(incoming);
+    }
+
+    @Override
+    public void update(RecordBatch incomingRecordBatch) {
       // Get sizing information for the batch.
-      setRecordBatchSizer(new RecordBatchSizer(incoming));
+      setRecordBatchSizer(new RecordBatchSizer(incomingRecordBatch));
 
       int fieldId = 0;
       int newOutgoingRowWidth = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -584,6 +584,11 @@ public abstract class HashAggTemplate implements HashAggregator {
         currentBatchRecordCount = incoming.getRecordCount(); // initialize for first non empty batch
         // Calculate the number of partitions based on actual incoming data
         delayedSetup();
+        // Update the record batch manager since this is the first batch with data; we need to
+        // perform the update before any processing.
+        // NOTE - We pass the incoming record batch explicitly because it could be a spilled record (different
+        //        from the instance owned by the HashAggBatch).
+        outgoing.getRecordBatchMemoryManager().update(incoming);
       }
 
       //
@@ -666,7 +671,9 @@ public abstract class HashAggTemplate implements HashAggregator {
           // remember EMIT, but continue like handling OK
 
         case OK:
-          outgoing.getRecordBatchMemoryManager().update();
+          // NOTE - We pass the incoming record batch explicitly because it could be a spilled record (different
+          //        from the instance owned by the HashAggBatch).
+          outgoing.getRecordBatchMemoryManager().update(incoming);
 
           currentBatchRecordCount = incoming.getRecordCount(); // size of next batch
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
@@ -154,6 +154,9 @@ public class RecordBatchMemoryManager {
 
   public void update() {};
 
+  public void update(RecordBatch recordBatch) {
+  }
+
   public void update(RecordBatch recordBatch, int index) {
     // Get sizing information for the batch.
     setRecordBatchSizer(index, new RecordBatchSizer(recordBatch));


### PR DESCRIPTION
@Ben-Zvi, can you please review the fix?
Thanks!

There were two bugs in the Aggregator batch sizing logic:
Issue I
- The aggregator runs in a loop to consume all input batches
- The loop was updating the batch sizing stats after they were consumed
- Assume output-row-count is 1 and we receive a batch with at least 32k + 1 records
- The code would create 32k output batches (one per incoming record) and then fails because of overflow
- Fix - Now updating the batch sizing logic when a non-empty batch is received and before the processing loop

Issue II
- The Aggregator has two main modules: AggregatorBatch and Aggregator objects
- Both share the same "incoming" record batch instance
- Though there is logic to spill incoming batches when under pressure
- The batch sizing logic was not aware that when batches are spilled the shared "incoming" object instance will diverge; that is, the Aggregator object will mutate the incoming object
- The batch sizer was being invoked with a stale "incoming" object (the one from the AggregatorBatch)
- Fix - Update the  Aggregator code to always pass the active incoming object explicitly