### PR TITLE
DRILL-6785: DataClient is using RootAllocator in the bootstrap instea…

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/data/DataClient.java
@@ -50,7 +50,7 @@ public class DataClient extends BasicClient<RpcType, DataClientConnection, BitCl
     super(
         DataRpcConfig.getMapping(config.getBootstrapContext().getConfig(),
             config.getBootstrapContext().getExecutor()),
-        config.getBootstrapContext().getAllocator().getAsByteBufAllocator(),
+        config.getAllocator().getAsByteBufAllocator(),
         config.getBootstrapContext().getBitClientLoopGroup(),
         RpcType.HANDSHAKE,
         BitServerHandshake.class,


### PR DESCRIPTION
…d of dataPool