### PR TITLE
DRILL-6887: Fix FunctionInitializerTest.init() failure

### DIFF
--- a/exec/java-exec/src/test/resources/drill-udf/pom.xml
+++ b/exec/java-exec/src/test/resources/drill-udf/pom.xml
@@ -28,6 +28,8 @@
   <version>1.0</version>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <jar.finalName>${project.name}</jar.finalName>
     <custom.buildDirectory>${project.basedir}/target</custom.buildDirectory>
     <drill.version>1.13.0</drill.version>
@@ -58,6 +60,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
         <configuration>
           <includes>
             <include>${include.files}</include>


### PR DESCRIPTION
It fixes `FunctionInitializerTest.init()` failure for jdk9 and above.