### PR TITLE
DRILL-2035: Add ability to cancel multiple queries

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/list.ftl
@@ -47,6 +47,43 @@
         } );
       } );
     } );
+
+    //Close the cancellation status popup
+    function refreshStatus() {
+        $("#queryCancelModal").modal("hide");
+        console.log("location.reload(true);")
+        location.reload(true);
+    }
+
+    //Toggle Selection for canceling running queries
+    function toggleRunningSelection(source) {
+        let checkboxes = document.getElementsByName('cancelQ');
+        let toggleCount = checkboxes.length;
+        for(let i=0; i < toggleCount; i++) {
+            checkboxes[i].checked = source.checked;
+        }
+    }
+
+    //Submit Cancellations & show status
+    function cancelSelection() {
+        let checkedBoxes = document.querySelectorAll('input[name=cancelQ]:checked');
+        //dBug
+        console.log("Cancelling => " + checkedBoxes.length);
+        let checkedCount = checkedBoxes.length;
+        if (checkedCount == 0)  return;
+
+        for(var i=0; i < checkedCount; i++) {
+            let queryToCancel = checkedBoxes[i].value;
+            //Asynchronously cancel the query
+            $.get("/profiles/cancel/" + queryToCancel, function(data, status){
+                /*Not Tracking Response*/
+            });
+        }
+        document.getElementById("cancelTitle").innerHTML = "Drillbit on " + location.hostname + " says";
+        document.getElementById("cancelText").innerHTML = "Issued cancellation for "+checkedCount+" quer"+(checkedCount == 1 ? "y":"ies");
+        $("#queryCancelModal").modal("show");
+    }
+
 </script>
 
 <!-- CSS to control DataTable Elements -->
@@ -72,7 +109,6 @@
     float:left 
   }
 </style>
-
 </#macro>
 
 <#macro page_body>
@@ -88,7 +124,25 @@
     </div>
   </#if>
   <#if (model.getRunningQueries()?size > 0) >
-    <h3>Running Queries</h3>
+    <h3>Running Queries 
+    <div  style="display: inline-block; line-height:2" >
+      <button type="button" class="btn btn-warning btn-sm" onClick="cancelSelection()">
+      Cancel Selected</button>
+    </div></h3>
+    <!-- Cancellation Modal -->
+    <div class="modal fade" id="queryCancelModal" role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" onclick="refreshStatus()">&times;</button>
+            <h4 class="modal-title" id="cancelTitle"></h4>
+          </div>
+          <div class="modal-body" style="line-height:2" ><h3 id="cancelText">Cancellation Status</h3></div>
+          <div class="modal-footer"><button type="button" class="btn btn-default" onclick="refreshStatus()">Close</button></div>
+        </div>
+      </div>
+    </div>
+
     <@list_queries queries=model.getRunningQueries() stateList="running" />
     <div class="page-header">
     </div>
@@ -142,6 +196,9 @@
         <table id="profileList_${stateList}" class="table table-hover dataTable" role="grid">
             <thead>
             <tr role="row">
+                <#if stateList == "running" >
+                <th><input type="checkbox" name="selectToggle" onClick="toggleRunningSelection(this)" /></th>
+                </#if>
                 <th>Time</th>
                 <th>User</th>
                 <th>Query</th>
@@ -153,6 +210,9 @@
             <tbody>
             <#list queries as query>
             <tr>
+                <#if stateList == "running" >
+                <td><input type="checkbox" name="cancelQ" value="${query.getQueryId()}"/></td>
+                </#if>
                 <td>${query.getTime()}</td>
                 <td>${query.getUser()}</td>
                 <td>


### PR DESCRIPTION
Currently Drill UI allows canceling one query at a time.
This commit (on lines of DRILL-5571 /  PR #1531) allows for cancelling multiple `running` queries.

Multi Selection :
![image](https://user-images.githubusercontent.com/4335237/48370170-5a8fd700-e66d-11e8-95c6-17534876d83a.png)

Cancel Status Popup:
![image](https://user-images.githubusercontent.com/4335237/48370162-52d03280-e66d-11e8-8887-0e1972c30bd3.png)

Auto Refreshed  page:
![image](https://user-images.githubusercontent.com/4335237/48370142-46e47080-e66d-11e8-9745-9c1cab7b16fd.png)
