### PR TITLE
DRILL-6762: Dynamic UDFs registered on 1 Drillbit not visible on others

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -408,7 +408,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
    * @return true is local registry should be refreshed, false otherwise
    */
   private boolean isRegistrySyncNeeded(long remoteVersion, long localVersion) {
-    return remoteVersion != -1 && remoteVersion != localVersion;
+    return remoteVersion != RemoteFunctionRegistry.UNREACHABLE && remoteVersion != localVersion;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
@@ -84,6 +84,7 @@ public class RemoteFunctionRegistry implements AutoCloseable {
   private static final String registry_path = "registry";
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RemoteFunctionRegistry.class);
   private static final ObjectMapper mapper = new ObjectMapper().enable(INDENT_OUTPUT);
+  public static final int UNREACHABLE = Integer.MIN_VALUE;
 
   private final TransientStoreListener unregistrationListener;
   private int retryAttempts;
@@ -108,9 +109,9 @@ public class RemoteFunctionRegistry implements AutoCloseable {
 
   /**
    * Returns current remote function registry version.
-   * If remote function registry is not found or unreachable, logs error and returns -1.
+   * If remote function registry is not found or unreachable, logs error and returns UNREACHABLE (Integer.MIN_VALUE) .
    *
-   * @return remote function registry version if any, -1 otherwise
+   * @return remote function registry version if any, RemoteFunctionRegistry.UNREACHABLE otherwise
    */
   public long getRegistryVersion() {
     DataChangeVersion version = new DataChangeVersion();
@@ -124,7 +125,7 @@ public class RemoteFunctionRegistry implements AutoCloseable {
       return version.getVersion();
     } else {
       logger.error("Remote function registry [{}] is unreachable", registry_path);
-      return -1;
+      return UNREACHABLE;
     }
   }
 


### PR DESCRIPTION
The issue is with the registry version value of -1 being, both a valid version number and indicative of the (remote) registry being unreachable. DRILL-6053 exacerbates this ambiguity. The workaround is to provide a different value for the registry version when it is unreachable. In this case, we picked Integer.MIN_VALUE which is << -1 