### PR TITLE
DRILL-6919: Fix compilation error in TestGracefulShutdown class for mapr profile

### DIFF
--- a/contrib/storage-opentsdb/src/test/java/org/apache/drill/store/openTSDB/TestOpenTSDBPlugin.java
+++ b/contrib/storage-opentsdb/src/test/java/org/apache/drill/store/openTSDB/TestOpenTSDBPlugin.java
@@ -22,17 +22,12 @@ import org.apache.drill.PlanTestBase;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.openTSDB.OpenTSDBStoragePluginConfig;
+import org.apache.drill.test.QueryTestUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.BindException;
-import java.net.ServerSocket;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -55,7 +50,6 @@ import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POS
 import static org.apache.drill.store.openTSDB.TestDataHolder.SAMPLE_DATA_FOR_POST_REQUEST_WITH_TAGS;
 
 public class TestOpenTSDBPlugin extends PlanTestBase {
-  private static final Logger logger = LoggerFactory.getLogger(TestOpenTSDBPlugin.class);
 
   private static int portNumber;
 
@@ -64,7 +58,7 @@ public class TestOpenTSDBPlugin extends PlanTestBase {
 
   @BeforeClass
   public static void setup() throws Exception {
-    portNumber = getFreePortNumber(10_000, 200);
+    portNumber = QueryTestUtil.getFreePortNumber(10_000, 200);
     final StoragePluginRegistry pluginRegistry = getDrillbitContext().getStorage();
     OpenTSDBStoragePluginConfig storagePluginConfig =
         new OpenTSDBStoragePluginConfig(String.format("http://localhost:%s", portNumber));
@@ -190,28 +184,5 @@ public class TestOpenTSDBPlugin extends PlanTestBase {
     test("use openTSDB");
     test("describe `warp.speed.test`");
     Assert.assertEquals(1, testSql("show tables"));
-  }
-
-  /**
-   * Checks that port with specified number is free and returns it.
-   * Otherwise, increases port number and checks until free port is found
-   * or the number of attempts is reached specified numberOfAttempts
-   *
-   * @param portNumber     initial port number
-   * @param numberOfAttempts max number of attempts to find port with greater number
-   * @return free port number
-   * @throws BindException if free port was not found and all attempts were used.
-   */
-  private static int getFreePortNumber(int portNumber, int numberOfAttempts) throws IOException {
-    for (int i = portNumber; i <= portNumber + numberOfAttempts; i++) {
-      try (ServerSocket socket = new ServerSocket(i)) {
-        return socket.getLocalPort();
-      } catch (BindException e) {
-        logger.warn("Port {} is already in use.", i);
-      }
-    }
-
-    throw new BindException(String.format("Free port could not be found in the range [%s-%s].\n" +
-        "Please release any of used ports in this range.", portNumber, portNumber + numberOfAttempts));
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.Drillbit;
-import org.apache.hadoop.net.ServerSocketUtil;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -184,8 +183,8 @@ public class TestGracefulShutdown extends BaseTestQuery {
     Drillbit drillbit = null;
     Drillbit drillbitWithSamePort = null;
 
-    int userPort = ServerSocketUtil.getPort(31170, 300);
-    int bitPort = ServerSocketUtil.getPort(31180, 300);
+    int userPort = QueryTestUtil.getFreePortNumber(31170, 300);
+    int bitPort = QueryTestUtil.getFreePortNumber(31180, 300);
     ClusterFixtureBuilder fixtureBuilder = ClusterFixture.bareBuilder(dirTestWatcher).withLocalZk()
         .configProperty(ExecConstants.INITIAL_USER_PORT, userPort)
         .configProperty(ExecConstants.INITIAL_BIT_PORT, bitPort);


### PR DESCRIPTION
In the fix for DRILL-6912 was used a class from hadoop 2.7.4, but for `mapr` profile hadoop 2.7.1 is used, where this class is absent.

In this PR removed usage of `ServerSocketUtil` class.

For details please see [DRILL-6919](https://issues.apache.org/jira/browse/DRILL-6919).