### PR TITLE
DRILL-6913: Fix multiple error output in the console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <guava.version>19.0</guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.10.0</parquet.version>
-    <calcite.version>1.17.0-drill-r1</calcite.version>
+    <calcite.version>1.17.0-drill-r2</calcite.version>
     <avatica.version>1.12.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.6.0</sqlline.version>


### PR DESCRIPTION
1. Bump up Calcite version to 1.17.0-drill-r2 (includes CALCITE-2463).
2. Optimized exception handling in DrillSqlWorker getPlan method.

Details in [DRILL-6913](https://issues.apache.org/jira/browse/DRILL-6913).