### PR TITLE
DRILL-6764: Query fails with IOB when Unnest has reference to deep ne…

### DIFF
--- a/exec/java-exec/src/test/resources/lateraljoin/nested-customer-map.json
+++ b/exec/java-exec/src/test/resources/lateraljoin/nested-customer-map.json
@@ -1,0 +1,134 @@
+{
+  "c_name" : "customer1",
+  "c_id" : 1,
+  "c_phone" : ["6505200001", "4085201234", "6125205678"],
+  "orders" : [{"o_id": 1, "o_shop": "Meno Park 1st", "o_amount": 4.5,
+               "items" : [ {"i_name" : "paper towel", "i_number": 2, "i_supplier": "oregan"},
+                           {"i_name" : "map", "i_number": 1, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 9, "i_supplier": "california"}
+                         ]
+
+              },
+              {"o_id": 2, "o_shop": "Mountain View 1st", "o_amount": 104.5,
+               "items" : [ {"i_name" : "beef", "i_number": 3, "i_supplier": "montana"},
+                           {"i_name" : "tooth paste", "i_number": 4, "i_supplier": "washington"},
+                           {"i_name" : "hat", "i_number": 7, "i_supplier": "california"}
+                         ]
+
+              },
+              {"o_id": 3, "o_shop": "Sunnyvale 1st", "o_amount": 294.5,
+               "items" : [ {"i_name" : "paper towel", "i_number": 5, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 6, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 8, "i_supplier": "california"}
+                         ]
+              }
+             ],
+  "c_address" : {
+              "Area": "bay area",
+	      "City": "Santa Clara",
+              "State" : "CA",
+              "c_phone": [{"area_code": "650", "phone": "5200001"}, {"area_code": "408", "phone": "5201234"}, {"area_code" : "612", "phone": "5205678"}]
+            }
+}
+{
+  "c_name" : "customer2",
+  "c_id" : 2,
+  "c_phone" : ["1505200001", "7085201234", "2125205678"],
+  "orders" : [{"o_id": 10, "o_shop": "Mountain View 1st", "o_amount": 724.5,
+               "items" : [ {"i_name" : "beef", "i_number": 12, "i_supplier": "montana"},
+                           {"i_name" : "tooth paste", "i_number": 11, "i_supplier": "washington"},
+                           {"i_name" : "hat", "i_number": 10, "i_supplier": "california"}
+                         ]
+
+              },
+
+              {"o_id": 11, "o_shop": "Sunnyvale 1st", "o_amount": 179.5,
+               "items" : [ {"i_name" : "paper towel", "i_number": 13, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 14, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 15, "i_supplier": "california"}
+                         ]
+              },
+              {"o_id": 12, "o_shop": "Meno Park 1st", "o_amount": 80.0,
+               "items" : [ {"i_name" : "paper towel", "i_number": 13, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 14, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 15, "i_supplier": "california"}
+                         ]
+              }
+             ],
+  "c_address" : {
+               "Area": "Greater LA",
+               "City": "LA",
+               "State" : "CA",
+               "c_phone": [{"area_code": "150", "phone" : "5200001"}, {"area_code": "708", "phone": "5201234"}, {"area_code" : "212", "phone": "5205678"}]
+              }
+}
+{
+  "c_name" : "customer3",
+  "c_id" : 3,
+  "c_phone" : ["1205200001", "7285201234", "2325205678"],
+  "orders" : [{"o_id": 21, "o_shop": "Meno Park 1st", "o_amount": 192.5,
+               "items" : [ {"i_name" : "beef", "i_number": 22, "i_supplier": "montana"},
+                           {"i_name" : "tooth paste", "i_number": 21, "i_supplier": "washington"},
+                           {"i_name" : "hat", "i_number": 20, "i_supplier": "california"}
+                         ]
+
+              },
+
+              {"o_id": 22, "o_shop": "Mountain View 1st", "o_amount": 680.9,
+               "items" : [ {"i_name" : "paper towel", "i_number": 23, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 24, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 25, "i_supplier": "california"}
+                         ]
+              },
+
+              {"o_id": 23, "o_shop": "Sunnyvale 1st", "o_amount": 772.2,
+               "items" : [ {"i_name" : "paper towel", "i_number": 26, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 27, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 28, "i_supplier": "california"}
+                         ]
+              }
+
+             ],
+  "c_address" : {
+                "Area": "bay area, CA",
+                "City": "Milpitas",
+                "State": "CA",
+                "c_phone": [{"area_code" : "120", "phone": "5200001"}, {"area_code": "728", "phone": "5201234"}, {"area_code": "232", "phone" :"5205678"}]
+             }
+}
+{
+  "c_name" : "customer4",
+  "c_id" : 4,
+  "c_phone" : ["6509200001", "4088201234", "6127205678"],
+  "orders" : [{"o_id": 30, "o_shop": "Mountain View 1st", "o_amount": 870.2,
+               "items" : [ {"i_name" : "beef", "i_number": 32, "i_supplier": "montana"},
+                           {"i_name" : "tooth paste", "i_number": 31, "i_supplier": "washington"},
+                           {"i_name" : "hat", "i_number": 30, "i_supplier": "california"}
+                         ]
+
+              },
+
+              {"o_id": 31, "o_shop": "Sunnyvale 1st", "o_amount": 970.5,
+               "items" : [ {"i_name" : "beef", "i_number": 32, "i_supplier": "montana"},
+                           {"i_name" : "tooth paste", "i_number": 31, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 30, "i_supplier": "california"}
+                         ]
+
+              },
+
+              {"o_id": 32, "o_shop": "Meno Park 1st", "o_amount": 1030.1,
+               "items" : [ {"i_name" : "paper towel", "i_number": 36, "i_supplier": "oregan"},
+                           {"i_name" : "tooth paste", "i_number": 37, "i_supplier": "washington"},
+                           {"i_name" : "cheese", "i_number": 38, "i_supplier": "california"}
+                         ]
+              }
+
+             ],
+  "c_address" : {
+               "Area": "Greater Sandiego",
+               "City": "Sandiego",
+               "State": "CA",
+               "c_phone": [{"area_code": "650", "phone": "9200001"}, {"area_code": "408", "phone": "8201234"}, {"area_code": "612", "phone": "7205678"}]
+              } 
+}
+


### PR DESCRIPTION
…sted field like (t.c_orders.o_lineitems).

The PR fixes an index out of bound issue when more than one field is projected from an unnest column.  @vvysotskyi  Please review this PR.
