### PR TITLE
DRILL-6651: Add missing package statements

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestComplexColumnInSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestComplexColumnInSchema.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.exec.store.parquet.ParquetReaderUtility;
+package org.apache.drill.exec.store.parquet;
 
+import org.apache.drill.common.expression.SchemaPath;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderUtility.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderUtility.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.apache.drill.exec.store.parquet.ParquetReaderUtility;
+package org.apache.drill.exec.store.parquet;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;


### PR DESCRIPTION
Added missing "package" stmts and removed thus unused imports (of those packages).
