### PR TITLE
DRILL-6837: Missing reference for dynamically created Javascript library

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -29,7 +29,8 @@
 </#if>
   <!-- Ace Libraries for Syntax Formatting -->
   <script src="/static/js/ace-code-editor/ace.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/static/js/ace-code-editor/mode-sql.js" type="text/javascript" charset="utf-8"></script>
+  <!-- Disabled in favour of dynamic: script src="/static/js/ace-code-editor/mode-sql.js" type="text/javascript" charset="utf-8" -->
+  <script src="/dynamic/mode-sql.js" type="text/javascript" charset="utf-8"></script>
   <script src="/static/js/ace-code-editor/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
   <script src="/static/js/ace-code-editor/theme-sqlserver.js" type="text/javascript" charset="utf-8"></script>
   <script src="/static/js/ace-code-editor/snippets/sql.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
A PR for DRILL-6084 broke the auto-complete library required for Edit Query page, with the removal of the static javascript library.
https://github.com/apache/drill/pull/1491/files#diff-2bb3c04f1a9eead1faf57212cce5d2a9

The dynamically loaded script is not defined in the Freemarker template page.
The fix is trivial.

This is the console error:
![image](https://user-images.githubusercontent.com/4335237/48236808-ba8a3300-e378-11e8-937b-fad6817c839f.png)
