### PR TITLE
DRILL-3988: Expose Drill built-in functions & UDFs  in a system table

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -293,10 +293,6 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
     return false;
   }
 
-  public LocalFunctionRegistry getLocalFunctionRegistry() {
-    return localFunctionRegistry;
-  }
-
   public RemoteFunctionRegistry getRemoteFunctionRegistry() {
     return remoteFunctionRegistry;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -491,13 +491,13 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
 
   /**
    * Retrieve all functions, mapped by source jars (after syncing)
-   * @return Map of source jars and their functions
+   * @return Map of source jars and their functionHolders
    */
-  public Map<String, List<FunctionHolder>> getAllFunctionsHoldersByJar() {
+  public Map<String, List<FunctionHolder>> getAllJarsWithFunctionsHolders() {
     if (useDynamicUdfs) {
       syncWithRemoteRegistry(localFunctionRegistry.getVersion());
     }
-    return localFunctionRegistry.getAllFunctionsHoldersByJar();
+    return localFunctionRegistry.getAllJarsWithFunctionsHolders();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -28,6 +28,7 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,6 +55,7 @@ import org.apache.drill.exec.coord.store.TransientStoreListener;
 import org.apache.drill.exec.exception.FunctionValidationException;
 import org.apache.drill.exec.exception.JarValidationException;
 import org.apache.drill.exec.expr.fn.registry.LocalFunctionRegistry;
+import org.apache.drill.exec.expr.fn.registry.FunctionHolder;
 import org.apache.drill.exec.expr.fn.registry.JarScan;
 import org.apache.drill.exec.expr.fn.registry.RemoteFunctionRegistry;
 import org.apache.drill.exec.planner.sql.DrillOperatorTable;
@@ -291,6 +293,10 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
     return false;
   }
 
+  public LocalFunctionRegistry getLocalFunctionRegistry() {
+    return localFunctionRegistry;
+  }
+
   public RemoteFunctionRegistry getRemoteFunctionRegistry() {
     return remoteFunctionRegistry;
   }
@@ -481,6 +487,17 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
       }
     }
     return missingJars;
+  }
+
+  /**
+   * Retrieve all functions, mapped by source jars (after syncing)
+   * @return Map of source jars and their functions
+   */
+  public Map<String, List<FunctionHolder>> getAllFunctionsHoldersByJar() {
+    if (useDynamicUdfs) {
+      syncWithRemoteRegistry(localFunctionRegistry.getVersion());
+    }
+    return localFunctionRegistry.getAllFunctionsHoldersByJar();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
@@ -236,6 +236,14 @@ public class LocalFunctionRegistry {
   }
 
   /**
+   * Returns a map of all function holders mapped by source jars
+   * @return all functions organized by source jars
+   */
+  public Map<String, List<FunctionHolder>> getAllFunctionsHoldersByJar() {
+    return registryHolder.getAllFunctionHoldersByJar();
+  }
+
+  /**
    * Registers all functions present in {@link DrillOperatorTable},
    * also sets sync registry version used at the moment of function registration.
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
@@ -239,8 +239,8 @@ public class LocalFunctionRegistry {
    * Returns a map of all function holders mapped by source jars
    * @return all functions organized by source jars
    */
-  public Map<String, List<FunctionHolder>> getAllFunctionsHoldersByJar() {
-    return registryHolder.getAllFunctionHoldersByJar();
+  public Map<String, List<FunctionHolder>> getAllJarsWithFunctionsHolders() {
+    return registryHolder.getAllJarsWithFunctionHolders();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -239,6 +239,8 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     Preconditions.checkArgument(this.buffers == null, "Can only set buffers once.");
     this.buffers = buffers;
   }
+
+  @Override
   public QueryProfileStoreContext getProfileStoreContext() {
     return context.getProfileStoreContext();
   }
@@ -248,6 +250,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return context.getUserConnections();
   }
 
+  @Override
   public void setExecutorState(final ExecutorState executorState) {
     Preconditions.checkArgument(this.executorState == null, "ExecutorState can only be set once.");
     this.executorState = executorState;
@@ -257,6 +260,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     executorState.fail(cause);
   }
 
+  @Override
   public SchemaPlus getFullRootSchema() {
     if (queryContext == null) {
       fail(new UnsupportedOperationException("Schema tree can only be created in root fragment. " +
@@ -278,6 +282,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return queryContext.getFullRootSchema(schemaConfig);
   }
 
+  @Override
   public FragmentStats getStats() {
     return stats;
   }
@@ -326,10 +331,12 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
    * The FragmentHandle for this Fragment
    * @return FragmentHandle
    */
+  @Override
   public FragmentHandle getHandle() {
     return fragment.getHandle();
   }
 
+  @Override
   public String getFragIdString() {
     final FragmentHandle handle = getHandle();
     final String frag = handle != null ? handle.getMajorFragmentId() + ":" + handle.getMinorFragmentId() : "0:0";
@@ -361,6 +368,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
    * Get this fragment's allocator.
    * @return the allocator
    */
+  @Override
   @Deprecated
   public BufferAllocator getAllocator() {
     if (allocator == null) {
@@ -411,10 +419,12 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return tunnel;
   }
 
+  @Override
   public IncomingBuffers getBuffers() {
     return buffers;
   }
 
+  @Override
   public OperatorContext newOperatorContext(PhysicalOperator popConfig, OperatorStats stats)
       throws OutOfMemoryException {
     OperatorContextImpl context = new OperatorContextImpl(popConfig, this, stats);
@@ -422,6 +432,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return context;
   }
 
+  @Override
   public OperatorContext newOperatorContext(PhysicalOperator popConfig)
       throws OutOfMemoryException {
     OperatorContextImpl context = new OperatorContextImpl(popConfig, this);
@@ -444,10 +455,12 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return executionControls;
   }
 
+  @Override
   public String getQueryUserName() {
     return fragment.getCredentials().getUserName();
   }
 
+  @Override
   public boolean isImpersonationEnabled() {
     // TODO(DRILL-2097): Until SimpleRootExec tests are removed, we need to consider impersonation disabled if there is
     // no config
@@ -509,6 +522,7 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
     return valueHolder;
   }
 
+  @Override
   public ExecutorService getExecutor(){
     return context.getExecutor();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -261,7 +261,9 @@ public class DrillbitContext implements AutoCloseable {
     return classpathScan;
   }
 
-  public RemoteFunctionRegistry getRemoteFunctionRegistry() { return functionRegistry.getRemoteFunctionRegistry(); }
+  public RemoteFunctionRegistry getRemoteFunctionRegistry() {
+    return functionRegistry.getRemoteFunctionRegistry();
+  }
 
   /**
    * Use the operator table built during startup when "exec.udf.use_dynamic" option

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FunctionsIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FunctionsIterator.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.store.sys;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -50,30 +49,32 @@ public class FunctionsIterator implements Iterator<Object> {
     }
 
     List<FunctionInfo> functionList = new ArrayList<FunctionsIterator.FunctionInfo>(functionMap.values());
-    functionList.sort(new Comparator<FunctionInfo>() {
-      @Override
-      public int compare(FunctionInfo o1, FunctionInfo o2) {
-        int result = o1.name.compareTo(o2.name);
-        if (result == 0) {
-          result = o1.signature.compareTo(o2.signature);
-        }
-        if (result == 0) {
-          return o1.returnType.compareTo(o2.returnType);
-        }
-        return result;
+    functionList.sort((FunctionInfo o1, FunctionInfo o2) -> {
+      int result = o1.name.compareTo(o2.name);
+      if (result == 0) {
+        result = o1.signature.compareTo(o2.signature);
       }
+      if (result == 0) {
+        return o1.returnType.compareTo(o2.returnType);
+      }
+      return result;
     });
 
     sortedIterator = functionList.iterator();
   }
 
-  //Populate the map for a given Jar-DrillFunctionHolder
+  /**
+   * Populate the map of functionInfo based on the functionSignatureKey for a given Jar-DrillFunctionHolder
+   * @param functionMap map to populate
+   * @param jarName name of the source jar
+   * @param dfh functionHolder that carries all the registered names and the signature
+   */
   private void populateFunctionMap(Map<String, FunctionInfo> functionMap, String jarName, DrillFuncHolder dfh) {
     String registeredNames[] = dfh.getRegisteredNames();
     String signature = dfh.getInputParameters();
     String returnType = dfh.getReturnType().getMinorType().toString();
     for (String name : registeredNames) {
-      //Generate a uniqueKey to allow for fnName#fnSignature
+      //Generate a unique key for a function holder as 'functionName#functionSignature'
       String funcSignatureKey = new StringBuilder(64).append(name).append('#').append(signature).toString();
       functionMap.put(funcSignatureKey, new FunctionInfo(name, signature, returnType, jarName));
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FunctionsIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/FunctionsIterator.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.drill.exec.expr.fn.DrillFuncHolder;
+import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.expr.fn.registry.FunctionHolder;
+import org.apache.drill.exec.expr.fn.registry.LocalFunctionRegistry;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.store.pojo.NonNullable;
+
+/**
+ * List functions as a System Table
+ */
+public class FunctionsIterator implements Iterator<Object> {
+  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FunctionsIterator.class);
+
+  private Iterator<FunctionInfo> sortedIterator;
+
+  public FunctionsIterator(ExecutorFragmentContext context) {
+    Map<String, FunctionInfo> functionMap = new HashMap<String, FunctionInfo>();
+    //Access Registry for function list
+    FunctionImplementationRegistry funcImplRegistry = (FunctionImplementationRegistry) context.getFunctionRegistry();
+    Map<String, List<FunctionHolder>>  jarFunctionListMap = funcImplRegistry.getAllFunctionsHoldersByJar();
+
+    //Step 1: Load Built-In
+    for (FunctionHolder builtInEntry : jarFunctionListMap.get(LocalFunctionRegistry.BUILT_IN)) {
+      populateFunctionMap(functionMap, LocalFunctionRegistry.BUILT_IN, builtInEntry.getHolder());
+    }
+    //Step 2: Load UDFs
+    for (String jarName : new ArrayList<>(jarFunctionListMap.keySet())) {
+      if (!jarName.equals(LocalFunctionRegistry.BUILT_IN)) {
+        for (FunctionHolder udfEntry : jarFunctionListMap.get(jarName)) {
+          populateFunctionMap(functionMap, jarName, udfEntry.getHolder());
+        }
+      }
+    }
+
+    List<FunctionInfo> functionList = new ArrayList<FunctionsIterator.FunctionInfo>(functionMap.values());
+    functionList.sort(new Comparator<FunctionInfo>() {
+      @Override
+      public int compare(FunctionInfo o1, FunctionInfo o2) {
+        int result = o1.name.compareTo(o2.name);
+        if (result == 0) {
+          result = o1.signature.compareTo(o2.signature);
+        }
+        if (result == 0) {
+          return o1.returnType.compareTo(o2.returnType);
+        }
+        return result;
+      }
+    });
+
+    sortedIterator = functionList.iterator();
+  }
+
+  //Populate for give Jar-FunctionHolder Entry
+  private void populateFunctionMap(Map<String, FunctionInfo> functionMap, String jarName, DrillFuncHolder dfh) {
+    String registeredNames[] = dfh.getRegisteredNames();
+    String signature = dfh.getInputParameters();
+    String returnType = dfh.getReturnType().getMinorType().toString();
+    for (String name : registeredNames) {
+      //Generate a uniqueKey to allow for fnName#fnSignature
+      String funcSignatureKey = new StringBuilder(64).append(name).append('#').append(signature).toString();
+      functionMap.put(funcSignatureKey, new FunctionInfo(name, signature, returnType, jarName));
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return sortedIterator.hasNext();
+  }
+
+  @Override
+  public FunctionInfo next() {
+    return sortedIterator.next();
+  }
+
+  public static class FunctionInfo {
+    @NonNullable
+    public final String name;
+    @NonNullable
+    public final String signature;
+    public final String returnType;
+    public final String source;
+
+    public FunctionInfo(String funcName, String funcSignature, String funcReturnType, String jarName) {
+      this.name = funcName;
+      this.signature = funcSignature;
+      this.returnType = funcReturnType;
+      this.source = jarName;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTable.java
@@ -112,8 +112,15 @@ public enum SystemTable {
 
   THREADS("threads", true, ThreadsIterator.ThreadsInfo.class) {
     @Override
-  public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
       return new ThreadsIterator(context);
+    }
+  },
+
+  FUNCTIONS("functions", false, FunctionsIterator.FunctionInfo.class) {
+    @Override
+    public Iterator<Object> getIterator(final ExecutorFragmentContext context, final int maxRecords) {
+      return new FunctionsIterator(context);
     }
   };
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.expr.fn.registry;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
 import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.exec.expr.fn.DrillFuncHolder;
 import org.junit.Before;
@@ -28,6 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,11 +61,11 @@ public class FunctionRegistryHolderTest {
     FunctionHolder lower = new FunctionHolder(LOWER_FUNC_NAME, "lower(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder upper = new FunctionHolder("upper", "upper(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder shuffle = new FunctionHolder(SHUFFLE_FUNC_NAME, "shuffle()", mock(DrillFuncHolder.class));
-    newJars.put(built_in, Lists.newArrayList(lower, upper, shuffle));
+    newJars.put(built_in, new ArrayList<>(Arrays.asList(lower, upper, shuffle)));
     FunctionHolder custom_lower = new FunctionHolder("custom_lower", "lower(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder custom_upper = new FunctionHolder("custom_upper", "custom_upper(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder overloaded_shuffle = new FunctionHolder(SHUFFLE_FUNC_NAME, "shuffle(FLOAT8-REQUIRED,FLOAT8-OPTIONAL)", mock(DrillFuncHolder.class));
-    newJars.put(udf_jar, Lists.newArrayList(custom_lower, custom_upper, overloaded_shuffle));
+    newJars.put(udf_jar, new ArrayList<>(Arrays.asList(custom_lower, custom_upper, overloaded_shuffle)));
   }
 
   @Before
@@ -166,7 +166,7 @@ public class FunctionRegistryHolderTest {
   public void testGetAllJarsWithFunctionHolders() {
     Map<String, List<FunctionHolder>> fnHoldersInRegistry = registryHolder.getAllJarsWithFunctionHolders();
     //Iterate and confirm lists are same
-    for (String jarName : Lists.newArrayList(newJars.keySet())) {
+    for (String jarName : newJars.keySet()) {
       List<DrillFuncHolder> expectedHolderList = newJars.get(jarName).stream()
           .map(FunctionHolder::getHolder) //Extract DrillFuncHolder
           .collect(Collectors.toList());
@@ -180,7 +180,7 @@ public class FunctionRegistryHolderTest {
     Map<String, String> shuffleFunctionMap = new HashMap<>();
     // Confirm that same function spans multiple jars with different signatures
     //Init: Expected Map of items
-    for (String jarName : Lists.newArrayList(newJars.keySet())) {
+    for (String jarName : newJars.keySet()) {
       for (FunctionHolder funcHolder : newJars.get(jarName)) {
         if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {
           shuffleFunctionMap.put(funcHolder.getSignature(), jarName);
@@ -262,8 +262,8 @@ public class FunctionRegistryHolderTest {
 
   @Test
   public void testGetHoldersByFunctionName() {
-    List<DrillFuncHolder> expectedUniqueResult = Lists.newArrayList();
-    List<DrillFuncHolder> expectedMultipleResult = Lists.newArrayList();
+    List<DrillFuncHolder> expectedUniqueResult = new ArrayList<>();
+    List<DrillFuncHolder> expectedMultipleResult = new ArrayList<>();
     for (List<FunctionHolder> functionHolders : newJars.values()) {
       for (FunctionHolder functionHolder : functionHolders) {
         if (LOWER_FUNC_NAME.equals(functionHolder.getName())) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -163,11 +163,18 @@ public class FunctionRegistryHolderTest {
   }
 
   @Test
-  public void testGetAllFunctionHoldersByJar() {
-    Map<String, List<FunctionHolder>> fnHoldersInRegistry = registryHolder.getAllFunctionHoldersByJar();
+  public void testGetAllJarsWithFunctionHolders() {
+    Map<String, List<FunctionHolder>> fnHoldersInRegistry = registryHolder.getAllJarsWithFunctionHolders();
     //Iterate and confirm lists are same
     for (String jarName : Lists.newArrayList(newJars.keySet())) {
-      compareTwoLists(newJars.get(jarName), fnHoldersInRegistry.get(jarName));
+      List<DrillFuncHolder> expectedHolderList = newJars.get(jarName).stream()
+          .map(FunctionHolder::getHolder) //Extract DrillFuncHolder
+          .collect(Collectors.toList());
+      List<DrillFuncHolder> testHolderList = fnHoldersInRegistry.get(jarName).stream()
+          .map(FunctionHolder::getHolder) //Extract DrillFuncHolder
+          .collect(Collectors.toList());
+
+      compareTwoLists(expectedHolderList, testHolderList);
     }
 
     Map<String, String> shuffleFunctionMap = new HashMap<>();
@@ -181,7 +188,7 @@ public class FunctionRegistryHolderTest {
       }
     }
 
-    //Test: Remove items from ExpectedMap
+    //Test: Remove items from ExpectedMap based on match from testJar's functionHolder items
     for (String testJar : registryHolder.getAllJarNames()) {
       for (FunctionHolder funcHolder : fnHoldersInRegistry.get(testJar)) {
         if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -30,8 +30,11 @@ import org.junit.experimental.categories.Category;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -46,6 +49,8 @@ public class FunctionRegistryHolderTest {
 
   private static final String built_in = "built-in";
   private static final String udf_jar = "DrillUDF-1.0.jar";
+  private static final String LOWER_FUNC_NAME = "lower";
+  private static final String SHUFFLE_FUNC_NAME = "shuffle";
 
   private static Map<String, List<FunctionHolder>> newJars;
   private FunctionRegistryHolder registryHolder;
@@ -53,12 +58,14 @@ public class FunctionRegistryHolderTest {
   @BeforeClass
   public static void init() {
     newJars = new HashMap<>();
-    FunctionHolder lower = new FunctionHolder("lower", "lower(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
+    FunctionHolder lower = new FunctionHolder(LOWER_FUNC_NAME, "lower(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder upper = new FunctionHolder("upper", "upper(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
-    newJars.put(built_in, Lists.newArrayList(lower, upper));
+    FunctionHolder shuffle = new FunctionHolder(SHUFFLE_FUNC_NAME, "shuffle()", mock(DrillFuncHolder.class));
+    newJars.put(built_in, Lists.newArrayList(lower, upper, shuffle));
     FunctionHolder custom_lower = new FunctionHolder("custom_lower", "lower(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
     FunctionHolder custom_upper = new FunctionHolder("custom_upper", "custom_upper(VARCHAR-REQUIRED)", mock(DrillFuncHolder.class));
-    newJars.put(udf_jar, Lists.newArrayList(custom_lower, custom_upper));
+    FunctionHolder overloaded_shuffle = new FunctionHolder(SHUFFLE_FUNC_NAME, "shuffle(FLOAT8-REQUIRED,FLOAT8-OPTIONAL)", mock(DrillFuncHolder.class));
+    newJars.put(udf_jar, Lists.newArrayList(custom_lower, custom_upper, overloaded_shuffle));
   }
 
   @Before
@@ -87,16 +94,16 @@ public class FunctionRegistryHolderTest {
   @Test
   public void testAddJars() {
     resetRegistry();
-    int functionsSize = 0;
     List<String> jars = new ArrayList<>();
     ListMultimap<String, DrillFuncHolder> functionsWithHolders = ArrayListMultimap.create();
     ListMultimap<String, String> functionsWithSignatures = ArrayListMultimap.create();
+    Set<String> functionsSet = new HashSet<>();
     for (Map.Entry<String, List<FunctionHolder>> jar : newJars.entrySet()) {
       jars.add(jar.getKey());
       for (FunctionHolder functionHolder : jar.getValue()) {
         functionsWithHolders.put(functionHolder.getName(), functionHolder.getHolder());
         functionsWithSignatures.put(functionHolder.getName(), functionHolder.getSignature());
-        functionsSize++;
+        functionsSet.add(functionHolder.getName()); //Track unique function names
       }
     }
 
@@ -104,7 +111,7 @@ public class FunctionRegistryHolderTest {
     registryHolder.addJars(newJars, ++expectedVersion);
     assertEquals("Version number should match", expectedVersion, registryHolder.getVersion());
     compareTwoLists(jars, registryHolder.getAllJarNames());
-    assertEquals(functionsSize, registryHolder.functionsSize());
+    assertEquals(functionsSet.size(), registryHolder.functionsSize());
     compareListMultimaps(functionsWithHolders, registryHolder.getAllFunctionsWithHolders());
     compareListMultimaps(functionsWithSignatures, registryHolder.getAllFunctionsWithSignatures());
   }
@@ -112,7 +119,7 @@ public class FunctionRegistryHolderTest {
   @Test
   public void testAddTheSameJars() {
     resetRegistry();
-    int functionsSize = 0;
+    Set<String> functionsSet = new HashSet<>();
     List<String> jars = new ArrayList<>();
     ListMultimap<String, DrillFuncHolder> functionsWithHolders = ArrayListMultimap.create();
     ListMultimap<String, String> functionsWithSignatures = ArrayListMultimap.create();
@@ -121,14 +128,14 @@ public class FunctionRegistryHolderTest {
       for (FunctionHolder functionHolder : jar.getValue()) {
         functionsWithHolders.put(functionHolder.getName(), functionHolder.getHolder());
         functionsWithSignatures.put(functionHolder.getName(), functionHolder.getSignature());
-        functionsSize++;
+        functionsSet.add(functionHolder.getName()); //Track unique function names
       }
     }
     int expectedVersion = 0;
     registryHolder.addJars(newJars, ++expectedVersion);
     assertEquals("Version number should match", expectedVersion, registryHolder.getVersion());
     compareTwoLists(jars, registryHolder.getAllJarNames());
-    assertEquals(functionsSize, registryHolder.functionsSize());
+    assertEquals(functionsSet.size(), registryHolder.functionsSize());
     compareListMultimaps(functionsWithHolders, registryHolder.getAllFunctionsWithHolders());
     compareListMultimaps(functionsWithSignatures, registryHolder.getAllFunctionsWithSignatures());
 
@@ -136,7 +143,7 @@ public class FunctionRegistryHolderTest {
     registryHolder.addJars(newJars, ++expectedVersion);
     assertEquals("Version number should match", expectedVersion, registryHolder.getVersion());
     compareTwoLists(jars, registryHolder.getAllJarNames());
-    assertEquals(functionsSize, registryHolder.functionsSize());
+    assertEquals(functionsSet.size(), registryHolder.functionsSize());
     compareListMultimaps(functionsWithHolders, registryHolder.getAllFunctionsWithHolders());
     compareListMultimaps(functionsWithSignatures, registryHolder.getAllFunctionsWithSignatures());
   }
@@ -153,6 +160,40 @@ public class FunctionRegistryHolderTest {
   public void testGetAllJarNames() {
     List<String> expectedResult = new ArrayList<>(newJars.keySet());
     compareTwoLists(expectedResult, registryHolder.getAllJarNames());
+  }
+
+  @Test
+  public void testGetAllFunctionHoldersByJar() {
+    Map<String, List<FunctionHolder>> fnHoldersInRegistry = registryHolder.getAllFunctionHoldersByJar();
+    //Iterate and confirm lists are same
+    for (String jarName : Lists.newArrayList(newJars.keySet())) {
+      compareTwoLists(newJars.get(jarName), fnHoldersInRegistry.get(jarName));
+    }
+
+    Map<String, String> shuffleFunctionMap = new HashMap<>();
+    // Confirm that same function spans multiple jars with different signatures
+    //Init: Expected Map of items
+    for (String jarName : Lists.newArrayList(newJars.keySet())) {
+      for (FunctionHolder funcHolder : newJars.get(jarName)) {
+        if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {
+          shuffleFunctionMap.put(funcHolder.getSignature(), jarName);
+        }
+      }
+    }
+
+    //Test: Remove items from ExpectedMap
+    for (String testJar : registryHolder.getAllJarNames()) {
+      for (FunctionHolder funcHolder : fnHoldersInRegistry.get(testJar)) {
+        if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {
+          String testSignature = funcHolder.getSignature();
+          String expectedJar = shuffleFunctionMap.get(testSignature);
+          if (testJar.equals(expectedJar)) {
+            shuffleFunctionMap.remove(testSignature);
+          }
+        }
+      }
+    }
+    assertTrue(shuffleFunctionMap.isEmpty());
   }
 
   @Test
@@ -202,26 +243,38 @@ public class FunctionRegistryHolderTest {
   public void testGetHoldersByFunctionNameWithVersion() {
     List<DrillFuncHolder> expectedResult = newJars.values().stream()
         .flatMap(Collection::stream)
-        .filter(f -> "lower".equals(f.getName()))
+        .filter(f -> LOWER_FUNC_NAME.equals(f.getName()))
         .map(FunctionHolder::getHolder)
         .collect(Collectors.toList());
 
     assertFalse(expectedResult.isEmpty());
     AtomicInteger version = new AtomicInteger();
-    compareTwoLists(expectedResult, registryHolder.getHoldersByFunctionName("lower", version));
+    compareTwoLists(expectedResult, registryHolder.getHoldersByFunctionName(LOWER_FUNC_NAME, version));
     assertEquals("Version number should match", version.get(), registryHolder.getVersion());
   }
 
   @Test
   public void testGetHoldersByFunctionName() {
-    List<DrillFuncHolder> expectedResult = newJars.values().stream()
-        .flatMap(Collection::stream)
-        .filter(f -> "lower".equals(f.getName()))
-        .map(FunctionHolder::getHolder)
-        .collect(Collectors.toList());
+    List<DrillFuncHolder> expectedUniqueResult = Lists.newArrayList();
+    List<DrillFuncHolder> expectedMultipleResult = Lists.newArrayList();
+    for (List<FunctionHolder> functionHolders : newJars.values()) {
+      for (FunctionHolder functionHolder : functionHolders) {
+        if (LOWER_FUNC_NAME.equals(functionHolder.getName())) {
+          expectedUniqueResult.add(functionHolder.getHolder());
+        } else
+          if (SHUFFLE_FUNC_NAME.equals(functionHolder.getName())) {
+            expectedMultipleResult.add(functionHolder.getHolder());
+          }
+      }
+    }
 
-    assertFalse(expectedResult.isEmpty());
-    compareTwoLists(expectedResult, registryHolder.getHoldersByFunctionName("lower"));
+    //Test for function with one signature
+    assertFalse(expectedUniqueResult.isEmpty());
+    compareTwoLists(expectedUniqueResult, registryHolder.getHoldersByFunctionName(LOWER_FUNC_NAME));
+
+    //Test for function with multiple signatures
+    assertFalse(expectedMultipleResult.isEmpty());
+    compareTwoLists(expectedMultipleResult, registryHolder.getHoldersByFunctionName(SHUFFLE_FUNC_NAME));
   }
 
   @Test
@@ -232,10 +285,23 @@ public class FunctionRegistryHolderTest {
 
   @Test
   public void testFunctionsSize() {
-    int count = newJars.values().stream()
-        .mapToInt(List::size)
-        .sum();
-    assertEquals("Functions size should match", count, registryHolder.functionsSize());
+    int fnCountInRegistryHolder = 0;
+    int fnCountInNewJars = 0;
+
+    Set<String> functionNameSet = new HashSet<>();
+    for (List<FunctionHolder> functionHolders : newJars.values()) {
+      for (FunctionHolder functionHolder : functionHolders) {
+        functionNameSet.add(functionHolder.getName()); //Track unique function names
+        fnCountInNewJars++; //Track all functions
+      }
+    }
+    assertEquals("Unique function name count should match", functionNameSet.size(), registryHolder.functionsSize());
+
+    for (String jarName : registryHolder.getAllJarNames()) {
+      fnCountInRegistryHolder += registryHolder.getFunctionNamesByJar(jarName).size();
+    }
+
+    assertEquals("Function count should match", fnCountInNewJars, fnCountInRegistryHolder);
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -182,7 +182,7 @@ public class FunctionRegistryHolderTest {
     //Init: Expected Map of items
     for (String jarName : newJars.keySet()) {
       for (FunctionHolder funcHolder : newJars.get(jarName)) {
-        if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {
+        if (SHUFFLE_FUNC_NAME.equals(funcHolder.getName())) {
           shuffleFunctionMap.put(funcHolder.getSignature(), jarName);
         }
       }
@@ -191,7 +191,7 @@ public class FunctionRegistryHolderTest {
     //Test: Remove items from ExpectedMap based on match from testJar's functionHolder items
     for (String testJar : registryHolder.getAllJarNames()) {
       for (FunctionHolder funcHolder : fnHoldersInRegistry.get(testJar)) {
-        if (funcHolder.getName().equals(SHUFFLE_FUNC_NAME)) {
+        if (SHUFFLE_FUNC_NAME.equals(funcHolder.getName())) {
           String testSignature = funcHolder.getSignature();
           String expectedJar = shuffleFunctionMap.get(testSignature);
           if (testJar.equals(expectedJar)) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestSystemTable.java
@@ -77,6 +77,11 @@ public class TestSystemTable extends PlanTestBase {
   }
 
   @Test
+  public void functionsTable() throws Exception {
+    test("select * from sys.functions");
+  }
+
+  @Test
   public void profilesTable() throws Exception {
     test("select * from sys.profiles");
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -149,7 +149,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(18, tables.size());
+    assertEquals(19, tables.size());
 
     verifyTable("information_schema", "CATALOGS", tables);
     verifyTable("information_schema", "COLUMNS", tables);
@@ -157,15 +157,10 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("information_schema", "TABLES", tables);
     verifyTable("information_schema", "VIEWS", tables);
     verifyTable("information_schema", "FILES", tables);
-    verifyTable("sys", "boot", tables);
-    verifyTable("sys", "drillbits", tables);
-    verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
-    verifyTable("sys", "threads", tables);
-    verifyTable("sys", "version", tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    //Verify System Tables
+    for (SystemTable sysTbl : SystemTable.values()) {
+      verifyTable("sys", sysTbl.getTableName(), tables);
+    }
   }
 
   @Test
@@ -187,7 +182,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(18, tables.size());
+    assertEquals(19, tables.size());
 
     verifyTable("information_schema", "CATALOGS", tables);
     verifyTable("information_schema", "COLUMNS", tables);
@@ -195,15 +190,10 @@ public class TestMetadataProvider extends BaseTestQuery {
     verifyTable("information_schema", "TABLES", tables);
     verifyTable("information_schema", "VIEWS", tables);
     verifyTable("information_schema", "FILES", tables);
-    verifyTable("sys", "boot", tables);
-    verifyTable("sys", "drillbits", tables);
-    verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
-    verifyTable("sys", "threads", tables);
-    verifyTable("sys", "version", tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    //Verify System Tables
+    for (SystemTable sysTbl : SystemTable.values()) {
+      verifyTable("sys", sysTbl.getTableName(), tables);
+    }
   }
 
   @Test
@@ -216,15 +206,15 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();
-    assertEquals(10, tables.size());
+    assertEquals(11, tables.size());
 
-    verifyTable("sys", "boot", tables);
-    verifyTable("sys", "memory", tables);
-    verifyTable("sys", SystemTable.OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.OPTIONS.getTableName(), tables);
-    verifyTable("sys", "version", tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS_OLD.getTableName(), tables);
-    verifyTable("sys", SystemTable.INTERNAL_OPTIONS.getTableName(), tables);
+    //Verify System Tables
+    for (SystemTable sysTbl : SystemTable.values()) {
+      String sysTblName = sysTbl.getTableName();
+      if (sysTblName.contains("o")) {
+        verifyTable("sys", sysTblName, tables);
+      }
+    }
   }
 
   @Test
@@ -250,7 +240,7 @@ public class TestMetadataProvider extends BaseTestQuery {
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<ColumnMetadata> columns = resp.getColumnsList();
-    assertEquals(135, columns.size());
+    assertEquals(139, columns.size());
     // too many records to verify the output.
   }
 
@@ -265,11 +255,11 @@ public class TestMetadataProvider extends BaseTestQuery {
     List<ColumnMetadata> columns = resp.getColumnsList();
     assertEquals(6, columns.size());
 
-    verifyColumn("sys", "drillbits", "user_port", columns);
-    verifyColumn("sys", "drillbits", "control_port", columns);
-    verifyColumn("sys", "drillbits", "data_port", columns);
-    verifyColumn("sys", "memory", "user_port", columns);
-    verifyColumn("sys", "threads", "user_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "user_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "control_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "data_port", columns);
+    verifyColumn("sys", SystemTable.MEMORY.getTableName(), "user_port", columns);
+    verifyColumn("sys", SystemTable.THREADS.getTableName(), "user_port", columns);
   }
 
   @Test
@@ -285,9 +275,9 @@ public class TestMetadataProvider extends BaseTestQuery {
     List<ColumnMetadata> columns = resp.getColumnsList();
     assertEquals(4, columns.size());
 
-    verifyColumn("sys", "drillbits", "user_port", columns);
-    verifyColumn("sys", "drillbits", "control_port", columns);
-    verifyColumn("sys", "drillbits", "data_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "user_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "control_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "data_port", columns);
   }
 
   @Test
@@ -306,10 +296,10 @@ public class TestMetadataProvider extends BaseTestQuery {
     List<ColumnMetadata> columns = resp.getColumnsList();
     assertEquals(4, columns.size());
 
-    verifyColumn("sys", "drillbits", "user_port", columns);
-    verifyColumn("sys", "drillbits", "control_port", columns);
-    verifyColumn("sys", "drillbits", "data_port", columns);
-    verifyColumn("sys", "drillbits", "http_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "user_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "control_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "data_port", columns);
+    verifyColumn("sys", SystemTable.DRILLBITS.getTableName(), "http_port", columns);
   }
 
   /** Helper method to verify schema contents */


### PR DESCRIPTION
This commit exposes available SQL functions in Drill and also detects UDFs that have been dynamically loaded into Drill. 
An example is shown below for 2 UDFs dynamically loaded into the cluster, along side the existing built-in functions that come with Drill.

```
0: jdbc:drill:schema=sys> select source, count(*) as functionCount from sys.functions group by source;
+-----------------------------------------+----------------+
|                 source                  | functionCount  |
+-----------------------------------------+----------------+
| built-in                                | 2704           |
| simple-drill-function-1.0-SNAPSHOT.jar  | 12             |
| drill-url-tools-1.0.jar                 | 1              |
+-----------------------------------------+----------------+
3 rows selected (0.209 seconds)
```

The system table exposes information as shown. The UDF is initialized, making the `returnType` available.
The `random(FLOAT8-REQUIRED,FLOAT8-REQUIRED)` function is an example of a UDF that has overloaded arguments (see `signature`).
The `url_parse(VARCHAR-REQUIRED)` function is another example of an initialized UDF.
Rest are built-in functions that meet the query's filter criteria.
```
0: jdbc:drill:schema=sys> select * from sys.functions where name like 'random' or name like '%url%';
+-------------+----------------------------------+-------------+-----------------------------------------+
|    name     |            signature             | returnType  |                 source                  |
+-------------+----------------------------------+-------------+-----------------------------------------+
| parse_url   | VARCHAR-REQUIRED                 | LATE        | built-in                                |
| random      |                                  | FLOAT8      | built-in                                |
| random      | FLOAT8-REQUIRED,FLOAT8-REQUIRED  | FLOAT8      | simple-drill-function-1.0-SNAPSHOT.jar  |
| url_decode  | VARCHAR-REQUIRED                 | VARCHAR     | built-in                                |
| url_encode  | VARCHAR-REQUIRED                 | VARCHAR     | built-in                                |
| url_parse   | VARCHAR-REQUIRED                 | LATE        | drill-url-tools-1.0.jar                 |
+-------------+----------------------------------+-------------+-----------------------------------------+
6 rows selected (0.619 seconds)
```