### PR TITLE
DRILL-6848: Duration panel in a query profile's WebUI does not open

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -254,12 +254,12 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">
-          <a data-toggle="collapse" href="#query-profile-duration in">
+          <a data-toggle="collapse" href="#query-profile-duration">
              Duration
           </a>
         </h4>
       </div>
-      <div id="query-profile-duration" class="panel-collapse collapse">
+      <div id="query-profile-duration" class="panel-collapse collapse in">
         <div class="panel-body">
           <table class="table table-bordered">
             <thead>


### PR DESCRIPTION
DRILL-5571 ( PR #1531 ) accidentally introduced a bug that permanently keeps the "Duration" panel closed instead of opening it. This trivial patch fixes that.