### PR TITLE
DRILL-6883: Force reload of options after resetting parameter

### DIFF
--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -23,7 +23,7 @@
     <script type="text/javascript" language="javascript" src="/static/js/dataTables.colVis-1.1.0.min.js"></script>
     <script>
         function resetToDefault(optionName, optionValue, optionKind) {
-            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function (status) { location.reload(true); } );
+            $.post("/option/"+optionName, {kind: optionKind, name: optionName, value: optionValue}, function (status) { window.location=location.protocol+"//"+location.host+"/options"; } );
         }
     </script>
     <!-- List of Option Descriptions -->

--- a/exec/java-exec/src/main/resources/rest/options.ftl
+++ b/exec/java-exec/src/main/resources/rest/options.ftl
@@ -33,9 +33,12 @@
     function alterSysOptionUsingId(optionRawName) {
         //Escaping '.' for id search
         let optionName = optionRawName.replace(/\./gi, "\\.");
+        //Extracting datatype from the form
         let optionKind = $("#"+optionName+" input[name='kind']").attr("value");
+        //Extracting value from the form's INPUT element
         let optionValue = $("#"+optionName+" input[name='value']").val();
         if (optionKind == "BOOLEAN") {
+            //Extracting boolean value from the form's SELECT element (since this is a dropdown input)
             optionValue = $("#"+optionName+" select[name='value']").val();
         } else if (optionKind != "STRING") { //i.e. it is a number (FLOAT/DOUBLE/LONG)
             if (isNaN(optionValue)) {


### PR DESCRIPTION
If an update is initiated, the webpage loaded changes. Attempting a reset tries to reload this page, but it does not show the updated values from the back end.
This patch forces the reload of updated values by redirecting to /options page