### PR TITLE
 DRILL-6668: In Web UI, highlight options that are not default values 

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -90,7 +90,7 @@ public class StatusResources {
     OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
-      options.add(new OptionWrapper(option.name, option.getValue(), option.accessibleScopes, option.kind, option.scope));
+      options.add(new OptionWrapper(option.name, option.getValue(), optionManager.getDefault(option.name).getValue(), option.accessibleScopes, option.kind, option.scope));
     }
 
     Collections.sort(options, new Comparator<OptionWrapper>() {
@@ -171,6 +171,7 @@ public class StatusResources {
 
     private String name;
     private Object value;
+    private Object defaultValue;
     private OptionValue.AccessibleScopes accessibleScopes;
     private String kind;
     private String optionScope;
@@ -178,11 +179,13 @@ public class StatusResources {
     @JsonCreator
     public OptionWrapper(@JsonProperty("name") String name,
                          @JsonProperty("value") Object value,
+                         @JsonProperty("defaultValue") Object defaultValue,
                          @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
                          @JsonProperty("kind") Kind kind,
                          @JsonProperty("optionScope") OptionValue.OptionScope scope) {
       this.name = name;
       this.value = value;
+      this.defaultValue = defaultValue;
       this.accessibleScopes = type;
       this.kind = kind.name();
       this.optionScope = scope.name();
@@ -201,6 +204,10 @@ public class StatusResources {
       return value;
     }
 
+    public Object getDefaultValueAsString() {
+      return defaultValue.toString();
+    }
+
     public OptionValue.AccessibleScopes getAccessibleScopes() {
       return accessibleScopes;
     }
@@ -215,7 +222,7 @@ public class StatusResources {
 
     @Override
     public String toString() {
-      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' +'}';
+      return "OptionWrapper{" + "name='" + name + '\'' + ", value=" + value + ", default=" + defaultValue + ", accessibleScopes=" + accessibleScopes + ", kind='" + kind + '\'' + ", scope='" + optionScope + '\'' +'}';
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -90,7 +90,7 @@ public class StatusResources {
     OptionList optionList = internal ? optionManager.getInternalOptionList(): optionManager.getPublicOptionList();
 
     for (OptionValue option : optionList) {
-      options.add(new OptionWrapper(option.name, option.getValue(), optionManager.getDefault(option.name).getValue(), option.accessibleScopes, option.kind, option.scope));
+      options.add(new OptionWrapper(option.name, option.getValue(), optionManager.getDefault(option.name).getValue().toString(), option.accessibleScopes, option.kind, option.scope));
     }
 
     Collections.sort(options, new Comparator<OptionWrapper>() {
@@ -171,7 +171,7 @@ public class StatusResources {
 
     private String name;
     private Object value;
-    private Object defaultValue;
+    private String defaultValue;
     private OptionValue.AccessibleScopes accessibleScopes;
     private String kind;
     private String optionScope;
@@ -179,7 +179,7 @@ public class StatusResources {
     @JsonCreator
     public OptionWrapper(@JsonProperty("name") String name,
                          @JsonProperty("value") Object value,
-                         @JsonProperty("defaultValue") Object defaultValue,
+                         @JsonProperty("defaultValue") String defaultValue,
                          @JsonProperty("accessibleScopes") OptionValue.AccessibleScopes type,
                          @JsonProperty("kind") Kind kind,
                          @JsonProperty("optionScope") OptionValue.OptionScope scope) {
@@ -204,8 +204,8 @@ public class StatusResources {
       return value;
     }
 
-    public Object getDefaultValueAsString() {
-      return defaultValue.toString();
+    public String getDefaultValue() {
+      return defaultValue;
     }
 
     public OptionValue.AccessibleScopes getAccessibleScopes() {

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -90,9 +90,9 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
                   </#if>
                     <div class="input-group-btn">
                       <button class="btn btn-default" type="submit">Update</button>
-                      <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" type="button"
-                              <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
-                      title="Reset to ${option.getDefaultValueAsString()}"</#if>>Reset</button>
+                      <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValue()}', '${option.getKind()}')" type="button"
+                              <#if option.getDefaultValue() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
+                      title="Reset to ${option.getDefaultValue()}"</#if>>Reset</button>
                     </div>
                   </div>
                 </div>

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -92,7 +92,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
                       <button class="btn btn-default" type="submit">Update</button>
                       <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" type="button"
                               <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
-                      title="Reset to ${option.getDefaultValueAsString()}"</#if>>Default</button>
+                      title="Reset to ${option.getDefaultValueAsString()}"</#if>>Reset</button>
                     </div>
                   </div>
                 </div>

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -22,8 +22,23 @@
     <script type="text/javascript" language="javascript"  src="/static/js/jquery.dataTables-1.10.16.min.js"> </script>
     <script type="text/javascript" language="javascript" src="/static/js/dataTables.colVis-1.1.0.min.js"></script>
     <script>
-        function resetToDefault(optionName, optionValue, optionKind) {
-            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function (status) { location.reload(true); } );
+        //Alter System Values
+        function alterSysOption(optionName, optionValue, optionKind) {
+            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function () {
+                location.reload(true);
+            });
+        }
+
+        //Read Values and apply
+        function alterSysOptionUsingId(optionRawName) {
+            //Escaping '.' for id search
+            let optionName = optionRawName.replace(/\./gi, "\\.");
+            let optionKind = $("#"+optionName+" input[name='kind']").attr("value");
+            let optionValue = $("#"+optionName+" input[name='value']").val();
+            if (optionKind == "BOOLEAN") {
+                optionValue = $("#"+optionName+" select[name='value']").val();
+            }
+            alterSysOption(optionRawName, optionValue, optionKind);
         }
     </script>
     <!-- List of Option Descriptions -->
@@ -75,7 +90,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
           <tr id="row-${i}">
             <td style="font-family:Courier New; vertical-align:middle" id='optionName'>${option.getName()}</td>
             <td>
-              <form class="form-inline" role="form" action="/option/${option.getName()}" method="POST">
+              <form class="form-inline" role="form" id="${option.getName()}">
                 <div class="form-group">
                 <input type="hidden" class="form-control" name="kind" value="${option.getKind()}">
                 <input type="hidden" class="form-control" name="name" value="${option.getName()}">
@@ -89,9 +104,8 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
                     <input type="text" class="form-control" placeholder="${option.getValueAsString()}" name="value" value="${option.getValueAsString()}">
                   </#if>
                     <div class="input-group-btn">
-                      <button class="btn btn-default" type="submit">Update</button>
-                      <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" type="button"
-                              <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
+                      <button class="btn btn-default" type="button" onclick="alterSysOptionUsingId('${option.getName()}')">Update</button>
+                      <button class="btn btn-default" type="button" onclick="alterSysOption('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
                       title="Reset to ${option.getDefaultValueAsString()}"</#if>>Default</button>
                     </div>
                   </div>

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -22,23 +22,8 @@
     <script type="text/javascript" language="javascript"  src="/static/js/jquery.dataTables-1.10.16.min.js"> </script>
     <script type="text/javascript" language="javascript" src="/static/js/dataTables.colVis-1.1.0.min.js"></script>
     <script>
-        //Alter System Values
-        function alterSysOption(optionName, optionValue, optionKind) {
-            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function () {
-                location.reload(true);
-            });
-        }
-
-        //Read Values and apply
-        function alterSysOptionUsingId(optionRawName) {
-            //Escaping '.' for id search
-            let optionName = optionRawName.replace(/\./gi, "\\.");
-            let optionKind = $("#"+optionName+" input[name='kind']").attr("value");
-            let optionValue = $("#"+optionName+" input[name='value']").val();
-            if (optionKind == "BOOLEAN") {
-                optionValue = $("#"+optionName+" select[name='value']").val();
-            }
-            alterSysOption(optionRawName, optionValue, optionKind);
+        function resetToDefault(optionName, optionValue, optionKind) {
+            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function (status) { location.reload(true); } );
         }
     </script>
     <!-- List of Option Descriptions -->
@@ -90,7 +75,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
           <tr id="row-${i}">
             <td style="font-family:Courier New; vertical-align:middle" id='optionName'>${option.getName()}</td>
             <td>
-              <form class="form-inline" role="form" id="${option.getName()}">
+              <form class="form-inline" role="form" action="/option/${option.getName()}" method="POST">
                 <div class="form-group">
                 <input type="hidden" class="form-control" name="kind" value="${option.getKind()}">
                 <input type="hidden" class="form-control" name="name" value="${option.getName()}">
@@ -104,8 +89,9 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
                     <input type="text" class="form-control" placeholder="${option.getValueAsString()}" name="value" value="${option.getValueAsString()}">
                   </#if>
                     <div class="input-group-btn">
-                      <button class="btn btn-default" type="button" onclick="alterSysOptionUsingId('${option.getName()}')">Update</button>
-                      <button class="btn btn-default" type="button" onclick="alterSysOption('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
+                      <button class="btn btn-default" type="submit">Update</button>
+                      <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" type="button"
+                              <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
                       title="Reset to ${option.getDefaultValueAsString()}"</#if>>Default</button>
                     </div>
                   </div>

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -21,6 +21,11 @@
 <#macro page_head>
     <script type="text/javascript" language="javascript"  src="/static/js/jquery.dataTables-1.10.16.min.js"> </script>
     <script type="text/javascript" language="javascript" src="/static/js/dataTables.colVis-1.1.0.min.js"></script>
+    <script>
+        function resetToDefault(optionName, optionValue, optionKind) {
+            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function (status) { location.reload(true); } );
+        }
+    </script>
     <!-- List of Option Descriptions -->
     <script src="/dynamic/options.describe.js"></script>
     <link href="/static/css/dataTables.colVis-1.1.0.min.css" rel="stylesheet">
@@ -85,6 +90,9 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
                   </#if>
                     <div class="input-group-btn">
                       <button class="btn btn-default" type="submit">Update</button>
+                      <button class="btn btn-default" onClick="resetToDefault('${option.getName()}','${option.getDefaultValueAsString()}', '${option.getKind()}')" type="button"
+                              <#if option.getDefaultValueAsString() == option.getValueAsString()>disabled="true" style="pointer-events:none" <#else>
+                      title="Reset to ${option.getDefaultValueAsString()}"</#if>>Default</button>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This commit introduces a new button on the options page that allows a user to reset an option to its system default value. 

To simplify things, a tooltip is shown when the mouse hovers over the button. If the option value is already default, the button is disabled.
![image](https://user-images.githubusercontent.com/4335237/48571523-dd0dd600-e8bb-11e8-9008-9d5ffc957bec.png)

In addition, a second commit refactor Update button functionality to use same code path and reuses what we already are using to set the default (using AJAX) and auto-refreshing