### PR TITLE
DRILL-6409: Updates mongo-java-driver to 3.8.0

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -45,7 +45,7 @@
   <dependency>
     <groupId>org.mongodb</groupId>
     <artifactId>mongo-java-driver</artifactId>
-    <version>3.2.0</version>
+    <version>3.8.0</version>
   </dependency>
 
     <!-- Test dependencie -->

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.2.0</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
This driver solves an issue with displaying BigDecimal data from MongoDB.