### PR TITLE
DRILL-6611 : Enable meta-enter query submission in web query interface

### DIFF
--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -111,6 +111,12 @@
       enableBasicAutocompletion: true,
       enableLiveAutocompletion: false
     });
+    // meta-enter to submit query
+    document.getElementById('queryForm')
+            .addEventListener('keydown', function(e) {
+      if (!(e.keyCode == 13 && e.metaKey)) return;
+      if (e.target.form) e.target.form.submit();
+    });
   </script>
 
 </#macro>


### PR DESCRIPTION
As the git info shows, one file —`query.ftl` has been modified with a small addition of vanilla javascript to add an event listener for meta-enter which will submit the query vs needing to use the mouse.