### PR TITLE
DRILL-6684: Swap sys.options and sys.options_val tables

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -31,28 +31,30 @@ import org.apache.drill.exec.store.sys.OptionIterator.OptionValueWrapper;
  * </p>
  */
 public enum SystemTable {
-  OPTION("options", false, OptionValueWrapper.class) {
+  OPTIONS_OLD("options_old", false, OptionValueWrapper.class) {
+    @Deprecated
     @Override
     public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_PUBLIC);
     }
   },
 
-  OPTION_VAL("options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
+  OPTIONS("options", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
     @Override
     public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ExtendedOptionIterator(context, false);
     }
   },
 
-  INTERNAL_OPTIONS("internal_options", false, OptionValueWrapper.class) {
+  INTERNAL_OPTIONS_OLD("internal_options_old", false, OptionValueWrapper.class) {
+    @Deprecated
     @Override
     public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new OptionIterator(context, OptionIterator.Mode.SYS_SESS_INTERNAL);
     }
   },
 
-  INTERNAL_OPTIONS_VAL("internal_options_val", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
+  INTERNAL_OPTIONS("internal_options", false, ExtendedOptionIterator.ExtendedOptionValueWrapper.class) {
     @Override
     public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ExtendedOptionIterator(context, true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -89,7 +89,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
   @Test
   public void testCountDistinctOnBoolColumn() throws Exception {
     testBuilder()
-        .sqlQuery("select count(distinct `bool_val`) as cnt from `sys`.`options`")
+        .sqlQuery("select count(distinct `bool_val`) as cnt from `sys`.`options_old`")
         .ordered()
         .baselineColumns("cnt")
         .baselineValues(2L)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptions.java
@@ -82,10 +82,10 @@ public class TestOptions extends BaseTestQuery {
     // check changed
     test("SELECT status, accessibleScopes, name FROM sys.options WHERE optionScope = 'SESSION';");
     testBuilder()
-      .sqlQuery("SELECT num_val FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
+      .sqlQuery("SELECT val FROM sys.options WHERE name = '%s' AND optionScope = 'SESSION'", SLICE_TARGET)
       .unOrdered()
-      .baselineColumns("num_val")
-      .baselineValues((long) 10)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(10L))
       .build()
       .run();
 
@@ -115,10 +115,10 @@ public class TestOptions extends BaseTestQuery {
     test("ALTER system SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
-      .baselineColumns("bool_val")
-      .baselineValues(true)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
 
@@ -140,10 +140,10 @@ public class TestOptions extends BaseTestQuery {
     test("SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
-      .baselineColumns("bool_val")
-      .baselineValues(true)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
 
@@ -165,7 +165,7 @@ public class TestOptions extends BaseTestQuery {
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -173,12 +173,21 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
       .build()
       .run();
+    // check changed new table
+    testBuilder()
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .unOrdered()
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
+      .build()
+      .run();
+
 
     // reset session option
     test("RESET `%s`;", ENABLE_VERBOSE_ERRORS_KEY);
@@ -191,10 +200,10 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check unchanged
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
-      .baselineColumns("bool_val")
-      .baselineValues(true)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
     // reset system option
@@ -208,7 +217,7 @@ public class TestOptions extends BaseTestQuery {
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -216,10 +225,18 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
+      .build()
+      .run();
+    // check changed for new table
+    testBuilder()
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .unOrdered()
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
 
@@ -234,10 +251,10 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
-      .baselineColumns("bool_val")
-      .baselineValues(true)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
   }
@@ -249,7 +266,7 @@ public class TestOptions extends BaseTestQuery {
     test("ALTER SYSTEM SET `%s` = %b;", ENABLE_VERBOSE_ERRORS_KEY, true);
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
@@ -257,10 +274,18 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT bool_val FROM sys.options_old WHERE optionScope = 'SYSTEM' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("bool_val")
       .baselineValues(true)
+      .build()
+      .run();
+    // check changed in new table
+    testBuilder()
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .unOrdered()
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
 
@@ -268,7 +293,7 @@ public class TestOptions extends BaseTestQuery {
     test("ALTER system RESET `%s`;", ENABLE_VERBOSE_ERRORS_KEY);
     // check reverted
     testBuilder()
-      .sqlQuery("SELECT status FROM sys.options WHERE name = '%s' AND optionScope = 'BOOT'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT status FROM sys.options_old WHERE optionScope = 'BOOT' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
       .baselineColumns("status")
       .baselineValues("DEFAULT")
@@ -276,10 +301,10 @@ public class TestOptions extends BaseTestQuery {
       .run();
     // check changed
     testBuilder()
-      .sqlQuery("SELECT bool_val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
+      .sqlQuery("SELECT val FROM sys.options WHERE optionScope = 'SESSION' AND name = '%s'", ENABLE_VERBOSE_ERRORS_KEY)
       .unOrdered()
-      .baselineColumns("bool_val")
-      .baselineValues(true)
+      .baselineColumns("val")
+      .baselineValues(String.valueOf(true))
       .build()
       .run();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestOptionsAuthEnabled.java
@@ -113,11 +113,11 @@ public class TestOptionsAuthEnabled extends BaseTestQuery {
     try {
       test(setSysOptionQuery);
       testBuilder()
-          .sqlQuery(String.format("SELECT num_val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'",
+          .sqlQuery(String.format("SELECT val FROM sys.options WHERE name = '%s' AND optionScope = 'SYSTEM'",
               ExecConstants.SLICE_TARGET))
           .unOrdered()
-          .baselineColumns("num_val")
-          .baselineValues(200L)
+          .baselineColumns("val")
+          .baselineValues(String.valueOf(200L))
           .go();
     } finally {
       test(String.format("ALTER SYSTEM SET `%s` = %d;", ExecConstants.SLICE_TARGET, ExecConstants.SLICE_TARGET_DEFAULT));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
@@ -62,9 +62,9 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String mockProp = client.queryBuilder().
-        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY).singletonString();
+        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), MOCK_PROPERTY).singletonString();
       String mockProp2 = client.queryBuilder().
-        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), MOCK_PROPERTY).singletonString();
+        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY).singletonString();
 
       assertEquals("a", mockProp);
       assertEquals("a", mockProp2);
@@ -82,9 +82,9 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String mockProp = client.queryBuilder().
-        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY).singletonString();
+        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), MOCK_PROPERTY).singletonString();
       String mockProp2 = client.queryBuilder().
-        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), MOCK_PROPERTY).singletonString();
+        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY).singletonString();
 
       assertEquals("a", mockProp);
       assertEquals("a", mockProp2);
@@ -98,7 +98,7 @@ public class TestConfigLinkage {
       .sessionOption(ExecConstants.SLICE_TARGET, 10);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SESSION'", SystemTable.OPTION_VAL
+      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SESSION'", SystemTable.OPTIONS
         .getTableName())
         .singletonString();
       assertEquals(slice_target, "10");
@@ -112,7 +112,7 @@ public class TestConfigLinkage {
       .systemOption(ExecConstants.SLICE_TARGET, 10000);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SYSTEM'", SystemTable.OPTION_VAL.getTableName())
+      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SYSTEM'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals(slice_target, "10000");
     }
@@ -130,10 +130,10 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String mockProp = client.queryBuilder().
-        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY)
+        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), MOCK_PROPERTY)
         .singletonString();
       String mockProp2 = client.queryBuilder().
-        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), MOCK_PROPERTY)
+        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS.getTableName(), MOCK_PROPERTY)
         .singletonString();
 
       assertEquals("blah", mockProp);
@@ -148,7 +148,7 @@ public class TestConfigLinkage {
             .setOptionDefault(ExecConstants.SLICE_TARGET, 1000);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'BOOT'", SystemTable.OPTION_VAL.getTableName())
+      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'BOOT'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals(slice_target, "1000");
     }
@@ -160,7 +160,7 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = ClusterFixture.standardCluster(dirTestWatcher);
          ClientFixture client = cluster.clientFixture()) {
       client.queryBuilder().sql("ALTER SYSTEM SET `planner.slice_target` = 10000").run();
-      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SYSTEM'", SystemTable.OPTION_VAL.getTableName())
+      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SYSTEM'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals(slice_target, "10000");
     }
@@ -174,7 +174,7 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       client.queryBuilder().sql("ALTER SESSION SET `planner.slice_target` = 10000").run();
-      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SESSION'", SystemTable.OPTION_VAL.getTableName())
+      String slice_target = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.slice_target' and optionScope = 'SESSION'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals(slice_target, "10000");
     }
@@ -187,7 +187,7 @@ public class TestConfigLinkage {
       .setOptionDefault(ExecConstants.MAX_WIDTH_PER_NODE_KEY, 2);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'BOOT'", SystemTable.OPTION_VAL.getTableName())
+      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'BOOT'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals("2", maxWidth);
     }
@@ -200,7 +200,7 @@ public class TestConfigLinkage {
       .systemOption(ExecConstants.MAX_WIDTH_PER_NODE_KEY, 3);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'SYSTEM'", SystemTable.OPTION_VAL.getTableName())
+      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'SYSTEM'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals("3", maxWidth);
     }
@@ -213,7 +213,7 @@ public class TestConfigLinkage {
       .sessionOption(ExecConstants.MAX_WIDTH_PER_NODE_KEY, 2);
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
-      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'SESSION'", SystemTable.OPTION_VAL.getTableName())
+      String maxWidth = client.queryBuilder().sql("SELECT val FROM sys.%s where name='planner.width.max_per_node' and optionScope = 'SESSION'", SystemTable.OPTIONS.getTableName())
         .singletonString();
       assertEquals("2", maxWidth);
     }
@@ -243,7 +243,7 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String scope = client.queryBuilder()
-                          .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTION_VAL.getTableName())
+                          .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTIONS.getTableName())
                           .singletonString();
       Assert.assertEquals("BOOT",scope);
     }
@@ -257,7 +257,7 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String scope = client.queryBuilder()
-              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTION_VAL.getTableName())
+              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTIONS.getTableName())
               .singletonString();
       Assert.assertEquals("SYSTEM",scope);
     }
@@ -271,7 +271,7 @@ public class TestConfigLinkage {
     try (ClusterFixture cluster = builder.build();
          ClientFixture client = cluster.clientFixture()) {
       String scope = client.queryBuilder()
-              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTION_VAL.getTableName())
+              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTIONS.getTableName())
               .singletonString();
       Assert.assertEquals("SESSION",scope);
     }
@@ -285,7 +285,7 @@ public class TestConfigLinkage {
          ClientFixture client = cluster.clientFixture()) {
       client.queryBuilder().sql("ALTER SYSTEM set `planner.slice_target`= 10000").run();
       String scope = client.queryBuilder()
-              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTION_VAL.getTableName())
+              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTIONS.getTableName())
               .singletonString();
       Assert.assertEquals("SYSTEM",scope);
     }
@@ -299,7 +299,7 @@ public class TestConfigLinkage {
          ClientFixture client = cluster.clientFixture()) {
       client.queryBuilder().sql("ALTER SESSION set `planner.slice_target`= 10000").run();
       String scope = client.queryBuilder()
-              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTION_VAL.getTableName())
+              .sql("SELECT optionScope from sys.%s where name='planner.slice_target'", SystemTable.OPTIONS.getTableName())
               .singletonString();
       Assert.assertEquals("SESSION",scope);
     }
@@ -317,13 +317,13 @@ public class TestConfigLinkage {
          ClientFixture client = cluster.clientFixture()) {
       client.queryBuilder().sql("ALTER SYSTEM SET `%s` = 'bleh'", MOCK_PROPERTY).run();
 
+      client.queryBuilder().sql("SELECT * FROM sys.%s", SystemTable.INTERNAL_OPTIONS_OLD.getTableName()).logCsv();
       client.queryBuilder().sql("SELECT * FROM sys.%s", SystemTable.INTERNAL_OPTIONS.getTableName()).logCsv();
-      client.queryBuilder().sql("SELECT * FROM sys.%s", SystemTable.INTERNAL_OPTIONS_VAL.getTableName()).logCsv();
 
       String mockProp = client.queryBuilder().
-        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS, MOCK_PROPERTY).singletonString();
+        sql("SELECT string_val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_OLD, MOCK_PROPERTY).singletonString();
       String mockProp2 = client.queryBuilder().
-        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS_VAL, MOCK_PROPERTY).singletonString();
+        sql("SELECT val FROM sys.%s where name='%s'", SystemTable.INTERNAL_OPTIONS, MOCK_PROPERTY).singletonString();
 
       assertEquals("bleh", mockProp);
       assertEquals("bleh", mockProp2);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestPStoreProviders.java
@@ -94,13 +94,13 @@ public class TestPStoreProviders extends TestWithZookeeper {
          ClientFixture client = cluster.clientFixture()) {
       String parquetPushdown = client.queryBuilder().
         sql("SELECT val FROM sys.%s where name='%s'",
-          SystemTable.OPTION_VAL.getTableName(),
+          SystemTable.OPTIONS.getTableName(),
           PlannerSettings.PARQUET_ROWGROUP_FILTER_PUSHDOWN_PLANNING_THRESHOLD_KEY).
         singletonString();
 
       String plannerWidth = client.queryBuilder().
         sql("SELECT val FROM sys.%s where name='%s'",
-          SystemTable.OPTION_VAL.getTableName(),
+          SystemTable.OPTIONS.getTableName(),
           ExecConstants.MAX_WIDTH_GLOBAL_KEY).
         singletonString();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -37,16 +37,16 @@ public class TestSystemTable extends PlanTestBase {
   public void alterSessionOption() throws Exception {
 
     newTest() //
-      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by accessibleScopes desc", ExecConstants.JSON_ALL_TEXT_MODE)
+      .sqlQuery("select val as bool from sys.options where name = '%s' order by accessibleScopes desc", ExecConstants.JSON_ALL_TEXT_MODE)
       .baselineColumns("bool")
       .ordered()
-      .baselineValues(false)
+      .baselineValues(String.valueOf(false))
       .go();
 
     test("alter session set `%s` = true", ExecConstants.JSON_ALL_TEXT_MODE);
 
-    newTest() //
-      .sqlQuery("select bool_val as bool from sys.options where name = '%s' order by accessibleScopes desc ", ExecConstants.JSON_ALL_TEXT_MODE)
+    newTest() //Using old table to detect both optionScopes: BOOT & SESSION
+      .sqlQuery("select bool_val as bool from sys.options_old where name = '%s' order by accessibleScopes desc ", ExecConstants.JSON_ALL_TEXT_MODE)
       .baselineColumns("bool")
       .ordered()
       .baselineValues(false)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -160,12 +160,12 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "drillbits", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
     verifyTable("sys", "threads", tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
     verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test
@@ -198,12 +198,12 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "drillbits", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
     verifyTable("sys", "threads", tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
     verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test
@@ -220,11 +220,11 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     verifyTable("sys", "boot", tables);
     verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTION.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTION_VAL.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
+    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
     verifyTable("sys", "version", tables);
+    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
     verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_VAL.getTableName(), tables);
   }
 
   @Test


### PR DESCRIPTION
(As a follow up to DRILL-5735)

The current sys.options table has a verbose layout, because of which sys.options_internal was introduced. The latter supports `descriptions`, which means it makes sense to have that table as the new `sys.options`. The recommendation is to deprecate the old format, so that any dependencies continue to make use of it as long as required.
Existing tests have been patched to account for the swap.