### PR TITLE
DRILL-6705: Fix various failures in Crypto / Network / Phonetic functions when invalid input is given

### DIFF
--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/CryptoFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/CryptoFunctions.java
@@ -22,10 +22,8 @@ import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
-import org.apache.drill.exec.expr.annotations.Workspace;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
-import javax.crypto.Cipher;
 import javax.inject.Inject;
 
 public class CryptoFunctions {
@@ -271,34 +269,25 @@ public class CryptoFunctions {
     @Inject
     DrillBuf buffer;
 
-    @Workspace
-    Cipher cipher;
-
     @Override
     public void setup() {
-      String key = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawKey.start, rawKey.end, rawKey.buffer);
+    }
 
+    @Override
+    public void eval() {
+      String key = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawKey.start, rawKey.end, rawKey.buffer);
+      String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
+      String encryptedText = "";
       try {
-        byte[] keyByteArray = key.getBytes("UTF-8");
+        byte[] keyByteArray = key.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
         keyByteArray = sha.digest(keyByteArray);
         keyByteArray = java.util.Arrays.copyOf(keyByteArray, 16);
         javax.crypto.spec.SecretKeySpec secretKey = new javax.crypto.spec.SecretKeySpec(keyByteArray, "AES");
 
-        cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-      } catch (Exception e) {
-        //Exceptions are ignored
-      }
-    }
-
-    @Override
-    public void eval() {
-
-      String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
-      String encryptedText = "";
-      try {
-        encryptedText = javax.xml.bind.DatatypeConverter.printBase64Binary(cipher.doFinal(input.getBytes("UTF-8")));
+        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding");
+        cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, secretKey);
+        encryptedText = javax.xml.bind.DatatypeConverter.printBase64Binary(cipher.doFinal(input.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
       } catch (Exception e) {
         //Exceptions are ignored
       }
@@ -331,33 +320,24 @@ public class CryptoFunctions {
     @Inject
     DrillBuf buffer;
 
-    @Workspace
-    Cipher cipher;
-
     @Override
     public void setup() {
-      String key = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawKey.start, rawKey.end, rawKey.buffer);
+    }
 
+    @Override
+    public void eval() {
+      String key = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawKey.start, rawKey.end, rawKey.buffer);
+      String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
+      String decryptedText = "";
       try {
-        byte[] keyByteArray = key.getBytes("UTF-8");
+        byte[] keyByteArray = key.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         java.security.MessageDigest sha = java.security.MessageDigest.getInstance("SHA-1");
         keyByteArray = sha.digest(keyByteArray);
         keyByteArray = java.util.Arrays.copyOf(keyByteArray, 16);
         javax.crypto.spec.SecretKeySpec secretKey = new javax.crypto.spec.SecretKeySpec(keyByteArray, "AES");
 
-        cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-        cipher.init(Cipher.DECRYPT_MODE, secretKey);
-      } catch (Exception e) {
-        //Exceptions are ignored
-      }
-    }
-
-    @Override
-    public void eval() {
-
-      String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
-      String decryptedText = "";
-      try {
+        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/ECB/PKCS5Padding");
+        cipher.init(javax.crypto.Cipher.DECRYPT_MODE, secretKey);
         decryptedText = new String(cipher.doFinal(javax.xml.bind.DatatypeConverter.parseBase64Binary(input)));
       } catch (Exception e) {
         //Exceptions are ignored

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/NetworkFunctions.java
@@ -24,6 +24,8 @@ import org.apache.drill.exec.expr.annotations.Output;
 import org.apache.drill.exec.expr.annotations.Param;
 import org.apache.drill.exec.expr.holders.BigIntHolder;
 import org.apache.drill.exec.expr.holders.BitHolder;
+import org.apache.drill.exec.expr.holders.NullableBigIntHolder;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
 import org.apache.drill.exec.expr.holders.VarCharHolder;
 
 import javax.inject.Inject;
@@ -50,18 +52,15 @@ public class NetworkFunctions {
 
 
     public void eval() {
-
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputIP.start, inputIP.end, inputIP.buffer);
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
 
-      int result = 0;
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
-
-      if (utils.getInfo().isInRange(ipString)) {
-        result = 1;
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        out.value = utils.getInfo().isInRange(ipString) ? 1 : 0;
+      } catch (IllegalArgumentException e) {
+        // return false in case of invalid input
       }
-
-      out.value = result;
     }
   }
 
@@ -76,17 +75,20 @@ public class NetworkFunctions {
     VarCharHolder inputCIDR;
 
     @Output
-    BigIntHolder out;
+    NullableBigIntHolder out;
 
     public void setup() {
     }
 
     public void eval() {
-
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
-
-      out.value = utils.getInfo().getAddressCountLong();
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        out.value = utils.getInfo().getAddressCountLong();
+        out.isSet = 1;
+      } catch (IllegalArgumentException e) {
+        // return null in case of invalid input
+      }
     }
 
   }
@@ -101,7 +103,7 @@ public class NetworkFunctions {
     VarCharHolder inputCIDR;
 
     @Output
-    VarCharHolder out;
+    NullableVarCharHolder out;
 
     @Inject
     DrillBuf buffer;
@@ -110,16 +112,19 @@ public class NetworkFunctions {
     }
 
     public void eval() {
-
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        String outputValue = utils.getInfo().getBroadcastAddress();
 
-      String outputValue = utils.getInfo().getBroadcastAddress();
-
-      out.buffer = buffer;
-      out.start = 0;
-      out.end = outputValue.getBytes().length;
-      buffer.setBytes(0, outputValue.getBytes());
+        out.buffer = buffer;
+        out.start = 0;
+        out.end = outputValue.getBytes().length;
+        buffer.setBytes(0, outputValue.getBytes());
+        out.isSet = 1;
+      } catch (IllegalArgumentException e) {
+        // return null is case of invalid input
+      }
     }
 
   }
@@ -134,7 +139,7 @@ public class NetworkFunctions {
     VarCharHolder inputCIDR;
 
     @Output
-    VarCharHolder out;
+    NullableVarCharHolder out;
 
     @Inject
     DrillBuf buffer;
@@ -143,16 +148,19 @@ public class NetworkFunctions {
     }
 
     public void eval() {
-
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        String outputValue = utils.getInfo().getNetmask();
 
-      String outputValue = utils.getInfo().getNetmask();
-
-      out.buffer = buffer;
-      out.start = 0;
-      out.end = outputValue.getBytes().length;
-      buffer.setBytes(0, outputValue.getBytes());
+        out.buffer = buffer;
+        out.start = 0;
+        out.end = outputValue.getBytes().length;
+        buffer.setBytes(0, outputValue.getBytes());
+        out.isSet = 1;
+      } catch (IllegalArgumentException e) {
+        // return null is case of invalid input
+      }
     }
 
   }
@@ -167,7 +175,7 @@ public class NetworkFunctions {
     VarCharHolder inputCIDR;
 
     @Output
-    VarCharHolder out;
+    NullableVarCharHolder out;
 
     @Inject
     DrillBuf buffer;
@@ -176,16 +184,19 @@ public class NetworkFunctions {
     }
 
     public void eval() {
-
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        String outputValue = utils.getInfo().getLowAddress();
 
-      String outputValue = utils.getInfo().getLowAddress();
-
-      out.buffer = buffer;
-      out.start = 0;
-      out.end = outputValue.getBytes().length;
-      buffer.setBytes(0, outputValue.getBytes());
+        out.buffer = buffer;
+        out.start = 0;
+        out.end = outputValue.getBytes().length;
+        buffer.setBytes(0, outputValue.getBytes());
+        out.isSet = 1;
+      } catch (IllegalArgumentException e) {
+        // return null is case of invalid input
+      }
     }
 
   }
@@ -200,7 +211,7 @@ public class NetworkFunctions {
     VarCharHolder inputCIDR;
 
     @Output
-    VarCharHolder out;
+    NullableVarCharHolder out;
 
     @Inject
     DrillBuf buffer;
@@ -209,16 +220,19 @@ public class NetworkFunctions {
     }
 
     public void eval() {
-
       String cidrString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputCIDR.start, inputCIDR.end, inputCIDR.buffer);
-      org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+      try {
+        org.apache.commons.net.util.SubnetUtils utils = new org.apache.commons.net.util.SubnetUtils(cidrString);
+        String outputValue = utils.getInfo().getHighAddress();
 
-      String outputValue = utils.getInfo().getHighAddress();
-
-      out.buffer = buffer;
-      out.start = 0;
-      out.end = outputValue.getBytes().length;
-      buffer.setBytes(0, outputValue.getBytes());
+        out.buffer = buffer;
+        out.start = 0;
+        out.end = outputValue.getBytes().length;
+        buffer.setBytes(0, outputValue.getBytes());
+        out.isSet = 1;
+      } catch (IllegalArgumentException e) {
+        // return null is case of invalid input
+      }
     }
   }
 
@@ -226,7 +240,7 @@ public class NetworkFunctions {
    * This function encodes URL strings.
    */
   @FunctionTemplate(name = "url_encode", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
-  public static class urlencodeFunction implements DrillSimpleFunc {
+  public static class UrlEncodeFunction implements DrillSimpleFunc {
 
     @Param
     VarCharHolder inputString;
@@ -261,7 +275,7 @@ public class NetworkFunctions {
    * This function decodes URL strings.
    */
   @FunctionTemplate(name = "url_decode", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
-  public static class urldecodeFunction implements DrillSimpleFunc {
+  public static class UrlDecodeFunction implements DrillSimpleFunc {
 
     @Param
     VarCharHolder inputString;
@@ -308,27 +322,20 @@ public class NetworkFunctions {
     @Inject
     DrillBuf buffer;
 
-
     public void setup() {
     }
 
 
     public void eval() {
       StringBuilder result = new StringBuilder(15);
-
       long inputInt = in.value;
-
       for (int i = 0; i < 4; i++) {
-
         result.insert(0, Long.toString(inputInt & 0xff));
-
         if (i < 3) {
           result.insert(0, '.');
         }
-
         inputInt = inputInt >> 8;
       }
-
       String outputValue = result.toString();
 
       out.buffer = buffer;
@@ -356,13 +363,26 @@ public class NetworkFunctions {
 
     public void eval() {
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextA.start, inputTextA.end, inputTextA.buffer);
+      org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
+      if (!validator.isValidInet4Address(ipString)) {
+        return;
+      }
 
       String[] ipAddressInArray = ipString.split("\\.");
+      if (ipAddressInArray.length < 3) {
+        return;
+      }
 
-      int[] octets = new int[3];
-
-      for (int i = 0; i < 3; i++) {
-        octets[i] = Integer.parseInt(ipAddressInArray[i]);
+      // only first two octets are needed for the check
+      int[] octets = new int[2];
+      for (int i = 0; i < 2; i++) {
+        try {
+          octets[i] = Integer.parseInt(ipAddressInArray[i]);
+        } catch (NumberFormatException e) {
+          // should not happen since we validated the address
+          // but if does, return false
+          return;
+        }
       }
 
       int result = 0;
@@ -392,7 +412,7 @@ public class NetworkFunctions {
     VarCharHolder inputTextA;
 
     @Output
-    BigIntHolder out;
+    NullableBigIntHolder out;
 
     public void setup() {
     }
@@ -400,20 +420,26 @@ public class NetworkFunctions {
 
     public void eval() {
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputTextA.start, inputTextA.end, inputTextA.buffer);
-      if (ipString == null || ipString.isEmpty()) {
-        out.value = 0;
-      } else {
-        String[] ipAddressInArray = ipString.split("\\.");
+      org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
+      if (!validator.isValidInet4Address(ipString)) {
+        return;
+      }
 
-        long result = 0;
-        for (int i = 0; i < ipAddressInArray.length; i++) {
-          int power = 3 - i;
+      String[] ipAddressInArray = ipString.split("\\.");
+      long result = 0;
+      for (int i = 0; i < ipAddressInArray.length; i++) {
+        int power = 3 - i;
+        try {
           int ip = Integer.parseInt(ipAddressInArray[i]);
           result += ip * Math.pow(256, power);
+        } catch (NumberFormatException e) {
+          // should not happen since we validated the address
+          // but if does, return null
+          return;
         }
-
-        out.value = result;
       }
+      out.value = result;
+      out.isSet = 1;
     }
   }
 
@@ -435,18 +461,8 @@ public class NetworkFunctions {
 
     public void eval() {
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputIP.start, inputIP.end, inputIP.buffer);
-      if (ipString == null || ipString.isEmpty()) {
-        out.value = 0;
-      } else {
-        org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
-
-        boolean valid = validator.isValid(ipString);
-        if (valid) {
-          out.value = 1;
-        } else {
-          out.value = 0;
-        }
-      }
+      org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
+      out.value = validator.isValid(ipString) ? 1 : 0;
     }
   }
 
@@ -465,21 +481,10 @@ public class NetworkFunctions {
     public void setup() {
     }
 
-
     public void eval() {
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputIP.start, inputIP.end, inputIP.buffer);
-      if (ipString == null || ipString.isEmpty()) {
-        out.value = 0;
-      } else {
-        org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
-
-        boolean valid = validator.isValidInet4Address(ipString);
-        if (valid) {
-          out.value = 1;
-        } else {
-          out.value = 0;
-        }
-      }
+      org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
+      out.value = validator.isValidInet4Address(ipString) ? 1 : 0;
     }
   }
 
@@ -500,18 +505,8 @@ public class NetworkFunctions {
 
     public void eval() {
       String ipString = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(inputIP.start, inputIP.end, inputIP.buffer);
-      if (ipString == null || ipString.isEmpty()) {
-        out.value = 0;
-      } else {
-        org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
-
-        boolean valid = validator.isValidInet6Address(ipString);
-        if (valid) {
-          out.value = 1;
-        } else {
-          out.value = 0;
-        }
-      }
+      org.apache.commons.validator.routines.InetAddressValidator validator = org.apache.commons.validator.routines.InetAddressValidator.getInstance();
+      out.value = validator.isValidInet6Address(ipString) ? 1 : 0;
     }
   }
 }

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/PhoneticFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/PhoneticFunctions.java
@@ -383,6 +383,7 @@ public class PhoneticFunctions {
 
       String input = org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(rawInput.start, rawInput.end, rawInput.buffer);
       String outputString = new org.apache.commons.codec.language.DoubleMetaphone().doubleMetaphone(input);
+      outputString = outputString == null ? "" : outputString;
 
       out.buffer = buffer;
       out.start = 0;

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestCryptoFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestCryptoFunctions.java
@@ -17,14 +17,23 @@
  */
 package org.apache.drill.exec.udfs;
 
-import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
-public class TestCryptoFunctions extends BaseTestQuery {
+public class TestCryptoFunctions extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+  }
 
   @Test
   public void testMD5() throws Exception {
@@ -74,23 +83,48 @@ public class TestCryptoFunctions extends BaseTestQuery {
 
   @Test
   public void testAESEncrypt() throws Exception {
-    final String query = "select aes_encrypt('testing', 'secret_key') as encrypted FROM (VALUES(1))";
     testBuilder()
-      .sqlQuery(query)
+      .sqlQuery("select aes_encrypt('testing', 'secret_key') as encrypted from (values(1))")
       .ordered()
       .baselineColumns("encrypted")
       .baselineValues("ICf+zdOrLitogB8HUDru0w==")
       .go();
+
+    testBuilder()
+        .sqlQuery("select aes_encrypt(cast(null as varchar), 'secret_key') as encrypted from (values(1))")
+        .ordered()
+        .baselineColumns("encrypted")
+        .baselineValues((String) null)
+        .go();
+    testBuilder()
+        .sqlQuery("select aes_encrypt('testing', cast (null as varchar)) as encrypted from (values(1))")
+        .ordered()
+        .baselineColumns("encrypted")
+        .baselineValues((String) null)
+        .go();
   }
 
   @Test
   public void testAESDecrypt() throws Exception {
-    final String query = "select aes_decrypt('ICf+zdOrLitogB8HUDru0w==', 'secret_key') as decrypt from (values(1))";
     testBuilder()
-      .sqlQuery(query)
+      .sqlQuery("select aes_decrypt('ICf+zdOrLitogB8HUDru0w==', 'secret_key') as decrypt from (values(1))")
       .ordered()
       .baselineColumns("decrypt")
       .baselineValues("testing")
       .go();
+
+    testBuilder()
+        .sqlQuery("select aes_decrypt(cast(null as varchar), 'secret_key') as decrypt from (values(1))")
+        .ordered()
+        .baselineColumns("decrypt")
+        .baselineValues((String) null)
+        .go();
+
+    testBuilder()
+        .sqlQuery("select aes_decrypt('ICf+zdOrLitogB8HUDru0w==', cast(null as varchar)) as decrypt from (values(1))")
+        .ordered()
+        .baselineColumns("decrypt")
+        .baselineValues((String) null)
+        .go();
   }
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNetworkFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestNetworkFunctions.java
@@ -19,23 +19,44 @@ package org.apache.drill.exec.udfs;
 
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
-import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
-public class TestNetworkFunctions extends BaseTestQuery {
+public class TestNetworkFunctions extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+  }
 
   @Test
   public void testInetAton() throws Exception {
-    final String query = "select inet_aton('192.168.0.1') as inet from (values(1))";
-    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues(Long.parseLong("3232235521")).go();
+    String query = "select inet_aton('192.168.0.1') as inet from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues(3232235521L).go();
+
+    query = "select inet_aton('192.168.0') as inet from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues((Long) null).go();
+
+    query = "select inet_aton('') as inet from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues((Long) null).go();
+
+    query = "select inet_aton(cast(null as varchar)) as inet from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues((Long) null).go();
   }
 
   @Test
   public void testInetNtoa() throws Exception {
-    final String query = "select inet_ntoa(3232235521) as inet from (values(1))";
+    String query = "select inet_ntoa(3232235521) as inet from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues("192.168.0.1").go();
+
+    query = "select inet_ntoa(cast(null as int)) as inet from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("inet").baselineValues((String) null).go();
   }
 
   @Test
@@ -46,32 +67,68 @@ public class TestNetworkFunctions extends BaseTestQuery {
 
   @Test
   public void testNotInNetwork() throws Exception {
-    final String query = "select in_network('10.10.10.10', '192.168.0.0/28') as in_net FROM (values(1))";
+    String query = "select in_network('10.10.10.10', '192.168.0.0/28') as in_net from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("in_net").baselineValues(false).go();
+
+    query = "select in_network('10.10.10.10', '') as in_net from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("in_net").baselineValues(false).go();
+
+    query = "select in_network('', '192.168.0.0/28') as in_net from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("in_net").baselineValues(false).go();
+
+    query = "select in_network(cast(null as varchar), '192.168.0.0/28') as in_net from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("in_net").baselineValues((Boolean) null).go();
+
+    query = "select in_network('10.10.10.10', cast(null as varchar)) as in_net from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("in_net").baselineValues((Boolean) null).go();
   }
 
   @Test
   public void testBroadcastAddress() throws Exception {
-    final String query = "select broadcast_address( '192.168.0.0/28' ) AS broadcast_address FROM (values(1))";
+    String query = "select broadcast_address('192.168.0.0/28') as broadcast_address from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("broadcast_address").baselineValues("192.168.0.15").go();
+
+    query = "select broadcast_address('192.168.') as broadcast_address from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("broadcast_address").baselineValues((String) null).go();
+
+    query = "select broadcast_address('') as broadcast_address from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("broadcast_address").baselineValues((String) null).go();
   }
 
   @Test
   public void testNetmask() throws Exception {
-    final String query = "select netmask('192.168.0.0/28') AS netmask FROM (values(1))";
+    String query = "select netmask('192.168.0.0/28') as netmask from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("netmask").baselineValues("255.255.255.240").go();
+
+    query = "select netmask('192222') as netmask from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("netmask").baselineValues((String) null).go();
+
+    query = "select netmask('') as netmask from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("netmask").baselineValues((String) null).go();
   }
 
   @Test
   public void testLowAddress() throws Exception {
-    final String query = "SELECT low_address('192.168.0.0/28') AS low FROM (values(1))";
+    String query = "select low_address('192.168.0.0/28') as low from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("low").baselineValues("192.168.0.1").go();
+
+    query = "select low_address('192.168.0.0/') as low from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("low").baselineValues((String) null).go();
+
+    query = "select low_address('192.168.0.0/') as low from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("low").baselineValues((String) null).go();
   }
 
   @Test
   public void testHighAddress() throws Exception {
-    final String query = "SELECT high_address('192.168.0.0/28') AS high FROM (values(1))";
+    String query = "select high_address('192.168.0.0/28') as high from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("high").baselineValues("192.168.0.14").go();
+
+    query = "select high_address('192.168.0.') as high from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("high").baselineValues((String) null).go();
+
+    query = "select high_address('') as high from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("high").baselineValues((String) null).go();
   }
 
   @Test
@@ -88,8 +145,20 @@ public class TestNetworkFunctions extends BaseTestQuery {
 
   @Test
   public void testNotPrivateIP() throws Exception {
-    final String query = "SELECT is_private_ip('8.8.8.8') AS is_private_ip FROM (values(1))";
+    String query = "select is_private_ip('8.8.8.8') as is_private_ip from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("is_private_ip").baselineValues(false).go();
+
+    query = "select is_private_ip('8.A.8') as is_private_ip from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_private_ip").baselineValues(false).go();
+
+    query = "select is_private_ip('192.168') as is_private_ip from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_private_ip").baselineValues(false).go();
+
+    query = "select is_private_ip('') as is_private_ip from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_private_ip").baselineValues(false).go();
+
+    query = "select is_private_ip(cast(null as varchar)) as is_private_ip from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_private_ip").baselineValues((Boolean) null).go();
   }
 
   @Test
@@ -100,8 +169,17 @@ public class TestNetworkFunctions extends BaseTestQuery {
 
   @Test
   public void testNotValidIP() throws Exception {
-    final String query = "SELECT is_valid_IP('258.257.234.23') AS is_valid_IP FROM (values(1))";
+    String query = "select is_valid_IP('258.257.234.23') as is_valid_IP from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP").baselineValues(false).go();
+
+    query = "select is_valid_IP('258.257.2') as is_valid_IP from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP").baselineValues(false).go();
+
+    query = "select is_valid_IP('') as is_valid_IP from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP").baselineValues(false).go();
+
+    query = "select is_valid_IP(cast(null as varchar)) as is_valid_IP from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP").baselineValues((Boolean) null).go();
   }
 
   @Test
@@ -112,8 +190,17 @@ public class TestNetworkFunctions extends BaseTestQuery {
 
   @Test
   public void testNotValidIPv4() throws Exception {
-    final String query = "SELECT is_valid_IPv4( '192.168.0.257') AS is_valid_IP4 FROM (values(1))";
+    String query = "select is_valid_IPv4('192.168.0.257') as is_valid_IP4 from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP4").baselineValues(false).go();
+
+    query = "select is_valid_IPv4('192123') as is_valid_IP4 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP4").baselineValues(false).go();
+
+    query = "select is_valid_IPv4('') as is_valid_IP4 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP4").baselineValues(false).go();
+
+    query = "select is_valid_IPv4(cast(null as varchar)) as is_valid_IP4 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP4").baselineValues((Boolean) null).go();
   }
 
   @Test
@@ -130,8 +217,32 @@ public class TestNetworkFunctions extends BaseTestQuery {
 
   @Test
   public void testNotValidIPv6() throws Exception {
-    final String query = "SELECT is_valid_IPv6('1050:0:0:0:5:600:300c:326g') AS is_valid_IP6 FROM (values(1))";
+    String query = "select is_valid_IPv6('1050:0:0:0:5:600:300c:326g') as is_valid_IP6 from (values(1))";
     testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP6").baselineValues(false).go();
+
+    query = "select is_valid_IPv6('1050:0:0:0:5:600_AAA') as is_valid_IP6 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP6").baselineValues(false).go();
+
+    query = "select is_valid_IPv6('') as is_valid_IP6 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP6").baselineValues(false).go();
+
+    query = "select is_valid_IPv6(cast(null as varchar)) as is_valid_IP6 from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("is_valid_IP6").baselineValues((Boolean) null).go();
+  }
+
+  @Test
+  public void testAddressCount() throws Exception {
+    String query = "select address_count('192.168.0.1/30') as address_count from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("address_count").baselineValues(2L).go();
+
+    query = "select address_count('192.168') as address_count from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("address_count").baselineValues((Long) null).go();
+
+    query = "select address_count('192.168.0.1/100') as address_count from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("address_count").baselineValues((Long) null).go();
+
+    query = "select address_count('') as address_count from (values(1))";
+    testBuilder().sqlQuery(query).ordered().baselineColumns("address_count").baselineValues((Long) null).go();
   }
 
 }

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestPhoneticFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestPhoneticFunctions.java
@@ -19,12 +19,10 @@ package org.apache.drill.exec.udfs;
 
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
-import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,9 +30,6 @@ import static org.junit.Assert.assertEquals;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
 public class TestPhoneticFunctions extends ClusterTest {
-
-  @Rule
-  public final BaseDirTestWatcher baseDirTestWatcher = new BaseDirTestWatcher();
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -112,5 +107,10 @@ public class TestPhoneticFunctions extends ClusterTest {
         .sql("SELECT double_metaphone('Phoenix') AS meta FROM (VALUES(1))")
         .singletonString();
     assertEquals("FNKS", result);
+
+    result = queryBuilder()
+        .sql("SELECT double_metaphone('') AS meta FROM (VALUES(1))")
+        .singletonString();
+    assertEquals("", result);
   }
 }


### PR DESCRIPTION
1. aes_decrypt / aes_ecrypt - moved cyper init part into eval method since it not a constant and can be different for each input
2. double_metaphone - fixed NPE when given string is empty
3. in_network / address_count / broadcast_address / netmask / low_address / high_address / - fixed IllegalArgumentException in case of invalid input
4. is_private_ip / inet_aton - fixed ArrayIndexOutOfBoundsException / NumberFormatException in case of invalid input
5. is_valid_IP / is_valid_IPv4 / is_valid_IPv6 - removed unnecessary checks
6. Added appropriate unit tests