### PR TITLE
DRILL-6637: Remove dependency on tests in the maven-javadoc-plugin in  the drill-root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
               <version>${hadoop.version}</version>
               <classifier>tests</classifier>
             </dependency>
+ <!--  Remove dependency on tests - see DRILL-6637
             <dependency>
               <groupId>org.apache.drill.exec</groupId>
               <artifactId>drill-java-exec</artifactId>
@@ -266,6 +267,7 @@
               <version>${project.version}</version>
               <classifier>tests</classifier>
             </dependency>
+ -->
             <dependency>
               <groupId>com.github.tomakehurst</groupId>
               <artifactId>wiremock-standalone</artifactId>


### PR DESCRIPTION
Commented out (may revisit in the future) the dependency on "tests" for drill-java-exec and drill-common in the maven-javadoc-plugin in the root pom.xml ; otherwise the "Preparing the release" step fails, probably due to confusion between 1.14.0-SNAPSHOT build just made and the needed 1.14.0 .
