### PR TITLE
DRILL-3933: Surround $QUERY variable in double-quotes to avoid asterisk expansion in sqlline script

### DIFF
--- a/distribution/src/resources/sqlline
+++ b/distribution/src/resources/sqlline
@@ -91,7 +91,7 @@ if [ -n "$_DRILL_WRAPPER_" ]; then
 fi
 
 if [ -n "$QUERY" ] ; then
-  echo $QUERY | exec $CMD "${SLARGS[@]}"
+  echo "$QUERY" | exec $CMD "${SLARGS[@]}"
 elif [ -n "$FILE" ] ; then
   exec $CMD "${SLARGS[@]}" --run=$FILE
 else


### PR DESCRIPTION
Details in [DRILL-3933](https://issues.apache.org/jira/browse/DRILL-3933).