### PR TITLE
DRILL-6733: Unit tests from KafkaFilterPushdownTest are failing in so…

### DIFF
--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaTestBase.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaTestBase.java
@@ -86,7 +86,9 @@ public class KafkaTestBase extends PlanTestBase {
 
   @AfterClass
   public static void tearDownKafkaTestBase() throws Exception {
-    TestKafkaSuit.tearDownCluster();
+    if (TestKafkaSuit.isRunningSuite()) {
+      TestKafkaSuit.tearDownCluster();
+    }
   }
 
 }


### PR DESCRIPTION
…me environments.

Added a check that prevents the cluster tear down if TestKafkaSuit is not running.