### PR TITLE
DRILL-6775: The schema for empty output is not shown in Drill Web UI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.server.rest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserRemoteException;
@@ -113,10 +112,6 @@ public class QueryWrapper {
 
     if (webUserConnection.getError() != null) {
       throw new UserRemoteException(webUserConnection.getError());
-    }
-
-    if (webUserConnection.results.isEmpty()) {
-      webUserConnection.results.add(Maps.<String, String>newHashMap());
     }
 
     // Return the QueryResult.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
@@ -75,20 +75,20 @@ public class WebUserConnection extends AbstractDisposableUserClientConnection im
 
   @Override
   public void sendData(RpcOutcomeListener<Ack> listener, QueryWritableBatch result) {
-    // Check if there is any data or not. There can be overflow here but DrillBuf doesn't support allocating with
+    // There can be overflow here but DrillBuf doesn't support allocating with
     // bytes in long. Hence we are just preserving the earlier behavior and logging debug log for the case.
     final int dataByteCount = (int) result.getByteCount();
 
-    if (dataByteCount <= 0) {
+    if (dataByteCount < 0) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Either no data received in this batch or there is BufferOverflow in dataByteCount: {}",
+        logger.debug("There is BufferOverflow in dataByteCount: {}",
             dataByteCount);
       }
       listener.success(Acks.OK, null);
       return;
     }
 
-    // If here that means there is some data for sure. Create a ByteBuf with all the data in it.
+    // Create a ByteBuf with all the data in it.
     final int rows = result.getHeader().getRowCount();
     final BufferAllocator allocator = webSessionResources.getAllocator();
     final DrillBuf bufferWithData = allocator.buffer(dataByteCount);


### PR DESCRIPTION
Removed an excess check for the result emptiness that prevented retrieval of the column names.