### PR TITLE
DRILL-6655: Require package declaration in files.

### DIFF
--- a/src/main/resources/checkstyle-config.xml
+++ b/src/main/resources/checkstyle-config.xml
@@ -35,7 +35,7 @@
 
     <module name="AvoidStarImport"/>
     <module name="NeedBraces"/>
-
+    <module name="PackageDeclaration"/>
   </module>
 
   <module name="FileTabCharacter"/>


### PR DESCRIPTION
This checkstyle check prevents errors with package declarations (https://issues.apache.org/jira/browse/DRILL-6651) from sneaking in.