### PR TITLE
DRILL-6747: Fixed IOB in HashJoin for inner and right joins on empty probe side

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -174,7 +174,7 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
       first = false;
 
       if (batch == null) {
-        batchLoader.clear();
+        batchLoader.zero();
         if (!context.getExecutorState().shouldContinue()) {
           return IterOutcome.STOP;
         }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -115,6 +115,14 @@ public interface RecordBatch extends VectorAccessible {
      *   This value will be returned only after {@link #OK_NEW_SCHEMA} has been
      *   returned at least once (not necessarily <em>immediately</em> after).
      * </p>
+     * <p>
+     *   Also after a RecordBatch returns NONE a RecordBatch should:
+     *   <ul>
+     *     <li>Contain the last valid schema seen by the operator.</li>
+     *     <li>Contain a VectorContainer with empty columns corresponding to the last valid schema.</li>
+     *     <li>Return a record count of 0.</li>
+     *   </ul>
+     * </p>
      */
     NONE(false),
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
@@ -277,6 +277,14 @@ public class RecordBatchLoader implements VectorAccessible, Iterable<VectorWrapp
   public void resetRecordCount() { valueCount = 0; }
 
   /**
+   * Removes an data from the loader, but maintains the schema and empty vectors.
+   */
+  public void zero() {
+    container.zeroVectors();
+    resetRecordCount();
+  }
+
+  /**
    * Clears this loader, which clears the internal vector container (see
    * {@link VectorContainer#clear}) and resets the record count to zero.
    */


### PR DESCRIPTION
 - Fixed IOB in HashJoin for inner and right joins on empty probe side.
 - Documentated expected behavior of RecordBatch after returning NONE.
 - Made UnorderedReceiver obey contract after returning NONE.