### PR TITLE
DRILL-6101: Optimized implicit columns handling within scanner

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ColumnExplorer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ColumnExplorer.java
@@ -255,13 +255,17 @@ public class ColumnExplorer {
    * 1. table columns
    * 2. partition columns
    * 3. implicit file columns
+   * If it is a star query, then only includes implicit columns that were
+   * explicitly selected (e.g., SELECT *, FILENAME FROM ..)
    */
   private void init() {
-    if (isStarQuery) {
-      selectedImplicitColumns.putAll(allImplicitColumns);
-    } else {
-      for (SchemaPath column : columns) {
-        String path = column.getRootSegmentPath();
+    for (SchemaPath column : columns) {
+      final String path = column.getRootSegmentPath();
+      if (isStarQuery) {
+        if (allImplicitColumns.get(path) != null) {
+          selectedImplicitColumns.put(path, allImplicitColumns.get(path));
+        }
+      } else {
         if (isPartitionColumn(partitionDesignator, path)) {
           selectedPartitionColumns.add(Integer.parseInt(path.substring(partitionDesignator.length())));
         } else if (allImplicitColumns.get(path) != null) {


### PR DESCRIPTION
Problem Description -

File based implicit columns are projected only if explicitly requested within the query
Note that Partition Columns are not included in this discussion (only referring about FILENAME, FILEPATH, FQN, and SUFFIX)
The scanner operator is called with three sets of columns to handle: Table Columns, Partition Columns, and Implicit Columns
When a SELECT_STAR is used, the operator doesn't receive the original query selection (only '**' is received)
This behavior mandates that the Scanner operator projects all file based Implicit Columns only for these to be filtered out later on by the Project Operator
Performance tests indicates this behavior introduces a 30% degradation within the scanning phase for some TPCH queries (this degradation is larger for tables with long paths)
Fix -

Noticed the code uses a Utility to figure out whether a selection is a STAR_QUERY; this utility expects a list of columns and attempts to detect the presence of the STAR selection keyword
Modified the code to include all selection columns (including the ones in the where clause)
This allowed the execution layer to invoke the Scan operator with the correct implicit columns (the ones explicitly listed within the query) and thus addressing this performance issue
Note that readers are not impacted with the newly added metadata as the reader code doesn't use the columns list when a STAR_QUERY is involved