### PR TITLE
DRILL-6645: Transform TopN in Lateral Unnest pipeline to Sort and Limit.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/AggPrelBase.java
@@ -189,7 +189,7 @@ public abstract class AggPrelBase extends DrillAggregateRelBase implements Prel 
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     List<Integer> groupingCols = Lists.newArrayList();
     groupingCols.add(0);
     for (int groupingCol : groupSet.asList()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/FilterPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/FilterPrel.java
@@ -85,7 +85,7 @@ public class FilterPrel extends DrillFilterRelBase implements Prel {
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     RexBuilder builder = this.getCluster().getRexBuilder();
     // right shift the previous field indices.
     return (Prel) this.copy(this.traitSet, children.get(0), DrillRelOptUtil.transformExpr(builder,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/LimitPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/LimitPrel.java
@@ -111,7 +111,7 @@ public class LimitPrel extends DrillLimitRelBase implements Prel {
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     return new LimitPrel(this.getCluster(), this.traitSet, children.get(0), getOffset(), getFetch(), isPushDown(), true);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/Prel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/Prel.java
@@ -56,7 +56,13 @@ public interface Prel extends DrillRelNode, Iterable<Prel> {
   SelectionVectorMode getEncoding();
   boolean needsFinalColumnReordering();
 
-  default Prel addImplicitRowIDCol(List<RelNode> children) {
+  /**
+   * If the operator is in Lateral/Unnest pipeline, then it generates a new operator which knows how to process
+   * the rows accordingly during execution.
+   * eg: TopNPrel -> SortPrel and LimitPrel
+   * Other operators like FilterPrel, ProjectPrel etc will add an implicit row id to the output.
+   */
+  default Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     throw new UnsupportedOperationException("Adding Implicit RowID column is not supported for " +
             this.getClass().getSimpleName() + " operator ");
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ProjectPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ProjectPrel.java
@@ -136,7 +136,7 @@ public class ProjectPrel extends DrillProjectRelBase implements Prel{
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     RelDataTypeFactory typeFactory = this.getCluster().getTypeFactory();
     RexBuilder builder = this.getCluster().getRexBuilder();
     List<RexNode> projects = Lists.newArrayList();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SelectionVectorRemoverPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SelectionVectorRemoverPrel.java
@@ -55,7 +55,7 @@ public class SelectionVectorRemoverPrel extends SinglePrel{
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     return (Prel) this.copy(this.traitSet, children);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrel.java
@@ -124,7 +124,7 @@ public class SortPrel extends org.apache.calcite.rel.core.Sort implements Prel {
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     List<RelFieldCollation> relFieldCollations = Lists.newArrayList();
     relFieldCollations.add(new RelFieldCollation(0,
                             RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.FIRST));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnnestPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnnestPrel.java
@@ -86,7 +86,7 @@ public class UnnestPrel extends DrillUnnestRelBase implements Prel {
   }
 
   @Override
-  public Prel addImplicitRowIDCol(List<RelNode> children) {
+  public Prel prepareForLateralUnnestPipeline(List<RelNode> children) {
     RelDataTypeFactory typeFactory = this.getCluster().getTypeFactory();
     List<String> fieldNames = new ArrayList<>();
     List<RelDataType> fieldTypes = new ArrayList<>();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/LateralUnnestRowIDVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/LateralUnnestRowIDVisitor.java
@@ -43,7 +43,7 @@ public class LateralUnnestRowIDVisitor extends BasePrelVisitor<Prel, Boolean, Ru
   public Prel visitPrel(Prel prel, Boolean isRightOfLateral) throws RuntimeException {
     List<RelNode> children = getChildren(prel, isRightOfLateral);
     if (isRightOfLateral) {
-      return prel.addImplicitRowIDCol(children);
+      return prel.prepareForLateralUnnestPipeline(children);
     } else {
       return (Prel) prel.copy(prel.getTraitSet(), children);
     }
@@ -61,7 +61,7 @@ public class LateralUnnestRowIDVisitor extends BasePrelVisitor<Prel, Boolean, Ru
   @Override
   public Prel visitLateral(LateralJoinPrel prel, Boolean value) throws RuntimeException {
     List<RelNode> children = Lists.newArrayList();
-    children.add(((Prel)prel.getInput(0)).accept(this, false));
+    children.add(((Prel)prel.getInput(0)).accept(this, value));
     children.add(((Prel) prel.getInput(1)).accept(this, true));
 
     return (Prel) prel.copy(prel.getTraitSet(), children);
@@ -69,6 +69,6 @@ public class LateralUnnestRowIDVisitor extends BasePrelVisitor<Prel, Boolean, Ru
 
   @Override
   public Prel visitUnnest(UnnestPrel prel, Boolean value) throws RuntimeException {
-    return prel.addImplicitRowIDCol(null);
+    return prel.prepareForLateralUnnestPipeline(null);
   }
 }


### PR DESCRIPTION

In Lateral/Unnest pipeline, for the sake of getting correct results it is required to introduce a ParitionLimit instead of Limit. ParitionLimit is introduced by PR for DRILL-6652. Similarly a TopN should have another version like PartitionTopN. Since ParitionTopN operator is not yet implemented we can use Limit and sort to replace a TopN. This PR includes changes to transform the TopN -> Sort and Limit.

@gparai  @sohami  Can you please review these changes.

This PR needs to be committed after the DRILL-6652 committed.