### PR TITLE
DRILL-6656: Disallow extra semicolons in import statements.

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -57,7 +57,7 @@ public class Types {
   }
 
   public static boolean isRepeated(final MajorType type) {
-    return type.getMode() == REPEATED ;
+    return type.getMode() == REPEATED;
   }
 
   public static boolean isNumericType(final MajorType type) {

--- a/common/src/main/java/org/apache/drill/common/util/DrillStringUtils.java
+++ b/common/src/main/java/org/apache/drill/common/util/DrillStringUtils.java
@@ -117,7 +117,7 @@ public class DrillStringUtils {
    */
   public static String toBinaryString(ByteBuf buf, int strStart, int strEnd) {
     StringBuilder result = new StringBuilder();
-    for (int i = strStart; i < strEnd ; ++i) {
+    for (int i = strStart; i < strEnd; ++i) {
       appendByte(result, buf.getByte(i));
     }
     return result.toString();

--- a/common/src/test/java/org/apache/drill/test/DrillAssert.java
+++ b/common/src/test/java/org/apache/drill/test/DrillAssert.java
@@ -36,9 +36,11 @@ public class DrillAssert {
         ch1 = expected.charAt(idx1);
         ch2 = actual.charAt(idx2);
         if (isNewLineChar(ch1)) {
-          idx1++; continue;
+          idx1++;
+          continue;
         } else if (isNewLineChar(ch2)) {
-          idx2++; continue;
+          idx2++;
+          continue;
         } else if (ch1 != ch2) {
           break outside;
         } else {

--- a/common/src/test/java/org/apache/drill/test/DrillAssert.java
+++ b/common/src/test/java/org/apache/drill/test/DrillAssert.java
@@ -42,7 +42,8 @@ public class DrillAssert {
         } else if (ch1 != ch2) {
           break outside;
         } else {
-          idx1++; idx2++;
+          idx1++;
+          idx2++;
         }
       }
       // skip newlines at the end

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseFilterBuilder.java
@@ -292,7 +292,7 @@ public class HBaseFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void,
             startRow = prefix.getBytes(Charsets.UTF_8);
             stopRow = startRow.clone();
             boolean isMaxVal = true;
-            for (int i = stopRow.length - 1; i >= 0 ; --i) {
+            for (int i = stopRow.length - 1; i >= 0; --i) {
               int nextByteValue = (0xff & stopRow[i]) + 1;
               if (nextByteValue < 0xff) {
                 stopRow[i] = (byte) nextByteValue;

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
@@ -125,7 +125,7 @@ public abstract class HBasePushFilterIntoScan extends StoragePluginOptimizerRule
     final ScanPrel newScanPrel = ScanPrel.create(scan, filter.getTraitSet(), newGroupsScan, scan.getRowType());
 
     // Depending on whether is a project in the middle, assign either scan or copy of project to childRel.
-    final RelNode childRel = project == null ? newScanPrel : project.copy(project.getTraitSet(), ImmutableList.of((RelNode)newScanPrel));
+    final RelNode childRel = project == null ? newScanPrel : project.copy(project.getTraitSet(), ImmutableList.of(newScanPrel));
 
     if (hbaseFilterBuilder.isAllExpressionsConverted()) {
         /*

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBasePushFilterIntoScan.java
@@ -125,7 +125,7 @@ public abstract class HBasePushFilterIntoScan extends StoragePluginOptimizerRule
     final ScanPrel newScanPrel = ScanPrel.create(scan, filter.getTraitSet(), newGroupsScan, scan.getRowType());
 
     // Depending on whether is a project in the middle, assign either scan or copy of project to childRel.
-    final RelNode childRel = project == null ? newScanPrel : project.copy(project.getTraitSet(), ImmutableList.of((RelNode)newScanPrel));;
+    final RelNode childRel = project == null ? newScanPrel : project.copy(project.getTraitSet(), ImmutableList.of((RelNode)newScanPrel));
 
     if (hbaseFilterBuilder.isAllExpressionsConverted()) {
         /*

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseConnectionManager.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseConnectionManager.java
@@ -31,8 +31,8 @@ public class TestHBaseConnectionManager extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "row_key\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` tableName"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` tableName",
+        8);
 
     /*
      * Simulate HBase connection close and ensure that the connection
@@ -42,8 +42,8 @@ public class TestHBaseConnectionManager extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "row_key\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` tableName"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` tableName",
+        8);
 
     /*
      * Simulate HBase cluster restart and ensure that running query against
@@ -54,8 +54,8 @@ public class TestHBaseConnectionManager extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "row_key\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` tableName"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` tableName",
+        8);
 
   }
 

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseFilterPushDown.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseFilterPushDown.java
@@ -91,8 +91,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') < DATE '2015-06-18' AND\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') > DATE '2015-06-13'"
-        , 12);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') > DATE '2015-06-13'",
+        12);
   }
 
   @Test
@@ -104,8 +104,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + ", CONVERT_FROM(tableName.f.c, 'UTF8') \n"
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') = DATE '2015-08-22'"
-        , 3);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') = DATE '2015-08-22'",
+        3);
   }
 
   @Test
@@ -118,8 +118,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') < DATE '2015-06-18' AND\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') > DATE '2015-06-13'"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'date_epoch_be') > DATE '2015-06-13'",
+        1);
   }
 
   @Test
@@ -133,8 +133,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'timestamp_epoch_be') >= TIMESTAMP '2015-06-18 08:00:00.000' AND\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'timestamp_epoch_be') < TIMESTAMP '2015-06-20 16:00:00.000'"
-        , 7);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'timestamp_epoch_be') < TIMESTAMP '2015-06-20 16:00:00.000'",
+        7);
   }
 
   @Test
@@ -146,8 +146,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + ", CONVERT_FROM(tableName.f.c, 'UTF8') \n"
         + " FROM hbase.`TestTableCompositeTime` tableName\n"
         + " WHERE\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') = TIME '23:57:15.275'"//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'), 'BIGINT_BE') \n"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') = TIME '23:57:15.275'",//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'), 'BIGINT_BE') \n"
+        1);
   }
 
   @Test
@@ -159,8 +159,9 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + ", CONVERT_FROM(tableName.f.c, 'UTF8') \n"
         + " FROM hbase.`TestTableCompositeTime` tableName\n"
         + " WHERE\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') = TIME '23:55:51.250'"//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'), 'BIGINT_BE') \n"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') = TIME '23:55:51.250'",//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'),
+        // 'BIGINT_BE') \n"
+        1);
   }
 
   @Test
@@ -173,8 +174,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeTime` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') > TIME '23:57:06' AND"//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'), 'BIGINT_BE') \n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') < TIME '23:59:59'"
-        , 8);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'time_epoch_be') < TIME '23:59:59'",
+        8);
   }
 
   @Test
@@ -186,8 +187,9 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + ", CONVERT_FROM(tableName.f.c, 'UTF8') \n"
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'bigint_be') = cast(1409040000000 as bigint)"//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'), 'BIGINT_BE') \n"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'bigint_be') = cast(1409040000000 as bigint)",//convert_from(binary_string('\\x00\\x00\\x00\\x00\\x55\\x4D\\xBE\\x80'),
+        // 'BIGINT_BE') \n"
+        1);
   }
 
   @Test
@@ -202,8 +204,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeDate` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'uint8_be') > cast(1438300800000 as bigint) AND\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'uint8_be') < cast(1438617600000 as bigint)"
-        , 10);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 8), 'uint8_be') < cast(1438617600000 as bigint)",
+        10);
   }
 
   @Test
@@ -216,8 +218,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeInt` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') >= cast(423 as int) AND"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') < cast(940 as int)"
-        , 11);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') < cast(940 as int)",
+        11);
   }
 
   @Test
@@ -230,8 +232,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + " FROM hbase.`TestTableCompositeInt` tableName\n"
         + " WHERE\n"
         + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') >= cast(300 as int) AND"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') < cast(900 as int)"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') < cast(900 as int)",
+        1);
   }
 
   @Test
@@ -243,8 +245,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + ", CONVERT_FROM(tableName.f.c, 'UTF8') \n"
         + " FROM hbase.`TestTableCompositeInt` tableName\n"
         + " WHERE\n"
-        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') = cast(658 as int)"
-        , 1);
+        + " CONVERT_FROM(BYTE_SUBSTR(row_key, 1, 4), 'uint4_be') = cast(658 as int)",
+        1);
   }
 
   @Test
@@ -256,8 +258,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "FROM\n"
         + "  hbase.`TestTableDoubleOB` t\n"
         + "WHERE\n"
-        + "  CONVERT_FROM(row_key, 'DOUBLE_OB') > cast(95.54 as DOUBLE)"
-        , 6);
+        + "  CONVERT_FROM(row_key, 'DOUBLE_OB') > cast(95.54 as DOUBLE)",
+        6);
   }
 
   @Test
@@ -270,8 +272,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "FROM\n"
         + "  hbase.`TestTableDoubleOB` t\n"
         + "WHERE\n"
-        + "  CONVERT_FROM(row_key, 'DOUBLE_OB') > cast(95.54 as DOUBLE)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'DOUBLE_OB') > cast(95.54 as DOUBLE)",
+        1);
   }
 
   @Test
@@ -283,8 +285,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "FROM\n"
         + "  hbase.`TestTableDoubleOBDesc` t\n"
         + "WHERE\n"
-        + "  CONVERT_FROM(row_key, 'DOUBLE_OBD') > cast(95.54 as DOUBLE)"
-        , 6);
+        + "  CONVERT_FROM(row_key, 'DOUBLE_OBD') > cast(95.54 as DOUBLE)",
+        6);
   }
 
   @Test
@@ -297,8 +299,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "FROM\n"
         + "  hbase.`TestTableDoubleOBDesc` t\n"
         + "WHERE\n"
-        + "  CONVERT_FROM(row_key, 'DOUBLE_OBD') > cast(95.54 as DOUBLE)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'DOUBLE_OBD') > cast(95.54 as DOUBLE)",
+        1);
   }
 
   @Test
@@ -311,8 +313,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableIntOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'INT_OB') >= cast(-32 as INT) AND"
-        + "  CONVERT_FROM(row_key, 'INT_OB') < cast(59 as INT)"
-        , 91);
+        + "  CONVERT_FROM(row_key, 'INT_OB') < cast(59 as INT)",
+        91);
   }
 
   @Test
@@ -325,8 +327,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableIntOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'INT_OBD') >= cast(-32 as INT) AND"
-        + "  CONVERT_FROM(row_key, 'INT_OBD') < cast(59 as INT)"
-        , 91);
+        + "  CONVERT_FROM(row_key, 'INT_OBD') < cast(59 as INT)",
+        91);
   }
 
   @Test
@@ -340,8 +342,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableIntOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'INT_OB') > cast(-23 as INT) AND"
-        + "  CONVERT_FROM(row_key, 'INT_OB') < cast(14 as INT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'INT_OB') < cast(14 as INT)",
+        1);
   }
 
   @Test
@@ -355,8 +357,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableIntOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'INT_OBD') > cast(-23 as INT) AND"
-        + "  CONVERT_FROM(row_key, 'INT_OBD') < cast(14 as INT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'INT_OBD') < cast(14 as INT)",
+        1);
   }
 
   @Test
@@ -369,8 +371,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableBigIntOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'BIGINT_OB') > cast(1438034423063 as BIGINT) AND"
-        + "  CONVERT_FROM(row_key, 'BIGINT_OB') <= cast(1438034423097 as BIGINT)"
-        , 34);
+        + "  CONVERT_FROM(row_key, 'BIGINT_OB') <= cast(1438034423097 as BIGINT)",
+        34);
   }
 
   @Test
@@ -384,8 +386,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableBigIntOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'BIGINT_OB') > cast(1438034423063 as BIGINT) AND"
-        + "  CONVERT_FROM(row_key, 'BIGINT_OB') < cast(1438034423097 as BIGINT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'BIGINT_OB') < cast(1438034423097 as BIGINT)",
+        1);
   }
 
   @Test
@@ -398,8 +400,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableFloatOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'FLOAT_OB') > cast(95.74 as FLOAT) AND"
-        + "  CONVERT_FROM(row_key, 'FLOAT_OB') < cast(99.5 as FLOAT)"
-        , 5);
+        + "  CONVERT_FROM(row_key, 'FLOAT_OB') < cast(99.5 as FLOAT)",
+        5);
   }
 
   @Test
@@ -413,8 +415,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableFloatOB` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'FLOAT_OB') > cast(95.54 as FLOAT) AND"
-        + "  CONVERT_FROM(row_key, 'FLOAT_OB') < cast(99.77 as FLOAT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'FLOAT_OB') < cast(99.77 as FLOAT)",
+        1);
   }
 
   @Test
@@ -427,8 +429,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableBigIntOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'BIGINT_OBD') > cast(1438034423063 as BIGINT) AND"
-        + "  CONVERT_FROM(row_key, 'BIGINT_OBD') <= cast(1438034423097 as BIGINT)"
-        , 34);
+        + "  CONVERT_FROM(row_key, 'BIGINT_OBD') <= cast(1438034423097 as BIGINT)",
+        34);
   }
 
   @Test
@@ -442,8 +444,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableBigIntOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'BIGINT_OBD') > cast(1438034423063 as BIGINT) AND"
-        + "  CONVERT_FROM(row_key, 'BIGINT_OBD') < cast(1438034423097 as BIGINT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'BIGINT_OBD') < cast(1438034423097 as BIGINT)",
+        1);
   }
 
   @Test
@@ -456,8 +458,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableFloatOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'FLOAT_OBD') > cast(95.74 as FLOAT) AND"
-        + "  CONVERT_FROM(row_key, 'FLOAT_OBD') < cast(99.5 as FLOAT)"
-        , 5);
+        + "  CONVERT_FROM(row_key, 'FLOAT_OBD') < cast(99.5 as FLOAT)",
+        5);
   }
 
   @Test
@@ -471,8 +473,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "  hbase.`TestTableFloatOBDesc` t\n"
         + "WHERE\n"
         + "  CONVERT_FROM(row_key, 'FLOAT_OBD') > cast(95.54 as FLOAT) AND"
-        + "  CONVERT_FROM(row_key, 'FLOAT_OBD') < cast(99.77 as FLOAT)"
-        , 1);
+        + "  CONVERT_FROM(row_key, 'FLOAT_OBD') < cast(99.77 as FLOAT)",
+        1);
   }
 
   @Test
@@ -680,8 +682,8 @@ public class TestHBaseFilterPushDown extends BaseHBaseTest {
         + "FROM\n"
         + "  hbase.`[TABLE_NAME]` tableName\n"
         + "WHERE\n"
-        + "  convert_from(row_key, 'INT_BE') = 75"
-        , 1);
+        + "  convert_from(row_key, 'INT_BE') = 75",
+        1);
   }
 
   @Test

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseProjectPushDown.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseProjectPushDown.java
@@ -31,8 +31,8 @@ public class TestHBaseProjectPushDown extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "row_key\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` tableName"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` tableName",
+        8);
   }
 
   @Test
@@ -41,8 +41,8 @@ public class TestHBaseProjectPushDown extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "t.f2.c7 as `t.f2.c7`\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` t"
-        , 1);
+        + "  hbase.`[TABLE_NAME]` t",
+        1);
   }
 
   @Test
@@ -55,8 +55,8 @@ public class TestHBaseProjectPushDown extends BaseHBaseTest {
         + "row_key, t.f.c1 * 31 as `t dot f dot c1 * 31`, "
         + "t.f.c2 as `t dot f dot c2`, 5 as `5`, 'abc' as `'abc'`\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` t"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` t",
+        8);
   }
 
   @Test
@@ -65,8 +65,8 @@ public class TestHBaseProjectPushDown extends BaseHBaseTest {
     runHBaseSQLVerifyCount("SELECT\n"
         + "row_key, f, f2\n"
         + "FROM\n"
-        + "  hbase.`[TABLE_NAME]` tableName"
-        , 8);
+        + "  hbase.`[TABLE_NAME]` tableName",
+        8);
   }
 
 }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseQueries.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseQueries.java
@@ -54,8 +54,8 @@ public class TestHBaseQueries extends BaseHBaseTest {
       setColumnWidths(new int[] {8, 15});
       runHBaseSQLVerifyCount("SELECT *\n"
           + "FROM\n"
-          + "  hbase.`" + tableName + "` tableName\n"
-          , 1);
+          + "  hbase.`" + tableName + "` tableName\n",
+          1);
     } finally {
       try {
         admin.disableTable(tableName);
@@ -78,8 +78,8 @@ public class TestHBaseQueries extends BaseHBaseTest {
       setColumnWidths(new int[] {8, 15});
       runHBaseSQLVerifyCount("SELECT row_key, count(*)\n"
           + "FROM\n"
-          + "  hbase.`" + tableName + "` tableName GROUP BY row_key\n"
-          , 0);
+          + "  hbase.`" + tableName + "` tableName GROUP BY row_key\n",
+          0);
     } finally {
       try {
         admin.disableTable(tableName);

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseRegionScanAssignments.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestHBaseRegionScanAssignments.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NavigableMap;
@@ -176,8 +177,9 @@ public class TestHBaseRegionScanAssignments extends BaseHBaseTest {
     scan.applyAssignments(endpoints);
 
     LinkedList<Integer> sizes = Lists.newLinkedList();
-    sizes.add(1); sizes.add(1); sizes.add(1); sizes.add(1); sizes.add(1); sizes.add(1); sizes.add(1); sizes.add(1);
-    sizes.add(2); sizes.add(2); sizes.add(2); sizes.add(2); sizes.add(2);
+    Collections.addAll(sizes, 1, 1, 1, 1, 1, 1, 1, 1);
+    Collections.addAll(sizes, 2, 2, 2, 2, 2);
+
     for (int i = 0; i < endpoints.size(); i++) {
       assertTrue(sizes.remove((Integer)scan.getSpecificScan(i).getRegionScanSpecList().size()));
     }

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestTableGenerator.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/TestTableGenerator.java
@@ -235,7 +235,8 @@ public class TestTableGenerator {
       for (int i = 0; i < numberRegions; i++) {
         Put p = new Put((""+rowKeyChar+iteration).getBytes());
         for (int j = 1; j <= numColumns; j++) {
-          bytes = new byte[5000]; random.nextBytes(bytes);
+          bytes = new byte[5000];
+          random.nextBytes(bytes);
           p.addColumn("f".getBytes(), ("c"+j).getBytes(), bytes);
         }
         table.mutate(p);
@@ -316,7 +317,7 @@ public class TestTableGenerator {
     long endTime    = startTime + MILLISECONDS_IN_A_YEAR;
     long interval   = MILLISECONDS_IN_A_DAY / 3;
 
-    for (long ts = startTime, counter = 0; ts < endTime; ts += interval, counter ++) {
+    for (long ts = startTime, counter = 0; ts < endTime; ts += interval, counter++) {
       byte[] rowKey = ByteBuffer.allocate(16) .putLong(ts).array();
 
       for(int i = 0; i < 8; ++i) {
@@ -356,7 +357,7 @@ public class TestTableGenerator {
     long largeInterval   = MILLISECONDS_IN_A_SEC * 42;
     long interval        = smallInterval;
 
-    for (long ts = startTime, counter = 0; ts < endTime; ts += interval, counter ++) {
+    for (long ts = startTime, counter = 0; ts < endTime; ts += interval, counter++) {
       byte[] rowKey = ByteBuffer.allocate(16) .putLong(ts).array();
 
       for(int i = 0; i < 8; ++i) {
@@ -398,7 +399,7 @@ public class TestTableGenerator {
     int stopVal = 1000;
     int interval = 47;
     long counter = 0;
-    for (int i = startVal; i < stopVal; i += interval, counter ++) {
+    for (int i = startVal; i < stopVal; i += interval, counter++) {
       byte[] rowKey = ByteBuffer.allocate(12).putInt(i).array();
 
       for(int j = 0; j < 8; ++j) {
@@ -492,7 +493,7 @@ public class TestTableGenerator {
 
     BufferedMutator table = conn.getBufferedMutator(tableName);
     long startTime = (long)1438034423 * 1000;
-    for (long i = startTime; i <= startTime + 100; i ++) {
+    for (long i = startTime; i <= startTime + 100; i++) {
       byte[] bytes = new byte[9];
       PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
       OrderedBytes.encodeInt64(br, i, Order.ASCENDING);
@@ -523,7 +524,7 @@ public class TestTableGenerator {
 
     BufferedMutator table = conn.getBufferedMutator(tableName);
 
-    for (int i = -49; i <= 100; i ++) {
+    for (int i = -49; i <= 100; i++) {
       byte[] bytes = new byte[5];
       PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
       OrderedBytes.encodeInt32(br, i, Order.ASCENDING);
@@ -616,7 +617,7 @@ public class TestTableGenerator {
 
     BufferedMutator table = conn.getBufferedMutator(tableName);
     long startTime = (long)1438034423 * 1000;
-    for (long i = startTime; i <= startTime + 100; i ++) {
+    for (long i = startTime; i <= startTime + 100; i++) {
       byte[] bytes = new byte[9];
       PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 9);
       OrderedBytes.encodeInt64(br, i, Order.DESCENDING);
@@ -648,7 +649,7 @@ public class TestTableGenerator {
 
     BufferedMutator table = conn.getBufferedMutator(tableName);
 
-    for (int i = -49; i <= 100; i ++) {
+    for (int i = -49; i <= 100; i++) {
       byte[] bytes = new byte[5];
       PositionedByteRange br = new SimplePositionedMutableByteRange(bytes, 0, 5);
       OrderedBytes.encodeInt32(br, i, Order.DESCENDING);

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveUtilities.java
@@ -436,7 +436,7 @@ public class HiveUtilities {
       storageHandler.configureInputJobProperties(tableDesc, table.getParameters());
       return (Class<? extends InputFormat<?, ?>>) storageHandler.getInputFormatClass();
     } else {
-      return (Class<? extends InputFormat<?, ?>>) Class.forName(inputFormatName) ;
+      return (Class<? extends InputFormat<?, ?>>) Class.forName(inputFormatName);
     }
   }
 

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/DefaultReadersInitializer.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/initilializers/DefaultReadersInitializer.java
@@ -46,7 +46,7 @@ public class DefaultReadersInitializer extends AbstractReadersInitializer {
 
     List<RecordReader> readers = new LinkedList<>();
     Constructor<? extends HiveAbstractReader> readerConstructor = createReaderConstructor();
-    for (int i = 0 ; i < inputSplits.size(); i++) {
+    for (int i = 0; i < inputSplits.size(); i++) {
       readers.add(createReader(readerConstructor, hasPartitions ? partitions.get(i) : null, inputSplits.get(i)));
     }
     return readers;

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestSampleHiveUDFs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/fn/hive/TestSampleHiveUDFs.java
@@ -84,7 +84,8 @@ public class TestSampleHiveUDFs extends HiveTestBase {
   @Test
   public void floatInOut() throws Exception{
     String query = "SELECT testHiveUDFFloat(float_field) as col1 FROM hive.readtest";
-    String expected = "col1\n" + "4.67\n" + "null\n";    helper(query, expected);
+    String expected = "col1\n" + "4.67\n" + "null\n";
+    helper(query, expected);
   }
 
   @Test
@@ -105,7 +106,8 @@ public class TestSampleHiveUDFs extends HiveTestBase {
   public void binaryInOut() throws Exception{
     String query = "SELECT testHiveUDFBinary(binary_field) as col1 FROM hive.readtest";
     String expected = "col1\n" + "binaryfield\n" + "null\n";
-    helper(query, expected);    helper(query, expected);
+    helper(query, expected);
+    helper(query, expected);
   }
 
   @Test

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcExpressionCheck.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcExpressionCheck.java
@@ -80,7 +80,6 @@ class JdbcExpressionCheck implements RexVisitor<Boolean> {
     if (!visitCall(over)) {
       return false;
     }
-    ;
 
     final RexWindow window = over.getWindow();
     for (RexFieldCollation orderKey : window.orderKeys) {

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcStoragePlugin.java
@@ -305,7 +305,8 @@ public class JdbcStoragePlugin extends AbstractStoragePlugin {
     public JdbcCatalogSchema(String name) {
       super(ImmutableList.<String> of(), name);
 
-      try (Connection con = source.getConnection(); ResultSet set = con.getMetaData().getCatalogs()) {
+      try (Connection con = source.getConnection();
+           ResultSet set = con.getMetaData().getCatalogs()) {
         while (set.next()) {
           final String catalogName = set.getString(1);
           CapitalizingJdbcSchema schema = new CapitalizingJdbcSchema(
@@ -347,7 +348,8 @@ public class JdbcStoragePlugin extends AbstractStoragePlugin {
 
     private boolean addSchemas() {
       boolean added = false;
-      try (Connection con = source.getConnection(); ResultSet set = con.getMetaData().getSchemas()) {
+      try (Connection con = source.getConnection();
+           ResultSet set = con.getMetaData().getSchemas()) {
         while (set.next()) {
           final String schemaName = set.getString(1);
           final String catalogName = set.getString(2);

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpecBuilder.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpecBuilder.java
@@ -41,7 +41,7 @@ public class KafkaPartitionScanSpecBuilder extends
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(KafkaPartitionScanSpecBuilder.class);
   private final LogicalExpression le;
   private final KafkaGroupScan groupScan;
-  private final KafkaConsumer<? ,?> kafkaConsumer;
+  private final KafkaConsumer<?, ?> kafkaConsumer;
   private ImmutableMap<TopicPartition, KafkaPartitionScanSpec> fullScanSpec;
   private static final long CLOSE_TIMEOUT_MS = 200;
 

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/BatchScheduler.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/BatchScheduler.java
@@ -35,7 +35,10 @@ public class BatchScheduler extends AbstractScheduler {
   }
 
   @Override
-  public int resize(int level) { quantity = level; return quantity; }
+  public int resize(int level) {
+    quantity = level;
+    return quantity;
+  }
 
   @Override
   public int getTarget() { return quantity; }

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AMSecurityManagerImpl.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/http/AMSecurityManagerImpl.java
@@ -182,7 +182,6 @@ public class AMSecurityManagerImpl implements AMSecurityManager {
       managerImpl.init();
     } else if (DoYUtil.isBlank(authType)
         || DrillOnYarnConfig.AUTH_TYPE_NONE.equals(authType)) {
-      ;
     } else {
       LOG.error("Unrecognized authorization type for "
           + DrillOnYarnConfig.HTTP_AUTH_TYPE + ": " + authType

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/client/CleanCommand.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/client/CleanCommand.java
@@ -70,7 +70,6 @@ public class CleanCommand extends ClientCommand {
     try {
       dfs.removeDrillFile(archiveName);
       System.out.println(" Removed");
-      ;
     } catch (DfsFacadeException e) {
       System.out.println();
       System.err.println(e.getMessage());

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/core/TestConfig.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/core/TestConfig.java
@@ -81,7 +81,7 @@ public class TestConfig {
         try {
           return file.toURI().toURL();
         } catch (MalformedURLException e) {
-          ;
+          // noop
         }
       }
       return null;

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/ScriptUtils.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/ScriptUtils.java
@@ -809,7 +809,7 @@ public class ScriptUtils {
         }
         result.analyze();
       } catch (FileNotFoundException e) {
-        ;
+        // noop
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -49,7 +49,7 @@ public final class ExecConstants {
   public static final String ZK_REFRESH = "drill.exec.zk.refresh";
   public static final String BIT_RETRY_TIMES = "drill.exec.rpc.bit.server.retry.count";
   public static final String BIT_RETRY_DELAY = "drill.exec.rpc.bit.server.retry.delay";
-  public static final String BIT_TIMEOUT = "drill.exec.bit.timeout" ;
+  public static final String BIT_TIMEOUT = "drill.exec.bit.timeout";
   public static final String SERVICE_NAME = "drill.exec.cluster-id";
   public static final String INITIAL_BIT_PORT = "drill.exec.rpc.bit.server.port";
   public static final String INITIAL_DATA_PORT = "drill.exec.rpc.bit.server.dataport";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/cache/SerializationDefinition.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/cache/SerializationDefinition.java
@@ -29,8 +29,7 @@ public enum SerializationDefinition {
   STORAGE_PLUGINS(3003, StoragePlugins.class),
   FRAGMENT_STATUS(3004, FragmentStatus.class),
   FRAGMENT_HANDLE(3005, FragmentHandle.class),
-  PLAN_FRAGMENT(3006, PlanFragment.class)
-  ;
+  PLAN_FRAGMENT(3006, PlanFragment.class);
 
   public final int id;
   public final Class<?> clazz;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -824,7 +824,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
   private class ListHoldingResultsListener implements UserResultsListener {
     private final Vector<QueryDataBatch> results = new Vector<>();
     private final SettableFuture<List<QueryDataBatch>> future = SettableFuture.create();
-    private final UserProtos.RunQuery query ;
+    private final UserProtos.RunQuery query;
 
     public ListHoldingResultsListener(UserProtos.RunQuery query) {
       logger.debug( "Listener created for query \"\"\"{}\"\"\"", query );

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DumpCat.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DumpCat.java
@@ -180,7 +180,7 @@ public class DumpCat {
       aggBatchMetaInfo.add(getBatchMetaInfo(vcSerializable));
 
       if (vectorContainer.getRecordCount() == 0) {
-        emptyBatchNum ++;
+        emptyBatchNum++;
       }
 
       if (prevSchema != null && !vectorContainer.getSchema().equals(prevSchema)) {
@@ -188,7 +188,7 @@ public class DumpCat {
       }
 
       prevSchema = vectorContainer.getSchema();
-      batchNum ++;
+      batchNum++;
 
       vectorContainer.zeroVectors();
     }
@@ -219,7 +219,7 @@ public class DumpCat {
 
     VectorAccessibleSerializable vcSerializable = null;
 
-    while (input.available() > 0 && batchNum ++ < targetBatchNum) {
+    while (input.available() > 0 && batchNum++ < targetBatchNum) {
       vcSerializable = new VectorAccessibleSerializable(DumpCat.allocator);
       vcSerializable.readFromStream(input);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/CodeGeneratorMethod.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/compile/sig/CodeGeneratorMethod.java
@@ -58,7 +58,7 @@ public class CodeGeneratorMethod implements Iterable<CodeGeneratorArgument> {
       throw new RuntimeException(String.format("Unexpected number of parameter names %s.  Expected %s on method %s.", Arrays.toString(parameterNames), Arrays.toString(types), m.toGenericString()));
     }
     arguments = new CodeGeneratorArgument[parameterNames.length];
-    for (int i = 0 ; i < parameterNames.length; i++) {
+    for (int i = 0; i < parameterNames.length; i++) {
       arguments[i] = new CodeGeneratorArgument(parameterNames[i], types[i]);
     }
     exs = m.getExceptionTypes();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/dotdrill/DotDrillType.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/dotdrill/DotDrillType.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 public enum DotDrillType {
-  VIEW
+  VIEW;
   // ,FORMAT
   // ,STATS
-  ;
+
 
   private final String ending;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -778,7 +778,7 @@ public class EvaluationVisitor {
         setBlock.assign(out.getValue(), JExpr.lit(1));
       } else {
         assert (e == null);
-        eval.assign(out.getValue(), JExpr.lit(1)) ;
+        eval.assign(out.getValue(), JExpr.lit(1));
       }
 
       generator.unNestEvalBlock();     // exit from nested block
@@ -841,7 +841,7 @@ public class EvaluationVisitor {
         setBlock.assign(out.getValue(), JExpr.lit(0));
       } else {
         assert (e == null);
-        eval.assign(out.getValue(), JExpr.lit(0)) ;
+        eval.assign(out.getValue(), JExpr.lit(0));
       }
 
       generator.unNestEvalBlock();   // exit from nested block.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/SizedJBlock.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/SizedJBlock.java
@@ -42,7 +42,7 @@ public class SizedJBlock {
   }
 
   public void incCounter() {
-    this.count ++;
+    this.count++;
   }
 
   public int getCount() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
@@ -93,13 +93,13 @@ class DrillAggFuncHolder extends DrillFuncHolder {
         //Loop through all workspace vectors, to get the minimum of size of all workspace vectors.
         JVar sizeVar = setupBlock.decl(g.getModel().INT, "vectorSize", JExpr.lit(Integer.MAX_VALUE));
         JClass mathClass = g.getModel().ref(Math.class);
-        for (int id = 0; id < getWorkspaceVars().length; id ++) {
+        for (int id = 0; id < getWorkspaceVars().length; id++) {
           if (!getWorkspaceVars()[id].isInject()) {
             setupBlock.assign(sizeVar,mathClass.staticInvoke("min").arg(sizeVar).arg(g.getWorkspaceVectors().get(getWorkspaceVars()[id]).invoke("getValueCapacity")));
           }
         }
 
-        for(int i =0 ; i < getWorkspaceVars().length; i++) {
+        for (int i = 0; i < getWorkspaceVars().length; i++) {
           if (!getWorkspaceVars()[i].isInject()) {
             setupBlock.assign(workspaceJVars[i], JExpr._new(g.getHolderType(getWorkspaceVars()[i].getMajorType())));
           }
@@ -156,7 +156,7 @@ class DrillAggFuncHolder extends DrillFuncHolder {
   private JVar[] declareWorkspaceVectors(ClassGenerator<?> g) {
     JVar[] workspaceJVars = new JVar[getWorkspaceVars().length];
 
-    for(int i =0 ; i < getWorkspaceVars().length; i++){
+    for (int i = 0; i < getWorkspaceVars().length; i++) {
       if (getWorkspaceVars()[i].isInject()) {
         workspaceJVars[i] = g.declareClassField("work", g.getModel()._ref(getWorkspaceVars()[i].getType()));
         g.getBlock(BlockType.SETUP).assign(workspaceJVars[i], g.getMappingSet().getIncoming().invoke("getContext").invoke("getManagedBuffer"));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/Hash32Functions.java
@@ -346,7 +346,7 @@ public class Hash32Functions {
     }
   }
 
-  @FunctionTemplate(names = {"hash", "hash32" ,"hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"hash", "hash32", "hash32AsDouble"}, scope = FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class NullableTimeHash implements DrillSimpleFunc {
     @Param  NullableTimeHolder in;
     @Output IntHolder out;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -711,9 +711,9 @@ public class StringFunctions{
         final int charCount = org.apache.drill.exec.expr.fn.impl.StringFunctionUtil.getUTF8CharLength(string.buffer, string.start, string.end);
         final int charLen;
         if (length.value > 0) {
-          charLen = Math.min((int)length.value, charCount);  //left('abc', 5) -> 'abc'
+          charLen = Math.min((int) length.value, charCount);  //left('abc', 5) -> 'abc'
         } else if (length.value < 0) {
-          charLen = Math.max(0, charCount + (int)length.value); // left('abc', -5) ==> ''
+          charLen = Math.max(0, charCount + (int) length.value); // left('abc', -5) ==> ''
         } else {
           charLen = 0;
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -498,7 +498,7 @@ public class StringFunctions{
 
       for (int id = input.start; id < input.end; id++) {
         byte  currentByte = input.buffer.getByte(id);
-        out.buffer.setByte(id - input.start, Character.toLowerCase(currentByte)) ;
+        out.buffer.setByte(id - input.start, Character.toLowerCase(currentByte));
       }
     }
   }
@@ -529,7 +529,7 @@ public class StringFunctions{
 
       for (int id = input.start; id < input.end; id++) {
         byte currentByte = input.buffer.getByte(id);
-        out.buffer.setByte(id - input.start, Character.toUpperCase(currentByte)) ;
+        out.buffer.setByte(id - input.start, Character.toUpperCase(currentByte));
       }
     }
   }
@@ -713,7 +713,7 @@ public class StringFunctions{
         if (length.value > 0) {
           charLen = Math.min((int)length.value, charCount);  //left('abc', 5) -> 'abc'
         } else if (length.value < 0) {
-          charLen = Math.max(0, charCount + (int)length.value) ; // left('abc', -5) ==> ''
+          charLen = Math.max(0, charCount + (int)length.value); // left('abc', -5) ==> ''
         } else {
           charLen = 0;
         }
@@ -830,7 +830,7 @@ public class StringFunctions{
 
           if (j == from.end ) {
             //find a true match ("from" is not empty), copy entire "to" string to out buffer
-            for (int k = to.start ; k < to.end; k++) {
+            for (int k = to.start; k < to.end; k++) {
               out.buffer.setByte(out.end++, to.buffer.getByte(k));
             }
 
@@ -921,7 +921,7 @@ public class StringFunctions{
                 (currentByte & 0xE0) == 0xC0 ||   // 2-byte char. First byte is 110xxxxx
                 (currentByte & 0xF0) == 0xE0 ||   // 3-byte char. First byte is 1110xxxx
                 (currentByte & 0xF8) == 0xF0) {   //4-byte char. First byte is 11110xxx
-              count ++;  //Advance the counter, since we find one char.
+              count++;  //Advance the counter, since we find one char.
             }
             out.buffer.setByte(out.end++, currentByte);
           }
@@ -1070,7 +1070,7 @@ public class StringFunctions{
                 (currentByte & 0xE0) == 0xC0 ||   // 2-byte char. First byte is 110xxxxx
                 (currentByte & 0xF0) == 0xE0 ||   // 3-byte char. First byte is 1110xxxx
                 (currentByte & 0xF8) == 0xF0) {   //4-byte char. First byte is 11110xxx
-              count ++;  //Advance the counter, since we find one char.
+              count++;  //Advance the counter, since we find one char.
             }
             out.buffer.setByte(out.end++, currentByte);
           }
@@ -1429,7 +1429,7 @@ public class StringFunctions{
 
     @Override
     public void eval() {
-      out.buffer = buffer = buffer.reallocIfNeeded( (left.end - left.start) + (right.end - right.start));
+      out.buffer = buffer = buffer.reallocIfNeeded((left.end - left.start) + (right.end - right.start));
       out.start = out.end = 0;
 
       int id = 0;
@@ -1493,7 +1493,7 @@ public class StringFunctions{
 
     @Override
     public void eval() {
-      out.buffer = buffer = buffer.reallocIfNeeded( (left.end - left.start) + (right.end - right.start));;
+      out.buffer = buffer = buffer.reallocIfNeeded((left.end - left.start) + (right.end - right.start));
       out.start = out.end = 0;
 
       int id = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/JsonConvertTo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/JsonConvertTo.java
@@ -44,7 +44,8 @@ public class JsonConvertTo {
 
   private JsonConvertTo(){}
 
-  @FunctionTemplate(names = { "convert_toJSON", "convert_toSIMPLEJSON" } , scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL,
+  @FunctionTemplate(names = { "convert_toJSON", "convert_toSIMPLEJSON" },
+                    scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL,
                     outputWidthCalculatorType = FunctionTemplate.OutputWidthCalculatorType.CUSTOM_FIXED_WIDTH_DEFUALT)
   public static class ConvertToJson implements DrillSimpleFunc{
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolder.java
@@ -316,7 +316,7 @@ public class FunctionRegistryHolder {
       final String functionName = function.getName();
       Queue<String> jarFunctions = jar.get(functionName);
       if (jarFunctions == null) {
-        jarFunctions = Queues.newConcurrentLinkedQueue();;
+        jarFunctions = Queues.newConcurrentLinkedQueue();
         jar.put(functionName, jarFunctions);
       }
       final String functionSignature = function.getSignature();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
@@ -104,6 +104,6 @@ public class HashAggregate extends AbstractSingle {
   public boolean isBufferedOperator(QueryContext queryContext) {
     // In case forced to use a single partition - do not consider this a buffered op (when memory is divided)
     return queryContext == null ||
-      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR) ;
+      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
@@ -104,6 +104,6 @@ public class HashAggregate extends AbstractSingle {
   public boolean isBufferedOperator(QueryContext queryContext) {
     // In case forced to use a single partition - do not consider this a buffered op (when memory is divided)
     return queryContext == null ||
-      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR);
+      1 < (int) queryContext.getOptions().getOption(ExecConstants.HASHAGG_NUM_PARTITIONS_VALIDATOR);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
@@ -88,6 +88,6 @@ public class HashJoinPOP extends AbstractJoinPop {
   public boolean isBufferedOperator(QueryContext queryContext) {
     // In case forced to use a single partition - do not consider this a buffered op (when memory is divided)
     return queryContext == null ||
-      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHJOIN_NUM_PARTITIONS_VALIDATOR) ;
+      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHJOIN_NUM_PARTITIONS_VALIDATOR);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
@@ -88,6 +88,6 @@ public class HashJoinPOP extends AbstractJoinPop {
   public boolean isBufferedOperator(QueryContext queryContext) {
     // In case forced to use a single partition - do not consider this a buffered op (when memory is divided)
     return queryContext == null ||
-      1 < (int)queryContext.getOptions().getOption(ExecConstants.HASHJOIN_NUM_PARTITIONS_VALIDATOR);
+      1 < (int) queryContext.getOptions().getOption(ExecConstants.HASHJOIN_NUM_PARTITIONS_VALIDATOR);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -154,7 +154,13 @@ public abstract class HashAggTemplate implements HashAggregator {
   private int cycleNum = 0; // primary, secondary, tertiary, etc.
   private int originalPartition = -1; // the partition a secondary reads from
 
-  private static class SpilledPartition { public int spilledBatches; public String spillFile; int cycleNum; int origPartn; int prevOrigPartn; }
+  private static class SpilledPartition {
+    public int spilledBatches;
+    public String spillFile;
+    int cycleNum;
+    int origPartn;
+    int prevOrigPartn;
+  }
 
   private ArrayList<SpilledPartition> spilledPartitionsList;
   private int operatorId; // for the spill file name

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -193,7 +193,6 @@ public abstract class HashAggTemplate implements HashAggregator {
     AVG_OUTPUT_BATCH_BYTES,
     AVG_OUTPUT_ROW_BYTES,
     OUTPUT_RECORD_COUNT;
-    ;
 
     @Override
     public int metricId() {
@@ -333,7 +332,7 @@ public abstract class HashAggTemplate implements HashAggregator {
 
     is2ndPhase = hashAggrConfig.getAggPhase() == AggPrelBase.OperatorPhase.PHASE_2of2;
     isTwoPhase = hashAggrConfig.getAggPhase() != AggPrelBase.OperatorPhase.PHASE_1of1;
-    is1stPhase = isTwoPhase && ! is2ndPhase ;
+    is1stPhase = isTwoPhase && !is2ndPhase;
     canSpill = isTwoPhase; // single phase can not spill
 
     // Typically for testing - force a spill after a partition has more than so many batches
@@ -410,8 +409,8 @@ public abstract class HashAggTemplate implements HashAggregator {
       updateEstMaxBatchSize(incoming);
     }
     // create "reserved memory" and adjust the memory limit down
-    reserveValueBatchMemory = reserveOutgoingMemory = estValuesBatchSize ;
-    long newMemoryLimit = allocator.getLimit() - reserveValueBatchMemory - reserveOutgoingMemory ;
+    reserveValueBatchMemory = reserveOutgoingMemory = estValuesBatchSize;
+    long newMemoryLimit = allocator.getLimit() - reserveValueBatchMemory - reserveOutgoingMemory;
     long memAvail = newMemoryLimit - allocator.getAllocatedMemory();
     if ( memAvail <= 0 ) { throw new OutOfMemoryException("Too little memory available"); }
     allocator.setLimit(newMemoryLimit);
@@ -458,9 +457,9 @@ public abstract class HashAggTemplate implements HashAggregator {
     bitsInMask = Integer.bitCount(partitionMask); // e.g. 0x1F -> 5
 
     // Create arrays (one entry per partition)
-    htables = new HashTable[numPartitions] ;
-    batchHolders = (ArrayList<BatchHolder>[]) new ArrayList<?>[numPartitions] ;
-    outBatchIndex = new int[numPartitions] ;
+    htables = new HashTable[numPartitions];
+    batchHolders = (ArrayList<BatchHolder>[]) new ArrayList<?>[numPartitions];
+    outBatchIndex = new int[numPartitions];
     writers = new Writer[numPartitions];
     spilledBatchesCount = new int[numPartitions];
     spillFiles = new String[numPartitions];
@@ -486,7 +485,11 @@ public abstract class HashAggTemplate implements HashAggregator {
       this.batchHolders[i] = new ArrayList<BatchHolder>(); // First BatchHolder is created when the first put request is received.
     }
     // Initialize the value vectors in the generated code (which point to the incoming or outgoing fields)
-    try { htables[0].updateBatches(); } catch (SchemaChangeException sc) { throw new UnsupportedOperationException(sc); };
+    try {
+      htables[0].updateBatches();
+    } catch (SchemaChangeException sc) {
+      throw new UnsupportedOperationException(sc);
+    }
   }
   /**
    * get new incoming: (when reading spilled files like an "incoming")
@@ -689,7 +692,7 @@ public abstract class HashAggTemplate implements HashAggregator {
 
           // Either flag buildComplete or handleEmit (or earlyOutput) would cause returning of
           // the outgoing batch downstream (see innerNext() in HashAggBatch).
-          buildComplete = true ; // now should go and return outgoing
+          buildComplete = true; // now should go and return outgoing
 
           if ( handleEmit ) {
             buildComplete = false; // This was not a real NONE - more incoming is expected
@@ -939,7 +942,7 @@ public abstract class HashAggTemplate implements HashAggregator {
     }
     // Give the current (if already spilled) some priority
     if ( ! tryAvoidCurr && isSpilled(currPart) && ( currPartSize + 1 >= maxSizeSpilled )) {
-      maxSizeSpilled = currPartSize ;
+      maxSizeSpilled = currPartSize;
       indexMaxSpilled = currPart;
     }
     // now find the largest non-spilled partition
@@ -948,7 +951,7 @@ public abstract class HashAggTemplate implements HashAggregator {
     // Use the largest spilled (if found) as a base line, with a factor of 4
     if ( indexMaxSpilled > -1 && maxSizeSpilled > 1 ) {
       indexMax = indexMaxSpilled;
-      maxSize = 4 * maxSizeSpilled ;
+      maxSize = 4 * maxSizeSpilled;
     }
     for ( int insp = 0; insp < numPartitions; insp++) {
       if ( ! isSpilled(insp) && maxSize < batchHolders[insp].size() ) {
@@ -1159,7 +1162,11 @@ public abstract class HashAggTemplate implements HashAggregator {
         originalPartition = sp.origPartn; // used for the filename
         logger.trace("Reading back spilled original partition {} as an incoming",originalPartition);
         // Initialize .... new incoming, new set of partitions
-        try { initializeSetup(newIncoming); } catch (Exception e) { throw new RuntimeException(e); }
+        try {
+          initializeSetup(newIncoming);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
         // update the cycle num if needed
         // The current cycle num should always be one larger than in the spilled partition
         if ( cycleNum == sp.cycleNum ) {
@@ -1179,7 +1186,7 @@ public abstract class HashAggTemplate implements HashAggregator {
         return AggIterOutcome.AGG_RESTART;
       }
 
-      partitionToReturn = nextPartitionToReturn ;
+      partitionToReturn = nextPartitionToReturn;
 
     }
 
@@ -1187,7 +1194,7 @@ public abstract class HashAggTemplate implements HashAggregator {
     int numPendingOutput = currPartition.get(currOutBatchIndex).getNumPendingOutput();
 
     // The following accounting is for logging, metrics, etc.
-    rowsInPartition += numPendingOutput ;
+    rowsInPartition += numPendingOutput;
     if ( ! handlingSpills ) { rowsNotSpilled += numPendingOutput; }
     else { rowsSpilledReturned += numPendingOutput; }
     if ( earlyOutput ) { rowsReturnedEarly += numPendingOutput; }
@@ -1238,7 +1245,7 @@ public abstract class HashAggTemplate implements HashAggregator {
           logger.debug("HASH AGG: Finished (early) re-init partition {}, mem allocated: {}", earlyPartition, allocator.getAllocatedMemory());
         }
         outBatchIndex[earlyPartition] = 0; // reset, for next time
-        earlyOutput = false ; // done with early output
+        earlyOutput = false; // done with early output
       }
       else if ( handleEmit ) {
         // When returning the last outgoing batch (following an incoming EMIT), then replace OK with EMIT
@@ -1290,9 +1297,9 @@ public abstract class HashAggTemplate implements HashAggregator {
    */
   private String getOOMErrorMsg(String prefix) {
     String errmsg;
-    if ( !isTwoPhase ) {
-      errmsg = "Single Phase Hash Aggregate operator can not spill." ;
-    } else if ( ! canSpill ) {  // 2nd phase, with only 1 partition
+    if (!isTwoPhase) {
+      errmsg = "Single Phase Hash Aggregate operator can not spill.";
+    } else if (!canSpill) {  // 2nd phase, with only 1 partition
       errmsg = "Too little memory available to operator to facilitate spilling.";
     } else { // a bug ?
       errmsg = prefix + " OOM at " + (is2ndPhase ? "Second Phase" : "First Phase") + ". Partitions: " + numPartitions +
@@ -1353,9 +1360,11 @@ public abstract class HashAggTemplate implements HashAggregator {
     }
 
     // right shift hash code for secondary (or tertiary...) spilling
-    for (int i = 0; i < cycleNum; i++) { hashCode >>>= bitsInMask; }
+    for (int i = 0; i < cycleNum; i++) {
+      hashCode >>>= bitsInMask;
+    }
 
-    int currentPartition = hashCode & partitionMask ;
+    int currentPartition = hashCode & partitionMask;
     hashCode >>>= bitsInMask;
     HashTable.PutStatus putStatus = null;
     long allocatedBeforeHTput = allocator.getAllocatedMemory();
@@ -1398,7 +1407,7 @@ public abstract class HashAggTemplate implements HashAggregator {
         throw new UnsupportedOperationException("Unexpected schema change", e);
     }
     long allocatedBeforeAggCol = allocator.getAllocatedMemory();
-    boolean needToCheckIfSpillIsNeeded = allocatedBeforeAggCol > allocatedBeforeHTput ;
+    boolean needToCheckIfSpillIsNeeded = allocatedBeforeAggCol > allocatedBeforeHTput;
 
     // Add an Aggr batch if needed:
     //

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggregator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggregator.java
@@ -44,7 +44,7 @@ public interface HashAggregator {
 
   // For returning results from outputCurrentBatch
   // OK - batch returned, NONE - end of data, RESTART - call again, EMIT - like OK but EMIT
-  enum AggIterOutcome { AGG_OK, AGG_NONE, AGG_RESTART , AGG_EMIT }
+  enum AggIterOutcome { AGG_OK, AGG_NONE, AGG_RESTART, AGG_EMIT }
 
   void setup(HashAggregate hashAggrConfig, HashTableConfig htConfig, FragmentContext context, OperatorContext oContext, RecordBatch incoming, HashAggBatch outgoing,
              LogicalExpression[] valueExprs, List<TypedFieldId> valueFieldIds, TypedFieldId[] keyFieldIds, VectorContainer outContainer, int extraRowBytes) throws SchemaChangeException, IOException, ClassTransformationException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
@@ -135,7 +135,7 @@ public class SpilledRecordbatch implements CloseableRecordBatch {
 
     if ( spillStream == null ) {
       throw new IllegalStateException("Spill stream was null");
-    };
+    }
 
     if ( spillSet.getPosition(spillStream)  < 0 ) {
       HashAggTemplate.logger.warn("Position is {} for stream {}", spillSet.getPosition(spillStream), spillStream.toString());
@@ -155,7 +155,7 @@ public class SpilledRecordbatch implements CloseableRecordBatch {
       throw UserException.dataReadError(e).addContext("Failed reading from a spill file").build(HashAggTemplate.logger);
     }
 
-    spilledBatches-- ; // one less batch to read
+    spilledBatches--; // one less batch to read
     return IterOutcome.OK;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggregator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggregator.java
@@ -49,8 +49,7 @@ public interface StreamingAggregator {
     RETURN_OUTCOME,
     CLEANUP_AND_RETURN,
     UPDATE_AGGREGATOR,
-    RETURN_AND_RESET
-    ;
+    RETURN_AND_RESET;
   }
 
   public abstract void setup(OperatorContext context, RecordBatch incoming, StreamingAggBatch outgoing) throws SchemaChangeException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableStats.java
@@ -28,10 +28,10 @@ public class HashTableStats {
   }
 
   public void addStats (HashTableStats newStats) {
-    this.numBuckets += newStats.numBuckets ;
-    this.numEntries += newStats.numEntries ;
-    this.numResizing += newStats.numResizing ;
-    this.resizingTime += newStats.resizingTime ;
+    this.numBuckets += newStats.numBuckets;
+    this.numEntries += newStats.numEntries;
+    this.numResizing += newStats.numResizing;
+    this.resizingTime += newStats.resizingTime;
   }
 }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
@@ -476,7 +476,7 @@ public abstract class HashTableTemplate implements HashTable {
     if (tableSize > MAXIMUM_CAPACITY) {
       tableSize = MAXIMUM_CAPACITY;
     }
-    originalTableSize = tableSize ; // retain original size
+    originalTableSize = tableSize; // retain original size
 
     threshold = (int) Math.ceil(tableSize * loadf);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/flatten/FlattenTemplate.java
@@ -113,7 +113,7 @@ public abstract class FlattenTemplate implements Flattener {
               } catch (OversizedAllocationException ex) {
                 // unable to flatten due to a soft buffer overflow. split the batch here and resume execution.
                 logger.debug("Reached allocation limit. Splitting the batch at input index: {} - inner index: {} - current completed index: {}",
-                    valueIndexLocal, innerValueIndexLocal, currentInnerValueIndexLocal) ;
+                    valueIndexLocal, innerValueIndexLocal, currentInnerValueIndexLocal);
 
                 /*
                  * TODO

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -776,7 +776,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> {
         for (int ind = 0; ind < currentRecordCount; ind++) {
           int hashCode = ( cycleNum == 0 ) ? partitions[0].getBuildHashCode(ind)
             : read_right_HV_vector.getAccessor().get(ind); // get the hash value from the HV column
-          int currPart = hashCode & partitionMask ;
+          int currPart = hashCode & partitionMask;
           hashCode >>>= bitsInMask;
           // Append the new inner row to the appropriate partition; spill (that partition) if needed
           partitions[currPart].appendInnerRow(buildBatch.getContainer(), ind, hashCode, buildCalc); // may spill if needed

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -162,7 +162,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
    */
   private int appendBuild(VectorContainer buildSrcContainer, int buildSrcIndex) {
     // "- 1" to skip the last "hash values" added column
-    int lastColIndex = buildSrcContainer.getNumberOfColumns() - 1 ;
+    int lastColIndex = buildSrcContainer.getNumberOfColumns() - 1;
     for (int vectorIndex = 0; vectorIndex < lastColIndex; vectorIndex++) {
       ValueVector destVector = container.getValueVector(vectorIndex).getValueVector();
       ValueVector srcVector = buildSrcContainer.getValueVector(vectorIndex).getValueVector();
@@ -292,7 +292,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
           int hashCode = ( cycleNum == 0 ) ?
             partitions[0].getProbeHashCode(recordsProcessed)
             : read_left_HV_vector.getAccessor().get(recordsProcessed);
-          int currBuildPart = hashCode & partitionMask ;
+          int currBuildPart = hashCode & partitionMask;
           hashCode >>>= bitsInMask;
 
           // Set and keep the current partition (may be used again on subsequent probe calls as

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
@@ -235,7 +235,7 @@ public class JoinUtils {
       if (currentrel instanceof DrillAggregateRel) {
         agg = (DrillAggregateRel)currentrel;
       } else if (currentrel instanceof RelSubset) {
-        currentrel = ((RelSubset)currentrel).getBest();
+        currentrel = ((RelSubset) currentrel).getBest();
       } else if (currentrel instanceof DrillLimitRel) {
         // TODO: Improve this check when DRILL-5691 is fixed.
         // The problem is that RelMdMaxRowCount currently cannot be used

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
@@ -235,7 +235,7 @@ public class JoinUtils {
       if (currentrel instanceof DrillAggregateRel) {
         agg = (DrillAggregateRel)currentrel;
       } else if (currentrel instanceof RelSubset) {
-        currentrel = ((RelSubset) currentrel).getBest() ;
+        currentrel = ((RelSubset)currentrel).getBest();
       } else if (currentrel instanceof DrillLimitRel) {
         // TODO: Improve this check when DRILL-5691 is fixed.
         // The problem is that RelMdMaxRowCount currently cannot be used

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
@@ -624,8 +624,8 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
           if (leftUpstream == EMIT || leftUpstream == OK_NEW_SCHEMA) {
             break;
           } else {
-            logger.debug("Output batch still has some space left, getting new batches from left and right. OutIndex: {}"
-              , outputIndex);
+            logger.debug("Output batch still has some space left, getting new batches from left and right. OutIndex: {}",
+              outputIndex);
             // Get both left batch and the right batch and make sure indexes are properly set
             leftUpstream = processLeftBatch();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
@@ -269,7 +269,7 @@ public class PartitionSenderRootExec extends BaseRootExec {
     // set up partitioning function
     final LogicalExpression expr = operator.getExpr();
     final ErrorCollector collector = new ErrorCollectorImpl();
-    final ClassGenerator<Partitioner> cg ;
+    final ClassGenerator<Partitioner> cg;
 
     cg = CodeGenerator.getRoot(Partitioner.TEMPLATE_DEFINITION, context.getOptions());
     cg.getCodeGenerator().plainJavaCapable(true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestImpl.java
@@ -54,7 +54,7 @@ public class UnnestImpl implements Unnest {
   private RepeatedValueVector.RepeatedAccessor accessor;
   private RecordBatch outgoing;
 
-  private IntVector rowIdVector ; // Allocated and owned by the UnnestRecordBatch
+  private IntVector rowIdVector; // Allocated and owned by the UnnestRecordBatch
   private IntVector.Mutator rowIdVectorMutator;
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/SortMemoryManager.java
@@ -266,7 +266,7 @@ public class SortMemoryManager {
     memoryLimit = (configMemoryLimit == 0) ? opMemoryLimit
                 : Math.min(opMemoryLimit, configMemoryLimit);
 
-    preferredSpillBatchSize = config.spillBatchSize();;
+    preferredSpillBatchSize = config.spillBatchSize();
     preferredMergeBatchSize = config.mergeBatchSize();
 
     // Initialize the buffer memory limit for the first batch.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnState.java
@@ -347,8 +347,7 @@ public abstract class ColumnState {
       .attribute("addVersion", addVersion)
       .attribute("state", state)
       .attributeIdentity("writer", writer)
-      .attribute("vectorState")
-      ;
+      .attribute("vectorState");
     vectorState.dump(format);
     format.endObject();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
@@ -795,8 +795,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
       .attribute("activeSchemaVersion", activeSchemaVersion)
       .attribute("harvestSchemaVersion", harvestSchemaVersion)
       .attribute("pendingRowCount", pendingRowCount)
-      .attribute("targetRowCount", targetRowCount)
-      ;
+      .attribute("targetRowCount", targetRowCount);
     format.attribute("root");
     rootState.dump(format);
     format.attribute("rootWriter");

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
@@ -44,7 +44,7 @@ public abstract class AbstractPartitionDescriptor implements PartitionDescriptor
    * Create sublists of the partition locations, each sublist of size
    * at most {@link PartitionDescriptor#PARTITION_BATCH_SIZE}
    */
-  protected abstract void createPartitionSublists() ;
+  protected abstract void createPartitionSublists();
 
   /**
    * Iterator that traverses over the super list of partition locations and

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/StarColumnHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/StarColumnHelper.java
@@ -65,7 +65,7 @@ public class StarColumnHelper {
   }
 
   public static boolean isPrefixedStarColumn(String fieldName) {
-    return fieldName.indexOf(PREFIXED_STAR_COLUMN) > 0 ; // the delimiter * starts at none-zero position.
+    return fieldName.indexOf(PREFIXED_STAR_COLUMN) > 0; // the delimiter * starts at none-zero position.
   }
 
   public static boolean isNonPrefixedStarColumn(String fieldName) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillJoinRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillJoinRelBase.java
@@ -137,7 +137,7 @@ public abstract class DrillJoinRelBase extends Join implements DrillRelNode {
                                     // just to make sure Cartesian Join is more expensive
                                     // than Non-Cartesian Join.
 
-    final int keySize = 1 ;  // assume having 1 join key, when estimate join cost.
+    final int keySize = 1;  // assume having 1 join key, when estimate join cost.
     final DrillCostBase cost = (DrillCostBase) computeHashJoinCostWithKeySize(planner, keySize, mq).multiplyBy(mulFactor);
 
     // Cartesian join row count will be product of two inputs. The other factors come from the above estimated DrillCost.
@@ -197,7 +197,7 @@ public abstract class DrillJoinRelBase extends Join implements DrillRelNode {
         ) * buildRowCount * factor;
 
     double cpuCost = joinConditionCost * (probeRowCount) // probe size determine the join condition comparison cost
-        + cpuCostBuild + cpuCostProbe ;
+        + cpuCostBuild + cpuCostProbe;
 
     DrillCostFactory costFactory = (DrillCostFactory) planner.getCostFactory();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLimitRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillLimitRelBase.java
@@ -84,7 +84,7 @@ public abstract class DrillLimitRelBase extends SingleRel implements DrillRelNod
 
   @Override
   public double estimateRowCount(RelMetadataQuery mq) {
-    int off = offset != null ? RexLiteral.intValue(offset) : 0 ;
+    int off = offset != null? RexLiteral.intValue(offset): 0;
 
     if (fetch == null) {
       // If estimated rowcount is less than offset return 0

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillProjectRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillProjectRelBase.java
@@ -60,7 +60,7 @@ import com.google.common.collect.Lists;
  * Base class for logical and physical Project implemented in Drill
  */
 public abstract class DrillProjectRelBase extends Project implements DrillRelNode {
-  private final int nonSimpleFieldCount ;
+  private final int nonSimpleFieldCount;
 
   protected DrillProjectRelBase(Convention convention, RelOptCluster cluster, RelTraitSet traits, RelNode child, List<? extends RexNode> exps,
       RelDataType rowType) {
@@ -128,10 +128,10 @@ public abstract class DrillProjectRelBase extends Project implements DrillRelNod
     for (RexNode expr : this.getProjects()) {
       if (expr instanceof RexInputRef) {
         // Simple Field reference.
-        cnt ++;
+        cnt++;
       } else if (expr instanceof RexCall && expr.accept(complexFieldIdentifer)) {
         // Complex field with named segments only.
-        cnt ++;
+        cnt++;
       }
     }
     return cnt;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
@@ -169,7 +169,7 @@ public class DrillCostBase implements DrillRelOptCost {
       || (this.io == Double.POSITIVE_INFINITY)
       || (this.network == Double.POSITIVE_INFINITY)
       || (this.rowCount == Double.POSITIVE_INFINITY)
-      || (this.memory == Double.POSITIVE_INFINITY) ;
+      || (this.memory == Double.POSITIVE_INFINITY);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillFilterRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillFilterRel.java
@@ -51,7 +51,7 @@ public class DrillFilterRel extends DrillFilterRelBase implements DrillRel {
   }
 
   public static DrillFilterRel create(RelNode child, RexNode condition) {
-    return new DrillFilterRel(child.getCluster(), child.getTraitSet(), child, condition)  ;
+    return new DrillFilterRel(child.getCluster(), child.getTraitSet(), child, condition);
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -301,12 +301,14 @@ public class DrillOptiq {
       case "CHAR":
         castType = Types.required(MinorType.VARCHAR).toBuilder().setPrecision(call.getType().getPrecision()).build();
         break;
-
-      case "INTEGER": castType = Types.required(MinorType.INT);
+      case "INTEGER":
+        castType = Types.required(MinorType.INT);
         break;
-      case "FLOAT": castType = Types.required(MinorType.FLOAT4);
+      case "FLOAT":
+        castType = Types.required(MinorType.FLOAT4);
         break;
-      case "DOUBLE": castType = Types.required(MinorType.FLOAT8);
+      case "DOUBLE":
+        castType = Types.required(MinorType.FLOAT8);
         break;
       case "DECIMAL":
         if (!context.getPlannerSettings().getOptions().getOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY).bool_val) {
@@ -330,7 +332,8 @@ public class DrillOptiq {
 
         case "INTERVAL_YEAR":
         case "INTERVAL_YEAR_MONTH":
-        case "INTERVAL_MONTH": castType = Types.required(MinorType.INTERVALYEAR);
+        case "INTERVAL_MONTH":
+          castType = Types.required(MinorType.INTERVALYEAR);
           break;
         case "INTERVAL_DAY":
         case "INTERVAL_DAY_HOUR":
@@ -341,14 +344,19 @@ public class DrillOptiq {
         case "INTERVAL_HOUR_SECOND":
         case "INTERVAL_MINUTE":
         case "INTERVAL_MINUTE_SECOND":
-        case "INTERVAL_SECOND": castType = Types.required(MinorType.INTERVALDAY);
+        case "INTERVAL_SECOND":
+          castType = Types.required(MinorType.INTERVALDAY);
           break;
-        case "BOOLEAN": castType = Types.required(MinorType.BIT);
+        case "BOOLEAN":
+          castType = Types.required(MinorType.BIT);
           break;
-        case "BINARY": castType = Types.required(MinorType.VARBINARY);
+        case "BINARY":
+          castType = Types.required(MinorType.VARBINARY);
           break;
-        case "ANY": return arg; // Type will be same as argument.
-        default: castType = Types.required(MinorType.valueOf(call.getType().getSqlTypeName().getName()));
+        case "ANY":
+          return arg; // Type will be same as argument.
+        default:
+          castType = Types.required(MinorType.valueOf(call.getType().getSqlTypeName().getName()));
       }
       return FunctionCallFactory.createCast(castType, ExpressionPosition.UNKNOWN, arg);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -302,9 +302,12 @@ public class DrillOptiq {
         castType = Types.required(MinorType.VARCHAR).toBuilder().setPrecision(call.getType().getPrecision()).build();
         break;
 
-      case "INTEGER": castType = Types.required(MinorType.INT); break;
-      case "FLOAT": castType = Types.required(MinorType.FLOAT4); break;
-      case "DOUBLE": castType = Types.required(MinorType.FLOAT8); break;
+      case "INTEGER": castType = Types.required(MinorType.INT);
+        break;
+      case "FLOAT": castType = Types.required(MinorType.FLOAT4);
+        break;
+      case "DOUBLE": castType = Types.required(MinorType.FLOAT8);
+        break;
       case "DECIMAL":
         if (!context.getPlannerSettings().getOptions().getOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY).bool_val) {
           throw UserException
@@ -327,7 +330,8 @@ public class DrillOptiq {
 
         case "INTERVAL_YEAR":
         case "INTERVAL_YEAR_MONTH":
-        case "INTERVAL_MONTH": castType = Types.required(MinorType.INTERVALYEAR); break;
+        case "INTERVAL_MONTH": castType = Types.required(MinorType.INTERVALYEAR);
+          break;
         case "INTERVAL_DAY":
         case "INTERVAL_DAY_HOUR":
         case "INTERVAL_DAY_MINUTE":
@@ -337,9 +341,12 @@ public class DrillOptiq {
         case "INTERVAL_HOUR_SECOND":
         case "INTERVAL_MINUTE":
         case "INTERVAL_MINUTE_SECOND":
-        case "INTERVAL_SECOND": castType = Types.required(MinorType.INTERVALDAY); break;
-        case "BOOLEAN": castType = Types.required(MinorType.BIT); break;
-        case "BINARY": castType = Types.required(MinorType.VARBINARY); break;
+        case "INTERVAL_SECOND": castType = Types.required(MinorType.INTERVALDAY);
+          break;
+        case "BOOLEAN": castType = Types.required(MinorType.BIT);
+          break;
+        case "BINARY": castType = Types.required(MinorType.VARBINARY);
+          break;
         case "ANY": return arg; // Type will be same as argument.
         default: castType = Types.required(MinorType.valueOf(call.getType().getSqlTypeName().getName()));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillUnionAllRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillUnionAllRule.java
@@ -61,7 +61,7 @@ public class DrillUnionAllRule extends RelOptRule {
       call.transformTo(new DrillUnionRel(union.getCluster(), traits, convertedInputs, union.all,
           true /* check compatibility */));
     } catch (InvalidRelException e) {
-      tracer.warn(e.toString()) ;
+      tracer.warn(e.toString());
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillUnionRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillUnionRel.java
@@ -50,7 +50,7 @@ public class DrillUnionRel extends DrillUnionRelBase implements DrillRel {
       return new DrillUnionRel(getCluster(), traitSet, inputs, all,
           false /* don't check compatibility during copy */);
     } catch (InvalidRelException e) {
-      throw new AssertionError(e) ;
+      throw new AssertionError(e);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
@@ -49,7 +49,7 @@ public abstract class AggPrelBase extends DrillAggregateRelBase implements Prel 
 
   public enum OperatorPhase {PHASE_1of1, PHASE_1of2, PHASE_2of2}
 
-  protected OperatorPhase operPhase = OperatorPhase.PHASE_1of1 ; // default phase
+  protected OperatorPhase operPhase = OperatorPhase.PHASE_1of1; // default phase
   protected List<NamedExpression> keys = Lists.newArrayList();
   protected List<NamedExpression> aggExprs = Lists.newArrayList();
   protected List<AggregateCall> phase2AggCallList = Lists.newArrayList();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/BroadcastExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/BroadcastExchangePrel.java
@@ -56,7 +56,7 @@ public class BroadcastExchangePrel extends ExchangePrel{
     final double inputRows = mq.getRowCount(child);
 
     final int  rowWidth = child.getRowType().getFieldCount() * DrillCostBase.AVG_FIELD_WIDTH;
-    final double cpuCost = broadcastFactor * DrillCostBase.SVR_CPU_COST * inputRows ;
+    final double cpuCost = broadcastFactor * DrillCostBase.SVR_CPU_COST * inputRows;
     final double networkCost = broadcastFactor * DrillCostBase.BYTE_NETWORK_COST * inputRows * rowWidth * numEndPoints;
 
     return new DrillCostBase(inputRows, cpuCost, 0, networkCost);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
@@ -96,7 +96,7 @@ public class DrillDistributionTrait implements RelTrait {
 
   @Override
   public int hashCode() {
-    return  fields == null ? type.hashCode() : type.hashCode() | fields.hashCode() << 4 ;
+    return  fields == null? type.hashCode(): type.hashCode() | fields.hashCode() << 4;
   }
 
   @Override
@@ -106,7 +106,7 @@ public class DrillDistributionTrait implements RelTrait {
     }
     if (obj instanceof DrillDistributionTrait) {
       DrillDistributionTrait that = (DrillDistributionTrait) obj;
-      return this.type == that.type && this.fields.equals(that.fields) ;
+      return this.type == that.type && this.fields.equals(that.fields);
     }
     return false;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashAggPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashAggPrule.java
@@ -91,7 +91,7 @@ public class HashAggPrule extends AggPruleBase {
         createTransformRequest(call, aggregate, input, traits);
 
         if (create2PhasePlan(call, aggregate)) {
-          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL) ;
+          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL);
 
           RelNode convertedInput = convert(input, traits);
           new TwoPhaseSubset(call, distOnAllKeys).go(aggregate, convertedInput);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashToMergeExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashToMergeExchangePrel.java
@@ -38,7 +38,7 @@ public class HashToMergeExchangePrel extends ExchangePrel {
 
   private final List<DistributionField> distFields;
   private int numEndPoints = 0;
-  private final RelCollation collation ;
+  private final RelCollation collation;
 
   public HashToMergeExchangePrel(RelOptCluster cluster, RelTraitSet traitSet, RelNode input,
                                  List<DistributionField> fields,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SingleMergeExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SingleMergeExchangePrel.java
@@ -40,7 +40,7 @@ import org.apache.drill.exec.server.options.OptionManager;
 
 public class SingleMergeExchangePrel extends ExchangePrel {
 
-  private final RelCollation collation ;
+  private final RelCollation collation;
 
   public SingleMergeExchangePrel(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RelCollation collation) {
     super(cluster, traitSet, input);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/StreamAggPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/StreamAggPrule.java
@@ -70,7 +70,7 @@ public class StreamAggPrule extends AggPruleBase {
         final RelTraitSet singleDistTrait = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL).plus(singleDist);
 
         if (create2PhasePlan(call, aggregate)) {
-          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL) ;
+          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL);
 
           RelNode convertedInput = convert(input, traits);
           new SubsetTransformer<DrillAggregateRel, InvalidRelException>(call){
@@ -138,7 +138,7 @@ public class StreamAggPrule extends AggPruleBase {
         // createTransformRequest(call, aggregate, input, traits);
 
         if (create2PhasePlan(call, aggregate)) {
-          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL) ;
+          traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL);
           RelNode convertedInput = convert(input, traits);
 
           new SubsetTransformer<DrillAggregateRel, InvalidRelException>(call){

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
@@ -84,7 +84,7 @@ class NumberingRelWriter implements RelWriter {
     s.append("  ");
 
     if (id != null && id.opId == 0) {
-      for(int i = 0; i < spacer.get(); i++) {
+      for (int i = 0; i < spacer.get(); i++) {
         s.append('-');
       }
     }else{

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/explain/NumberingRelWriter.java
@@ -84,7 +84,9 @@ class NumberingRelWriter implements RelWriter {
     s.append("  ");
 
     if (id != null && id.opId == 0) {
-      for(int i =0; i < spacer.get(); i++){ s.append('-');}
+      for(int i = 0; i < spacer.get(); i++) {
+        s.append('-');
+      }
     }else{
       spacer.spaces(s);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/StarColumnConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/StarColumnConverter.java
@@ -248,7 +248,7 @@ public class StarColumnConverter extends BasePrelVisitor<Prel, Void, RuntimeExce
 
     for (String s : names) {
       if (uniqueNames.contains(s)) {
-        for (int i = 0; ; i++ ) {
+        for (int i = 0;; i++) {
           s = s + i;
           if (! origNames.contains(s) && ! uniqueNames.contains(s)) {
             break;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/Controller.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/control/Controller.java
@@ -42,7 +42,7 @@ public interface Controller extends AutoCloseable {
    * @param node
    * @return
    */
-  public ControlTunnel getTunnel(DrillbitEndpoint node) ;
+  public ControlTunnel getTunnel(DrillbitEndpoint node);
 
   public DrillbitEndpoint start(DrillbitEndpoint partialEndpoint, boolean allowPortHunting)
       throws DrillbitStartupException;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -65,7 +65,7 @@ public class ProfileWrapper {
     this.profile = profile;
     this.id = profile.hasQueryId() ? profile.getQueryId() : QueryIdHelper.getQueryId(profile.getId());
     //Generating Operator Name map (DRILL-6140)
-    String profileTextPlan = profile.hasPlan() ? profile.getPlan() : "" ;
+    String profileTextPlan = profile.hasPlan()? profile.getPlan(): "";
     generateOpMap(profileTextPlan);
 
     final List<FragmentWrapper> fragmentProfiles = new ArrayList<>();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/SimpleDurationFormat.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/SimpleDurationFormat.java
@@ -72,6 +72,6 @@ public class SimpleDurationFormat {
     return (days > 0 ? days + " day " : "") +
         ((hours + days) > 0 ? hours + " hr " : "") +
         ((minutes + hours + days) > 0 ? String.format("%02d min ", minutes) : "") +
-        seconds + "." + String.format("%03d sec", milliSeconds) ;
+        seconds + "." + String.format("%03d sec", milliSeconds);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
@@ -253,8 +253,7 @@ public abstract class SSLConfig {
           .append("\n\ttrustStorePassword: ").append(getPrintablePassword(getTrustStorePassword()))
           .append("\n\thandshakeTimeout: ").append(getHandshakeTimeout())
           .append("\n\tdisableHostVerification: ").append(disableHostVerification())
-          .append("\n\tdisableCertificateVerification: ").append(disableCertificateVerification())
-      ;
+          .append("\n\tdisableCertificateVerification: ").append(disableCertificateVerification());
     }
     return sb.toString();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonProcessor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonProcessor.java
@@ -51,7 +51,7 @@ public interface JsonProcessor {
                                                        String msg,
                                                        Object... args);
 
-  public boolean ignoreJSONParseError() ;
+  public boolean ignoreJSONParseError();
 
   public void setIgnoreJSONParseErrors(boolean ignoreJSONParseErrors);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/HeaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/HeaderBuilder.java
@@ -224,7 +224,7 @@ public class HeaderBuilder extends TextOutput {
         // "col", "col_2", "col_2_2", "col_2_2_2".
         // No mapping scheme is perfect...
 
-        for (int l = 2;  ; l++) {
+        for (int l = 2;; l++) {
           final String rewritten = header + "_" + l;
           key = rewritten.toLowerCase();
           if (! idents.contains(key)) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/TextInput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/TextInput.java
@@ -96,7 +96,7 @@ final class TextInput {
     this.lineSeparator = settings.getNewLineDelimiter();
     byte normalizedLineSeparator = settings.getNormalizedNewLine();
     Preconditions.checkArgument(input instanceof Seekable, "Text input only supports an InputStream that supports Seekable.");
-    boolean isCompressed = input instanceof CompressionInputStream ;
+    boolean isCompressed = input instanceof CompressionInputStream;
     Preconditions.checkArgument(!isCompressed || startPos == 0, "Cannot use split on compressed stream.");
 
     // splits aren't allowed with compressed data.  The split length will be the compressed size which means we'll normally end prematurely.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/Records.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/Records.java
@@ -130,9 +130,15 @@ public class Records {
           break;
         // 2.  SqlTypeName enumerators whose names (currently) do not match SQL's
         //     values for DATA_TYPE:
-        case CHAR:                this.DATA_TYPE = "CHARACTER";         break;
-        case VARCHAR:             this.DATA_TYPE = "CHARACTER VARYING"; break;
-        case VARBINARY:           this.DATA_TYPE = "BINARY VARYING";    break;
+        case CHAR:
+          this.DATA_TYPE = "CHARACTER";
+          break;
+        case VARCHAR:
+          this.DATA_TYPE = "CHARACTER VARYING";
+          break;
+        case VARBINARY:
+          this.DATA_TYPE = "BINARY VARYING";
+          break;
         case INTERVAL_YEAR:
         case INTERVAL_YEAR_MONTH:
         case INTERVAL_MONTH:
@@ -145,7 +151,9 @@ public class Records {
         case INTERVAL_HOUR_SECOND:
         case INTERVAL_MINUTE:
         case INTERVAL_MINUTE_SECOND:
-        case INTERVAL_SECOND:     this.DATA_TYPE = "INTERVAL";          break;
+        case INTERVAL_SECOND:
+          this.DATA_TYPE = "INTERVAL";
+          break;
         // 3:  SqlTypeName enumerators not yet seen and confirmed or handled.
         default:
           logger.warn( "Type not handled explicitly (code needs review): "
@@ -212,10 +220,18 @@ public class Records {
           this.CHARACTER_OCTET_LENGTH = null;
           // This NUMERIC_PRECISION is in bits since NUMERIC_PRECISION_RADIX is 2.
           switch ( sqlTypeName ) {
-            case TINYINT:  NUMERIC_PRECISION =  8; break;
-            case SMALLINT: NUMERIC_PRECISION = 16; break;
-            case INTEGER:  NUMERIC_PRECISION = 32; break;
-            case BIGINT:   NUMERIC_PRECISION = 64; break;
+            case TINYINT:
+              NUMERIC_PRECISION = 8;
+              break;
+            case SMALLINT:
+              NUMERIC_PRECISION = 16;
+              break;
+            case INTEGER:
+              NUMERIC_PRECISION = 32;
+              break;
+            case BIGINT:
+              NUMERIC_PRECISION = 64;
+              break;
             default:
               throw new AssertionError(
                   "Unexpected " + sqlTypeName.getClass().getName() + " value "
@@ -253,9 +269,15 @@ public class Records {
           this.CHARACTER_OCTET_LENGTH = null;
           // This NUMERIC_PRECISION is in bits since NUMERIC_PRECISION_RADIX is 2.
           switch ( sqlTypeName ) {
-            case REAL:   NUMERIC_PRECISION = 24; break;
-            case FLOAT:  NUMERIC_PRECISION = 24; break;
-            case DOUBLE: NUMERIC_PRECISION = 53; break;
+            case REAL:
+              NUMERIC_PRECISION = 24;
+              break;
+            case FLOAT:
+              NUMERIC_PRECISION = 24;
+              break;
+            case DOUBLE:
+              NUMERIC_PRECISION = 53;
+              break;
             default:
               throw new AssertionError(
                   "Unexpected type " + sqlTypeName + " in approximate-types branch" );
@@ -285,7 +307,9 @@ public class Records {
           this.INTERVAL_TYPE = null;
           this.INTERVAL_PRECISION = null;
           switch(sqlTypeName) {
-          case DATE: this.COLUMN_SIZE = 10; break;// yyyy-MM-dd
+          case DATE:
+            this.COLUMN_SIZE = 10;
+            break;// yyyy-MM-dd
           case TIME: this.COLUMN_SIZE = this.DATETIME_PRECISION == 0
               ? 8 // HH::mm::ss
               : 8 + 1 + this.DATETIME_PRECISION;
@@ -373,8 +397,12 @@ public class Records {
             switch(start) {
             case YEAR:
               switch(end) {
-              case YEAR: this.COLUMN_SIZE = INTERVAL_PRECISION + 2; break;// P..Y
-              case MONTH: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 5; break; // P..Y12M
+              case YEAR:
+                this.COLUMN_SIZE = INTERVAL_PRECISION + 2;
+                break;// P..Y
+              case MONTH:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 5;
+                break; // P..Y12M
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }
@@ -382,7 +410,9 @@ public class Records {
 
             case MONTH:
               switch(end) {
-              case MONTH: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 2; break; // P..M
+              case MONTH:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 2;
+                break; // P..M
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }
@@ -390,10 +420,18 @@ public class Records {
 
             case DAY:
               switch(end) {
-              case DAY: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 2; break; // P..D
-              case HOUR: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6; break; // P..DT12H
-              case MINUTE: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 9; break; // P..DT12H60M
-              case SECOND: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 12 + extraSecondIntervalSize; break; // P..DT12H60M60....S
+              case DAY:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 2;
+                break; // P..D
+              case HOUR:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6;
+                break; // P..DT12H
+              case MINUTE:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 9;
+                break; // P..DT12H60M
+              case SECOND:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 12 + extraSecondIntervalSize;
+                break; // P..DT12H60M60....S
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }
@@ -401,9 +439,15 @@ public class Records {
 
             case HOUR:
               switch(end) {
-              case HOUR: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3; break; // PT..H
-              case MINUTE: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6; break; // PT..H60M
-              case SECOND: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 9 + extraSecondIntervalSize; break; // PT..H12M60....S
+              case HOUR:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3;
+                break; // PT..H
+              case MINUTE:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6;
+                break; // PT..H60M
+              case SECOND:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 9 + extraSecondIntervalSize;
+                break; // PT..H12M60....S
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }
@@ -411,8 +455,12 @@ public class Records {
 
             case MINUTE:
               switch(end) {
-              case MINUTE: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3; break; // PT...M
-              case SECOND: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6 + extraSecondIntervalSize; break; // PT..M60....S
+              case MINUTE:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3;
+                break; // PT...M
+              case SECOND:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 6 + extraSecondIntervalSize;
+                break; // PT..M60....S
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }
@@ -421,7 +469,9 @@ public class Records {
 
             case SECOND:
               switch(end) {
-              case SECOND: this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3 + extraSecondIntervalSize; break; // PT....S
+              case SECOND:
+                this.COLUMN_SIZE = this.INTERVAL_PRECISION + 3 + extraSecondIntervalSize;
+                break; // PT....S
               default:
                 throw new AssertionError("Unexpected interval type " + this.INTERVAL_TYPE + " in interval-types branch" );
               }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFilterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFilterBuilder.java
@@ -214,7 +214,7 @@ public class ParquetFilterBuilder extends AbstractExprVisitor<LogicalExpression,
     }
 
     if (value.contains(funcHolderExpr)) {
-      ValueHolder result ;
+      ValueHolder result;
       try {
         result = InterpreterEvaluator.evaluateConstantExpr(udfUtilities, funcHolderExpr);
       } catch (Exception e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetPushDownFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetPushDownFilter.java
@@ -167,7 +167,7 @@ public abstract class ParquetPushDownFilter extends StoragePluginOptimizerRule {
       return;
     }
 
-    RelNode newScan = ScanPrel.create(scan, scan.getTraitSet(), newGroupScan, scan.getRowType());;
+    RelNode newScan = ScanPrel.create(scan, scan.getTraitSet(), newGroupScan, scan.getRowType());
 
     if (project != null) {
       newScan = project.copy(project.getTraitSet(), ImmutableList.of(newScan));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReader.java
@@ -78,7 +78,10 @@ public abstract class ColumnReader<V extends ValueVector> {
   int currDefLevel;
 
   // variables for a single read pass
-  long readStartInBytes = 0, readLength = 0, readLengthInBits = 0, recordsReadInThisIteration = 0;
+  long readStartInBytes = 0;
+  long readLength = 0;
+  long readLengthInBits = 0;
+  long recordsReadInThisIteration = 0;
   private ExecutorService threadPool;
 
   volatile boolean isShuttingDown; //Indicate to not submit any new AsyncPageReader Tasks during clear()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataPathUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataPathUtils.java
@@ -87,7 +87,7 @@ public class MetadataPathUtils {
       ParquetTableMetadata_v3 tableMetadataWithAbsolutePaths, String baseDir) {
     List<String> directoriesWithRelativePaths = Lists.newArrayList();
     for (String directory : tableMetadataWithAbsolutePaths.getDirectories()) {
-      directoriesWithRelativePaths.add(relativize(baseDir, directory)) ;
+      directoriesWithRelativePaths.add(relativize(baseDir, directory));
     }
     List<ParquetFileMetadata_v3> filesWithRelativePaths = Lists.newArrayList();
     for (ParquetFileMetadata_v3 file : tableMetadataWithAbsolutePaths.files) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/BlockMapBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/BlockMapBuilder.java
@@ -192,7 +192,7 @@ public class BlockMapBuilder {
     final Timer.Context context = metrics.timer(BLOCK_MAP_BUILDER_TIMER).time();
     BlockLocation[] blocks;
     ImmutableRangeMap<Long,BlockLocation> blockMap;
-    blocks = fs.getFileBlockLocations(status, 0 , status.getLen());
+    blocks = fs.getFileBlockLocations(status, 0, status.getLen());
     ImmutableRangeMap.Builder<Long, BlockLocation> blockMapBuilder = new ImmutableRangeMap.Builder<Long,BlockLocation>();
     for (BlockLocation block : blocks) {
       long start = block.getOffset();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
@@ -56,7 +56,7 @@ public class VectorUtil {
       int columnCounter = 0;
       for (VectorWrapper<?> vw : va) {
         boolean lastColumn = columnCounter == width - 1;
-        Object o ;
+        Object o;
         try{
           o = vw.getValueVector().getAccessor().getObject(row);
         } catch (Exception e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/DataCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/DataCollector.java
@@ -24,7 +24,7 @@ import org.apache.drill.exec.record.RawFragmentBatch;
 
 public interface DataCollector extends AutoCloseable {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DataCollector.class);
-  public boolean batchArrived(int minorFragmentId, RawFragmentBatch batch) throws IOException ;
+  public boolean batchArrived(int minorFragmentId, RawFragmentBatch batch) throws IOException;
   public int getOppositeMajorFragmentId();
   public RawBatchBuffer[] getBuffers();
   public int getTotalIncomingFragments();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/UnlimitedRawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/UnlimitedRawBatchBuffer.java
@@ -40,7 +40,7 @@ public class UnlimitedRawBatchBuffer extends BaseRawBatchBuffer<RawFragmentBatch
   }
 
   private class UnlimitedBufferQueue implements BufferQueue<RawFragmentBatch> {
-    private final LinkedBlockingDeque<RawFragmentBatch> buffer = Queues.newLinkedBlockingDeque();;
+    private final LinkedBlockingDeque<RawFragmentBatch> buffer = Queues.newLinkedBlockingDeque();
 
     @Override
     public void addOomBatch(RawFragmentBatch batch) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/ResourceManagerBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/rm/ResourceManagerBuilder.java
@@ -53,7 +53,7 @@ public class ResourceManagerBuilder {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ResourceManagerBuilder.class);
 
-  private DrillbitContext context ;
+  private DrillbitContext context;
 
   public ResourceManagerBuilder(final DrillbitContext context) {
     this.context = context;

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -85,7 +85,7 @@ public class PlanningBase extends ExecTest {
     provider.start();
     final ScanResult scanResult = ClassPathScanner.fromPrescan(config);
     final LogicalPlanPersistence logicalPlanPersistence = new LogicalPlanPersistence(config, scanResult);
-    final SystemOptionManager systemOptions = new SystemOptionManager(logicalPlanPersistence , provider, config);
+    final SystemOptionManager systemOptions = new SystemOptionManager(logicalPlanPersistence, provider, config);
     systemOptions.init();
     @SuppressWarnings("resource")
     final UserSession userSession = UserSession.Builder.newBuilder().withOptionManager(systemOptions).build();

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -293,7 +293,7 @@ public class TestStarQueries extends BaseTestQuery {
   @Test(expected = UserException.class)  // Should get "At line 1, column 8: Column 'n_nationkey' is ambiguous"
   public void testSelStarAmbiguousJoin() throws Exception {
     try {
-      test("select x.n_nationkey, x.n_name, x.n_regionkey, x.r_name from (select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey) x " ) ;
+      test("select x.n_nationkey, x.n_name, x.n_regionkey, x.r_name from (select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey) x " );
     } catch (UserException e) {
       logger.info("***** Test resulted in expected failure: " + e.getMessage());
       throw e;

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -475,8 +475,8 @@ public class TestUnionAll extends BaseTestQuery {
             "(select columns[0] c2 from cp.`%s` t2 \n" +
             "where t2.columns[0] is not null \n" +
             "group by columns[0])) \n" +
-            "group by col0"
-          , root, root)
+            "group by col0",
+            root, root)
         .unOrdered()
         .baselineColumns("col0")
         .baselineValues("290")

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/RunRootExec.java
@@ -55,7 +55,7 @@ public class RunRootExec {
     FunctionImplementationRegistry registry = bitContext.getFunctionImplementationRegistry();
     FragmentContextImpl context = new FragmentContextImpl(bitContext, PlanFragment.getDefaultInstance(), null, registry);
     SimpleRootExec exec;
-    for (int i = 0; i < iterations; i ++) {
+    for (int i = 0; i < iterations; i++) {
       Stopwatch w = Stopwatch.createStarted();
       logger.info("STARTITER: {}", i);
       exec = new SimpleRootExec(ImplCreator.getExec(context, (FragmentRoot) plan.getSortedOperators(false).iterator().next()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -204,7 +204,7 @@ public class FunctionRegistryHolderTest {
     for (List<FunctionHolder> functionHolders : newJars.values()) {
       for (FunctionHolder functionHolder : functionHolders) {
         if ("lower".equals(functionHolder.getName())) {
-          expectedResult.add(functionHolder.getHolder()) ;
+          expectedResult.add(functionHolder.getHolder());
         }
       }
     }
@@ -220,7 +220,7 @@ public class FunctionRegistryHolderTest {
     for (List<FunctionHolder> functionHolders : newJars.values()) {
       for (FunctionHolder functionHolder : functionHolders) {
         if ("lower".equals(functionHolder.getName())) {
-          expectedResult.add(functionHolder.getHolder()) ;
+          expectedResult.add(functionHolder.getHolder());
         }
       }
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunction.java
@@ -85,7 +85,7 @@ public class TestAggregateFunction extends PopUnitTestBase {
   public void testCovarianceCorrelation() throws Throwable {
     String planPath = "/functions/test_covariance.json";
     String dataPath = "/covariance_input.json";
-    Double expectedValues[] = {4.571428571428571d, 4.857142857142857d, -6.000000000000002d, 4.0d , 4.25d, -5.250000000000002d, 1.0d, 0.9274260335029677d, -1.0000000000000004d};
+    Double expectedValues[] = {4.571428571428571d, 4.857142857142857d, -6.000000000000002d, 4.0d, 4.25d, -5.250000000000002d, 1.0d, 0.9274260335029677d, -1.0000000000000004d};
 
     runTest(expectedValues, planPath, dataPath);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateTruncFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestDateTruncFunctions.java
@@ -87,7 +87,7 @@ public class TestDateTruncFunctions extends BaseTestQuery {
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
-        .baselineColumns("second", "minute", "hour", "day", "month", "week" , "year", "q1", "q2", "q3", "decade1", "decade2", "decade3")
+        .baselineColumns("second", "minute", "hour", "day", "month", "week", "year", "q1", "q2", "q3", "decade1", "decade2", "decade3")
         .baselineValues(
             DateUtility.parseLocalDate("2011-02-03"), // seconds
             DateUtility.parseLocalDate("2011-02-03"), // minute
@@ -183,7 +183,7 @@ public class TestDateTruncFunctions extends BaseTestQuery {
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
-        .baselineColumns("second", "minute", "hour", "day", "month", "week" , "year", "q1", "q2", "q3", "decade1", "decade2", "decade3")
+        .baselineColumns("second", "minute", "hour", "day", "month", "week", "year", "q1", "q2", "q3", "decade1", "decade2", "decade3")
         .baselineValues(
             DateUtility.parseLocalDateTime("2011-02-03 10:11:12.0"), // seconds
             DateUtility.parseLocalDateTime("2011-02-03 10:11:00.0"), // minute

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
@@ -227,7 +227,7 @@ public class ExpressionInterpreterTest  extends PopUnitTestBase {
   }
 
   private void showValueVectorContent(ValueVector vw) {
-    for (int row = 0; row < vw.getAccessor().getValueCount(); row ++ ) {
+    for (int row = 0; row < vw.getAccessor().getValueCount(); row++ ) {
       final Object o = vw.getAccessor().getObject(row);
       final String cellString;
       if (o instanceof byte[]) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/interp/ExpressionInterpreterTest.java
@@ -227,7 +227,7 @@ public class ExpressionInterpreterTest  extends PopUnitTestBase {
   }
 
   private void showValueVectorContent(ValueVector vw) {
-    for (int row = 0; row < vw.getAccessor().getValueCount(); row++ ) {
+    for (int row = 0; row < vw.getAccessor().getValueCount(); row++) {
       final Object o = vw.getAccessor().getObject(row);
       final String cellString;
       if (o instanceof byte[]) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationMetadata.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationMetadata.java
@@ -65,7 +65,7 @@ public class TestImpersonationMetadata extends BaseTestImpersonation {
     addMiniDfsBasedStorage(createTestWorkspaces());
   }
 
-  private static Map<String , WorkspaceConfig> createTestWorkspaces() throws Exception {
+  private static Map<String, WorkspaceConfig> createTestWorkspaces() throws Exception {
     // Create "/tmp" folder and set permissions to "777"
     final Path tmpPath = new Path("/tmp");
     fs.delete(tmpPath, true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
@@ -181,8 +181,7 @@ public class TestAllocators extends DrillTest {
     final DrillConfig config = DrillConfig.create(TEST_CONFIGURATIONS);
 
     try (final RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-        final Drillbit bit = new Drillbit(config, serviceSet)) {
-      ;
+         final Drillbit bit = new Drillbit(config, serviceSet)) {
       bit.run();
       final DrillbitContext bitContext = bit.getContext();
       FunctionImplementationRegistry functionRegistry = bitContext.getFunctionImplementationRegistry();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/PartitionLimit/TestPartitionLimitBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/PartitionLimit/TestPartitionLimitBatch.java
@@ -344,7 +344,7 @@ public class TestPartitionLimitBatch extends BaseTestOpBatchEmitOutcome {
     expectedRowSets.add(expectedRowSet1);
     expectedRowSets.add(expectedRowSet2);
 
-    testPartitionLimitCommon(0 ,1);
+    testPartitionLimitCommon(0, 1);
   }
 
   @Test
@@ -385,7 +385,7 @@ public class TestPartitionLimitBatch extends BaseTestOpBatchEmitOutcome {
 
     expectedRowSets.add(expectedRowSet1);
 
-    testPartitionLimitCommon(2 ,3);
+    testPartitionLimitCommon(2, 3);
   }
 
   /**
@@ -440,7 +440,7 @@ public class TestPartitionLimitBatch extends BaseTestOpBatchEmitOutcome {
     expectedRowSets.add(expectedRowSet1);
     expectedRowSets.add(expectedRowSet2);
 
-    testPartitionLimitCommon(0 ,5);
+    testPartitionLimitCommon(0, 5);
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDecimal.java
@@ -159,7 +159,7 @@ public class TestDecimal extends PopUnitTestBase {
 
             String addOutput[] = {"123456888.0", "22.2", "0.2", "-0.2", "-987654444.2","-3.0"};
             String subtractOutput[] = {"123456690.0", "0.0", "0.0", "0.0", "-987654198.0", "-1.0"};
-            String multiplyOutput[] = {"12222222111.00" , "123.21" , "0.01", "0.01",  "121580246927.41", "2.00"};
+            String multiplyOutput[] = {"12222222111.00", "123.21", "0.01", "0.01",  "121580246927.41", "2.00"};
 
             Iterator<VectorWrapper<?>> itr = batchLoader.iterator();
 
@@ -208,7 +208,7 @@ public class TestDecimal extends PopUnitTestBase {
             QueryDataBatch batch = results.get(0);
             assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            String addOutput[] = {"-99999998877.700000000", "11.423456789", "123456789.100000000", "-0.119998000", "100000000112.423456789" , "-99999999879.907000000", "123456789123456801.300000000"};
+            String addOutput[] = {"-99999998877.700000000", "11.423456789", "123456789.100000000", "-0.119998000", "100000000112.423456789", "-99999999879.907000000", "123456789123456801.300000000"};
             String subtractOutput[] = {"-100000001124.300000000", "10.823456789", "-123456788.900000000", "-0.120002000", "99999999889.823456789", "-100000000122.093000000", "123456789123456776.700000000"};
 
             Iterator<VectorWrapper<?>> itr = batchLoader.iterator();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -43,8 +43,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
   public void oneBitOneExchangeOneEntryRun() throws Exception{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
-        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
+    try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.toString(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"), Charsets.UTF_8));
@@ -64,8 +64,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
   public void oneBitOneExchangeTwoEntryRun() throws Exception{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
-        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
+    try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.toString(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), Charsets.UTF_8));
@@ -84,8 +84,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
     public void oneBitOneExchangeTwoEntryRunLogical() throws Exception{
         RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-        try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
-            DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
+        try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
           bit1.run();
           client.connect();
           List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, Files.toString(DrillFileUtils.getResourceAsFile("/scan_screen_logical.json"), Charsets.UTF_8));
@@ -104,9 +104,9 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
     public void twoBitOneExchangeTwoEntryRun() throws Exception{
       RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-      try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
-          Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
-          DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
+      try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+           Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
+           DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
         bit1.run();
         bit2.run();
         client.connect();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestDistributedFragmentRun.java
@@ -43,7 +43,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
   public void oneBitOneExchangeOneEntryRun() throws Exception{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet); DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator());){
+    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.toString(DrillFileUtils.getResourceAsFile("/physical_single_exchange.json"), Charsets.UTF_8));
@@ -63,7 +64,8 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
   public void oneBitOneExchangeTwoEntryRun() throws Exception{
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet); DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator());){
+    try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(QueryType.PHYSICAL, Files.toString(DrillFileUtils.getResourceAsFile("/physical_single_exchange_double_entry.json"), Charsets.UTF_8));
@@ -82,16 +84,17 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
     public void oneBitOneExchangeTwoEntryRunLogical() throws Exception{
         RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-        try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet); DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator());){
-            bit1.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, Files.toString(DrillFileUtils.getResourceAsFile("/scan_screen_logical.json"), Charsets.UTF_8));
-            int count = 0;
-            for(QueryDataBatch b : results){
-                count += b.getHeader().getRowCount();
-                b.release();
-            }
-            assertEquals(100, count);
+        try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+            DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
+          bit1.run();
+          client.connect();
+          List<QueryDataBatch> results = client.runQuery(QueryType.LOGICAL, Files.toString(DrillFileUtils.getResourceAsFile("/scan_screen_logical.json"), Charsets.UTF_8));
+          int count = 0;
+          for (QueryDataBatch b : results) {
+            count += b.getHeader().getRowCount();
+            b.release();
+          }
+          assertEquals(100, count);
         }
 
 
@@ -101,7 +104,9 @@ public class TestDistributedFragmentRun extends PopUnitTestBase{
     public void twoBitOneExchangeTwoEntryRun() throws Exception{
       RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
-      try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet); Drillbit bit2 = new Drillbit(CONFIG, serviceSet); DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator());){
+      try(Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+          Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
+          DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())){
         bit1.run();
         bit2.run();
         client.connect();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TopN/TestTopNSchemaChanges.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TopN/TestTopNSchemaChanges.java
@@ -72,7 +72,7 @@ public class TestTopNSchemaChanges extends BaseTestQuery {
       .ordered()
       .baselineColumns("kl", "vl");
 
-    for (long i = 0; i< 12 ; ++i) {
+    for (long i = 0; i < 12; ++i) {
       if (i %2 == 0) {
         builder.baselineValues(i, i);
       } else {
@@ -102,7 +102,7 @@ public class TestTopNSchemaChanges extends BaseTestQuery {
       .ordered()
       .baselineColumns("kl", "vl");
 
-    for (long i = 0; i< 24 ; i+=2) {
+    for (long i = 0; i < 24; i+=2) {
         builder.baselineValues(i, i);
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggEmitOutcome.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggEmitOutcome.java
@@ -84,7 +84,7 @@ public class TestHashAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
     // First input batch
     RowSetBuilder builder2 = operatorFixture.rowSetBuilder(inputSchema);
     if ( inp2_1 != null ) {
-      for ( int i = 0; i < inp2_1.length ; i++) {
+      for (int i = 0; i < inp2_1.length; i++) {
         builder2 = builder2.addRow(inp2_1[i], inp2_2[i], inp2_3[i]);
       }
     }
@@ -93,7 +93,7 @@ public class TestHashAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
     // Second input batch
     RowSetBuilder builder3 = operatorFixture.rowSetBuilder(inputSchema);
     if ( inp3_1 != null ) {
-      for ( int i = 0; i < inp3_1.length ; i++) {
+      for (int i = 0; i < inp3_1.length; i++) {
         builder3 = builder3.addRow(inp3_1[i], inp3_2[i], inp3_3[i]);
       }
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -55,7 +55,7 @@ public class TestHashAggrSpill extends DrillTest {
      *
      * @throws Exception
      */
-    private void testSpill(long maxMem, long numPartitions, long minBatches, int maxParallel, boolean fallback ,boolean predict,
+    private void testSpill(long maxMem, long numPartitions, long minBatches, int maxParallel, boolean fallback, boolean predict,
                            String sql, long expectedRows, int cycle, int fromPart, int toPart) throws Exception {
         ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
           .sessionOption(ExecConstants.HASHAGG_MAX_MEMORY_KEY,maxMem)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashPartitionTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashPartitionTest.java
@@ -216,7 +216,7 @@ public class HashPartitionTest {
         hashPartition.completeAnInnerBatch(false, false);
         hashPartition.spillThisPartition();
         final String spillFile = hashPartition.getSpillFile();
-        final int batchesCount = hashPartition.getPartitionBatchesCount();;
+        final int batchesCount = hashPartition.getPartitionBatchesCount();
         hashPartition.closeWriter();
 
         SpilledRecordbatch spilledBuildBatch = new SpilledRecordbatch(spillFile, batchesCount, context, buildSchema, operatorContext, spillSet);
@@ -270,8 +270,8 @@ public class HashPartitionTest {
         final BatchSchema probeSchema = new BatchSchema(BatchSchema.SelectionVectorMode.NONE, probeCols);
         final RecordBatch probeBatch = testCase.createProbeBatch(probeSchema, allocator);
 
-        final LogicalExpression buildColExpression = SchemaPath.getSimplePath(buildColB.getName());;
-        final LogicalExpression probeColExpression = SchemaPath.getSimplePath(probeColB.getName());;
+        final LogicalExpression buildColExpression = SchemaPath.getSimplePath(buildColB.getName());
+        final LogicalExpression probeColExpression = SchemaPath.getSimplePath(probeColB.getName());
 
         final JoinCondition condition = new JoinCondition(DrillJoinRel.EQUALITY_CONDITION, probeColExpression, buildColExpression);
         final List<Comparator> comparators = Lists.newArrayList(JoinUtils.checkAndReturnSupportedJoinComparator(condition));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
@@ -336,7 +336,7 @@ public class TestFlatten extends BaseTestQuery {
     // currently runs
     // TODO - re-verify results by hand
     if(RUN_ADVANCED_TESTS){
-      test("select flatten(kvgen(visited_cellid_counts)) as mytb from dfs.`tmp/mapkv.json`") ;
+      test("select flatten(kvgen(visited_cellid_counts)) as mytb from dfs.`tmp/mapkv.json`");
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinSpill.java
@@ -101,7 +101,7 @@ public class TestHashJoinSpill extends PhysicalOpUnitTestBase {
     List<String> rightTable = Lists.newArrayList("[{\"rgt\": 0, \"b\" : \"a string\"}]",
       "[{\"rgt\": 0, \"b\" : \"a different string\"},{\"rgt\": 0, \"b\" : \"yet another\"}]");
     int numRows = 4_000; // 100_000
-    for ( int cnt = 1; cnt <= numRows / 2 ; cnt++ ) { // inner use only half, to check the left-outer join
+    for (int cnt = 1; cnt <= numRows / 2; cnt++) { // inner use only half, to check the left-outer join
       // leftTable.add("[{\"lft\": " + cnt + ", \"a\" : \"a string\"}]");
       rightTable.add("[{\"rgt\": " + cnt + ", \"b\" : \"a string\"}]");
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
@@ -101,7 +101,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
     @Override
     public boolean buildSchema() {
       buildSchemaCalled = true;
-      return ! schemaEOF;
+      return !schemaEOF;
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
@@ -99,7 +99,10 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
     }
 
     @Override
-    public boolean buildSchema() { buildSchemaCalled = true; return ! schemaEOF; }
+    public boolean buildSchema() {
+      buildSchemaCalled = true;
+      return ! schemaEOF;
+    }
 
     @Override
     public boolean next() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestParquetWriter.java
@@ -164,7 +164,7 @@ public class TestParquetWriter extends BaseTestQuery {
     final int numCols = 1000;
     String[] colNames = new String[numCols];
     Object[] values = new Object[numCols];
-    for (int i = 0 ; i < numCols - 1; i++) {
+    for (int i = 0; i < numCols - 1; i++) {
       sb.append(String.format("\"col_%d\" : 100,", i));
       colNames[i] = "col_" + i;
       values[i] = 100L;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMapArray.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMapArray.java
@@ -101,8 +101,7 @@ public class TestResultSetLoaderMapArray extends SubOperatorTest {
       .addRow(30, mapArray(
           mapValue(310, "d3.1"),
           mapValue(320, "d3.2"),
-          mapValue(330, "d3.3")))
-      ;
+          mapValue(330, "d3.3")));
 
     // Verify the first batch
 
@@ -144,8 +143,7 @@ public class TestResultSetLoaderMapArray extends SubOperatorTest {
       .addRow(60, mapArray(
           mapValue(610, "d6.1", "e6.1"),
           mapValue(620, "d6.2", null),
-          mapValue(630, "d6.3", "e6.3")))
-      ;
+          mapValue(630, "d6.3", "e6.3")));
 
     // Verify the second batch
 
@@ -207,8 +205,7 @@ public class TestResultSetLoaderMapArray extends SubOperatorTest {
       .addRow(30, mapArray(
           mapValue(310, strArray("d3.1.1", "d3.2.2")),
           mapValue(320, strArray()),
-          mapValue(330, strArray("d3.3.1", "d1.2.2"))))
-      ;
+          mapValue(330, strArray("d3.3.1", "d1.2.2"))));
 
     // Verify the batch
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
@@ -553,8 +553,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
       .addRow(10, mapValue(intArray(110, 120, 130),
                            strArray("d1.1", "d1.2", "d1.3", "d1.4")))
       .addRow(20, mapValue(intArray(210), strArray()))
-      .addRow(30, mapValue(intArray(), strArray("d3.1")))
-      ;
+      .addRow(30, mapValue(intArray(), strArray("d3.1")));
 
     // Validate first batch
 
@@ -573,15 +572,13 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     rsLoader.startBatch();
     rootWriter
       .addRow(40, mapValue(intArray(410, 420), strArray("d4.1", "d4.2")))
-      .addRow(50, mapValue(intArray(510), strArray("d5.1")))
-      ;
+      .addRow(50, mapValue(intArray(510), strArray("d5.1")));
 
     TupleWriter mapWriter = rootWriter.tuple("m");
     mapWriter.addColumn(SchemaBuilder.columnSchema("e", MinorType.VARCHAR, DataMode.REPEATED));
     rootWriter
       .addRow(60, mapValue(intArray(610, 620), strArray("d6.1", "d6.2"), strArray("e6.1", "e6.2")))
-      .addRow(70, mapValue(intArray(710), strArray(), strArray("e7.1", "e7.2")))
-      ;
+      .addRow(70, mapValue(intArray(710), strArray(), strArray("e7.1", "e7.2")));
 
     // Validate first batch. The new array should have been back-filled with
     // empty offsets for the missing rows.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTorture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTorture.java
@@ -250,7 +250,7 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
     public BatchReader(TestSetup setup, RowSetReader reader, ReadState readState) {
       this.setup = setup;
       this.rootReader = reader;
-      this.readState = readState;;
+      this.readState = readState;
 
       TupleReader m1Reader = rootReader.tuple("m1");
       n1Reader = m1Reader.scalar("n1");
@@ -351,12 +351,11 @@ public class TestResultSetLoaderTorture extends SubOperatorTest {
 
   @Test
   public void tortureTest() {
-    LogFixtureBuilder logBuilder = new LogFixtureBuilder()
+    LogFixtureBuilder logBuilder = new LogFixtureBuilder();
 
         // Enable to get detailed tracing when things go wrong.
 
 //        .logger("org.apache.drill.exec.physical.rowSet", Level.TRACE)
-        ;
     try (LogFixture logFixture = logBuilder.build()) {
       doTortureTest();
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/MiniPlanUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/MiniPlanUnitTestBase.java
@@ -230,7 +230,7 @@ public class MiniPlanUnitTestBase extends PhysicalOpUnitTestBase {
     protected long maxAllocation = MAX_ALLOCATION;
 
     final private List<RecordBatch> inputs = Lists.newArrayList();
-    final PopBuilder parent ;
+    final PopBuilder parent;
 
     public PopBuilder() {
       this.parent = null;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/MiniPlanUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/MiniPlanUnitTestBase.java
@@ -91,14 +91,14 @@ public class MiniPlanUnitTestBase extends PhysicalOpUnitTestBase {
      * @param baselineValues
      * @return
      */
-    public MiniPlanTestBuilder baselineValues(Object ... baselineValues) {
+    public MiniPlanTestBuilder baselineValues(Object... baselineValues) {
       if (baselineRecords == null) {
         baselineRecords = new ArrayList<>();
       }
 
       Map<String, Object> ret = new HashMap<>();
       int i = 0;
-      Preconditions.checkArgument(expectSchema != null , "Expected schema should be set before specify baseline values.");
+      Preconditions.checkArgument(expectSchema != null, "Expected schema should be set before specify baseline values.");
       Preconditions.checkArgument(baselineValues.length == expectSchema.getFieldCount(),
           "Must supply the same number of baseline values as columns in expected schema.");
 
@@ -334,13 +334,13 @@ public class MiniPlanUnitTestBase extends PhysicalOpUnitTestBase {
     }
 
     @SuppressWarnings("unchecked")
-    public T columnsToRead(SchemaPath ... columnsToRead) {
+    public T columnsToRead(SchemaPath... columnsToRead) {
       this.columnsToRead = Lists.newArrayList(columnsToRead);
       return (T) this;
     }
 
     @SuppressWarnings("unchecked")
-    public T columnsToRead(String ... columnsToRead) {
+    public T columnsToRead(String... columnsToRead) {
       this.columnsToRead = Lists.newArrayList();
 
       for (String column : columnsToRead) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/TestNullInputMiniPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/TestNullInputMiniPlan.java
@@ -525,7 +525,7 @@ public class TestNullInputMiniPlan extends MiniPlanUnitTestBase{
         .expectNullBatch(true)
         .go();
 
-    final RecordBatch input2 = createScanBatchFromJson(SINGLE_EMPTY_JSON, SINGLE_EMPTY_JSON2);;
+    final RecordBatch input2 = createScanBatchFromJson(SINGLE_EMPTY_JSON, SINGLE_EMPTY_JSON2);
     RecordBatch batch2 = new PopBuilder()
         .physicalOperator(pop)
         .addInput(input2)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordBatchSizer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordBatchSizer.java
@@ -1333,7 +1333,7 @@ public class TestRecordBatchSizer extends SubOperatorTest {
       ValueVector valueVector1 = mapVector.getChild("value");
       assertEquals(((Integer.highestOneBit(testRowCount * STD_REPETITION_FACTOR) << 1)), keyVector.getValueCapacity());
       offsetVector = ((VariableWidthVector)valueVector1).getOffsetVector();
-      assertEquals((Integer.highestOneBit(testRowCount * STD_REPETITION_FACTOR) << 1) , offsetVector.getValueCapacity());
+      assertEquals((Integer.highestOneBit(testRowCount * STD_REPETITION_FACTOR) << 1), offsetVector.getValueCapacity());
       assertEquals(Integer.highestOneBit(testRowCount * STD_REPETITION_FACTOR << 1)  - 1, valueVector1.getValueCapacity());
 
       // Allocates the same as value passed since it is already power of two.

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
@@ -138,8 +138,8 @@ public class TestDateTypes extends PopUnitTestBase {
 
                 ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals(accessor.getObject(0).toString() ,"1970-01-02 10:20:33.000");
-                assertEquals(accessor.getObject(1).toString() ,"2008-12-28 11:34:00.129");
+                assertEquals(accessor.getObject(0).toString(),"1970-01-02 10:20:33.000");
+                assertEquals(accessor.getObject(1).toString(),"2008-12-28 11:34:00.129");
                 assertEquals(accessor.getObject(2).toString(), "2000-02-27 14:24:00.000");
             }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFileSelection.java
@@ -54,7 +54,7 @@ public class TestFileSelection extends BaseTestQuery {
             {"/tmp", "../etc/bad"},  //  goes outside parent; resolves to /etc/bad
             {"", "/bad"},            //  empty parent
             {"/", ""},               //  empty path
-        } ;
+        };
 
 
     for (int i = 0; i < badPaths.length; i++) {
@@ -82,7 +82,7 @@ public class TestFileSelection extends BaseTestQuery {
             {"/", "etc/tmp/../../good"},   //  no leading slash in path
             {"/", "../good"},              //  resolves to /../good which is OK
             {"/", "/good"}
-        } ;
+        };
 
     for (int i = 0; i < goodPaths.length; i++) {
       try {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetInternalsTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetInternalsTest.java
@@ -39,9 +39,9 @@ public class ParquetInternalsTest extends ClusterTest {
 
   @BeforeClass
   public static void setup( ) throws Exception {
-    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
       // Set options, etc.
-      ;
+
     startCluster(builder);
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetSimpleTestFileGenerator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetSimpleTestFileGenerator.java
@@ -87,7 +87,7 @@ public class ParquetSimpleTestFileGenerator {
           //  "      required int64 _TIMESTAMP_MICROS_int64  ( TIMESTAMP_MICROS ) ; \n" +
           "  required fixed_len_byte_array(12) _INTERVAL_fixed_len_byte_array_12  ( INTERVAL ) ; \n" +
           "  required int96  _INT96_RAW  ; \n" +
-          "} \n" ;
+          "} \n";
   public static String simpleNullableSchemaMsg =
       "message ParquetLogicalDataTypes { \n" +
           "  required int32 rowKey; \n" +
@@ -115,7 +115,7 @@ public class ParquetSimpleTestFileGenerator {
           //  "      optional int64 _TIMESTAMP_MICROS_int64  ( TIMESTAMP_MICROS ) ; \n" +
           "  optional fixed_len_byte_array(12) _INTERVAL_fixed_len_byte_array_12  ( INTERVAL ) ; \n" +
           "  optional int96  _INT96_RAW  ; \n" +
-          "} \n" ;
+          "} \n";
 
   public static String complexSchemaMsg =
       "message ParquetLogicalDataTypes { \n" +
@@ -160,7 +160,7 @@ public class ParquetSimpleTestFileGenerator {
           "      required int96  _INT96_RAW  ; \n" +
           "    } \n" +
           "  } \n" +
-          "} \n" ;
+          "} \n";
   public static String complexNullableSchemaMsg =
       "message ParquetLogicalDataTypes { \n" +
           "  required int32 rowKey; \n" +
@@ -204,7 +204,7 @@ public class ParquetSimpleTestFileGenerator {
           "      optional int96  _INT96_RAW  ; \n" +
           "    } \n" +
           "  } \n" +
-          "} \n" ;
+          "} \n";
 
   public static MessageType simpleSchema = MessageTypeParser.parseMessageType(simpleSchemaMsg);
   public static MessageType complexSchema = MessageTypeParser.parseMessageType(complexSchemaMsg);
@@ -292,7 +292,8 @@ public class ParquetSimpleTestFileGenerator {
           .append("_INT_64", 0x7FFFFFFFFFFFFFFFL)
           .append("_UINT_64", 0xFFFFFFFFFFFFFFFFL)
           .append("_DECIMAL_decimal18", 0xFFFFFFFFFFFFFFFFL);
-      byte[] bytes = new byte[30]; Arrays.fill(bytes, (byte)1);
+      byte[] bytes = new byte[30];
+      Arrays.fill(bytes, (byte)1);
       numeric.addGroup("FixedLen").append("_DECIMAL_fixed_n", Binary.fromConstantByteArray(bytes, 0, 20));
       numeric.addGroup("Binary").append("_DECIMAL_unlimited", Binary.fromConstantByteArray(bytes, 0, 30));
       numeric.addGroup("DateTimeTypes")
@@ -375,7 +376,8 @@ public class ParquetSimpleTestFileGenerator {
     }
     {
       Group simpleGroup = sgf.newGroup();
-      byte[] bytes = new byte[30]; Arrays.fill(bytes, (byte)1);
+      byte[] bytes = new byte[30];
+      Arrays.fill(bytes, (byte)1);
       simpleGroup.append("rowKey", ++rowKey);
       simpleGroup.append("_UTF8", "UTF8 string" + rowKey)
           .append("_Enum", MAX_VALUE.toString())

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetSimpleTestFileGenerator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/ParquetSimpleTestFileGenerator.java
@@ -293,7 +293,7 @@ public class ParquetSimpleTestFileGenerator {
           .append("_UINT_64", 0xFFFFFFFFFFFFFFFFL)
           .append("_DECIMAL_decimal18", 0xFFFFFFFFFFFFFFFFL);
       byte[] bytes = new byte[30];
-      Arrays.fill(bytes, (byte)1);
+      Arrays.fill(bytes, (byte) 1);
       numeric.addGroup("FixedLen").append("_DECIMAL_fixed_n", Binary.fromConstantByteArray(bytes, 0, 20));
       numeric.addGroup("Binary").append("_DECIMAL_unlimited", Binary.fromConstantByteArray(bytes, 0, 30));
       numeric.addGroup("DateTimeTypes")
@@ -377,7 +377,7 @@ public class ParquetSimpleTestFileGenerator {
     {
       Group simpleGroup = sgf.newGroup();
       byte[] bytes = new byte[30];
-      Arrays.fill(bytes, (byte)1);
+      Arrays.fill(bytes, (byte) 1);
       simpleGroup.append("rowKey", ++rowKey);
       simpleGroup.append("_UTF8", "UTF8 string" + rowKey)
           .append("_Enum", MAX_VALUE.toString())

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetComplex.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetComplex.java
@@ -215,10 +215,10 @@ public class TestParquetComplex extends BaseTestQuery {
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns(columns)
-        .baselineValues(mapOf("a","a","b","b")  , 0L                   , 0           , 0        , 0       , 0L                    , 0            , 0       ,0       )
-        .baselineValues(mapOf("a","a","b","b")  , -1L                  , -1          , -1       , -1      , -1L                   , -1           , -1      , -1     )
-        .baselineValues(mapOf("a","a","b","b")  , 1L                   , 1           , 1        , 1       , -9223372036854775808L , 1            , 1       , 1      )
-        .baselineValues(mapOf("a","a","b","b")  , 9223372036854775807L , 2147483647  , 65535    , 255     , 9223372036854775807L  , -2147483648  , -32768  , -128   )
+        .baselineValues(mapOf("a","a","b","b"), 0L, 0, 0, 0, 0L, 0, 0, 0)
+        .baselineValues(mapOf("a","a","b","b"), -1L, -1, -1, -1, -1L, -1, -1, -1)
+        .baselineValues(mapOf("a","a","b","b"), 1L, 1, 1, 1, -9223372036854775808L, 1, 1, 1)
+        .baselineValues(mapOf("a","a","b","b"), 9223372036854775807L, 2147483647, 65535, 255, 9223372036854775807L, -2147483648, -32768, -128)
         .build()
         .run();
   }
@@ -253,23 +253,23 @@ public class TestParquetComplex extends BaseTestQuery {
         " cp.`store/parquet/complex/parquet_logical_types_complex.parquet` t " +
         " order by t.rowKey ";
     String[] columns = {
-        "rowKey " ,
-        "_UTF8" ,
-        "_Enum" ,
-        "_INT32_RAW" ,
-        "_INT_8" ,
-        "_INT_16" ,
-        "_INT_32" ,
-        "_UINT_8" ,
-        "_UINT_16" ,
-        "_UINT_32" ,
-        "_INT64_RAW" ,
-        "_INT_64" ,
-        "_UINT_64" ,
-        "_DATE_int32" ,
-        "_TIME_MILLIS_int32" ,
-        "_TIMESTAMP_MILLIS_int64" ,
-        "_INTERVAL_fixed_len_byte_array_12" ,
+        "rowKey ",
+        "_UTF8",
+        "_Enum",
+        "_INT32_RAW",
+        "_INT_8",
+        "_INT_16",
+        "_INT_32",
+        "_UINT_8",
+        "_UINT_16",
+        "_UINT_32",
+        "_INT64_RAW",
+        "_INT_64",
+        "_UINT_64",
+        "_DATE_int32",
+        "_TIME_MILLIS_int32",
+        "_TIMESTAMP_MILLIS_int64",
+        "_INTERVAL_fixed_len_byte_array_12",
         "_INT96_RAW"
 
     };
@@ -327,23 +327,23 @@ public class TestParquetComplex extends BaseTestQuery {
             " cp.`store/parquet/complex/parquet_logical_types_complex_nullable.parquet` t " +
             " order by t.rowKey ";
     String[] columns = {
-        "rowKey " ,
-        "_UTF8" ,
-        "_Enum" ,
-        "_INT32_RAW" ,
-        "_INT_8" ,
-        "_INT_16" ,
-        "_INT_32" ,
-        "_UINT_8" ,
-        "_UINT_16" ,
-        "_UINT_32" ,
-        "_INT64_RAW" ,
-        "_INT_64" ,
-        "_UINT_64" ,
-        "_DATE_int32" ,
-        "_TIME_MILLIS_int32" ,
-        "_TIMESTAMP_MILLIS_int64" ,
-        "_INTERVAL_fixed_len_byte_array_12" ,
+        "rowKey ",
+        "_UTF8",
+        "_Enum",
+        "_INT32_RAW",
+        "_INT_8",
+        "_INT_16",
+        "_INT_32",
+        "_UINT_8",
+        "_UINT_16",
+        "_UINT_32",
+        "_INT64_RAW",
+        "_INT_64",
+        "_UINT_64",
+        "_DATE_int32",
+        "_TIME_MILLIS_int32",
+        "_TIMESTAMP_MILLIS_int64",
+        "_INTERVAL_fixed_len_byte_array_12",
         "_INT96_RAW"
 
     };

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetPhysicalPlan.java
@@ -54,7 +54,8 @@ public class TestParquetPhysicalPlan extends ExecTest {
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
     DrillConfig config = DrillConfig.create();
 
-    try (Drillbit bit1 = new Drillbit(config, serviceSet); DrillClient client = new DrillClient(config, serviceSet.getCoordinator())) {
+    try (Drillbit bit1 = new Drillbit(config, serviceSet);
+         DrillClient client = new DrillClient(config, serviceSet.getCoordinator())) {
       bit1.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL, Resources.toString(Resources.getResource(fileName),Charsets.UTF_8));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet2/TestDrillParquetReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet2/TestDrillParquetReader.java
@@ -117,10 +117,10 @@ public class TestDrillParquetReader extends BaseTestQuery {
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns(columns)
-        .baselineValues( 0L                   , 0           , 0        , 0       , 0L                    , 0            , 0       ,0       )
-        .baselineValues( -1L                  , -1          , -1       , -1      , -1L                   , -1           , -1      , -1     )
-        .baselineValues( 1L                   , 1           , 1        , 1       , -9223372036854775808L , 1            , 1       , 1      )
-        .baselineValues( 9223372036854775807L , 2147483647  , 65535    , 255     , 9223372036854775807L  , -2147483648  , -32768  , -128   )
+        .baselineValues(0L, 0, 0, 0, 0L, 0, 0, 0)
+        .baselineValues(-1L, -1, -1, -1, -1L, -1, -1, -1)
+        .baselineValues(1L, 1, 1, 1, -9223372036854775808L, 1, 1, 1)
+        .baselineValues(9223372036854775807L, 2147483647, 65535, 255, 9223372036854775807L, -2147483648, -32768, -128)
         .build()
         .run();
   }
@@ -156,23 +156,23 @@ public class TestDrillParquetReader extends BaseTestQuery {
             " order by t.rowKey "
     );
     String[] columns = {
-        "rowKey " ,
-        "_UTF8" ,
-        "_Enum" ,
-        "_INT32_RAW" ,
-        "_INT_8" ,
-        "_INT_16" ,
-        "_INT_32" ,
-        "_UINT_8" ,
-        "_UINT_16" ,
-        "_UINT_32" ,
-        "_INT64_RAW" ,
-        "_INT_64" ,
-        "_UINT_64" ,
-        "_DATE_int32" ,
-        "_TIME_MILLIS_int32" ,
-        "_TIMESTAMP_MILLIS_int64" ,
-        "_INTERVAL_fixed_len_byte_array_12" ,
+        "rowKey ",
+        "_UTF8",
+        "_Enum",
+        "_INT32_RAW",
+        "_INT_8",
+        "_INT_16",
+        "_INT_32",
+        "_UINT_8",
+        "_UINT_16",
+        "_UINT_32",
+        "_INT64_RAW",
+        "_INT_64",
+        "_UINT_64",
+        "_DATE_int32",
+        "_TIME_MILLIS_int32",
+        "_TIMESTAMP_MILLIS_int64",
+        "_INTERVAL_fixed_len_byte_array_12",
         "_INT96_RAW"
 
     };
@@ -231,23 +231,23 @@ public class TestDrillParquetReader extends BaseTestQuery {
             " order by t.rowKey "
     );
     String[] columns = {
-        "rowKey " ,
-        "_UTF8" ,
-        "_Enum" ,
-        "_INT32_RAW" ,
-        "_INT_8" ,
-        "_INT_16" ,
-        "_INT_32" ,
-        "_UINT_8" ,
-        "_UINT_16" ,
-        "_UINT_32" ,
-        "_INT64_RAW" ,
-        "_INT_64" ,
-        "_UINT_64" ,
-        "_DATE_int32" ,
-        "_TIME_MILLIS_int32" ,
-        "_TIMESTAMP_MILLIS_int64" ,
-        "_INTERVAL_fixed_len_byte_array_12" ,
+        "rowKey ",
+        "_UTF8",
+        "_Enum",
+        "_INT32_RAW",
+        "_INT_8",
+        "_INT_16",
+        "_INT_32",
+        "_UINT_8",
+        "_UINT_16",
+        "_UINT_32",
+        "_INT64_RAW",
+        "_INT_64",
+        "_UINT_64",
+        "_DATE_int32",
+        "_TIME_MILLIS_int32",
+        "_TIMESTAMP_MILLIS_int64",
+        "_INTERVAL_fixed_len_byte_array_12",
         "_INT96_RAW"
 
     };

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet2/TestDrillParquetReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet2/TestDrillParquetReader.java
@@ -128,7 +128,8 @@ public class TestDrillParquetReader extends BaseTestQuery {
   @Test //DRILL-5971
   public void testLogicalIntTypes2() throws Exception {
     byte[] bytes12 = {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b' };
-    byte[] bytesOnes = new byte[12]; Arrays.fill(bytesOnes, (byte)1);
+    byte[] bytesOnes = new byte[12];
+    Arrays.fill(bytesOnes, (byte)1);
     byte[] bytesZeros = new byte[12];
     String query = String.format(
         " select " +
@@ -202,7 +203,8 @@ public class TestDrillParquetReader extends BaseTestQuery {
   @Test //DRILL-5971
   public void testLogicalIntTypes3() throws Exception {
     byte[] bytes12 = {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b' };
-    byte[] bytesOnes = new byte[12]; Arrays.fill(bytesOnes, (byte)1);
+    byte[] bytesOnes = new byte[12];
+    Arrays.fill(bytesOnes, (byte)1);
     byte[] bytesZeros = new byte[12];
     String query = String.format(
         " select " +

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -170,9 +170,9 @@ public class TestSplitAndTransfer {
     bitVector.allocateNew(valueCount  + 8); // extra byte at the end that gets filled with junk
     final int[] compareArray = new int[valueCount];
 
-    int testBitValue = 0 ;
+    int testBitValue = 0;
     final BitVector.Mutator mutator = bitVector.getMutator();
-    for (int i = 0; i < valueCount; i ++) {
+    for (int i = 0; i < valueCount; i++) {
       testBitValue = getBit(pattern, i);
       mutator.set(i, testBitValue);
       compareArray[i] = testBitValue;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
@@ -591,7 +591,7 @@ public class TestJsonReader extends BaseTestQuery {
       table_dir.mkdir();
       BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(new File(table_dir, "mostlynulls.json")));
       // Create an entire batch of null values for 3 columns
-      for (int i = 0 ; i < JSONRecordReader.DEFAULT_ROWS_PER_BATCH; i++) {
+      for (int i = 0; i < JSONRecordReader.DEFAULT_ROWS_PER_BATCH; i++) {
         os.write("{\"a\": null, \"b\": null, \"c\": null}".getBytes());
       }
       // Add a row with {bigint,  float, string} values

--- a/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
@@ -627,7 +627,7 @@ public class DrillTestWrapper {
 
       compareMergedVectors(expectedSuperVectors, actualSuperVectors);
     } catch (Exception e) {
-      throw new Exception(e.getMessage() + "\nFor query: " + query , e);
+      throw new Exception(e.getMessage() + "\nFor query: " + query, e);
     } finally {
       cleanupBatches(expected, actual);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
@@ -134,7 +134,8 @@ public class ExampleTest {
 
       ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher).configProperty(ExecConstants.SLICE_TARGET, 10);
 
-      try (ClusterFixture cluster = builder.build(); ClientFixture client = cluster.clientFixture()) {
+      try (ClusterFixture cluster = builder.build();
+           ClientFixture client = cluster.clientFixture()) {
         String sql = "SELECT * FROM `dfs`.`test/employee.json`";
         logger.info(client.queryBuilder().sql(sql).explainJson());
         QuerySummary results = client.queryBuilder().sql(sql).run();

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
@@ -52,7 +52,7 @@ public class QueryRowSetIterator implements Iterator<DirectRowSet>, Iterable<Dir
 
   @Override
   public boolean hasNext() {
-    for ( ; ; ) {
+    for (;;) {
       QueryEvent event = listener.get();
       state = event.state;
       batch = null;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestBuilder.java
@@ -334,7 +334,7 @@ public class TestBuilder {
    * @param baselineValues - the baseline values to validate
    * @return the test builder
    */
-  public TestBuilder baselineValues(Object ... baselineValues) {
+  public TestBuilder baselineValues(Object... baselineValues) {
     assert getExpectedSchema() == null : "The expected schema is not needed when baselineValues are provided ";
     if (ordered == null) {
       throw new RuntimeException("Ordering not set, before specifying baseline data you must explicitly call the ordered() or unOrdered() method on the " + this.getClass().getSimpleName());
@@ -410,7 +410,7 @@ public class TestBuilder {
         baselineTypeMap, baselineOptionSettingQueries, testOptionSettingQueries, highPerformanceComparison, expectedNumBatches);
   }
 
-  public BaselineQueryTestBuilder sqlBaselineQuery(String query, String ...replacements) {
+  public BaselineQueryTestBuilder sqlBaselineQuery(String query, String... replacements) {
     return sqlBaselineQuery(String.format(query, (Object[]) replacements));
   }
 
@@ -471,7 +471,7 @@ public class TestBuilder {
     }
 
     // convenience method to convert minor types to major types if no decimals with precisions are needed
-    public CSVTestBuilder baselineTypes(TypeProtos.MinorType ... baselineTypes) {
+    public CSVTestBuilder baselineTypes(TypeProtos.MinorType... baselineTypes) {
       TypeProtos.MajorType[] majorTypes = new TypeProtos.MajorType[baselineTypes.length];
       int i = 0;
       for(TypeProtos.MinorType minorType : baselineTypes) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestBuilder.java
@@ -442,7 +442,7 @@ public class TestBuilder {
         precision = String.format("(%d,%d)", type.getPrecision(), type.getScale());
         break;
       default:
-        ; // do nothing empty string set above
+        // do nothing empty string set above
     }
     return precision;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -71,7 +71,7 @@ public class TestGracefulShutdown extends BaseTestQuery {
   @Test
   public void testOnlineEndPoints() throws  Exception {
 
-    String[] drillbits = {"db1" ,"db2","db3"};
+    String[] drillbits = {"db1", "db2", "db3"};
     ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withLocalZk().withBits(drillbits);
     enableDrillPortHunting(builder);
 
@@ -142,7 +142,7 @@ public class TestGracefulShutdown extends BaseTestQuery {
   @Test
   public void testRestApiShutdown() throws Exception {
 
-    String[] drillbits = {"db1" ,"db2", "db3"};
+    String[] drillbits = {"db1", "db2", "db3"};
     ClusterFixtureBuilder builder = ClusterFixture.bareBuilder(dirTestWatcher).withLocalZk().withBits(drillbits);
     enableWebServer(builder);
     QueryBuilder.QuerySummaryFuture listener;

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestFixedWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestFixedWidthWriter.java
@@ -401,7 +401,7 @@ public class TestFixedWidthWriter extends SubOperatorTest {
       });
       writer.startWrite();
       try {
-        for (int i = 0; ; i++ ) {
+        for (int i = 0;; i++ ) {
           index.index = i;
           writer.startRow();
           writer.setInt(i);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestOffsetVectorWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestOffsetVectorWriter.java
@@ -384,7 +384,7 @@ public class TestOffsetVectorWriter extends SubOperatorTest {
       });
       writer.startWrite();
       try {
-        for (int i = 0; ; i++ ) {
+        for (int i = 0;; i++ ) {
           index.index = i;
           writer.startRow();
           writer.setNextOffset(i);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariableWidthWriter.java
@@ -382,7 +382,7 @@ public class TestVariableWidthWriter extends SubOperatorTest {
       byte value[] = new byte[423];
       Arrays.fill(value, (byte) 'X');
       try {
-        for (int i = 0; ; i++ ) {
+        for (int i = 0;; i++ ) {
           index.index = i;
           writer.startRow();
           writer.setBytes(value, value.length);

--- a/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
+++ b/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
@@ -175,7 +175,8 @@ public class ITTestShadedJar {
   private static void printQuery(Connection c, String query) throws SQLException {
     final StringBuilder sb = new StringBuilder();
 
-    try (Statement s = c.createStatement(); ResultSet result = s.executeQuery(query)) {
+    try (Statement s = c.createStatement();
+         ResultSet result = s.executeQuery(query)) {
       while (result.next()) {
         final int columnCount = result.getMetaData().getColumnCount();
         for(int i = 1; i < columnCount+1; i++){

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillColumnMetaDataList.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillColumnMetaDataList.java
@@ -128,10 +128,16 @@ public class DrillColumnMetaDataList extends BasicList<ColumnMetaData>{
 
       final int nullability;
       switch ( field.getDataMode() ) {
-        case OPTIONAL: nullability = ResultSetMetaData.columnNullable; break;
-        case REQUIRED: nullability = ResultSetMetaData.columnNoNulls;  break;
+        case OPTIONAL:
+          nullability = ResultSetMetaData.columnNullable;
+          break;
+        case REQUIRED:
+          nullability = ResultSetMetaData.columnNoNulls;
+          break;
         // Should REPEATED still map to columnNoNulls? or to columnNullable?
-        case REPEATED: nullability = ResultSetMetaData.columnNoNulls;  break;
+        case REPEATED:
+          nullability = ResultSetMetaData.columnNoNulls;
+          break;
         default:
           throw new AssertionError( "Unexpected new DataMode value '"
                                     + field.getDataMode().name() + "'" );

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/ProxiesManager.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/proxy/ProxiesManager.java
@@ -107,8 +107,7 @@ class ProxiesManager {
       catch ( InstantiationException | IllegalAccessException
               | IllegalArgumentException | InvocationTargetException
               | NoSuchMethodException | SecurityException e ) {
-        throw new RuntimeException(
-            "Error creating proxy for " + declaredType + ": " + e , e );
+        throw new RuntimeException("Error creating proxy for " + declaredType + ": " + e, e);
       }
     }
     return proxyInstance;

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
@@ -258,7 +258,7 @@ public class PreparedStatementTest extends JdbcTestBase {
   public void testDefaultGetQueryTimeout() throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(SYS_VERSION_SQL)) {
       int timeoutValue = stmt.getQueryTimeout();
-      assertEquals( 0L , timeoutValue );
+      assertEquals(0L, timeoutValue);
     }
   }
 
@@ -288,7 +288,7 @@ public class PreparedStatementTest extends JdbcTestBase {
       int valueToSet = new Random(20150304).nextInt(59)+1;
       logger.info("Setting timeout as {} seconds", valueToSet);
       stmt.setQueryTimeout(valueToSet);
-      assertEquals( valueToSet , stmt.getQueryTimeout() );
+      assertEquals(valueToSet, stmt.getQueryTimeout());
     }
   }
 
@@ -306,7 +306,7 @@ public class PreparedStatementTest extends JdbcTestBase {
         rs.getBytes(1);
         rowCount++;
       }
-      assertEquals( 3 , rowCount );
+      assertEquals(3, rowCount);
     }
   }
 
@@ -406,7 +406,7 @@ public class PreparedStatementTest extends JdbcTestBase {
         rs.getBytes(1);
         rowCount++;
       }
-      assertEquals( 1 , rowCount );
+      assertEquals(1, rowCount);
     }
   }
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementTest.java
@@ -83,7 +83,7 @@ public class StatementTest extends JdbcTestBase {
   public void testDefaultGetQueryTimeout() throws SQLException {
     try(Statement stmt = connection.createStatement()) {
       int timeoutValue = stmt.getQueryTimeout();
-      assertEquals( 0 , timeoutValue );
+      assertEquals( 0, timeoutValue );
     }
   }
 
@@ -116,7 +116,7 @@ public class StatementTest extends JdbcTestBase {
       int valueToSet = new Random(20150304).nextInt(59)+1;
       logger.info("Setting timeout as {} seconds", valueToSet);
       stmt.setQueryTimeout(valueToSet);
-      assertEquals( valueToSet , stmt.getQueryTimeout() );
+      assertEquals( valueToSet, stmt.getQueryTimeout() );
     }
   }
 
@@ -135,7 +135,7 @@ public class StatementTest extends JdbcTestBase {
         rs.getBytes(1);
         rowCount++;
       }
-      assertEquals( 3 , rowCount );
+      assertEquals( 3, rowCount );
     }
   }
 
@@ -235,7 +235,7 @@ public class StatementTest extends JdbcTestBase {
         rs.getBytes(1);
         rowCount++;
       }
-      assertEquals( 1 , rowCount );
+      assertEquals( 1, rowCount );
     }
   }
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementTest.java
@@ -83,7 +83,7 @@ public class StatementTest extends JdbcTestBase {
   public void testDefaultGetQueryTimeout() throws SQLException {
     try(Statement stmt = connection.createStatement()) {
       int timeoutValue = stmt.getQueryTimeout();
-      assertEquals( 0, timeoutValue );
+      assertEquals(0, timeoutValue);
     }
   }
 

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/BaseAllocator.java
@@ -788,8 +788,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   public static enum Verbosity {
     BASIC(false, false), // only include basic information
     LOG(true, false), // include basic
-    LOG_WITH_STACKTRACE(true, true) //
-    ;
+    LOG_WITH_STACKTRACE(true, true);
 
     public final boolean includeHistoricalLog;
     public final boolean includeStackTraces;

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcBus.java
@@ -135,7 +135,6 @@ public abstract class RpcBus<T extends EnumLite, C extends RemoteConnection> imp
 
         }
       }
-      ;
     }
   }
 

--- a/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
@@ -59,7 +59,7 @@ public class BooleanOperator extends FunctionCall{
       i++;
     }
 
-    return (int) (cost / i) ;
+    return cost / i;
   }
 
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/IfExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/IfExpression.java
@@ -153,7 +153,7 @@ public class IfExpression extends LogicalExpressionBase {
       i++;
     }
 
-    return (int) (cost / i) ;
+    return cost / i;
   }
 
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/NullExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/NullExpression.java
@@ -53,7 +53,7 @@ public class NullExpression implements LogicalExpression{
     return Iterators.emptyIterator();
   }
 
-  public int getSelfCost() { return 0 ; }
+  public int getSelfCost() { return 0; }
 
   public int getCumulativeCost() { return 0; }
 

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>5.9</version>
+            <version>7.8.2</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/src/main/resources/checkstyle-config.xml
+++ b/src/main/resources/checkstyle-config.xml
@@ -44,14 +44,6 @@
 
   <module name="FileTabCharacter"/>
 
-  <!--
-    This check is necessary because none of the existing checks catch consecutive semicolons in imports.
-  -->
-  <module name="RegexpSingleline">
-    <property name="format" value=";;$"/>
-    <property name="message" value="A line of code cannot end with multiple semicolons."/>
-  </module>
-
   <module name="RegexpSingleline">
     <property name="format" value="\s+$"/>
     <property name="message" value="A line of code cannot contain any trailing whitespace"/>

--- a/src/main/resources/checkstyle-config.xml
+++ b/src/main/resources/checkstyle-config.xml
@@ -36,9 +36,21 @@
     <module name="AvoidStarImport"/>
     <module name="NeedBraces"/>
     <module name="PackageDeclaration"/>
+    <module name="EmptyStatement"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OneStatementPerLine"/>
+
   </module>
 
   <module name="FileTabCharacter"/>
+
+  <!--
+    This check is necessary because none of the existing checks catch consecutive semicolons in imports.
+  -->
+  <module name="RegexpSingleline">
+    <property name="format" value=";;$"/>
+    <property name="message" value="A line of code cannot end with multiple semicolons."/>
+  </module>
 
   <module name="RegexpSingleline">
     <property name="format" value="\s+$"/>


### PR DESCRIPTION
Due to this jdk bug https://bugs.openjdk.java.net/browse/JDK-8072390, IntelliJ and openjdk 7 and 8 allow extra semicolons in imports. This is technically disallowed by the java spec and results in a compilation issue in eclipse. This resulted in this issue https://issues.apache.org/jira/browse/DRILL-6650. This change adds some checkstyle regexes to prevent a similar mistake from being repeated.

This PR adds the following checkstyle checks:

1. Disallow lines starting with a semicolon.
2. Disallow two consecutive semicolons separated by nothing but whitespace. 
3. Disallowing empty statements in java statements. This check does not effect semicolons in imports; however, since we are already fixing semicolons in imports we might as well fix them everywhere.

The first two checks catch semicolons in imports, but as a side effect also detect strange usages of semicolons in the body of a java files. As a result things like the following are disallowed as well:

```
for (;;
) {
}
```

or 

```
new Builder()
   .someStuff()
   .thatStuff()
  .build()
;
```

But I think we should disallow these strange usages of semicolons anyway.