### PR TITLE
DRILL-6847: Add Query Metadata to RESTful Interface

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -115,7 +115,7 @@ public class QueryWrapper {
     }
 
     // Return the QueryResult.
-    return new QueryResult(queryId, webUserConnection.columns, webUserConnection.results);
+    return new QueryResult(queryId, webUserConnection, webUserConnection.results);
   }
 
   //Detect possible excess heap
@@ -127,12 +127,15 @@ public class QueryWrapper {
     private final String queryId;
     public final Collection<String> columns;
     public final List<Map<String, String>> rows;
+    public final List<String> metadata;
 
-    public QueryResult(QueryId queryId, Collection<String> columns, List<Map<String, String>> rows) {
-      this.queryId = QueryIdHelper.getQueryId(queryId);
-      this.columns = columns;
-      this.rows = rows;
-    }
+    //DRILL-6847:  Modified the constructor so that the method has access to all the properties in webUserConnection
+    public QueryResult(QueryId queryId, WebUserConnection webUserConnection, List<Map<String, String>> rows) {
+        this.queryId = QueryIdHelper.getQueryId(queryId);
+        this.columns = webUserConnection.columns;
+        this.metadata = webUserConnection.metadata;
+        this.rows = rows;
+      }
 
     public String getQueryId() {
       return queryId;


### PR DESCRIPTION
The Drill RESTful interface does not return the structure of the query results.   This makes integrating Drill with other BI tools difficult because they do not know what kind of data to expect.  
This PR adds a new section to the results called Metadata which contains a list of the minor types of all the columns returned.

The query below will now return the following in the RESTful interface:

```
SELECT CAST( employee_id AS INT) AS employee_id,
full_name,
first_name, 
last_name, 
CAST( position_id AS BIGINT) AS position_id, 
position_title 
FROM cp.`employee.json` LIMIT 2
```
```
{
  "queryId": "2414bf3f-b4f4-d4df-825f-73dfb3a56681",
  "columns": [
    "employee_id",
    "full_name",
    "first_name",
    "last_name",
    "position_id",
    "position_title"
  ],
  "metadata": [
    "INT",
    "VARCHAR",
    "VARCHAR",
    "VARCHAR",
    "BIGINT",
    "VARCHAR"
  ],
  "rows": [
    {
      "full_name": "Sheri Nowmer",
      "employee_id": "1",
      "last_name": "Nowmer",
      "position_title": "President",
      "first_name": "Sheri",
      "position_id": "1"
    },
    {
      "full_name": "Derrick Whelply",
      "employee_id": "2",
      "last_name": "Whelply",
      "position_title": "VP Country Manager",
      "first_name": "Derrick",
      "position_id": "2"
    }
  ]
}
```