### PR TITLE
DRILL-6759: Make columns array name for csv data case insensitive

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/RepeatedVarCharOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/compliant/RepeatedVarCharOutput.java
@@ -133,7 +133,7 @@ class RepeatedVarCharOutput extends TextOutput {
         for (SchemaPath path : columns) {
           assert path.getRootSegment().isNamed() : "root segment should be named";
           pathStr = path.getRootSegment().getPath();
-          Preconditions.checkArgument(COL_NAME.equals(pathStr) || (SchemaPath.DYNAMIC_STAR.equals(pathStr) && path.getRootSegment().getChild() == null),
+          Preconditions.checkArgument(COL_NAME.equalsIgnoreCase(pathStr) || (SchemaPath.DYNAMIC_STAR.equals(pathStr) && path.getRootSegment().getChild() == null),
               String.format("Selected column '%s' must have name 'columns' or must be plain '*'", pathStr));
 
           if (path.getRootSegment().getChild() != null) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/text/TestTextColumn.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/text/TestTextColumn.java
@@ -22,7 +22,8 @@ import java.util.List;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestTextColumn extends BaseTestQuery {
   @Test
@@ -41,7 +42,7 @@ public class TestTextColumn extends BaseTestQuery {
     expectedResultSet.addRow("g, h,\",\"i\",\"j,, \\n k");
 
     TestResultSet actualResultSet = new TestResultSet(actualResults);
-    assertTrue(expectedResultSet.equals(actualResultSet));
+    assertEquals(expectedResultSet, actualResultSet);
   }
 
   @Test
@@ -55,6 +56,22 @@ public class TestTextColumn extends BaseTestQuery {
     expectedResultSet.addRow("g, h,", "i", "j,, \\n k", "l\\\"m");
 
     TestResultSet actualResultSet = new TestResultSet(actualResults);
-    assertTrue(expectedResultSet.equals(actualResultSet));
+    assertEquals(expectedResultSet, actualResultSet);
   }
+
+  @Test
+  public void testColumnsCaseInsensitive() throws Exception {
+    testBuilder()
+        .sqlQuery("select columns as c from cp.`store/text/data/letters.csv`")
+        .unOrdered()
+        .sqlBaselineQuery("select COLUMNS as c from cp.`store/text/data/letters.csv`")
+        .go();
+
+    testBuilder()
+        .sqlQuery("select columns[0], columns[1] from cp.`store/text/data/letters.csv`")
+        .unOrdered()
+        .sqlBaselineQuery("select COLUMNS[0], CoLuMnS[1] from cp.`store/text/data/letters.csv`")
+        .go();
+  }
+
 }


### PR DESCRIPTION
Details in [DRILL-6759](https://issues.apache.org/jira/browse/DRILL-6759).