### PR TITLE
DRILL-6702: Disable CPU Reporting for non-HotSpot JDKs

### DIFF
--- a/common/src/main/java/org/apache/drill/exec/metrics/CpuGaugeSet.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/CpuGaugeSet.java
@@ -55,7 +55,7 @@ public class CpuGaugeSet implements MetricSet {
   private static OperatingSystemMXBean getOSMXBeanForCpuMetrics() {
     try {
       return (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
-    } catch (Exception ex) {
+    } catch (ClassCastException ex) {
       logger.warn("{}. Detected non-Supported JVM [{}]. CPU Metrics in the WebUI will not be available!", ex.getMessage(), System.getProperty("java.vm.name"));
     }
     return null;


### PR DESCRIPTION
When running Drill on the IBM JDK (J9), the webUI throws an ClassCastException :
Caused by: java.lang.ClassCastException: com.ibm.lang.management.ExtendedOperatingSystem incompatible with com.sun.management.OperatingSystemMXBean

This PR simply disables that, since Drill should ideally be recompiled with these alternative JDKs. 