### PR TITLE
DRILL-6900: maven-release-plugin failure on the release:perform stage

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -156,7 +156,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
         <executions>
           <execution>
             <goals>

--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -112,7 +112,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <!-- Extract ValueVectorTypes.tdd from drill-vector.jar and put 
             it under ${project.build.directory}/codegen/data where all freemarker data 

--- a/docs/dev/Docker.md
+++ b/docs/dev/Docker.md
@@ -4,7 +4,7 @@
 
    To build an Apache Drill docker image, you need to have the following software installed on your system to successfully complete a build. 
   * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-  * [Maven 3.3.1 or greater](https://maven.apache.org/download.cgi)
+  * [Maven 3.3.3 or greater](https://maven.apache.org/download.cgi)
   * [Docker CE](https://store.docker.com/search?type=edition&offering=community)
   
    If you are using an older Mac or PC, additionally configure [docker-machine](https://docs.docker.com/machine/overview/#what-is-docker-machine) on your system

--- a/docs/dev/Environment.md
+++ b/docs/dev/Environment.md
@@ -4,7 +4,7 @@
 
 Currently, the Apache Drill build process is known to work on Linux, Windows and OSX.  To build, you need to have the following software installed on your system to successfully complete a build. 
   * Java 8
-  * Maven 3.3.1 or greater
+  * Maven 3.3.3 or greater
 
 ## Confirm settings
     # java -version
@@ -13,7 +13,7 @@ Currently, the Apache Drill build process is known to work on Linux, Windows and
     Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
     # mvn --version
-    Apache Maven 3.3.1 (cab6659f9874fa96462afef40fcf6bc033d58c1c; 2015-03-13T13:10:27-07:00)
+    Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T21:41:47+03:00)
 
 ## Checkout
 

--- a/docs/dev/Environment.md
+++ b/docs/dev/Environment.md
@@ -13,7 +13,7 @@ Currently, the Apache Drill build process is known to work on Linux, Windows and
     Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
     # mvn --version
-    Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T21:41:47+03:00)
+    Apache Maven 3.3.3
 
 ## Checkout
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
     <excludedGroups />
     <memoryMb>4096</memoryMb>
     <directMemoryMb>4096</directMemoryMb>
-    <additionalparam>-Xdoclint:none</additionalparam>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
     <docker.repository>drill/apache-drill</docker.repository>
@@ -574,7 +573,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.1</version>
           <executions>
             <execution>
               <goals>
@@ -701,11 +699,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -907,6 +900,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version> <!--the 3.0.1 version causes failures on the release:prepare stage-->
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
         </plugin>
 
         <!--Note: apache-21.pom has the latest versions of apache-rat-plugin, maven-dependency-plugin and

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,12 @@
     <excludedGroups />
     <memoryMb>4096</memoryMb>
     <directMemoryMb>4096</directMemoryMb>
-    <doclint>none</doclint>
+    <additionalparam>-Xdoclint:none</additionalparam>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
     <docker.repository>drill/apache-drill</docker.repository>
     <antlr.version>4.7.1</antlr.version>
+    <lowestMavenVersion>3.3.3</lowestMavenVersion>
   </properties>
 
   <scm>
@@ -399,7 +400,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
@@ -493,7 +493,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.3.1,4)</version>
+                  <version>[{$lowestMavenVersion},4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,12)</version>
@@ -574,6 +574,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.1</version>
           <executions>
             <execution>
               <goals>
@@ -704,7 +705,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -738,6 +739,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M2</version>
           <executions>
             <execution>
               <id>default-test</id>
@@ -749,7 +751,7 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>2.21.0</version>
+              <version>3.0.0-M2</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -881,6 +883,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -890,6 +893,25 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>2.12.1</version> <!--it necessary to solve Checkstyle7.8.2 errors to update it to latest version-->
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.4</version> <!--the 3.0.1 version causes failures on the release:prepare stage-->
+        </plugin>
+
+        <!--Note: apache-21.pom has the latest versions of apache-rat-plugin, maven-dependency-plugin and
+        maven-clean-plugin. Once the newer versions are needed and present in maven repo, the plugins versions can be
+        overridden here-->
       </plugins>
     </pluginManagement>
   </build>
@@ -1708,7 +1730,6 @@
           <!-- override the parent assembly execution to customize the assembly final name -->
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>source-release-assembly</id>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -62,7 +62,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-clean-plugin</artifactId>
-            <version>3.0.0</version>
             <configuration>
               <filesets>
                 <fileset>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.3.3</version>
+      <version>${lowestMavenVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-logging</artifactId>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.3.3</version>
+      <version>${lowestMavenVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.fmpp-maven-plugin</groupId>


### PR DESCRIPTION
- downgrade maven-javadoc-plugin version
- update some Drill maven plugins versions and place them to pluginManagement block
- bump up lowest maven mevrsion supported by Drill in correspondence to org.apache.maven dependencies