### PR TITLE
DRILL-6878: Use DrillPushRowKeyJoinToScan rule on DrillJoin pattern to o account for DrillSemiJoin

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillJoin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillJoin.java
@@ -45,4 +45,7 @@ public interface DrillJoin extends DrillRelNode {
 
   /* Right RelNode of the Join Relation */
   RelNode getRight();
+
+  /* Does semi-join? */
+  boolean isSemiJoin();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillJoinRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillJoinRel.java
@@ -189,4 +189,9 @@ public class DrillJoinRel extends DrillJoinRelBase implements DrillRel {
         inputs.left, inputs.right, rexCondition, join.getJoinType());
     return joinRel;
   }
+
+  @Override
+  public boolean isSemiJoin() {
+    return false;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillSemiJoinRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillSemiJoinRel.java
@@ -98,4 +98,9 @@ public class DrillSemiJoinRel extends SemiJoin implements DrillJoin, DrillRel {
 
     return new LogicalSemiJoin(leftOp, rightOp, conditions, joinType);
   }
+
+  @Override
+  public boolean isSemiJoin() {
+    return true;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/RowKeyJoinCallContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/RowKeyJoinCallContext.java
@@ -34,7 +34,7 @@ public class RowKeyJoinCallContext {
   private int rowKeyPos;
   // swapping of row-key join inputs necessary
   private boolean swapInputs;
-  private DrillJoinRel joinRel;
+  private DrillJoin joinRel;
   // rels on the rowkey side of the join to be transformed
   private DrillProjectRel upperProjectRel;
   private DrillFilterRel filterRel;
@@ -42,7 +42,7 @@ public class RowKeyJoinCallContext {
   private DrillScanRel scanRel;
 
   public RowKeyJoinCallContext (RelOptRuleCall call, RowKey rowKeyLoc, int rowKeyPos, boolean swapInputs,
-      DrillJoinRel joinRel, DrillProjectRel upperProjectRel, DrillFilterRel filterRel, DrillProjectRel lowerProjectRel,
+      DrillJoin joinRel, DrillProjectRel upperProjectRel, DrillFilterRel filterRel, DrillProjectRel lowerProjectRel,
           DrillScanRel scanRel) {
     this.call = call;
     this.rowKeyLoc = rowKeyLoc;
@@ -71,7 +71,7 @@ public class RowKeyJoinCallContext {
     return swapInputs;
   }
 
-  public DrillJoinRel getJoinRel() {
+  public DrillJoin getJoinRel() {
     return joinRel;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/RowKeyJoinRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/RowKeyJoinRel.java
@@ -18,24 +18,40 @@
 package org.apache.drill.exec.planner.logical;
 
 
+import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.InvalidRelException;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexChecker;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.logical.data.Join;
 import org.apache.drill.common.logical.data.LogicalOperator;
 import org.apache.drill.exec.planner.torel.ConversionContext;
-
-import java.util.List;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public class RowKeyJoinRel extends DrillJoinRel implements DrillRel {
+
+  /* Whether this join represents a semi-join. This is done to skip creating another logical join
+   * RowKeySemiJoinRel
+   */
+  boolean isSemiJoin;
 
   public RowKeyJoinRel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition,
                       JoinRelType joinType)  {
     super(cluster, traits, left, right, condition, joinType);
+  }
+
+  public RowKeyJoinRel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition,
+                       JoinRelType joinType, boolean isSemiJoin)  {
+    super(cluster, traits, left, right, condition, joinType);
+    this.isSemiJoin = isSemiJoin;
   }
 
   public RowKeyJoinRel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition,
@@ -51,12 +67,31 @@ public class RowKeyJoinRel extends DrillJoinRel implements DrillRel {
   @Override
   public RowKeyJoinRel copy(RelTraitSet traitSet, RexNode condition, RelNode left, RelNode right, JoinRelType joinType,
       boolean semiJoinDone) {
-    return new RowKeyJoinRel(getCluster(), traitSet, left, right, condition, joinType);
+    return new RowKeyJoinRel(getCluster(), traitSet, left, right, condition, joinType, isSemiJoin());
   }
 
   @Override
   public LogicalOperator implement(DrillImplementor implementor) {
     return super.implement(implementor);
+  }
+
+  /**
+   * Returns whether this RowKeyJoin represents a {@link org.apache.calcite.rel.core.SemiJoin}
+   * @return true if join represents a {@link org.apache.calcite.rel.core.SemiJoin}, false otherwise.
+   */
+  public boolean isSemiJoin() {
+    return isSemiJoin;
+  }
+
+  @Override
+  public RelDataType deriveRowType() {
+    return SqlValidatorUtil.deriveJoinRowType(
+            left.getRowType(),
+            isSemiJoin() ? null : right.getRowType(),
+            JoinRelType.INNER,
+            getCluster().getTypeFactory(),
+            null,
+            ImmutableList.of());
   }
 
   public static RowKeyJoinRel convert(Join join, ConversionContext context) throws InvalidRelException {
@@ -65,5 +100,41 @@ public class RowKeyJoinRel extends DrillJoinRel implements DrillRel {
     RowKeyJoinRel joinRel = new RowKeyJoinRel(context.getCluster(), context.getLogicalTraits(),
         inputs.left, inputs.right, rexCondition, join.getJoinType());
     return joinRel;
+  }
+
+  /** The parent method relies the class being an instance of {@link org.apache.calcite.rel.core.SemiJoin}
+   * in deciding row-type validity. We override this method to account for the RowKeyJoinRel logical rel
+   * representing both both regular and semi-joins */
+  @Override public boolean isValid(Litmus litmus, Context context) {
+    if (getRowType().getFieldCount()
+            != getSystemFieldList().size()
+            + left.getRowType().getFieldCount()
+            + ((this.isSemiJoin()) ? 0 : right.getRowType().getFieldCount())) {
+      return litmus.fail("field count mismatch");
+    }
+    if (condition != null) {
+      if (condition.getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
+        return litmus.fail("condition must be boolean: {}",
+                condition.getType());
+      }
+      // The input to the condition is a row type consisting of system
+      // fields, left fields, and right fields. Very similar to the
+      // output row type, except that fields have not yet been made due
+      // due to outer joins.
+      RexChecker checker =
+              new RexChecker(
+                      getCluster().getTypeFactory().builder()
+                              .addAll(getSystemFieldList())
+                              .addAll(getLeft().getRowType().getFieldList())
+                              .addAll(getRight().getRowType().getFieldList())
+                              .build(),
+                      context, litmus);
+      condition.accept(checker);
+      if (checker.getFailureCount() > 0) {
+        return litmus.fail(checker.getFailureCount()
+                + " failures in condition " + condition);
+      }
+    }
+    return litmus.succeed();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashJoinPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashJoinPrule.java
@@ -73,11 +73,11 @@ public class HashJoinPrule extends JoinPruleBase {
 
       if(isDist){
         createDistBothPlan(call, join, PhysicalJoinType.HASH_JOIN,
-            left, right, null /* left collation */, null /* right collation */, hashSingleKey, isSemi);
+            left, right, null /* left collation */, null /* right collation */, hashSingleKey);
       }else{
         if (checkBroadcastConditions(call.getPlanner(), join, left, right)) {
           createBroadcastPlan(call, join, join.getCondition(), PhysicalJoinType.HASH_JOIN,
-              left, right, null /* left collation */, null /* right collation */, isSemi);
+              left, right, null /* left collation */, null /* right collation */);
         }
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MergeJoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MergeJoinPrel.java
@@ -50,6 +50,11 @@ public class MergeJoinPrel  extends JoinPrel {
     joincategory = JoinUtils.getJoinCategory(left, right, condition, leftKeys, rightKeys, filterNulls);
   }
 
+  public MergeJoinPrel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition,
+                       JoinRelType joinType, boolean semijoin) throws InvalidRelException {
+    super(cluster, traits, left, right, condition, joinType, semijoin);
+    joincategory = JoinUtils.getJoinCategory(left, right, condition, leftKeys, rightKeys, filterNulls);
+  }
 
   @Override
   public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MergeJoinPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MergeJoinPrule.java
@@ -70,11 +70,11 @@ public class MergeJoinPrule extends JoinPruleBase {
       RelCollation collationRight = getCollation(join.getRightKeys());
 
       if(isDist){
-        createDistBothPlan(call, join, PhysicalJoinType.MERGE_JOIN, left, right, collationLeft, collationRight, hashSingleKey, false);
+        createDistBothPlan(call, join, PhysicalJoinType.MERGE_JOIN, left, right, collationLeft, collationRight, hashSingleKey);
       }else{
         if (checkBroadcastConditions(call.getPlanner(), join, left, right)) {
           createBroadcastPlan(call, join, join.getCondition(), PhysicalJoinType.MERGE_JOIN,
-              left, right, collationLeft, collationRight, false);
+              left, right, collationLeft, collationRight);
         }
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrel.java
@@ -46,6 +46,11 @@ public class NestedLoopJoinPrel  extends JoinPrel {
     super(cluster, traits, left, right, condition, joinType);
   }
 
+  public NestedLoopJoinPrel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right, RexNode condition,
+                            JoinRelType joinType, boolean semijoin) throws InvalidRelException {
+    super(cluster, traits, left, right, condition, joinType, semijoin);
+  }
+
   @Override
   public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType, boolean semiJoinDone) {
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrule.java
@@ -94,7 +94,7 @@ public class NestedLoopJoinPrule extends JoinPruleBase {
 
       if (checkBroadcastConditions(call.getPlanner(), join, left, right)) {
         createBroadcastPlan(call, join, join.getCondition(), PhysicalJoinType.NESTEDLOOP_JOIN,
-            left, right, null /* left collation */, null /* right collation */, false);
+            left, right, null /* left collation */, null /* right collation */);
       }
 
     } catch (InvalidRelException e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RowKeyJoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/RowKeyJoinPrel.java
@@ -47,6 +47,12 @@ public class RowKeyJoinPrel extends JoinPrel implements Prel {
     Preconditions.checkArgument(joinType == JoinRelType.INNER);
   }
 
+  public RowKeyJoinPrel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right,
+                        RexNode condition, JoinRelType joinType, boolean isSemiJoin) throws InvalidRelException {
+    super(cluster, traits, left, right, condition, joinType, isSemiJoin);
+    Preconditions.checkArgument(joinType == JoinRelType.INNER);
+  }
+
   @Override
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
     PhysicalOperator leftPop = ((Prel)left).getPhysicalOperator(creator);
@@ -67,7 +73,8 @@ public class RowKeyJoinPrel extends JoinPrel implements Prel {
   public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right,
       JoinRelType joinType, boolean semiJoinDone) {
     try {
-      RowKeyJoinPrel rkj = new RowKeyJoinPrel(this.getCluster(), traitSet, left, right, conditionExpr, joinType);
+      RowKeyJoinPrel rkj = new RowKeyJoinPrel(this.getCluster(), traitSet, left, right, conditionExpr,
+          joinType, isSemiJoin());
       rkj.setEstimatedRowCount(this.estimatedRowCount);
       return rkj;
     } catch (InvalidRelException e) {


### PR DESCRIPTION
@amansinha100 can you please review the PR? Thanks!

With the fix, I see the following wrong results which would be fixed in a separate JIRA. I can disable them as well.

IndexPlanTest.testCastTimestampPlan
IndexPlanTest.testRowkeyJoinPushdown_1
IndexPlanTest.testRowkeyJoinPushdown_10
IndexPlanTest.testRowkeyJoinPushdown_13
IndexPlanTest.testRowkeyJoinPushdown_6
IndexPlanTest.testRowkeyJoinPushdown_7
IndexPlanTest.testRowkeyJoinPushdown_9

IndexPlanTest.testNoFilterGroupByHashIndex
IndexPlanTest.testNoFilterOrderByHashIndex

testRowkeyJoinPushdown_12 is disabled because we no longer get the desired pattern after semi-join kicks-in. The join order changes making it illegal to apply the transformation. Hence, we do not generate a rowkeyjoin so I disabled this positive testcase.