### PR TITLE
DRILL-6915: Disable generation of test tables with case-sensitive names for non-Linux systems

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -34,6 +34,7 @@
     <mysql.connector.version>8.0.13</mysql.connector.version>
     <derby.database.name>drill_derby_test</derby.database.name>
     <mysql.database.name>drill_mysql_test</mysql.database.name>
+    <mysql.scriptFile.name>mysql-test-data.sql</mysql.scriptFile.name>
   </properties>
 
   <dependencies>
@@ -77,6 +78,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>linux</id>
+      <properties>
+        <!-- Reg expr includes both mysql-test-data.sql and mysql-test-data-linux.sql script files -->
+        <mysql.scriptFile.name>mysql-test-data*.sql</mysql.scriptFile.name>
+      </properties>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+    </profile>
+  </profiles>
 
   <build>
     <testResources>
@@ -223,6 +239,20 @@
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-mysql-maven-plugin</artifactId>
         <version>0.9</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.0.0.Final</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>mysql-test</id>
@@ -254,7 +284,7 @@
         </dependencies>
         <configuration>
           <skip>${skipTests}</skip>
-          <driver>com.mysql.jdbc.Driver</driver>
+          <driver>com.mysql.cj.jdbc.Driver</driver>
           <username>root</username>
           <password>root</password>
           <url>jdbc:mysql://localhost:${mysql.reserved.port}/${mysql.database.name}</url>
@@ -271,7 +301,7 @@
               <fileset>
                 <basedir>${basedir}/src/test/resources</basedir>
                 <includes>
-                  <include>mysql-test-data.sql</include>
+                  <include>${mysql.scriptFile.name}</include>
                 </includes>
               </fileset>
             </configuration>

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -21,6 +21,7 @@ import org.apache.drill.categories.JdbcStorageTest;
 import org.apache.drill.exec.expr.fn.impl.DateUtility;
 import org.apache.drill.PlanTestBase;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -145,6 +146,11 @@ public class TestJdbcPluginWithMySQLIT extends PlanTestBase {
 
   @Test
   public void testCaseSensitiveTableNames() throws Exception {
+    String osName = System.getProperty("os.name").toLowerCase();
+    Assume.assumeTrue(
+        "Skip tests for non-linux systems due to " +
+            "table names case-insensitivity problems on Windows and MacOS",
+        osName.startsWith("linux"));
     test("use mysqlCaseInsensitive.`drill_mysql_test`");
     // two table names match the filter ignoring the case
     assertEquals(2, testSql("show tables like 'caseSensitiveTable'"));

--- a/contrib/storage-jdbc/src/test/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-jdbc/src/test/resources/bootstrap-storage-plugins.json
@@ -9,13 +9,13 @@
         },
         mysql : {
           type    : "jdbc",
-          driver  : "com.mysql.jdbc.Driver",
+          driver  : "com.mysql.cj.jdbc.Driver",
           url     : "jdbc:mysql://localhost:${mysql.reserved.port}/${mysql.database.name}?user=root&password=root&useJDBCCompliantTimezoneShift=true",
           enabled : true
         },
         mysqlCaseInsensitive : {
           type    : "jdbc",
-          driver  : "com.mysql.jdbc.Driver",
+          driver  : "com.mysql.cj.jdbc.Driver",
           url     : "jdbc:mysql://localhost:${mysql.reserved.port}/${mysql.database.name}?user=root&password=root&useJDBCCompliantTimezoneShift=true",
           caseInsensitiveTableNames: true,
           enabled : true

--- a/contrib/storage-jdbc/src/test/resources/mysql-test-data-linux.sql
+++ b/contrib/storage-jdbc/src/test/resources/mysql-test-data-linux.sql
@@ -1,0 +1,10 @@
+set global time_zone = "+00:00";
+
+use drill_mysql_test;
+
+create table CASESENSITIVETABLE (
+  a   BLOB,
+  b   BLOB
+);
+
+insert into CASESENSITIVETABLE (a, b) values ('this is a test', 'for case sensitive table names');

--- a/contrib/storage-jdbc/src/test/resources/mysql-test-data.sql
+++ b/contrib/storage-jdbc/src/test/resources/mysql-test-data.sql
@@ -9,13 +9,6 @@ create table caseSensitiveTable (
 
 insert into caseSensitiveTable (a) values ('this is a test');
 
-create table CASESENSITIVETABLE (
-  a   BLOB,
-  b   BLOB
-);
-
-insert into CASESENSITIVETABLE (a, b) values ('this is a test', 'for case sensitive table names');
-
 create table person (
   person_id       INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 


### PR DESCRIPTION
- Splited scripts to generate regular tables for tests in one script and tables with a different case in names in another one.
- Introduced "linux" profile to specify a script which generates tables with names in different case only when the Linux system is used. 
- Disabled test which checks table names case sensitivity for non-Linux systems.
- Updated `hibernate-validator` dependency for `jcabi-mysql-maven-plugin` to fix `NoClassDefFoundError` error and specified `jaxb-api` to avoid problems with JDK 9+.
- Changed driver from `com.mysql.jdbc.Driver` to `com.mysql.cj.jdbc.Driver` for tests to avoid warnings (see https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-api-changes.html)

For details please see [DRILL-6915](https://issues.apache.org/jira/browse/DRILL-6915).