### PR TITLE
DRILL-6611: Add Ctrl+Enter support for query submission

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -106,6 +106,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
         <form role="form" id="queryForm" action="/query" method="POST">
           <div id="query-editor" class="form-group">${model.getProfile().query}</div>
           <input class="form-control" id="query" name="query" type="hidden" value="${model.getProfile().query}"/>
+          <div style="padding:5px"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
           <div class="form-group">
             <div class="radio-inline">
               <label>
@@ -459,7 +460,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
       enableLiveAutocompletion: false
     });
 
-    //Pops out a new window and provids prompt to print
+    //Pops out a new window and provide prompt to print
     var popUpAndPrintPlan = function() {
       var srcSvg = $('#query-visual-canvas');
       var screenRatio=0.9;
@@ -467,6 +468,21 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
       printWindow.document.writeln($(srcSvg).parent().html());
       printWindow.print();
     };
+
+    //Provides hint based on OS
+    var browserOS = navigator.platform.toLowerCase();
+    if ((browserOS.indexOf("mac") > -1)) {
+      document.getElementById('keyboardHint').innerHTML="Meta+Enter";
+    } else {
+      document.getElementById('keyboardHint').innerHTML="Ctrl+Enter";
+    }
+
+    // meta+enter / ctrl+enter to submit query
+    document.getElementById('queryForm')
+            .addEventListener('keydown', function(e) {
+      if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
+      if (e.target.form) doSubmitQueryWithUserName();
+    });
     </script>
 
 </#macro>

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -72,7 +72,8 @@
       </div>
     </div>
     <div class="form-group">
-      <label for="query">Query</label>
+      <div style="display: inline-block"><label for="query">Query</label></div>
+      <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
       <div id="query-editor-format"></div>
       <input class="form-control" type="hidden" id="query" name="query"/>
     </div>
@@ -112,11 +113,20 @@
       enableBasicAutocompletion: true,
       enableLiveAutocompletion: false
     });
-    // meta-enter to submit query
+
+    //Provides hint based on OS
+    var browserOS = navigator.platform.toLowerCase();
+    if ((browserOS.indexOf("mac") > -1)) {
+      document.getElementById('keyboardHint').innerHTML="Meta+Enter";
+    } else {
+      document.getElementById('keyboardHint').innerHTML="Ctrl+Enter";
+    }
+
+    // meta+enter / ctrl+enter to submit query
     document.getElementById('queryForm')
             .addEventListener('keydown', function(e) {
-      if (!(e.keyCode == 13 && e.metaKey)) return;
-      if (e.target.form) e.target.form.submit();
+      if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
+      if (e.target.form) doSubmitQueryWithUserName();
     });
   </script>
 

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -112,6 +112,12 @@
       enableBasicAutocompletion: true,
       enableLiveAutocompletion: false
     });
+    // meta-enter to submit query
+    document.getElementById('queryForm')
+            .addEventListener('keydown', function(e) {
+      if (!(e.keyCode == 13 && e.metaKey)) return;
+      if (e.target.form) e.target.form.submit();
+    });
   </script>
 
 </#macro>


### PR DESCRIPTION
1. BugFix on parent commit: Ensure query submission is done with user name when impersonation is enabled.
2. Support non-Mac browsers
3. Support keyboard submission for profile pages with Edit Query tab. 

Preview of Hint on Windows (Chrome):
![image](https://user-images.githubusercontent.com/4335237/47946452-0fd1ca80-dec9-11e8-8a9c-e4ce3fc3def9.png)
