### PR TITLE
DRILL-6712: Creation of jdbc storage plugin fails with NoSuchMethod

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
-      <version>2.1</version>
+      <version>2.6.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Update of commons-pool2 dependency