### PR TITLE
DRILL-6788: Intermittent unit test failure TestDrillbitResilience.fai…

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -742,8 +742,10 @@ public class TestDrillbitResilience extends DrillTest {
 
     final String exceptionDesc = "sql-parsing";
     final Class<? extends Throwable> exceptionClass = ForemanSetupException.class;
+    // Inject the failure twice since there can be retry after first failure introduced in DRILL-6762. Retry is because
+    // of version mismatch in local and remote function registry which syncs up lazily.
     final String controls = Controls.newBuilder()
-    .addException(DrillSqlWorker.class, exceptionDesc, exceptionClass)
+      .addException(DrillSqlWorker.class, exceptionDesc, exceptionClass, 0, 2)
       .build();
     assertFailsWithException(controls, exceptionClass, exceptionDesc);
 


### PR DESCRIPTION
…lsWhenParsing: Query state should be FAILED (and not COMPLETED)