### PR TITLE
DRILL-6688 Data batches for Project operator exceed the maximum specified

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/output/OutputWidthCalculators.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/output/OutputWidthCalculators.java
@@ -59,7 +59,7 @@ public class OutputWidthCalculators {
                 throw new IllegalArgumentException();
             }
             for (FixedLenExpr expr : args) {
-                outputSize += expr.getWidth();
+                outputSize += expr.getDataWidth();
             }
             outputSize = adjustOutputWidth(outputSize, "ConcatOutputWidthCalculator:");
             return outputSize;
@@ -85,7 +85,7 @@ public class OutputWidthCalculators {
             if (args == null || args.size() < 1) {
                 throw new IllegalArgumentException();
             }
-            outputSize = args.get(0).getWidth();
+            outputSize = args.get(0).getDataWidth();
             outputSize = adjustOutputWidth(outputSize, "CloneOutputWidthCalculator:");
             return outputSize;
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/OutputWidthExpression.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/OutputWidthExpression.java
@@ -133,11 +133,18 @@ public abstract class OutputWidthExpression {
      */
 
     public static class FixedLenExpr extends OutputWidthExpression {
-        int fixedWidth;
+        /**
+         * Only the width of the payload is saved in fixedDataWidth.
+         * Metadata width is added when the final output row size is calculated.
+         * This is to avoid function {@link OutputWidthCalculator} from using
+         * metadata width in the calculations.
+         */
+        private int fixedDataWidth;
+
         public FixedLenExpr(int fixedWidth) {
-            this.fixedWidth = fixedWidth;
+            this.fixedDataWidth = fixedWidth;
         }
-        public int getWidth() { return fixedWidth;}
+        public int getDataWidth() { return fixedDataWidth;}
 
         @Override
         public <T, V, E extends Exception> T accept(AbstractExecExprVisitor<T, V, E> visitor, V value) throws E {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.vector.NullableVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.physical.impl.project.OutputWidthExpression.FixedLenExpr;
 import org.apache.drill.exec.vector.VariableWidthVector;
-import org.apache.drill.exec.vector.complex.BaseRepeatedValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 
 import java.util.HashMap;
@@ -172,7 +171,9 @@ public class ProjectMemoryManager extends RecordBatchMemoryManager {
             throw new IllegalArgumentException("getWidthOfFixedWidthType() cannot handle variable width types");
         }
 
-        if (minorType == MinorType.NULL) { return 0; }
+        if (minorType == MinorType.NULL) {
+            return 0;
+        }
 
         return TypeHelper.getSize(majorType);
     }
@@ -334,9 +335,9 @@ public class ProjectMemoryManager extends RecordBatchMemoryManager {
             width += ((VariableWidthVector)vv).getOffsetVector().getPayloadByteCount(1);
         }
 
-        if (vv instanceof BaseRepeatedValueVector) {
-            width += ((BaseRepeatedValueVector)vv).getOffsetVector().getPayloadByteCount(1);
-            width += (getMetadataWidth(((BaseRepeatedValueVector)vv).getDataVector()) * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
+        if (vv instanceof RepeatedValueVector) {
+            width += ((RepeatedValueVector)vv).getOffsetVector().getPayloadByteCount(1);
+            width += (getMetadataWidth(((RepeatedValueVector)vv).getDataVector()) * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
         }
         return width;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectMemoryManager.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.vector.NullableVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.physical.impl.project.OutputWidthExpression.FixedLenExpr;
 import org.apache.drill.exec.vector.VariableWidthVector;
+import org.apache.drill.exec.vector.complex.BaseRepeatedValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedValueVector;
 
 import java.util.HashMap;
@@ -288,7 +289,6 @@ public class ProjectMemoryManager extends RecordBatchMemoryManager {
                 width = ((FixedLenExpr)reducedExpr).getDataWidth();
                 Preconditions.checkState(width >= 0);
                 int metadataWidth = getMetadataWidth(columnWidthInfo.outputVV);
-                Preconditions.checkState(metadataWidth >= 0);
                 logger.trace("update(): fieldName {} width: {} metadataWidth: {}",
                         columnWidthInfo.outputVV.getField().getName(), width, metadataWidth);
                 width += metadataWidth;
@@ -335,9 +335,9 @@ public class ProjectMemoryManager extends RecordBatchMemoryManager {
             width += ((VariableWidthVector)vv).getOffsetVector().getPayloadByteCount(1);
         }
 
-        if (vv instanceof RepeatedValueVector) {
-            width += ((RepeatedValueVector)vv).getOffsetVector().getPayloadByteCount(1);
-            width += (getMetadataWidth(((RepeatedValueVector)vv).getDataVector()) * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
+        if (vv instanceof BaseRepeatedValueVector) {
+            width += ((BaseRepeatedValueVector)vv).getOffsetVector().getPayloadByteCount(1);
+            width += (getMetadataWidth(((BaseRepeatedValueVector)vv).getDataVector()) * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
         }
         return width;
     }


### PR DESCRIPTION
This change separates the metadata-width and data-width of a variable-width column such that the data-width is used in all intermediate calculations and the meta-data width is added finally when the column's width is accumulated into the total width.