### PR TITLE
DRILL-6629 BitVector split and transfer does not work correctly for transfer length < 8

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -94,6 +94,16 @@ public class TestSplitAndTransfer {
   @Test
   public void testBitVectorUnalignedStart() throws Exception {
 
+    testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ONE);
+    testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ZERO);
+    testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.RANDOM);
+
+    testBitVectorImpl(4096, new int[][] {{1020, 8}}, TestBitPattern.ONE);
+    testBitVectorImpl(4096, new int[][] {{1020, 8}}, TestBitPattern.ZERO);
+    testBitVectorImpl(4096, new int[][] {{1020, 8}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(4096, new int[][] {{1020, 8}}, TestBitPattern.RANDOM);
+
     testBitVectorImpl(24, new int[][] {{5, 17}}, TestBitPattern.ONE);
     testBitVectorImpl(24, new int[][] {{5, 17}}, TestBitPattern.ZERO);
     testBitVectorImpl(24, new int[][] {{5, 17}}, TestBitPattern.ALTERNATING);
@@ -112,6 +122,16 @@ public class TestSplitAndTransfer {
 
   @Test
   public void testBitVectorAlignedStart() throws Exception {
+
+    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ONE);
+    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ZERO);
+    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.RANDOM);
+
+    testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.ONE);
+    testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.ZERO);
+    testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.ALTERNATING);
+    testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.RANDOM);
 
     testBitVectorImpl(24, new int[][] {{0, 17}}, TestBitPattern.ONE);
     testBitVectorImpl(24, new int[][] {{0, 17}}, TestBitPattern.ZERO);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -94,6 +94,11 @@ public class TestSplitAndTransfer {
   @Test
   public void testBitVectorUnalignedStart() throws Exception {
 
+    testBitVectorImpl(16, new int[][] {{2, 4}}, TestBitPattern.RANDOM);
+    testBitVectorImpl(16, new int[][] {{2, 4}}, TestBitPattern.ONE);
+    testBitVectorImpl(16, new int[][] {{2, 4}}, TestBitPattern.ZERO);
+    testBitVectorImpl(16, new int[][] {{2, 4}}, TestBitPattern.ALTERNATING);
+
     testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ONE);
     testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ZERO);
     testBitVectorImpl(4096, new int[][] {{4092, 4}}, TestBitPattern.ALTERNATING);
@@ -123,10 +128,11 @@ public class TestSplitAndTransfer {
   @Test
   public void testBitVectorAlignedStart() throws Exception {
 
+    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.RANDOM);
     testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ONE);
     testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ZERO);
     testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.ALTERNATING);
-    testBitVectorImpl(32, new int[][] {{0, 4}}, TestBitPattern.RANDOM);
+
 
     testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.ONE);
     testBitVectorImpl(32, new int[][] {{0, 8}}, TestBitPattern.ZERO);

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -323,7 +323,8 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
       if (length % 8 != 0) {
         // start is not byte aligned so we have to copy some bits from the last full byte read in the
         // previous loop
-        byte lastButOneByte = byteIPlus1;
+        // if numBytesHoldingSourceBits == 1, lastButOneByte is the first byte, but we have not read it yet, so read it
+        byte lastButOneByte = (numBytesHoldingSourceBits == 1) ? this.data.getByte(firstByteIndex) : byteIPlus1;
         byte bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
 
         // If we have to read more bits than what we have already read, read it into lastByte otherwise set lastByte to 0.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -326,6 +326,11 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
         // if numBytesHoldingSourceBits == 1, lastButOneByte is the first byte, but we have not read it yet, so read it
         byte lastButOneByte = (numBytesHoldingSourceBits == 1) ? this.data.getByte(firstByteIndex) : byteIPlus1;
         byte bitsFromLastButOneByte = (byte)((lastButOneByte & 0xFF) >>> firstBitOffset);
+        // if last bit to be copied is before the end of the first byte, then mask of the trailing extra bits
+        if (8 > (length + firstBitOffset)) {
+          byte mask = (byte)((0x1 << length) - 1);
+          bitsFromLastButOneByte = (byte)((bitsFromLastButOneByte & mask));
+        }
 
         // If we have to read more bits than what we have already read, read it into lastByte otherwise set lastByte to 0.
         // (length % 8) is num of remaining bits to be read.


### PR DESCRIPTION
The first src byte was not being read when the transfer length was < 0