### PR TITLE
DRILL-6762: Fix dynamic UDFs versioning issue

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/ErrorHelper.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/ErrorHelper.java
@@ -181,4 +181,17 @@ public class ErrorHelper {
     return (UserException) cause;
   }
 
+  /**
+   * Helps to hide checked exception from the compiler but then actually throw it.
+   * Is useful when implementing functional interfaces that allow checked exceptions.
+   *
+   * @param e original exception instance
+   * @param <E> exception type
+   * @throws E exception instance
+   */
+  @SuppressWarnings("unchecked")
+  public static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+    throw (E) e;
+  }
+
 }

--- a/common/src/main/java/org/apache/drill/common/util/function/CheckedFunction.java
+++ b/common/src/main/java/org/apache/drill/common/util/function/CheckedFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.util.function;
+
+import java.util.function.Function;
+
+import static org.apache.drill.common.exceptions.ErrorHelper.sneakyThrow;
+
+/**
+ * Extension of {@link Function} that allows to throw checked exception.
+ *
+ * @param <T> function argument type
+ * @param <R> function result type
+ * @param <E> exception type
+ */
+@FunctionalInterface
+public interface CheckedFunction<T, R, E extends Throwable> extends Function<T, R> {
+
+  /**
+   * Overrides {@link Function#apply(Object)} method to allow calling functions that throw checked exceptions.
+   * Is useful when used in methods that accept {@link Function}.
+   * For example: {@link java.util.Map#computeIfAbsent(Object, Function)}.
+   *
+   * @param t the function argument
+   * @return the function result
+   */
+  @Override
+  default R apply(T t) {
+    try {
+      return applyAndThrow(t);
+    } catch (Throwable e) {
+      sneakyThrow(e);
+    }
+    // should never happen
+    throw new RuntimeException();
+  }
+
+  /**
+   * Applies function to the given argument.
+   *
+   * @param t the function argument
+   * @return the function result
+   * @throws E exception in case of errors
+   */
+  R applyAndThrow(T t) throws E;
+
+}
+

--- a/common/src/main/java/org/apache/drill/common/util/function/CheckedSupplier.java
+++ b/common/src/main/java/org/apache/drill/common/util/function/CheckedSupplier.java
@@ -15,10 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.util;
+package org.apache.drill.common.util.function;
 
 /**
- * The java standard library does not provide a lambda function interface for funtions that take no arguments,
+ * The java standard library does not provide a lambda function interface for functions that take no arguments,
  * but that throw an exception. So, we have to define our own here.
  * @param <T> The return type of the lambda function.
  * @param <E> The type of exception thrown by the lambda function.

--- a/common/src/test/java/org/apache/drill/common/util/function/TestCheckedFunction.java
+++ b/common/src/test/java/org/apache/drill/common/util/function/TestCheckedFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.util.function;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestCheckedFunction {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testComputeIfAbsentWithCheckedFunction() {
+    ExceptionProducer producer = new ExceptionProducer();
+    Map<String, String> map = new HashMap<>();
+    String message = "Exception message";
+    CheckedFunction<String, String, Exception> function = producer::failWithMessage;
+
+    thrown.expect(Exception.class);
+    thrown.expectMessage(message);
+
+    map.computeIfAbsent(message, function);
+  }
+
+  private class ExceptionProducer {
+
+    String failWithMessage(String message) throws Exception {
+      throw new Exception(message);
+    }
+
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/store/TransientStoreFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/store/TransientStoreFactory.java
@@ -25,7 +25,7 @@ public interface TransientStoreFactory extends AutoCloseable {
   /**
    * Returns a {@link TransientStore transient store} instance for the given configuration.
    *
-   * Note that implementors have liberty to cache previous {@link PersistentStore store} instances.
+   * Note that implementors have liberty to cache previous {@link TransientStore store} instances.
    *
    * @param config  store configuration
    * @param <V>  store value type

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolder.java
@@ -19,18 +19,18 @@ package org.apache.drill.exec.expr.fn.registry;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
 import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
-import org.apache.drill.shaded.guava.com.google.common.collect.Queues;
 
 import org.apache.drill.common.AutoCloseables.Closeable;
 import org.apache.drill.common.concurrent.AutoCloseableLock;
 import org.apache.drill.exec.expr.fn.DrillFuncHolder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -45,9 +45,10 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Holder is designed to allow concurrent reads and single writes to keep data consistent.
  * This is achieved by {@link ReadWriteLock} implementation usage.
  * Holder has number version which indicates remote function registry version number it is in sync with.
- *
+ * <p/>
  * Structure example:
  *
+ * <pre>
  * JARS
  * built-in   -> upper          -> upper(VARCHAR-REQUIRED)
  *            -> lower          -> lower(VARCHAR-REQUIRED)
@@ -72,12 +73,12 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * custom_lower -> custom_lower(VARCHAR-REQUIRED) -> function holder for custom_lower(VARCHAR-REQUIRED)
  *              -> custom_lower(VARCHAR-OPTIONAL) -> function holder for custom_lower(VARCHAR-OPTIONAL)
- *
+ * </pre>
  * where
- * First.jar is jar name represented by String
- * upper is function name represented by String
- * upper(VARCHAR-REQUIRED) is signature name represented by String which consist of function name, list of input parameters
- * function holder for upper(VARCHAR-REQUIRED) is {@link DrillFuncHolder} initiated for each function.
+ * <li><b>First.jar</b> is jar name represented by {@link String}.</li>
+ * <li><b>upper</b> is function name represented by {@link String}.</li>
+ * <li><b>upper(VARCHAR-REQUIRED)</b> is signature name represented by String which consist of function name, list of input parameters.</li>
+ * <li><b>function holder for upper(VARCHAR-REQUIRED)</b> is {@link DrillFuncHolder} initiated for each function.</li>
  *
  */
 public class FunctionRegistryHolder {
@@ -88,7 +89,7 @@ public class FunctionRegistryHolder {
   private final AutoCloseableLock readLock = new AutoCloseableLock(readWriteLock.readLock());
   private final AutoCloseableLock writeLock = new AutoCloseableLock(readWriteLock.writeLock());
   // remote function registry number, it is in sync with
-  private long version;
+  private int version;
 
   // jar name, Map<function name, Queue<function signature>
   private final Map<String, Map<String, Queue<String>>> jars;
@@ -97,15 +98,15 @@ public class FunctionRegistryHolder {
   private final Map<String, Map<String, DrillFuncHolder>> functions;
 
   public FunctionRegistryHolder() {
-    this.functions = Maps.newConcurrentMap();
-    this.jars = Maps.newConcurrentMap();
+    this.functions = new ConcurrentHashMap<>();
+    this.jars = new ConcurrentHashMap<>();
   }
 
   /**
    * This is read operation, so several users at a time can get this data.
    * @return local function registry version number
    */
-  public long getVersion() {
+  public int getVersion() {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()) {
       return version;
     }
@@ -122,12 +123,12 @@ public class FunctionRegistryHolder {
    *
    * @param newJars jars and list of their function holders, each contains function name, signature and holder
    */
-  public void addJars(Map<String, List<FunctionHolder>> newJars, long version) {
+  public void addJars(Map<String, List<FunctionHolder>> newJars, int version) {
     try (@SuppressWarnings("unused") Closeable lock = writeLock.open()) {
       for (Map.Entry<String, List<FunctionHolder>> newJar : newJars.entrySet()) {
         String jarName = newJar.getKey();
         removeAllByJar(jarName);
-        Map<String, Queue<String>> jar = Maps.newConcurrentMap();
+        Map<String, Queue<String>> jar = new ConcurrentHashMap<>();
         jars.put(jarName, jar);
         addFunctions(jar, newJar.getValue());
       }
@@ -156,7 +157,7 @@ public class FunctionRegistryHolder {
    */
   public List<String> getAllJarNames() {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()) {
-      return Lists.newArrayList(jars.keySet());
+      return new ArrayList<>(jars.keySet());
     }
   }
 
@@ -171,7 +172,7 @@ public class FunctionRegistryHolder {
   public List<String> getFunctionNamesByJar(String jarName) {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()){
       Map<String, Queue<String>> functions = jars.get(jarName);
-      return functions == null ? Lists.<String>newArrayList() : Lists.newArrayList(functions.keySet());
+      return functions == null ? new ArrayList<>() : new ArrayList<>(functions.keySet());
     }
   }
 
@@ -185,14 +186,14 @@ public class FunctionRegistryHolder {
    * @param version version holder
    * @return all functions which their holders
    */
-  public ListMultimap<String, DrillFuncHolder> getAllFunctionsWithHolders(AtomicLong version) {
+  public ListMultimap<String, DrillFuncHolder> getAllFunctionsWithHolders(AtomicInteger version) {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()) {
       if (version != null) {
         version.set(this.version);
       }
       ListMultimap<String, DrillFuncHolder> functionsWithHolders = ArrayListMultimap.create();
       for (Map.Entry<String, Map<String, DrillFuncHolder>> function : functions.entrySet()) {
-        functionsWithHolders.putAll(function.getKey(), Lists.newArrayList(function.getValue().values()));
+        functionsWithHolders.putAll(function.getKey(), new ArrayList<>(function.getValue().values()));
       }
       return functionsWithHolders;
     }
@@ -220,7 +221,7 @@ public class FunctionRegistryHolder {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()) {
       ListMultimap<String, String> functionsWithSignatures = ArrayListMultimap.create();
       for (Map.Entry<String, Map<String, DrillFuncHolder>> function : functions.entrySet()) {
-        functionsWithSignatures.putAll(function.getKey(), Lists.newArrayList(function.getValue().keySet()));
+        functionsWithSignatures.putAll(function.getKey(), new ArrayList<>(function.getValue().keySet()));
       }
       return functionsWithSignatures;
     }
@@ -236,13 +237,13 @@ public class FunctionRegistryHolder {
    * @param version version holder
    * @return list of function holders
    */
-  public List<DrillFuncHolder> getHoldersByFunctionName(String functionName, AtomicLong version) {
+  public List<DrillFuncHolder> getHoldersByFunctionName(String functionName, AtomicInteger version) {
     try (@SuppressWarnings("unused") Closeable lock = readLock.open()) {
       if (version != null) {
         version.set(this.version);
       }
       Map<String, DrillFuncHolder> holders = functions.get(functionName);
-      return holders == null ? Lists.<DrillFuncHolder>newArrayList() : Lists.newArrayList(holders.values());
+      return holders == null ? new ArrayList<>() : new ArrayList<>(holders.values());
     }
   }
 
@@ -316,17 +317,13 @@ public class FunctionRegistryHolder {
       final String functionName = function.getName();
       Queue<String> jarFunctions = jar.get(functionName);
       if (jarFunctions == null) {
-        jarFunctions = Queues.newConcurrentLinkedQueue();
+        jarFunctions = new ConcurrentLinkedQueue<>();
         jar.put(functionName, jarFunctions);
       }
       final String functionSignature = function.getSignature();
       jarFunctions.add(functionSignature);
 
-      Map<String, DrillFuncHolder> signatures = functions.get(functionName);
-      if (signatures == null) {
-        signatures = Maps.newConcurrentMap();
-        functions.put(functionName, signatures);
-      }
+      Map<String, DrillFuncHolder> signatures = functions.computeIfAbsent(functionName, k -> new ConcurrentHashMap<>());
       signatures.put(functionSignature, function.getHolder());
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillOperatorTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/DrillOperatorTable.java
@@ -54,7 +54,7 @@ public class DrillOperatorTable extends SqlStdOperatorTable {
   private final ArrayListMultimap<String, SqlOperator> drillOperatorsWithInferenceMap = ArrayListMultimap.create();
   // indicates remote function registry version based on which drill operator were loaded
   // is used to define if we need to reload operator table in case remote function registry version has changed
-  private long functionRegistryVersion;
+  private int functionRegistryVersion;
 
   private final OptionManager systemOptionManager;
 
@@ -70,14 +70,14 @@ public class DrillOperatorTable extends SqlStdOperatorTable {
    *
    * @param version registry version
    */
-  public void setFunctionRegistryVersion(long version) {
+  public void setFunctionRegistryVersion(int version) {
     functionRegistryVersion = version;
   }
 
   /**
    * @return function registry version based on which operator table was loaded
    */
-  public long getFunctionRegistryVersion() {
+  public int getFunctionRegistryVersion() {
     return functionRegistryVersion;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStoreProvider.java
@@ -18,24 +18,37 @@
 package org.apache.drill.exec.store.sys;
 
 import org.apache.drill.exec.exception.StoreException;
-import org.apache.drill.exec.store.sys.store.VersionedDelegatingStore;
+import org.apache.drill.exec.store.sys.store.UndefinedVersionDelegatingStore;
 
 /**
  * A factory used to create {@link PersistentStore store} instances.
- *
  */
 public interface PersistentStoreProvider extends AutoCloseable {
+
   /**
    * Gets or creates a {@link PersistentStore persistent store} for the given configuration.
    *
    * Note that implementors have liberty to cache previous {@link PersistentStore store} instances.
    *
-   * @param config  store configuration
-   * @param <V>  store value type
+   * @param config store configuration
+   * @param <V> store value type
+   * @return persistent store instance
+   * @throws StoreException in case when unable to create store
    */
   <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> config) throws StoreException;
+
+  /**
+   * Override this method if store supports versioning and return versioning instance.
+   * By default, undefined version wrapper will be used.
+   *
+   * @param config store configuration
+   * @param <V> store value type
+   * @return versioned persistent store instance
+   * @throws StoreException in case when unable to create store
+   */
   default <V> VersionedPersistentStore<V> getOrCreateVersionedStore(PersistentStoreConfig<V> config) throws StoreException {
-    return new VersionedDelegatingStore<>(getOrCreateStore(config));
+    // for those stores that do not support versioning
+    return new UndefinedVersionDelegatingStore<>(getOrCreateStore(config));
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DataChangeVersion.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DataChangeVersion.java
@@ -17,9 +17,17 @@
  */
 package org.apache.drill.exec.store.sys.store;
 
+/**
+ * Holder for store version. By default version is {@link DataChangeVersion#UNDEFINED}.
+ */
 public class DataChangeVersion {
 
-  private int version;
+  // is used when store in unreachable
+  public static final int NOT_AVAILABLE = -1;
+  // is used when store does not support versioning
+  public static final int UNDEFINED = -2;
+
+  private int version = UNDEFINED;
 
   public void setVersion(int version) {
     this.version = version;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/UndefinedVersionDelegatingStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/UndefinedVersionDelegatingStore.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import org.apache.drill.exec.store.sys.PersistentStore;
+import org.apache.drill.exec.store.sys.PersistentStoreMode;
+import org.apache.drill.exec.store.sys.VersionedPersistentStore;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Wrapper store that delegates operations to PersistentStore.
+ * Does not keep versioning and returns {@link DataChangeVersion#UNDEFINED} when version is required.
+ *
+ * @param <V> store value type
+ */
+public class UndefinedVersionDelegatingStore<V> implements VersionedPersistentStore<V> {
+
+  private final PersistentStore<V> store;
+
+  public UndefinedVersionDelegatingStore(PersistentStore<V> store) {
+    this.store = store;
+  }
+
+  @Override
+  public boolean contains(String key, DataChangeVersion version) {
+    version.setVersion(DataChangeVersion.UNDEFINED);
+    return store.contains(key);
+  }
+
+  @Override
+  public V get(String key, DataChangeVersion version) {
+    version.setVersion(DataChangeVersion.UNDEFINED);
+    return store.get(key);
+  }
+
+  @Override
+  public void put(String key, V value, DataChangeVersion version) {
+    store.put(key, value);
+  }
+
+  @Override
+  public PersistentStoreMode getMode() {
+    return store.getMode();
+  }
+
+  @Override
+  public void delete(String key) {
+    store.delete(key);
+  }
+
+  @Override
+  public boolean putIfAbsent(String key, V value) {
+    return store.putIfAbsent(key, value);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
+    return store.getRange(skip, take);
+  }
+
+  @Override
+  public void close() throws Exception {
+    store.close();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/InMemoryStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/InMemoryStoreProvider.java
@@ -17,11 +17,12 @@
  */
 package org.apache.drill.exec.store.sys.store.provider;
 
-import org.apache.drill.exec.exception.StoreException;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreProvider;
+import org.apache.drill.exec.store.sys.VersionedPersistentStore;
 import org.apache.drill.exec.store.sys.store.InMemoryStore;
+import org.apache.drill.exec.store.sys.store.VersionedDelegatingStore;
 
 public class InMemoryStoreProvider implements PersistentStoreProvider {
 
@@ -35,10 +36,15 @@ public class InMemoryStoreProvider implements PersistentStoreProvider {
   public void close() throws Exception { }
 
   @Override
-  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> config) throws StoreException {
+  public <V> PersistentStore<V> getOrCreateStore(PersistentStoreConfig<V> config) {
     return new InMemoryStore<>(capacity);
   }
 
   @Override
-  public void start() throws Exception { }
+  public <V> VersionedPersistentStore<V> getOrCreateVersionedStore(PersistentStoreConfig<V> config) {
+    return new VersionedDelegatingStore<>(getOrCreateStore(config));
+  }
+
+  @Override
+  public void start() { }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -26,7 +26,9 @@ import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.sys.PersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreRegistry;
+import org.apache.drill.exec.store.sys.VersionedPersistentStore;
 import org.apache.drill.exec.store.sys.store.LocalPersistentStore;
+import org.apache.drill.exec.store.sys.store.VersionedDelegatingStore;
 import org.apache.drill.exec.testing.store.NoWriteLocalStore;
 import org.apache.hadoop.fs.Path;
 
@@ -70,6 +72,10 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
     }
   }
 
+  @Override
+  public <V> VersionedPersistentStore<V> getOrCreateVersionedStore(PersistentStoreConfig<V> config) {
+    return new VersionedDelegatingStore<>(getOrCreateStore(config));
+  }
 
   @Override
   public void close() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/TestDynamicUDFSupport.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/TestDynamicUDFSupport.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -762,7 +762,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
 
     DataChangeVersion version = new DataChangeVersion();
     Registry registry = remoteFunctionRegistry.getRegistry(version);
-    assertEquals("Remote registry version should match", 1, version.getVersion());
+    assertEquals("Remote registry version should match", 2, version.getVersion());
     List<Jar> jarList = registry.getJarList();
     assertEquals("Only one jar should be registered", 1, jarList.size());
     assertEquals("Jar name should match", jar1, jarList.get(0).getName());
@@ -823,7 +823,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
 
     DataChangeVersion version = new DataChangeVersion();
     Registry registry = remoteFunctionRegistry.getRegistry(version);
-    assertEquals("Remote registry version should match", 2, version.getVersion());
+    assertEquals("Remote registry version should match", 3, version.getVersion());
 
     List<Jar> actualJars = registry.getJarList();
     List<String> expectedJars = Lists.newArrayList(jar1, jar2);
@@ -861,7 +861,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
           assertTrue("syncWithRemoteRegistry() should return true", result);
           return true;
         })
-        .when(functionImplementationRegistry).syncWithRemoteRegistry(anyLong());
+        .when(functionImplementationRegistry).syncWithRemoteRegistry(anyInt());
 
     SimpleQueryRunner simpleQueryRunner = new SimpleQueryRunner(query);
     Thread thread1 = new Thread(simpleQueryRunner);
@@ -873,10 +873,10 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
     thread1.join();
     thread2.join();
 
-    verify(functionImplementationRegistry, times(2)).syncWithRemoteRegistry(anyLong());
+    verify(functionImplementationRegistry, times(2)).syncWithRemoteRegistry(anyInt());
     LocalFunctionRegistry localFunctionRegistry = (LocalFunctionRegistry)FieldUtils.readField(
         functionImplementationRegistry, "localFunctionRegistry", true);
-    assertEquals("Sync function registry version should match", 1L, localFunctionRegistry.getVersion());
+    assertEquals("Sync function registry version should match", 2, localFunctionRegistry.getVersion());
   }
 
   @Test
@@ -895,7 +895,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
           assertFalse("syncWithRemoteRegistry() should return false", result);
           return false;
         })
-        .when(functionImplementationRegistry).syncWithRemoteRegistry(anyLong());
+        .when(functionImplementationRegistry).syncWithRemoteRegistry(anyInt());
 
     test("select custom_lower('A') from (values(1))");
 
@@ -906,10 +906,10 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
       assertThat(e.getMessage(), containsString("No match found for function signature unknown_lower(<CHARACTER>)"));
     }
 
-    verify(functionImplementationRegistry, times(2)).syncWithRemoteRegistry(anyLong());
+    verify(functionImplementationRegistry, times(2)).syncWithRemoteRegistry(anyInt());
     LocalFunctionRegistry localFunctionRegistry = (LocalFunctionRegistry)FieldUtils.readField(
         functionImplementationRegistry, "localFunctionRegistry", true);
-    assertEquals("Sync function registry version should match", 1L, localFunctionRegistry.getVersion());
+    assertEquals("Sync function registry version should match", 2, localFunctionRegistry.getVersion());
   }
 
   private static String buildJars(String jarName, String includeFiles, String includeResources) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PrintingUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PrintingUtils.java
@@ -19,7 +19,7 @@ package org.apache.drill.test;
 
 import ch.qos.logback.classic.Level;
 import org.apache.drill.exec.client.LoggingResultsListener;
-import org.apache.drill.exec.util.CheckedSupplier;
+import org.apache.drill.common.util.function.CheckedSupplier;
 import org.apache.drill.exec.util.VectorUtil;
 
 import java.util.function.Supplier;


### PR DESCRIPTION
1. Added UndefinedVersionDelegatingStore to serve as versioned wrapper for those stores that do not support versioning.
2. Aligned remote and local function registries version type. Type will be represented as int since ZK version is returned as int.
3. Added NOT_AVAILABLE and UNDEFINED versions to DataChangeVersion holder to indicate proper registry state.
4. Added additional trace logging.
5. Minor refactoring and clean up.

Details in [DRILL-6762](https://issues.apache.org/jira/browse/DRILL-6762).