### PR TITLE
DRILL-6676: Add Union, List and Repeated List types to Result Set Loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ CMakeFiles
 Makefile
 cmake_install.cmake
 install_manifest.txt
+.*.md.html
+*.swp
 # TODO - DRILL-4336
 exec/jdbc-all/dependency-reduced-pom.xml

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/README.md
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/README.md
@@ -1,0 +1,359 @@
+# Result Set Loader Overview
+
+Please see `/vector/src/main/java/org/apache/drill/exec/vector/accessor/Overview.md`
+for the basics.
+
+The result set loader assembles batches, handles projection, allocates
+batches, creates writers, handles overflow and more.
+
+## Requirements
+
+To understand the result set loader, it helps to start with requirements:
+
+* Write to a set of batches (together, the "result set")
+* Create and allocate the vectors and buffers needed for each batch
+* Allow "early schema" (known up front) and "late schema" (discovered on
+the fly)
+* Use the column writers to write data
+* Orchestrate the vector overflow process
+* Support projection push-down
+* Implement the "vector persistence" required by Drill's iterator protocol
+
+An informal requirement is to keep the application-facing API as simple as
+possible.
+
+## Lifecycle
+
+Another way to get a handle on the result set loader is to consider a
+typical lifecycle:
+
+* Setup
+  * Optionally specify a schema
+  * Optionally specify a set of projected columns
+* Per Batch
+  * Start the batch
+  * Write rows to the batch
+  * Handle overflow, if required
+  * Harvest the batch
+* Wrap-up
+  * Release resources
+
+## Structure
+
+The result set loader API is meant to be simple. See
+[`TestResultSetLoaderProtocol`](https://github.com/apache/drill/blob/master/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderProtocol.java)`.testInitialSchema()`
+for a simple example of the public API. (This test uses the test-only dynamic
+mechanism to write rows, but would work equally well using the form shown in the
+column writers section of the overview mentioned above.)
+
+The simple API masks a complex internal structure. The structure must handle
+a number of tasks:
+
+* Hold onto the set of columns that make up a row (or map)
+* For each column, hold onto the vector and its column writer
+* Orchestrate activities that involve both the vectors and writers (such as
+allocation, overflow and so on.)
+
+The classes that manage the write-time state are called "state" classes. It
+has been pointed out that this is confusing. These are not "state" in the
+sense of the name of a state. Rather, they are "state" in the sense of the
+opposite of "stateless." Writers and vectors are stateless, the column and
+other state add a stateful layer on top of them.
+
+### Result Set Loader Implementation
+
+The result set loader implementation class is
+[`ResultSetLoaderImpl`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java).
+Its primary task is to implement the lifecycle API, maintain a state machine
+that tracks the lifecycle, and hold onto the root row structure.
+
+### Tuple State
+
+Every batch is made of rows. A row is a collection of columns. The tuple state
+maintains the list of columns for the row. The same class also maintains the
+state for a map. (In Drill, rows and maps are both tuples.)
+
+The tuple state accepts events from the result set loader and passes them down
+to each contained column. The tuple state is also the unit of schema evolution:
+it implements the callback from the tuple writer to add a column.
+
+The tuple state is mostly a collection of very specific operations: the best way
+to understand it is simply to read the code and the ample comments within the code.
+
+### Column State
+
+A row is made up of columns (some of which are maps that contain another tuple.)
+A column is defined by three key attributes:
+
+* Metadata
+* Vector
+* Writer
+
+If the column is a map then it will also hold onto a tuple schema for the map,
+creating a recursive tree structure. (A similar structure exists for unions.)
+
+The column state implements a state machine that tracks the column lifecycle:
+
+* Normal: column is being written
+* Overflow: the column has overflowed and has data "rolled over" to the "overflow"
+batch.
+* LookAhead: the previous row has been harvested. The roll-over data is now in
+the main batch.
+* NewLookAhead: the column was added in the overflow row. It did not exist in
+the harvest row, but exists internally and will exist in the next batch.
+
+The job of the column state is to "do the right thing" in response to various
+events in the states defined above. Please see the code for a much more complete
+description as the set of operations best understood at the code level.
+
+### Vector State
+
+Most columns hold onto a vector. (The exception is a map as we'll discuss
+below.) If the column is unprojected (see below), then the vector might be
+null. Further, different vectors have different internal structure: nullable
+vectors, for example, have two "real" vectors: the bits and the data.
+
+The vector state abstracts away this complexity by providing a defined API
+that is implemented as needed for the various cases described above. This
+allows the column state to be much simpler: the same "primitive" column
+state can handle required, optional and repeated vectors since the differences
+are handed within the vector state.
+
+In addition, when overflow occurs, the column state will maintain two
+vectors: one for the full batch, another for the "look ahead" batch. By
+encapsulating the vector behavior in the vector state, the column state
+need not contain either redundant code, nor if-statements, to work with the
+two vectors.
+
+### Column Builder
+
+By now it should be clear that quite a bit of machinery is needed to
+maintain a column. For a primitive column we need the vector, the vector
+state, the writer, the column state. Arrays and maps add additional structure.
+Building this structure is a task in its own right.
+
+The [`ColumnBuilder`](https://github.com/apache/drill/blob/master/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/schema/ColumnBuilder.java)
+class tackles this work. It also handles the task of parsing metadata to
+determine which kind of column to create. While "mainstream" Drill has only
+a few types, the addition of unions, lists and repeated lists adds quite a
+bit of complexity.
+
+## Vector Overflow
+
+All of the above machinery is in support of one specific task: handling
+vector overflow. As noted in previous sections, overflow occurs when we
+decide that we have a value to write to a vector, do not have room in the
+vector, and decide that we don't want to increase the size of the vector.
+Instead, we create a new vector and place the data in that new vector.
+
+### Overflow Use Cases
+
+This turns out to be extremely finicky. We must handle many cases such as:
+
+* For a simple fixed-width vector, simply create the new vector and write
+the value in the first position of that new vector.
+* For an array of fixed-width values, we must also copy all previous values
+for the same row. (If the array is multi-dimensional (an array of maps
+containing an array of `INT`s, say), we must copy values for all arrays in
+the current row.)
+* For a `VarChar` or array vector, we must consider the offset vector. We
+cannot simply copy the offsets, since the offsets are different in the new
+vector. Instead, we must use the "old" offset values to calculate new offset
+values for the new vector.
+
+The tuple state, column state and vector state classes were created as a
+way to manage the complexity of this process: each handles one particular
+bit of the process, delegating work downward. For example, when working with
+arrays, the array column state will determine the extent of the array, then
+push that data downward. (In practice, this is maintained as row-start
+positions in the associated writer index.)
+
+### Look-ahead Vectors
+
+Overflow works by maintaining two vectors: the "main" vector that holds the
+data to be "harvested" for the current batch, and a "look-ahead" batch
+holding the first row of data for the next batch. Rather than move the data
+twice (from main batch to overflow and back), we "exchange" buffers between
+the two batches. (This is like a transfer pair, but bidirectional.)
+
+One implication of this design is that, when doing memory planning for an
+operator that uses this mechanism, assign the operator *2* batch units: one
+for the main batch, another for the overflow.
+
+### Schema Considerations
+
+Consider how to requirements cited above interact. Suppose an application
+writes a row and encounters overflow. Suppose that, in the same row, the
+application decides to add column `x`. The only value for 'x' will be
+written into the look-ahead batch. What do we do?
+
+We have two choices:
+
+* Include column `x` in the full batch, even though all its values will
+be NULL.
+* Omit `x` from the full batch, but add it to the next batch.
+
+One could argue both cases. The current code choose the second. The reason
+is this. Suppose that overflow occurred on row 1000. The batch that results
+will contain rows 1-999.
+
+Suppose that, rather than overflowing, the application had decided to stop
+reading just before the overflow row. The resulting batch would contain rows
+1-999 and would not contain column `x`. (`x` will be in the next batch.)
+
+The application receiving the batch should not know or care which case
+occurred: overflow or stopping at 999. To keep things simple, we make
+the overflow case look like the stop-at-999 case by omitting column `x`.
+
+### Implementation Details
+
+The best way to understand this process is to read the code, run the
+tests, and step through the process. Expect to be confused the first
+few times. (Heck, *I* wrote it and *I'm* still confused at times.) Focus
+on each part rather than trying to understand the entire process in on go.
+
+## Projection
+
+As explained earlier, the result set loader mechanism is designed to help
+with projection. Suppose that the query asks for columns ('b', 'a'). Suppose
+that that we are in a scan operator and that the reader works with a table
+that can provide rows ('a', 'c'). Several steps are needed to project the
+table schema to the query schema.
+
+The result set loader takes the project list. Each time the application
+(record reader in this case) asks to add a column, the result set loader
+consults its project list. Suppose the record reader adds column `a`. The
+result set loader notices that `a` is projected and thus creates a vector,
+writer column state and so on as described above.
+
+Then, the record reader asks to create column `c`. The result set loader
+finds that `c` is not projected. But, the record reader presumably wants
+to write the values anyway (such as for CSV.) So, the result set loader
+constructs a "dummy" column that has a dummy writer, but with no underlying
+vector.
+
+The example above illustrates work that must be done elsewhere: how to fill
+in the missing column `b`, and how to reorder the table columns into the
+order desired by the query. That is the job of the projection mechanism in
+the scan operator. (This discussion again highlights a key design philosophy:
+break tasks into small pieces, then build up the complete functionality via
+composition.)
+
+## Schema Versioning
+
+The result set loader allows the application to add columns at any time.
+Within a batch, the loader needs to know if a column has been added since
+the last "harvest." The traditional solution in Drill is to add a "schema
+has changed" flag. But, this raises two questions: "changed since when?"
+and "who resets the flag?"
+
+To avoid the ambiguity inherent in a flag, the result set loader uses a
+schema version. The version is bumped each time a new column is added. So,
+the version starts at 0. Add column "a" and the version bumps to 1. And so on.
+
+The number is used internally (discussed below.) It is also visible to the
+application. The application can compare the versions of two results to
+determine if the schema has changed since the previous output batch.
+
+## Harvest Operation
+
+We now have enough background to consider the "harvest" operation: the
+task of creating an output batch.
+
+The result set loader uses tuple, column and vector states to track vectors.
+It *does not* use a `VectorContainer`. So, the first job of harvest is to
+assemble that vector container. To do this, the first harvest:
+
+* Create a `VectorContainer` to hold the output batch.
+* Add all columns to the vector container in the order they were added to
+the writer (which is the order they appear in the tuple writer, map writer
+and so on.)
+* But, exclude columns added since overflow. (Clearly, those must always be
+the last columns in any row or map.)
+* Remember the schema version at the time of the harvest.
+* Make the output container and the schema version available to the application.
+
+Note a special case for the output version number. It must be the version
+number at the end of the last non-overflow row. That is, we do not include
+columns (and thus their version numbers) added in the overflow row.
+
+Then, on the next harvest:
+
+* Spin through columns, adding those added since the previous version (again
+excluding newly added overflow columns.)
+* Update the output version.
+
+### Maps
+
+We mentioned above that the result set loader does not maintain its vectors
+in a vector container; instead it assembles the container at harvest time.
+We also noted that maps and rows are both tuples. So, extending our logic,
+we also do not maintain map vectors for maps. Instead, the map vector is
+created only in the output container. (In Drill, a map vector is not a true
+vector: it has no memory buffer. It is just a container for the map members.)
+Repeated maps are a bit different. We keep only the offset vector in the
+result set loader. We create the repeated map vector in the output, then
+populate it with both the member vectors and the offset vector.
+
+### Unions
+
+Unions should probably follow the same rules as for maps and rows. (A union
+is a "tuple" but one keyed by type, not name.) But, since union vectors are
+barely supported, we did not go through the trouble of fancy schema management.
+Instead, the full vector schema is always available. This rule cascades to
+maps within the unions and so on.
+
+## Vector Persistence
+
+The result set loader is designed to work with a single record reader since
+each reader should define its schema independent of any other reader that
+happens to exist in the same scan operator. That is, the behavior of a record
+reader should not depend on which readers might have preceded it in the scan
+operator. (If it did, we'd have a very large number of cases to test.)
+
+Drill, however, requires that the scan operator provide not just the same set
+of columns ("a", "b" and "c", say), but that it provides the same *vectors*
+for those columns.
+
+So, we've got a challenge. Each reader should be independent. But, they must
+oordinate to use the same vectors. What do we do?
+
+The result set loader solves the problem with a
+[`ResultVectorCache`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/ResultVectorCache.java).
+This cache, holds onto all vectors created at that level. When a reader asks
+to create a new column, the result set loader first checks the cache, and
+reuses any existing vector. Otherwise, it creates a new vector and adds it
+to the cache for possible reuse later.
+
+The result is that we achieve both goals. Readers have complete control over
+their schema and output schema. But, if the readers do define the same columns,
+they will end up using the same vectors.
+
+There is not just one cache, but potentially many. Each tuple has its own.
+There is one for the top-level row. If that row contains a map, then the map
+gets its own cache. The same is true for unions, lists and repeated lists.
+
+## Unit Tests
+
+This page has described a number of complex mechanisms. There is quite a bit
+that must work together, and quite a bit to go wrong.
+
+An [extensive set of unit tests](https://github.com/paul-rogers/drill/tree/RowSetRev3/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl)
+exists for the mechanism. When making changes, start with the basic tests, then
+work toward the most complex (the "torture" test).
+
+Also, when making changes, **add new tests**. This mechanism is far to complex
+to test the traditional way: make a change, run a query, and declare victory.
+You must exercise every code path with a unit test so you can catch issues
+early and in a form that the issues can be debugged. Waiting to find issues
+in integration tests will waste a huge amount of time, will be quite
+frustrating, and will thus slow the adoption and evolution of the feature.
+
+For debugging, it works best to use Test-Driven Development (TDD). Find a
+uitable test and run it. Make your change. Create new tests (or extend
+existing ones) to exercise the new case (in all its code paths!) Run those
+tests. Then, run all the related tests to catch regressions.
+
+Is your change so simple (or under such time pressure) that you don't need
+the above? If so, go back to the top of this section and reread it: you
+don't have time to *not* test.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/BuildFromSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/BuildFromSchema.java
@@ -19,19 +19,31 @@ package org.apache.drill.exec.physical.rowSet.impl;
 
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
 
 /**
  * Build the set of writers from a defined schema. Uses the same
  * mechanism as dynamic schema: walks the schema tree adding each
- * column, then recursively adding the contents of maps and variants.
+ * column, then recursively adds the contents of maps and variants.
  * <p>
  * Recursion is much easier if we can go bottom-up. But, writers
  * require top-down construction.
  */
 
 public class BuildFromSchema {
+
+  /**
+   * The shim interface provides a uniform way to add a column
+   * to a parent structured column writer without the need for
+   * a bunch of if-statements. Tuples (i.e. maps), UNIONs and
+   * repeated LISTs all are structured (composite) columns,
+   * but have slightly different semantics. This shim wraps
+   * the semantics so the builder code is simpler.
+   */
 
   private interface ParentShim {
     ObjectWriter add(ColumnMetadata colSchema);
@@ -46,8 +58,34 @@ public class BuildFromSchema {
 
     @Override
     public ObjectWriter add(ColumnMetadata colSchema) {
-      int index = writer.addColumn(colSchema);
+      final int index = writer.addColumn(colSchema);
       return writer.column(index);
+    }
+  }
+
+  private static class UnionShim implements ParentShim {
+    private final VariantWriter writer;
+
+    public UnionShim(VariantWriter writer) {
+      this.writer = writer;
+    }
+
+    @Override
+    public ObjectWriter add(ColumnMetadata colSchema) {
+      return writer.addMember(colSchema);
+    }
+  }
+
+  private static class RepeatedListShim implements ParentShim {
+    private final RepeatedListWriter writer;
+
+    public RepeatedListShim(RepeatedListWriter writer) {
+      this.writer = writer;
+    }
+
+    @Override
+    public ObjectWriter add(ColumnMetadata colSchema) {
+      return writer.defineElement(colSchema);
     }
   }
 
@@ -60,21 +98,37 @@ public class BuildFromSchema {
    */
 
   public void buildTuple(TupleWriter writer, TupleMetadata schema) {
-    ParentShim tupleShim = new TupleShim(writer);
+    final ParentShim tupleShim = new TupleShim(writer);
     for (int i = 0; i < schema.size(); i++) {
-      ColumnMetadata colSchema = schema.metadata(i);
+      final ColumnMetadata colSchema = schema.metadata(i);
       buildColumn(tupleShim, colSchema);
     }
   }
 
   private void buildColumn(ParentShim parent, ColumnMetadata colSchema) {
 
-    if (colSchema.isMap()) {
+    if (colSchema.isMultiList()) {
+      buildRepeatedList(parent, colSchema);
+    } else if (colSchema.isMap()) {
       buildMap(parent, colSchema);
+    } else if (isSingleList(colSchema)) {
+      buildSingleList(parent, colSchema);
+    } else if (colSchema.isVariant()) {
+      buildVariant(parent, colSchema);
     } else {
       buildPrimitive(parent, colSchema);
     }
   }
+
+  /**
+   * Determine if the schema represents a column with a LIST type that
+   * includes elements all of a single type. (Lists can be of a single
+   * type (with nullable elements) or can be of unions.)
+   *
+   * @param colSchema schema for the column
+   * @return true if the column is of type LIST with a single
+   * element type
+   */
 
   private boolean isSingleList(ColumnMetadata colSchema) {
     return colSchema.isVariant() && colSchema.isArray() && colSchema.variantSchema().isSingleType();
@@ -85,7 +139,7 @@ public class BuildFromSchema {
   }
 
   private void buildMap(ParentShim parent, ColumnMetadata colSchema) {
-    ObjectWriter colWriter = parent.add(colSchema.cloneEmpty());
+    final ObjectWriter colWriter = parent.add(colSchema.cloneEmpty());
     expandMap(colWriter, colSchema);
   }
 
@@ -94,6 +148,93 @@ public class BuildFromSchema {
       buildTuple(colWriter.array().tuple(), colSchema.mapSchema());
     } else {
       buildTuple(colWriter.tuple(), colSchema.mapSchema());
+    }
+  }
+
+  /**
+   * Expand a variant column. We use the term "variant" to mean either
+   * a UNION, or a LIST of UNIONs. (A LIST of UNIONs is, conceptually,
+   * a repeated UNION, though it is far more complex.)
+   *
+   * @param parent shim object used to associate the UNION types with its
+   * parent column (which is a UNION or a LIST). Since UNION and LIST are
+   * far different types, the shim provides a facade that encapsulates
+   * the common behavior
+   * @param colSchema the schema of the variant (LIST or UNION) column
+   */
+
+  private void buildVariant(ParentShim parent, ColumnMetadata colSchema) {
+    final ObjectWriter colWriter = parent.add(colSchema.cloneEmpty());
+    expandVariant(colWriter, colSchema);
+  }
+
+  private void expandVariant(ObjectWriter colWriter, ColumnMetadata colSchema) {
+    if (colSchema.isArray()) {
+      buildUnion(colWriter.array().variant(), colSchema.variantSchema());
+    } else {
+      buildUnion(colWriter.variant(), colSchema.variantSchema());
+    }
+  }
+
+  public void buildUnion(VariantWriter writer, VariantMetadata schema) {
+    final UnionShim unionShim = new UnionShim(writer);
+    for (final ColumnMetadata member : schema.members()) {
+      buildColumn(unionShim, member);
+    }
+  }
+
+  private void buildSingleList(ParentShim parent, ColumnMetadata colSchema) {
+    final ColumnMetadata seed = colSchema.cloneEmpty();
+    final ColumnMetadata subtype = colSchema.variantSchema().listSubtype();
+    seed.variantSchema().addType(subtype.cloneEmpty());
+    seed.variantSchema().becomeSimple();
+    final ObjectWriter listWriter = parent.add(seed);
+    expandColumn(listWriter, subtype);
+  }
+
+  /**
+   * Expand a repeated list. The list may be multi-dimensional, meaning that
+   * it may have may layers of other repeated lists before we get to the element
+   * (inner-most) array.
+   *
+   * @param writer tuple writer for the tuple that holds the array
+   * @param colSchema schema definition of the array
+   */
+
+  private void buildRepeatedList(ParentShim parent, ColumnMetadata colSchema) {
+    final ColumnMetadata seed = colSchema.cloneEmpty();
+    final RepeatedListWriter listWriter = (RepeatedListWriter) parent.add(seed).array();
+    final ColumnMetadata elements = colSchema.childSchema();
+    if (elements != null) {
+      final RepeatedListShim listShim = new RepeatedListShim(listWriter);
+      buildColumn(listShim, elements);
+    }
+  }
+
+  /**
+   * We've just built a writer for column. If the column is structured
+   * (AKA "complex", meaning a map or list or array), then we need to
+   * build writer for the components of the column. We do that recursively
+   * here.
+   *
+   * @param colWriter the writer for the (possibly structured) column
+   * @param colSchema the schema definition for the column
+   */
+
+  private void expandColumn(ObjectWriter colWriter, ColumnMetadata colSchema) {
+
+    if (colSchema.isMultiList()) {
+      // For completeness, should never occur.
+      assert false;
+    } else if (colSchema.isMap()) {
+      expandMap(colWriter, colSchema);
+    } else if (isSingleList(colSchema)) {
+      // For completeness, should never occur.
+      assert false;
+    } else if (colSchema.isVariant()) {
+      expandVariant(colWriter, colSchema);
+    // } else {
+      // Nothing to expand for primitives
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnBuilder.java
@@ -19,28 +19,48 @@ package org.apache.drill.exec.physical.rowSet.impl;
 
 import java.util.ArrayList;
 
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.rowSet.impl.ColumnState.PrimitiveColumnState;
+import org.apache.drill.exec.physical.rowSet.impl.ListState.ListVectorState;
+import org.apache.drill.exec.physical.rowSet.impl.RepeatedListState.RepeatedListColumnState;
+import org.apache.drill.exec.physical.rowSet.impl.RepeatedListState.RepeatedListVectorState;
 import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.OffsetVectorState;
 import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.SimpleVectorState;
 import org.apache.drill.exec.physical.rowSet.impl.TupleState.MapArrayState;
 import org.apache.drill.exec.physical.rowSet.impl.TupleState.MapColumnState;
 import org.apache.drill.exec.physical.rowSet.impl.TupleState.MapVectorState;
 import org.apache.drill.exec.physical.rowSet.impl.TupleState.SingleMapState;
+import org.apache.drill.exec.physical.rowSet.impl.UnionState.UnionColumnState;
+import org.apache.drill.exec.physical.rowSet.impl.UnionState.UnionVectorState;
+import org.apache.drill.exec.physical.rowSet.project.ImpliedTupleRequest;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.AbstractColumnMetadata;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.PrimitiveColumnMetadata;
 import org.apache.drill.exec.record.metadata.ProjectionType;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
 import org.apache.drill.exec.vector.NullableVector;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.writer.AbstractArrayWriter;
+import org.apache.drill.exec.vector.accessor.writer.AbstractArrayWriter.ArrayObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.AbstractTupleWriter.TupleObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.ColumnWriterFactory;
+import org.apache.drill.exec.vector.accessor.writer.EmptyListShim;
+import org.apache.drill.exec.vector.accessor.writer.ListWriterImpl;
 import org.apache.drill.exec.vector.accessor.writer.MapWriter;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.VariantObjectWriter;
+import org.apache.drill.exec.vector.complex.ListVector;
 import org.apache.drill.exec.vector.complex.MapVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector;
 import org.apache.drill.exec.vector.complex.RepeatedValueVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
 
 /**
  * Algorithms for building a column given a metadata description of the column and
@@ -51,6 +71,10 @@ import org.apache.drill.exec.vector.complex.RepeatedValueVector;
  * then add its members using the writer for the column. This ensures a uniform API
  * for adding columns whether done dynamically at read time or statically at create
  * time.
+ * <p>
+ * The single exception is the case of a list with exactly one type: in this case
+ * the list metadata must contain that one type so the code knows how to build
+ * the nullable array writer for that column.
  */
 
 public class ColumnBuilder {
@@ -77,6 +101,17 @@ public class ColumnBuilder {
     switch (columnSchema.structureType()) {
     case TUPLE:
       return buildMap(parent, columnSchema);
+    case VARIANT:
+      // Variant: UNION or (non-repeated) LIST
+      if (columnSchema.isArray()) {
+        // (non-repeated) LIST (somewhat like a repeated UNION)
+        return buildList(parent, columnSchema);
+      } else {
+        // (Non-repeated) UNION
+        return buildUnion(parent, columnSchema);
+      }
+    case MULTI_ARRAY:
+      return buildRepeatedList(parent, columnSchema);
     default:
       return buildPrimitive(parent, columnSchema);
     }
@@ -92,7 +127,6 @@ public class ColumnBuilder {
    * @return column state for the new column
    */
 
-  @SuppressWarnings("resource")
   private static ColumnState buildPrimitive(ContainerState parent, ColumnMetadata columnSchema) {
     ValueVector vector;
     if (columnSchema.isProjected()) {
@@ -116,7 +150,7 @@ public class ColumnBuilder {
 
     // Create the writer.
 
-    AbstractObjectWriter colWriter = ColumnWriterFactory.buildColumnWriter(columnSchema, vector);
+    final AbstractObjectWriter colWriter = ColumnWriterFactory.buildColumnWriter(columnSchema, vector);
 
     // Build the vector state which manages the vector.
 
@@ -168,7 +202,6 @@ public class ColumnBuilder {
     }
   }
 
-  @SuppressWarnings("resource")
   private static ColumnState buildSingleMap(ContainerState parent, ColumnMetadata columnSchema) {
     MapVector vector;
     VectorState vectorState;
@@ -185,15 +218,14 @@ public class ColumnBuilder {
       vector = null;
       vectorState = new NullVectorState();
     }
-    TupleObjectWriter mapWriter = MapWriter.buildMap(columnSchema,
+    final TupleObjectWriter mapWriter = MapWriter.buildMap(columnSchema,
         vector, new ArrayList<AbstractObjectWriter>());
-    SingleMapState mapState = new SingleMapState(parent.loader(),
+    final SingleMapState mapState = new SingleMapState(parent.loader(),
         parent.vectorCache().childCache(columnSchema.name()),
         parent.projectionSet().mapProjection(columnSchema.name()));
     return new MapColumnState(mapState, mapWriter, vectorState, parent.isVersioned());
   }
 
-  @SuppressWarnings("resource")
   private static ColumnState buildMapArray(ContainerState parent, ColumnMetadata columnSchema) {
 
     // Create the map's offset vector.
@@ -206,7 +238,7 @@ public class ColumnBuilder {
       // give it a materialized field with children. So, instead pass a clone
       // without children so we can add them.
 
-      ColumnMetadata mapColSchema = columnSchema.cloneEmpty();
+      final ColumnMetadata mapColSchema = columnSchema.cloneEmpty();
 
       // Don't get the map vector from the vector cache. Map vectors may
       // have content that varies from batch to batch. Only the leaf
@@ -223,7 +255,7 @@ public class ColumnBuilder {
 
     // Create the writer using the offset vector
 
-    AbstractObjectWriter writer = MapWriter.buildMapArray(
+    final AbstractObjectWriter writer = MapWriter.buildMapArray(
         columnSchema, mapVector,
         new ArrayList<AbstractObjectWriter>());
 
@@ -238,13 +270,262 @@ public class ColumnBuilder {
     } else {
       offsetVectorState = new NullVectorState();
     }
-    VectorState mapVectorState = new MapVectorState(mapVector, offsetVectorState);
+    final VectorState mapVectorState = new MapVectorState(mapVector, offsetVectorState);
 
     // Assemble it all into the column state.
 
-    MapArrayState mapState = new MapArrayState(parent.loader(),
+    final MapArrayState mapState = new MapArrayState(parent.loader(),
         parent.vectorCache().childCache(columnSchema.name()),
         parent.projectionSet().mapProjection(columnSchema.name()));
     return new MapColumnState(mapState, writer, mapVectorState, parent.isVersioned());
+  }
+
+  /**
+   * Builds a union column.
+   * <p>
+   * The union vector type is not well supported in Drill. The idea is that
+   * arbitrary operators can absorb schema changes by converting vectors to
+   * unions so that an operator can handle, say, a nullable int and a varchar.
+   * In practice, most operators don't support this feature. (Sort does -- but
+   * does not manage memory for the union case.) In principal, union can't solve
+   * the problem because ODBC and JDBC don't support unions, and it is easy
+   * to envision changes that unions won't solve (int and varchar types combining
+   * in a join column, say.) Still, Drill supports unions, so the code here
+   * does so. Unions are fully tested in the row set writer mechanism.
+   *
+   * @param parent
+   * @param columnSchema
+   * @return
+   */
+
+  private static ColumnState buildUnion(ContainerState parent, ColumnMetadata columnSchema) {
+    assert columnSchema.isVariant() && ! columnSchema.isArray();
+
+    if (! columnSchema.isProjected()) {
+      throw new UnsupportedOperationException("Drill does not currently support unprojected union columns: " +
+          columnSchema.name());
+    }
+
+    // Create the union vector.
+    // Don't get the union vector from the vector cache. Union vectors may
+    // have content that varies from batch to batch. Only the leaf
+    // vectors can be cached.
+
+    assert columnSchema.variantSchema().size() == 0;
+    final UnionVector vector = new UnionVector(columnSchema.schema(), parent.loader().allocator(), null);
+
+    // Then the union writer.
+
+    final UnionWriterImpl unionWriter = new UnionWriterImpl(columnSchema, vector, null);
+    final VariantObjectWriter writer = new VariantObjectWriter(unionWriter);
+
+    // The union vector state which manages the types vector.
+
+    final UnionVectorState vectorState = new UnionVectorState(vector, unionWriter);
+
+    // Create the manager for the columns within the union.
+
+    final UnionState unionState = new UnionState(parent.loader(),
+        parent.vectorCache().childCache(columnSchema.name()), new ImpliedTupleRequest(true));
+
+    // Bind the union state to the union writer to handle column additions.
+
+    unionWriter.bindListener(unionState);
+
+    // Assemble it all into a union column state.
+
+    return new UnionColumnState(parent.loader(), writer, vectorState, unionState);
+  }
+
+  private static ColumnState buildList(ContainerState parent, ColumnMetadata columnSchema) {
+
+    // If the list has declared a single type, and has indicated that this
+    // is the only type expected, then build the list as a nullable array
+    // of that type. Else, build the list as array of (a possibly empty)
+    // union.
+
+    final VariantMetadata variant = columnSchema.variantSchema();
+    if (variant.isSimple()) {
+      if (variant.size() == 1) {
+        return buildSimpleList(parent, columnSchema);
+      } else if (variant.size() == 0) {
+        throw new IllegalArgumentException("Size of a non-expandable list can't be zero");
+      }
+    }
+    return buildUnionList(parent, columnSchema);
+  }
+
+  /**
+   * Create a list that is promised to only ever contain a single type (at least
+   * during this write session). The list acts as a repeated vector in which each
+   * element can be null. The writer is presented as an array of the single type.
+   * <p>
+   * List vectors (lists of optional values) are not supported in
+   * Drill. The code here works up through the scan operator. But, other operators do
+   * not support the <tt>ListVector</tt> type.
+   *
+   * @param parent the parent (tuple, union or list) that holds this list
+   * @param columnSchema metadata description of the list which must contain
+   * exactly one subtype
+   * @return the column state for the list
+   */
+
+  private static ColumnState buildSimpleList(ContainerState parent, ColumnMetadata columnSchema) {
+
+    // The variant must have the one and only type.
+
+    assert columnSchema.variantSchema().size() == 1;
+    assert columnSchema.variantSchema().isSimple();
+
+    // Create the manager for the one and only column within the list.
+
+    final ListState listState = new ListState(parent.loader(),
+        parent.vectorCache().childCache(columnSchema.name()),
+        new ImpliedTupleRequest(true));
+
+    // Create the child vector, writer and state.
+
+    final ColumnMetadata memberSchema = columnSchema.variantSchema().listSubtype();
+    final ColumnState memberState = buildColumn(listState, memberSchema);
+    listState.setSubColumn(memberState);
+
+    // Create the list vector. Contains a single type.
+
+    final ListVector listVector = new ListVector(columnSchema.schema().cloneEmpty(),
+        parent.loader().allocator(), null);
+    listVector.setChildVector(memberState.vector());
+
+    // Create the list writer: an array of the one type.
+
+    final ListWriterImpl listWriter = new ListWriterImpl(columnSchema,
+        listVector, memberState.writer());
+    final AbstractObjectWriter listObjWriter = new ArrayObjectWriter(listWriter);
+
+    // Create the list vector state that tracks the list vector lifecycle.
+
+    final ListVectorState vectorState = new ListVectorState(listWriter, memberState.writer(), listVector);
+
+    // Assemble it all into a union column state.
+
+    return new UnionColumnState(parent.loader(),
+        listObjWriter, vectorState, listState);
+  }
+
+  /**
+   * Create a list based on a (possible) union. The list starts empty here. The client
+   * can then add types as they are discovered. The list itself will transition from a
+   * list of nulls (no child type), to a list of a single type, to a list of unions.
+   * The writer interface will consistently present the list as a list of unions, even
+   * when the list itself has no subtype or a single subtype.
+   * <p>
+   * List vectors (lists of unions) are not supported in
+   * Drill. The code here works up through the scan operator. But, other operators do
+   * not support the <tt>ListVector</tt> type.
+   *
+   * @param parent the parent (tuple, union or list) that holds this list
+   * @param columnSchema metadata description of the list (must be empty of
+   * subtypes)
+   * @return the column state for the list
+   */
+
+  private static ColumnState buildUnionList(ContainerState parent, ColumnMetadata columnSchema) {
+
+    // The variant must start out empty.
+
+    assert columnSchema.variantSchema().size() == 0;
+
+    // Create the union writer, bound to an empty list shim.
+
+    final UnionWriterImpl unionWriter = new UnionWriterImpl(columnSchema);
+    unionWriter.bindShim(new EmptyListShim());
+    final VariantObjectWriter unionObjWriter = new VariantObjectWriter(unionWriter);
+
+    // Create the list vector. Starts with the default (dummy) data
+    // vector which corresponds to the empty union shim above.
+    // Don't get the list vector from the vector cache. List vectors may
+    // have content that varies from batch to batch. Only the leaf
+    // vectors can be cached.
+
+    final ListVector listVector = new ListVector(columnSchema.schema(),
+        parent.loader().allocator(), null);
+
+    // Create the list vector state that tracks the list vector lifecycle.
+
+    final ListVectorState vectorState = new ListVectorState(unionWriter, listVector);
+
+    // Create the list writer: an array of unions.
+
+    final AbstractObjectWriter listWriter = new ArrayObjectWriter(
+        new ListWriterImpl(columnSchema, listVector, unionObjWriter));
+
+    // Create the manager for the columns within the list (which may or
+    // may not be grouped into a union.)
+
+    final ListState listState = new ListState(parent.loader(),
+        parent.vectorCache().childCache(columnSchema.name()),
+        ImpliedTupleRequest.ALL_MEMBERS);
+
+    // Bind the union state to the union writer to handle column additions.
+
+    unionWriter.bindListener(listState);
+
+    // Assemble it all into a union column state.
+
+    return new UnionColumnState(parent.loader(),
+        listWriter, vectorState, listState);
+  }
+
+  private static ColumnState buildRepeatedList(ContainerState parent,
+      ColumnMetadata columnSchema) {
+
+    assert columnSchema.type() == MinorType.LIST;
+    assert columnSchema.mode() == DataMode.REPEATED;
+
+    // The schema provided must be empty. The caller must add
+    // the element type after creating the repeated writer itself.
+
+    assert columnSchema.childSchema() == null;
+
+    // Build the repeated vector.
+
+    final RepeatedListVector vector = new RepeatedListVector(
+        columnSchema.emptySchema(), parent.loader().allocator(), null);
+
+    // No inner type yet. The result set loader builds the subtype
+    // incrementally because it might be complex (a map or another
+    // repeated list.) To start, use a dummy to avoid need for if-statements
+    // everywhere.
+
+    final ColumnMetadata dummyElementSchema = new PrimitiveColumnMetadata(
+        MaterializedField.create(columnSchema.name(),
+            Types.repeated(MinorType.NULL)));
+    final AbstractObjectWriter dummyElement = ColumnWriterFactory.buildDummyColumnWriter(dummyElementSchema);
+
+    // Create the list writer: an array of arrays.
+
+    final AbstractObjectWriter arrayWriter = RepeatedListWriter.buildRepeatedList(
+        columnSchema, vector, dummyElement);
+
+    // Create the list vector state that tracks the list vector lifecycle.
+    // For a repeated list, we only care about
+
+    final RepeatedListVectorState vectorState = new RepeatedListVectorState(
+        arrayWriter.array(), vector);
+
+    // Build the container that tracks the array contents
+
+    final RepeatedListState listState = new RepeatedListState(
+        parent.loader(),
+        parent.vectorCache().childCache(columnSchema.name()));
+
+    // Bind the list state as the list event listener.
+
+    ((RepeatedListWriter) arrayWriter.array()).bindListener(listState);
+
+    // Assemble it all into a column state. This state will
+    // propagate events down to the (one and only) child state.
+
+    return new RepeatedListColumnState(parent.loader(),
+        arrayWriter, vectorState, listState);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ListState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ListState.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.rowSet.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.ResultVectorCache;
+import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.FixedWidthVectorState;
+import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.OffsetVectorState;
+import org.apache.drill.exec.physical.rowSet.impl.UnionState.UnionVectorState;
+import org.apache.drill.exec.physical.rowSet.project.RequestedTuple;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+import org.apache.drill.exec.record.metadata.VariantSchema;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.accessor.WriterPosition;
+import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
+import org.apache.drill.exec.vector.accessor.writer.ListWriterImpl;
+import org.apache.drill.exec.vector.accessor.writer.SimpleListShim;
+import org.apache.drill.exec.vector.accessor.writer.UnionVectorShim;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
+
+/**
+ * Represents the contents of a list vector. A list vector is an odd creature.
+ * It starts as a list of nothing, evolves to be a nullable array of a single
+ * type, then becomes a nullable array of nullable unions holding nullable
+ * types.
+ * <p>
+ * At the writer level, the list consists of two parts: an array writer and
+ * a union writer. The union writer is needed because, unless the client tells
+ * us otherwise, we must be prepared for the list to become a union.
+ * <p>
+ * Holds the column states for the "columns" that make up the type members
+ * of the union, and implements the writer callbacks to add members to
+ * a list (disguised as a union), creating the actual union with the
+ * number of member types becomes two or more.
+ * <p>
+ * This class is similar to the {@link UnionState}, except that this
+ * version must handle the list transitions from no members to single
+ * member to union, and so this class is a bit more complex than the
+ * simple union case.
+ * <p>
+ * This implementation is based on a desired invariant: that once a client
+ * obtains a writer for the list, that writer never becomes invalid. This
+ * means we must carefully consider the list lifecycle. The list is
+ * represented as an array writer. When the list has
+ * no members, there would be no child for the array writer, a call to
+ * <tt>listArray.entry()</tt> would have to return null, which would be
+ * awkward and unlike any other writer use case. Once the list has a single
+ * type, the call to <tt>listArray.entry()</tt> might return a writer for
+ * that type. But, once the list becomes a repeated union, then
+ * <tt>listArray.entry()</tt> would have to return a union writer. This is
+ * the kind of muddy semantics we wish to avoid.
+ * <p>
+ * Instead, we model the list as a repeated union at all times. When the
+ * list has no type, then the list is a repeated union with no members.
+ * Once the list has a member, we have a repeated union of one member type.
+ * Finally, when adding another type, we have a repeated union of two
+ * types. The key is, in all cases, <tt>listArray.entry()</tt> returns
+ * a {@link UnionWriter}, so the client gets a consistent view.
+ * <p>
+ * Since the list itself changes form (no type, single type, then
+ * union), we hide that lifecycle internal to the writer and to this
+ * list state. The result is that the client need not care about the
+ * odd list lifecycle. But, on the flip side, this class, and the union
+ * writer, must go out of their way to hide these details.
+ * <p>
+ * At the writer level, the union writer uses "shims" to map from the union
+ * view to the actual list representation (no type, single type or union.)
+ * <p>
+ * At this level, this class must handle those cases as well, creating the
+ * union (by promoting the list) when needed. The result is a bit complex
+ * (for the code here), but simple for the client.
+ */
+
+public class ListState extends ContainerState
+  implements VariantWriter.VariantWriterListener {
+
+  /**
+   * Wrapper around the list vector (and its optional contained union).
+   * Manages the state of the "overhead" vectors such as the bits and
+   * offset vectors for the list, and (via the union vector state) the
+   * types vector for the union. The union vector state starts of as
+   * a dummy state (before the list has been "promoted" to a union)
+   * then becomes populated with the union state once the list is
+   * promoted.
+   */
+
+  protected static class ListVectorState implements VectorState {
+
+    private final ColumnMetadata schema;
+    private final ListVector vector;
+    private final FixedWidthVectorState bitsVectorState;
+    private final OffsetVectorState offsetVectorState;
+    private VectorState memberVectorState;
+
+    public ListVectorState(UnionWriterImpl writer, ListVector vector) {
+      this.schema = writer.schema();
+      this.vector = vector;
+      bitsVectorState = new FixedWidthVectorState(writer, vector.getBitsVector());
+      offsetVectorState = new OffsetVectorState(writer, vector.getOffsetVector(), writer.elementPosition());
+      memberVectorState = new NullVectorState();
+    }
+
+    public ListVectorState(ListWriterImpl writer, WriterPosition elementWriter, ListVector vector) {
+      this.schema = writer.schema();
+      this.vector = vector;
+      bitsVectorState = new FixedWidthVectorState(writer, vector.getBitsVector());
+      offsetVectorState = new OffsetVectorState(writer, vector.getOffsetVector(), elementWriter);
+      memberVectorState = new NullVectorState();
+    }
+
+    private void replaceMember(VectorState memberState) {
+      memberVectorState = memberState;
+    }
+
+    private VectorState memberVectorState() { return memberVectorState; }
+
+    @Override
+    public int allocate(int cardinality) {
+      return bitsVectorState.allocate(cardinality) +
+          offsetVectorState.allocate(cardinality + 1) +
+          memberVectorState.allocate(childCardinality(cardinality));
+    }
+
+    @Override
+    public void rollover(int cardinality) {
+      bitsVectorState.rollover(cardinality);
+      offsetVectorState.rollover(cardinality);
+      memberVectorState.rollover(childCardinality(cardinality));
+    }
+
+    private int childCardinality(int cardinality) {
+      return cardinality * schema.expectedElementCount();
+    }
+
+    @Override
+    public void harvestWithLookAhead() {
+      bitsVectorState.harvestWithLookAhead();
+      offsetVectorState.harvestWithLookAhead();
+      memberVectorState.harvestWithLookAhead();
+    }
+
+    @Override
+    public void startBatchWithLookAhead() {
+      bitsVectorState.startBatchWithLookAhead();
+      offsetVectorState.startBatchWithLookAhead();
+      memberVectorState.startBatchWithLookAhead();
+    }
+
+    @Override
+    public void close() {
+      bitsVectorState.close();
+      offsetVectorState.close();
+      memberVectorState.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ListVector vector() {
+      return vector;
+    }
+
+    @Override
+    public boolean isProjected() {
+      return true;
+    }
+
+    @Override
+    public void dump(HierarchicalFormatter format) {
+      // TODO Auto-generated method stub
+    }
+  }
+
+  /**
+   * Map of types to member columns, used to track the set of child
+   * column states for this list. This map mimics the actual set of
+   * vectors in the union (or list, before a list becomes a union),
+   * and matches the set of child writers in the union writer.
+   */
+
+  private final Map<MinorType, ColumnState> columns = new HashMap<>();
+
+  public ListState(LoaderInternals loader, ResultVectorCache vectorCache,
+      RequestedTuple projectionSet) {
+    super(loader, vectorCache, projectionSet);
+  }
+
+  public VariantMetadata variantSchema() {
+    return parentColumn.schema().variantSchema();
+  }
+
+  public ListWriterImpl listWriter() {
+    return (ListWriterImpl) parentColumn.writer.array();
+  }
+
+  private UnionWriterImpl unionWriter() {
+    return (UnionWriterImpl) listWriter().variant();
+  }
+
+  private ListVector listVector() {
+    return parentColumn.vector();
+  }
+
+  private UnionVector unionVector() {
+    return (UnionVector) listVectorState().memberVectorState().vector();
+  }
+
+  private ListVectorState listVectorState() {
+    return (ListVectorState) parentColumn.vectorState();
+  }
+
+  private boolean isSingleType() {
+    return variantSchema().isSimple();
+  }
+
+  @Override
+  public ObjectWriter addType(MinorType type) {
+    return addMember(VariantSchema.memberMetadata(type));
+  }
+
+  @Override
+  public ObjectWriter addMember(ColumnMetadata member) {
+    if (variantSchema().hasType(member.type())) {
+      throw new IllegalArgumentException("Duplicate type: " + member.type().toString());
+    }
+    if (isSingleType()) {
+      throw new IllegalStateException("List is defined to contains a single type.");
+    }
+    return addColumn(member).writer();
+  }
+
+  /**
+   * Add a new column representing a type within the list. This is where the list
+   * strangeness occurs. The list starts with no type, then evolves to have a single
+   * type (held by the list vector). Upon the second type, the list vector is modified
+   * to hold a union vector, which then holds the existing type and the new type.
+   * After that, the third and later types simply are added to the union.
+   * Very, very ugly, but it is how the list vector works until we improve it...
+   * <p>
+   * We must make three parallel changes:
+   * <ul>
+   * <li>Modify the list vector structure.</li>
+   * <li>Modify the union writer structure. (If a list type can evolve, then the
+   * writer structure is an array of unions. But, since the union itself does
+   * not exist in the 0 and 1 type cases, we use "shims" to model these odd
+   * cases.</li>
+   * <li>Modify the vector state for the list. If the list is "promoted" to a
+   * union, then add the union to the list vector's state for management in
+   * vector events.</li>
+   * </ul>
+   */
+
+  @Override
+  protected void addColumn(ColumnState colState) {
+    final MinorType type = colState.schema().type();
+    assert ! columns.containsKey(type);
+
+    // Add the new column (type) to metadata.
+
+    final int prevColCount = columns.size();
+    columns.put(type, colState);
+
+    if (prevColCount == 0) {
+      addFirstType(colState);
+    } else if (prevColCount == 1) {
+      addSecondType(colState);
+    } else {
+
+      // Already have a union; just add another type.
+
+      unionVector().addType(colState.vector());
+    }
+  }
+
+  private void addFirstType(ColumnState colState) {
+
+    // Going from no types to one type.
+
+    // Add the member to the list as its data vector.
+
+    listVector().setChildVector(colState.vector());
+
+    // Don't add the type to the vector state; we manage it as part
+    // of the collection of member columns.
+
+    // Note that we may have written 1 or more nulls to the array
+    // before we make this 0-to-1 type transition. If the new type is
+    // a scalar, it is nullable. Automatic back-fill will fill prior values
+    // with null, so there is nothing to do here.
+    //
+    // Note, however, that if this first type is a map, there is no way
+    // to mark that map as null; we loose the nullability state. However,
+    // if we later promote the single-type map to a union, we can't
+    // recover the null states and so the previously-null values won't
+    // be null. We could fix this, for a single batch, by keeping track
+    // of the null positions. But, there is no way to mark later maps
+    // as null. Another choice would be to force a transition directly
+    // to a union if the first type is a map. None of this has ever worked
+    // and so is left as an exercise for later once we work out what we
+    // actually want to support.
+
+    // Create the single type shim.
+
+    unionWriter().bindShim(new SimpleListShim());
+  }
+
+  /**
+   * Perform the delicate dance of promoting a list vector from a single type to
+   * a union, while leaving the writer client blissfully ignorant that the underlying
+   * vector representation just did a radical change. Key tasks:
+   * <ul>
+   * <li>Create the new column (type member) requested by the client.</li>
+   * <li>The List vector currently has a single type. Promote the list to
+   * a union, adding the existing type (column) as the first union member.</li>
+   * <li>Initialize the union's type vector with either the type of the existing
+   * column, or null, depending on the setting of the is-set bits in the existing
+   * column vector.</li>
+   * <li>Since we've written values into the union's type vector, mark the
+   * last-write position in the union vector's type vector writer to reflect
+   * these writes. (Otherwise, the writer will helpfully zero-fill the previous
+   * positions as part of it's back-fill handling.</li>
+   * <li>Replace the single-type shim in the union vector with a full union
+   * shim.</li>
+   * <li>Move the existing column writer or the member column across from the
+   * single-writer shim to the new union shim.</li>
+   * <li>Augment the list vector's vector state to include a vector state for
+   * the newly created union vector.</li>
+   * </ul>
+   * <p>
+   * Here, yet again, an editorial comment might be useful. List vectors are
+   * very strange and not at all well designed for high-speed writing. They are
+   * too complex; too much can go wrong and there are too many states to handle.
+   * Not only that, variant types don't play well with a relational model like
+   * SQL. This code works, but the overall list concept really needs rethinking.
+   *
+   * @param colState the column state for the newly added type column; the
+   * one causing the list to change from single-type to a union
+   */
+
+  private void addSecondType(ColumnState colState) {
+    final UnionWriterImpl unionWriter = unionWriter();
+    final ListVector listVector = listVector();
+
+    // Going from one type to a union
+
+    // Convert the list from single type to a union,
+    // moving across the previous type vector.
+
+    final int typeFillCount = unionWriter.elementPosition().writeIndex();
+    final UnionVector unionVector = listVector.convertToUnion(
+        innerCardinality(), typeFillCount);
+    unionVector.addType(colState.vector());
+
+    // Replace the single-type shim with a union shim, copying
+    // across the existing writer.
+
+    final SimpleListShim oldShim = (SimpleListShim) unionWriter.shim();
+    final UnionVectorShim newShim = new UnionVectorShim(unionVector);
+    unionWriter.bindShim(newShim);
+    newShim.addMemberWriter(oldShim.memberWriter());
+    newShim.initTypeIndex(typeFillCount);
+
+    // The union vector will be managed within the list vector state.
+    // (Do this last because the union vector state expects the union
+    // writer to be operating in "union mode".
+
+    listVectorState().replaceMember(new UnionVectorState(unionVector, unionWriter));
+  }
+
+  /**
+   * Set the one and only type when building a single-type list.
+   *
+   * @param memberState the column state for the list elements
+   */
+
+  public void setSubColumn(ColumnState memberState) {
+    assert columns.isEmpty();
+    columns.put(memberState.schema().type(), memberState);
+  }
+
+  @Override
+  protected Collection<ColumnState> columnStates() {
+    return columns.values();
+  }
+
+  @Override
+  public int innerCardinality() {
+    return parentColumn.innerCardinality();
+  }
+
+  @Override
+  protected boolean isVersioned() { return false; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/RepeatedListState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/RepeatedListState.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.rowSet.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.drill.exec.physical.rowSet.ResultVectorCache;
+import org.apache.drill.exec.physical.rowSet.impl.ColumnState.BaseContainerColumnState;
+import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.OffsetVectorState;
+import org.apache.drill.exec.physical.rowSet.project.ImpliedTupleRequest;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.RepeatedListColumnMetadata;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
+import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Represents the internal state of a RepeatedList vector. The repeated list
+ * is wrapped in a repeated list "column state" that manages the column as a
+ * whole. The repeated list acts as a container which the <tt>RepeatedListState<tt>
+ * implements. At the vector level, we track the repeated list vector, but
+ * only perform operations on its associated offset vector.
+ */
+
+public class RepeatedListState extends ContainerState implements RepeatedListWriter.ArrayListener {
+
+  /**
+   * Repeated list column state.
+   */
+
+  public static class RepeatedListColumnState extends BaseContainerColumnState {
+
+    private final RepeatedListState listState;
+
+    public RepeatedListColumnState(LoaderInternals loader,
+        AbstractObjectWriter writer,
+        RepeatedListVectorState vectorState,
+        RepeatedListState listState) {
+      super(loader, writer, vectorState);
+      this.listState = listState;
+      listState.bindColumnState(this);
+    }
+
+    /**
+     * Get the output schema. For a primitive (non-structured) column,
+     * the output schema is the same as the internal schema.
+     */
+    @Override
+    public ColumnMetadata outputSchema() { return schema(); }
+
+    @Override
+    public ContainerState container() { return listState; }
+  }
+
+  /**
+   * Track the repeated list vector. The vector state holds onto the repeated
+   * list vector, but only performs operations on the actual storage: the
+   * offset vector. The child column state manages the repeated list content
+   * (which may be complex: another repeated list, a map, a union, etc.)
+   */
+
+  public static class RepeatedListVectorState implements VectorState {
+
+    private final ArrayWriter arrayWriter;
+    private final RepeatedListVector vector;
+    private final OffsetVectorState offsetsState;
+
+    public RepeatedListVectorState(ArrayWriter arrayWriter, RepeatedListVector vector) {
+      this.vector = vector;
+      this.arrayWriter = arrayWriter;
+      offsetsState = new OffsetVectorState(
+          arrayWriter, vector.getOffsetVector(),
+          arrayWriter.entryType() == null ? null : arrayWriter.array());
+    }
+
+    /**
+     * Bind the child writer once the child is created. Note: must pass
+     * in the child writer because it is not yet bound to the repeated
+     * list vector at the time of this call.
+     *
+     * @param childWriter child array writer for the inner dimension
+     * of the repeated list
+     */
+
+    public void updateChildWriter(AbstractObjectWriter childWriter) {
+      offsetsState.setChildWriter(childWriter.array());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public RepeatedListVector vector() { return vector; }
+
+    @Override
+    public int allocate(int cardinality) {
+      return offsetsState.allocate(cardinality);
+    }
+
+    @Override
+    public void rollover(int cardinality) {
+      offsetsState.rollover(cardinality);
+    }
+
+    @Override
+    public void harvestWithLookAhead() {
+      offsetsState.harvestWithLookAhead();
+    }
+
+    @Override
+    public void startBatchWithLookAhead() {
+      offsetsState.startBatchWithLookAhead();
+    }
+
+    @Override
+    public void close() {
+      offsetsState.close();
+    }
+
+    @Override
+    public boolean isProjected() { return true; }
+
+    @Override
+    public void dump(HierarchicalFormatter format) {
+      format
+        .startObject(this)
+        .attribute("schema", arrayWriter.schema())
+        .attributeIdentity("writer", arrayWriter)
+        .attributeIdentity("vector", vector)
+        .attribute("offsetsState");
+      offsetsState.dump(format);
+      format
+        .endObject();
+    }
+  }
+
+  private ColumnState childState;
+
+  public RepeatedListState(LoaderInternals loader,
+      ResultVectorCache vectorCache) {
+    super(loader, vectorCache, ImpliedTupleRequest.ALL_MEMBERS);
+  }
+
+  @Override
+  public int innerCardinality() {
+    return parentColumn.innerCardinality();
+  }
+
+  @Override
+  protected void addColumn(ColumnState colState) {
+
+    // Remember the one and only child column.
+
+    assert childState == null;
+    childState = colState;
+
+    // Add the new child schema to the existing repeated list
+    // schema.
+
+    ((RepeatedListColumnMetadata) parentColumn.schema()).childSchema(colState.schema());
+
+    // Add the child vector to the existing repeated list
+    // vector.
+
+    RepeatedListVectorState vectorState = (RepeatedListVectorState) parentColumn.vectorState();
+    RepeatedListVector listVector = vectorState.vector;
+    listVector.setChildVector(childState.vector());
+
+    // The repeated list's offset vector state needs to know the offset
+    // of the inner vector. Bind that information now that we have
+    // an inner writer.
+
+    vectorState.updateChildWriter(childState.writer());
+  }
+
+  @Override
+  protected Collection<ColumnState> columnStates() {
+
+    // Turn the one and only child into a list of children for
+    // the general container mechanism.
+
+    if (childState == null) {
+      return new ArrayList<>();
+    } else {
+      return Lists.newArrayList(childState);
+    }
+  }
+
+  /**
+   * The repeated list vector does not support versioning
+   * of maps within the list. (That is, if a new field is
+   * added in the overflow row, it will appear in the output
+   * of the first batch.) The reasons for not versioning are simple:
+   * 1) repeated lists are a very obscure and low-priority area of Drill,
+   * and 2) given that background, the additional work of versioning is
+   * not worth the effort.
+   */
+
+  @Override
+  protected boolean isVersioned() { return false; }
+
+  // Callback from the repeated list vector to add the child.
+
+  @Override
+  public AbstractObjectWriter setChild(ArrayWriter array,
+      ColumnMetadata columnSchema) {
+
+    assert childState == null;
+    return addColumn(columnSchema).writer();
+  }
+
+  // Callback from the repeated list vector to add the child.
+
+  @Override
+  public AbstractObjectWriter setChild(ArrayWriter array,
+      MaterializedField field) {
+    return setChild(array, MetadataUtils.fromField(field));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/RepeatedListState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/RepeatedListState.java
@@ -34,7 +34,7 @@ import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
 import org.apache.drill.exec.vector.complex.RepeatedListVector;
 
-import com.google.common.collect.Lists;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
  * Represents the internal state of a RepeatedList vector. The repeated list
@@ -182,8 +182,8 @@ public class RepeatedListState extends ContainerState implements RepeatedListWri
     // Add the child vector to the existing repeated list
     // vector.
 
-    RepeatedListVectorState vectorState = (RepeatedListVectorState) parentColumn.vectorState();
-    RepeatedListVector listVector = vectorState.vector;
+    final RepeatedListVectorState vectorState = (RepeatedListVectorState) parentColumn.vectorState();
+    final RepeatedListVector listVector = vectorState.vector;
     listVector.setChildVector(childState.vector());
 
     // The repeated list's offset vector state needs to know the offset

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/TupleState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/TupleState.java
@@ -294,7 +294,7 @@ public abstract class TupleState extends ContainerState
     @Override
     public int addOutputColumn(ValueVector vector, ColumnMetadata colSchema) {
       outputContainer.add(vector);
-      int index = outputSchema.addColumn(colSchema);
+      final int index = outputSchema.addColumn(colSchema);
       assert outputContainer.getNumberOfColumns() == outputSchema.size();
       return index;
     }
@@ -326,14 +326,13 @@ public abstract class TupleState extends ContainerState
       writer().bindListener(this);
     }
 
-    @SuppressWarnings("resource")
     @Override
     public int addOutputColumn(ValueVector vector, ColumnMetadata colSchema) {
-      AbstractMapVector mapVector = parentColumn.vector();
+      final AbstractMapVector mapVector = parentColumn.vector();
       if (isVersioned()) {
         mapVector.putChild(colSchema.name(), vector);
       }
-      int index = outputSchema.addColumn(colSchema);
+      final int index = outputSchema.addColumn(colSchema);
       assert mapVector.size() == outputSchema.size();
       assert mapVector.getField().getChildren().size() == outputSchema.size();
       return index;
@@ -353,8 +352,7 @@ public abstract class TupleState extends ContainerState
       // columns must be nullable, so back-filling of nulls is possible.
 
       if (! isVersioned()) {
-        @SuppressWarnings("resource")
-        AbstractMapVector mapVector = parentColumn.vector();
+        final AbstractMapVector mapVector = parentColumn.vector();
         mapVector.putChild(colState.schema().name(), colState.vector());
       }
     }
@@ -496,8 +494,8 @@ public abstract class TupleState extends ContainerState
 
     // Verify name is not a (possibly case insensitive) duplicate.
 
-    TupleMetadata tupleSchema = schema();
-    String colName = columnSchema.name();
+    final TupleMetadata tupleSchema = schema();
+    final String colName = columnSchema.name();
     if (tupleSchema.column(colName) != null) {
       throw UserException
         .validationError()
@@ -514,7 +512,7 @@ public abstract class TupleState extends ContainerState
   }
 
   public boolean hasProjections() {
-    for (ColumnState colState : columns) {
+    for (final ColumnState colState : columns) {
       if (colState.isProjected()) {
         return true;
       }
@@ -532,7 +530,7 @@ public abstract class TupleState extends ContainerState
     // Scan all columns
 
     for (int i = 0; i < columns.size(); i++) {
-      ColumnState colState = columns.get(i);
+      final ColumnState colState = columns.get(i);
 
       // Ignore unprojected columns
 
@@ -562,7 +560,7 @@ public abstract class TupleState extends ContainerState
       // output schema.
 
       if (colState.schema().isMap()) {
-        MapState childMap = ((MapColumnState) colState).mapState();
+        final MapState childMap = ((MapColumnState) colState).mapState();
         childMap.updateOutput(curSchemaVersion);
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/UnionState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/UnionState.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.rowSet.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.ResultVectorCache;
+import org.apache.drill.exec.physical.rowSet.impl.ColumnState.BaseContainerColumnState;
+import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.FixedWidthVectorState;
+import org.apache.drill.exec.physical.rowSet.impl.SingleVectorState.SimpleVectorState;
+import org.apache.drill.exec.physical.rowSet.project.RequestedTuple;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+import org.apache.drill.exec.record.metadata.VariantSchema;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
+import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionVectorShim;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl;
+import org.apache.drill.exec.vector.complex.UnionVector;
+
+/**
+ * Represents the contents of a union vector (or a pseudo-union for lists).
+ * Holds the column states for the "columns" that make up the type members
+ * of the union, and implements the writer callbacks to add members to
+ * a union. This class is used when a column is a (single, non-repeated)
+ * UNION. See the {@link ListState} for when the union is used inside
+ * a LIST (repeated union) type.
+ */
+
+public class UnionState extends ContainerState
+  implements VariantWriter.VariantWriterListener {
+
+  /**
+   * Union or list (repeated union) column state.
+   */
+
+  public static class UnionColumnState extends BaseContainerColumnState {
+
+    private final ContainerState unionState;
+
+    public UnionColumnState(LoaderInternals loader,
+        AbstractObjectWriter writer,
+        VectorState vectorState,
+        ContainerState unionState) {
+      super(loader, writer, vectorState);
+      this.unionState = unionState;
+      unionState.bindColumnState(this);
+    }
+
+    @Override
+    public boolean isProjected() {
+      // Unions and lists are always projected
+      return true;
+    }
+
+    /**
+     * Get the output schema. For a primitive (non-structured) column,
+     * the output schema is the same as the internal schema.
+     */
+    @Override
+    public ColumnMetadata outputSchema() { return schema(); }
+
+    @Override
+    public ContainerState container() { return unionState; }
+  }
+
+  /**
+   * Vector wrapper for a union vector. Union vectors contain a types
+   * vector (which indicates the type of each row) along with member
+   * vectors for each supported type. This class manages the types
+   * vector. The member vectors are managed as children of the
+   * {@link UnionState} class. The union vector itself is just a
+   * holder; it has no state to be managed.
+   */
+
+  public static class UnionVectorState implements VectorState {
+
+    private final UnionVector vector;
+    private final SimpleVectorState typesVectorState;
+
+    public UnionVectorState(UnionVector vector, UnionWriterImpl unionWriter) {
+      this.vector = vector;
+      typesVectorState = new FixedWidthVectorState(
+          ((UnionVectorShim) unionWriter.shim()).typeWriter(), vector.getTypeVector());
+    }
+
+    @Override
+    public int allocate(int cardinality) {
+      return typesVectorState.allocate(cardinality);
+    }
+
+    @Override
+    public void rollover(int cardinality) {
+      typesVectorState.rollover(cardinality);
+    }
+
+    @Override
+    public void harvestWithLookAhead() {
+      typesVectorState.harvestWithLookAhead();
+    }
+
+    @Override
+    public void startBatchWithLookAhead() {
+      typesVectorState.startBatchWithLookAhead();
+    }
+
+    @Override
+    public void close() {
+      typesVectorState.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public UnionVector vector() { return vector; }
+
+    @Override
+    public boolean isProjected() { return true; }
+
+    @Override
+    public void dump(HierarchicalFormatter format) {
+      // TODO Auto-generated method stub
+    }
+  }
+
+  /**
+   * Map of types to member columns, used to track the set of child
+   * column states for this union. This map mimics the actual set of
+   * vectors in the union,
+   * and matches the set of child writers in the union writer.
+   */
+
+  private final Map<MinorType, ColumnState> columns = new HashMap<>();
+
+  public UnionState(LoaderInternals events, ResultVectorCache vectorCache, RequestedTuple projectionSet) {
+    super(events, vectorCache, projectionSet);
+  }
+
+  public UnionWriterImpl writer() {
+    return (UnionWriterImpl) parentColumn.writer.variant();
+  }
+
+  public VariantMetadata variantSchema() {
+    return writer().variantSchema();
+  }
+
+  public UnionVector vector() {
+    return parentColumn.vector();
+  }
+
+  @Override
+  public ObjectWriter addType(MinorType type) {
+    return addMember(VariantSchema.memberMetadata(type));
+  }
+
+  @Override
+  public ObjectWriter addMember(ColumnMetadata member) {
+    if (variantSchema().hasType(member.type())) {
+      throw new IllegalArgumentException("Duplicate type: " + member.type().toString());
+    }
+    return addColumn(member).writer();
+  }
+
+  @Override
+  protected void addColumn(ColumnState colState) {
+    assert ! columns.containsKey(colState.schema().type());
+    columns.put(colState.schema().type(), colState);
+    vector().addType(colState.vector());
+  }
+
+  @Override
+  protected Collection<ColumnState> columnStates() {
+    return columns.values();
+  }
+
+  @Override
+  public int innerCardinality() {
+    return parentColumn.innerCardinality();
+  }
+
+  @Override
+  protected boolean isVersioned() { return false; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/ContainerVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/ContainerVisitor.java
@@ -41,18 +41,17 @@ public class ContainerVisitor<R, A> {
 
   public R visitChildren(VectorContainer container, A arg) {
     for (int i = 0; i < container.getNumberOfColumns(); i++) {
-      @SuppressWarnings("resource")
-      ValueVector vector = container.getValueVector(i).getValueVector();
+      final ValueVector vector = container.getValueVector(i).getValueVector();
       apply(vector, arg);
     }
     return null;
   }
 
   protected R apply(ValueVector vector, A arg) {
-    MaterializedField schema = vector.getField();
-    MajorType majorType = schema.getType();
-    MinorType type = majorType.getMinorType();
-    DataMode mode = majorType.getMode();
+    final MaterializedField schema = vector.getField();
+    final MajorType majorType = schema.getType();
+    final MinorType type = majorType.getMinorType();
+    final DataMode mode = majorType.getMode();
     switch (type) {
     case MAP:
       if (mode == DataMode.REPEATED) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BaseReaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BaseReaderBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.model.AbstractReaderBuilder;
 import org.apache.drill.exec.physical.rowSet.model.MetadataProvider;
 import org.apache.drill.exec.physical.rowSet.model.MetadataProvider.VectorDescrip;
@@ -31,30 +32,57 @@ import org.apache.drill.exec.vector.accessor.reader.AbstractObjectReader;
 import org.apache.drill.exec.vector.accessor.reader.AbstractScalarReader;
 import org.apache.drill.exec.vector.accessor.reader.ArrayReaderImpl;
 import org.apache.drill.exec.vector.accessor.reader.MapReader;
+import org.apache.drill.exec.vector.accessor.reader.UnionReaderImpl;
 import org.apache.drill.exec.vector.accessor.reader.VectorAccessor;
 import org.apache.drill.exec.vector.accessor.reader.VectorAccessors.SingleVectorAccessor;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
+
+/**
+ * Builds a set of readers for a single (non-hyper) batch. Single batches
+ * are indexed directly or via a simple indirection vector.
+ * <p>
+ * Derived classes handle the details of the various kinds of readers.
+ * Today there is a single subclass that builds (test-time)
+ * {@link RowSet} objects. The idea, however, is that we may eventually
+ * want to create a "result set reader" for use in internal operators,
+ * in parallel to the "result set loader". The result set reader would
+ * handle a stream of incoming batches. The extant RowSet class handles
+ * just one batch (the batch that is returned from a test.)
+ * <p>
+ * Readers are built recursively by walking the tree that defines a
+ * row's structure. For a classic relational tuple, the tree has just
+ * a root and a set of primitives. But, once we add array (repeated),
+ * variant (LIST, UNION) and tuple (MAP) columns, the tree grows
+ * quite complex.
+ */
 
 public abstract class BaseReaderBuilder extends AbstractReaderBuilder {
 
   protected List<AbstractObjectReader> buildContainerChildren(
       VectorContainer container, MetadataProvider mdProvider) {
-    List<AbstractObjectReader> readers = new ArrayList<>();
+    final List<AbstractObjectReader> readers = new ArrayList<>();
     for (int i = 0; i < container.getNumberOfColumns(); i++) {
-      ValueVector vector = container.getValueVector(i).getValueVector();
-      VectorDescrip descrip = new VectorDescrip(mdProvider, i, vector.getField());
+      final ValueVector vector = container.getValueVector(i).getValueVector();
+      final VectorDescrip descrip = new VectorDescrip(mdProvider, i, vector.getField());
       readers.add(buildVectorReader(vector, descrip));
     }
     return readers;
   }
 
   protected AbstractObjectReader buildVectorReader(ValueVector vector, VectorDescrip descrip) {
-    VectorAccessor va = new SingleVectorAccessor(vector);
-    MajorType type = va.type();
+    final VectorAccessor va = new SingleVectorAccessor(vector);
+    final MajorType type = va.type();
 
     switch(type.getMinorType()) {
     case MAP:
       return buildMap((AbstractMapVector) vector, va, type.getMode(), descrip);
+    case UNION:
+      return buildUnion((UnionVector) vector, va, descrip);
+    case LIST:
+      return buildList(vector, va, descrip);
     case LATE:
 
       // Occurs for a list with no type: a list of nulls.
@@ -67,11 +95,11 @@ public abstract class BaseReaderBuilder extends AbstractReaderBuilder {
 
   private AbstractObjectReader buildMap(AbstractMapVector vector, VectorAccessor va, DataMode mode, VectorDescrip descrip) {
 
-    boolean isArray = mode == DataMode.REPEATED;
+    final boolean isArray = mode == DataMode.REPEATED;
 
     // Map type
 
-    AbstractObjectReader mapReader = MapReader.build(
+    final AbstractObjectReader mapReader = MapReader.build(
         descrip.metadata,
         isArray ? null : va,
         buildMapMembers(vector,
@@ -89,14 +117,96 @@ public abstract class BaseReaderBuilder extends AbstractReaderBuilder {
   }
 
   protected List<AbstractObjectReader> buildMapMembers(AbstractMapVector mapVector, MetadataProvider provider) {
-    List<AbstractObjectReader> readers = new ArrayList<>();
+    final List<AbstractObjectReader> readers = new ArrayList<>();
     int i = 0;
-    for (ValueVector vector : mapVector) {
-      VectorDescrip descrip = new VectorDescrip(provider, i, vector.getField());
+    for (final ValueVector vector : mapVector) {
+      final VectorDescrip descrip = new VectorDescrip(provider, i, vector.getField());
       readers.add(buildVectorReader(vector, descrip));
       i++;
     }
     return readers;
   }
 
+  private AbstractObjectReader buildUnion(UnionVector vector, VectorAccessor unionAccessor, VectorDescrip descrip) {
+    final MetadataProvider provider = descrip.childProvider();
+    final AbstractObjectReader variants[] = new AbstractObjectReader[MinorType.values().length];
+    int i = 0;
+    for (final MinorType type : vector.getField().getType().getSubTypeList()) {
+
+      // This call will create the vector if it does not yet exist.
+      // Will throw an exception for unsupported types.
+      // so call this only if the MajorType reports that the type
+      // already exists.
+
+      final ValueVector memberVector = vector.getMember(type);
+      final VectorDescrip memberDescrip = new VectorDescrip(provider, i++, memberVector.getField());
+      variants[type.ordinal()] = buildVectorReader(memberVector, memberDescrip);
+    }
+    return UnionReaderImpl.build(
+        descrip.metadata,
+        unionAccessor,
+        variants);
+  }
+
+  private AbstractObjectReader buildList(ValueVector vector, VectorAccessor listAccessor,
+      VectorDescrip listDescrip) {
+    if (vector.getField().getType().getMode() == DataMode.REPEATED) {
+      return buildMultiDList((RepeatedListVector) vector, listAccessor, listDescrip);
+    } else {
+      return build1DList((ListVector) vector, listAccessor, listDescrip);
+    }
+  }
+
+  private AbstractObjectReader buildMultiDList(RepeatedListVector vector,
+      VectorAccessor listAccessor, VectorDescrip listDescrip) {
+
+    final ValueVector child = vector.getDataVector();
+    if (child == null) {
+      throw new UnsupportedOperationException("No child vector for repeated list.");
+    }
+    final VectorDescrip childDescrip = new VectorDescrip(listDescrip.childProvider(), 0, child.getField());
+    final AbstractObjectReader elementReader = buildVectorReader(child, childDescrip);
+    return ArrayReaderImpl.buildRepeatedList(listDescrip.metadata, listAccessor, elementReader);
+  }
+
+  /**
+   * Build a list vector.
+   * <p>
+   * The list vector is a complex, somewhat ad-hoc structure. It can
+   * take the place of repeated vectors, with some extra features.
+   * The four "modes" of list vector, and thus list reader, are:
+   * <ul>
+   * <li>Similar to a scalar array.</li>
+   * <li>Similar to a map (tuple) array.</li>
+   * <li>The only way to represent an array of unions.</li>
+   * <li>The only way to represent an array of lists.</li>
+   * </ul>
+   * Lists add an extra feature compared to the "regular" scalar or
+   * map arrays. Each array entry can be either null or empty (regular
+   * arrays can only be empty.)
+   * <p>
+   * When working with unions, this introduces an ambiguity: both the
+   * list and the union have a null flag. Here, we assume that the
+   * list flag has precedence, and that if the list entry is not null
+   * then the union must also be not null. (Experience will show whether
+   * existing code does, in fact, follow that convention.)
+   */
+
+  private AbstractObjectReader build1DList(ListVector vector, VectorAccessor listAccessor,
+      VectorDescrip listDescrip) {
+    final ValueVector dataVector = vector.getDataVector();
+    VectorDescrip dataMetadata;
+    if (dataVector.getField().getType().getMinorType() == MinorType.UNION) {
+
+      // At the metadata level, a list always holds a union. But, at the
+      // implementation layer, a union of a single type is collapsed out
+      // to leave just a list of that single type.
+
+      dataMetadata = listDescrip;
+    } else {
+      dataMetadata = new VectorDescrip(listDescrip.childProvider(), 0, dataVector.getField());
+    }
+    return ArrayReaderImpl.buildList(listDescrip.metadata,
+        listAccessor, buildVectorReader(dataVector, dataMetadata));
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BaseWriterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BaseWriterBuilder.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.rowSet.model.single;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.model.MetadataProvider;
@@ -28,46 +29,140 @@ import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.ColumnWriterFactory;
+import org.apache.drill.exec.vector.accessor.writer.ListWriterImpl;
 import org.apache.drill.exec.vector.accessor.writer.MapWriter;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl;
+import org.apache.drill.exec.vector.accessor.writer.AbstractArrayWriter.ArrayObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.VariantObjectWriter;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
 
 /**
  * Build a set of writers for a single (non-hyper) vector container.
+ * This base class provides behavior common to the test-time RowSet
+ * abstractions, and the production result set loader abstractions.
+ * <p>
+ * Writers are built recursively by walking the tree that defines a
+ * row's structure. For a classic relational tuple, the tree has just
+ * a root and a set of primitives. But, once we add array (repeated),
+ * variant (LIST, UNION) and tuple (MAP) columns, the tree grows
+ * quite complex.
  */
 
 public abstract class BaseWriterBuilder {
 
   protected List<AbstractObjectWriter> buildContainerChildren(VectorContainer container, MetadataProvider mdProvider) {
-    List<AbstractObjectWriter> writers = new ArrayList<>();
+    final List<AbstractObjectWriter> writers = new ArrayList<>();
     for (int i = 0; i < container.getNumberOfColumns(); i++) {
-      @SuppressWarnings("resource")
-      ValueVector vector = container.getValueVector(i).getValueVector();
-      VectorDescrip descrip = new VectorDescrip(mdProvider, i, vector.getField());
+      final ValueVector vector = container.getValueVector(i).getValueVector();
+      final VectorDescrip descrip = new VectorDescrip(mdProvider, i, vector.getField());
       writers.add(buildVectorWriter(vector, descrip));
     }
     return writers;
   }
 
   private AbstractObjectWriter buildVectorWriter(ValueVector vector, VectorDescrip descrip) {
-    MajorType type = vector.getField().getType();
-    if (type.getMinorType() == MinorType.MAP) {
+    final MajorType type = vector.getField().getType();
+    switch (type.getMinorType()) {
+    case MAP:
       return MapWriter.buildMapWriter(descrip.metadata,
           (AbstractMapVector) vector,
           buildMap((AbstractMapVector) vector, descrip));
-    } else {
+
+    case UNION:
+      return buildUnion((UnionVector) vector, descrip);
+
+    case LIST:
+      return buildList(vector, descrip);
+
+    default:
       return ColumnWriterFactory.buildColumnWriter(descrip.metadata, vector);
     }
   }
 
   private List<AbstractObjectWriter> buildMap(AbstractMapVector vector, VectorDescrip descrip) {
-    List<AbstractObjectWriter> writers = new ArrayList<>();
-    MetadataProvider provider = descrip.parent.childProvider(descrip.metadata);
+    final List<AbstractObjectWriter> writers = new ArrayList<>();
+    final MetadataProvider provider = descrip.parent.childProvider(descrip.metadata);
     int i = 0;
-    for (ValueVector child : vector) {
-      VectorDescrip childDescrip = new VectorDescrip(provider, i, child.getField());
+    for (final ValueVector child : vector) {
+      final VectorDescrip childDescrip = new VectorDescrip(provider, i, child.getField());
       writers.add(buildVectorWriter(child, childDescrip));
       i++;
     }
     return writers;
+  }
+
+  private AbstractObjectWriter buildUnion(UnionVector vector, VectorDescrip descrip) {
+
+    // Dummy writers are used when the schema is known up front, but the
+    // query chooses not to project a column. Variants are used in the case when
+    // the schema is not known, and we discover it on the fly. In this case,
+    // (which currently occurs only in JSON) dummy vectors are not used.
+
+    if (vector == null) {
+      throw new UnsupportedOperationException("Dummy variant writer not yet supported");
+    }
+    final AbstractObjectWriter variants[] = new AbstractObjectWriter[MinorType.values().length];
+    final MetadataProvider mdProvider = descrip.childProvider();
+    int i = 0;
+    for (final MinorType type : vector.getField().getType().getSubTypeList()) {
+
+      // This call will create the vector if it does not yet exist.
+      // Will throw an exception for unsupported types.
+      // so call this only if the MajorType reports that the type
+      // already exists.
+
+      final ValueVector memberVector = vector.getMember(type);
+      final VectorDescrip memberDescrip = new VectorDescrip(mdProvider, i++, memberVector.getField());
+      variants[type.ordinal()] = buildVectorWriter(memberVector, memberDescrip);
+    }
+    return new VariantObjectWriter(
+        new UnionWriterImpl(descrip.metadata, vector, variants));
+  }
+
+  private AbstractObjectWriter buildList(ValueVector vector,
+      VectorDescrip descrip) {
+    if (vector == null) {
+      throw new UnsupportedOperationException("Dummy list writer not yet supported");
+    }
+    if (vector.getField().getType().getMode() == DataMode.REPEATED) {
+      return buildMultiDList((RepeatedListVector) vector, descrip);
+    } else {
+      return build1DList((ListVector) vector, descrip);
+    }
+  }
+
+  private AbstractObjectWriter buildMultiDList(RepeatedListVector vector,
+      VectorDescrip descrip) {
+
+    final ValueVector child = vector.getDataVector();
+    if (child == null) {
+      throw new UnsupportedOperationException("No child vector for repeated list.");
+    }
+    final VectorDescrip childDescrip = new VectorDescrip(descrip.childProvider(), 0, child.getField());
+    final AbstractObjectWriter childWriter = buildVectorWriter(child, childDescrip);
+    return RepeatedListWriter.buildRepeatedList(descrip.metadata, vector, childWriter);
+  }
+
+  private AbstractObjectWriter build1DList(ListVector vector,
+      VectorDescrip descrip) {
+    final ValueVector dataVector = vector.getDataVector();
+    VectorDescrip dataMetadata;
+    if (dataVector.getField().getType().getMinorType() == MinorType.UNION) {
+
+      // If the list holds a union, then the list and union are collapsed
+      // together in the metadata layer.
+
+      dataMetadata = descrip;
+    } else {
+      dataMetadata = new VectorDescrip(descrip.childProvider(), 0, dataVector.getField());
+    }
+    return new ArrayObjectWriter(
+      new ListWriterImpl(descrip.metadata,
+          vector,
+          buildVectorWriter(dataVector, dataMetadata)));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BuildVectorsFromMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BuildVectorsFromMetadata.java
@@ -18,18 +18,31 @@
 package org.apache.drill.exec.physical.rowSet.model.single;
 
 import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
 
 /**
  * Build (materialize) as set of vectors based on a provided
- * metadata schema.
+ * metadata schema. The vectors are bundled into a
+ * {@link VectorContainer} which is the end product of this
+ * builder.
+ * <p>
+ * Vectors are built recursively by walking the tree that defines a
+ * row's structure. For a classic relational tuple, the tree has just
+ * a root and a set of primitives. But, once we add array (repeated),
+ * variant (LIST, UNION) and tuple (MAP) columns, the tree grows
+ * quite complex.
  */
 
 public class BuildVectorsFromMetadata {
@@ -41,7 +54,7 @@ public class BuildVectorsFromMetadata {
   }
 
   public VectorContainer build(TupleMetadata schema) {
-    VectorContainer container = new VectorContainer(allocator);
+    final VectorContainer container = new VectorContainer(allocator);
     for (int i = 0; i < schema.size(); i++) {
       container.add(buildVector(schema.metadata(i)));
     }
@@ -57,9 +70,26 @@ public class BuildVectorsFromMetadata {
     switch (metadata.structureType()) {
     case TUPLE:
       return buildMap(metadata);
+    case VARIANT:
+      if (metadata.isArray()) {
+        return builList(metadata);
+      } else {
+        return buildUnion(metadata);
+      }
+    case MULTI_ARRAY:
+      return buildRepeatedList(metadata);
     default:
       return TypeHelper.getNewVector(metadata.schema(), allocator, null);
     }
+  }
+
+  private ValueVector buildRepeatedList(ColumnMetadata metadata) {
+    final RepeatedListVector listVector = new RepeatedListVector(metadata.emptySchema(), allocator, null);
+    if (metadata.childSchema() != null) {
+      final ValueVector child = buildVector(metadata.childSchema());
+      listVector.setChildVector(child);
+    }
+    return listVector;
   }
 
   /**
@@ -76,7 +106,7 @@ public class BuildVectorsFromMetadata {
     // give it a materialized field with children. So, instead pass a clone
     // without children so we can add the children as we add vectors.
 
-    AbstractMapVector mapVector = (AbstractMapVector) TypeHelper.getNewVector(schema.emptySchema(), allocator, null);
+    final AbstractMapVector mapVector = (AbstractMapVector) TypeHelper.getNewVector(schema.emptySchema(), allocator, null);
     populateMap(mapVector, schema.mapSchema(), false);
     return mapVector;
   }
@@ -91,7 +121,7 @@ public class BuildVectorsFromMetadata {
   private void populateMap(AbstractMapVector mapVector,
       TupleMetadata mapSchema, boolean inUnion) {
     for (int i = 0; i < mapSchema.size(); i++) {
-      ColumnMetadata childSchema = mapSchema.metadata(i);
+      final ColumnMetadata childSchema = mapSchema.metadata(i);
 
       // Check for union-compatible types. But, maps must be required.
 
@@ -99,6 +129,56 @@ public class BuildVectorsFromMetadata {
         throw new IllegalArgumentException("Map members in a list or union must not be non-nullable");
       }
       mapVector.putChild(childSchema.name(), buildVector(childSchema));
+    }
+  }
+
+  private ValueVector buildUnion(ColumnMetadata metadata) {
+    final ValueVector vector = TypeHelper.getNewVector(metadata.emptySchema(), allocator, null);
+    populateUnion((UnionVector) vector, metadata.variantSchema());
+    return vector;
+  }
+
+  private void populateUnion(UnionVector unionVector,
+      VariantMetadata variantSchema) {
+    for (final MinorType type : variantSchema.types()) {
+      final ValueVector childVector = unionVector.getMember(type);
+      switch (type) {
+      case LIST:
+        populateList((ListVector) childVector,
+            variantSchema.member(MinorType.LIST).variantSchema());
+        break;
+      case MAP:
+
+        // Force the map to require nullable or repeated types.
+        // Not perfect; does not extend down to maps within maps.
+        // Since this code is used in testing, not adding that complexity
+        // for now.
+
+        populateMap((AbstractMapVector) childVector,
+            variantSchema.member(MinorType.MAP).mapSchema(),
+            true);
+        break;
+      default:
+        // Nothing additional needed
+      }
+    }
+  }
+
+  private ValueVector builList(ColumnMetadata metadata) {
+    final ValueVector vector = TypeHelper.getNewVector(metadata.emptySchema(), allocator, null);
+    populateList((ListVector) vector, metadata.variantSchema());
+    return vector;
+  }
+
+  private void populateList(ListVector vector, VariantMetadata variantSchema) {
+    if (variantSchema.size() == 0) {
+      return;
+    } else if (variantSchema.size() == 1) {
+      final ColumnMetadata subtype = variantSchema.listSubtype();
+      final ValueVector childVector = buildVector(subtype);
+      vector.setChildVector(childVector);
+    } else {
+      populateUnion(vector.fullPromoteToUnion(), variantSchema);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/VectorAllocator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/VectorAllocator.java
@@ -63,14 +63,13 @@ public class VectorAllocator {
 
   public void allocate(int rowCount, MetadataProvider mdProvider) {
     for (int i = 0; i < container.getNumberOfColumns(); i++) {
-      @SuppressWarnings("resource")
-      ValueVector vector = container.getValueVector(i).getValueVector();
+      final ValueVector vector = container.getValueVector(i).getValueVector();
       allocateVector(vector, mdProvider.metadata(i, vector.getField()), rowCount, mdProvider);
     }
   }
 
   private void allocateVector(ValueVector vector, ColumnMetadata metadata, int valueCount, MetadataProvider mdProvider) {
-    MajorType type = vector.getField().getType();
+    final MajorType type = vector.getField().getType();
     assert vector.getField().getName().equals(metadata.name());
     assert type.getMinorType() == metadata.type();
     if (type.getMinorType() == MinorType.MAP) {
@@ -94,17 +93,17 @@ public class VectorAllocator {
 
   private void allocateMapArray(RepeatedMapVector vector,
       ColumnMetadata metadata, int valueCount, MetadataProvider mdProvider) {
-    ((RepeatedMapVector) vector).getOffsetVector().allocateNew(valueCount);
-    int expectedValueCount = valueCount * metadata.expectedElementCount();
+    vector.getOffsetVector().allocateNew(valueCount);
+    final int expectedValueCount = valueCount * metadata.expectedElementCount();
     allocateMap(vector, metadata, expectedValueCount, mdProvider);
   }
 
   private void allocateMap(AbstractMapVector vector, ColumnMetadata metadata, int valueCount, MetadataProvider mdProvider) {
-    MetadataProvider mapProvider = mdProvider.childProvider(metadata);
-    TupleMetadata mapSchema = metadata.mapSchema();
+    final MetadataProvider mapProvider = mdProvider.childProvider(metadata);
+    final TupleMetadata mapSchema = metadata.mapSchema();
     assert mapSchema != null;
     int i = 0;
-    for (ValueVector child : vector) {
+    for (final ValueVector child : vector) {
       allocateVector(child, mapProvider.metadata(i, child.getField()), valueCount, mapProvider);
       i++;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/project/RequestedColumnImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/project/RequestedColumnImpl.java
@@ -116,7 +116,7 @@ public class RequestedColumnImpl implements RequestedColumn {
       return 0;
     }
     int max = 0;
-    for (Integer index : indexes) {
+    for (final Integer index : indexes) {
       max = Math.max(max, index);
     }
     return max;
@@ -127,9 +127,9 @@ public class RequestedColumnImpl implements RequestedColumn {
     if (! hasIndexes()) {
       return null;
     }
-    int max = maxIndex();
-    boolean map[] = new boolean[max+1];
-    for (Integer index : indexes) {
+    final int max = maxIndex();
+    final boolean map[] = new boolean[max+1];
+    for (final Integer index : indexes) {
       map[index] = true;
     }
     return map;
@@ -137,7 +137,7 @@ public class RequestedColumnImpl implements RequestedColumn {
 
   @Override
   public String fullName() {
-    StringBuilder buf = new StringBuilder();
+    final StringBuilder buf = new StringBuilder();
     buildName(buf);
     return buf.toString();
   }
@@ -189,7 +189,7 @@ public class RequestedColumnImpl implements RequestedColumn {
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder();
+    final StringBuilder buf = new StringBuilder();
     buf
       .append("[")
       .append(getClass().getSimpleName())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
@@ -78,7 +78,7 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     if (!releasable) {
       return;
     }
-    for (T x : vectors) {
+    for (final T x : vectors) {
       x.clear();
     }
   }
@@ -90,10 +90,10 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
       return this;
     }
 
-    ValueVector[] vectors = new ValueVector[this.vectors.length];
+    final ValueVector[] vectors = new ValueVector[this.vectors.length];
     int index = 0;
 
-    for (ValueVector v : this.vectors) {
+    for (final ValueVector v : this.vectors) {
       ValueVector vector = v;
       for (int i = 1; i < ids.length; i++) {
         final AbstractMapVector mapLike = AbstractMapVector.class.cast(vector);
@@ -108,10 +108,9 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     return new HyperVectorWrapper<ValueVector>(vectors[0].getField(), vectors);
   }
 
-  @SuppressWarnings("resource")
   @Override
   public TypedFieldId getFieldIdIfMatches(int id, SchemaPath expectedPath) {
-    ValueVector v = vectors[0];
+    final ValueVector v = vectors[0];
     return FieldIdUtil.getFieldId(v, id, expectedPath, true);
   }
 
@@ -154,7 +153,7 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
     Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
     Preconditions.checkArgument(vectors.length == ((HyperVectorWrapper<?>)destination).vectors.length);
 
-    ValueVector[] destionationVectors = ((HyperVectorWrapper<?>)destination).vectors;
+    final ValueVector[] destionationVectors = ((HyperVectorWrapper<?>)destination).vectors;
     for (int i = 0; i < vectors.length; ++i) {
       vectors[i].makeTransferPair(destionationVectors[i]).transfer();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -57,7 +57,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
 
   public AbstractColumnMetadata(MaterializedField schema) {
     name = schema.getName();
-    MajorType majorType = schema.getType();
+    final MajorType majorType = schema.getType();
     type = majorType.getMinorType();
     mode = majorType.getMode();
     precision = majorType.getPrecision();
@@ -122,6 +122,9 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
   public boolean isVariant() { return false; }
 
   @Override
+  public boolean isMultiList() { return false; }
+
+  @Override
   public TupleMetadata mapSchema() { return null; }
 
   @Override
@@ -132,7 +135,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
 
   @Override
   public boolean isVariableWidth() {
-    MinorType type = type();
+    final MinorType type = type();
     return type == MinorType.VARCHAR || type == MinorType.VAR16CHAR || type == MinorType.VARBINARY;
   }
 
@@ -177,7 +180,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder()
+    final StringBuilder buf = new StringBuilder()
         .append("[")
         .append(getClass().getSimpleName())
         .append(" ")

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/RepeatedListColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/RepeatedListColumnMetadata.java
@@ -62,8 +62,11 @@ public class RepeatedListColumnMetadata extends AbstractColumnMetadata {
   public StructureType structureType() { return StructureType.MULTI_ARRAY; }
 
   @Override
+  public boolean isMultiList() { return true; }
+
+  @Override
   public MaterializedField schema() {
-    MaterializedField field = emptySchema();
+    final MaterializedField field = emptySchema();
     if (childSchema != null) {
       field.addChild(childSchema.schema());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderMaps.java
@@ -59,7 +59,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testBasics() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("c", MinorType.INT)
@@ -67,17 +67,17 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
           .resumeSchema()
         .add("e", MinorType.VARCHAR)
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertFalse(rsLoader.isProjectionEmpty());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Verify structure and schema
 
     assertEquals(5, rsLoader.schemaVersion());
-    TupleMetadata actualSchema = rootWriter.tupleSchema();
+    final TupleMetadata actualSchema = rootWriter.tupleSchema();
     assertEquals(3, actualSchema.size());
     assertTrue(actualSchema.metadata(1).isMap());
     assertEquals(2, actualSchema.metadata("m").mapSchema().size());
@@ -87,11 +87,11 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Write a row the way that clients will do.
 
-    ScalarWriter aWriter = rootWriter.scalar("a");
-    TupleWriter mWriter = rootWriter.tuple("m");
-    ScalarWriter cWriter = mWriter.scalar("c");
-    ScalarWriter dWriter = mWriter.scalar("d");
-    ScalarWriter eWriter = rootWriter.scalar("e");
+    final ScalarWriter aWriter = rootWriter.scalar("a");
+    final TupleWriter mWriter = rootWriter.tuple("m");
+    final ScalarWriter cWriter = mWriter.scalar("c");
+    final ScalarWriter dWriter = mWriter.scalar("d");
+    final ScalarWriter eWriter = rootWriter.scalar("e");
 
     rootWriter.start();
     aWriter.setInt(10);
@@ -105,7 +105,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     try {
       mWriter.addColumn(SchemaBuilder.columnSchema("c", MinorType.INT, DataMode.OPTIONAL));
       fail();
-    } catch (UserException e) {
+    } catch (final UserException e) {
       // Expected
     }
 
@@ -115,16 +115,15 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Harvest the batch
 
-    RowSet actual = fixture.wrap(rsLoader.harvest());
+    final RowSet actual = fixture.wrap(rsLoader.harvest());
     assertEquals(5, rsLoader.schemaVersion());
     assertEquals(2, actual.rowCount());
-    @SuppressWarnings("resource")
-    MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
+    final MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
     assertEquals(2, mapVector.getAccessor().getValueCount());
 
     // Validate data
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10, mapValue(110, "fred"), "pebbles")
         .addRow(20, mapValue(210, "barney"), "bam-bam")
         .build();
@@ -141,18 +140,18 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testMapEvolution() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("b", MinorType.VARCHAR)
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertEquals(3, rsLoader.schemaVersion());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
     rootWriter
@@ -176,7 +175,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     // the batch starts, one before the first row, and one after
     // the first row.
 
-    TupleWriter mapWriter = rootWriter.tuple("m");
+    final TupleWriter mapWriter = rootWriter.tuple("m");
     mapWriter.addColumn(SchemaBuilder.columnSchema("c", MinorType.INT, DataMode.REQUIRED));
 
     rsLoader.startBatch();
@@ -193,7 +192,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Validate first batch
 
-    TupleMetadata expectedSchema = new SchemaBuilder()
+    final TupleMetadata expectedSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("b", MinorType.VARCHAR)
@@ -217,28 +216,28 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testMapAddition() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertEquals(1, rsLoader.schemaVersion());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Start without the map. Add a map after the first row.
 
     rsLoader.startBatch();
     rootWriter.addRow(10);
 
-    int mapIndex = rootWriter.addColumn(SchemaBuilder.columnSchema("m", MinorType.MAP, DataMode.REQUIRED));
-    TupleWriter mapWriter = rootWriter.tuple(mapIndex);
+    final int mapIndex = rootWriter.addColumn(SchemaBuilder.columnSchema("m", MinorType.MAP, DataMode.REQUIRED));
+    final TupleWriter mapWriter = rootWriter.tuple(mapIndex);
 
     // Add a column to the map with the same name as the top-level column.
     // Verifies that the name spaces are independent.
 
-    int colIndex = mapWriter.addColumn(SchemaBuilder.columnSchema("a", MinorType.VARCHAR, DataMode.REQUIRED));
+    final int colIndex = mapWriter.addColumn(SchemaBuilder.columnSchema("a", MinorType.VARCHAR, DataMode.REQUIRED));
     assertEquals(0, colIndex);
 
     // Ensure metadata was added
@@ -251,25 +250,25 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
       .addRow(20, mapValue("fred"))
       .addRow(30, mapValue("barney"));
 
-    RowSet actual = fixture.wrap(rsLoader.harvest());
+    final RowSet actual = fixture.wrap(rsLoader.harvest());
     assertEquals(3, rsLoader.schemaVersion());
     assertEquals(3, actual.rowCount());
 
-    MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
-    MaterializedField mapField = mapVector.getField();
+    final MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
+    final MaterializedField mapField = mapVector.getField();
     assertEquals(1, mapField.getChildren().size());
     assertTrue(mapWriter.scalar(colIndex).schema().schema().isEquivalent(
         mapField.getChildren().iterator().next()));
 
     // Validate first batch
 
-    TupleMetadata expectedSchema = new SchemaBuilder()
+    final TupleMetadata expectedSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("a", MinorType.VARCHAR)
           .resumeSchema()
         .buildSchema();
-    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+    final SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
         .addRow(10, mapValue(""))
         .addRow(20, mapValue("fred"))
         .addRow(30, mapValue("barney"))
@@ -287,23 +286,23 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testEmptyMapAddition() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertEquals(1, rsLoader.schemaVersion());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Start without the map. Add a map after the first row.
 
     rsLoader.startBatch();
     rootWriter.addRow(10);
 
-    int mapIndex = rootWriter.addColumn(SchemaBuilder.columnSchema("m", MinorType.MAP, DataMode.REQUIRED));
-    TupleWriter mapWriter = rootWriter.tuple(mapIndex);
+    final int mapIndex = rootWriter.addColumn(SchemaBuilder.columnSchema("m", MinorType.MAP, DataMode.REQUIRED));
+    final TupleWriter mapWriter = rootWriter.tuple(mapIndex);
 
     rootWriter
       .addRow(20, mapValue())
@@ -367,7 +366,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testNestedMapsRequired() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m1")
           .add("b", MinorType.VARCHAR)
@@ -376,12 +375,12 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
             .resumeMap()
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertEquals(5, rsLoader.schemaVersion());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
     rootWriter.addRow(10, mapValue("b1", mapValue("c1")));
@@ -401,9 +400,9 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     rsLoader.startBatch();
     rootWriter.addRow(20, mapValue("b2", mapValue("c2")));
 
-    TupleWriter m1Writer = rootWriter.tuple("m1");
+    final TupleWriter m1Writer = rootWriter.tuple("m1");
     m1Writer.addColumn(SchemaBuilder.columnSchema("d", MinorType.VARCHAR, DataMode.REQUIRED));
-    TupleWriter m2Writer = m1Writer.tuple("m2");
+    final TupleWriter m2Writer = m1Writer.tuple("m2");
     m2Writer.addColumn(SchemaBuilder.columnSchema("e", MinorType.VARCHAR, DataMode.REQUIRED));
 
     rootWriter.addRow(30, mapValue("b3", mapValue("c3", "e3"), "d3"));
@@ -420,7 +419,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     actual = fixture.wrap(rsLoader.harvest());
     assertEquals(9, rsLoader.schemaVersion());
 
-    TupleMetadata expectedSchema = new SchemaBuilder()
+    final TupleMetadata expectedSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m1")
           .add("b", MinorType.VARCHAR)
@@ -450,7 +449,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testNestedMapsNullable() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m1")
           .addNullable("b", MinorType.VARCHAR)
@@ -459,11 +458,11 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
             .resumeMap()
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    RowSetLoader rootWriter = rsLoader.writer();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
     rootWriter.addRow(10, mapValue("b1", mapValue("c1")));
@@ -474,8 +473,6 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10, mapValue("b1", mapValue("c1")))
         .build();
-//    actual.print();
-//    expected.print();
 
     RowSetUtilities.verify(expected, actual);
 
@@ -484,9 +481,9 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     rsLoader.startBatch();
     rootWriter.addRow(20, mapValue("b2", mapValue("c2")));
 
-    TupleWriter m1Writer = rootWriter.tuple("m1");
+    final TupleWriter m1Writer = rootWriter.tuple("m1");
     m1Writer.addColumn(SchemaBuilder.columnSchema("d", MinorType.VARCHAR, DataMode.OPTIONAL));
-    TupleWriter m2Writer = m1Writer.tuple("m2");
+    final TupleWriter m2Writer = m1Writer.tuple("m2");
     m2Writer.addColumn(SchemaBuilder.columnSchema("e", MinorType.VARCHAR, DataMode.OPTIONAL));
 
     rootWriter.addRow(30, mapValue("b3", mapValue("c3", "e3"), "d3"));
@@ -501,7 +498,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
     // Validate second batch
 
     actual = fixture.wrap(rsLoader.harvest());
-    TupleMetadata expectedSchema = new SchemaBuilder()
+    final TupleMetadata expectedSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m1")
           .addNullable("b", MinorType.VARCHAR)
@@ -533,18 +530,18 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testMapWithArray() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .addArray("c", MinorType.INT)
           .addArray("d", MinorType.VARCHAR)
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    RowSetLoader rootWriter = rsLoader.writer();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Write some rows
 
@@ -574,7 +571,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
       .addRow(40, mapValue(intArray(410, 420), strArray("d4.1", "d4.2")))
       .addRow(50, mapValue(intArray(510), strArray("d5.1")));
 
-    TupleWriter mapWriter = rootWriter.tuple("m");
+    final TupleWriter mapWriter = rootWriter.tuple("m");
     mapWriter.addColumn(SchemaBuilder.columnSchema("e", MinorType.VARCHAR, DataMode.REPEATED));
     rootWriter
       .addRow(60, mapValue(intArray(610, 620), strArray("d6.1", "d6.2"), strArray("e6.1", "e6.2")))
@@ -603,7 +600,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testMapWithOverflow() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m1")
           .add("b", MinorType.INT)
@@ -614,14 +611,14 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
             .resumeMap()
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    RowSetLoader rootWriter = rsLoader.writer();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader rootWriter = rsLoader.writer();
 
-    byte value[] = new byte[512];
+    final byte value[] = new byte[512];
     Arrays.fill(value, (byte) 'X');
     int count = 0;
     rsLoader.startBatch();
@@ -632,7 +629,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Our row count should include the overflow row
 
-    int expectedCount = ValueVector.MAX_BUFFER_SIZE / value.length;
+    final int expectedCount = ValueVector.MAX_BUFFER_SIZE / value.length;
     assertEquals(expectedCount + 1, count);
 
     // Loader's row count should include only "visible" rows
@@ -650,11 +647,9 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Ensure the odd map vector value count variable is set correctly.
 
-    @SuppressWarnings("resource")
-    MapVector m1Vector = (MapVector) result.container().getValueVector(1).getValueVector();
+    final MapVector m1Vector = (MapVector) result.container().getValueVector(1).getValueVector();
     assertEquals(expectedCount, m1Vector.getAccessor().getValueCount());
-    @SuppressWarnings("resource")
-    MapVector m2Vector = (MapVector) m1Vector.getChildByOrdinal(1);
+    final MapVector m2Vector = (MapVector) m1Vector.getChildByOrdinal(1);
     assertEquals(expectedCount, m2Vector.getAccessor().getValueCount());
 
     result.clear();
@@ -682,30 +677,30 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testMapOverflowWithNewColumn() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("b", MinorType.INT)
           .add("c", MinorType.VARCHAR)
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertEquals(4, rsLoader.schemaVersion());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Can't use the shortcut to populate rows when doing a schema
     // change.
 
-    ScalarWriter aWriter = rootWriter.scalar("a");
-    TupleWriter mWriter = rootWriter.tuple("m");
-    ScalarWriter bWriter = mWriter.scalar("b");
-    ScalarWriter cWriter = mWriter.scalar("c");
+    final ScalarWriter aWriter = rootWriter.scalar("a");
+    final TupleWriter mWriter = rootWriter.tuple("m");
+    final ScalarWriter bWriter = mWriter.scalar("b");
+    final ScalarWriter cWriter = mWriter.scalar("c");
 
-    byte value[] = new byte[512];
+    final byte value[] = new byte[512];
     Arrays.fill(value, (byte) 'X');
     int count = 0;
     rsLoader.startBatch();
@@ -731,7 +726,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     assertEquals(4, rsLoader.schemaVersion());
     assertTrue(schema.isEquivalent(result.schema()));
-    BatchSchema expectedSchema = new BatchSchema(SelectionVectorMode.NONE, schema.toFieldList());
+    final BatchSchema expectedSchema = new BatchSchema(SelectionVectorMode.NONE, schema.toFieldList());
     assertTrue(expectedSchema.isEquivalent(result.batchSchema()));
 
     // Use a reader to validate row-by-row. Too large to create an expected
@@ -775,32 +770,32 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testOverwriteRow() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("b", MinorType.INT)
           .add("c", MinorType.VARCHAR)
         .resumeSchema()
       .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    RowSetLoader rootWriter = rsLoader.writer();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     // Can't use the shortcut to populate rows when doing overwrites.
 
-    ScalarWriter aWriter = rootWriter.scalar("a");
-    TupleWriter mWriter = rootWriter.tuple("m");
-    ScalarWriter bWriter = mWriter.scalar("b");
-    ScalarWriter cWriter = mWriter.scalar("c");
+    final ScalarWriter aWriter = rootWriter.scalar("a");
+    final TupleWriter mWriter = rootWriter.tuple("m");
+    final ScalarWriter bWriter = mWriter.scalar("b");
+    final ScalarWriter cWriter = mWriter.scalar("c");
 
     // Write 100,000 rows, overwriting 99% of them. This will cause vector
     // overflow and data corruption if overwrite does not work; but will happily
     // produce the correct result if everything works as it should.
 
-    byte value[] = new byte[512];
+    final byte value[] = new byte[512];
     Arrays.fill(value, (byte) 'X');
     int count = 0;
     rsLoader.startBatch();
@@ -817,10 +812,10 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Verify using a reader.
 
-    RowSet result = fixture.wrap(rsLoader.harvest());
+    final RowSet result = fixture.wrap(rsLoader.harvest());
     assertEquals(count / 100, result.rowCount());
-    RowSetReader reader = result.reader();
-    TupleReader mReader = reader.tuple("m");
+    final RowSetReader reader = result.reader();
+    final TupleReader mReader = reader.tuple("m");
     int rowId = 1;
     while (reader.next()) {
       assertEquals(rowId * 100, reader.scalar("a").getInt());
@@ -840,7 +835,7 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
   @Test
   public void testNameSpace() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .add("a", MinorType.INT)
@@ -849,22 +844,22 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
             .resumeMap()
           .resumeSchema()
         .buildSchema();
-    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
         .setSchema(schema)
         .build();
-    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
     assertFalse(rsLoader.isProjectionEmpty());
-    RowSetLoader rootWriter = rsLoader.writer();
+    final RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
 
     // Write a row the way that clients will do.
 
-    ScalarWriter a1Writer = rootWriter.scalar("a");
-    TupleWriter m1Writer = rootWriter.tuple("m");
-    ScalarWriter a2Writer = m1Writer.scalar("a");
-    TupleWriter m2Writer = m1Writer.tuple("m");
-    ScalarWriter a3Writer = m2Writer.scalar("a");
+    final ScalarWriter a1Writer = rootWriter.scalar("a");
+    final TupleWriter m1Writer = rootWriter.tuple("m");
+    final ScalarWriter a2Writer = m1Writer.scalar("a");
+    final TupleWriter m2Writer = m1Writer.tuple("m");
+    final ScalarWriter a3Writer = m2Writer.scalar("a");
 
     rootWriter.start();
     a1Writer.setInt(11);
@@ -886,9 +881,9 @@ public class TestResultSetLoaderMaps extends SubOperatorTest {
 
     // Verify
 
-    RowSet actual = fixture.wrap(rsLoader.harvest());
+    final RowSet actual = fixture.wrap(rsLoader.harvest());
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(11, mapValue(12, mapValue(13)))
         .addRow(21, mapValue(22, mapValue(23)))
         .addRow(31, mapValue(32, mapValue(33)))

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderRepeatedList.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderRepeatedList.java
@@ -54,7 +54,7 @@ import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
 import org.apache.drill.test.rowSet.schema.SchemaBuilder;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 
 /**
  * Tests repeated list support. Repeated lists add another layer of dimensionality

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderRepeatedList.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderRepeatedList.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.rowSet.impl;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.objArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleObjArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSetLoader;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.ColumnMetadata.StructureType;
+import org.apache.drill.exec.record.metadata.RepeatedListColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ArrayReader;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarReader;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.ValueType;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSet;
+import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.schema.SchemaBuilder;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Tests repeated list support. Repeated lists add another layer of dimensionality
+ * on top of other repeated types. Since a repeated list can wrap another repeated
+ * list, the repeated list allows creating 2D, 3D or higher dimensional arrays (lists,
+ * actually, since the different "slices" need not have the same length...)
+ * Repeated lists appear to be used only by JSON.
+ */
+
+public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
+
+  @Test
+  public void test2DEarlySchema() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+
+    do2DTest(schema, rsLoader);
+    rsLoader.close();
+  }
+
+  private void do2DTest(TupleMetadata schema, ResultSetLoader rsLoader) {
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Sanity check of writer structure
+
+    assertEquals(2, writer.size());
+    final ObjectWriter listObj = writer.column("list2");
+    assertEquals(ObjectType.ARRAY, listObj.type());
+    final ArrayWriter listWriter = listObj.array();
+    assertEquals(ObjectType.ARRAY, listWriter.entryType());
+    final ArrayWriter innerWriter = listWriter.array();
+    assertEquals(ObjectType.SCALAR, innerWriter.entryType());
+    final ScalarWriter strWriter = innerWriter.scalar();
+    assertEquals(ValueType.STRING, strWriter.valueType());
+
+    // Sanity test of schema
+
+    final TupleMetadata rowSchema = writer.tupleSchema();
+    assertEquals(2, rowSchema.size());
+    final ColumnMetadata listSchema = rowSchema.metadata(1);
+    assertEquals(MinorType.LIST, listSchema.type());
+    assertEquals(DataMode.REPEATED, listSchema.mode());
+    assertTrue(listSchema instanceof RepeatedListColumnMetadata);
+    assertEquals(StructureType.MULTI_ARRAY, listSchema.structureType());
+    assertNotNull(listSchema.childSchema());
+
+    final ColumnMetadata elementSchema = listSchema.childSchema();
+    assertEquals(listSchema.name(), elementSchema.name());
+    assertEquals(MinorType.VARCHAR, elementSchema.type());
+    assertEquals(DataMode.REPEATED, elementSchema.mode());
+
+    // Write values
+
+    rsLoader.startBatch();
+    writer
+        .addRow(1, objArray(strArray("a", "b"), strArray("c", "d")))
+        .addRow(2, objArray(strArray("e"), strArray(), strArray("f", "g", "h")))
+        .addRow(3, objArray())
+        .addRow(4, objArray(strArray(), strArray("i"), strArray()));
+
+    // Verify the values.
+    // (Relies on the row set level repeated list tests having passed.)
+
+    final RowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, objArray(strArray("a", "b"), strArray("c", "d")))
+        .addRow(2, objArray(strArray("e"), strArray(), strArray("f", "g", "h")))
+        .addRow(3, objArray())
+        .addRow(4, objArray(strArray(), strArray("i"), strArray()))
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+  }
+
+  @Test
+  public void test2DLateSchema() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Add columns dynamically
+
+    writer.addColumn(schema.metadata(0));
+    writer.addColumn(schema.metadata(1).cloneEmpty());
+
+    // Yes, this is ugly. The whole repeated array idea is awkward.
+    // The only place it is used at present is in JSON where the
+    // awkwardness is mixed in with a logs of JSON complexity.
+    // Consider improving this API in the future.
+
+    ((RepeatedListWriter) writer.array(1)).defineElement(schema.metadata(1).childSchema());
+
+    do2DTest(schema, rsLoader);
+    rsLoader.close();
+  }
+
+  @Test
+  public void test2DLateSchemaIncremental() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Add columns dynamically
+
+    writer.addColumn(schema.metadata(0));
+
+    // Write a row without the array.
+
+    rsLoader.startBatch();
+    writer.addRow(1);
+
+    // Add the repeated list, but without contents.
+
+    writer.addColumn(schema.metadata(1).cloneEmpty());
+
+    // Sanity check of writer structure
+
+    assertEquals(2, writer.size());
+    final ObjectWriter listObj = writer.column("list2");
+    assertEquals(ObjectType.ARRAY, listObj.type());
+    final ArrayWriter listWriter = listObj.array();
+
+    // No child defined yet. A dummy child is inserted instead.
+
+    assertEquals(MinorType.NULL, listWriter.entry().schema().type());
+    assertEquals(ObjectType.ARRAY, listWriter.entryType());
+    assertEquals(ObjectType.SCALAR, listWriter.array().entryType());
+    assertEquals(ValueType.NULL, listWriter.array().scalar().valueType());
+
+    // Although we don't know the type of the inner, we can still
+    // create null (empty) elements in the outer array.
+
+    writer
+      .addRow(2, null)
+      .addRow(3, objArray())
+      .addRow(4, objArray(objArray(), null));
+
+    // Define the inner type.
+
+    final RepeatedListWriter listWriterImpl = (RepeatedListWriter) listWriter;
+    listWriterImpl.defineElement(MaterializedField.create("list2", Types.repeated(MinorType.VARCHAR)));
+
+    // Sanity check of completed structure
+
+    assertEquals(ObjectType.ARRAY, listWriter.entryType());
+    final ArrayWriter innerWriter = listWriter.array();
+    assertEquals(ObjectType.SCALAR, innerWriter.entryType());
+    final ScalarWriter strWriter = innerWriter.scalar();
+    assertEquals(ValueType.STRING, strWriter.valueType());
+
+    // Write values
+
+    writer
+        .addRow(5, objArray(strArray("a", "b"), strArray("c", "d")));
+
+    // Verify the values.
+    // (Relies on the row set level repeated list tests having passed.)
+
+    final RowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, objArray())
+        .addRow(2, objArray())
+        .addRow(3, objArray())
+        .addRow(4, objArray(objArray(), null))
+        .addRow(5, objArray(strArray("a", "b"), strArray("c", "d")))
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+    rsLoader.close();
+  }
+
+  @Test
+  public void test2DOverflow() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Fill the batch with enough data to cause overflow.
+    // Data must be large enough to cause overflow before 64K rows
+    // Make a bit bigger to overflow early.
+
+    final int outerSize = 7;
+    final int innerSize = 5;
+    final int strLength = ValueVector.MAX_BUFFER_SIZE / ValueVector.MAX_ROW_COUNT / outerSize / innerSize + 20;
+    final byte value[] = new byte[strLength - 6];
+    Arrays.fill(value, (byte) 'X');
+    final String strValue = new String(value, Charsets.UTF_8);
+    int rowCount = 0;
+    int elementCount = 0;
+
+    final ArrayWriter outerWriter = writer.array(1);
+    final ArrayWriter innerWriter = outerWriter.array();
+    final ScalarWriter elementWriter = innerWriter.scalar();
+    rsLoader.startBatch();
+    while (! writer.isFull()) {
+      writer.start();
+      writer.scalar(0).setInt(rowCount);
+      for (int j = 0; j < outerSize; j++) {
+        for (int k = 0; k < innerSize; k++) {
+          elementWriter.setString(String.format("%s%06d", strValue, elementCount));
+          elementCount++;
+        }
+        outerWriter.save();
+      }
+      writer.save();
+      rowCount++;
+    }
+
+    // Number of rows should be driven by vector size.
+    // Our row count should include the overflow row
+
+    final int expectedCount = ValueVector.MAX_BUFFER_SIZE / (strLength * innerSize * outerSize);
+    assertEquals(expectedCount + 1, rowCount);
+
+    // Loader's row count should include only "visible" rows
+
+    assertEquals(expectedCount, writer.rowCount());
+
+    // Total count should include invisible and look-ahead rows.
+
+    assertEquals(expectedCount + 1, rsLoader.totalRowCount());
+
+    // Result should exclude the overflow row
+
+    RowSet result = fixture.wrap(rsLoader.harvest());
+    assertEquals(expectedCount, result.rowCount());
+
+    // Verify the data.
+
+    RowSetReader reader = result.reader();
+    ArrayReader outerReader = reader.array(1);
+    ArrayReader innerReader = outerReader.array();
+    ScalarReader strReader = innerReader.scalar();
+    int readRowCount = 0;
+    int readElementCount = 0;
+    while (reader.next()) {
+      assertEquals(readRowCount, reader.scalar(0).getInt());
+      for (int i = 0; i < outerSize; i++) {
+        assertTrue(outerReader.next());
+        for (int j = 0; j < innerSize; j++) {
+          assertTrue(innerReader.next());
+          assertEquals(String.format("%s%06d", strValue, readElementCount),
+              strReader.getString());
+          readElementCount++;
+        }
+        assertFalse(innerReader.next());
+      }
+      assertFalse(outerReader.next());
+      readRowCount++;
+    }
+    assertEquals(readRowCount, result.rowCount());
+    result.clear();
+
+    // Write a few more rows to verify the overflow row.
+
+    rsLoader.startBatch();
+    for (int i = 0; i < 1000; i++) {
+      writer.start();
+      writer.scalar(0).setInt(rowCount);
+      for (int j = 0; j < outerSize; j++) {
+        for (int k = 0; k < innerSize; k++) {
+          elementWriter.setString(String.format("%s%06d", strValue, elementCount));
+          elementCount++;
+        }
+        outerWriter.save();
+      }
+      writer.save();
+      rowCount++;
+    }
+
+    result = fixture.wrap(rsLoader.harvest());
+    assertEquals(1001, result.rowCount());
+
+    final int startCount = readRowCount;
+    reader = result.reader();
+    outerReader = reader.array(1);
+    innerReader = outerReader.array();
+    strReader = innerReader.scalar();
+    while (reader.next()) {
+      assertEquals(readRowCount, reader.scalar(0).getInt());
+      for (int i = 0; i < outerSize; i++) {
+        assertTrue(outerReader.next());
+        for (int j = 0; j < innerSize; j++) {
+          assertTrue(innerReader.next());
+          elementWriter.setString(String.format("%s%06d", strValue, readElementCount));
+          assertEquals(String.format("%s%06d", strValue, readElementCount),
+              strReader.getString());
+          readElementCount++;
+        }
+        assertFalse(innerReader.next());
+      }
+      assertFalse(outerReader.next());
+      readRowCount++;
+    }
+    assertEquals(readRowCount - startCount, result.rowCount());
+    result.clear();
+    rsLoader.close();
+  }
+
+  // Adapted from TestRepeatedListAccessors.testSchema3DWriterReader
+  // That test exercises the low-level schema and writer mechanisms.
+  // Here we simply ensure that the 3D case continues to work when
+  // wrapped in the Result Set Loader
+
+  @Test
+  public void test3DEarlySchema() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+
+        // Uses a short-hand method to avoid mucking with actual
+        // nested lists.
+
+        .addArray("cube", MinorType.VARCHAR, 3)
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+
+    rsLoader.startBatch();
+    final RowSetLoader writer = rsLoader.writer();
+    writer
+      .addRow(1,
+          objArray(
+              objArray(
+                  strArray("a", "b"),
+                  strArray("c")),
+              objArray(
+                  strArray("d", "e", "f"),
+                  null),
+              null,
+              objArray()))
+      .addRow(2, null)
+      .addRow(3, objArray())
+      .addRow(4, objArray(objArray()))
+      .addRow(5, singleObjArray(
+          objArray(
+              strArray("g", "h"),
+              strArray("i"))));
+
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+      .addRow(1,
+          objArray(
+              objArray(
+                  strArray("a", "b"),
+                  strArray("c")),
+              objArray(
+                  strArray("d", "e", "f"),
+                  strArray()),
+              objArray(),
+              objArray()))
+      .addRow(2, objArray())
+      .addRow(3, objArray())
+      .addRow(4, objArray(objArray()))
+      .addRow(5, singleObjArray(
+          objArray(
+              strArray("g", "h"),
+              strArray("i"))))
+      .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+  }
+
+  // TODO: Test union list as inner
+  // TODO: Test repeated map as inner
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderUnions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderUnions.java
@@ -65,7 +65,7 @@ import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.drill.test.rowSet.schema.SchemaBuilder;
 import org.junit.Test;
 
-import com.google.common.base.Charsets;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 
 /**
  * Tests the result set loader support for union vectors. Union vectors

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderUnions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderUnions.java
@@ -1,0 +1,648 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.rowSet.impl;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.listValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.variantArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSetLoader;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.NullableIntVector;
+import org.apache.drill.exec.vector.NullableVarCharVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.ValueType;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.accessor.writer.EmptyListShim;
+import org.apache.drill.exec.vector.accessor.writer.ListWriterImpl;
+import org.apache.drill.exec.vector.accessor.writer.SimpleListShim;
+import org.apache.drill.exec.vector.accessor.writer.UnionVectorShim;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSet;
+import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.RowSetBuilder;
+import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.apache.drill.test.rowSet.schema.SchemaBuilder;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Tests the result set loader support for union vectors. Union vectors
+ * are only lightly supported in Apache Drill and not supported at all
+ * in commercial versions. They have may problems: both in code and in theory.
+ * Most operators do not support them. But, JSON uses them, so they must
+ * be made to work in the result set loader layer.
+ */
+
+public class TestResultSetLoaderUnions extends SubOperatorTest {
+
+  @Test
+  public void testUnionBasics() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addUnion("u")
+          .addType(MinorType.VARCHAR)
+          .addMap()
+            .addNullable("a", MinorType.INT)
+            .addNullable("b", MinorType.VARCHAR)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Sanity check of writer structure
+
+    final ObjectWriter wo = writer.column(1);
+    assertEquals(ObjectType.VARIANT, wo.type());
+    final VariantWriter vw = wo.variant();
+
+    assertTrue(vw.hasType(MinorType.VARCHAR));
+    assertNotNull(vw.memberWriter(MinorType.VARCHAR));
+
+    assertTrue(vw.hasType(MinorType.MAP));
+    assertNotNull(vw.memberWriter(MinorType.MAP));
+
+    // Write values
+
+    rsLoader.startBatch();
+    writer
+      .addRow(1, "first")
+      .addRow(2, mapValue(20, "fred"))
+      .addRow(3, null)
+      .addRow(4, mapValue(40, null))
+      .addRow(5, "last");
+
+    // Verify the values.
+    // (Relies on the row set level union tests having passed.)
+
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+      .addRow(1, "first")
+      .addRow(2, mapValue(20, "fred"))
+      .addRow(3, null)
+      .addRow(4, mapValue(40, null))
+      .addRow(5, "last")
+      .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+  }
+
+  @Test
+  public void testUnionAddTypes() {
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final RowSetLoader writer = rsLoader.writer();
+
+    rsLoader.startBatch();
+
+    // First row, (1, "first"), create types as we go.
+
+    writer.start();
+    writer.addColumn(SchemaBuilder.columnSchema("id", MinorType.INT, DataMode.REQUIRED));
+    writer.scalar("id").setInt(1);
+    writer.addColumn(SchemaBuilder.columnSchema("u", MinorType.UNION, DataMode.OPTIONAL));
+    final VariantWriter variant = writer.column("u").variant();
+    variant.member(MinorType.VARCHAR).scalar().setString("first");
+    writer.save();
+
+    // Second row, (2, {20, "fred"}), create types as we go.
+
+    writer.start();
+    writer.scalar("id").setInt(2);
+    final TupleWriter innerMap = variant.member(MinorType.MAP).tuple();
+    innerMap.addColumn(SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.OPTIONAL));
+    innerMap.scalar("a").setInt(20);
+    innerMap.addColumn(SchemaBuilder.columnSchema("b", MinorType.VARCHAR, DataMode.OPTIONAL));
+    innerMap.scalar("b").setString("fred");
+    writer.save();
+
+    // Write remaining rows using convenient methods, using
+    // schema defined above.
+
+    writer
+      .addRow(3, null)
+      .addRow(4, mapValue(40, null))
+      .addRow(5, "last");
+
+    // Verify the values.
+    // (Relies on the row set level union tests having passed.)
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addUnion("u")
+          .addType(MinorType.VARCHAR)
+          .addMap()
+            .addNullable("a", MinorType.INT)
+            .addNullable("b", MinorType.VARCHAR)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+      .addRow(1, "first")
+      .addRow(2, mapValue(20, "fred"))
+      .addRow(3, null)
+      .addRow(4, mapValue(40, null))
+      .addRow(5, "last")
+      .build();
+
+    final RowSet result = fixture.wrap(rsLoader.harvest());
+    RowSetUtilities.verify(expected, result);
+  }
+
+  @Test
+  public void testUnionOverflow() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addUnion("u")
+          .addType(MinorType.INT)
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Fill the batch with enough data to cause overflow.
+    // Fill even rows with a Varchar, odd rows with an int.
+    // Data must be large enough to cause overflow before 32K rows
+    // (the half that get strings.
+    // 16 MB / 32 K = 512 bytes
+    // Make a bit bigger to overflow early.
+
+    final int strLength = 600;
+    final byte value[] = new byte[strLength - 6];
+    Arrays.fill(value, (byte) 'X');
+    final String strValue = new String(value, Charsets.UTF_8);
+    int count = 0;
+
+    rsLoader.startBatch();
+    while (! writer.isFull()) {
+      if (count % 2 == 0) {
+        writer.addRow(count, String.format("%s%06d", strValue, count));
+      } else {
+        writer.addRow(count, count * 10);
+      }
+      count++;
+    }
+
+    // Number of rows should be driven by vector size.
+    // Our row count should include the overflow row
+
+    final int expectedCount = ValueVector.MAX_BUFFER_SIZE / strLength * 2;
+    assertEquals(expectedCount + 1, count);
+
+    // Loader's row count should include only "visible" rows
+
+    assertEquals(expectedCount, writer.rowCount());
+
+    // Total count should include invisible and look-ahead rows.
+
+    assertEquals(expectedCount + 1, rsLoader.totalRowCount());
+
+    // Result should exclude the overflow row
+
+    RowSet result = fixture.wrap(rsLoader.harvest());
+    assertEquals(expectedCount, result.rowCount());
+
+    // Verify the data.
+
+    RowSetReader reader = result.reader();
+    int readCount = 0;
+    while (reader.next()) {
+      assertEquals(readCount, reader.scalar(0).getInt());
+      if (readCount % 2 == 0) {
+        assertEquals(String.format("%s%06d", strValue, readCount),
+            reader.variant(1).scalar().getString());
+      } else {
+        assertEquals(readCount * 10, reader.variant(1).scalar().getInt());
+      }
+      readCount++;
+    }
+    assertEquals(readCount, result.rowCount());
+    result.clear();
+
+    // Write a few more rows to verify the overflow row.
+
+    rsLoader.startBatch();
+    for (int i = 0; i < 1000; i++) {
+      if (count % 2 == 0) {
+        writer.addRow(count, String.format("%s%06d", strValue, count));
+      } else {
+        writer.addRow(count, count * 10);
+      }
+      count++;
+    }
+
+    result = fixture.wrap(rsLoader.harvest());
+    assertEquals(1001, result.rowCount());
+
+    final int startCount = readCount;
+    reader = result.reader();
+    while (reader.next()) {
+      assertEquals(readCount, reader.scalar(0).getInt());
+      if (readCount % 2 == 0) {
+        assertEquals(String.format("%s%06d", strValue, readCount),
+            reader.variant(1).scalar().getString());
+      } else {
+        assertEquals(readCount * 10, reader.variant(1).scalar().getInt());
+      }
+      readCount++;
+    }
+    assertEquals(readCount - startCount, result.rowCount());
+    result.clear();
+    rsLoader.close();
+  }
+
+  /**
+   * Test for the case of a list defined to contain exactly one type.
+   * Relies on the row set tests to verify that the single type model
+   * works for lists. Here we test that the ResultSetLoader put the
+   * pieces together correctly.
+   */
+
+  @Test
+  public void testSimpleList() {
+
+    // Schema with a list declared with one type, not expandable
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addList("list")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    schema.metadata("list").variantSchema().becomeSimple();
+
+    final ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schema)
+        .build();
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Sanity check: should be an array of Varchar because we said the
+    // types within the list is not expandable.
+
+    final ArrayWriter arrWriter = writer.array("list");
+    assertEquals(ObjectType.SCALAR, arrWriter.entryType());
+    final ScalarWriter strWriter = arrWriter.scalar();
+    assertEquals(ValueType.STRING, strWriter.valueType());
+
+    // Can write a batch as if this was a repeated Varchar, except
+    // that any value can also be null.
+
+    rsLoader.startBatch();
+    writer
+      .addRow(1, strArray("fred", "barney"))
+      .addRow(2, null)
+      .addRow(3, strArray("wilma", "betty", "pebbles"));
+
+    // Verify
+
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, strArray("fred", "barney"))
+        .addRow(2, null)
+        .addRow(3, strArray("wilma", "betty", "pebbles"))
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+  }
+
+  /**
+   * Test a simple list created dynamically at load time.
+   * The list must include a single type member.
+   */
+
+  @Test
+  public void testSimpleListDynamic() {
+
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Can write a batch as if this was a repeated Varchar, except
+    // that any value can also be null.
+
+    rsLoader.startBatch();
+
+    writer.addColumn(MaterializedField.create("id", Types.required(MinorType.INT)));
+
+    final ColumnMetadata colSchema = MetadataUtils.newVariant("list", DataMode.REPEATED);
+    colSchema.variantSchema().addType(MinorType.VARCHAR);
+    colSchema.variantSchema().becomeSimple();
+    writer.addColumn(colSchema);
+
+    // Sanity check: should be an array of Varchar because we said the
+    // types within the list is not expandable.
+
+    final ArrayWriter arrWriter = writer.array("list");
+    assertEquals(ObjectType.SCALAR, arrWriter.entryType());
+    final ScalarWriter strWriter = arrWriter.scalar();
+    assertEquals(ValueType.STRING, strWriter.valueType());
+
+    writer
+      .addRow(1, strArray("fred", "barney"))
+      .addRow(2, null)
+      .addRow(3, strArray("wilma", "betty", "pebbles"));
+
+    // Verify
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addList("list")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, strArray("fred", "barney"))
+        .addRow(2, null)
+        .addRow(3, strArray("wilma", "betty", "pebbles"))
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
+  }
+
+  /**
+   * Try to create a simple (non-expandable) list without
+   * giving a member type. Expected to fail.
+   */
+
+  @Test
+  public void testSimpleListNoTypes() {
+
+    // Schema with a list declared with one type, not expandable
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addList("list")
+          .resumeSchema()
+        .buildSchema();
+
+    try {
+      schema.metadata("list").variantSchema().becomeSimple();
+      fail();
+    } catch (final IllegalStateException e) {
+      // expected
+    }
+  }
+
+  /**
+   * Try to create a simple (non-expandable) list while specifying
+   * two types. Expected to fail.
+   */
+
+  @Test
+  public void testSimpleListMultiTypes() {
+
+    // Schema with a list declared with one type, not expandable
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addList("list")
+          .addType(MinorType.VARCHAR)
+          .addType(MinorType.INT)
+          .resumeSchema()
+        .buildSchema();
+
+    try {
+      schema.metadata("list").variantSchema().becomeSimple();
+      fail();
+    } catch (final IllegalStateException e) {
+      // expected
+    }
+  }
+
+
+  /**
+   * Test a variant list created dynamically at load time.
+   * The list starts with no type, at which time it can hold
+   * only null values. Then we add a Varchar, and finally an
+   * Int.
+   * <p>
+   * This test is superficial. There are many odd cases to consider.
+   * <ul>
+   * <li>Write nulls to a list with no type. (This test ensures that
+   * adding a (nullable) scalar "does the right thing.")</li>
+   * <li>Add a map to the list. Maps carry no "bits" vector, so null
+   * list entries to that point are lost. (For maps, we could go straight
+   * to a union, with just a map, to preserve the null states. This whole
+   * area is a huge mess...)</li>
+   * <li>Do the type transitions when writing to a row. (The tests here
+   * do the transition between rows.</li>
+   * </ul>
+   *
+   * The reason for the sparse coverage is that Drill barely supports lists
+   * and unions; most code is just plain broken. Our goal here is not to fix
+   * all those problems, just to leave things no more broken than before.
+   */
+
+  @Test
+  public void testVariantListDynamic() {
+
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Can write a batch as if this was a repeated Varchar, except
+    // that any value can also be null.
+
+    rsLoader.startBatch();
+
+    writer.addColumn(MaterializedField.create("id", Types.required(MinorType.INT)));
+    writer.addColumn(MaterializedField.create("list", Types.optional(MinorType.LIST)));
+
+    // Sanity check: should be an array of variants because we said the
+    // types within the list are expandable (which is the default.)
+
+    final ArrayWriter arrWriter = writer.array("list");
+    assertEquals(ObjectType.VARIANT, arrWriter.entryType());
+    final VariantWriter variant = arrWriter.variant();
+
+    // We need to verify that the internal state is what we expect, so
+    // the next assertion peeks inside the private bits of the union
+    // writer. No client code should ever need to do this, of course.
+
+    assertTrue(((UnionWriterImpl) variant).shim() instanceof EmptyListShim);
+
+    // No types, so all we can do is add a null list, or a list of nulls.
+
+    writer
+      .addRow(1, null)
+      .addRow(2, variantArray())
+      .addRow(3, variantArray(null, null));
+
+    // Add a String. Now we can create a list of strings and/or nulls.
+
+    variant.addMember(MinorType.VARCHAR);
+    assertTrue(variant.hasType(MinorType.VARCHAR));
+
+    // Sanity check: sniff inside to ensure that the list contains a single
+    // type.
+
+    assertTrue(((UnionWriterImpl) variant).shim() instanceof SimpleListShim);
+    assertTrue(((ListWriterImpl) arrWriter).vector().getDataVector() instanceof NullableVarCharVector);
+
+    writer
+      .addRow(4, variantArray("fred", null, "barney"));
+
+    // Add an integer. The list vector should be promoted to union.
+    // Now we can add both types.
+
+    variant.addMember(MinorType.INT);
+
+    // Sanity check: sniff inside to ensure promotion to union occurred
+
+    assertTrue(((UnionWriterImpl) variant).shim() instanceof UnionVectorShim);
+    assertTrue(((ListWriterImpl) arrWriter).vector().getDataVector() instanceof UnionVector);
+
+    writer
+      .addRow(5, variantArray("wilma", null, 30));
+
+    // Verify
+
+    final RowSet result = fixture.wrap(rsLoader.harvest());
+//    result.print();
+
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addList("list")
+          .addType(MinorType.VARCHAR)
+          .addType(MinorType.INT)
+          .resumeSchema()
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, null)
+        .addRow(2, variantArray())
+        .addRow(3, variantArray(null, null))
+        .addRow(4, variantArray("fred", null, "barney"))
+        .addRow(5, variantArray("wilma", null, 30))
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+  }
+
+  /**
+   * The semantics of the ListVector are such that it allows
+   * multi-dimensional lists. In this way, it is like a (slightly
+   * more normalized) version of the repeated list vector. This form
+   * allows arrays to be null.
+   * <p>
+   * This test verifies that the (non-repeated) list vector can
+   * be used to create multi-dimensional arrays in the result set
+   * loader layer. However, the rest of Drill does not support this
+   * functionality at present, so this test is more of a proof-of-
+   * concept than a necessity.
+   */
+
+  @Test
+  public void testListofListofScalar() {
+
+    // JSON equivalent: {a: [[1, 2], [3, 4]]}
+
+    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final RowSetLoader writer = rsLoader.writer();
+
+    // Can write a batch as if this was a repeated Varchar, except
+    // that any value can also be null.
+
+    rsLoader.startBatch();
+
+    writer.addColumn(MaterializedField.create("a", Types.optional(MinorType.LIST)));
+    final ArrayWriter outerArray = writer.array("a");
+    final VariantWriter outerVariant = outerArray.variant();
+    outerVariant.addMember(MinorType.LIST);
+    final ArrayWriter innerArray = outerVariant.array();
+    final VariantWriter innerVariant = innerArray.variant();
+    innerVariant.addMember(MinorType.INT);
+
+    writer.addSingleCol(listValue(listValue(1, 2), listValue(3, 4)));
+    final RowSet results = fixture.wrap(rsLoader.harvest());
+
+    // Verify metadata
+
+    final ListVector outer = (ListVector) results.container().getValueVector(0).getValueVector();
+    final MajorType outerType = outer.getField().getType();
+    assertEquals(1, outerType.getSubTypeCount());
+    assertEquals(MinorType.LIST, outerType.getSubType(0));
+    assertEquals(1, outer.getField().getChildren().size());
+
+    final ListVector inner = (ListVector) outer.getDataVector();
+    assertSame(inner.getField(), outer.getField().getChildren().iterator().next());
+    final MajorType innerType = inner.getField().getType();
+    assertEquals(1, innerType.getSubTypeCount());
+    assertEquals(MinorType.INT, innerType.getSubType(0));
+    assertEquals(1, inner.getField().getChildren().size());
+
+    final ValueVector data = inner.getDataVector();
+    assertSame(data.getField(), inner.getField().getChildren().iterator().next());
+    assertEquals(MinorType.INT, data.getField().getType().getMinorType());
+    assertEquals(DataMode.OPTIONAL, data.getField().getType().getMode());
+    assertTrue(data instanceof NullableIntVector);
+
+    // Note use of TupleMetadata: BatchSchema can't hold the
+    // structure of a list.
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addList()
+            .addType(MinorType.INT)
+            .buildNested()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(listValue(listValue(1, 2), listValue(3, 4)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  // TODO: Simple list of map
+  // TODO: Regular list of map
+  // TODO: Regular list of union
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultVectorCache.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultVectorCache.java
@@ -38,7 +38,7 @@ public class TestResultVectorCache extends SubOperatorTest {
   @Test
   public void testIsPromotable() {
 
-    MaterializedField required = MaterializedField.create("a",
+    final MaterializedField required = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.REQUIRED)
@@ -51,7 +51,7 @@ public class TestResultVectorCache extends SubOperatorTest {
 
     // Required is promotable to null
 
-    MaterializedField nullable = MaterializedField.create("a",
+    final MaterializedField nullable = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.OPTIONAL)
@@ -66,7 +66,7 @@ public class TestResultVectorCache extends SubOperatorTest {
 
     // Arrays cannot be promoted to/from other types
 
-    MaterializedField repeated = MaterializedField.create("a",
+    final MaterializedField repeated = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.REPEATED)
@@ -79,19 +79,19 @@ public class TestResultVectorCache extends SubOperatorTest {
 
     // Narrower precision promotable to wider
 
-    MaterializedField narrow = MaterializedField.create("a",
+    final MaterializedField narrow = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .setPrecision(10)
           .build());
-    MaterializedField wide = MaterializedField.create("a",
+    final MaterializedField wide = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .setPrecision(20)
           .build());
-    MaterializedField unset = MaterializedField.create("a",
+    final MaterializedField unset = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
@@ -104,34 +104,33 @@ public class TestResultVectorCache extends SubOperatorTest {
     assertFalse(narrow.isPromotableTo(unset, false));
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void testBasics() {
-    ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator());
+    final ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator());
 
     // Create a vector
 
-    MaterializedField required = MaterializedField.create("a",
+    final MaterializedField required = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.REQUIRED)
           .build());
-    ValueVector vector1 = cache.addOrGet(required);
+    final ValueVector vector1 = cache.addOrGet(required);
     assertTrue(vector1.getField().isEquivalent(required));
 
     // Request the same schema, should get the same vector.
 
-    ValueVector vector2 = cache.addOrGet(required);
+    final ValueVector vector2 = cache.addOrGet(required);
     assertSame(vector1, vector2);
 
     // Non-permissive. Change in mode means different vector.
 
-    MaterializedField optional = MaterializedField.create("a",
+    final MaterializedField optional = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.OPTIONAL)
           .build());
-    ValueVector vector3 = cache.addOrGet(optional);
+    final ValueVector vector3 = cache.addOrGet(optional);
     assertTrue(vector3.getField().isEquivalent(optional));
     assertNotSame(vector1, vector3);
 
@@ -139,51 +138,51 @@ public class TestResultVectorCache extends SubOperatorTest {
     // Name is the key, and we can have only one type associated
     // with each name.
 
-    ValueVector vector4 = cache.addOrGet(required);
+    final ValueVector vector4 = cache.addOrGet(required);
     assertTrue(vector4.getField().isEquivalent(required));
     assertNotSame(vector3, vector4);
     assertNotSame(vector1, vector4);
 
     // Varchar, no precision.
 
-    MaterializedField varchar1 = MaterializedField.create("a",
+    final MaterializedField varchar1 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .build());
 
-    ValueVector vector5 = cache.addOrGet(varchar1);
+    final ValueVector vector5 = cache.addOrGet(varchar1);
     assertTrue(vector5.getField().isEquivalent(varchar1));
 
     // Varchar, with precision, no match.
 
-    MaterializedField varchar2 = MaterializedField.create("a",
+    final MaterializedField varchar2 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .setPrecision(10)
           .build());
 
-    ValueVector vector6 = cache.addOrGet(varchar2);
+    final ValueVector vector6 = cache.addOrGet(varchar2);
     assertTrue(vector6.getField().isEquivalent(varchar2));
     assertNotSame(vector5, vector6);
 
     // Does match if same precision.
 
-    ValueVector vector7 = cache.addOrGet(varchar2);
+    final ValueVector vector7 = cache.addOrGet(varchar2);
     assertTrue(vector7.getField().isEquivalent(varchar2));
     assertSame(vector6, vector7);
 
     // Different names have different types
 
-    MaterializedField varchar3 = MaterializedField.create("b",
+    final MaterializedField varchar3 = MaterializedField.create("b",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .setPrecision(10)
           .build());
 
-    ValueVector vector8 = cache.addOrGet(varchar3);
+    final ValueVector vector8 = cache.addOrGet(varchar3);
     assertTrue(vector8.getField().isEquivalent(varchar3));
     assertSame(vector7, cache.addOrGet(varchar2));
     assertSame(vector8, cache.addOrGet(varchar3));
@@ -191,80 +190,79 @@ public class TestResultVectorCache extends SubOperatorTest {
     ((ResultVectorCacheImpl) cache).close();
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void testPermissive() {
-    ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator(), true);
+    final ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator(), true);
 
     // Create a nullable vector
 
-    MaterializedField optional = MaterializedField.create("a",
+    final MaterializedField optional = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.OPTIONAL)
           .build());
-    ValueVector vector1 = cache.addOrGet(optional);
+    final ValueVector vector1 = cache.addOrGet(optional);
 
     // Ask for a required version of the same name and type.
     // Should return the nullable version.
 
-    MaterializedField required = MaterializedField.create("a",
+    final MaterializedField required = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.REQUIRED)
           .build());
-    ValueVector vector2 = cache.addOrGet(required);
+    final ValueVector vector2 = cache.addOrGet(required);
     assertTrue(vector2.getField().isEquivalent(optional));
     assertSame(vector1, vector2);
 
     // Repeat with Varchar
 
-    MaterializedField varchar1 = MaterializedField.create("a",
+    final MaterializedField varchar1 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.OPTIONAL)
           .build());
 
-    ValueVector vector3 = cache.addOrGet(varchar1);
+    final ValueVector vector3 = cache.addOrGet(varchar1);
 
-    MaterializedField varchar2 = MaterializedField.create("a",
+    final MaterializedField varchar2 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .build());
 
-    ValueVector vector4 = cache.addOrGet(varchar2);
+    final ValueVector vector4 = cache.addOrGet(varchar2);
     assertSame(vector3, vector4);
 
     // Larger precision. Needs new vector.
 
-    MaterializedField varchar3 = MaterializedField.create("a",
+    final MaterializedField varchar3 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.OPTIONAL)
           .setPrecision(10)
           .build());
 
-    ValueVector vector5 = cache.addOrGet(varchar3);
+    final ValueVector vector5 = cache.addOrGet(varchar3);
     assertTrue(vector5.getField().isEquivalent(varchar3));
     assertNotSame(vector4, vector5);
 
     // Smaller precision, reuse vector.
 
-    ValueVector vector6 = cache.addOrGet(varchar1);
+    final ValueVector vector6 = cache.addOrGet(varchar1);
     assertTrue(vector6.getField().isEquivalent(varchar3));
     assertSame(vector5, vector6);
 
     // Same precision, required: reuse vector.
 
-    MaterializedField varchar4 = MaterializedField.create("a",
+    final MaterializedField varchar4 = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.VARCHAR)
           .setMode(DataMode.REQUIRED)
           .setPrecision(5)
           .build());
 
-    ValueVector vector7 = cache.addOrGet(varchar4);
+    final ValueVector vector7 = cache.addOrGet(varchar4);
     assertTrue(vector7.getField().isEquivalent(varchar3));
     assertSame(vector5, vector7);
 
@@ -273,19 +271,18 @@ public class TestResultVectorCache extends SubOperatorTest {
     ((ResultVectorCacheImpl) cache).close();
   }
 
-  @SuppressWarnings("resource")
   @Test
   public void testClose() {
-    ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator());
+    final ResultVectorCache cache = new ResultVectorCacheImpl(fixture.allocator());
 
     // Create a vector
 
-    MaterializedField required = MaterializedField.create("a",
+    final MaterializedField required = MaterializedField.create("a",
         MajorType.newBuilder()
           .setMinorType(MinorType.INT)
           .setMode(DataMode.REQUIRED)
           .build());
-    IntVector vector1 = (IntVector) cache.addOrGet(required);
+    final IntVector vector1 = (IntVector) cache.addOrGet(required);
     vector1.allocateNew(100);
 
     // Close the cache. Note: close is on the implementation, not

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/RowSetTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/RowSetTest.java
@@ -87,11 +87,11 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testScalarStructure() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .buildSchema();
-    ExtendableRowSet rowSet = fixture.rowSet(schema);
-    RowSetWriter writer = rowSet.writer();
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
 
     // Required Int
     // Verify the invariants of the "full" and "simple" access paths
@@ -108,13 +108,13 @@ public class RowSetTest extends SubOperatorTest {
     try {
       writer.column(0).array();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
     try {
       writer.column(0).tuple();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
 
@@ -131,8 +131,8 @@ public class RowSetTest extends SubOperatorTest {
 
     // Finish the row set and get a reader.
 
-    SingleRowSet actual = writer.done();
-    RowSetReader reader = actual.reader();
+    final SingleRowSet actual = writer.done();
+    final RowSetReader reader = actual.reader();
 
     // Verify invariants
 
@@ -163,7 +163,7 @@ public class RowSetTest extends SubOperatorTest {
     // Test the above again via the writer and reader
     // utility classes.
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10)
         .addRow(20)
         .addRow(30)
@@ -181,11 +181,11 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testScalarArrayStructure() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .addArray("a", MinorType.INT)
         .buildSchema();
-    ExtendableRowSet rowSet = fixture.rowSet(schema);
-    RowSetWriter writer = rowSet.writer();
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
 
     // Repeated Int
     // Verify the invariants of the "full" and "simple" access paths
@@ -207,19 +207,19 @@ public class RowSetTest extends SubOperatorTest {
     try {
       writer.column(0).scalar();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
     try {
       writer.column(0).tuple();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
 
     // Write some data
 
-    ScalarWriter intWriter = writer.array("a").scalar();
+    final ScalarWriter intWriter = writer.array("a").scalar();
     intWriter.setInt(10);
     intWriter.setInt(11);
     writer.save();
@@ -235,8 +235,8 @@ public class RowSetTest extends SubOperatorTest {
 
     // Finish the row set and get a reader.
 
-    SingleRowSet actual = writer.done();
-    RowSetReader reader = actual.reader();
+    final SingleRowSet actual = writer.done();
+    final RowSetReader reader = actual.reader();
 
     // Verify the invariants of the "full" and "simple" access paths
 
@@ -252,8 +252,8 @@ public class RowSetTest extends SubOperatorTest {
 
     // Read and verify the rows
 
-    ArrayReader arrayReader = reader.array(0);
-    ScalarReader intReader = arrayReader.scalar();
+    final ArrayReader arrayReader = reader.array(0);
+    final ScalarReader intReader = arrayReader.scalar();
     assertTrue(reader.next());
     assertFalse(arrayReader.isNull());
     assertEquals(2, arrayReader.size());
@@ -297,7 +297,7 @@ public class RowSetTest extends SubOperatorTest {
     // Test the above again via the writer and reader
     // utility classes.
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addSingleCol(intArray(10, 11))
         .addSingleCol(intArray(20, 21, 22))
         .addSingleCol(intArray(30))
@@ -315,14 +315,14 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testMapStructure() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMap("m")
           .addArray("b", MinorType.INT)
           .resumeSchema()
         .buildSchema();
-    ExtendableRowSet rowSet = fixture.rowSet(schema);
-    RowSetWriter writer = rowSet.writer();
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
 
     // Map and Int
     // Test Invariants
@@ -333,12 +333,12 @@ public class RowSetTest extends SubOperatorTest {
     assertEquals(ObjectType.TUPLE, writer.column(1).type());
     assertSame(writer.column(1).tuple(), writer.tuple(1));
 
-    TupleWriter mapWriter = writer.column(1).tuple();
+    final TupleWriter mapWriter = writer.column(1).tuple();
     assertEquals(ObjectType.SCALAR, mapWriter.column("b").array().entry().type());
     assertEquals(ObjectType.SCALAR, mapWriter.column("b").array().entryType());
 
-    ScalarWriter aWriter = writer.column("a").scalar();
-    ScalarWriter bWriter = writer.column("m").tuple().column("b").array().entry().scalar();
+    final ScalarWriter aWriter = writer.column("a").scalar();
+    final ScalarWriter bWriter = writer.column("m").tuple().column("b").array().entry().scalar();
     assertSame(bWriter, writer.tuple(1).array(0).scalar());
     assertEquals(ValueType.INTEGER, bWriter.valueType());
 
@@ -347,13 +347,13 @@ public class RowSetTest extends SubOperatorTest {
     try {
       writer.column(1).scalar();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
     try {
       writer.column(1).array();
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (final UnsupportedOperationException e) {
       // Expected
     }
 
@@ -374,8 +374,8 @@ public class RowSetTest extends SubOperatorTest {
 
     // Finish the row set and get a reader.
 
-    SingleRowSet actual = writer.done();
-    RowSetReader reader = actual.reader();
+    final SingleRowSet actual = writer.done();
+    final RowSetReader reader = actual.reader();
 
     assertEquals(ObjectType.SCALAR, reader.column("a").type());
     assertEquals(ObjectType.SCALAR, reader.column(0).type());
@@ -383,11 +383,11 @@ public class RowSetTest extends SubOperatorTest {
     assertEquals(ObjectType.TUPLE, reader.column(1).type());
     assertSame(reader.column(1).tuple(), reader.tuple(1));
 
-    ScalarReader aReader = reader.column(0).scalar();
-    TupleReader mReader = reader.column(1).tuple();
-    ArrayReader bArray = mReader.column("b").array();
+    final ScalarReader aReader = reader.column(0).scalar();
+    final TupleReader mReader = reader.column(1).tuple();
+    final ArrayReader bArray = mReader.column("b").array();
     assertEquals(ObjectType.SCALAR, bArray.entryType());
-    ScalarReader bReader = bArray.scalar();
+    final ScalarReader bReader = bArray.scalar();
     assertEquals(ValueType.INTEGER, bReader.valueType());
 
     // Row 1: (10, {[11, 12]})
@@ -430,10 +430,10 @@ public class RowSetTest extends SubOperatorTest {
 
     // Verify that the map accessor's value count was set.
 
-    MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
+    final MapVector mapVector = (MapVector) actual.container().getValueVector(1).getValueVector();
     assertEquals(actual.rowCount(), mapVector.getAccessor().getValueCount());
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10, objArray(intArray(11, 12)))
         .addRow(20, objArray(intArray(21, 22)))
         .addRow(30, objArray(intArray(31, 32)))
@@ -444,15 +444,15 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testRepeatedMapStructure() {
-    TupleMetadata schema = new SchemaBuilder()
+    final TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .addMapArray("m")
           .add("b", MinorType.INT)
           .add("c", MinorType.INT)
           .resumeSchema()
         .buildSchema();
-    ExtendableRowSet rowSet = fixture.rowSet(schema);
-    RowSetWriter writer = rowSet.writer();
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
 
     // Map and Int
     // Pick out components and lightly test. (Assumes structure
@@ -462,16 +462,16 @@ public class RowSetTest extends SubOperatorTest {
     assertEquals(ObjectType.SCALAR, writer.column("a").type());
     assertEquals(ObjectType.ARRAY, writer.column("m").type());
 
-    ArrayWriter maWriter = writer.column(1).array();
+    final ArrayWriter maWriter = writer.column(1).array();
     assertEquals(ObjectType.TUPLE, maWriter.entryType());
 
-    TupleWriter mapWriter = maWriter.tuple();
+    final TupleWriter mapWriter = maWriter.tuple();
     assertEquals(ObjectType.SCALAR, mapWriter.column("b").type());
     assertEquals(ObjectType.SCALAR, mapWriter.column("c").type());
 
-    ScalarWriter aWriter = writer.column("a").scalar();
-    ScalarWriter bWriter = mapWriter.scalar("b");
-    ScalarWriter cWriter = mapWriter.scalar("c");
+    final ScalarWriter aWriter = writer.column("a").scalar();
+    final ScalarWriter bWriter = mapWriter.scalar("b");
+    final ScalarWriter cWriter = mapWriter.scalar("c");
     assertEquals(ValueType.INTEGER, aWriter.valueType());
     assertEquals(ValueType.INTEGER, bWriter.valueType());
     assertEquals(ValueType.INTEGER, cWriter.valueType());
@@ -507,24 +507,24 @@ public class RowSetTest extends SubOperatorTest {
 
     // Finish the row set and get a reader.
 
-    SingleRowSet actual = writer.done();
-    RowSetReader reader = actual.reader();
+    final SingleRowSet actual = writer.done();
+    final RowSetReader reader = actual.reader();
 
     // Verify reader structure
 
     assertEquals(ObjectType.SCALAR, reader.column("a").type());
     assertEquals(ObjectType.ARRAY, reader.column("m").type());
 
-    ArrayReader maReader = reader.column(1).array();
+    final ArrayReader maReader = reader.column(1).array();
     assertEquals(ObjectType.TUPLE, maReader.entryType());
 
-    TupleReader mapReader = maReader.tuple();
+    final TupleReader mapReader = maReader.tuple();
     assertEquals(ObjectType.SCALAR, mapReader.column("b").type());
     assertEquals(ObjectType.SCALAR, mapReader.column("c").type());
 
-    ScalarReader aReader = reader.column("a").scalar();
-    ScalarReader bReader = mapReader.scalar("b");
-    ScalarReader cReader = mapReader.scalar("c");
+    final ScalarReader aReader = reader.column("a").scalar();
+    final ScalarReader bReader = mapReader.scalar("b");
+    final ScalarReader cReader = mapReader.scalar("c");
     assertEquals(ValueType.INTEGER, aReader.valueType());
     assertEquals(ValueType.INTEGER, bReader.valueType());
     assertEquals(ValueType.INTEGER, cReader.valueType());
@@ -573,12 +573,12 @@ public class RowSetTest extends SubOperatorTest {
 
     // Verify that the map accessor's value count was set.
 
-    RepeatedMapVector mapVector = (RepeatedMapVector) actual.container().getValueVector(1).getValueVector();
+    final RepeatedMapVector mapVector = (RepeatedMapVector) actual.container().getValueVector(1).getValueVector();
     assertEquals(3, mapVector.getAccessor().getValueCount());
 
     // Verify the readers and writers again using the testing tools.
 
-    SingleRowSet expected = fixture.rowSetBuilder(schema)
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10, objArray(objArray(101, 102), objArray(111, 112)))
         .addRow(20, objArray(objArray(201, 202), objArray(211, 212)))
         .addRow(30, objArray(objArray(301, 302), objArray(311, 312)))
@@ -594,15 +594,15 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testTopFixedWidthArray() {
-    BatchSchema batchSchema = new SchemaBuilder()
+    final BatchSchema batchSchema = new SchemaBuilder()
         .add("c", MinorType.INT)
         .addArray("a", MinorType.INT)
         .build();
 
-    ExtendableRowSet rs1 = fixture.rowSet(batchSchema);
-    RowSetWriter writer = rs1.writer();
+    final ExtendableRowSet rs1 = fixture.rowSet(batchSchema);
+    final RowSetWriter writer = rs1.writer();
     writer.scalar(0).setInt(10);
-    ScalarWriter array = writer.array(1).scalar();
+    final ScalarWriter array = writer.array(1).scalar();
     array.setInt(100);
     array.setInt(110);
     writer.save();
@@ -614,11 +614,11 @@ public class RowSetTest extends SubOperatorTest {
     writer.scalar(0).setInt(30);
     writer.save();
 
-    SingleRowSet result = writer.done();
+    final SingleRowSet result = writer.done();
 
-    RowSetReader reader = result.reader();
-    ArrayReader arrayReader = reader.array(1);
-    ScalarReader elementReader = arrayReader.scalar();
+    final RowSetReader reader = result.reader();
+    final ArrayReader arrayReader = reader.array(1);
+    final ScalarReader elementReader = arrayReader.scalar();
 
     assertTrue(reader.next());
     assertEquals(10, reader.scalar(0).getInt());
@@ -644,7 +644,7 @@ public class RowSetTest extends SubOperatorTest {
     assertEquals(0, arrayReader.size());
     assertFalse(reader.next());
 
-    SingleRowSet rs2 = fixture.rowSetBuilder(batchSchema)
+    final SingleRowSet rs2 = fixture.rowSetBuilder(batchSchema)
       .addRow(10, intArray(100, 110))
       .addRow(20, intArray(200, 120, 220))
       .addRow(30, null)
@@ -661,12 +661,12 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testRowBounds() {
-    BatchSchema batchSchema = new SchemaBuilder()
+    final BatchSchema batchSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .build();
 
-    ExtendableRowSet rs = fixture.rowSet(batchSchema);
-    RowSetWriter writer = rs.writer();
+    final ExtendableRowSet rs = fixture.rowSet(batchSchema);
+    final RowSetWriter writer = rs.writer();
     int count = 0;
     while (! writer.isFull()) {
       writer.scalar(0).setInt(count++);
@@ -695,22 +695,22 @@ public class RowSetTest extends SubOperatorTest {
 
   @Test
   public void testBufferBounds() {
-    BatchSchema batchSchema = new SchemaBuilder()
+    final BatchSchema batchSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .add("b", MinorType.VARCHAR)
         .build();
 
     String varCharValue;
     try {
-      byte rawValue[] = new byte[512];
+      final byte rawValue[] = new byte[512];
       Arrays.fill(rawValue, (byte) 'X');
       varCharValue = new String(rawValue, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
+    } catch (final UnsupportedEncodingException e) {
       throw new IllegalStateException(e);
     }
 
-    ExtendableRowSet rs = fixture.rowSet(batchSchema);
-    RowSetWriter writer = rs.writer();
+    final ExtendableRowSet rs = fixture.rowSet(batchSchema);
+    final RowSetWriter writer = rs.writer();
     int count = 0;
     try {
 
@@ -727,7 +727,7 @@ public class RowSetTest extends SubOperatorTest {
         writer.save();
         count++;
       }
-    } catch (Exception e) {
+    } catch (final Exception e) {
       assertTrue(e.getMessage().contains("Overflow"));
     }
     writer.done();
@@ -751,7 +751,7 @@ public class RowSetTest extends SubOperatorTest {
     // will be provided by a reader, by an incoming batch,
     // etc.
 
-    BatchSchema schema = new SchemaBuilder()
+    final BatchSchema schema = new SchemaBuilder()
         .add("a", MinorType.VARCHAR)
         .addArray("b", MinorType.INT)
         .addMap("c")
@@ -764,11 +764,11 @@ public class RowSetTest extends SubOperatorTest {
     // a batch-oriented test. Done automatically in the
     // result set loader.
 
-    DirectRowSet drs = DirectRowSet.fromSchema(fixture.allocator(), schema);
+    final DirectRowSet drs = DirectRowSet.fromSchema(fixture.allocator(), schema);
 
     // Step 3: Create the writer.
 
-    RowSetWriter writer = drs.writer();
+    final RowSetWriter writer = drs.writer();
 
     // Step 4: Populate data. Here we do it the way an app would:
     // using the individual accessors. See tests above for the many
@@ -782,10 +782,10 @@ public class RowSetTest extends SubOperatorTest {
     // use byte arrays.
 
     writer.scalar("a").setString("fred");
-    ArrayWriter bWriter = writer.array("b");
+    final ArrayWriter bWriter = writer.array("b");
     bWriter.scalar().setInt(10);
     bWriter.scalar().setInt(11);
-    TupleWriter cWriter = writer.tuple("c");
+    final TupleWriter cWriter = writer.tuple("c");
     cWriter.scalar("c1").setInt(12);
     cWriter.scalar("c2").setString("wilma");
     writer.save();
@@ -800,11 +800,11 @@ public class RowSetTest extends SubOperatorTest {
     // Step 5: "Harvest" the batch. Done differently in the
     // result set loader.
 
-    SingleRowSet rowSet = writer.done();
+    final SingleRowSet rowSet = writer.done();
 
     // Step 5: Create a reader.
 
-    RowSetReader reader = rowSet.reader();
+    final RowSetReader reader = rowSet.reader();
 
     // Step 6: Retrieve the data. Here we just print the
     // values.
@@ -812,11 +812,11 @@ public class RowSetTest extends SubOperatorTest {
     while (reader.next()) {
       final StringBuilder sb = new StringBuilder();
       sb.append(print(reader.scalar("a").getString()));
-      ArrayReader bReader = reader.array("b");
+      final ArrayReader bReader = reader.array("b");
       while (bReader.next()) {
         sb.append(print(bReader.scalar().getInt()));
       }
-      TupleReader cReader = reader.tuple("c");
+      final TupleReader cReader = reader.tuple("c");
       sb.append(print(cReader.scalar("c1").getInt()));
       sb.append(print(cReader.scalar("c2").getString()));
       logger.debug(sb.toString());

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestHyperVectorReaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestHyperVectorReaders.java
@@ -20,6 +20,7 @@ package org.apache.drill.test.rowSet.test;
 import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
 import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.variantArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -358,6 +359,138 @@ public class TestHyperVectorReaders extends SubOperatorTest {
         .addRow(2, mapArray(mapValue(21, "second.1"), mapValue(22, "second.2")))
         .addRow(3, mapArray(mapValue(31, "third.1"),  mapValue(32, "third.2"), mapValue(33, "third.3")))
         .addRow(4, mapArray(mapValue(41, "fourth.1")))
+        .build();
+
+    RowSetUtilities.verify(expected, hyperSet);
+  }
+
+  @Test
+  public void testUnion() {
+    TupleMetadata schema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addUnion("u")
+          .addType(MinorType.INT)
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    SingleRowSet rowSet1 = fixture.rowSetBuilder(schema)
+        .addRow(2, 20)
+        .addRow(4, "fourth")
+        .build();
+
+    SingleRowSet rowSet2 = fixture.rowSetBuilder(schema)
+        .addRow(1, "first")
+        .addRow(3, 30)
+        .build();
+
+    // Build the hyper batch
+
+    HyperRowSet hyperSet = HyperRowSetImpl.fromRowSets(fixture.allocator(), rowSet1, rowSet2);
+    assertEquals(4, hyperSet.rowCount());
+    SelectionVector4 sv4 = hyperSet.getSv4();
+    sv4.set(0, 1, 0);
+    sv4.set(1, 0, 0);
+    sv4.set(2, 1, 1);
+    sv4.set(3, 0, 1);
+
+    SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, "first")
+        .addRow(2, 20)
+        .addRow(3, 30)
+        .addRow(4, "fourth")
+        .build();
+
+    RowSetUtilities.verify(expected, hyperSet);
+  }
+
+  @Test
+  public void testScalarList() {
+    TupleMetadata schema = new SchemaBuilder()
+        .addList("a")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    schema.metadata("a").variantSchema().becomeSimple();
+
+    SingleRowSet rowSet1 = fixture.rowSetBuilder(schema)
+        .addSingleCol(strArray("sixth", "6.1", "6.2"))
+        .addSingleCol(null)
+        .addSingleCol(strArray("fourth", "4.1"))
+        .build();
+
+    SingleRowSet rowSet2 = fixture.rowSetBuilder(schema)
+        .addSingleCol(strArray("fifth", "51", "5.2"))
+        .addSingleCol(strArray("first", "1.1", "1.2", "1.3"))
+        .addSingleCol(strArray("third", "3.1"))
+        .build();
+
+    // Build the hyper batch
+
+    HyperRowSet hyperSet = HyperRowSetImpl.fromRowSets(fixture.allocator(), rowSet1, rowSet2);
+    assertEquals(6, hyperSet.rowCount());
+    SelectionVector4 sv4 = hyperSet.getSv4();
+    sv4.set(0, 1, 1);
+    sv4.set(1, 0, 1);
+    sv4.set(2, 1, 2);
+    sv4.set(3, 0, 2);
+    sv4.set(4, 1, 0);
+    sv4.set(5, 0, 0);
+
+    SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addSingleCol(strArray("first", "1.1", "1.2", "1.3"))
+        .addSingleCol(null)
+        .addSingleCol(strArray("third", "3.1"))
+        .addSingleCol(strArray("fourth", "4.1"))
+        .addSingleCol(strArray("fifth", "51", "5.2"))
+        .addSingleCol(strArray("sixth", "6.1", "6.2"))
+        .build();
+
+    RowSetUtilities.verify(expected, hyperSet);
+  }
+
+  @Test
+  public void testUnionList() {
+    TupleMetadata schema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addList("list")
+          .addType(MinorType.INT)
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    SingleRowSet rowSet1 = fixture.rowSetBuilder(schema)
+        .addRow(6, variantArray("sixth", 61, "6.2"))
+        .addRow(2, variantArray("second", "2.1", 22, "2.3"))
+        .addRow(4, variantArray("fourth", 41))
+        .build();
+
+    SingleRowSet rowSet2 = fixture.rowSetBuilder(schema)
+        .addRow(5, variantArray("fifth", "5.1", 52))
+        .addRow(1, variantArray("first", 11, "1.2", 13))
+        .addRow(3, variantArray("third", 31))
+        .build();
+
+    // Build the hyper batch
+
+    HyperRowSet hyperSet = HyperRowSetImpl.fromRowSets(fixture.allocator(), rowSet1, rowSet2);
+    assertEquals(6, hyperSet.rowCount());
+    SelectionVector4 sv4 = hyperSet.getSv4();
+    sv4.set(0, 1, 1);
+    sv4.set(1, 0, 1);
+    sv4.set(2, 1, 2);
+    sv4.set(3, 0, 2);
+    sv4.set(4, 1, 0);
+    sv4.set(5, 0, 0);
+
+    SingleRowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, variantArray("first", 11, "1.2", 13))
+        .addRow(2, variantArray("second", "2.1", 22, "2.3"))
+        .addRow(3, variantArray("third", 31))
+        .addRow(4, variantArray("fourth", 41))
+        .addRow(5, variantArray("fifth", "5.1", 52))
+        .addRow(6, variantArray("sixth", 61, "6.2"))
         .build();
 
     RowSetUtilities.verify(expected, hyperSet);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestRepeatedListAccessors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestRepeatedListAccessors.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.test.rowSet.test;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.objArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleObjArray;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.RepeatedVarCharVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ArrayReader;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectReader;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarReader;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.complex.BaseRepeatedValueVector;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+import org.apache.drill.exec.record.metadata.ColumnMetadata.StructureType;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.DirectRowSet;
+import org.apache.drill.test.rowSet.RowSet;
+import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.schema.SchemaBuilder;
+import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.apache.drill.test.rowSet.RowSetWriter;
+import org.junit.Test;
+
+/**
+ * Test the basics of repeated list support in the schema builder,
+ * column writers and column readers. These tests work with a
+ * single row set (batch). These tests should pass before moving
+ * on to the result set loader tests.
+ */
+
+public class TestRepeatedListAccessors extends SubOperatorTest {
+
+  /**
+   * Test the intermediate case in which a repeated list
+   * does not yet have child type.
+   */
+
+  @Test
+  public void testSchemaIncompleteBatch() {
+    final BatchSchema schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .resumeSchema()
+        .build();
+
+    assertEquals(2, schema.getFieldCount());
+    final MaterializedField list = schema.getColumn(1);
+    assertEquals("list2", list.getName());
+    assertEquals(MinorType.LIST, list.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, list.getType().getMode());
+    assertTrue(list.getChildren().isEmpty());
+  }
+
+  @Test
+  public void testSchemaIncompleteMetadata() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .resumeSchema()
+        .buildSchema();
+
+    assertEquals(2, schema.size());
+    final ColumnMetadata list = schema.metadata(1);
+    assertEquals("list2", list.name());
+    assertEquals(MinorType.LIST, list.type());
+    assertEquals(DataMode.REPEATED, list.mode());
+    assertNull(list.childSchema());
+  }
+
+  /**
+   * Test the case of a simple 2D array. Drill represents
+   * this as two levels of materialized fields.
+   */
+
+  @Test
+  public void testSchema2DBatch() {
+    final BatchSchema schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .build();
+
+    assertEquals(2, schema.getFieldCount());
+    final MaterializedField list = schema.getColumn(1);
+    assertEquals("list2", list.getName());
+    assertEquals(MinorType.LIST, list.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, list.getType().getMode());
+    assertEquals(1, list.getChildren().size());
+
+    final MaterializedField inner = list.getChildren().iterator().next();
+    assertEquals("list2", inner.getName());
+    assertEquals(MinorType.VARCHAR, inner.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, inner.getType().getMode());
+  }
+
+  /**
+   * Test a 2D array using metadata. The metadata also uses
+   * a column per dimension as that provides the easiest mapping
+   * to the nested fields. A better design might be a single level
+   * (as in repeated fields), but with a single attribute that
+   * describes the number of dimensions. The <tt>dimensions()</tt>
+   * method is a compromise.
+   */
+
+  @Test
+  public void testSchema2DMetadata() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    assertEquals(2, schema.size());
+    final ColumnMetadata list = schema.metadata(1);
+    assertEquals("list2", list.name());
+    assertEquals(MinorType.LIST, list.type());
+    assertEquals(DataMode.REPEATED, list.mode());
+    assertEquals(StructureType.MULTI_ARRAY, list.structureType());
+    assertTrue(list.isArray());
+    assertEquals(2, list.dimensions());
+    assertNotNull(list.childSchema());
+
+    final ColumnMetadata child = list.childSchema();
+    assertEquals("list2", child.name());
+    assertEquals(MinorType.VARCHAR, child.type());
+    assertEquals(DataMode.REPEATED, child.mode());
+    assertTrue(child.isArray());
+    assertEquals(1, child.dimensions());
+    assertNull(child.childSchema());
+  }
+
+  @Test
+  public void testSchema3DBatch() {
+    final BatchSchema schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addDimension()
+            .addArray(MinorType.VARCHAR)
+            .resumeList()
+          .resumeSchema()
+        .build();
+
+    assertEquals(2, schema.getFieldCount());
+    final MaterializedField list = schema.getColumn(1);
+    assertEquals("list2", list.getName());
+    assertEquals(MinorType.LIST, list.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, list.getType().getMode());
+    assertEquals(1, list.getChildren().size());
+
+    final MaterializedField child1 = list.getChildren().iterator().next();
+    assertEquals("list2", child1.getName());
+    assertEquals(MinorType.LIST, child1.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, child1.getType().getMode());
+    assertEquals(1, child1.getChildren().size());
+
+    final MaterializedField child2 = child1.getChildren().iterator().next();
+    assertEquals("list2", child2.getName());
+    assertEquals(MinorType.VARCHAR, child2.getType().getMinorType());
+    assertEquals(DataMode.REPEATED, child2.getType().getMode());
+    assertEquals(0, child2.getChildren().size());
+  }
+
+  @Test
+  public void testSchema3DMetadata() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addDimension()
+            .addArray(MinorType.VARCHAR)
+            .resumeList()
+          .resumeSchema()
+        .buildSchema();
+
+    assertEquals(2, schema.size());
+    final ColumnMetadata list = schema.metadata(1);
+    assertEquals("list2", list.name());
+    assertEquals(MinorType.LIST, list.type());
+    assertEquals(DataMode.REPEATED, list.mode());
+    assertEquals(StructureType.MULTI_ARRAY, list.structureType());
+    assertTrue(list.isArray());
+    assertEquals(3, list.dimensions());
+    assertNotNull(list.childSchema());
+
+    final ColumnMetadata child1 = list.childSchema();
+    assertEquals("list2", child1.name());
+    assertEquals(MinorType.LIST, child1.type());
+    assertEquals(DataMode.REPEATED, child1.mode());
+    assertEquals(StructureType.MULTI_ARRAY, child1.structureType());
+    assertTrue(child1.isArray());
+    assertEquals(2, child1.dimensions());
+    assertNotNull(child1.childSchema());
+
+    final ColumnMetadata child2 = child1.childSchema();
+    assertEquals("list2", child2.name());
+    assertEquals(MinorType.VARCHAR, child2.type());
+    assertEquals(DataMode.REPEATED, child2.mode());
+    assertTrue(child2.isArray());
+    assertEquals(1, child2.dimensions());
+    assertNull(child2.childSchema());
+  }
+
+  @Test
+  public void testIncompleteVectors() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .resumeSchema()
+        .buildSchema();
+
+    final DirectRowSet rowSet = DirectRowSet.fromSchema(fixture.allocator(), schema);
+    final VectorContainer container = rowSet.container();
+    assertEquals(2, container.getNumberOfColumns());
+    assertTrue(container.getValueVector(1).getValueVector() instanceof RepeatedListVector);
+    final RepeatedListVector list = (RepeatedListVector) container.getValueVector(1).getValueVector();
+    assertSame(BaseRepeatedValueVector.DEFAULT_DATA_VECTOR, list.getDataVector());
+    assertTrue(list.getField().getChildren().isEmpty());
+    rowSet.clear();
+  }
+
+  @Test
+  public void testSchema2DVector() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final DirectRowSet rowSet = DirectRowSet.fromSchema(fixture.allocator(), schema);
+    final VectorContainer container = rowSet.container();
+    assertEquals(2, container.getNumberOfColumns());
+    assertTrue(container.getValueVector(1).getValueVector() instanceof RepeatedListVector);
+    final RepeatedListVector list = (RepeatedListVector) container.getValueVector(1).getValueVector();
+    assertEquals(1, list.getField().getChildren().size());
+
+    final ValueVector child = list.getDataVector();
+    assertTrue(child instanceof RepeatedVarCharVector);
+    assertSame(list.getField().getChildren().iterator().next(), child.getField());
+    rowSet.clear();
+  }
+
+  @Test
+  public void testSchema3DVector() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addDimension()
+            .addArray(MinorType.VARCHAR)
+            .resumeList()
+          .resumeSchema()
+        .buildSchema();
+
+    final DirectRowSet rowSet = DirectRowSet.fromSchema(fixture.allocator(), schema);
+    final VectorContainer container = rowSet.container();
+    assertEquals(2, container.getNumberOfColumns());
+    assertTrue(container.getValueVector(1).getValueVector() instanceof RepeatedListVector);
+    final RepeatedListVector list = (RepeatedListVector) container.getValueVector(1).getValueVector();
+    assertEquals(1, list.getField().getChildren().size());
+
+    assertTrue(list.getDataVector() instanceof RepeatedListVector);
+    final RepeatedListVector child1 = (RepeatedListVector) list.getDataVector();
+    assertEquals(1, child1.getField().getChildren().size());
+    assertSame(list.getField().getChildren().iterator().next(), child1.getField());
+
+    final ValueVector child2 = child1.getDataVector();
+    assertTrue(child2 instanceof RepeatedVarCharVector);
+    assertSame(child1.getField().getChildren().iterator().next(), child2.getField());
+    rowSet.clear();
+  }
+
+  @Test
+  public void testSchema2DWriterReader() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+        .addRepeatedList("list2")
+          .addArray(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final DirectRowSet rowSet = DirectRowSet.fromSchema(fixture.allocator(), schema);
+    SingleRowSet result;
+    {
+      final RowSetWriter writer = rowSet.writer();
+      assertEquals(2, writer.size());
+      final ObjectWriter listObj = writer.column("list2");
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayWriter listWriter = listObj.array();
+      assertEquals(ObjectType.ARRAY, listWriter.entryType());
+      final ArrayWriter innerWriter = listWriter.array();
+      assertEquals(ObjectType.SCALAR, innerWriter.entryType());
+      final ScalarWriter strWriter = innerWriter.scalar();
+
+      // Write one row using writers explicitly.
+      //
+      // (1, [["a, "b"], ["c", "d"]])
+      //
+      // Note auto increment of inner list on write.
+
+      writer.scalar("id").setInt(1);
+      strWriter.setString("a");
+      strWriter.setString("b");
+      listWriter.save();
+      strWriter.setString("c");
+      strWriter.setString("d");
+      listWriter.save();
+      writer.save();
+
+      // Write more rows using the convenience methods.
+      //
+      // (2, [["e"], [], ["f", "g", "h"]])
+      // (3, [])
+      // (4, [[], ["i"], []])
+
+      writer
+        .addRow(2, objArray(strArray("e"), strArray(), strArray("f", "g", "h")))
+        .addRow(3, objArray())
+        .addRow(4, objArray(strArray(), strArray("i"), strArray()));
+
+      result = writer.done();
+    }
+
+    // Verify one row using the individual readers.
+
+    {
+      final RowSetReader reader = result.reader();
+
+      assertEquals(2, reader.columnCount());
+      final ObjectReader listObj = reader.column("list2");
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayReader listReader = listObj.array();
+      assertEquals(ObjectType.ARRAY, listReader.entryType());
+      final ArrayReader innerReader = listReader.array();
+      assertEquals(ObjectType.SCALAR, innerReader.entryType());
+      final ScalarReader strReader = innerReader.scalar();
+
+      // Write one row using writers explicitly.
+      //
+      // (1, [["a, "b"], ["c", "d"]])
+
+      assertTrue(reader.next());
+      assertEquals(2, listReader.size());
+        assertTrue(listReader.next());
+          assertEquals(2, innerReader.size());
+          assertTrue(innerReader.next());
+          assertEquals("a", strReader.getString());
+          assertTrue(innerReader.next());
+          assertEquals("b", strReader.getString());
+          assertFalse(innerReader.next());
+        assertTrue(listReader.next());
+          assertEquals(2, innerReader.size());
+          assertTrue(innerReader.next());
+          assertEquals("c", strReader.getString());
+          assertTrue(innerReader.next());
+          assertEquals("d", strReader.getString());
+          assertFalse(innerReader.next());
+        assertFalse(listReader.next());
+    }
+
+    // Verify both rows by building another row set and comparing.
+
+    final RowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(1, objArray(strArray("a", "b"), strArray("c", "d")))
+        .addRow(2, objArray(strArray("e"), strArray(), strArray("f", "g", "h")))
+        .addRow(3, objArray())
+        .addRow(4, objArray(strArray(), strArray("i"), strArray()))
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+  }
+
+  @Test
+  public void testSchema3DWriterReader() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("id", MinorType.INT)
+
+        // Uses a short-hand method to avoid mucking with actual
+        // nested lists.
+
+        .addArray("cube", MinorType.VARCHAR, 3)
+        .buildSchema();
+
+    final SingleRowSet actual = fixture.rowSetBuilder(schema)
+      .addRow(1,
+          objArray(
+              objArray(
+                  strArray("a", "b"),
+                  strArray("c")),
+              objArray(
+                  strArray("d", "e", "f"),
+                  null),
+              null,
+              objArray()))
+      .addRow(2, null)
+      .addRow(3, objArray())
+      .addRow(4, objArray(objArray()))
+      .addRow(5, singleObjArray(
+          objArray(
+              strArray("g", "h"),
+              strArray("i"))))
+      .build();
+
+    final SingleRowSet expected = fixture.rowSetBuilder(schema)
+      .addRow(1,
+          objArray(
+              objArray(
+                  strArray("a", "b"),
+                  strArray("c")),
+              objArray(
+                  strArray("d", "e", "f"),
+                  strArray()),
+              objArray(),
+              objArray()))
+      .addRow(2, objArray())
+      .addRow(3, objArray())
+      .addRow(4, objArray(objArray()))
+      .addRow(5, singleObjArray(
+          objArray(
+              strArray("g", "h"),
+              strArray("i"))))
+      .build();
+
+    RowSetUtilities.verify(expected, actual);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariantAccessors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestVariantAccessors.java
@@ -1,0 +1,1177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.test.rowSet.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.NullableBigIntVector;
+import org.apache.drill.exec.vector.NullableFloat8Vector;
+import org.apache.drill.exec.vector.NullableIntVector;
+import org.apache.drill.exec.vector.NullableVarCharVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ArrayReader;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectReader;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarReader;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantReader;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.exec.vector.complex.MapVector;
+import org.apache.drill.exec.vector.complex.UnionVector;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetWriter;
+import org.apache.drill.test.rowSet.RowSet.ExtendableRowSet;
+import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.schema.SchemaBuilder;
+import org.junit.Test;
+
+/**
+ * Tests for readers and writers for union and list types.
+ * <p>
+ * Note that the union type is only partially supported in Drill.
+ * The list type is unsupported. (However, the list type works in
+ * the schema builder, row set writer, row set reader and the
+ * result set builder. It does not, however, work in the Project
+ * and other operators. Some assembly required for future use.)
+ */
+
+public class TestVariantAccessors extends SubOperatorTest {
+
+  @Test
+  public void testBuildRowSetUnion() {
+    final TupleMetadata schema = new SchemaBuilder()
+
+        // Union with simple and complex types
+
+        .addUnion("u")
+          .addType(MinorType.INT)
+          .addMap()
+            .addNullable("c", MinorType.BIGINT)
+            .addNullable("d", MinorType.VARCHAR)
+            .resumeUnion()
+          .addList()
+            .addType(MinorType.VARCHAR)
+            .buildNested()
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final VectorContainer vc = rowSet.container();
+    assertEquals(1, vc.getNumberOfColumns());
+
+    // Single union
+
+    final ValueVector vector = vc.getValueVector(0).getValueVector();
+    assertTrue(vector instanceof UnionVector);
+    final UnionVector union = (UnionVector) vector;
+
+    final MapVector typeMap = union.getTypeMap();
+    ValueVector member = typeMap.getChild(MinorType.INT.name());
+    assertTrue(member instanceof NullableIntVector);
+
+    // Inner map
+
+    member = typeMap.getChild(MinorType.MAP.name());
+    assertTrue(member instanceof MapVector);
+    member = typeMap.getChild(MinorType.MAP.name());
+    assertTrue(member instanceof MapVector);
+    final MapVector childMap = (MapVector) member;
+    ValueVector mapMember = childMap.getChild("c");
+    assertNotNull(mapMember);
+    assertTrue(mapMember instanceof NullableBigIntVector);
+    mapMember = childMap.getChild("d");
+    assertNotNull(mapMember);
+    assertTrue(mapMember instanceof NullableVarCharVector);
+
+    // Inner list
+
+    member = typeMap.getChild(MinorType.LIST.name());
+    assertTrue(member instanceof ListVector);
+    final ListVector list = (ListVector) member;
+    assertTrue(list.getDataVector() instanceof NullableVarCharVector);
+
+    rowSet.clear();
+  }
+
+  /**
+   * Test a variant (AKA "union vector") at the top level, using
+   * just scalar values.
+   */
+
+  @Test
+  public void testScalarVariant() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addUnion("u")
+          .addType(MinorType.INT)
+          .addType(MinorType.VARCHAR)
+          .addType(MinorType.FLOAT8)
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rs = fixture.rowSet(schema);
+    final RowSetWriter writer = rs.writer();
+
+    // Sanity check of writer structure
+
+    final ObjectWriter wo = writer.column(0);
+    assertEquals(ObjectType.VARIANT, wo.type());
+    final VariantWriter vw = wo.variant();
+    assertSame(vw, writer.variant(0));
+    assertSame(vw, writer.variant("u"));
+    assertTrue(vw.hasType(MinorType.INT));
+    assertTrue(vw.hasType(MinorType.VARCHAR));
+    assertTrue(vw.hasType(MinorType.FLOAT8));
+
+    // Write values of different types
+
+    vw.scalar(MinorType.INT).setInt(10);
+    writer.save();
+
+    vw.scalar(MinorType.VARCHAR).setString("fred");
+    writer.save();
+
+    // The entire variant is null
+
+    vw.setNull();
+    writer.save();
+
+    vw.scalar(MinorType.FLOAT8).setDouble(123.45);
+    writer.save();
+
+    // Strange case: just the value is null, but the variant
+    // is not null.
+
+    vw.scalar(MinorType.INT).setNull();
+    writer.save();
+
+    // Marker to avoid fill-empty issues (fill-empties tested elsewhere.)
+
+    vw.scalar(MinorType.INT).setInt(20);
+    writer.save();
+
+    final SingleRowSet result = writer.done();
+    assertEquals(6, result.rowCount());
+
+    // Read the values.
+
+    final RowSetReader reader = result.reader();
+
+    // Sanity check of structure
+
+    final ObjectReader ro = reader.column(0);
+    assertEquals(ObjectType.VARIANT, ro.type());
+    final VariantReader vr = ro.variant();
+    assertSame(vr, reader.variant(0));
+    assertSame(vr, reader.variant("u"));
+    for (final MinorType type : MinorType.values()) {
+      if (type == MinorType.INT || type == MinorType.VARCHAR || type == MinorType.FLOAT8) {
+        assertTrue(vr.hasType(type));
+      } else {
+        assertFalse(vr.hasType(type));
+      }
+    }
+
+    // Can get readers up front
+
+    final ScalarReader intReader = vr.scalar(MinorType.INT);
+    final ScalarReader strReader = vr.scalar(MinorType.VARCHAR);
+    final ScalarReader floatReader = vr.scalar(MinorType.FLOAT8);
+
+    // Verify the data
+
+    // Int 10
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.INT);
+    assertSame(intReader, vr.scalar());
+    assertNotNull(vr.member());
+    assertSame(vr.scalar(), vr.member().scalar());
+    assertFalse(intReader.isNull());
+    assertEquals(10, intReader.getInt());
+    assertTrue(strReader.isNull());
+    assertTrue(floatReader.isNull());
+
+    // String "fred"
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.VARCHAR);
+    assertSame(strReader, vr.scalar());
+    assertFalse(strReader.isNull());
+    assertEquals("fred", strReader.getString());
+    assertTrue(intReader.isNull());
+    assertTrue(floatReader.isNull());
+
+    // Null value
+
+    assertTrue(reader.next());
+    assertTrue(vr.isNull());
+    assertNull(vr.dataType());
+    assertNull(vr.scalar());
+    assertTrue(intReader.isNull());
+    assertTrue(strReader.isNull());
+    assertTrue(floatReader.isNull());
+
+    // Double 123.45
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.FLOAT8);
+    assertSame(floatReader, vr.scalar());
+    assertFalse(floatReader.isNull());
+    assertEquals(123.45, vr.scalar().getDouble(), 0.001);
+    assertTrue(intReader.isNull());
+    assertTrue(strReader.isNull());
+
+    // Strange case: null int (but union is not null)
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.INT);
+    assertTrue(intReader.isNull());
+
+    // Int 20
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertFalse(intReader.isNull());
+    assertEquals(20, intReader.getInt());
+
+    assertFalse(reader.next());
+    result.clear();
+  }
+
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testBuildRowSetScalarList() {
+    final TupleMetadata schema = new SchemaBuilder()
+
+        // Top-level single-element list
+
+        .addList("list2")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final VectorContainer vc = rowSet.container();
+    assertEquals(1, vc.getNumberOfColumns());
+
+
+    // Single-type list
+
+    final ValueVector vector = vc.getValueVector(0).getValueVector();
+    assertTrue(vector instanceof ListVector);
+    final ListVector list = (ListVector) vector;
+    assertTrue(list.getDataVector() instanceof NullableVarCharVector);
+
+    rowSet.clear();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void testBuildRowSetUnionArray() {
+    final TupleMetadata schema = new SchemaBuilder()
+
+        // List with multiple types
+
+        .addList("list1")
+          .addType(MinorType.BIGINT)
+          .addMap()
+            .addNullable("a", MinorType.INT)
+            .addNullable("b", MinorType.VARCHAR)
+            .resumeUnion()
+
+          // Nested single-element list
+
+          .addList()
+            .addType(MinorType.FLOAT8)
+            .buildNested()
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final VectorContainer vc = rowSet.container();
+    assertEquals(1, vc.getNumberOfColumns());
+
+    // List with complex internal structure
+
+    final ValueVector vector = vc.getValueVector(0).getValueVector();
+    assertTrue(vector instanceof ListVector);
+    final ListVector list = (ListVector) vector;
+    assertTrue(list.getDataVector() instanceof UnionVector);
+    final UnionVector union = (UnionVector) list.getDataVector();
+
+    // Union inside the list
+
+    final MajorType unionType = union.getField().getType();
+    final List<MinorType> types = unionType.getSubTypeList();
+    assertEquals(3, types.size());
+    assertTrue(types.contains(MinorType.BIGINT));
+    assertTrue(types.contains(MinorType.MAP));
+    assertTrue(types.contains(MinorType.LIST));
+
+    final MapVector typeMap = union.getTypeMap();
+    ValueVector member = typeMap.getChild(MinorType.BIGINT.name());
+    assertTrue(member instanceof NullableBigIntVector);
+
+    // Map inside the list
+
+    member = typeMap.getChild(MinorType.MAP.name());
+    assertTrue(member instanceof MapVector);
+    final MapVector childMap = (MapVector) member;
+    ValueVector mapMember = childMap.getChild("a");
+    assertNotNull(mapMember);
+    assertTrue(mapMember instanceof NullableIntVector);
+    mapMember = childMap.getChild("b");
+    assertNotNull(mapMember);
+    assertTrue(mapMember instanceof NullableVarCharVector);
+
+    // Single-type list inside the outer list
+
+    member = typeMap.getChild(MinorType.LIST.name());
+    assertTrue(member instanceof ListVector);
+    final ListVector childList = (ListVector) member;
+    assertTrue(childList.getDataVector() instanceof NullableFloat8Vector);
+
+    rowSet.clear();
+  }
+
+  /**
+   * Test a variant (AKA "union vector") at the top level which
+   * includes a map.
+   */
+
+  @Test
+  public void testUnionWithMap() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addUnion("u")
+          .addType(MinorType.VARCHAR)
+          .addMap()
+            .addNullable("a", MinorType.INT)
+            .addNullable("b", MinorType.VARCHAR)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+
+    SingleRowSet result;
+
+    // Write values
+
+    {
+      final ExtendableRowSet rs = fixture.rowSet(schema);
+      final RowSetWriter writer = rs.writer();
+
+      // Sanity check of writer structure
+
+      final ObjectWriter wo = writer.column(0);
+      assertEquals(ObjectType.VARIANT, wo.type());
+      final VariantWriter vw = wo.variant();
+
+      assertTrue(vw.hasType(MinorType.VARCHAR));
+      final ObjectWriter strObj = vw.member(MinorType.VARCHAR);
+      final ScalarWriter strWriter = strObj.scalar();
+      assertSame(strWriter, vw.scalar(MinorType.VARCHAR));
+
+      assertTrue(vw.hasType(MinorType.MAP));
+      final ObjectWriter mapObj = vw.member(MinorType.MAP);
+      final TupleWriter mWriter = mapObj.tuple();
+      assertSame(mWriter, vw.tuple());
+
+      final ScalarWriter aWriter = mWriter.scalar("a");
+      final ScalarWriter bWriter = mWriter.scalar("b");
+
+      // First row: string "first"
+
+      vw.setType(MinorType.VARCHAR);
+      strWriter.setString("first");
+      writer.save();
+
+      // Second row: a map
+
+      vw.setType(MinorType.MAP);
+      aWriter.setInt(20);
+      bWriter.setString("fred");
+      writer.save();
+
+      // Third row: null
+
+      vw.setNull();
+      writer.save();
+
+      // Fourth row: map with a null string
+
+      vw.setType(MinorType.MAP);
+      aWriter.setInt(40);
+      bWriter.setNull();
+      writer.save();
+
+      // Fifth row: string "last"
+
+      vw.setType(MinorType.VARCHAR);
+      strWriter.setString("last");
+      writer.save();
+
+      result = writer.done();
+      assertEquals(5, result.rowCount());
+    }
+
+    // Read the values.
+
+    {
+      final RowSetReader reader = result.reader();
+
+      // Sanity check of structure
+
+      final ObjectReader ro = reader.column(0);
+      assertEquals(ObjectType.VARIANT, ro.type());
+      final VariantReader vr = ro.variant();
+
+      assertTrue(vr.hasType(MinorType.VARCHAR));
+      final ObjectReader strObj = vr.member(MinorType.VARCHAR);
+      final ScalarReader strReader = strObj.scalar();
+      assertSame(strReader, vr.scalar(MinorType.VARCHAR));
+
+      assertTrue(vr.hasType(MinorType.MAP));
+      final ObjectReader mapObj = vr.member(MinorType.MAP);
+      final TupleReader mReader = mapObj.tuple();
+      assertSame(mReader, vr.tuple());
+
+      final ScalarReader aReader = mReader.scalar("a");
+      final ScalarReader bReader = mReader.scalar("b");
+
+      // First row: string "first"
+
+      assertTrue(reader.next());
+      assertFalse(vr.isNull());
+      assertEquals(MinorType.VARCHAR, vr.dataType());
+      assertFalse(strReader.isNull());
+      assertTrue(mReader.isNull());
+      assertEquals("first", strReader.getString());
+
+      // Second row: a map
+
+      assertTrue(reader.next());
+      assertFalse(vr.isNull());
+      assertEquals(MinorType.MAP, vr.dataType());
+      assertTrue(strReader.isNull());
+      assertFalse(mReader.isNull());
+      assertFalse(aReader.isNull());
+      assertEquals(20, aReader.getInt());
+      assertFalse(bReader.isNull());
+      assertEquals("fred", bReader.getString());
+
+      // Third row: null
+
+      assertTrue(reader.next());
+      assertTrue(vr.isNull());
+      assertTrue(strReader.isNull());
+      assertTrue(mReader.isNull());
+      assertTrue(aReader.isNull());
+      assertTrue(bReader.isNull());
+
+      // Fourth row: map with a null string
+
+      assertTrue(reader.next());
+      assertEquals(MinorType.MAP, vr.dataType());
+      assertEquals(40, aReader.getInt());
+      assertTrue(bReader.isNull());
+
+      // Fifth row: string "last"
+
+      assertTrue(reader.next());
+      assertEquals(MinorType.VARCHAR, vr.dataType());
+      assertEquals("last", strReader.getString());
+
+      assertFalse(reader.next());
+    }
+
+    result.clear();
+  }
+
+  /**
+   * Test a scalar list. Should act just like a repeated type, with the
+   * addition of allowing the list for a row to be null. But, a list
+   * writer does not do auto-increment, so we must do that explicitly
+   * after each write.
+   */
+
+  @Test
+  public void testScalarList() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addList("list")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
+
+    {
+      final ObjectWriter listObj = writer.column(0);
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayWriter listArray = listObj.array();
+
+      // The list contains only a scalar. But, because lists can,
+      // in general, contain multiple contents, the list requires
+      // an explicit save after each entry.
+
+      final ObjectWriter itemObj = listArray.entry();
+      assertEquals(ObjectType.SCALAR, itemObj.type());
+      final ScalarWriter strWriter = itemObj.scalar();
+
+      // First row: two strings and a null
+      // Unlike a repeated type, a list can mark individual elements
+      // as null.
+      // List will automatically detect that data was written.
+
+      strWriter.setString("fred");
+      listArray.save();
+      strWriter.setNull();
+      listArray.save();
+      strWriter.setString("wilma");
+      listArray.save();
+      writer.save();
+
+      // Second row: null
+
+      writer.save();
+
+      // Third row: one string
+
+      strWriter.setString("dino");
+      listArray.save();
+      writer.save();
+
+      // Fourth row: empty array. Note that there is no trigger
+      // to say that the column is not null, so we have to do it
+      // explicitly.
+
+      listArray.setNull(false);
+      writer.save();
+
+      // Last row: a null string and non-null
+
+      strWriter.setNull();
+      listArray.save();
+      strWriter.setString("pebbles");
+      listArray.save();
+      writer.save();
+    }
+
+    final SingleRowSet result = writer.done();
+    assertEquals(5, result.rowCount());
+
+    {
+      final RowSetReader reader = result.reader();
+
+      final ObjectReader listObj = reader.column(0);
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayReader listArray = listObj.array();
+
+      // The list is a repeated scalar
+
+      assertEquals(ObjectType.SCALAR, listArray.entry().type());
+      final ScalarReader strReader = listArray.scalar();
+
+      // First row: two strings and a null
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(3, listArray.size());
+      assertTrue(listArray.next());
+      assertFalse(strReader.isNull());
+      assertEquals("fred", strReader.getString());
+      assertTrue(listArray.next());
+      assertTrue(strReader.isNull());
+      assertTrue(listArray.next());
+      assertFalse(strReader.isNull());
+      assertEquals("wilma", strReader.getString());
+      assertFalse(listArray.next());
+
+      // Second row: null
+
+      assertTrue(reader.next());
+      assertTrue(listArray.isNull());
+      assertEquals(0, listArray.size());
+
+      // Third row: one string
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(1, listArray.size());
+      assertTrue(listArray.next());
+      assertEquals("dino", strReader.getString());
+      assertFalse(listArray.next());
+
+      // Fourth row: empty array.
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(0, listArray.size());
+      assertFalse(listArray.next());
+
+      // Last row: a null string and non-null
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(2, listArray.size());
+      assertTrue(listArray.next());
+      assertTrue(strReader.isNull());
+      assertTrue(listArray.next());
+      assertFalse(strReader.isNull());
+      assertEquals("pebbles", strReader.getString());
+      assertFalse(listArray.next());
+
+      assertFalse(reader.next());
+    }
+
+    result.clear();
+  }
+
+  /**
+   * List of maps. Like a repeated map, but each list entry can be
+   * null.
+   */
+
+  @Test
+  public void testListOfMaps() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addList("list")
+          .addMap()
+            .addNullable("a", MinorType.INT)
+            .addNullable("b", MinorType.VARCHAR)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
+
+    {
+      final ObjectWriter listObj = writer.column("list");
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayWriter listArray = listObj.array();
+      final ObjectWriter itemObj = listArray.entry();
+      assertEquals(ObjectType.TUPLE, itemObj.type());
+      final TupleWriter mapWriter = itemObj.tuple();
+      final ScalarWriter aWriter = mapWriter.scalar("a");
+      final ScalarWriter bWriter = mapWriter.scalar("b");
+
+      // First row:
+      // {1, "fred"}, null, {3, null}
+
+      aWriter.setInt(1);
+      bWriter.setString("fred");
+
+      listArray.save();
+      // Can't mark the map as null. Instead, we simply skip
+      // the map and the contained nullable members will automatically
+      // back-fill each entry with a null value.
+      listArray.save();
+
+      aWriter.setInt(3);
+      bWriter.setNull();
+      listArray.save();
+      writer.save();
+
+      // Second row: null
+
+      writer.save();
+
+      // Third row: {null, "dino"}
+
+      aWriter.setNull();
+      bWriter.setString("dino");
+      listArray.save();
+      writer.save();
+
+      // Fourth row: empty array. Note that there is no trigger
+      // to say that the column is not null, so we have to do it
+      // explicitly.
+
+      listArray.setNull(false);
+      writer.save();
+
+      // Last row: {4, "pebbles"}
+
+      aWriter.setInt(4);
+      bWriter.setString("pebbles");
+      listArray.save();
+      writer.save();
+    }
+
+    final SingleRowSet result = writer.done();
+    assertEquals(5, result.rowCount());
+
+    {
+      final RowSetReader reader = result.reader();
+
+      final ObjectReader listObj = reader.column("list");
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayReader listArray = listObj.array();
+      assertEquals(ObjectType.TUPLE, listArray.entry().type());
+      final TupleReader mapReader = listArray.tuple();
+      final ScalarReader aReader = mapReader.scalar("a");
+      final ScalarReader bReader = mapReader.scalar("b");
+
+      // First row:
+      // {1, "fred"}, null, {3, null}
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertFalse(mapReader.isNull());
+      assertEquals(3, listArray.size());
+
+      assertTrue(listArray.next());
+      assertFalse(aReader.isNull());
+      assertEquals(1, aReader.getInt());
+      assertFalse(bReader.isNull());
+      assertEquals("fred", bReader.getString());
+
+      assertTrue(listArray.next());
+      // Awkward: the map has no null state, but its
+      // members do.
+      assertTrue(aReader.isNull());
+      assertTrue(bReader.isNull());
+
+      assertTrue(listArray.next());
+      assertFalse(aReader.isNull());
+      assertEquals(3, aReader.getInt());
+      assertTrue(bReader.isNull());
+
+      assertFalse(listArray.next());
+
+      // Second row: null
+
+      assertTrue(reader.next());
+      assertTrue(listArray.isNull());
+      assertEquals(0, listArray.size());
+
+      // Third row: {null, "dino"}
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(1, listArray.size());
+      assertTrue(listArray.next());
+      assertTrue(aReader.isNull());
+      assertFalse(bReader.isNull());
+      assertEquals("dino", bReader.getString());
+      assertFalse(listArray.next());
+
+      // Fourth row: empty array.
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(0, listArray.size());
+      assertFalse(listArray.next());
+
+      // Last row: {4, "pebbles"}
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(1, listArray.size());
+      assertTrue(listArray.next());
+      assertEquals(4, aReader.getInt());
+      assertEquals("pebbles", bReader.getString());
+      assertFalse(listArray.next());
+
+      assertFalse(reader.next());
+    }
+
+    result.clear();
+  }
+
+  /**
+   * Test a union list.
+   */
+
+  @Test
+  public void testListOfUnions() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addList("list")
+          .addType(MinorType.INT)
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final ExtendableRowSet rowSet = fixture.rowSet(schema);
+    final RowSetWriter writer = rowSet.writer();
+
+    {
+      final ObjectWriter listObj = writer.column(0);
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayWriter listArray = listObj.array();
+      final ObjectWriter itemObj = listArray.entry();
+      assertEquals(ObjectType.VARIANT, itemObj.type());
+      final VariantWriter variant = itemObj.variant();
+      final ScalarWriter intWriter = variant.scalar(MinorType.INT);
+      final ScalarWriter strWriter = variant.scalar(MinorType.VARCHAR);
+
+      // First row: (1, "two", 3)
+
+      variant.setType(MinorType.INT);
+      intWriter.setInt(1);
+      listArray.save();
+      variant.setType(MinorType.VARCHAR);
+      strWriter.setString("two");
+      listArray.save();
+      variant.setType(MinorType.INT);
+      intWriter.setInt(3);
+      listArray.save();
+      writer.save();
+
+      // Second row: null
+
+      writer.save();
+
+      // Third row: 4, null, "six", null int, null string
+
+      variant.setType(MinorType.INT);
+      intWriter.setInt(4);
+      listArray.save();
+      variant.setNull();
+      listArray.save();
+      variant.setType(MinorType.VARCHAR);
+      strWriter.setString("six");
+      listArray.save();
+      variant.setType(MinorType.INT);
+      intWriter.setNull();
+      listArray.save();
+      variant.setType(MinorType.VARCHAR);
+      intWriter.setNull();
+      listArray.save();
+      writer.save();
+
+      // Fourth row: empty array.
+
+      listArray.setNull(false);
+      writer.save();
+
+      // Fifth row: 9
+
+      variant.setType(MinorType.INT);
+      intWriter.setInt(9);
+      listArray.save();
+      writer.save();
+    }
+
+    final SingleRowSet result = writer.done();
+    assertEquals(5, result.rowCount());
+
+    {
+      final RowSetReader reader = result.reader();
+
+      final ObjectReader listObj = reader.column(0);
+      assertEquals(ObjectType.ARRAY, listObj.type());
+      final ArrayReader listArray = listObj.array();
+      assertEquals(ObjectType.VARIANT, listArray.entry().type());
+      final VariantReader variant = listArray.variant();
+      final ScalarReader intReader = variant.scalar(MinorType.INT);
+      final ScalarReader strReader = variant.scalar(MinorType.VARCHAR);
+
+      // First row: (1, "two", 3)
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(3, listArray.size());
+
+      assertTrue(listArray.next());
+      assertEquals(MinorType.INT, variant.dataType());
+      assertFalse(intReader.isNull());
+      assertTrue(strReader.isNull());
+      assertEquals(1, intReader.getInt());
+      assertEquals(1, variant.scalar().getInt());
+
+      assertTrue(listArray.next());
+      assertEquals(MinorType.VARCHAR, variant.dataType());
+      assertTrue(intReader.isNull());
+      assertFalse(strReader.isNull());
+      assertEquals("two", strReader.getString());
+      assertEquals("two", variant.scalar().getString());
+
+      assertTrue(listArray.next());
+      assertEquals(MinorType.INT, variant.dataType());
+      assertEquals(3, intReader.getInt());
+
+      assertFalse(listArray.next());
+
+      // Second row: null
+
+      assertTrue(reader.next());
+      assertTrue(listArray.isNull());
+      assertEquals(0, listArray.size());
+
+      // Third row: 4, null, "six", null int, null string
+
+      assertTrue(reader.next());
+      assertEquals(5, listArray.size());
+
+      assertTrue(listArray.next());
+      assertEquals(4, intReader.getInt());
+
+      assertTrue(listArray.next());
+      assertTrue(variant.isNull());
+
+      assertTrue(listArray.next());
+      assertEquals("six", strReader.getString());
+
+      assertTrue(listArray.next());
+      assertEquals(MinorType.INT, variant.dataType());
+      assertTrue(intReader.isNull());
+
+      assertTrue(listArray.next());
+      assertEquals(MinorType.VARCHAR, variant.dataType());
+      assertTrue(strReader.isNull());
+
+      assertFalse(listArray.next());
+
+      // Fourth row: empty array.
+
+      assertTrue(reader.next());
+      assertFalse(listArray.isNull());
+      assertEquals(0, listArray.size());
+      assertFalse(listArray.next());
+
+      // Fifth row: 9
+
+      assertTrue(reader.next());
+      assertEquals(1, listArray.size());
+
+      assertTrue(listArray.next());
+      assertEquals(9, intReader.getInt());
+      assertFalse(listArray.next());
+
+      assertFalse(reader.next());
+    }
+
+    result.clear();
+  }
+
+  /**
+   * Test a variant (AKA "union vector") at the top level, using
+   * just scalar values.
+   */
+
+  @Test
+  public void testAddTypes() {
+    final BatchSchema batchSchema = new SchemaBuilder()
+        .addNullable("v", MinorType.UNION)
+        .build();
+
+    final ExtendableRowSet rs = fixture.rowSet(batchSchema);
+    final RowSetWriter writer = rs.writer();
+
+    // Sanity check of writer structure
+
+    final ObjectWriter wo = writer.column(0);
+    assertEquals(ObjectType.VARIANT, wo.type());
+    final VariantWriter vw = wo.variant();
+    assertSame(vw, writer.variant(0));
+    assertSame(vw, writer.variant("v"));
+    for (final MinorType type : MinorType.values()) {
+      assertFalse(vw.hasType(type));
+    }
+
+    // Write values of different types
+
+    vw.scalar(MinorType.INT).setInt(10);
+    assertTrue(vw.hasType(MinorType.INT));
+    assertFalse(vw.hasType(MinorType.VARCHAR));
+    writer.save();
+
+    vw.scalar(MinorType.VARCHAR).setString("fred");
+    assertTrue(vw.hasType(MinorType.VARCHAR));
+    writer.save();
+
+    vw.setNull();
+    writer.save();
+
+    vw.scalar(MinorType.FLOAT8).setDouble(123.45);
+    assertTrue(vw.hasType(MinorType.INT));
+    assertTrue(vw.hasType(MinorType.FLOAT8));
+    writer.save();
+
+    final SingleRowSet result = writer.done();
+
+    assertEquals(4, result.rowCount());
+
+    // Read the values.
+
+    final RowSetReader reader = result.reader();
+
+    // Sanity check of structure
+
+    final ObjectReader ro = reader.column(0);
+    assertEquals(ObjectType.VARIANT, ro.type());
+    final VariantReader vr = ro.variant();
+    assertSame(vr, reader.variant(0));
+    assertSame(vr, reader.variant("v"));
+    for (final MinorType type : MinorType.values()) {
+      if (type == MinorType.INT || type == MinorType.VARCHAR || type == MinorType.FLOAT8) {
+        assertTrue(vr.hasType(type));
+      } else {
+        assertFalse(vr.hasType(type));
+      }
+    }
+
+    // Verify the data
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.INT);
+    assertSame(vr.scalar(MinorType.INT), vr.scalar());
+    assertNotNull(vr.member());
+    assertSame(vr.scalar(), vr.member().scalar());
+    assertEquals(10, vr.scalar().getInt());
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.VARCHAR);
+    assertSame(vr.scalar(MinorType.VARCHAR), vr.scalar());
+    assertEquals("fred", vr.scalar().getString());
+
+    assertTrue(reader.next());
+    assertTrue(vr.isNull());
+    assertNull(vr.dataType());
+    assertNull(vr.scalar());
+
+    assertTrue(reader.next());
+    assertFalse(vr.isNull());
+    assertTrue(vr.dataType() == MinorType.FLOAT8);
+    assertSame(vr.scalar(MinorType.FLOAT8), vr.scalar());
+    assertEquals(123.45, vr.scalar().getDouble(), 0.001);
+
+    assertFalse(reader.next());
+    result.clear();
+  }
+
+  /**
+   * Test a variant (AKA "union vector") at the top level which includes
+   * a list.
+   */
+
+  @Test
+  public void testUnionWithList() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .addUnion("u")
+          .addType(MinorType.INT)
+          .addList()
+            .addType(MinorType.VARCHAR)
+            .buildNested()
+          .resumeSchema()
+        .buildSchema();
+
+    SingleRowSet result;
+
+    // Write values
+
+    {
+      final ExtendableRowSet rs = fixture.rowSet(schema);
+      final RowSetWriter writer = rs.writer();
+      final VariantWriter vw = writer.variant("u");
+
+      assertTrue(vw.hasType(MinorType.INT));
+      final ScalarWriter intWriter = vw.scalar(MinorType.INT);
+
+      assertTrue(vw.hasType(MinorType.LIST));
+      final ArrayWriter aWriter = vw.array();
+      final ScalarWriter strWriter = aWriter.scalar();
+
+      // Row 1: 1, ["fred", "barney"]
+
+      intWriter.setInt(1);
+      strWriter.setString("fred");
+      aWriter.save();
+      strWriter.setString("barney");
+      aWriter.save();
+      writer.save();
+
+      // Row 2, 2, ["wilma", "betty"]
+
+      intWriter.setInt(2);
+      strWriter.setString("wilma");
+      aWriter.save();
+      strWriter.setString("betty");
+      aWriter.save();
+      writer.save();
+
+      result = writer.done();
+      assertEquals(2, result.rowCount());
+    }
+
+    // Read the values.
+
+    {
+      final RowSetReader reader = result.reader();
+      final VariantReader vr = reader.variant("u");
+
+      assertTrue(vr.hasType(MinorType.INT));
+      final ScalarReader intReader = vr.scalar(MinorType.INT);
+
+      assertTrue(vr.hasType(MinorType.LIST));
+      final ArrayReader aReader = vr.array();
+      final ScalarReader strReader = aReader.scalar();
+
+      assertTrue(reader.next());
+      assertEquals(1, intReader.getInt());
+      assertEquals(2, aReader.size());
+      assertTrue(aReader.next());
+      assertEquals("fred", strReader.getString());
+      assertTrue(aReader.next());
+      assertEquals("barney", strReader.getString());
+      assertFalse(aReader.next());
+
+      assertTrue(reader.next());
+      assertEquals(2, intReader.getInt());
+      assertEquals(2, aReader.size());
+      assertTrue(aReader.next());
+      assertEquals("wilma", strReader.getString());
+      assertTrue(aReader.next());
+      assertEquals("betty", strReader.getString());
+      assertFalse(aReader.next());
+
+      assertFalse(reader.next());
+    }
+
+    result.clear();
+  }
+
+  // TODO: Repeated list
+
+}

--- a/exec/vector/src/main/codegen/templates/ColumnAccessors.java
+++ b/exec/vector/src/main/codegen/templates/ColumnAccessors.java
@@ -331,14 +331,14 @@ public class ColumnAccessors {
       vectorIndex.nextElement();
     }
     <#if drillType == "VarChar">
-    
+
     @Override
     public final void setString(String value) {
       final byte bytes[] = value.getBytes(Charsets.UTF_8);
       setBytes(bytes, bytes.length);
     }
     <#elseif drillType == "Var16Char">
-    
+
     @Override
     public final void setString(String value) {
       final byte bytes[] = value.getBytes(Charsets.UTF_16);

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
@@ -126,6 +126,16 @@ public interface ColumnMetadata {
   boolean isVariant();
 
   /**
+   * Determine if the schema represents a column with a LIST type with
+   * UNION elements. (Lists can be of a single
+   * type (with nullable elements) or can be of unions.)
+   *
+   * @return true if the column is of type LIST of UNIONs
+   */
+
+  boolean isMultiList();
+
+  /**
    * Report whether one column is equivalent to another. Columns are equivalent
    * if they have the same name, type and structure (ignoring internal structure
    * such as offset vectors.)

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Accessors.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Accessors.md
@@ -1,0 +1,162 @@
+# Column Accessors
+
+The column accessors implement a (relatively) simple API to work with a
+collection of vectors. They form the foundation of both the row set
+reader/writer and the result set loader.
+
+The accessors started with the design of the existing "complex writers",
+then evolved in a distinct direction as we describe here. Like the complex
+writers, the column accessors somewhat follow the JSON model. While Drill
+provides only a complex "writer" (but no reader), the column accessors provide
+both readers and writers. As much as possible, the API is similar between the two.
+
+This section describes the common structure; later pages dive into the
+specifics of the writers and readers.
+
+## Structure
+
+Accessors are based on a structure, expressed here as pseudo-BNF:
+
+```
+Tuple : Object*
+Object : Scalar | Array | Tuple | Variant
+Scalar : Nullable Scalar | Non-Nullable Scalar
+Array : Scalar Array | Map Array | List | Repeated List
+Variant : Object*
+Repeated List : Array
+Scalar Array : Scalar
+Map Array : Tuple
+```
+
+### Tuple
+
+The tuple accessor represents both a row and a map and provides both name and
+index access to a set of columns. In the writer, the tuple is the unit of schema
+evolution, providing methods to add new columns on the fly.
+
+### Object
+
+The object accessor represents a column in Drill. That is, it represents a
+vector. The object accessor wraps the actual accessor, whether it be a scalar,
+array, map or whatever. The purpose of the object is to allow generic operations
+on accessors: all members of a tuple are objects, one then queries the object for
+its type and treats the column accordingly. In general, however, convenience
+methods on the accessors hide the object concept when not needed.
+
+The object accessor for a map wraps a tuple accessor, consistent with the idea
+that, conceptually, maps and rows are both tuples.
+
+### Array
+
+The array is a generic concept and consists of two parts: the array and the
+"entry". The array handles indexing over the array elements. The entry handles
+access to each entry. The entry is just one of the other accessors. (For a repeated
+list, it is just another array for example.) Thus, code that works with values
+need not care if the value is a top-level column, a column within a map, or an
+entry in an array.
+
+### Variant
+
+The variant accessor represents both a union and a (non-repeated) list. (The
+list is a very odd duck.) The term "variant" is borrowed from Microsoft (which
+borrowed it from earlier systems) and simply means a union with a type field.
+The Drill term "union" was avoided for two reasons. 1) Constant confusion with
+the UNION operator in SQL, and 2) The union implementation is quick and dirty
+and seems like a good candidate for rethinking.
+
+A variant is like a map, but it is a map keyed by type, not by name. When used
+in a (non-repeated) list, the union can be empty, a single item (which, in the
+list, is not a union at all) or a true union of two or more types. (Yes, indeed
+the list vector is odd.)
+
+## Object Type
+
+Every accessor provides an
+[`ObjectType`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectType.java)
+value that describes the above accessor types. Thus, interpreted code can get
+a column, check the object type, and decide how to proceed. The object type is
+akin to the JSON object type, but with specific types tailored to Drill.
+
+## Typed Access
+
+Drill provides 30+ data types (not all of which are supported or even fully
+implemented.) The "classic" complex writers provide a distinct writer class for
+each and every type: `INT`, `SMALLINT`, nullable `INT`, repeated `INT`, and so
+on. The column accessors take a more restrained approach. All scalar accessors
+provide the same interface. The implementations differ, but client code need
+not care. Each implementation provides implementations for one or more of the
+get or set methods, throwing exceptions for the others. Further, the get and
+set method revolve around Java types, not Drill types. So, for example,
+`TINYINT`, `SMALLINT`, `INT`, `UINT1` and `UINT2` all implement the same
+`setInt()` and `getInt()` methods.
+
+### ValueType enum
+
+To allow interpreted access, each scalar reader provides a value type
+expressed as an enum:
+
+```
+  ValueType valueType();
+```
+
+The value type identifies which `get` or `set` method is implemented.
+(Accessors are free to implement other methods in addition to the main
+one indicated by the value type.)
+
+### Open Issues
+
+One open issue is how best to deal with `INTERVAL` and `DECIMAL` types. At
+present, these are passed as Joda objects (`INTERVAL`, `DATE`, `TIME`) and
+`BigDecimal` (`DECIMAL` types.) Production code needs a different representation
+that avoids object allocations for every value. This is a straightforward
+addition best done once we figure out the mechanism that will best work for
+generated code. (The current technique in generated code, a separate `get()`
+or `set()` call for each field, is inefficient.)
+
+## Column Accessor, Metadata and Generic Access
+
+All the accessors defined above derive from a common base class, either
+`ColumnReader` or `ColumnWriter`. The base class provides generic services:
+
+* Access to [[metadata|BH Metadata]] for the column
+* The object type (described above)
+* Generic `Object get()` and `set(Object value)` methods
+
+## Index Abstraction
+
+Readers and writes implement the concept of an "index": a pointer to the current
+read or write position. Writers increment the index, readers allow random access.
+
+Consider a set of three vectors: a, b, and c. In most Drill code, the application
+keeps track of the index. Then, the application passes its index, (`rowIndex`,
+say) to each vector for each access. For example: `a.get(rowIndex)` or
+`b.set(rowIndex, value)`.
+
+This code is tedious, but not hard. However, the complexity vastly increases
+when we consider arrays, especially map arrays. In this case, the application
+must keep track not only of a `rowIndex`, but also a `repeatedMap1Index`, a
+`repeatedIntIndex` and so on. Keeping all this straight is fraught with
+opportunities for bugs, especially since there is only exactly one right way
+to do the work.
+
+The accessors take over this issue. In arrays, the accessors introduce new
+"local" indexes for the array. Child accessors use the "inner" index for array
+items. If we have multiple levels of repeated map, then we have multiple
+levels of index. The application does nothing other than tell the reader or
+writer to advance.
+
+Readers must deal with another level of complexity: selection vectors. The
+reader index encapsulates this indirection: the application asks for row 7,
+the reader figures out that this is actually row 1234 (for an SV2), or row
+4567 of batch 17 (for an SV4.)
+
+In short, the index removes all the index complexity from operators and
+readers and places it into the accessors where it can be implemented and
+tested once and for all.
+
+## Examples
+
+The `RowSetTest` class shows examples of working with readers and writers
+directly. The `RowSetBuilder` shows an example of generic (interpreted) use
+of the writer. `RowSetPrinter` and `RowSetComparison` show interpreted use
+of the reader.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayReader.java
@@ -60,6 +60,7 @@ public interface ArrayReader extends ColumnReader {
   ScalarReader scalar();
   TupleReader tuple();
   ArrayReader array();
+  VariantReader variant();
 
   /**
    * Set the array reader to read a given array entry. Not used for

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ArrayWriter.java
@@ -86,6 +86,7 @@ public interface ArrayWriter extends ColumnWriter {
   ScalarWriter scalar();
   TupleWriter tuple();
   ArrayWriter array();
+  VariantWriter variant();
 
   /**
    * When the array contains a tuple or an array, call <tt>save()</tt>

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.vector.accessor;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.ScalarWriter.ColumnWriterListener;
 import org.apache.drill.exec.vector.accessor.TupleWriter.TupleWriterListener;
+import org.apache.drill.exec.vector.accessor.VariantWriter.VariantWriterListener;
 
 /**
  * Generic information about a column writer including:
@@ -57,6 +58,10 @@ public interface ColumnWriter extends WriterPosition {
      */
 
     void bindListener(ColumnWriterListener listener);
+  }
+
+  interface VariantListenable {
+    void bindListener(VariantWriterListener listener);
   }
 
   /**

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Components.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Components.md
@@ -1,0 +1,240 @@
+# Column Accessor Components
+
+The code to manage batch sizes affects many aspects of Drill's low-level
+batch handling. This page provides an overview of the components so that,
+as you read the details for each, you can fit them into the larger picture.
+
+We list the components from the top downward. In general, higher-level
+components depend on lower level components, but not visa-versa (a
+restriction that is necessary to allow component-level unit testing.)
+
+## Scan Operator
+
+The readers are the worst offenders in terms of uncontrolled batch sizes.
+The original plan was to first create a framework, then upgrade the dozen
+readers using the framework. That is, replace a dozen ad-hoc implementations
+of projection and batch assembly with a single, robust, fully tested
+implementation, leaving the readers to just worry about fetching data from
+the input source. Two readers have been upgraded: CSV and JSON.
+
+### Easy Plugin Framework
+
+Package: [`org/apache/drill/exec/store/dfs/easy/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy)
+
+The highest-level components in this project are the revisions to the Easy
+Plugin framework which is used by many file-based readers. The work here extends
+the framework to support either the "classic" scan operator or the new size-aware
+scan operator. By allowing both, we allow each plugin to upgrade on its own schedule.
+Once all plugins are upgraded, the classic support can be deprecated.
+
+### JSON And CSV Plugins
+
+The project upgraded the CSV and JSON plugins. CSV was done first as a proof-of-concept
+because it has relatively modest needs. JSON was done next because JSON is, in
+some ways, Drill's most complex data structure. The work here simply replaces
+the old code to create readers with a new version.
+
+### JSON and CSV Readers
+
+Packages:
+* [`org/apache/drill/exec/store/easy/text/compliant/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant)
+* [`org/apache/drill/exec/store/easy/json/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json)
+
+The bulk of the work to replace the JSON and CSV readers are in the readers
+themselves. In the case of CSV, we replace the ad-hoc code that worked with
+direct memory buffers with code that uses the row set loader. The JSON reader
+was a bit of a larger project for two reasons. First, the old reader was a bit
+of a rat's nest of states and if statements, so we replaced it with a much
+cleaner state machine. Second, the old "complex readers" did some of the work
+that the JSON reader did, so that work was shifted to the JSON reader itself.
+The work to write to the row set loader was actually quite easy.
+
+As we will discuss, JSON presented some unique challenges because Drill's
+design is incomplete and ad-hoc: there is no good mapping from an arbitrary
+JSON structure into a columnar structure; instead we have a number of ad-hoc
+rules that, together, handle some of the more complex cases -- but only in
+some scenarios.
+
+### File Scan Framework
+
+Packages:
+* [`org/apache/drill/exec/physical/impl/scan/columns`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns)
+* [`org/apache/drill/exec/physical/impl/scan/file`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/file)
+
+Existing file-based readers do quite a bit of common work, but each in its own way.
+For example, different readers have different approaches to how they populate
+the file metadata (AKA "implicit") columns. The file scan framework is an
+implementation of a scan framework (see below) that provides a uniform way
+to handle file-related tasks. Plus, as a bonus, this framework provides
+incremental creation of readers as they are needed, rather than creating
+all up front.
+
+As we improve aspects of the file framework (such as Salim's improvements to
+the storage of implicit columns), we can implement it once in the common
+framework, and it will be immediately put to use by all file-oriented readers.
+
+### Scan Framework
+
+Package: [`org/apache/drill/exec/physical/impl/scan/framework`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework)
+
+Each reader also handles projection push-down in its own way. Projection turns
+out to be quite complex in the general cases with many special cases to be
+considered. (For example, Drill allows columns of the form `a.b`, which are
+not used for simple readers such as CSV, but such readers have to detect such
+columns anyway to create the necessary null columns.) Again, each reader does
+projection slightly differently.
+
+The scan framework provides a single, shared mechanism for projection. It
+handles all cases: scalar, array and map projection, file metadata,
+directory metadata, and so on. This framework highlights a common theme in
+this work: implement a feature once, do it completely, then unit test
+exhaustively to ensure that the mechanism will work everywhere needed.
+
+### Projection Push-Down Framework
+
+Package: [`org/apache/drill/exec/physical/impl/scan/project/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project)
+
+Most (all?) readers implement projection push-down. They all do it their own
+way. New readers must implement their own solutions. (This will be a topic in
+an upcoming book on Apache Drill.) Although the dozen implementations show a
+great flowering of creativity, it would be a daunting task to upgrade so many
+different implementations of the same basic idea.
+
+The projection framework provides a single, standard implementation. Projection
+turns out to be surprisingly complex because of Drill's schema-free nature.
+Projected columns can be simple, maps or arrays. Drill creates nulls for missing
+columns, so we need null simple, array and map columns. We must match up table
+schema and the project list, dropping unwanted columns and adding nulls. Things
+get particularly interesting if, say, the user requests `a.b, a.c`, but the
+table provides only `a.b` and Drill must invent a map member `a.c`.
+
+### Scan Operator
+
+Package: [`org/apache/drill/exec/physical/impl/scan/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan)
+
+The "classic" scan operator handles a variety of tasks making the code quite
+complex. The revised version does just one thing, and does it well. It handles
+the implementation of an operator that iterates over a set of readers,
+using a scan framework, and returns the resulting batches. All of the work specific
+to a kind of scan is factored into the scan framework described above. The work of
+writing to vectors is factored out into the row set loader. The scan operator itself
+is an implementation of the operator framework, described next.
+
+## Operator Framework
+
+Package: [`exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol)
+
+Drill's operator implementations (so-called "record batches") also handle a
+variety of tasks, making the implementations very complex and error-prone.
+The operator framework tackles this complexity using composition. The framework
+divides operator tasks into three parts: Drill iterator protocol, record batch
+(that is, vector container) management, and operator implementation. The first
+two can be common to all opeators, the third is unique to each.
+
+An important aspect of this design (and the reason for this version) is that
+it allows very convenient unit testing of each operator independent of the
+rest of Drill. As code grows in complexity, it becomes necessary to hit it
+with dozens of test cases in which we tightly control the test cases. That
+is hard to do with server-level integration tests, but very easy to do with
+JUnit tests.
+
+The operator framework is meant to handle all operators, but has been put to
+use for only the sort operator. Expect to extend or adjust the operator
+framework to fit other use cases.
+
+## Result Set Loader
+
+Packages:
+* [`org/apache/drill/test/rowSet/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/test/java/org/apache/drill/test/rowSet)
+* [`org/apache/drill/exec/physical/rowSet/model/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model)
+
+The result set loader is the core of this project. It provides a very simple
+way to write data to the set of vectors that form a batch, and to write to a
+sequence of batches (combined, the "result set.") The result set loader is
+similar to the existing "complex writers", but with a number of differences.
+First, the result set loader manages both the writers ("column writers" in
+this case) and vectors (a job formerly handled by the scan operator's
+`Mutator` class.)
+
+The result set loader is the pivot for this project. All changes below this
+level were done to provide the services that the row set loader needs to do
+its job. Changes in the layers above were done to enable readers (and other
+operators) to exploit the row set loader (and to reduce the cost of updating
+operators to use the result set loader by factoring out redundant
+implementations.)
+
+The result set loader is schema-aware: it can work with "early schema"
+(schema known up-front, as in Parquet) and "late schema" (schema discovered
+on the fly, as in JSON.) It also implements part of the projection mechanism.
+It allows writers to write all columns (such as in CSV), and will quietly
+discard data for non-projected columns. This makes it trivially easy to create
+a simple record reader: just read a row, write all columns, and let the row
+set loader worry about which are actually needed. More sophisticated readers
+(such as JSON or Parquet) can, of course, do the job their own way when needed.
+
+The main feature of the result set loader is the ability to limit batch size
+using a "roll-over" mechanism. That mechanism requires that the row set
+loader manage vectors: creation, allocation and so on.
+
+The "model" portion of this package provides tools to work with schemas: to
+build readers and writers given a schema and so on. Two forms exist: one
+for "single" batches and another for "hyper" batches.
+
+## Row Set
+
+Package: [`org/apache/drill/test/rowSet/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/test/java/org/apache/drill/test/rowSet)
+
+The row set tools have existed for a year or so and started as a way to
+create or verify record batches during unit testing. The column accessors,
+described below, started as the way that row sets work with vectors. As this
+project progressed, the row set tests were the first line of testing for
+each accessor change. The row set mechanism, including the ability to define
+schemas, build row sets, print row sets, compare row sets and so on, are used
+throughout the unit tests for the rest of the project.
+
+The `RowSetWriter` has a very simple relationship with the `ResultSetLoader`.
+The row set writer writes a single batch, with a fixed schema, then is done.
+The `ResultSetLoader` adds the complexity that ensues when the schema evolves,
+when writing multiple batches, and so on. Thus, to learn the mechanisms, start
+with the row set writer. Then, once that is familiar, graduate up to the
+result set loader.
+
+## Column Accessors
+
+Package: [`vector/org/apache/drill/exec/vector/accessor/`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor)
+
+The result set loader is basically an orchestrator. The actual work of writing
+to vectors is done by a set of "column writers." There is a similar set of
+readers. At this level, the readers and writers work with one batch at a time.
+This turns out to be very handy in its own right: it has allowed creation of
+the `RowSet` test framework that provides simple creation, display and comparison
+of row sets. This feature is used in low-level unit tests of all of the above layers.
+
+### Column Metadata
+
+Packages:
+* [`org/apache/drill/exec/record/metadata/`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata) (Implementation)
+
+Metadata is an important part of any data representation. While Drill provides
+one form (see below), that version turned out to be rather limited for the
+purposes of this project. So, we developed a new set, called the column metadata.
+It is defined in the vector layer (where the accessors reside), but implemented
+in `java-exec` (where some of the required dependencies reside.) Over time, it
+might be good to merge the two implementations, which can be done once both are
+together in the master branch.
+
+## Physical Vector Layer
+
+All data in Drill is stored in vectors. Some adjustments were needed to this layer.
+
+## Materialized Field Metadata
+
+As noted above, the vector layer currently provides the `MaterializedField` class
+that provides metadata for each vector. Adjustments where needed here to properly
+implement comparisons, to handle metadata for nested vectors and so on.
+
+## Vectors
+
+In several cases, new methods were added here and there. The union vector was
+heavily refurbished. The list vector was made to work (it was evidently not
+previously used.) And so on.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Futures.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Futures.md
@@ -1,0 +1,252 @@
+# Future Directions
+
+We've now taken the grand tour though the entire project and we
+can discuss futures.
+
+## Completing the Work
+
+The discussions here discussed not just how the code works, but *why* it was
+created as it was. The project spanned many months during which many issues
+arose, were discussed, and solutions adopted. For this reason, the project,
+as it exists, evolved to solve very specific issues that Drill presents.
+
+The path of least resistance is to complete the roll-out of the work up
+through the CSV and JSON readers, then to upgrade other important readers,
+uch as Parquet.
+
+Once the core readers are upgraded, attention can turn to other readers and
+operators as discussed below.
+
+## Next Steps
+
+After the present work is committed, two paths become open to the team:
+
+* Upgrade other readers
+* Upgrade other operators
+
+### Upgrade Readers
+
+The project chose to start with CSV (actually, the "compliant text") reader
+because it is simple and proved the basic concept. The project then tackled JSON
+because it is the hardest. (As noted, the work identified many unresolved design
+issues in the JSON reader.) All other readers fall somewhere in between.
+
+Readers where the focus of this project because readers are the largest source of
+batch size problems. While alternative solutions exist for internal (non-scan)
+operators, no solution exists for readers since, in general, readers do not know
+the size of incoming data until it is read.
+
+The logical progression is that each community member upgrades the readers that
+are important to them. MapR is Drill's primary sponsor, so perhaps MapR upgrades
+readers that are commercially important to MapR (such as the Parquet reader.)
+Other teams, at their convenience, upgrade other readers.
+
+The timing is flexible. Once the code is available, upgrades can happen at any
+time. But, once Drill moves to create an admission control solution, then Drill
+must be able to manage memory, and all readers must be upgraded or deprecated
+t that time. If any reader declines to limit its batch size, then the entire
+query may die because the fragment (and each operator in the fragment) will be
+forced to handle data beyond the budgeted memory size. The only three solutions
+at that time will be to either:
+
+* Turn off admission control for "unmanaged" readers.
+* Disable unmanaged readers when admission control is enabled.
+* Upgrade unmanaged readers so that they manage batch size.
+
+### Upgrade Other Operators
+
+Drills internal (non-scan) operators must also be upgraded, but here we have
+two choices.
+
+* Use the result set loader to write batches (and the corresponding reader
+to read batches), or
+* Use the "batch sizer" solutions employed in sort and hash agg to implement
+ad-hoc solutions. (This is the solution actually adopted.)
+
+Frankly, the "batch sizer" solution is the simplest short-term solution if
+our focus is exclusively batch size control. (Efforts are underway using
+this approach.)
+
+The cost of upgrading existing operators will be high because:
+
+* The generated code that works with vectors must be replaced by generated
+code that works with result set readers and writers.
+* The code generation mechanism, including semantic analysis, must be changed
+to understand the higher-level view of batches.
+* Mechanisms that currently work at the vector level (such as transfer pairs)
+must be evolved to work with vectors created by the result set loader.
+* The ad-hoc projection, batch assembly, vector allocation code should be
+upgraded to use common mechanisms (perhaps derived from the work done for scans.)
+* To enable this work (and unit testing) the operators should evolve to use
+the common operator framework rather than providing ad-hoc iterator
+implementations in each operator.
+
+## Long-Term Architectural Goals
+
+The above work is not justified just for batch size control since a simpler
+lternative exists. Instead, the above work is justified only if we get more
+value. Some long-term architectural advantages include:
+
+* Once all operators use the result set readers and writers, we become free to
+enhance the underlying vector storage format. Perhaps we move to Arrow or to
+using fixed-sized buffers. Since only the generated accessor code deals with
+the vector memory layout, such changes become much easier to make.
+* If we with to improve code generation, we will have to understand and enhance
+the code generation framework. (Perhaps we move to plain Java. Perhaps we
+replace some generated code with "pre-written" code such as for copying rows
+of data.) If we are going to revisit code generation, we might as well generate
+code for the column accessors than continue to work directly with vectors.
+* As Drill matures, thorough unit testing becomes the only reliable way to
+ensure continued quality. The current approach of running a few system tests
+is stochastic: maybe tests find problems and maybe they don't. We'd need
+well-designed, blackbox tests that exercise all (or most) code paths. That
+can only be done via unit tests. If we must modify operator structure to allow
+such testing, we might as well use that opportunity to use the new operator
+framework, which enables us to more easily move to use the new column accessors.
+
+Each of the above deserves far more detail than can be provided here. This
+should at least provide the flavor of the opportunities available.
+
+These are all complex architectural issues which are not at all obvious from
+a superficial task-oriented view of the code. For this reason, it may take years
+to understand the need for, and move toward, the above approaches. This again
+argues for using simpler (if less robust) solutions short-term.
+
+## Toward Fixed-Size Memory Buffers
+
+This project started, in part, from a desire to address memory fragmentation in
+Drill. The project solves one aspect of fragmentation (limiting vector sizes to
+the Netty block size or smaller.) But, it does not directly solve a more
+fundamental issue: that database experts have known since at least the '80s
+that memory fragmentation is unavoidable in a system that does random allocations
+or random sized blocks without compaction.
+
+C++ applications are subject to memory fragmentation because the follow the above
+patterns. Database systems written in C++ (such as Impala) solve the issue by
+allocing fixed size "buffers" that reside in a "buffer pool." Database systems
+have long shown that such a solution works well and avoids fragmentation.
+
+### Drill Challenges
+
+Java applications are not subject to fragmentation because the Java GC performs
+compaction and coalescing of free blocks. This prevents the issue of fragmentation
+by ensuring a steady supply of large spans of free memory (until the application
+allocates so many blocks that it exhausts heap.) Many Java developers (including
+Drill's) see GC as an unwanted cost, and look for alternatives.
+
+Fixed-size blocks work well for row-based systems: the system simply packs a block
+with rows until no more fit. Fixed-sized blocks are less obvious for columnar
+systems. Each column grows independently and each has different sized data.
+This is why Drill adopted a `malloc`-like approach. But, in so doing, Drill
+became subject to memory fragmentation. Is this a Catch-22?
+
+Drill uses direct memory to avoid GC costs. But, in so doing, Drill gave up
+the solution that allows random-sized allocations to work: compaction. So, to
+continue to use direct memory without compaction, Drill may find it necessary
+to follow most other database systems and adopt a memory model based on
+fixed-size blocks.
+
+### Fixed-Size Blocks for Drill
+
+One possible solution (for which a prototype exists) is to rethink the value
+vector. Today each value vector is represented as a single, variable-sized
+(but power-of-two sized) block. This leads to two issues:
+
+* Fragmentation of the Netty free list.
+* Excessive internal fragmentation (on average, 25% of each vector is unused).
+
+This model has the advantage of representing vectors as, essentially, Netty
+byte buffers. But, Netty points to an alternative solution: a composite byte buffer.
+
+In Netty, we can have a logical byte buffer which is actually comprised of
+a series of underlying buffers. Netty does the required offset translations.
+
+The prototype mentioned earlier does something similar, but with fixed size
+blocks. Rather than a vector being a single block, it is physically comprised
+of a string of fixed-size blocks:
+
+```
+Current:  [The quick brown fox jumps over the lazy dog.........]
+Revised:
+Logical:  [The quick brown fox jumps over the lazy dog.]
+Physical: [The quic][k brown ][fox jump][s over t][he lazy ][dog.....]
+```
+
+The implementation can be based on power-of-two blocks. The example uses
+8 bytes, but a real solution would use much larger. (The prototype found
+that 1 MB blocks amortize costs and are at least as fast as the current
+solution.) Power-of-two blocks allow a very simple indexing schema: just
+mask and shift similar to how SV4 vectors work.
+
+The prototype adds a simple caching scheme: writes happen sequentially,
+so the block reference need be resolved only when a block becomes full.
+
+### Simpler Memory Allocator
+
+Once fixed size blocks are implemented, various memory management designs
+become available. For example, if we decide to give each fragment x bytes
+of memory, then we are effectively giving the fragment (x / block size)
+blocks of memory. A block pool for the fragment can recycle those blocks:
+
+```
+Scan --> Filter --> SVR --> Sender
+ ^                   ^        |
+ |                   |        |
+ |                   v        v
+ +---- Block pool ---+--------+
+```
+
+Such a memory allocator would be, essentially, lock-free for all but the
+sender. (Sent blocks would be released in a Netty thread.) Since Drill's
+current allocator is designed to be lock-free, we would retain this benefit
+in the new solution.
+
+Further, the allocator becomes **far** simpler: we no longer need to
+anage variable-sized blocks at the byte level, no longer need ledgers, no
+longer need to manage operator allocations. All we need to do is manage the
+overall fragment memory, which should be driven by the kind of memory
+management plan discussed at the [start](Overview.md).
+
+## Drive Adoption via Community Reader Contributions
+
+To change topics just a bit, one of Drill's compelling advantages is that it
+is written in Java and thus can enable community-provided extensions. Drill
+already enjoys a variety of community-provided readers. However, there seems to
+e general agreement that it is far harder than necessary to create a reader.
+Each reader author must:
+
+* Become familiar with Drill internals
+* Learn how value vectors work, including the mutators
+* Learn the scan operator and its mutator
+* Learn how to do projection push-down
+* Learn how the Easy format plugin mechanism works, or start from scratch
+with the core format plugin mechanism
+* Learn how file extensions work, how plan time operations work, etc.
+* Figure out some way to debug the reader, often within a complete Drill
+server.
+
+One of the background goals of this project is to make it far easier to
+create a format plugin. This work can't solve all the issues, but it did
+attempt to do the following:
+
+* Provide a very simple API for most cases.
+* Allow readers to focus on getting data from the input source and writing
+it to the result set loader. The scan framework does all the other standard
+work.
+
+A good task for a community member would be, once the code is available,
+to create an example reader using the new framework, then publicize that
+example to encourage new reader contributions.
+
+## Conclusion
+
+And so we come full circle. We started with a desire to define a memory
+budget for a fragment (and thus a query) and to avoid one form of memory
+allocation. We worked out the technical mechanisms to do that. We have now
+seen how those solutions allow us to move to a fixed-size-block structure
+that sweeps away the remaining memory fragmentation issues, while resulting
+in a much simpler, proven memory allocation model.
+
+As the team moves forward with this project, please keep this big picture
+in mind. By doing so, we can continue to march forward towards our common
+goal of making Drill the best big-data query engine available.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Metadata.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Metadata.md
@@ -1,0 +1,267 @@
+# Column Accessor Metadata System
+
+Metadata is the glue that allows the many batch handling components to
+work together. There are several ways to categorize metadata:
+
+* Descriptive: Describe existing data (that is, existing vectors or
+an existing table).
+* Proscriptive: Describe the vectors we wish to build.
+
+Drill's existing metadata mechanisms are primarily focused on describing
+vectors, and turned out to not be a good it for the "proscriptive" use
+case above. Hence, the column accessor project created an extended metadata
+system that builds on the existing system to allow more dynamic description
+and creation of batches, readers, writers and so on.
+
+At present, metadata groups into two distinct systems:
+
+* Column metadata: used for proscriptive schemas and throughout the
+column accessor code. Provides many semantic services needed to describe,
+create and manage various kinds of metadata operations.
+* Materialized field and batch schema: used to describe existing vectors
+and record batches (so-called vector containers.)
+
+This section describes the purpose, services and role of each kind of metadata.
+
+## Describe a Vector
+
+Drill already provides the [`MaterializedField`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java) class to describe a vector. This class has three components:
+
+* Name
+* Major type
+  * Minor (data) type
+  * Data mode (cardinality)
+  * Subtypes (for a union)
+* Children (for a map, a repeated list or a list)
+
+### Immutability
+
+The materialized field is straightforward for simple types: `INT`, `VARCHAR`,
+`INTERVAL` and so on. The original design appears to be that, because these
+types are simple, a `MaterializedField` is immutable. Quite simple.
+
+Drill also supports complex types: those that are made up of one column that
+contains other columns. In Drill, the complex types are; Map, Repeated Map,
+(non-repeated) List, Repeated List and Union. In this case, `MaterializedField`
+must describe not only the complex vector itself, but also the children. (A map
+must describe its members, for example.)
+
+This requirement puts great strain on the concept that a `MaterializedField` is
+immutable. A map, say, allows adding new members at any time. How do we add new
+children to the map's `MaterializedField` if it is immutable? The solution
+appears to be that the name and type are immutable, but the list of children
+is not. It is a compromise, but it works.
+
+Unions (though they are barely supported) introduce another issue. A union
+contains a series of "subtypes" (vectors) that represent the data of the union.
+Each row contains a value in one of the subtypes: in, say, `INT` or `VARCHAR`.
+Unions allow the addition of subtypes at any time. Since the `MajorType` and
+`MaterializedField` are immutable, now do we handle this? The answer has been
+to create a new `MaterializedField` for the union vector.
+
+Now things get interesting. A map can contain a union. The map's
+`MaterializedField` holds a list of children, including the `MaterializedField`
+for the union. If we replace the union's `MaterializedField` the map will
+then hold onto a stale version and the schema becomes inconsistent.
+
+The code for this project tries to find and fix these issues where they are
+found. (But, we really should test every pair of complex types to ensure
+that all cases are handled.) In general, the solution is to discard the
+assumption that the `MaterializedField` is immutable, replacing with a
+finer-grain set of invariants (such as that neither the name nor the data
+type/mode can change.)
+
+### Hidden (Implementation) Children
+
+A nullable `INT` vector is, conceptually just a nullable `INT` type an a name.
+But, the nullable vector is represented as a container with children for the
+"bits" and "data" vectors. The actual `MaterializedField` contains these
+hidden vectors as children. But, from a conceptual point of view, the
+children are implementation details. One key place where this issue arrises
+is in comparison. Is a nullable `INT` (without children) equal to a nullable
+`INT` with children? For some purposes, yes. For others, no.
+
+The recently-added `isEquivalent()` method on `MaterializedField` resolves
+this ambiguity by considering children only for types in which children are
+user-visible (maps, unions, etc.)
+
+### Union Structure
+
+The (obscure) [`UnionVector`](https://github.com/apache/drill/blob/master/exec/vector/src/main/codegen/templates/UnionVector.java) is a single vector that can hold multiple types. A row is one type or another. The structure here is a bit unclear. What is clear is that, for a union vector, the child types are stored as subtypes in the `MajorType`. The children are also stored, as materialized fields, but in an awkward structure. Like a nullable vector, union vector has internal structure stored as children in the the materialized field. The actual type vectors are stored two levels down, as children of an internal map that is the child of the union.
+
+This structure works, but is very awkward for semantic processing because of
+the amount of implementation detail that "shows through" into the metadata.
+
+### List Structure
+
+Drill has two kinds of lists. The "non-repeated" (and basically unsupported)
+[`ListVector`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java)
+ and the [`RepeatedListVector`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java).
+ Despite the similar names, the are very separate concepts.
+
+The list vector is quite odd. It has a "bits" vector that allows arrays to
+be marked as null (as is needed for JSON.) It also can act as either a
+"nullable repeated nullable X" or as a "repeated union". The materialized
+field thus has a very complex structure.
+
+When acting as "nullable repeated nullable X", the materialized field for
+the "nullable X" appears as a child.
+
+But, when the list is "promoted to union", then the child structure changes.
+In this case, the union is the child of the list, and the "nullable X" is
+pushed two levels down as described for unions above.
+
+Again, this works, but becomes quite vexing for semantic processing.
+
+### Limitations
+
+The `MaterializedField` has a number of other limitations that make it
+awkward to use for semantic processing:
+
+* No convenient access to the most important properties: data type and
+cardinality. Each access requires an awkward chain of calls.
+* Inconvenient equality checks: equality is based on the equality of
+Protobufs, which have very odd semantics (such as whether a field is set
+or not.) Also, there is ambiguity with the hidden children.
+* Very awkward access to children (only an iterator is provided, not
+indexed access.)
+
+To be fair, `MaterializedField` was never meant for the kind of semantic
+processing we need. All of this is not meant as a critique of the code (the
+code is fine), but rather as a motivation for the enhanced metadata mechanism
+described below.
+
+## Batch Schema
+
+Drill represents a record batch (the data, not the operator) as a `VectorContainer`.
+The container gathers up the schemas of its vectors into a `BatchSchema`.
+However, the `BatchSchema` is a bit awkward, it is missing methods needed
+for semantic processing.
+
+## Column and Tuple Schema
+
+For these reasons (and more), this project decided to create a new metadata
+representation: one that is better suited to semantic processing. One of the
+key design goals of this approach was to realize a very helpful generalization:
+rows and maps are both tuples and should have the same metadata description.
+
+The metadata layer is defined in the `vector` module alongside the
+`MaterializedField` class, vectors and column accessors (described later).
+However, they are implemented in the `java-exec` package, which is where
+the `BatchSchema` is defined.
+
+The two key interfaces are:
+
+* `TupleMetadata` - generalized representation of a row or map.
+* `ColumnMetadata` - generalized representation of a named column.
+
+Two additional interfaces exist for Drill's obscure data types:
+
+* `VariantMetadata` - represents a Union or a (non-repeated) List
+
+The column/tuple metadata combine to form a simple tree structure, rooted in a
+tuple, that can describe (possibly repeated) maps to any level of depth.
+Include unions, and the tree can represent any combination of nesting of maps
+in unions, unions in maps, and so on.
+
+### Tuple Semantics
+
+Traditional databases employ the "tuple" concept. In practice, a tuple is a
+collection of values identified by both name an position. Consider JDBC as a
+typical example, we can access a column either by name ("myCol", say) or by
+position (4, say). Today Drill is a bit conflicted on indexed access.
+`VectorContainer` provides indexed access, as do maps. Unions do not, nor
+do `MaterializedField` child lists. Drill also provides name access, but it
+is implemented as a linear search in some cases.
+
+Since both name an indexed lookups are vital (name lookup for semantic
+processing, index for performant runtime lookups), the tuple metadata
+(as well as the column accessors) provide both indexed and name access.
+Name access is via a hash map for performance.
+
+### Simplified Schema Description
+
+In addition to the row/map unification, the column metadata helps to smooth
+over a number of other awkward bits in the `MaterializedField` representation:
+
+* The tuple schema reifies the concept of a map schema in a form much more
+convenient than the `MaterializedField` child iterator. The tuple schema
+provides services to easily build, traverse and query a row or map schema.
+* Many query methods for common conditions.
+* Divide columns up into four broad groups: Primitive, Tuple, Variant and
+Multi-Array. (The last represents a repeated list.)
+
+### Services
+
+The key job of the metadata interfaces are to provide semantic services such
+as names, types, cardinality, default data width, default array sizes, and more.
+In the implementation package, the RowSet version of the `SchemaBuilder`
+provides a fluent way to define a schema for tests. Once you understand the
+urpose of these classes, the JavaDoc in the class should provide the necessary
+details.
+
+One non-obvious service is to report, in the context of a scan operator, if a
+column is projected. In this way, a reader can declare it's view of the schema.
+(A CSV reader, say, can declare that it has 10 columns.) After schema
+negotiation, the scan operator will determine that only three of the ten
+columns are projected. The column metadata for the table (the CSV file)
+will identify which are projected into the scan operator's output schema.
+(More on this concept later.)
+
+### Vector Allocation
+
+When allocating a new vector, we often need to know up to three pieces of
+information:
+
+* The number of rows
+* The width (for VarChar fields)
+* The inner size (for arrays)
+
+Given this information, Drill can very accurately allocate a vector of the
+equired length. Doing so is important because it eliminates the doubling and
+copying required with poor guesses. Most Drill code provides only the number
+of rows, and guesses for the others. (This is where the infamous VarChar size
+of 50 comes in, along with a guess of 5 for array sizes.) The sort operator took
+an initial stab at an advanced batch allocator that uses the additional values
+(which it obtained by introspecting an incoming batch using the `BatchSizer`.)
+
+This mechanism goes a step further and adds the additional values to the
+metadata itself. Over time, readers can determine the value through inspection,
+and can (we hope) pass the values along with each batch so that other operators
+don't need to repeated run the `BatchSizer` over and over. But, that is a
+long-term goal.
+
+### Reverse Engineering a Batch
+
+Tools exist to examine a batch (using the `MaterializedField`s) and create the
+batch metadata. This is done, for example, in the `RowSet` classes to provide
+a simple schema description which is then used to generate readers or writers
+for that batch.
+
+### Forward Engineer a Batch From a Schema
+
+Other tools (also in the `RowSet` tools) can build a batch of vectors from a
+schema. Thus, the column metadata provide complete "round trip" engineering.
+(However, at present, the additional fields (width and array size) are lost
+in the process since `MaterializedField` does not support them.)
+
+### Scan Schema Negotiation
+
+The scan operator implements projection push-down in which the query (via the
+project list) "negotiates" with the data source (via the reader) for the of
+columns to provide. The scanner projects some, creates nulls for others, and
+implicit columns for others. In the new framework, all of this work uses the
+column/tuple metadata to represent a schema.
+
+## Future Directions
+
+Obviously it is less than ideal to have two distinct metadata systems. A good
+long-term goal would be to merge the two systems. In particular,
+`MaterializedField` would be replaced by the column metadata, and the
+`BatchSchema` would be replaced by the tuple schema.
+
+The rub, of course, is that such a change breaks the client/server API.
+Changing value vector metadata would require changes to the JDBC and ODBC
+clients to handle the new format. Without API versioning, this is a difficult
+change. So, for now, we use two systems as that approach, while awkward,
+does have the advantage of not breaking backward compatibility.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectReader.java
@@ -33,4 +33,5 @@ public interface ObjectReader extends ColumnReader {
   ScalarReader scalar();
   TupleReader tuple();
   ArrayReader array();
+  VariantReader variant();
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectType.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectType.java
@@ -24,5 +24,5 @@ package org.apache.drill.exec.vector.accessor;
  */
 
 public enum ObjectType {
-  SCALAR, TUPLE, ARRAY
+  SCALAR, TUPLE, ARRAY, VARIANT
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ObjectWriter.java
@@ -47,4 +47,6 @@ public interface ObjectWriter extends ColumnWriter {
   TupleWriter tuple();
 
   ArrayWriter array();
+
+  VariantWriter variant();
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Overview.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Overview.md
@@ -1,0 +1,403 @@
+# Conceptual Overview
+
+Memory management is a core service in a query engine. The column acessor
+project came about in support of enhancement memory management in Drill.
+This page discusses the motivation for the project. A more detailed version
+of this information can be found in
+[DRILL-5211](https://issues.apache.org/jira/browse/DRILL-5211).
+
+## Original Drill Memory Management
+
+The original Drill design appeared to be based on two complementary assumptions:
+
+* The user will ensure that Drill is provided with sufficient memory for each query and,
+* Memory management is best handled as a negotiation among operators within a minor fragment.
+
+### User-Centric Memory Management
+
+Drill is an in-memory, big-data query engine. Drill benefits from generous
+memory allocation. As originally designed, all operators work in memory. For
+example, to sort 1 TB of data, Drill would need 1 TB of memory (distributed
+across all nodes) to hold the data in memory during the sort. Since only the
+user knows the size of the queries to be run, and the user can make decisions
+about number of nodes, and memory per node, then the user is really the best
+one to ensure that Drill is provided with sufficient memory to run the desired
+queries.
+
+While this is a very simple and clear design, it turned out to not be workable
+in a multi-user environment: there is simply no good way for multiple users
+to coordinate to decide on memory usage, or to ensure that a query from one
+user does not use memory that another users may be planning to use.
+
+### Operator Negotiation
+
+Drill uses direct (not heap) memory to hold query data. Drill provides a very
+sophisticated memory manager to allocate, track, share, and release direct
+memory buffers. One of the features of the memory manager is a per-operator
+allocator which enforces a memory limit. For example, operator X may be given
+1 GB of memory. The allocator will raise an exception if operator X asks for
+even a single byte over the limit. Operator X can also receive an OOM if either
+1) the entire global memory pool is exhausted, or 2) the memory allocated to
+the minor fragment is exhausted.
+
+The original design appeared to be that each operator would catch the
+out-of-memory (OOM) exceptions, then negotiate with other operators for
+additional memory by sending a `OUT_OF_MEMORY` status to downstream operators.
+For example, a reader that runs out of memory can stop reading the current row,
+send the OOM status downstream, then resume reading the row once it is called
+again (presumably with more memory.)
+
+In practice, the mechanism was never fully implemented, nor is it clear that
+it could actually work. If, for example, operator X exhausts its local memory
+limit, sending OOM downstream won't change that fact. Operator code is made
+vastly more complex if each memory allocation is required to stop processing
+if OOM is returned. Further, most operators don't have much flexibility in
+managing memory: most operators work with a single batch and can't do useful
+work without sufficient memory for that batch. Buffering operators (sort,
+joins, etc.) might be able to take action in response to memory pressure
+(such as spilling). Since operators share a global memory pool, there is no
+good way for a sort for query Q1 to respond to memory pressures created by
+another sort in query Q1.
+
+In short, the idea of operators negotiating memory among themselves is elegant,
+it is not entirely clear how to write code to realize the idea.
+
+## Netty Slab Size
+
+Drill uses Netty as its memory allocator. Any memory management solution should
+also be aware of a feature of Netty: the Netty slab size. Netty contains a
+[jemalloc](http://jemalloc.net)-like memory allocator that works with
+fixed-size blocks (subdivided into power-of-two slices). The default size of a
+Netty block is 16 MB (though the size can be configured.) If an application asks
+or memory larger than the block size, Netty allocates the memory from the OS.
+This leads to a possible fragmentation scenario: all memory may be on a Netty free
+list where it is available for allocations of 16 MB or smaller, but none is
+available from the OS for allocations of 32 MB or larger. (All allocations must
+be in power-of-two sizes.)
+
+One possible solution is to increase the Netty slab size: but what is the largest
+size Drill will need? The maximum Drill vector size is 2 GB, so should the block
+size be that large? Are there reasons, aside from Netty concerns, to limit
+allocations in Drill? We'll discuss that issue below.
+
+Another possible solution is to find a way to force Netty to release unused
+blocks back to the OS. The
+[jemalloc paper](https://people.freebsd.org/~jasone/jemalloc/bsdcan2006/jemalloc.pdf)
+suggests that the Linux implementation does, in fact, release empty blocks.
+Perhaps Netty does also, with proper configuration. However, this still does
+not address the issue that, due to some use pattern, each Netty block is
+partially allocated. In that case, no free blocks can be released.
+
+The alert reader may be wondering how Java avoids these issues with Java
+objects. The answer is that the Java heap-based memory allocator is able
+to reallocate objects to coalesce free regions to create a single, large
+free block. Netty does not (and, indeed, cannot) provide this feature for
+direct memory.
+
+The key design constraint highlighted by this discussion is: Drill should
+avoid allocating buffers larger than 16 MB. This won't solve all fragmentation
+issues, but it will help reduce the problems related to OS/Netty free list
+competition.
+
+## Classic Database Memory Management: Fixed Size Blocks
+
+It is worth remembering that the
+[classic approach](http://users.informatik.uni-halle.de/~hinnebur/Lehre/2008_db_iib_web/uebung3_p560-effelsberg.pdf)
+to database memory management is to create a *buffer pool* of fixed-size
+blocks. In a classic DB, the blocks correspond to disk pages, allowing very
+elegant paging of database page into and out of memory. The same system works
+for temporary results (which can be materialized as temporary files as needed
+in response to memory pressures.)
+
+Indeed, the paper points out the classic problem with Drill's approach to
+variable-size block allocation:
+
+> Since pages cannot be displaced deliberately, variable-size pages would
+cause heavy fragmentation problems.
+
+Indeed, we cannot displace Drill's memory pages (blocks), Drill's blocks are
+variable-size, and we do see memory fragmentation problems under heavy load.
+
+Because Drill's design is now quite mature, we are not in a position to move to
+fixed-size pages (at least not in a single move.) We will return to this topic,
+however, in the conclusion to see how the mechanism described here can eventually
+allow the use of fixed-size pages, if doing so is ever desired.
+
+## Requirements
+
+From the above discussion, we can extract two key requirements:
+
+* Provide a mechanism to control memory use so that queries succeed (or at
+least don't fail due to unexpected memory consumption).
+* Work around the memory fragmentation issues inherent in the variable-size-page,
+unlimited-page-size, two-level memory allocator which Drill currently employs.
+
+## Budget-Based Memory Management
+
+To address the first requirement, Drill has discussed the idea of moving to a
+budget-based memory management concept. In brief, the idea is that each query
+is given some memory budget (using a mechanism discussed below). Once the
+query is given a memory budget, two things must follow:
+
+* The memory must actually be available (prevent the over-subscription of
+physical memory inherent in the original Drill memory allocation design).
+* Queries must implement mechanisms (such as spilling, reduced parallelism,
+etc.) to stay within their budget.
+
+### Admission Control
+
+The above is not quite complete, however. We must consider another factor:
+how is the budget provided? Drill currently allows an unlimited number of
+queries to run. How does one set a budget if one does not know the number
+of queries that will arrive?
+
+The solution is to move to a throttling model similar to that in most other
+query engines. The system *admits* queries until resources are consumed, then
+enqueues additional queries until resources free up. Since it is quite
+difficult to predict the actual resource consumption of a query, we might
+use a hybrid model:
+
+* The planner produces an order-of-magnitude estimate of memory needs for
+each query.
+* The scheduler (*admission control* mechanism) assigns an actual budget
+and admits the query only when that budget can be provided.
+* The query operates with the budget, even if the budget is not ideal, by
+spilling to disk or other means.
+
+### Divide and Conquer
+
+In this way, we divide scheduling into bite-size chunks, each of which
+can be refined in parallel:
+
+* How to more accurately estimate the memory needs of a query.
+* If a system is overloaded (queries are queued), how does the system determine
+which query to admit next (that is, establish a priority for queries, perhaps
+based on user, size, application, etc.)
+* If memory management works at the system level, then add resource pools so
+that each is given a slice of resources, and manages its own slice separately.
+* How to improve spilling performance, how to avoid spilling, and so on.
+
+The budget-based approach is used in many products and is very well
+understood. However, we should always keep an open mind: perhaps there is
+some way to make the original design work. Perhaps Drill will end up being
+used only in use cases in which memory management, to this degree, is not
+important. So, this is just one possible design; we should always consider
+alternatives.
+
+## Budget vs. Reactive Approaches
+
+It may be worth pointing out an intuitive alternative to the budget-based
+approach. The budget approach says that we allocate a fixed memory allotment
+up front, then a query must operate within that allotment. But, there is an
+alternative (tried, then abandoned by Impala), that uses a reactive approach.
+Why not launch a query, observe the amount of resources it actually uses, then
+admit new queries based on actual usage? Very easy, right?
+
+There are two problems.
+
+First, the very nature of a "memory-challenged" query (one that does heavy
+buffering) is that it accumulates data as it runs. The longer it runs, the
+more data it accumulates. The memory use early in the run is a poor predictor
+of the memory use later in the (as more data arrives.) Thus, simply observing
+memory use a point in time (especially early in the run) will cause us to assume
+that memory is available for other uses, only to be proved wrong when the query's
+memory use grows.
+
+In the controller community, such an approach is called an "open loop" system
+and such systems are prone to oscillations for the very reasons described above.
+
+The second problem is related: we are attracted to this solution because we
+don't have to figure out how much memory a query needs (or should be given),
+we just watch it to see what it uses. But, in such an environment, how would
+we ever know if we can admit a second query? How do we know if the first query
+has left enough resources for the second query to run successfully? In fact,
+we don't. We'd have to guess, and if we guess wrong, then the system may run
+out of memory, queries will fail, and users must retry.
+
+But, since the problem of OOM and retry is the very problem we are trying
+to solve, moving to an open-loop controller design really buys us nothing.
+
+## Fragment Budget
+
+Drill is columnar and works with data in *batches*: a set of rows implemented
+as a collection of *value vectors* which implement columns.
+
+Returning to the budget-based approach, it turns out we have two distinct
+challenges when setting memory budget:
+
+* For buffering operators (those that work with variable numbers of batches),
+determine the number of batches that can be in memory before spilling must start.
+* For single-batch (sometimes 2- or 3-batch) operators, how big should each batch be?
+
+Given the above decisions, we can work out the total budget. (Or, said another
+way, given a total budget, we can work out the actual numbers for the budget
+for each operator.)
+
+Let's focus on a single minor fragment, and let's assume that all buffering
+operators are to use the same amount of memory. (The solution can easily be
+extended for the more general case.) Let:
+```
+B = the number of buffering operators (sort, hash agg, hash join, etc.)
+F = the number of fixed-count operators (project, SVR, filter, screen, etc.)
+```
+We can observe that Drill runs the operators as a stack. Only one batch is in
+flight (though no batch may be in flight if a buffering operator is "doing
+its thing" such as sorting.)
+
+So, we need to allocate memory to hold enough batches for the larges of the
+fixed-count operators F. Let:
+```
+S = the size of each batch
+N = the number of batches used by the largest fixed operator (such as 2 for
+    SRV or project, 1 for filter, etc.)
+```
+So, our fragment needs, at a bare minimum memory, S*N bytes just to run
+batches up the operator tree.
+
+But, of course, we want our buffering operators to store as many in-memory
+batches as possible. Let:
+```
+M = the number of batches buffered by each buffering operator.
+```
+So, our buffering operators need B*M*S bytes to hold the desired number
+of batches.
+
+From this, we can figure out the total budget. Let
+```
+T = total fragment budget
+
+T = B\*N + B\*M\*S = B \* (N + M\*S)
+```
+Here, we see that the batch size, B, is a key piece of information.
+
+## Controlling Batch Size
+
+At present, Drill uses record counts to control the batch size. This
+means that the size of each batch is:
+```
+R = Number of rows in each batch (often 1000, 1K, 4K, 8K or 64K)
+W = The width of each row (which depends entirely on the input data)
+
+S = R*W
+```
+But, as noted, Drill has no control over row width; that depends on the
+user's data. (Perhaps Drill could advise users to keep rows small, or
+refuse to read rows above some maximum width.)
+
+Better is to control that which Drill has the ability to control: the number
+of rows per batch. Thus, rather than fixing the row count (and requiring the
+user to constrain row width to match), derive the row count from the batch
+size budget and observed row width. That is:
+```
+R = S/W
+```
+## Setting the Fragment Budget
+
+Once we can control batch size, budgeting becomes simple. We define a batch
+size S and limit batches to fit that size. The needs of the fixed-size operators
+is, well, fixed, so we treat those as a constant. That simply leaves working
+out the memory per buffering operator:
+```
+T = B*N + B*M*S
+
+T - B*N = B*M*S
+
+M = (T - B*N) / B*S
+```
+This says that if we know the number of buffering operators, the number of
+batches needed by fixed-size operators, the total memory and the batch size,
+then we can work out how many batches each buffering operator is allowed to
+store. The result is a complete fragment budget based on first principles.
+
+## Batch Size Control in Practice
+
+One of the key goals of this project is to create a mechanism to implement
+this idea. The concept is simple: limit each batch to the number of rows that
+fit in some batch size budget. In practice, we are faced with a number of challenges:
+
+* Drill allocation is lumpy: vectors grow in powers-of-two.
+* Effective batch size control requires that we check memory *before* we double
+a vector size, not after.
+* Row width is unknown (especially in readers): we must read the data to learn
+its size.
+* But, if we read data, we need a place to put it. If the data is too large for
+the current batch, we must store it somewhere (we can't "push" it back onto
+the input.)
+
+At the same time:
+
+* Handle all manner of Drill types, including arrays, arrays of maps and
+other complex types.
+* Ensure that no single vector exceeds the Netty block size (default of
+16 MB).
+
+We must also consider the consumer of the system: the reader or the internal
+(non-scan) operator. All operators (and readers) work row-by-row; they cannot
+easily stop in the middle of a row if a batch becomes full. That is, every
+operator must be able to write code that looks something like this:
+
+```
+void doBatch() {
+  while (! batchIsFull) {
+    for each column {
+      process column
+    }
+  }
+```
+
+Just to be crystal clear, let's state this in yet another way:
+
+* Drill stores data in vectors.
+* Vectors double in size as needed to hold more values.
+* We want to prevent the final doubling that would exceed our batch (or vector) size target.
+* We will thus exceed our batch size target on some column with some row.
+* Writers (operators, readers) cannot stop part-way through a row, they must write an entire row.
+
+A key feature (and source of complexity) in the present solution is that the mechanism
+handles "overflow": it quietly sets aside that row that causes the size limit to be
+exceeded, and instead includes that row in the following batch, ensuring that the
+current batch stays within the defined limit.
+
+## Design Approach
+
+To better understand the code, it helps to understand the design
+philosophy behind the code. Here are a few guiding principles.
+
+* Design for the long term. Determine what we'll need in a production
+system and work toward that. Avoid short-term hacks.
+* Minimize functional change. Our goal is to limit batch size by
+upgrading certain parts of Drill. We tried to minimize user-visible
+changes as such changes, even when useful, require extensive discussion
+and vetting. Better to make the core changes in one project (this one),
+then do a later project to roll out user-visible imrpovements (such as
+those to improve JSON.)
+* Let the code tell us what works. The project tried various approaches.
+The one that was cleanest, simplest, and easiest to test won out.
+* Keep it simple. Complex, deeply nested functions. Classes that do many
+things. State maintained by many flags. All are the path to chaos. Instead,
+this project used small, focused classes. Composition is used to build up
+complex functionality from simple pieces. Clean APIs are preferred over
+complex coupling of components.
+* Test. Unit testing is an integral part of the project. Every component
+is wrapped in tests. It is not quite TDD (test-driven development), but
+it is absolutely of the form "write a bit of code, test it, write a bit
+more and repeat."
+* Loose Coupling. Each component is loosely coupled to others. This allows
+unit testing, but it also makes it much easier to reason about each component.
+* Document. These notes. The specs. Extensive code comments. They not only
+help future readers such as yourself, they also served
+as a way to think through the design issues when writing the code.
+
+## Summary: The Big Picture
+
+Let's put all the pieces together.
+
+Because batch size is precisely controlled, the fragment budget calculations work, and
+we can set a per-fragment budget. Because we can set a per-fragment budget, we
+can set a per-query budget. With the per-query budget, we can effectively
+implement admission control to control the total queries. The result is that
+Drill queries never fail with OOM errors and the user experience is enhanced
+because users never see (memory related) query failures.
+
+That is quite a chain of consequences; which is why it is vital to implement
+the batch-size limitation mechanism.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/README.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/README.md
@@ -1,0 +1,46 @@
+# Column Accessor Overview
+
+The column accessor framework consists of a number of layers that combine to
+enable Drill to control the size of each record batch, which in turn allows
+Drill to implement effective memory management and admission control.
+
+The material here starts with concepts, then provides a tour of the various
+components. Each component is heavily commented, so after reading this
+material, you should be able to get the details from the code itself.
+
+The material here is a slightly-revised version of the material that
+orginally appeared in the `paul-rogers/drill` Wiki.
+
+* [Conceptual Overview](Overview.md)
+* [Components](Components.md)
+* [Metadata](Metadata.md)
+* [Row Set Mechanism](RowSet.md)
+* [Column Accessors](Accessors.md)
+* [Column Readers](Readers.md)
+* [Column Writers](Writers.md)
+* [Future Work](Futures.md)
+
+* [[Result Set Loader|BH Result Set Loader]]
+* [[Operator Framework|BH Operator Framework]]
+* [[Projection Framework|BH Projection Framework]]
+* [[Scan Framework|BH Scan Framework]]
+* [[Easy Format Plugin|BH Easy Format Plugin]]
+* [[CSV (Compliant Text) Reader|BH Compliant Text Reader]]
+* [[JSON Reader|BH JSON Reader]]
+
+## Code Overview
+
+The code for the mechanisms described here appears in multiple Drill modules,
+along with its unit tests. It is described here in one place to provide
+a complete overview.
+
+It can be hard to understand complex code. To make doing so easier, we offer
+three paths:
+
+* This set of notes (plus additional material in the JIRA).
+* Comments in the code.
+* Unit tests which illustrate how to use each component.
+
+The code itself has many comments and explanations; it is the best resource
+to understand the detailed algorithms and approaches.
+

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Readers.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Readers.md
@@ -1,0 +1,358 @@
+# Column Readers
+
+The column readers implement the patterns described in the
+[Column Accessors](Accessors.md) section. Here we look at the specific
+details of the readers.
+
+## Construction
+
+At present, the implementation provides only a per-batch reader
+(the `RowSetReader`). To construct a reader, we start with an existing batch
+(in the form of a row set.) We then do a recursive walk of the vectors,
+starting with the vector container. We examine each column, determine its
+category (map, scalar, union, etc.) and then build each column accordingly.
+Maps, unions, lists and repeated lists are containers: they contain other
+columns. So, we continue the recursive descent though these containers into
+their columns. The recursion stops when we hit a leaf (a possibly repeated
+scalar.)
+
+Then, on the way back up the call stack, we assemble container readers
+using the child readers. We continue up until we build the tuple reader
+for the whole row.
+
+As if this process were not complex enough, we have to do the work twice:
+once for a single batch, and a second way for a hyper batch. In a single
+batch, we can just inspect each vector directly to find the children. In a
+hyper batch, we have to make one pass over the batches to build up a
+combined schema (especially needed for unions), then a second pass to use
+the metadata to build the readers.
+
+* Single Batch: [`model.single.BaseReaderBuilder`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/single/BaseReaderBuilder.java)
+* Hyper Batch: [`model.hyper.BaseReaderBuilder`](https://github.com/apache/drill/blob/master/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/model/hyper/BaseReaderBuilder.java)
+
+Scalar readers are generated (see below). The template also generates a class to
+create a scalar reader given a type. The leaf reader builder methods call these
+generated methods. Then, to build up higher-level methods, we use composition
+to, say, build up a scalar array from an array (which handles the offset vector)
+and a scalar reader (to read each value.) A considerable amount of code goes into
+glueing the bits together.
+
+## Reader Index
+
+The reader must handle three distinct forms of indexing:
+
+* Direct (position x in the reader corresponds to row x in each vector)
+* Indirect (using an SV2: position x in the reader maps to `sv2[x]` in the
+vector)
+* Hyper: (using an SV4: position x in the reader corresponds to s`v4[x].offset`
+in batch `sv4[x].batch` of the hyper vector)
+
+The [`ColumnReaderIndex`](https://github.com/apache/drill/blob/master/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnReaderIndex.java)
+interface defines the common protocol; implementations exist to handle each case.
+The result is that reader code is ignorant of indirection: it simply asks the
+index which batch and offset to read.
+
+## HyperVectors and the Vector Accessor
+
+Readers would be quite simple if they worked only with a single batch. But,
+hyper vectors (hyper batches) add a large amount of complexity. A hyper batch
+is an abstraction that makes a collection of batches look like a single batch.
+That is, we start with a stack of batches:
+
+```
++---------+
+| Batch 1 |
+|---------|
+| Batch 2 |
+|---------|
+|   ...   |
+|---------|
+| Batch N |
++---------+
+```
+
+That is pretty simple. But, we want to work with these not as an array of
+batches, each with its list of columns, but rather as a list of columns, each
+associated with multiple batches.
+
+```
+      Hyper Batch
++-----------------------+
+|    a      b      c    |
+|  +---+  +---+  +---+  |
+|  | 1 |  | a |  | x |  | Batch 1
+|  | . |  | . |  | . |  |
+|  - - -  - - -  - - -  |
+|  | 8 |  | c |  | z |  | Batch 2
+|  | . |  | . |  | . |  |
+|  - - -  - - -  - - -  |
+|  | 3 |  | e |  | w |  | Batch 3
+|  | . |  | . |  | . |  |
+|  +---+  +---+  +---+  |
++-----------------------+
+```
+
+The diagram (attempts to) show that the hyper batch has three vectors:
+a, b, and c. All rows from all batches logically appear in each column, though
+each column is physically defined by a separate vector for each batch. (Yes,
+very complex. Plus, it is not entirely clear that this complexity will still
+be needed once operators migrate to the new mechanism. Something to keep in
+mind.)
+
+From the application's perspective, it just iterates over rows and asks for
+values. The reader must jump from one batch to another; find the right column,
+get the offset within that batch, and return the value.
+
+Hyper vectors make use of something called the `VectorWrapper` which is of two
+kinds: simple or hyper. (If you've ever wondered why getting a vector from a
+`VectorContainer` gives you a `VectorWrapper`, now you know.)
+
+The vector wrapper is the "glue" that splices together a hyper vector from a
+set of normal vectors: it glues them end-to-end.
+
+So, to access a top-level vector, we first get the column (column "c" above,
+say), then we go down to the 3rd entry (say) and get that vector.
+
+The SV4 provides two fields: the batch (index within the `VectorWrapper` and)
+offset (position within the vector.) (In practice, these "fields" are packed
+into a single `int`, hence all the strange shifting in generated code.) In
+the reader, the reader index takes care of splitting the two fields.
+
+### Nested Vectors and the Access Path
+
+The story told thus far, while it has some complexity, is not too bad:
+
+* Look up column c
+* Look up vector for batch b
+* Get the value from offset x
+
+What happens when we have complex types? Say we have a map, a union, a map
+of unions, a map of maps, and so on. The vector wrapper concept exists only
+at the top level of a row; it would be far too complex to push the
+representation down into maps. (In fact, it is too complex to even do this
+at the top level; that's why we can drop this complexity after moving to
+readers.)
+
+For a nested vector, the pattern is extended to:
+
+* Look up column c
+* Look up vector for batch b
+* Get the vector for map member m1
+* If the map is nested, get the vector for map member m2
+* At the leaf, get the value from offset x
+
+In a single batch, we can work out the navigation paths at build time: each
+reader can directly hold onto the vector that it reads.
+
+For top-level readers, each reader can hold onto the vector wrapper, and use
+the batch index to access the right vector.
+
+But, for nested vectors, we have to walk the access path *for every value*.
+Obviously this is quite slow. (It will lead to a vast slowdown as the depth
+gets greater in operators that use hyper vectors, such as sort.)
+
+### Vector Accessors
+
+The reader implements the access path concept using a vector accessor. Vector
+accessors nest.
+
+* At the top level, the vector accessor handles the vector wrapper indexing.
+* At nested levels, the vector accessor takes a parent, specifies the child
+to access, and looks up that child.
+
+To make the single and hyper cases consistent, a single-batch vector accessor
+simply holds onto the target vector, no per-access navigation needed.
+
+## Generated Scalar Readers
+
+A key goal of the scalar reader is to maximize speed: put as few instructions
+as possible in the code path of each `get` method. This means minimizing bounds
+checks. In most Drill code, the application decides the vector index, calls
+the vector accessor, which calls into the `DrillBuf` which checks bounds and
+calls into the UDLE, which checks bounds and calls into `PlatformDependent`
+to access direct memory. All the checks are needed because Drill has many,
+many ways to call the vector accessor, and some of them may have bugs.
+
+The readers avoid bounds checks by doing bounds checks only when a position
+advances (in a row or array.) Since the only way to access data is via the
+index that the reader keeps private, we need not do bounds checks on each
+alue access. Instead, we need only get the correct vector (as described above),
+then call an "unsafe" method in `DrillBuf` to get data from direct memory.
+
+Performance tests have shown that this design produces significant performance
+improvements. Depending on the cardinality (AKA "data mode") the performance
+boost has ranged from 50% to 200%. (Use the `PerformanceTool` class to run
+the tests yourself to check current performance.)
+
+As with the value vectors, the readers are generated from a Freemarker
+template defined in
+[`ColumnAccessors.java`](https://github.com/apache/drill/blob/master/exec/vector/src/main/codegen/templates/ColumnAccessors.java).
+ (The name "vector accessor" was already used, so this project chose the
+ name "column accessor" instead. In a way, the name is more accurate:
+ their job is to access columns regardless of the number of vectors involved.)
+
+Each generated class is as simple as possible: just some simple setup, then
+a type-specific `get` method. Everything else resides in an abstract base
+class. For example:
+
+```
+  public static class IntColumnReader extends BaseFixedWidthReader {
+
+    private static final int VALUE_WIDTH = IntVector.VALUE_WIDTH;
+
+    @Override
+    public ValueType valueType() {
+      return ValueType.INTEGER;
+    }
+
+    @Override public int width() { return VALUE_WIDTH; }
+
+    @Override
+    public int getInt() {
+      final DrillBuf buf = bufferAccessor.buffer();
+      final int readOffset = vectorIndex.offset();
+      return buf.unsafeGetInt(readOffset * VALUE_WIDTH);
+    }
+  }
+```
+
+Aside from the `get` method, the three key pieces of information provided
+by the generated code are:
+
+* The value type (which `get` method is implemented)
+* The width of each field (for fixed-width readers)
+* A method to bind the reader to an index and a vector accessor
+
+The bind method is needed to simplify object construction. We create the
+readers dynamically. It is much easier to call the no-argument constructor
+this way, then pass in the required bindings as a separate step. (**Note**:
+It turns out to be rather simple to pass these values into the constructor.
+Doing so would be a nice improvement. See the generated writers for an example.)
+
+The careful reader may notice that we generate code only for the "required"
+(non-nullable) cardinality. What about "optional" (nullable) and "repeated"
+(array)? Those are built up via composition as described below.
+
+## Nullable Scalar Reader
+
+A nullable reader is simply a wrapper around a non-nullable reader which
+mimics the internal structure of a nullable vector. The nullable reader
+holds two readers: one for the "bits" vector, another for the values vector.
+Here we see the value of the generic interfaces: we do not need type-specific
+nullable readers: a single reader handles all scalar types.
+
+## Array Reader
+
+An array reader is also composed of two parts: an offset reader and an
+element reader. The array reader introduces a new index level. The child level
+provides the index into the data vector. Because of this, the element reader
+is just a generated scalar reader. To make it an element reader, we pass in
+the child index for the array.
+
+Again, because of the generic structure of the readers, the same array
+implementation works for repeated scalars, lists, repeated maps and repeated lists.
+
+The application reads from an array by treating the array as an iterator.
+This ensures that the same mechanism works whether the array has a single
+value (a scalar array) or multiple values (such as a repeated map, or a
+repeated map that contains other repeated maps.) Methods exist to reset
+the index, or move the index to a specific location.
+
+## Tuple Reader
+
+The tuple reader holds onto a collection of object readers indexed by both
+position and name. Applications can use either, or switch back and forth.
+(Test code often does this.) The tuple reader represents both the row and
+any maps within the row. (The row reader often has few extra methods, such
+as those to advance the read position to the next row.)
+
+## Null State
+
+Detecting null values turns out to be complex in the general case. For a
+simple nullable column, we need only check the associated "bits" (is-set)
+vector. But, unions introduce another layer of complexity. A union can hold
+vectors of multiple types, each of which must be nullable. The union itself
+can be null. So, if we have a union of an `INT` and a `VARCHAR`, the `INT`
+is null in any of the following three cases:
+
+* The union itself is null
+* The union value is a type other than `INT`
+* The type is `INT` but the nullable `INT` is null
+
+The `LIST` vector adds yet another complexity. A list can be a repeated union,
+but has a null flag for each array. Thus, now a scalar can be null for any
+of the three reasons above, plus:
+
+* The list entry is null
+
+Clearly, writing if-statements to handle all this complexity would be a
+nightmare. Instead, the reader uses a "null state" object. Implementations
+exist for all three cases: simple nullable, union and list. The nullable
+reader simply asks the null state object if the value is null; the
+implementation of the null state object worries about the messy details.
+
+## Example Usage
+
+The reader mechanism is meant to be used directly by the application,
+so let's look at an example. The example uses this schema:
+
+```
+a: Varchar
+b: Repeated Int
+c: map
+  c1: Int
+  c2: Varchar
+```
+
+We'll use the reader to print the value of each row. Let's assume we
+have a `print()` method available to us.
+
+The key steps:
+
+* Get a reader somehow.
+* Iterate over the rows.
+* For each, call a method to print the row
+* Print column `a`
+* Iterate over the values in `b` and print them
+* Recursively call this method to visit the columns in map `c`.
+
+Here is the code:
+
+```
+    RowSetReader reader = ...
+
+    while (reader.next()) {
+      print(reader.scalar("a").getString());
+      ArrayReader bReader = reader.array("b");
+      while (bReader.next()) {
+        print(bReader.scalar().getInt());
+      }
+      TupleReader cReader = reader.tuple("c");
+      print(cReader.scalar("c1").getInt());
+      print(cReader.scalar("c2").getString());
+      endRow();
+    }
+```
+
+## Futures
+
+The reader code is complete and tested for all types of Drill vectors
+(including the obscure `List` and `Union` vectors.) Extensive unit tests
+show that the code works for direct, indirect (SV2) and hyper (SV4) cases.
+
+The two key future extensions are possible.
+
+First, as described earlier, provide a more efficient way to retrieve values
+for interval and decimal types. (The current implementation uses objects,
+hich is fine for testing, but slow in production.)
+
+Second, provide a multi-batch (not hyper-batch) reader. That is, a reader
+that accepts a sequence of batches, such as would be needed in, say, the
+filter or project operators. The batches are sequential over time. If the
+schema is identical, then the only task is to reset the indexes to 0 and
+set the new row count. If the schema changes (which we probably should not
+support), rebuild the readers to match the new schema.
+
+The multi-batch reader (call it a "result set reader") is the read dual
+of the "result set loader" for writing. This parallels the single-batch
+reader and writer in the row set package.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/RowSet.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/RowSet.md
@@ -1,0 +1,127 @@
+# Row Set Mechanism
+
+The row set mechanism is a handy, general purpose way to work with a batch
+of records. It came about from a desire to operator-level unit testing in
+which we create a batch of data, give it to the operator, and verify the
+resulting output. At that time, it was very difficult to create a batch of
+data: it required a large amount of complex code. (In production, this kind
+of code is generated, so we didn't have need to a simple interface.)
+
+The term "row set" came about because of the overloaded nature of the term
+"batch" in Drill where it is both a set of rows and the operator that
+operates on those rows. The term "row set" is meant to invoke the idea of a
+collection of relational rows. (Also, the term was not previously used.)
+
+The row set layer provides tools to work with all aspects of a batch life cycle:
+
+* Define a schema (using the `SchemaBuilder` class)
+* Build a row set from a schema and a fluent description of the data (`RowSetBuilder`)
+* Attach to an existing vector container (`RowSet` and its implementations)
+* Print the row set (`print()` method on the `RowSet` class)
+* Compare two row sets to verify test results (the awkwardly named `RowSetComparison`.)
+
+The classes currently reside in `src/main/test`. As least some of the classes
+may want to move to `src/main/java` so they can be used to diagnose problems
+in a Drill server.
+
+## Row Set Classes
+
+Drill has a whole menagerie of batch types:
+
+* `RowSet`
+  * `SingleRowSet`
+    * `DirectRowSet` (single batch without a selection vector)
+      * `ExtendableRowSet` (a writable single row set)
+    * `IndirectRowSet` (using an SV2)
+  * `HyperRowSet` (using an SV4)
+
+Many operations are similar across row set types, while some differ. The row
+set class hierarchy captures those differences to provide a simple, consistent,
+easy-to-use API, primarily for tests.
+
+## Schema Builder
+
+The fluent schema builder can build all types of Drill schemas from the simplest
+(scalar types in a flat row) to the most complex (deeply nested complex types.)
+
+(It is not entirely clear that the complex types earn their keep: they are very
+complex but only lightly used. They add tremendous complexity to the schema
+builder and all other parts of this project. We had to make them work, but one
+often wonders if they are really necessary.)
+
+See `ExampleTest` (or most of the tests in this project) for examples.
+
+## Row Set Writer
+
+The row set writer is the little brother of the result set loader. The row set
+writer works on a single row set with a fixed schema. This limitation is fine
+in tests. Indeed, most of the time you will never actually see the row set writer:
+it is wrapped by the `RowSetBuilder` which builds the vectors from schema,
+allocates the vectors, writes values to the vectors, and returns the fully
+populated row set.
+
+For our purposes in this project, the row set writer serves two purposes:
+
+* Allows us to create test batches easily.
+* Provides a simple, pure test of the column writers without the added complexity
+of the result set loader.
+
+Indeed, the row set writer uses exactly the same column writers as it's big
+brother, but without all the complexity of schema evolution, vector overflow,
+projection and the like. In short, if you change the column writers, test with
+the row set writer first before testing with the result set loader.
+
+For obvious reasons, the row set writer works only with an extendable single row
+set (no indirection, no hyper vector.) There is a tool, however, to build up a
+hyper vector from a set of single row sets.
+
+## Row Set Reader
+
+In some ways, the row set reader is simpler than the writer: it only need retrieve
+existing values. In other ways, the reader must handle more cases:
+
+* Direct row set
+* Indirect row set (using an SV2)
+* Hyper row set (using an SV4)
+
+The reader interface, however, is designed to hide all these details. The
+application simply creates a reader, steps through the rows, and reads out
+the values. The reader itself handles all necessary indirection.
+
+The row set reader also works with a single batch. If we want to use this
+mechanism in operators, then we'll need a "result set reader" that handles
+multiple batches (along with any schema changes across batches.) That should
+be a very simple mechanism to build on top of the existing row set reader.
+
+Most of the time you never use the row set reader directly. In a test, you
+want to know if a some "actual" batch (produced by an operator, say) matches
+an "expected" batch. The `RowSetComparison` class does that work for you.
+
+## Typed and Generic Object Access
+
+Both the reader and writer are designed for two distinct use cases:
+
+* Type-aware code, such as that produced by code generation.
+* Generic code, such as that that is convenient in tests.
+
+Here, "generic" means (as a Java object) (not in the sense of Java Generics.)
+
+The typed methods are much simpler than the "classic" complex writers which
+had a distinct "get" method for every data type. The readers and writers use
+a reduced set centered around the Java primitives. All types smaller than an
+`int` are accessed as an `int` (since Java uses that much space to pass values
+anyway.) Both `FLOAT4` and `FLOAT8` are returned as doubles. And so on.
+
+(Date/time and interval classes are currently passed as Joda objects. For
+production code, this must be replaced with something more performant, such
+as returning fields in an array of `int`s or some such.)
+
+The generic methods are designed to enable simple generic code, such as that
+in `RowSetComparison`: all values are treated as Java objects in both `set`
+and `get` methods. While we would never use these techniques in production,
+they same vast amount of complexity in tests.
+
+Further, the accessor mechanism itself is design for generic (interpreted)
+access. The accessors are self describing so it is easy for test code to
+walk a column three for various tasks. (Something used again and again in
+test code.)

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleReader.java
@@ -64,4 +64,6 @@ public interface TupleReader extends ColumnReader {
   TupleReader tuple(String colName);
   ArrayReader array(int colIndex);
   ArrayReader array(String colName);
+  VariantReader variant(int colIndex);
+  VariantReader variant(String colName);
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleWriter.java
@@ -86,7 +86,6 @@ public interface TupleWriter extends ColumnWriter, TupleListenable {
     }
   }
 
-
   /**
    * Allows a client to "sniff" the projection set to determine if a
    * field is projected. Some clients can omit steps if they know that
@@ -141,6 +140,10 @@ public interface TupleWriter extends ColumnWriter, TupleListenable {
   ArrayWriter array(int colIndex);
 
   ArrayWriter array(String colName);
+
+  VariantWriter variant(int colIndex);
+
+  VariantWriter variant(String colName);
 
   ObjectType type(int colIndex);
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/VariantReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/VariantReader.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+
+/**
+ * Reader for a Drill "union vector." The union vector is presented
+ * as a reader over a set of variants. In the old Visual Basic world,
+ * "the Variant data type is a tagged union that can be used to
+ * represent any other data type." The term is used here to avoid
+ * confusion with the "union operator" which is something entirely
+ * different.
+ * <p>
+ * At read time, the set of possible types is fixed. A request to
+ * obtain a reader for an unused type returns a null pointer.
+ * <p>
+ * This reader is essentially a map of types: it allows access to
+ * type-specific readers for the set of types supported in the
+ * current vector. A client checks the type of each value, then
+ * uses the proper type-specific reader to access that value.
+ *
+ * @see {@link VariantWriter}
+ */
+
+public interface VariantReader extends ColumnReader {
+
+  VariantMetadata variantSchema();
+
+  int size();
+
+  /**
+   * Determine if a given type is supported by the union vector
+   * for some value in the result set.
+   *
+   * @param type the Drill minor type to query
+   *
+   * @return <tt>true</tt> if a reader for the given type is available,
+   * <tt>false</tt> if a request for a reader of that type will return
+   * <tt>null</tt>.
+   */
+
+  boolean hasType(MinorType type);
+
+  /**
+   * Return the member reader for the given type. The type must be a member
+   * of the union. Allows caching readers across rows.
+   *
+   * @param type member type
+   * @return reader for that type
+   */
+
+  ObjectReader member(MinorType type);
+
+  /**
+   * Return the scalar reader for the given type member. The type must be a
+   * member of the union. Allows caching readers across rows. Identical to:<br>
+   * <tt>>member(type).scalar()</tt>
+   *
+   * @param type member type
+   * @return scalar reader for that type
+   */
+
+  ScalarReader scalar(MinorType type);
+
+  /**
+   * Return the data type of the current value. (What happens if the row is
+   * null, must it be a null of some type?)
+   *
+   * @return data type of the current data value
+   */
+
+  MinorType dataType();
+
+  /**
+   * Return the reader for the member type of the current row.
+   * Same as:<br/>
+   * <tt>member(dataType())</tt>
+   *
+   * @return reader for the member type of the current row.
+   */
+
+  ObjectReader member();
+
+  /**
+   * Return the appropriate scalar reader for the current value.
+   *
+   * @return <tt>null</tt> if {@link #isNull()} returns <tt>true</tt>,
+   * else the equivalent of {@link #scalar(MinorType) scalar}(
+   * {@link #dataType()} )
+   *
+   * @throws IllegalStateException if called for a variant that
+   * holds a tuple or an array
+   */
+
+  ScalarReader scalar();
+  TupleReader tuple();
+  ArrayReader array();
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/VariantWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/VariantWriter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+
+/**
+ * Writer for a Drill "union vector." The union vector is presented
+ * as a writer over a set of variants. In the old Visual Basic world,
+ * "the Variant data type is a tagged union that can be used to
+ * represent any other data type." The term is used here to avoid
+ * confusion with the "union operator" which is something entirely
+ * different.
+ * <p>
+ * At write time, the set of possible types is expanded upon the
+ * first write to each type. A request to obtain a writer for type
+ * will create the underlying storage vector if needed, then return
+ * a write of the proper type. Note that unlike most other writers,
+ * the caller is <i>required</i> to call the
+ * {@link #scalar(MinorType)} method for each value so that this
+ * writer knows which type of value is to be stored.
+ * <p>
+ * Alternatively, the client can cache a writer by calling
+ * {@link #memberWriter(MinorType)} to retrieve a writer (without setting
+ * the type for a row), then calling the set method on that writer for each
+ * row, <b>and</b> calling {@link #setType(MinorType)} for each row.
+ * <p>
+ * This writer acts as somewhat like a map: it allows access to
+ * type-specific writers.
+ * <p>
+ * Although the union and list vectors supports a union of any Drill
+ * type, the only sane combinations are:
+ * <ul>
+ * <li>One of a (single or repeated) (map or list), or</li>
+ * <li>One or more scalar type.</li>
+ * </ul>
+ *
+ * @see {@link VariantReader}
+ */
+
+public interface VariantWriter extends ColumnWriter {
+
+  interface VariantWriterListener {
+    ObjectWriter addMember(ColumnMetadata schema);
+    ObjectWriter addType(MinorType type);
+  }
+
+  /**
+   * Metadata description of the variant that includes the set of
+   * types, along with extended properties of the types such as
+   * expected allocations sizes, expected array cardinality, etc.
+   *
+   * @return metadata for the variant
+   */
+
+  VariantMetadata variantSchema();
+
+  /**
+   * Returns the number of types in the variant. Some implementations
+   * (such as lists) impart special meaning to a variant with a single type.
+   *
+   * @return number of types in the variant
+   */
+
+  int size();
+
+  /**
+   * Determine if the union vector has materialized storage for the
+   * given type. (The storage will be created as needed during writing.)
+   *
+   * @param type data type
+   * @return <tt>true</tt> if a value of the given type has been written
+   * and storage allocated (or storage was allocated implicitly),
+   * <tt>false</tt> otherwise
+   */
+
+  boolean hasType(MinorType type);
+
+  ObjectWriter addMember(MinorType type);
+  ObjectWriter addMember(ColumnMetadata schema);
+
+  /**
+   * Create or retrieve a writer for the given type. Use this form when
+   * caching writers. This form <i>does not</i> set the type of the current
+   * row; call {@link #setType(MinorType)} per row when the writers are
+   * cached. This method can be called at any time as it does not depend
+   * on an active batch.
+   *
+   * @param type the type of the writer to cache
+   * @return the writer for that type without setting the type of the
+   * current row.
+   */
+
+  ObjectWriter memberWriter(MinorType type);
+
+  /**
+   * Explicitly set the type of the present value. Use this when
+   * the writers are cached. The writer must already exist.
+   *
+   * @param type type to set for the current row
+   */
+
+  void setType(MinorType type);
+
+  /**
+   * Set the type of the present value and get the writer for
+   * that type. Available only when a batch is active. Use this form to
+   * declare the type of the current row, and retrieve a writer for that
+   * value.
+   *
+   * @param type type to set for the current row
+   * @return writer for the type just set
+   */
+
+  ObjectWriter member(MinorType type);
+  ScalarWriter scalar(MinorType type);
+  TupleWriter tuple();
+  ArrayWriter array();
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Writers.md
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/Writers.md
@@ -1,0 +1,491 @@
+# Column Writers
+
+The sections thus far have set the stage; now lets move to the first act: the
+column writers. On the surface, the column writers seem quite simple: write a
+value to a vector and increment an index. The devil, as they say, is in the
+details.
+
+## Requirements
+
+Let's start by identifying the requirements we wish to satisfy.
+
+* Handle all Drill column (that is, vector) types, even obscure ones such
+as unions and lists
+* Coordinate writing to a set of columns in a row (common row write index)
+* Handle writes to arrays (nested common write index)
+* Allow adding new columns during the write (to maps, unions, repeated
+lists, lists)
+* Handle (but don't implement) vector overflow
+* Minimize bounds checks for performance
+* Simplified API
+* Both type-aware and generic operations
+* Support unprojected columns
+
+That is quite the list! The list is not simply good ideas; it turns out to
+be what is needed to pass a robust set of unit tests. So, let's dive into
+each topic.
+
+## Writer Index
+
+As discussed earlier, the writers manage the row index common to the set of
+vectors that make up a batch. Further, since Drill supports arrays (of scalars,
+maps and others), we need nested indexes. Fortunately, for writes, we work only
+with a single batch with no indirection vectors.
+
+## Schema
+
+The writers write to vectors. For a variety of reasons, it turns out to be very
+handy to have a metadata description of the vectors. This allows, for example,
+for the schema to be specified first, and to use the schema to construct the
+vectors. The writes use the [[metadata mechanism|]BH Metadata] previously discussed.
+
+### Up-Front Schema
+
+Readers such as CSV, Parquet, JDBC and others are fortunate to know the schema
+up-front. Parquet, for example, has a fixed schema defined in the file footer.
+CSV assumes a single column (`columns[]`) or reads the header to determine the
+schema. And so on.
+
+In this case, the reader can define the schema, using the metadata mechanism,
+then create a matching set of writers. (There is an additional projection
+step, as we'll discuss later.)
+
+So, in this case, the order is:
+
+1. The reader determines the schema that the file offers.
+2. Drill builds writers to match before we begin reading data.
+
+We use the term "early schema" to describe the above use case.
+
+### Schema Evolution
+
+Readers such as JSON discover columns on the fly. That is, JSON does know
+that column "a" exists until it is read. We use the term "late schema" for
+such readers.
+
+At the point we add a new column, Drill is already reading a row of data. So,
+we must add columns in the fly, perhaps many rows into a record batch. The
+writer mechanism must add the new column, then get the column "caught up" with
+the existing columns. Much of the actual work is done by the result set loader
+layer; the writer layer simply needs to provide the APIs to support column
+addition. For example, in the `TupleWriter` class:
+
+```
+  int addColumn(ColumnMetadata column);
+  int addColumn(MaterializedField schema);
+```
+
+The writers are defined in the `vector` module, with the actual column addition
+logic defined in `java-exec`. Since `vector` cannot depend on `java-exec`,
+the writers use the listener pattern. The writers define a listener to handle
+column addition:
+
+```
+  interface TupleWriterListener {
+    ObjectWriter addColumn(TupleWriter tuple, ColumnMetadata column);
+    ObjectWriter addColumn(TupleWriter tuple, MaterializedField field);
+    ProjectionType projectionType(String columnName);
+  }
+```
+
+The `java-exec` layer implements the listener and registers it with the writer.
+
+## Bounds Checking
+
+Much has been said about the cost of doing per-write bounds checking in Drill
+vectors. The writers were specifically designed to minimize bounds checks.
+This part of the code is the most performance critical in the entire project.
+Great care should be taken when "improving" this code. Let's take a look at
+the specifics.
+
+We start by observing that the writers manage the vectors and the write index.
+The APIs are designed that neither of these critical items can be modified
+except via code paths managed by the writers. Thus, the writer takes full
+responsibility for monitoring vector size and the writer index.
+
+The vector code does bounds checks because it has no idea who is making the
+request: whether that caller knows what it is doing or not. So, we observe
+that, if we tightly control the access path, then only "known good" callers
+will write to vectors and so we can trust that caller and avoid the bounds
+checks.
+
+For this to work, the writers must be designed in a way that we know that
+they will not write out of bounds. Much of this work can be done outside
+the write path itself, allowing the write path to be as simple as possible.
+
+### Requirements
+
+To achieve our goals, we want the writers to handle six cases with respect
+to vector allocation:
+
+* Monitor current vector size to determine when a vector must be doubled.
+* Before doubling, determine if doing so would cause the vector to exceed
+the vector size limit (16 MB), and, if so, to take corrective action.
+* Further check whether the doubling would cause the entire batch to exceed
+the desired size limit and, if so, to take corrective action.
+* When doubling is needed, avoid repeated doubling that occurs in the current
+vector code. That is, if the vector is 256 bytes, but we need 1024, don't
+first double to 512, then double again to 1024. Do it in one step (in this
+case, quadrupling.)
+* Avoid doubling as much as possible by allowing the client to specify good
+initial size estimates (via the metadata discussed previously.)
+* When doubling, do not zero the vector. Instead, carefully manage writes
+to "fill empties" as needed. (The exception are bits vectors which require
+that the default value be unset (NULL).)
+
+### Implementation
+
+Many of the above requirements are handled through the vector writer code.
+The mechanism comes together in the generated `set()` methods. For example:
+
+```
+    @Override
+    public final void setInt(final int value) {
+      final int writeOffset = prepareWrite();
+      drillBuf.unsafePutInt(writeOffset * VALUE_WIDTH, value);
+      vectorIndex.nextElement();
+    }
+```
+
+This code does three things:
+
+* Determines the write position, which does bounds checks.
+* Writes the data (without bounds checks).
+* Optionally increments the writer index (as needed for scalar arrays.)
+
+What, then, does `prepareWrite()` do?
+
+```
+    protected final int prepareWrite() {
+      int writeIndex = vectorIndex.vectorIndex();
+      if (lastWriteIndex + 1 < writeIndex || writeIndex >= capacity) {
+        writeIndex = prepareWrite(writeIndex);
+      }
+      lastWriteIndex = writeIndex;
+      return writeIndex;
+    }
+```
+
+Here we do a single (two-part) check:
+
+* Do we have room in the vector for our data?
+* Do we need to "fill empties" since the last write?
+
+If not, we just return the write position. Otherwise, we have some work to do.
+
+```
+    protected final int prepareWrite(int writeIndex) {
+      writeIndex = resize(writeIndex);
+      fillEmpties(writeIndex);
+      return writeIndex;
+    }
+```
+
+In the above, we resize the vector (if needed). If overflow occurs, the writer
+index will change, so we handle that. Then, we fill any empty values.
+
+Resize is:
+
+```
+  protected final int resize(final int writeIndex) {
+    if (writeIndex < capacity) {
+      return writeIndex;
+    }
+    final int width = width();
+    final int size = BaseAllocator.nextPowerOfTwo(
+        Math.max((writeIndex + 1) * width, MIN_BUFFER_SIZE));
+
+    if (size <= ValueVector.MAX_BUFFER_SIZE &&
+        canExpand(size - capacity * width)) {
+      realloc(size);
+    } else {
+      overflowed();
+    }
+    return vectorIndex.vectorIndex();
+  }
+```
+
+We compute the required vector size, rounding to a power of two as the allocator
+will do. We then ask the listener if we are allowed to expand the buffer by the
+desired amount. If the buffer will be below the maximum size, and we are allowed
+to expand it, we do so. Else, we trigger overflow which will create a whole new
+atch transparently.
+
+As you can see, the bounds checks are minimized. Additional work is done only
+when needed. This code has been heavily optimized, but we can always improve.
+Just make sure that improvements really do reduce time; it is easy to make
+simple changes that actually slow performance.
+
+## Generated Writers
+
+The code example above shows most of the generated code for the `INT` writer.
+As in the readers, we generate code only for the non-nullable ("required") case.
+Nullable and array writers are composed on top of the required writers. The
+full generated code is as follows:
+
+```
+  public static class IntColumnWriter extends BaseFixedWidthWriter {
+
+    private static final int VALUE_WIDTH = IntVector.VALUE_WIDTH;
+
+    private final IntVector vector;
+
+    public IntColumnWriter(final ValueVector vector) {
+      this.vector = (IntVector) vector;
+    }
+
+    @Override public BaseDataValueVector vector() { return vector; }
+
+    @Override public int width() { return VALUE_WIDTH; }
+
+    @Override
+    public ValueType valueType() {
+      return ValueType.INTEGER;
+    }
+
+    @Override
+    public final void setInt(final int value) {
+      final int writeOffset = prepareWrite();
+      drillBuf.unsafePutInt(writeOffset * VALUE_WIDTH, value);
+      vectorIndex.nextElement();
+    }
+  }
+```
+
+The writer reports its value type and width (used by base classes.) It then
+holds onto its vector and implements one or more `set` methods.
+
+## Vector Overflow
+
+A key contribution of this implementation compared to the "classic" complex
+writer is the ability to handle overflow. Overflow describes the case in
+which we want to write a value to a vector, do not have space in the current
+buffer, but decide we do not want to expand the buffer.
+
+It would seem we have put ourselves in quite a bind. But, there is a way out.
+We can sneakily swap out the "full" buffer for a new empty one. Now, since the
+buffer is part of a vector, and that vector is part of a record batch, we must
+do the swap for *all* columns. (The code has some ASCII art that illustrates
+the details.)
+
+At the point we encounter overflow, we have to worry about four distinct
+cases. Suppose we have columns a, b, c and d.
+
+* We have written column a.
+* Column b has had no values for the last few rows.
+* We are trying to write column c.
+* We will then follow by writing column d.
+
+To handle these cases:
+
+* We have a value for "c" ready to write, but have a full vector, and we write
+the value to the first position in the new vector.
+* We have written "a". A the time of overflow, we need to copy the value of "a"
+for the current row from the old vector to the new one.
+* We have not written "b" for a while. We must fill empties up to (but
+excluding) the current row in the old "c" vector. The normal fill-empties
+mechanism will take care of additional empties.
+* We have not written "d", so there is no value to copy. We will fill in
+"d" shortly.
+
+Quite a bit of code is needed to precisely handle the above states. In arrays,
+the conditions are a bit more complex. The "current row value" may be a great
+number of values (the array values written for the current row.) In nested
+structures (arrays of maps that contain arrays of maps that contain scalar
+array), the logic must cascade.
+
+The writer layer is responsible for keeping the writers in sync with the
+changes made in overflow. The vector part of overflow handling is done by
+the result set loader layer. The writer triggers the process via the listener
+interface.
+
+## Rewrite a Row
+
+The writers are designed to handle an obscure, but useful, use case: the
+desire to write a row, then discard it, and overwrite that data with new data.
+
+Given that vectors are always written sequentially, abandoning a row is
+simply a matter of moving the write index back to the start of the row.
+(There are, of course, additional details.)
+
+An application of row rewriting would be to push filters into a reader.
+A reader could then do:
+
+```
+  while (batch is not full) {
+    readRow(writer)
+    if (keepRow()) {
+      writer.save();
+    }
+  }
+```
+
+Here, `readRow()` reads a row of data. `keepRow()` would use the values in the
+vectors to evaluate a filter expression. If the row passes the filter, we save
+it. Else, we read a new row that overwrites the current row.
+
+The result is that we still read each row, and the filter code always works
+with value vectors. But, we need not fill a vector with unwanted values, only
+to discard them in a later operator.
+
+This functionality is extensively tested in
+[`TestResultSetLoaderTorture`](https://github.com/apache/drill/blob/master/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTorture.java).
+
+It has been suggested that we add an explicit `discardRow()` method rather
+than just implicitly rewriting the row if we do not call `save()`. That would
+be a fine enhancement.
+
+(In writing this, another test case came to mind: do we handle resetting the
+"is-set" vector values? Something to verify.)
+
+## Writer Events
+
+The process described above for overflow is just one of several orchestration
+processes that the writer must handle. Others include:
+
+* Start a new batch
+* Start a new row
+* Start a new array value
+* Finish a row
+* Finish a batch
+
+Because of tree structure of the writers, these events can cascade downwards.
+An interface exists to clearly specify the events:
+
+```
+public interface WriterEvents {
+  enum State ...
+  void bindIndex(ColumnWriterIndex index);
+  void startWrite();
+  void startRow();
+  void endArrayValue();
+  void restartRow();
+  void saveRow();
+  void endWrite();
+  void preRollover();
+  void postRollover();
+}
+```
+
+The actual class contains substantial documentation, so we won't repeat
+those details here.
+
+## Projection and Dummy Writers
+
+The writers are designed to assist "dumb" readers such as CSV. CSV must
+read each column (since it is reading a file, and must read column 1 in order
+to find the start of column 2, and so on.) Queries can include projection:
+that is, request a subset of columns. Put the two together, and readers end
+up needing code such as:
+
+```
+  read column x
+  if (column x is projected) {
+    write column x to its vector
+  }
+```
+
+The above is quite tedious. The writers support an alternative dummy columns.
+A dummy column acts like a real one (implements the full writer protocol), but
+it has no backing vector and discards values. Thus, a reader can be simplified to:
+
+```
+  read column x
+  write column x to its vector
+```
+
+The write step is either a no-op, or an actual write.
+
+The dummy columns themselves are created by the result set loader in response
+to its projection analysis mechanism. The column writers, however, provide the
+necessary mechanisms.
+
+It may be worth noting that more sophisticated readers (JSON, Parquet) have
+mechanisms to work with non-projected columns. In Parquet, we don't even read
+the data. In JSON, a parser state "free-wheels" over unprojected columns
+(reading nested objects, arrays, etc.)
+
+Still, the dummy-column mechanism will be quite handy for community provided
+readers as it provides a very simple way to hide projection details from format
+plugin writers.
+
+## Union and List
+
+The writers are all pretty straightforward for the flat row case. Arrays and
+maps add a bit of complexity. However, a very large source of complexity turned
+out to be two barely-supported data types: union and list.
+
+As described earlier, a union is, essentially, a map keyed by type. Any row
+uses a value from only one type. Unions must allow new types to be added at
+any time, mirroring how columns are added to rows and maps.
+
+The insane level of complexity occurs in the list vector. A (non-repeated)
+list has the following crazy semantics:
+
+* The list can have no subtype. This is a list of null values.
+* The list can have a single subtype. This is a list of, say, nullable
+`INT` or nullable `VARCHAR`. (Or, even a non-nullable `Map`.
+* The list can be "promoted" to a union. Now it is a list of unions, and
+the union can hold multiple types.
+
+The semantics of writers assume that the application can obtain a writer and
+hold onto it for the lifetime of the write. The list vector wants to change
+the fundamental structure as the write proceeds. To bridge the gap, some quite
+complex code is needed in the `VariantWriter` to shield the application from
+the above modes.
+
+While the code works, and is fully unit tested, the list vector itself is
+highly dubious. First, it turns out to be unsupported (despite having been
+created specifically for JSON.) Second, the complexity is not worth the value
+it provides.
+
+Recommendation: drop support for the list vector. Come up with some more
+sensible alternative. See Arrow's implementation of their List type for ideas.
+
+## Repeated Lists
+
+Another obscure type which Drill does appear to support is the repeated list.
+(The list vector is repeated -- it is an array -- but is not considered a repeated
+list. Sigh...) A repeated list is basically a 2D array. It introduces an offset
+vector on top of a repeated type (including another repeated list.) The repeated
+list does not have null bits per value as does the (non-repeated) list. Nor does
+t allow unions.
+
+The repeated list type is implemented simply as an array writer whose entries are
+also array writers.
+
+## Example
+
+The above presents the developer's view of a writer. Here is the user's view to
+create a writer and write one row. The schema is:
+
+```
+(a: VARCHAR, b: REPEATED INT, c: MAP{c1: INT, c2: VARCHAR})
+```
+
+The row is:
+
+```
+("fred", [10, 11], {12, "wilma"})
+```
+
+Code:
+
+```
+    RowSetWriter writer = ...
+
+    writer.scalar("a").setString("fred");
+    ArrayWriter bWriter = writer.array("b");
+    bWriter.scalar().setInt(10);
+    bWriter.scalar().setInt(11);
+    TupleWriter cWriter = writer.tuple("c");
+    cWriter.scalar("c1").setInt(12);
+    cWriter.scalar("c2").setString("wilma");
+    writer.save();
+```
+
+The full code is in
+[`RowSetTest`](https://github.com/paul-rogers/drill/blob/RowSetRev3/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/RowSetTest.java)`.example()`.
+
+Using a result set loader is similar. The way we obtain a writer is different,
+but the write steps are identical.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractObjectReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractObjectReader.java
@@ -24,6 +24,7 @@ import org.apache.drill.exec.vector.accessor.ObjectReader;
 import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.accessor.VariantReader;
 
 public abstract class AbstractObjectReader implements ObjectReader {
 
@@ -48,6 +49,11 @@ public abstract class AbstractObjectReader implements ObjectReader {
   public abstract ReaderEvents events();
 
   public abstract ColumnReader reader();
+
+  @Override
+  public VariantReader variant() {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   public boolean isNull() { return reader().isNull(); }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractTupleReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractTupleReader.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.vector.accessor.ObjectReader;
 import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.accessor.VariantReader;
 
 /**
  * Reader for a tuple (a row or a map.) Provides access to each
@@ -146,6 +147,16 @@ public abstract class AbstractTupleReader implements TupleReader, ReaderEvents {
   @Override
   public ArrayReader array(String colName) {
     return column(colName).array();
+  }
+
+  @Override
+  public VariantReader variant(int colIndex) {
+    return column(colIndex).variant();
+  }
+
+  @Override
+  public VariantReader variant(String colName) {
+    return column(colName).variant();
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/ArrayReaderImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/ArrayReaderImpl.java
@@ -20,6 +20,8 @@ package org.apache.drill.exec.vector.accessor.reader;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.ArrayReader;
 import org.apache.drill.exec.vector.accessor.ColumnReader;
@@ -28,6 +30,7 @@ import org.apache.drill.exec.vector.accessor.ObjectReader;
 import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.accessor.VariantReader;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
@@ -241,6 +244,72 @@ public class ArrayReaderImpl implements ArrayReader, ReaderEvents {
     return new ArrayObjectReader(arrayReader);
   }
 
+  /**
+   * Build a list reader. Lists entries can be null. The reader can be a simple
+   * scalar, a map, a union, or another list.
+   *
+   * @param listAccessor
+   * @param elementReader
+   * @return
+   */
+
+  public static AbstractObjectReader buildList(ColumnMetadata schema,
+      VectorAccessor listAccessor,
+      AbstractObjectReader elementReader) {
+
+    // Create the array over whatever it is that the list holds.
+
+    ArrayReaderImpl arrayReader = new ArrayReaderImpl(schema, listAccessor, elementReader);
+
+    // The list carries a "bits" vector to allow list entries to be null.
+
+    NullStateReader arrayNullState = new NullStateReaders.ListIsSetVectorStateReader(
+        VectorAccessors.listBitsAccessor(listAccessor));
+    arrayReader.bindNullState(arrayNullState);
+
+    // The nullability of each list entry depends on both the list's null
+    // value, and the null state of the entry. But, if the list entry itself is
+    // null, then we can't iterate over the elements. So, no need to doctor up
+    // the entry's null state.
+
+    // Wrap it all in an object reader.
+
+    return new ArrayObjectReader(arrayReader);
+  }
+
+  /**
+   * Build a 2+D array reader. The backing vector must be a repeated
+   * list. The element reader must itself be a repeated list, or a
+   * repeated of some other type.
+   *
+   * @param schema
+   * @param listAccessor
+   * @param elementReader
+   * @return
+   */
+
+  public static AbstractObjectReader buildRepeatedList(ColumnMetadata schema,
+      VectorAccessor listAccessor,
+      AbstractObjectReader elementReader) {
+
+    assert schema.isArray();
+    assert listAccessor.type().getMinorType() == MinorType.LIST;
+    assert listAccessor.type().getMode() == DataMode.REPEATED;
+    assert elementReader.type() == ObjectType.ARRAY;
+
+    // Create the array over whatever it is that the list holds.
+
+    ArrayReaderImpl arrayReader = new ArrayReaderImpl(schema, listAccessor, elementReader);
+
+    // The repeated list has no bits vector, all values are non-null.
+
+    arrayReader.bindNullState(NullStateReaders.REQUIRED_STATE_READER);
+
+    // Wrap it all in an object reader.
+
+    return new ArrayObjectReader(arrayReader);
+  }
+
   @Override
   public void bindIndex(ColumnReaderIndex index) {
     arrayAccessor.bind(index);
@@ -317,6 +386,11 @@ public class ArrayReaderImpl implements ArrayReader, ReaderEvents {
   @Override
   public ArrayReader array() {
     return entry().array();
+  }
+
+  @Override
+  public VariantReader variant() {
+    return entry().variant();
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/UnionReaderImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/UnionReaderImpl.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.reader;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+import org.apache.drill.exec.vector.accessor.ArrayReader;
+import org.apache.drill.exec.vector.accessor.ColumnAccessors.UInt1ColumnReader;
+import org.apache.drill.exec.vector.accessor.ColumnReader;
+import org.apache.drill.exec.vector.accessor.ColumnReaderIndex;
+import org.apache.drill.exec.vector.accessor.ObjectReader;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ScalarReader;
+import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.accessor.VariantReader;
+import org.apache.drill.exec.vector.accessor.reader.VectorAccessors.SingleVectorAccessor;
+import org.apache.drill.exec.vector.accessor.reader.VectorAccessors.UnionTypeHyperVectorAccessor;
+import org.apache.drill.exec.vector.complex.UnionVector;
+
+/**
+ * Reader for a union vector. The union vector presents itself as a
+ * variant. This is an important, if subtle distinction. The current union
+ * vector format is highly inefficient (and buggy and not well supported
+ * in Drill's operators.) If the union concept is needed, then it should
+ * be redesigned, perhaps as a variable-width vector in which each entry
+ * consists of a type/value pair. (For variable-width values such as
+ * strings, the implementation would be a triple of (type, length,
+ * value). The API here is designed to abstract away the implementation
+ * and should work equally well for the current "union" implementation and
+ * the possible "variant" implementation. As a result, when changing the
+ * API, avoid introducing methods that assume an implementation.
+ */
+
+public class UnionReaderImpl implements VariantReader, ReaderEvents {
+
+  public static class UnionObjectReader extends AbstractObjectReader {
+
+    private UnionReaderImpl reader;
+
+    public UnionObjectReader(UnionReaderImpl reader) {
+      this.reader = reader;
+    }
+
+    @Override
+    public VariantReader variant() { return reader; }
+
+    @Override
+    public Object getObject() {
+      return reader.getObject();
+    }
+
+    @Override
+    public String getAsString() {
+      return reader.getAsString();
+    }
+
+    @Override
+    public ReaderEvents events() { return reader; }
+
+    @Override
+    public ColumnReader reader() { return reader; }
+  }
+
+  private final ColumnMetadata schema;
+  private final VectorAccessor unionAccessor;
+  private final VectorAccessor typeAccessor;
+  private final UInt1ColumnReader typeReader;
+  private final AbstractObjectReader variants[];
+  protected NullStateReader nullStateReader;
+
+  public UnionReaderImpl(ColumnMetadata schema, VectorAccessor va, AbstractObjectReader variants[]) {
+    this.schema = schema;
+    this.unionAccessor = va;
+    typeReader = new UInt1ColumnReader();
+    typeReader.bindNullState(NullStateReaders.REQUIRED_STATE_READER);
+    if (va.isHyper()) {
+      typeAccessor = new UnionTypeHyperVectorAccessor(va);
+    } else {
+      UnionVector unionVector = va.vector();
+      typeAccessor = new SingleVectorAccessor(unionVector.getTypeVector());
+    }
+    typeReader.bindVector(null, typeAccessor);
+    nullStateReader = new NullStateReaders.TypeVectorStateReader(typeReader);
+    assert variants != null  &&  variants.length == MinorType.values().length;
+    this.variants = variants;
+    rebindMemberNullState();
+  }
+
+  /**
+   * Rebind the null state reader to include the union's own state.
+   */
+
+  private void rebindMemberNullState() {
+    for (int i = 0; i < variants.length; i++) {
+      AbstractObjectReader objReader = variants[i];
+      if (objReader == null) {
+        continue;
+      }
+      NullStateReader nullReader;
+      MinorType type = MinorType.values()[i];
+      switch(type) {
+      case MAP:
+      case LIST:
+        nullReader = new NullStateReaders.ComplexMemberStateReader(typeReader, type);
+        break;
+      default:
+        nullReader =
+            new NullStateReaders.MemberNullStateReader(nullStateReader,
+                objReader.events().nullStateReader());
+      }
+      objReader.events().bindNullState(nullReader);
+    }
+  }
+
+  public static AbstractObjectReader build(ColumnMetadata schema, VectorAccessor va, AbstractObjectReader variants[]) {
+    return new UnionObjectReader(
+        new UnionReaderImpl(schema, va, variants));
+  }
+
+  @Override
+  public void bindNullState(NullStateReader nullStateReader) { }
+
+  @Override
+  public NullStateReader nullStateReader() { return nullStateReader; }
+
+  @Override
+  public void bindIndex(ColumnReaderIndex index) {
+    unionAccessor.bind(index);
+    typeAccessor.bind(index);
+    typeReader.bindIndex(index);
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().bindIndex(index);
+      }
+    }
+  }
+
+  @Override
+  public ObjectType type() { return ObjectType.VARIANT; }
+
+  @Override
+  public ColumnMetadata schema() { return schema; }
+
+  @Override
+  public VariantMetadata variantSchema() { return schema.variantSchema(); }
+
+  @Override
+  public int size() { return variantSchema().size(); }
+
+  @Override
+  public boolean hasType(MinorType type) {
+
+    // Probe the reader because we can't tell if the union has a type
+    // without probing for the underlying storage vector.
+    // Might be able to probe the MajorType.
+
+    return variants[type.ordinal()] != null;
+  }
+
+  @Override
+  public void reposition() {
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().reposition();
+      }
+    }
+  }
+
+  @Override
+  public boolean isNull() {
+    return nullStateReader.isNull();
+  }
+
+  @Override
+  public MinorType dataType() {
+    int typeCode = typeReader.getInt();
+    if (typeCode == UnionVector.NULL_MARKER) {
+      return null;
+    }
+    return MinorType.valueOf(typeCode);
+  }
+
+  @Override
+  public ObjectReader member(MinorType type) {
+    return variants[type.ordinal()];
+  }
+
+  private ObjectReader requireReader(MinorType type) {
+    ObjectReader reader = member(type);
+    if (reader == null) {
+      throw new IllegalArgumentException("Union does not include type " + type.toString());
+    }
+    return reader;
+  }
+
+  @Override
+  public ScalarReader scalar(MinorType type) {
+    return requireReader(type).scalar();
+  }
+
+  @Override
+  public ObjectReader member() {
+    MinorType type = dataType();
+    if (type == null) {
+      return null;
+    }
+    return member(type);
+  }
+
+  @Override
+  public ScalarReader scalar() {
+    ObjectReader reader = member();
+    if (reader == null) {
+      return null;
+    }
+    return reader.scalar();
+  }
+
+  @Override
+  public TupleReader tuple() {
+    return requireReader(MinorType.MAP).tuple();
+  }
+
+  @Override
+  public ArrayReader array() {
+    return requireReader(MinorType.LIST).array();
+  }
+
+  @Override
+  public Object getObject() {
+    MinorType type = dataType();
+    if (type == null) {
+      return null;
+    }
+    return requireReader(type).getObject();
+  }
+
+  @Override
+  public String getAsString() {
+    MinorType type = dataType();
+    if (type == null) {
+      return "null";
+    }
+    return requireReader(type).getAsString();
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
 import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
 
 /**
@@ -291,6 +292,11 @@ public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
   @Override
   public ArrayWriter array() {
     return elementObjWriter.array();
+  }
+
+  @Override
+  public VariantWriter variant() {
+    return elementObjWriter.variant();
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractObjectWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractObjectWriter.java
@@ -24,6 +24,7 @@ import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
 import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
 
 /**
@@ -51,6 +52,11 @@ public abstract class AbstractObjectWriter implements ObjectWriter {
 
   @Override
   public ArrayWriter array() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public VariantWriter variant() {
     throw new UnsupportedOperationException();
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
 import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
 
 /**
@@ -371,6 +372,16 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   @Override
   public ArrayWriter array(String colName) {
     return column(colName).array();
+  }
+
+  @Override
+  public VariantWriter variant(int colIndex) {
+    return column(colIndex).variant();
+  }
+
+  @Override
+  public VariantWriter variant(String colName) {
+    return column(colName).variant();
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ColumnWriterFactory.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ColumnWriterFactory.java
@@ -69,6 +69,7 @@ public class ColumnWriterFactory {
     case NULL:
     case LIST:
     case MAP:
+    case UNION:
       throw new UnsupportedOperationException(schema.type().toString());
     default:
       switch (schema.mode()) {
@@ -117,6 +118,7 @@ public class ColumnWriterFactory {
     case LATE:
     case LIST:
     case MAP:
+    case UNION:
       throw new UnsupportedOperationException(schema.type().toString());
     default:
       ScalarObjectWriter scalarWriter = new ScalarObjectWriter(

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/EmptyListShim.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/EmptyListShim.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.UnionShim;
+import com.google.common.base.Preconditions;
+
+/**
+ * Internal implementation for a list of (possible) variants when
+ * the list has no type associated with it at all. This shim is a
+ * placeholder that waits for the first type to be added. Used in
+ * the case that a list may eventually hold a union, but at present
+ * it holds nothing.
+ */
+
+public class EmptyListShim implements UnionShim {
+
+  private UnionWriterImpl writer;
+
+  @Override
+  public void bindWriter(UnionWriterImpl writer) {
+    this.writer = writer;
+  }
+
+  @Override
+  public void bindIndex(ColumnWriterIndex index) { }
+
+  @Override
+  public void startWrite() { }
+
+  @Override
+  public void startRow() { }
+
+  @Override
+  public void endArrayValue() { }
+
+  @Override
+  public void restartRow() { }
+
+  @Override
+  public void saveRow() { }
+
+  @Override
+  public void endWrite() { }
+
+  @Override
+  public void preRollover() { }
+
+  @Override
+  public void postRollover() { }
+
+  @Override
+  public void setNull() {
+    // OK to set a non-existent type to null
+  }
+
+  @Override
+  public boolean hasType(MinorType type) { return false; }
+
+  @Override
+  public ObjectWriter member(MinorType type) {
+    return addMember(type);
+  }
+
+  @Override
+  public void setType(MinorType type) {
+
+    // This shim has no types at all. Let the listener add a type.
+    // If the result is a new shim, then ask the writer to set the
+    // type using that new shim.
+
+    addMember(type);
+    writer.setType(type);
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(ColumnMetadata colSchema) {
+    return doAddMember((AbstractObjectWriter) writer.listener().addMember(colSchema));
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(MinorType type) {
+    return doAddMember((AbstractObjectWriter) writer.listener().addType(type));
+  }
+
+  /**
+   * This is a bit of magic. The listener will create the writer (and vector) for
+   * the requested type. It will also replace the shim in the writer with something
+   * that handles a single type or a union, so that, when the listener returns,
+   * this shim is no longer bound to the writer. Our dying act is to ask the
+   * new shim to add the new writer as a member.
+   *
+   * @param colWriter the column writer returned from the listener
+   * @return the same column writer
+   */
+
+  private AbstractObjectWriter doAddMember(AbstractObjectWriter colWriter) {
+    // Something went terribly wrong if the check below fails.
+    Preconditions.checkState(writer.shim() != this);
+    writer.shim().addMember(colWriter);
+    return colWriter;
+  }
+
+  @Override
+  public int lastWriteIndex() { return 0; }
+
+  @Override
+  public int rowStartIndex() { return 0; }
+
+  @Override
+  public void addMember(AbstractObjectWriter colWriter) {
+
+    // This shim has no types. If this is called, then the shim replacement
+    // logic has a bug.
+
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/EmptyListShim.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/EmptyListShim.java
@@ -22,7 +22,7 @@ import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.UnionShim;
-import com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 /**
  * Internal implementation for a list of (possible) variants when

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ListWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ListWriterImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import java.lang.reflect.Array;
+
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
+import org.apache.drill.exec.vector.accessor.ColumnAccessors.UInt1ColumnWriter;
+import org.apache.drill.exec.vector.complex.ListVector;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * List writer, which is basically an array writer, with the addition
+ * that each list element can be null. Lists never auto-increment
+ * their indexes since the contents of lists can change dynamically,
+ * and auto-increment is meaningful only for scalar arrays.
+ */
+
+public class ListWriterImpl extends ObjectArrayWriter {
+
+  private final ListVector vector;
+  private final UInt1ColumnWriter isSetWriter;
+
+  public ListWriterImpl(ColumnMetadata schema, ListVector vector, AbstractObjectWriter memberWriter) {
+    super(schema, vector.getOffsetVector(), memberWriter);
+    this.vector = vector;
+    isSetWriter = new UInt1ColumnWriter(vector.getBitsVector());
+    elementIndex = new ArrayElementWriterIndex();
+  }
+
+  @Override
+  public void bindIndex(ColumnWriterIndex index) {
+    super.bindIndex(index);
+    isSetWriter.bindIndex(index);
+  }
+
+  @VisibleForTesting
+  public ListVector vector() { return vector; }
+
+  @Override
+  public void setNull(boolean isNull) {
+    if (elementIndex.arraySize() > 0 && isNull) {
+      throw new IllegalStateException();
+    }
+    isSetWriter.setInt(isNull ? 0 : 1);
+  }
+
+  @Override
+  public void startWrite() {
+    super.startWrite();
+    isSetWriter.startWrite();
+  }
+
+  @Override
+  public void startRow() {
+    super.startRow();
+    isSetWriter.startRow();
+  }
+
+  @Override
+  public void endArrayValue() {
+
+    // Do the shim save first: it requires state which is reset
+    // in the super call.
+
+    if (elementIndex.arraySize() > 0) {
+      setNull(false);
+    }
+    super.endArrayValue();
+  }
+
+  @Override
+  public void restartRow() {
+    super.restartRow();
+    isSetWriter.restartRow();
+  }
+
+  @Override
+  public void saveRow() {
+    super.saveRow();
+    isSetWriter.saveRow();
+  }
+
+  @Override
+  public void preRollover() {
+    super.preRollover();
+    isSetWriter.preRollover();
+  }
+
+  @Override
+  public void postRollover() {
+    super.postRollover();
+    isSetWriter.postRollover();
+  }
+
+  @Override
+  public void endWrite() {
+    isSetWriter.endWrite();
+    super.endWrite();
+  }
+
+  @Override
+  public void setObject(Object array) {
+    setNull(array == null);
+    if (array == null) {
+      return;
+    }
+    int size = Array.getLength(array);
+    for (int i = 0; i < size; i++) {
+      Object value = Array.get(array, i);
+      if (value != null) {
+        elementObjWriter.setObject(value);
+      } else if (elementObjWriter.nullable()) {
+        elementObjWriter.setNull();
+      }
+      save();
+    }
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ListWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ListWriterImpl.java
@@ -24,7 +24,7 @@ import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
 import org.apache.drill.exec.vector.accessor.ColumnAccessors.UInt1ColumnWriter;
 import org.apache.drill.exec.vector.complex.ListVector;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 
 /**
  * List writer, which is basically an array writer, with the addition
@@ -122,9 +122,9 @@ public class ListWriterImpl extends ObjectArrayWriter {
     if (array == null) {
       return;
     }
-    int size = Array.getLength(array);
+    final int size = Array.getLength(array);
     for (int i = 0; i < size; i++) {
-      Object value = Array.get(array, i);
+      final Object value = Array.get(array, i);
       if (value != null) {
         elementObjWriter.setObject(value);
       } else if (elementObjWriter.nullable()) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/RepeatedListWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/RepeatedListWriter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.vector.UInt4Vector;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.complex.RepeatedListVector;
+
+/**
+ * Implements a writer for a repeated list. A repeated list is really
+ * an array of arrays. It is an "array" because it does not support
+ * nulls. (The Drill [non-repeated] "list vector" does support nulls.)
+ * The terminology is confusing, but it is what Drill has settled upon.
+ * <p>
+ * Because repeated lists can be nested, they support incremental
+ * construction. Build the outer array, then the inner, then the leaf
+ * to build a 3D array. Since building is incremental, this form of
+ * array must track state and use the state to keep the newly-added
+ * element writer in sync.
+ * <p>
+ * To keep things (relatively) simple, the repeated list array starts
+ * out with an inner list. For the row set writer, the inner list
+ * is the actual element writer. For the result set loader, the inner
+ * list is a dummy, to be replaced by the real one once it is discovered
+ * by reading data (or by parsing a schema.)
+ */
+
+public class RepeatedListWriter extends ObjectArrayWriter {
+
+  public interface ArrayListener {
+
+    AbstractObjectWriter setChild(ArrayWriter array, ColumnMetadata column);
+
+    AbstractObjectWriter setChild(ArrayWriter array, MaterializedField field);
+  }
+
+  private State state = State.IDLE;
+  private ArrayListener listener;
+
+  protected RepeatedListWriter(ColumnMetadata schema, UInt4Vector offsetVector,
+      AbstractObjectWriter elementWriter) {
+    super(schema, offsetVector, elementWriter);
+  }
+
+  public static AbstractObjectWriter buildRepeatedList(ColumnMetadata schema,
+      RepeatedListVector vector, AbstractObjectWriter elementWriter) {
+    AbstractArrayWriter arrayWriter = new RepeatedListWriter(schema,
+        vector.getOffsetVector(),
+        elementWriter);
+    return new ArrayObjectWriter(arrayWriter);
+  }
+
+  public void bindListener(ArrayListener listener) {
+    this.listener = listener;
+  }
+
+  public AbstractObjectWriter defineElement(MaterializedField schema) {
+    if (listener == null || elementObjWriter.schema().type() != MinorType.NULL) {
+      throw new UnsupportedOperationException();
+    } else {
+      return replaceChild(listener.setChild(this, schema));
+    }
+  }
+
+  public AbstractObjectWriter defineElement(ColumnMetadata schema) {
+    if (listener == null || elementObjWriter.schema().type() != MinorType.NULL) {
+      throw new UnsupportedOperationException();
+    } else {
+      return replaceChild(listener.setChild(this, schema));
+    }
+  }
+
+  private AbstractObjectWriter replaceChild(AbstractObjectWriter newChild) {
+    elementObjWriter = newChild;
+    elementObjWriter.events().bindIndex(elementIndex);
+    if (state != State.IDLE) {
+      elementObjWriter.events().startWrite();
+      if (state == State.IN_ROW) {
+        elementObjWriter.events().startRow();
+      }
+    }
+    return elementObjWriter;
+  }
+
+  @Override
+  public void startWrite() {
+    assert state == State.IDLE;
+    state = State.IN_WRITE;
+    super.startWrite();
+  }
+
+  @Override
+  public void startRow() {
+    assert state == State.IN_WRITE;
+    state = State.IN_ROW;
+    super.startRow();
+  }
+
+  @Override
+  public void saveRow() {
+    assert state == State.IN_ROW;
+    super.saveRow();
+    state = State.IN_WRITE;
+  }
+
+  @Override
+  public void endWrite() {
+    assert state != State.IDLE;
+    super.endWrite();
+    state = State.IDLE;
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/SimpleListShim.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/SimpleListShim.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.UnionShim;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Shim for a list that holds a single type, but may eventually become a
+ * list of variants. (A list that is declared to hold a single type
+ * is implemented using the {@link ListWriterImpl} class that
+ * directly holds that single type.) This shim is needed when we want
+ * to present a uniform variant interface for a list that holds zero
+ * one (this case) or many types.
+ */
+
+public class SimpleListShim implements UnionShim {
+
+  private UnionWriterImpl writer;
+  private AbstractObjectWriter colWriter;
+
+  public SimpleListShim() { }
+
+  public SimpleListShim(AbstractObjectWriter writer) {
+    this.colWriter = writer;
+  }
+
+  @Override
+  public void bindWriter(UnionWriterImpl writer) {
+    this.writer = writer;
+  }
+
+  @Override
+  public void bindIndex(ColumnWriterIndex index) {
+    events().bindIndex(index);
+  }
+
+  @Override
+  public boolean hasType(MinorType type) {
+    return type == colWriter.schema().type();
+  }
+
+  @Override
+  public void setType(MinorType type) {
+    if (! hasType(type)) {
+
+      // Not this type. Ask the listener to promote this writer
+      // to a union, then ask the writer to set the type on
+      // the resulting new shim.
+
+      addMember(type);
+      writer.setType(type);
+    }
+  }
+
+  @Override
+  public ObjectWriter member(MinorType type) {
+    if (hasType(type)) {
+      return colWriter;
+    }
+    return addMember(type);
+  }
+
+  public AbstractObjectWriter memberWriter() {
+    return colWriter;
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(ColumnMetadata colSchema) {
+    return doAddMember((AbstractObjectWriter) writer.listener().addMember(colSchema));
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(MinorType type) {
+    return doAddMember((AbstractObjectWriter) writer.listener().addType(type));
+  }
+
+  /**
+   * This is a bit of magic. The listener will create the writer (and vector) for
+   * the requested type. It will also replace the shim in the writer with something
+   * that handles a union, so that, when the listener returns,
+   * this shim is no longer bound to the writer. Our dying act is to ask the
+   * new shim to add the new writer as a member. The listener must have moved our
+   * existing reader to the new union shim; but we must add the new writer.
+   *
+   * @param colWriter the column writer returned from the listener
+   * @return the same column writer
+   */
+
+  private AbstractObjectWriter doAddMember(AbstractObjectWriter colWriter) {
+    // Something went terribly wrong if the check below fails.
+    Preconditions.checkState(writer.shim() != this);
+    writer.shim().addMember(colWriter);
+    return colWriter;
+  }
+
+  @Override
+  public void addMember(AbstractObjectWriter colWriter) {
+
+    // Should only be called when promoting from a no-type shim to this
+    // single type shim. Otherwise, something is wrong with the type
+    // promotion logic.
+
+    Preconditions.checkState(this.colWriter == null);
+    this.colWriter = colWriter;
+    writer.addMember(colWriter);
+  }
+
+  @Override
+  public void setNull() {
+    colWriter.setNull();
+  }
+
+  private WriterEvents events() { return colWriter.events(); }
+
+  @Override
+  public void startWrite() {
+
+    // startWrite called before the column is added.
+
+    if (colWriter != null) {
+      colWriter.events().startWrite();
+    }
+  }
+
+  @Override
+  public void startRow() {
+
+    // startRow called before the column is added.
+
+    if (colWriter != null) {
+      colWriter.events().startRow();
+    }
+  }
+
+  @Override
+  public void endArrayValue() {
+    events().endArrayValue();
+  }
+
+  @Override
+  public void restartRow() {
+    events().restartRow();
+  }
+
+  @Override
+  public void saveRow() {
+    events().saveRow();
+  }
+
+  @Override
+  public void endWrite() {
+    events().endWrite();
+  }
+
+  @Override
+  public void preRollover() {
+    events().preRollover();
+  }
+
+  @Override
+  public void postRollover() {
+    events().postRollover();
+  }
+
+  @Override
+  public int lastWriteIndex() {
+    return colWriter.lastWriteIndex();
+  }
+
+  @Override
+  public int rowStartIndex() {
+    return colWriter.rowStartIndex();
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/SimpleListShim.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/SimpleListShim.java
@@ -23,7 +23,7 @@ import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
 import org.apache.drill.exec.vector.accessor.ObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.UnionShim;
 
-import com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 /**
  * Shim for a list that holds a single type, but may eventually become a

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionVectorShim.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionVectorShim.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ColumnWriter;
+import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter.VariantWriterListener;
+import org.apache.drill.exec.vector.accessor.writer.AbstractFixedWidthWriter.BaseFixedWidthWriter;
+import org.apache.drill.exec.vector.accessor.writer.UnionWriterImpl.UnionShim;
+import org.apache.drill.exec.vector.complex.UnionVector;
+
+/**
+ * Lists can operate in three modes: no type, one type or many
+ * types (that is, a list of unions.) This shim implements the
+ * variant writer when the backing vector is a union or a list
+ * backed by a union. It is a distinct class so that a List
+ * writer can have a uniform variant-style interface even as the
+ * list itself evolves from no type, to a single type and to
+ * a union.
+ */
+
+public class UnionVectorShim implements UnionShim {
+
+  static class DefaultListener implements VariantWriterListener {
+
+    private UnionVectorShim shim;
+
+    private DefaultListener(UnionVectorShim shim) {
+      this.shim = shim;
+    }
+
+    @Override
+    public ObjectWriter addType(MinorType type) {
+
+      // This vector layer does not have visibility to the implementation
+      // classes for metadata. Use the methods provided to add the type
+      // which will create the member metadata. This means that the type
+      // will already be in the variant schema by the time we add the
+      // writer to the variant writer in a few steps from now.
+
+      ValueVector memberVector = shim.vector.getMember(type);
+      ColumnMetadata memberSchema = shim.writer.variantSchema().addType(type);
+      return ColumnWriterFactory.buildColumnWriter(memberSchema, memberVector);
+    }
+
+    @Override
+    public ObjectWriter addMember(ColumnMetadata schema) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private final UnionVector vector;
+  private final AbstractObjectWriter variants[];
+  private UnionWriterImpl writer;
+
+  /**
+   * Writer for the type vector associated with the union. The type vector
+   * says which union member holds the value for each row. The type vector
+   * can also indicate if the value is null.
+   */
+
+  private final BaseScalarWriter typeWriter;
+
+  public UnionVectorShim(UnionVector vector) {
+    this.vector = vector;
+    typeWriter = ColumnWriterFactory.newWriter(vector.getTypeVector());
+    variants = new AbstractObjectWriter[MinorType.values().length];
+  }
+
+  public UnionVectorShim(UnionVector vector,
+      AbstractObjectWriter variants[]) {
+    this.vector = vector;
+    typeWriter = ColumnWriterFactory.newWriter(vector.getTypeVector());
+    if (variants == null) {
+      this.variants = new AbstractObjectWriter[MinorType.values().length];
+    } else {
+      this.variants = variants;
+    }
+  }
+
+  @Override
+  public void bindWriter(UnionWriterImpl writer) {
+    this.writer = writer;
+    ColumnWriterIndex index = writer.index();
+    if (index != null) {
+      bindIndex(index);
+    }
+  }
+
+  @Override
+  public void bindIndex(ColumnWriterIndex index) {
+    typeWriter.bindIndex(index);
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().bindIndex(index);
+      }
+    }
+  }
+
+  @Override
+  public void setNull() {
+
+    // Not really necessary: the default value is 0.
+    // This lets a caller change its mind after setting a
+    // value.
+
+    typeWriter.setInt(UnionVector.NULL_MARKER);
+  }
+
+  @Override
+  public boolean hasType(MinorType type) {
+    return variants[type.ordinal()] != null;
+  }
+
+  @Override
+  public ObjectWriter member(MinorType type) {
+    AbstractObjectWriter colWriter = variants[type.ordinal()];
+    if (colWriter != null) {
+      return colWriter;
+    }
+    if (writer.listener() == null) {
+      writer.bindListener(new DefaultListener(this));
+    }
+    return addMember(type);
+  }
+
+  @Override
+  public void setType(MinorType type) {
+    typeWriter.setInt(type.getNumber());
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(ColumnMetadata schema) {
+    AbstractObjectWriter colWriter = (AbstractObjectWriter) writer.listener().addMember(schema);
+    addMember(colWriter);
+    return colWriter;
+  }
+
+  @Override
+  public AbstractObjectWriter addMember(MinorType type) {
+    AbstractObjectWriter colWriter = (AbstractObjectWriter) writer.listener().addType(type);
+    addMember(colWriter);
+    return colWriter;
+  }
+
+  /**
+   * Add a column writer to an existing union writer. Used for implementations
+   * that support "live" schema evolution: column discovery while writing.
+   * The corresponding metadata must already have been added to the schema.
+   *
+   * @param colWriter the column writer to add
+   */
+
+  @Override
+  public void addMember(AbstractObjectWriter colWriter) {
+    addMemberWriter(colWriter);
+    writer.addMember(colWriter);
+  }
+
+  /**
+   * Performs just the work of adding a vector to the list of existing
+   * variants. Called when adding a type via the writer, but also when
+   * the result set loader promotes a list from single type to a union,
+   * and provides this shim with the writer from the single-list shim.
+   * In the latter case, the writer is already initialized and is already
+   * part of the metadata for this list; so we don't want to call the
+   * list's <tt>addMember()</tt> and repeat those operations.
+   *
+   * @param colWriter the column (type) writer to add
+   */
+
+  public void addMemberWriter(AbstractObjectWriter colWriter) {
+    MinorType type = colWriter.schema().type();
+    assert variants[type.ordinal()] == null;
+    variants[type.ordinal()] = colWriter;
+  }
+
+  @Override
+  public void startWrite() {
+    typeWriter.startWrite();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().startWrite();
+      }
+    }
+  }
+
+  @Override
+  public void startRow() {
+    typeWriter.startRow();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().startRow();
+      }
+    }
+  }
+
+  @Override
+  public void endArrayValue() {
+    typeWriter.endArrayValue();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().endArrayValue();
+      }
+    }
+  }
+
+  @Override
+  public void restartRow() {
+    typeWriter.restartRow();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().restartRow();
+      }
+    }
+  }
+
+  @Override
+  public void saveRow() {
+    typeWriter.saveRow();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().saveRow();
+      }
+    }
+   }
+
+  @Override
+  public void preRollover() {
+    typeWriter.preRollover();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().preRollover();
+      }
+    }
+  }
+
+  @Override
+  public void postRollover() {
+    typeWriter.postRollover();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().postRollover();
+      }
+    }
+  }
+
+  @Override
+  public void endWrite() {
+    typeWriter.endWrite();
+    for (int i = 0; i < variants.length; i++) {
+      if (variants[i] != null) {
+        variants[i].events().endWrite();
+      }
+    }
+  }
+
+
+  /**
+   * Return the writer for the types vector. To be used only by the row set
+   * loader overflow logic; never by the application (which is why the method
+   * is not defined in the interface.)
+   *
+   * @return the writer for the types vector
+   */
+
+  public ColumnWriter typeWriter() { return typeWriter; }
+
+  @Override
+  public int lastWriteIndex() { return typeWriter.lastWriteIndex(); }
+
+  @Override
+  public int rowStartIndex() { return typeWriter.rowStartIndex(); }
+
+  /**
+   * When promoting the list to a union, the union's
+   * type vector was initialized for any rows written thus
+   * far. Tell the type writer that those positions have been
+   * written so that they are not zero-filled.
+   */
+
+  public void initTypeIndex(int typeFillCount) {
+    ((BaseFixedWidthWriter) typeWriter).setLastWriteIndex(typeFillCount);
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/UnionWriterImpl.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import java.math.BigDecimal;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.VariantMetadata;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ColumnWriterIndex;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+import org.apache.drill.exec.vector.accessor.WriterPosition;
+import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
+import org.apache.drill.exec.vector.complex.UnionVector;
+import org.joda.time.Period;
+
+/**
+ * Writer to a union vector.
+ */
+
+public class UnionWriterImpl implements VariantWriter, WriterEvents {
+
+  public interface UnionShim extends WriterEvents {
+    void bindWriter(UnionWriterImpl writer);
+    void setNull();
+    boolean hasType(MinorType type);
+
+    /**
+     * Return an existing writer for the given type, or create a new one
+     * if needed.
+     *
+     * @param type desired variant type
+     * @return a writer for that type
+     */
+
+    ObjectWriter member(MinorType type);
+    void setType(MinorType type);
+    int lastWriteIndex();
+    int rowStartIndex();
+    AbstractObjectWriter addMember(ColumnMetadata colSchema);
+    AbstractObjectWriter addMember(MinorType type);
+    void addMember(AbstractObjectWriter colWriter);
+  }
+
+  public static class VariantObjectWriter extends AbstractObjectWriter {
+
+    private final UnionWriterImpl writer;
+
+    public VariantObjectWriter(UnionWriterImpl writer) {
+      this.writer = writer;
+    }
+
+    @Override
+    public VariantWriter variant() { return writer; }
+
+    @Override
+    public WriterEvents events() { return writer; }
+
+    @Override
+    public void dump(HierarchicalFormatter format) {
+      writer.dump(format);
+    }
+  }
+
+  /**
+   * The result set loader requires information about the child positions
+   * of the array that this list represents. Since the children are mutable,
+   * we cannot simply ask for the child writer as with most arrays. Instead,
+   * we use a proxy that will route the request to the current shim. This
+   * way the proxy persists even as the shims change. Just another nasty
+   * side-effect of the overly-complex list structure...
+   * <p>
+   * This class is needed because both the child and this array writer
+   * need to implement the same methods, so we can't just implement these
+   * methods on the union writer itself.
+   */
+
+  private class ElementPositions implements WriterPosition {
+
+    @Override
+    public int rowStartIndex() { return shim.rowStartIndex(); }
+
+    @Override
+    public int lastWriteIndex() { return shim.lastWriteIndex(); }
+
+    @Override
+    public int writeIndex() {
+      return index.vectorIndex();
+    }
+  }
+
+  private final ColumnMetadata schema;
+  private UnionShim shim;
+  private ColumnWriterIndex index;
+  private State state = State.IDLE;
+  private VariantWriterListener listener;
+  private final WriterPosition elementPosition = new ElementPositions();
+
+  public UnionWriterImpl(ColumnMetadata schema) {
+    this.schema = schema;
+  }
+
+  public UnionWriterImpl(ColumnMetadata schema, UnionVector vector,
+      AbstractObjectWriter variants[]) {
+    this(schema);
+    bindShim(new UnionVectorShim(vector, variants));
+  }
+
+  @Override
+  public void bindIndex(ColumnWriterIndex index) {
+    this.index = index;
+    shim.bindIndex(index);
+  }
+
+  public void bindListener(VariantWriterListener listener) {
+    this.listener = listener;
+  }
+
+  // The following are for coordinating with the shim.
+
+  public State state() { return state; }
+  public ColumnWriterIndex index() { return index; }
+  public VariantWriterListener listener() { return listener; }
+  public UnionShim shim() { return shim; }
+  public WriterPosition elementPosition() { return elementPosition; }
+
+  public void bindShim(UnionShim shim) {
+    this.shim = shim;
+    shim.bindWriter(this);
+    if (state != State.IDLE) {
+      shim.startWrite();
+      if (state == State.IN_ROW) {
+        shim.startRow();
+      }
+    }
+  }
+
+  @Override
+  public ObjectType type() { return ObjectType.VARIANT; }
+
+  @Override
+  public boolean nullable() { return true; }
+
+  @Override
+  public ColumnMetadata schema() { return schema; }
+
+  @Override
+  public VariantMetadata variantSchema() { return schema.variantSchema(); }
+
+  @Override
+  public int size() { return variantSchema().size(); }
+
+  @Override
+  public boolean hasType(MinorType type) {
+    return shim.hasType(type);
+  }
+
+  @Override
+  public void setNull() {
+    shim.setNull();
+  }
+
+  @Override
+  public ObjectWriter memberWriter(MinorType type) {
+    return shim.member(type);
+  }
+
+  @Override
+  public ObjectWriter member(MinorType type) {
+
+    // Get the writer first, which may trigger the single-to-union
+    // conversion. Then set the type because, if the conversion is
+    // done, the type vector exists only after creating the member.
+
+    ObjectWriter writer = shim.member(type);
+    setType(type);
+    return writer;
+  }
+
+  @Override
+  public void setType(MinorType type) {
+    shim.setType(type);
+  }
+
+  @Override
+  public ObjectWriter addMember(ColumnMetadata colSchema) {
+    return shim.addMember(colSchema);
+  }
+
+  @Override
+  public ObjectWriter addMember(MinorType type) {
+    return shim.addMember(type);
+  }
+
+  /**
+   * Add a column writer to an existing union writer. Used for implementations
+   * that support "live" schema evolution: column discovery while writing.
+   * The corresponding metadata must already have been added to the schema.
+   * Called by the shim's <tt>addMember</tt> to do writer-level tasks.
+   *
+   * @param colWriter the column writer to add
+   */
+
+  protected void addMember(AbstractObjectWriter writer) {
+    MinorType type = writer.schema().type();
+
+    // If the metadata has not yet been added to the variant
+    // schema, do so now. (Unfortunately, the default listener
+    // does add the schema, while the row set loader does not.)
+
+    if (! variantSchema().hasType(type)) {
+      variantSchema().addType(writer.schema());
+    }
+    writer.events().bindIndex(index);
+    if (state != State.IDLE) {
+      writer.events().startWrite();
+      if (state == State.IN_ROW) {
+        writer.events().startRow();
+      }
+    }
+  }
+
+  @Override
+  public ScalarWriter scalar(MinorType type) {
+    return member(type).scalar();
+  }
+
+  @Override
+  public TupleWriter tuple() {
+    return member(MinorType.MAP).tuple();
+  }
+
+  @Override
+  public ArrayWriter array() {
+    return member(MinorType.LIST).array();
+  }
+
+  @Override
+  public void startWrite() {
+    assert state == State.IDLE;
+    state = State.IN_WRITE;
+    shim.startWrite();
+  }
+
+  @Override
+  public void startRow() {
+    assert state == State.IN_WRITE;
+    state = State.IN_ROW;
+    shim.startRow();
+  }
+
+  @Override
+  public void endArrayValue() {
+    shim.endArrayValue();
+  }
+
+  @Override
+  public void restartRow() {
+    assert state == State.IN_ROW;
+    shim.restartRow();
+  }
+
+  @Override
+  public void saveRow() {
+    assert state == State.IN_ROW;
+    shim.saveRow();
+    state = State.IN_WRITE;
+  }
+
+  @Override
+  public void preRollover() {
+    assert state == State.IN_ROW;
+    shim.preRollover();
+  }
+
+  @Override
+  public void postRollover() {
+    assert state == State.IN_ROW;
+    shim.postRollover();
+  }
+
+  @Override
+  public void endWrite() {
+    assert state != State.IDLE;
+    shim.endWrite();
+    state = State.IDLE;
+  }
+
+  @Override
+  public int lastWriteIndex() { return shim.lastWriteIndex(); }
+
+  @Override
+  public int rowStartIndex() { return shim.rowStartIndex(); }
+
+  @Override
+  public int writeIndex() {
+    return index.vectorIndex();
+  }
+
+  @Override
+  public void setObject(Object value) {
+    if (value == null) {
+      setNull();
+    } else if (value instanceof Integer) {
+      scalar(MinorType.INT).setInt((Integer) value);
+    } else if (value instanceof Long) {
+      scalar(MinorType.BIGINT).setLong((Long) value);
+    } else if (value instanceof String) {
+      scalar(MinorType.VARCHAR).setString((String) value);
+    } else if (value instanceof BigDecimal) {
+      // Can look for exactly one decimal type as is done for Object[] below
+      throw new IllegalArgumentException("Decimal is ambiguous, please use scalar(type)");
+    } else if (value instanceof Period) {
+      // Can look for exactly one period type as is done for Object[] below
+      throw new IllegalArgumentException("Period is ambiguous, please use scalar(type)");
+    } else if (value instanceof byte[]) {
+      byte[] bytes = (byte[]) value;
+      scalar(MinorType.VARBINARY).setBytes(bytes, bytes.length);
+    } else if (value instanceof Byte) {
+      scalar(MinorType.TINYINT).setInt((Byte) value);
+    } else if (value instanceof Short) {
+      scalar(MinorType.SMALLINT).setInt((Short) value);
+    } else if (value instanceof Double) {
+      scalar(MinorType.FLOAT8).setDouble((Double) value);
+    } else if (value instanceof Float) {
+      scalar(MinorType.FLOAT4).setDouble((Float) value);
+    } else if (value instanceof Object[]) {
+      if (hasType(MinorType.MAP) && hasType(MinorType.LIST)) {
+        throw new UnsupportedOperationException("Union has both a map and a list, so Object[] is ambiguous");
+      } else if (hasType(MinorType.MAP)) {
+        tuple().setObject(value);
+      } else if (hasType(MinorType.LIST)) {
+        array().setObject(value);
+      } else {
+        throw new IllegalArgumentException("Unsupported type " +
+            value.getClass().getSimpleName());
+      }
+    } else {
+      throw new IllegalArgumentException("Unsupported type " +
+                value.getClass().getSimpleName());
+    }
+  }
+
+  public void dump(HierarchicalFormatter format) {
+    // TODO Auto-generated method stub
+
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/package-info.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/package-info.java
@@ -153,6 +153,36 @@
  * (eventually) lists and repeated lists.</li>
  * </ul>
  *
+ * <h4>Lists</h4>
+ *
+ * As described in the API package, Lists and Unions in Drill are highly
+ * complex, and not well supported. This creates huge problems in the
+ * writer layer because we must support something which is broken and
+ * under-used, but which most people assume works (it is part of Drill's
+ * JSON-like, schema-free model.) Our goal here is to support Union and
+ * List well enough that nothing new is broken; though this layer cannot
+ * fix the issues elsewhere in Drill.
+ * <p>
+ * The most complex part is List support for the transition from a single
+ * type to a union of types. The API should be simple: the client should
+ * not have to be aware of the transition.
+ * <p>
+ * To make this work, the writers provide two options:
+ * <ol>
+ * <li>Use metadata to state that a List will have exactly one type and
+ * to specify that type. The List will present as an array of that type in
+ * which each array can be null.</li>
+ * <li>Otherwise, the list is repeated union (a array of variants), even
+ * if the list happens to have 0 or 1 types. In this case, the list presents
+ * as an array of variants.</li>
+ * </ol>
+ * The result is that client code assumes one or the other model, and never
+ * has to worry about transitioning from one to the other within a single
+ * operator.
+ * <p>
+ * The {@link PromotableListWriter} handles the complex details of providing
+ * the above simple API in the array-of-variant case.
+ *
  * <h4>Possible Improvements</h4>
  *
  * The code here works and has extensive unit tests. But, many improvements

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -19,17 +19,21 @@ package org.apache.drill.exec.vector.complex;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ObjectArrays;
 import io.netty.buffer.DrillBuf;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
-import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
+import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.util.CallBack;
 import org.apache.drill.exec.util.JsonStringArrayList;
 import org.apache.drill.exec.vector.AddOrGetResult;
+import org.apache.drill.exec.vector.NullableVector;
 import org.apache.drill.exec.vector.UInt1Vector;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
@@ -41,25 +45,161 @@ import org.apache.drill.exec.vector.complex.impl.UnionListWriter;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.FieldWriter;
 
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.ObjectArrays;
+
+import io.netty.buffer.DrillBuf;
+
+/**
+ * "Non-repeated" LIST vector. This vector holds some other vector as
+ * its data element. Unlike a repeated vector, the child element can
+ * change dynamically. It starts as nothing (the LATE type). It can then
+ * change to a single type (typically a map but can be anything.) If
+ * another type is needed, the list morphs again, this time to a list
+ * of unions. The prior single type becomes a member of the new union
+ * (which requires back-filling is-set values.)
+ * <p>
+ * Why this odd behavior? The LIST type apparently attempts to model
+ * certain JSON types. In JSON, we can have lists like this:
+ * <pre><code>
+ * {a: [null, null]}
+ * {a: [10, "foo"]}
+ * {a: [{name: "fred", balance: 10}, null]
+ * {a: null}
+ * </code></pre>
+ * Compared with Drill, JSON has a number of additional list-related
+ * abilities:
+ * <ul>
+ * <li>A list can be null. (In Drill, an array can be empty, but not
+ * null.)</li>
+ * <li>A list element can be null. (In Drill, a repeated type is an
+ * array of non-nullable elements, so list elements can't be
+ * null.</li>
+ * <li>A list can contain heterogeneous types. (In Drill, repeated
+ * types are arrays of a single type.</li>
+ * </ul>
+ * The LIST vector is an attempt to implement full JSON behavior. The
+ * list:
+ * <ul>
+ * <li>Allows the list value for a row to be null. (To handle the
+ * <code>{list: null}</code> case.</li>
+ * <li>Allows list elements to be null. (To handle the
+ * <code>{list: [10, null 30]}</code case.)</li>
+ * <li>Allows the list to be a single type. (To handle the list
+ * of nullable ints above.</li>
+ * <li>Allows the list to be of multiple types, by creating a list
+ * of UNIONs. (To handle the
+ * <code>{list: ["fred", 10]}</code> case.</li>
+ * </ul>
+ *
+ * <h4>Background</h4>
+ *
+ * The above is the theory. The problem is, the goals are very difficult
+ * to achieve, and the code here does not quite do so.
+ * The code here is difficult to maintain and understand.
+ * The first thing to understand is that union vectors are
+ * broken in most operators, and so major bugs remain in union
+ * and list vectors that
+ * have not had to be fixed. Recent revisions attempt to
+ * fix or works around some of the bugs, but many remain.
+ * <p>
+ * Unions have a null bit for the union itself. That is, a union can be an
+ * int, say, or. a Varchar, or null. Oddly, the Int and Varchar can also be
+ * null (we use nullable vectors so we can mark the unused values as null.)
+ * So, we have a two-level null bit. The most logical way to interpret it is
+ * that a union value can be:
+ * <ul>
+ * <li>Untyped null (if the type is not set and the null bit (really, the isSet
+ * bit) is unset.) Typed null if the type is set and EITHER the union's isSet
+ * bit is unset OR the union's isSet bit is set, but the data vector's isSet
+ * bit is not set. It is not clear in the code which convention is assumed, or
+ * if different code does it differently.</li>
+ * <li>Now, add all that to a list. A list can be a list of something (ints, say,
+ * or maps.) When the list is a list of maps, the entire value for a row can
+ * be null. But individual maps can't be null. In a list, however, individual
+ * ints can be null (because we use a nullable int vector.)</li>
+ * </ul>
+ * So, when a list of (non-nullable maps) converts to a list of unions (one of
+ * which is a map), we suddenly now have the list null bit and the union null
+ * bit to worry about. We have to go and back-patch the isSet vector for all
+ * the existing map entries in the new union so that we don't end up with all
+ * previous entries becoming null by default.
+ * <p>
+ * Another issue is that the metadata for a list should reflect the structure
+ * of the list. The {@link MaterializedField} contains a child field, which
+ * points to the element of the list. If that child is a UNION, then the UNION's
+ * <code>MaterializedField</code> contains subtypes for each type in the
+ * union. Now, note that the LIST's metadata contains the child, so we need
+ * to update the LIST's <code>MaterializedField</code> each time we add a
+ * type to the UNION. And, since the LIST is part of a row or map, then we
+ * have to update the metadata in those objects to propagate the change.
+ * <p>
+ * The problem is that the original design assumed that
+ * <code>MaterializedField</code> is immutable. The above shows that it
+ * clearly is not. So, we have a tension between the original immutable
+ * design and the necessity of mutating the <code>MaterializedField</code>
+ * to keep everything in sync.
+ * <p>
+ * Of course, there is another solution: don't include subtypes and children
+ * in the <code>MaterializedField</code>, then we don't have the propagation
+ * problem.
+ * <p>
+ * The code for this class kind of punts on the issue: the metadata is not
+ * maintained and can get out of sync. THis makes the metadata useless: one must
+ * recover actual structure by traversing vectors. There was an attempt to fix
+ * this, but doing so changes the metadata structure, which broke clients. So,
+ * we have to live with broken metadata and work around the issues. The metadata
+ * sync issue exists in many places, but is most obvious in the LIST vector
+ * because of the sheer complexity in this class.
+ * <p>
+ * This is why the code notes say that this is a mess.
+ * <p>
+ * It is hard to simply fix the bugs because this is a design problem. If the list
+ * and union vectors don't need to work (they barely work today), then any
+ * design is fine. See the list of JIRA tickets below for more information.
+ * <p>
+ * Fundamental issue: should Drill support unions and lists? Is the current
+ * approach compatible with SQL? Is there a better approach? If such changes
+ * are made, they are breaking changes, and so must be done as part of a major
+ * version, such as the much-discussed "Drill 2.0". Or, perhaps as part of
+ * a conversion to use Apache Arrow, which also would be a major breaking
+ * change.
+ *
+ * @see DRILL-5955, DRILL-6037, DRILL-5958, DRILL-6046, DRILL-6062, DRILL-3806
+ *      to get a flavor for the issues.
+ */
 
 public class ListVector extends BaseRepeatedValueVector {
 
-  private UInt4Vector offsets;
+  public static final String UNION_VECTOR_NAME = "$union$";
+
   private final UInt1Vector bits;
-  private Mutator mutator = new Mutator();
-  private Accessor accessor = new Accessor();
-  private UnionListWriter writer;
+  private final Mutator mutator = new Mutator();
+  private final Accessor accessor = new Accessor();
+  private final UnionListWriter writer;
   private UnionListReader reader;
 
   public ListVector(MaterializedField field, BufferAllocator allocator, CallBack callBack) {
     super(field, allocator);
+    // Can't do this. See below.
+//    super(field.cloneEmpty(), allocator);
     this.bits = new UInt1Vector(MaterializedField.create(BITS_VECTOR_NAME, Types.required(MinorType.UINT1)), allocator);
-    offsets = getOffsetVector();
     this.field.addChild(getDataVector().getField());
     this.writer = new UnionListWriter(this);
     this.reader = new UnionListReader(this);
+//
+//    // To be consistent with the map vector, create the child if a child is
+//    // given in the field. This is a mess. See DRILL-6046.
+//    But, can't do this because the deserialization mechanism passes in a
+//    field with children filled in, but with no expectation that the vector will
+//    match its schema until this vector itself is loaded. Indeed a mess.
+//
+//    assert field.getChildren().size() <= 1;
+//    for (MaterializedField child : field.getChildren()) {
+//      if (child.getName().equals(DATA_VECTOR_NAME)) {
+//        continue;
+//      }
+//      setChildVector(BasicTypeHelper.getNewVector(child, allocator, callBack));
+//    }
   }
 
   public UnionListWriter getWriter() {
@@ -86,9 +226,9 @@ public class ListVector extends BaseRepeatedValueVector {
   }
 
   public void copyFrom(int inIndex, int outIndex, ListVector from) {
-    FieldReader in = from.getReader();
+    final FieldReader in = from.getReader();
     in.setPosition(inIndex);
-    FieldWriter out = getWriter();
+    final FieldWriter out = getWriter();
     out.setPosition(outIndex);
     ComplexCopier.copy(in, out);
   }
@@ -99,9 +239,9 @@ public class ListVector extends BaseRepeatedValueVector {
   }
 
   @Override
-  public ValueVector getDataVector() {
-    return vector;
-  }
+  public ValueVector getDataVector() { return vector; }
+
+  public ValueVector getBitsVector() { return bits; }
 
   @Override
   public TransferPair getTransferPair(String ref, BufferAllocator allocator) {
@@ -115,7 +255,7 @@ public class ListVector extends BaseRepeatedValueVector {
 
   private class TransferImpl implements TransferPair {
 
-    ListVector to;
+    private final ListVector to;
 
     public TransferImpl(MaterializedField field, BufferAllocator allocator) {
       to = new ListVector(field, allocator, null);
@@ -175,13 +315,13 @@ public class ListVector extends BaseRepeatedValueVector {
      */
     boolean success = false;
     try {
-      if (!offsets.allocateNewSafe()) {
+      if (! offsets.allocateNewSafe()) {
         return false;
       }
       success = vector.allocateNewSafe();
       success = success && bits.allocateNewSafe();
     } finally {
-      if (!success) {
+      if (! success) {
         clear();
       }
     }
@@ -204,7 +344,7 @@ public class ListVector extends BaseRepeatedValueVector {
 
   @Override
   public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(VectorDescriptor descriptor) {
-    AddOrGetResult<T> result = super.addOrGetVector(descriptor);
+    final AddOrGetResult<T> result = super.addOrGetVector(descriptor);
     reader = new UnionListReader(this);
     return result;
   }
@@ -219,8 +359,6 @@ public class ListVector extends BaseRepeatedValueVector {
 
   @Override
   public void clear() {
-    offsets.clear();
-    vector.clear();
     bits.clear();
     lastSet = 0;
     super.clear();
@@ -228,10 +366,13 @@ public class ListVector extends BaseRepeatedValueVector {
 
   @Override
   public DrillBuf[] getBuffers(boolean clear) {
-    final DrillBuf[] buffers = ObjectArrays.concat(offsets.getBuffers(false), ObjectArrays.concat(bits.getBuffers(false),
-            vector.getBuffers(false), DrillBuf.class), DrillBuf.class);
+    final DrillBuf[] buffers = ObjectArrays.concat(
+        offsets.getBuffers(false),
+        ObjectArrays.concat(bits.getBuffers(false),
+            vector.getBuffers(false), DrillBuf.class),
+        DrillBuf.class);
     if (clear) {
-      for (DrillBuf buffer:buffers) {
+      for (final DrillBuf buffer : buffers) {
         buffer.retain();
       }
       clear();
@@ -250,7 +391,7 @@ public class ListVector extends BaseRepeatedValueVector {
     bits.load(bitMetadata, buffer.slice(offsetLength, bitLength));
 
     final UserBitShared.SerializedField vectorMetadata = metadata.getChild(2);
-    if (getDataVector() == DEFAULT_DATA_VECTOR) {
+    if (isEmptyType()) {
       addOrGetVector(VectorDescriptor.create(vectorMetadata.getMajorType()));
     }
 
@@ -258,12 +399,144 @@ public class ListVector extends BaseRepeatedValueVector {
     vector.load(vectorMetadata, buffer.slice(offsetLength + bitLength, vectorLength));
   }
 
+  public boolean isEmptyType() {
+    return getDataVector() == DEFAULT_DATA_VECTOR;
+  }
+
+  @Override
+  public void setChildVector(ValueVector childVector) {
+
+    // Unlike the repeated list vector, the (plain) list vector
+    // adds the dummy vector as a child type.
+
+    assert field.getChildren().size() == 1;
+    assert field.getChildren().iterator().next().getType().getMinorType() == MinorType.LATE;
+    field.removeChild(vector.getField());
+
+    super.setChildVector(childVector);
+
+    // Initial LATE type vector not added as a subtype initially.
+    // So, no need to remove it, just add the new subtype. Since the
+    // MajorType is immutable, must build a new one and replace the type
+    // in the materialized field. (We replace the type, rather than creating
+    // a new materialized field, to preserve the link to this field from
+    // a parent map, list or union.)
+
+    assert field.getType().getSubTypeCount() == 0;
+    field.replaceType(
+        field.getType().toBuilder()
+          .addSubType(childVector.getField().getType().getMinorType())
+          .build());
+  }
+
+  /**
+   * Promote the list to a union. Called from old-style writers. This implementation
+   * relies on the caller to set the types vector for any existing values.
+   * This method simply clears the existing vector.
+   *
+   * @return the new union vector
+   */
+
   public UnionVector promoteToUnion() {
-    MaterializedField newField = MaterializedField.create(getField().getName(), Types.optional(MinorType.UNION));
-    UnionVector vector = new UnionVector(newField, allocator, null);
+    final UnionVector vector = createUnion();
+
+    // Replace the current vector, clearing its data. (This is the
+    // old behavior.)
+
     replaceDataVector(vector);
     reader = new UnionListReader(this);
     return vector;
+  }
+
+  /**
+   * Revised form of promote to union that correctly fixes up the list
+   * field metadata to match the new union type. Since this form handles
+   * both the vector and metadata revisions, it is a "full" promotion.
+   *
+   * @return the new union vector
+   */
+
+  public UnionVector fullPromoteToUnion() {
+    final UnionVector unionVector = createUnion();
+
+    // Set the child vector, replacing the union vector's child
+    // metadata with the union vector's metadata. (This is the
+    // new, correct, behavior.)
+
+    setChildVector(unionVector);
+    return unionVector;
+  }
+
+  /**
+   * Promote to a union, preserving the existing data vector as a member of the
+   * new union. Back-fill the types vector with the proper type value for
+   * existing rows.
+   * @return the new union vector
+   */
+
+  public UnionVector convertToUnion(int allocValueCount, int valueCount) {
+    assert allocValueCount >= valueCount;
+    final UnionVector unionVector = createUnion();
+    unionVector.allocateNew(allocValueCount);
+
+    // Preserve the current vector (and its data) if it is other than
+    // the default. (New behavior used by column writers.)
+
+    if (! isEmptyType()) {
+      unionVector.addType(vector);
+      final int prevType = vector.getField().getType().getMinorType().getNumber();
+      final UInt1Vector.Mutator typeMutator = unionVector.getTypeVector().getMutator();
+
+      // If the previous vector was nullable, then promote the nullable state
+      // to the type vector by setting either the null marker or the type
+      // marker depending on the original nullable values.
+
+      if (vector instanceof NullableVector) {
+        final UInt1Vector.Accessor bitsAccessor =
+            ((UInt1Vector) ((NullableVector) vector).getBitsVector()).getAccessor();
+        for (int i = 0; i < valueCount; i++) {
+          typeMutator.setSafe(i, (bitsAccessor.get(i) == 0)
+              ? UnionVector.NULL_MARKER
+              : prevType);
+        }
+      } else {
+
+        // The value is not nullable. (Perhaps it is a map.)
+        // Note that the original design of lists have a flaw: if the sole member
+        // is a map, then map entries can't be nullable when the only type, but
+        // become nullable when in a union. What a mess...
+
+        for (int i = 0; i < valueCount; i++) {
+          typeMutator.setSafe(i, prevType);
+        }
+      }
+    }
+    vector = unionVector;
+    return unionVector;
+  }
+
+  private UnionVector createUnion() {
+    final MaterializedField newField = MaterializedField.create(UNION_VECTOR_NAME, Types.optional(MinorType.UNION));
+    final UnionVector unionVector = new UnionVector(newField, allocator, null);
+
+    // For efficiency, should not create a reader that will never be used.
+    // Keeping for backward compatibility.
+    //
+    // This vector already creates a reader for every vector. The reader isn't used for
+    // the ResultSetVector, but may be used by older code. Someone can perhaps
+    // track down uses, I kept this code. The Union vector is normally created in the
+    // older "complex writer" which may use this reader.
+    //
+    // Moving forward, we should revisit union vectors (and the older complex writer).
+    // At that time, we can determine if the vector needs to own a reader, or if
+    // the reader can be created as needed.
+    // If we create a "result set reader" that works cross-batch in parallel with the
+    // result set loader (for writing), then vectors would not carry their own readers.
+    //
+    // Yes indeed, union vectors are a mess.
+
+    reader = new UnionListReader(this);
+    return unionVector;
   }
 
   private int lastSet;

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -45,10 +45,6 @@ import org.apache.drill.exec.vector.complex.impl.UnionListWriter;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.FieldWriter;
 
-import com.google.common.collect.ObjectArrays;
-
-import io.netty.buffer.DrillBuf;
-
 /**
  * "Non-repeated" LIST vector. This vector holds some other vector as
  * its data element. Unlike a repeated vector, the child element can


### PR DESCRIPTION
Previous commits provided the core "result set loader" (RSL) structure and support for the "mainstream" vector types, including structured types such as maps and lists.

This PR adds the "obscure" (and partly implemented) types used for JSON: (non-repeated) list, repeated list and union.

The union type is complex: it is a bundle of vectors keyed by type, and can accept new types as a run proceeds. A (non-repeated) list is highly complex: it it can act like a repeated list, but with the ability to specify a null state for each entry. The non-repeated List can also act like a union type. This dual/morphing nature of a list required some rather complex magic behind the scenes to support the simple JSON-like interface used by the row set and result set loader mechanisms.

This PR introduces the idea of a "variant" to model unions and non-repeated-lists-as-list-of-unions. The name is taken from Microsoft Basic and simply means a tagged union. (Where "union" is taken from "C".)

Changes include fixing a number of issues with the list vectors, adding support in the column accessors and metadata layers, and adding support for creating vectors from metadata and metadata from vectors.

Unit tests demonstrate how to use the resulting behavior as well as verifying that the behavior is correct.

The focus of this PR is to enable union, list and repeated list support in the RSL and associated mechanisms. It is known that support of these vector types is incomplete: some operators fail when presented with such vectors. It is not the goal here to fix those issues: this is not a PR to fully support these types. Rather, the the scope of this PR is just to the RSL and associated classes.

For more information, see [this wiki entry](https://github.com/paul-rogers/drill/wiki/Batch-Handling-Upgrades).

This PR completes the result set loader work. The next PR in this series will introduce revisions to the scan operator that allow readers to use the RSL. After that, there are revised implementations for the delimited text (e.g. CSV) and JSON readers.