### PR TITLE
DRILL-6921: Add Clear button for /options filter

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -224,6 +224,8 @@ public final class ExecConstants {
   public static final String HTTP_AUTHENTICATION_MECHANISMS = "drill.exec.http.auth.mechanisms";
   public static final String HTTP_SPNEGO_PRINCIPAL = "drill.exec.http.auth.spnego.principal";
   public static final String HTTP_SPNEGO_KEYTAB = "drill.exec.http.auth.spnego.keytab";
+  //Customize filters in options
+  public static final String HTTP_WEB_OPTIONS_FILTERS = "drill.exec.http.web.options.filters";
   public static final String SYS_STORE_PROVIDER_CLASS = "drill.exec.sys.store.provider.class";
   public static final String SYS_STORE_PROVIDER_LOCAL_PATH = "drill.exec.sys.store.provider.local.path";
   public static final String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -31,13 +32,16 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.options.OptionList;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
@@ -63,6 +67,8 @@ public class StatusResources {
   public static final String PATH_INTERNAL_OPTIONS_JSON = "/internal_options" + REST_API_SUFFIX;
   public static final String PATH_OPTIONS = "/options";
   public static final String PATH_INTERNAL_OPTIONS = "/internal_options";
+  //Used to access current filter state in WebUI
+  private static final String CURRENT_FILTER_PARAM = "filter";
 
   @Inject UserAuthEnabled authEnabled;
   @Inject WorkManager work;
@@ -118,27 +124,35 @@ public class StatusResources {
     return getSystemOptionsJSONHelper(true);
   }
 
-  private Viewable getSystemOptionsHelper(boolean internal) {
+  //Generate model-view for WebUI (PATH_OPTIONS and PATH_INTERNAL_OPTIONS)
+  private Viewable getSystemOptionsHelper(boolean internal, UriInfo uriInfo) {
+    List<OptionWrapper> options = getSystemOptionsJSONHelper(internal);
+    List<String> fltrList = new ArrayList<>(work.getContext().getConfig().getStringList(ExecConstants.HTTP_WEB_OPTIONS_FILTERS));
+    String currFilter = (uriInfo != null) ? uriInfo.getQueryParameters().getFirst(CURRENT_FILTER_PARAM) : null;
+    if (currFilter == null) {
+      currFilter = "";
+    }
+
     return ViewableWithPermissions.create(authEnabled.get(),
       "/rest/options.ftl",
       sc,
-      getSystemOptionsJSONHelper(internal));
+      new OptionsListing(options, fltrList, currFilter));
   }
 
   @GET
   @Path(StatusResources.PATH_OPTIONS)
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.TEXT_HTML)
-  public Viewable getSystemPublicOptions() {
-    return getSystemOptionsHelper(false);
+  public Viewable getSystemPublicOptions(@Context UriInfo uriInfo) {
+    return getSystemOptionsHelper(false, uriInfo);
   }
 
   @GET
   @Path(StatusResources.PATH_INTERNAL_OPTIONS)
   @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
   @Produces(MediaType.TEXT_HTML)
-  public Viewable getSystemInternalOptions() {
-    return getSystemOptionsHelper(true);
+  public Viewable getSystemInternalOptions(@Context UriInfo uriInfo) {
+    return getSystemOptionsHelper(true, uriInfo);
   }
 
   @SuppressWarnings("resource")
@@ -160,9 +174,34 @@ public class StatusResources {
     }
 
     if (optionManager.getOptionDefinition(name).getMetaData().isInternal()) {
-      return getSystemInternalOptions();
+      return getSystemInternalOptions(null);
     } else {
-      return getSystemPublicOptions();
+      return getSystemPublicOptions(null);
+    }
+  }
+
+  /**
+   * Data Model for rendering /options on webUI
+   */
+  public static class OptionsListing {
+    private final List<OptionWrapper> options;
+    private final List<String> filters;
+    private final String dynamicFilter;
+
+    public OptionsListing(List<OptionWrapper> optList, List<String> fltrList, String currFilter) {
+      this.options = optList;
+      this.filters = fltrList;
+      this.dynamicFilter = currFilter;
+    }
+
+    public List<OptionWrapper> getOptions() {
+      return options;
+    }
+    public List<String> getFilters() {
+      return filters;
+    }
+    public String getDynamicFilter() {
+      return dynamicFilter;
     }
   }
 

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -155,7 +155,8 @@ drill.exec: {
             reservation: 0,
             maximum: 9223372036854775807
         }
-    }
+    },
+    web.options.filters: ["planner", "store", "parquet", "hashagg", "hashjoin"]
   },
   //setting javax variables for ssl configurations is being deprecated.
   ssl: {


### PR DESCRIPTION
This commit adds the following search enhancements:
1. Addition of a clear ('x') button in the search field
2. If a filter term has been entered in the search box, on clicking the Update or Reset-to-Default button of any option, the reloaded page will re-apply the last entered filter term in the search box. 
3. If the search box is empty, on clicking the Update or Reset-to-Default button of any option, the reloaded page will automatically filter out everything except the updated/reset option to show the changed value.
4. Customization of the quick search terms. (using defaults in drill-module.conf)

Screenshot of **Clear** button
![image](https://user-images.githubusercontent.com/4335237/50499064-40327280-09fb-11e9-8e50-29a0964305e6.png)

Screenshot when the search box was empty and a property (`drill.exec.memory.operator.output_batch_size_avail_mem_factor`) was updated from `0.1` to `0.5`:
![image](https://user-images.githubusercontent.com/4335237/50499083-63f5b880-09fb-11e9-8559-29b06d1d0083.png)
