### PR TITLE
DRILL-6864: Upgrade the git-commit-id plugin to 2.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.1.9</version>
+        <version>2.2.5</version>
         <executions>
           <execution>
             <id>for-jars</id>


### PR DESCRIPTION
The latest version of the git-commit-id seems to work OK (passed all the Jenkins tests; even though the maven repository shows dependency on jackson.databind version 2.9.6, while we use 2.9.5 ; see https://mvnrepository.com/artifact/pl.project13.maven/git-commit-id-plugin/2.2.5 )

Performance on Jenkins build seems the same, but on my Mac a full clean build is nearly 2 minutes faster. And when adding the new option to skip this plugin ( -Dmaven.gitcommitid.skip=true ) , the clean build is 3-4 minutes faster.

