### PR TITLE
DRILL-6889: Exclude Drill unit tests to avoid Travis timing out

### DIFF
--- a/common/src/test/java/org/apache/drill/categories/UnlikelyTest.java
+++ b/common/src/test/java/org/apache/drill/categories/UnlikelyTest.java
@@ -18,7 +18,7 @@
 package org.apache.drill.categories;
 
 /**
- * This is a category for tests which target very specific bugs or that excercise corner cases that your unlikely to break.
+ * This is a category for tests which target very specific bugs or that exercise  corner cases that your unlikely to break.
  */
 public interface UnlikelyTest {
 }

--- a/drill-yarn/pom.xml
+++ b/drill-yarn/pom.xml
@@ -136,4 +136,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>travis</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -35,7 +35,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category({SqlFunctionTest.class, OperatorTest.class, PlannerTest.class})
+@Category({SqlFunctionTest.class, OperatorTest.class, PlannerTest.class, UnlikelyTest.class})
 public class TestExampleQueries extends BaseTestQuery {
   @BeforeClass
   public static void setupTestFiles() {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -150,6 +150,7 @@ public class TestStarQueries extends BaseTestQuery {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testSelStarOrderByLimit() throws Exception{
     testBuilder()
         .ordered()
@@ -186,6 +187,7 @@ public class TestStarQueries extends BaseTestQuery {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testSelStarJoin() throws Exception {
     testBuilder()
         .ordered()
@@ -325,6 +327,7 @@ public class TestStarQueries extends BaseTestQuery {
   }
 
   @Test  // join two SubQuery, each having select * : regular columns appear in the select , where and on clause, group by, order by.
+  @Category(UnlikelyTest.class)
   public void testSelStarSubQJoin() throws Exception {
     // select clause, where.
     test(" select n.n_nationkey, n.n_name, n.n_regionkey, r.r_name \n" +

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -213,6 +213,7 @@ public class TestUnionAll extends BaseTestQuery {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testUnionAllViewExpandableStar() throws Exception {
     try {
       test("use dfs.tmp");
@@ -661,6 +662,7 @@ public class TestUnionAll extends BaseTestQuery {
   }
 
   @Test // see DRILL-2746
+  @Category(UnlikelyTest.class)
   public void testInListOnUnionAll() throws Exception {
     String query = "select n_nationkey \n" +
         "from (select n1.n_nationkey from cp.`tpch/nation.parquet` n1 inner join cp.`tpch/region.parquet` r1 on n1.n_regionkey = r1.r_regionkey \n" +

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestWindowFunctions.java
@@ -543,6 +543,7 @@ public class TestWindowFunctions extends BaseTestQuery {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testRankWithGroupBy() throws Exception {
     final String query = "select dense_rank() over (order by l_suppkey) as rank1 " +
         " from cp.`tpch/lineitem.parquet` group by l_partkey, l_suppkey order by 1 desc limit 1";
@@ -792,6 +793,7 @@ public class TestWindowFunctions extends BaseTestQuery {
   }
 
   @Test // DRILL-3679, DRILL-3680
+  @Category(UnlikelyTest.class)
   public void testWindowFunInNestSubQ() throws Exception {
     final String query =
         " select n_nationkey , n_regionkey , " +
@@ -855,6 +857,7 @@ public class TestWindowFunctions extends BaseTestQuery {
   }
 
   @Test // DRILL-2330
+  @Category(UnlikelyTest.class)
   public void testNestedAggregates() throws Exception {
 
     final String query = "select sum(min(l_extendedprice))"

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinAdvanced.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestMergeJoinAdvanced.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
+import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.test.TestTools;
 import org.apache.drill.categories.OperatorTest;
@@ -75,6 +76,7 @@ public class TestMergeJoinAdvanced extends JoinTestBase {
   }
 
   @Test
+  @Category({UnlikelyTest.class})
   public void testJoinWithDifferentTypesInCondition() throws Exception {
     String query = "select count(*) col1 from " +
         "(select t1.date_opt from cp.`parquet/date_dictionary.parquet` t1, cp.`parquet/timestamp_table.parquet` t2 " +
@@ -180,6 +182,7 @@ public class TestMergeJoinAdvanced extends JoinTestBase {
   }
 
   @Test
+  @Category({UnlikelyTest.class})
   public void testMergeLeftJoinLargeLeft() throws Exception {
     testMultipleBatchJoin(5000L, 1000L, "left", 5000L * 1000L + 2L);
   }
@@ -218,6 +221,7 @@ public class TestMergeJoinAdvanced extends JoinTestBase {
   }
 
   @Test
+  @Category({UnlikelyTest.class})
   public void testDrill4165() throws Exception {
     final String query = "select count(*) cnt from cp.`tpch/lineitem.parquet` l1, cp.`tpch/lineitem.parquet` l2 " +
         "where l1.l_partkey = l2.l_partkey and l1.l_suppkey < 30 and l2.l_suppkey < 30";
@@ -292,6 +296,7 @@ public class TestMergeJoinAdvanced extends JoinTestBase {
   }
 
   @Test // DRILL-6491
+  @Category({UnlikelyTest.class})
   public void testFullJoinIsNotSupported() throws Exception {
     thrown.expect(UserRemoteException.class);
     thrown.expectMessage(CoreMatchers.containsString("SYSTEM ERROR: CannotPlanException"));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/mergereceiver/TestMergingReceiver.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.pop.PopUnitTestBase;
@@ -40,7 +41,7 @@ import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.junit.experimental.categories.Category;
 
-@Category(OperatorTest.class)
+@Category({OperatorTest.class, SlowTest.class})
 public class TestMergingReceiver extends PopUnitTestBase {
   // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestMergingReceiver.class);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
@@ -283,6 +283,7 @@ public class TestWindowFrame extends BaseTestQuery {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testLeadWithPby() throws Exception {
     testBuilder()
       .sqlQuery(getFile("window/lead.pby.oby.sql"))

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
@@ -176,6 +176,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testFix4449() throws Exception {
     runSQL("CREATE TABLE dfs.tmp.`4449` PARTITION BY(l_discount) AS SELECT l_orderkey, l_discount FROM cp.`tpch/lineitem.parquet`");
     runSQL("REFRESH TABLE METADATA dfs.tmp.`4449`");
@@ -642,6 +643,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
   }
 
   @Test
+  @Category(UnlikelyTest.class)
   public void testInnerMetadataFilesAreAbsent() throws Exception {
     final String innerMetaCorruptedTable = "inner_meta_corrupted_table";
     File dataDir = dirTestWatcher.copyResourceToRoot(
@@ -814,6 +816,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
   }
 
   @Test // DRILL-4139
+  @Category(UnlikelyTest.class)
   public void testPartitionPruningWithIsNull() throws Exception {
     try {
       test("create table dfs.tmp.`t6/a` as\n" +

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -857,6 +857,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>travis</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -186,5 +186,11 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>travis</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Excluding more tests from TravisCI build to avoid timing out.
See Jira description for more information [DRILL-6889](https://issues.apache.org/jira/browse/DRILL-6889)