### PR TITLE
DRILL-6632: Increase jdbc-all jar size limit to 36500000

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -506,7 +506,7 @@
                   This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                   </message>
-                  <maxsize>36000000</maxsize>
+                  <maxsize>36500000</maxsize>
                   <minsize>15000000</minsize>
                   <files>
                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>


### PR DESCRIPTION
Increased the jdbc-all jar file size limit to allow a Release build (for 1.14)
 