### PR TITLE
DRILL-6929: Exclude maprfs jar for default profile

### DIFF
--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -100,7 +100,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-sources-as-resources</id>
@@ -187,12 +186,14 @@
       <artifactId>maprdb</artifactId>
       <version>${mapr.release.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.mapr.hadoop</groupId>
       <artifactId>maprfs</artifactId>
       <version>${mapr.release.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -142,11 +142,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.drill.contrib</groupId>
-      <artifactId>drill-format-mapr</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -175,7 +170,34 @@
   <profiles>
     <profile>
       <id>mapr</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-mapr-sources</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>scrMapr/main/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
+        <dependency>
+          <groupId>org.apache.drill.contrib</groupId>
+          <artifactId>drill-format-mapr</artifactId>
+          <version>${project.version}</version>
+        </dependency>
         <dependency>
           <groupId>com.tdunning</groupId>
           <artifactId>json</artifactId>
@@ -183,7 +205,6 @@
         <dependency>
           <groupId>org.apache.hive</groupId>
           <artifactId>hive-maprdb-json-handler</artifactId>
-          <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>com.mapr.db</groupId>

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -153,7 +153,6 @@
         <!-- Allows us to reserve ports for external servers that we will launch  -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
         <executions>
           <execution>
             <id>reserve-network-port</id>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -752,7 +752,6 @@
       <plugin> <!-- source file must end up in the jar for janino parsing -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-sources-as-resources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -711,6 +711,11 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.0.0-M2</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
         <plugin> <!-- classpath scanning  -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
- Moved dependency on `drill-format-mapr` into mapr profile in `contrib/storage-hive/core/pom.xml`
- Moved class `ConvertHiveMapRDBJsonScanToDrillMapRDBJsonScan` which uses `drill-format-mapr` classes into `scrMapr/main/java` folder
- Specified `scrMapr/main/java` as source directory only for mapr profile using `build-helper-maven-plugin`

For problem description please see [DRILL-6929](https://issues.apache.org/jira/browse/DRILL-6929).