### PR TITLE
DRILL-6933: Fix ctrl+enter when Impersonation is disabled

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -313,7 +313,7 @@ public class DrillRestServer extends ResourceConfig {
      * @return session user principal
      */
     private Principal createSessionUserPrincipal(DrillConfig config, HttpServletRequest request) {
-      if (WebServer.isImpersonationOnlyEnabled(config)) {
+      if (WebServer.isOnlyImpersonationEnabled(config)) {
         final String userName = request.getHeader("User-Name");
         if (!Strings.isNullOrEmpty(userName)) {
           return new DrillUserPrincipal(userName, true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -59,7 +59,7 @@ public class QueryResources {
         "/rest/query/query.ftl",
         sc,
         // if impersonation is enabled without authentication, will provide mechanism to add user name to request header from Web UI
-        WebServer.isImpersonationOnlyEnabled(work.getContext().getConfig()));
+        WebServer.isOnlyImpersonationEnabled(work.getContext().getConfig()));
   }
 
   @POST

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -164,7 +164,7 @@ public class WebServer implements AutoCloseable {
    * @param config Drill configuration
    * @return true if impersonation without authentication is enabled, false otherwise
    */
-  public static boolean isImpersonationOnlyEnabled(DrillConfig config) {
+  public static boolean isOnlyImpersonationEnabled(DrillConfig config) {
     return !config.getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED)
         && config.getBoolean(ExecConstants.IMPERSONATION_ENABLED);
   }
@@ -259,7 +259,7 @@ public class WebServer implements AutoCloseable {
       servletContextHandler.setSessionHandler(createSessionHandler(servletContextHandler.getSecurityHandler()));
     }
 
-    if (isImpersonationOnlyEnabled(workManager.getContext().getConfig())) {
+    if (isOnlyImpersonationEnabled(workManager.getContext().getConfig())) {
       for (String path : new String[]{"/query", "/query.json"}) {
         servletContextHandler.addFilter(UserNameFilter.class, path, EnumSet.of(DispatcherType.REQUEST));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -130,7 +130,7 @@ public class ProfileWrapper {
     }
     this.options = options;
 
-    this.onlyImpersonationEnabled = WebServer.isImpersonationOnlyEnabled(drillConfig);
+    this.onlyImpersonationEnabled = WebServer.isOnlyImpersonationEnabled(drillConfig);
     this.noProgressWarningThreshold = String.valueOf(drillConfig.getInt(ExecConstants.PROFILE_WARNING_PROGRESS_THRESHOLD));
   }
 

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -23,18 +23,16 @@
 <script src="/static/js/dagre-d3.min.js"></script>
 <script src="/static/js/graph.js"></script>
 <script src="/static/js/jquery.dataTables-1.10.16.min.js"></script>
-<#if model.isOnlyImpersonationEnabled()>
-    <script src="/static/js/jquery.form.js"></script>
-    <script src="/static/js/querySubmission.js"></script>
-</#if>
-  <!-- Ace Libraries for Syntax Formatting -->
-  <script src="/static/js/ace-code-editor/ace.js" type="text/javascript" charset="utf-8"></script>
-  <!-- Disabled in favour of dynamic: script src="/static/js/ace-code-editor/mode-sql.js" type="text/javascript" charset="utf-8" -->
-  <script src="/dynamic/mode-sql.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/static/js/ace-code-editor/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/static/js/ace-code-editor/theme-sqlserver.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/static/js/ace-code-editor/snippets/sql.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/static/js/ace-code-editor/mode-snippets.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/jquery.form.js"></script>
+<script src="/static/js/querySubmission.js"></script>
+<!-- Ace Libraries for Syntax Formatting -->
+<script src="/static/js/ace-code-editor/ace.js" type="text/javascript" charset="utf-8"></script>
+<!-- Disabled in favour of dynamic: script src="/static/js/ace-code-editor/mode-sql.js" type="text/javascript" charset="utf-8" -->
+<script src="/dynamic/mode-sql.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/ace-code-editor/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/ace-code-editor/theme-sqlserver.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/ace-code-editor/snippets/sql.js" type="text/javascript" charset="utf-8"></script>
+<script src="/static/js/ace-code-editor/mode-snippets.js" type="text/javascript" charset="utf-8"></script>
 
 <script>
     var globalconfig = {
@@ -176,7 +174,7 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
               </label>
             </div>
             </div>
-            <button class="btn btn-default" type=<#if model.isOnlyImpersonationEnabled()>"button" onclick="doSubmitQueryWithUserName()"<#else>"submit"</#if>>
+            <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>submitQuery()</#if>">
             Re-run query
             </button>
           </form>
@@ -573,7 +571,8 @@ table.sortable thead .sorting_desc { background-image: url("/static/img/black-de
     document.getElementById('queryForm')
             .addEventListener('keydown', function(e) {
       if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
-      if (e.target.form) doSubmitQueryWithUserName();
+      if (e.target.form) 
+        <#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>submitQuery()</#if>;
     });
     </script>
 

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -19,10 +19,8 @@
 -->
 <#include "*/generic.ftl">
 <#macro page_head>
-    <#if model?? && model>
-      <script src="/static/js/jquery.form.js"></script>
-      <script src="/static/js/querySubmission.js"></script>
-    </#if>
+  <script src="/static/js/jquery.form.js"></script>
+  <script src="/static/js/querySubmission.js"></script>
   <!-- Ace Libraries for Syntax Formatting -->
   <script src="/static/js/ace-code-editor/ace.js" type="text/javascript" charset="utf-8"></script>
   <!-- Disabled in favour of dynamic: script src="/static/js/ace-code-editor/mode-sql.js" type="text/javascript" charset="utf-8" -->
@@ -77,7 +75,7 @@
       <input class="form-control" type="hidden" id="query" name="query"/>
     </div>
 
-    <button class="btn btn-default" type=<#if model?? && model>"button" onclick="doSubmitQueryWithUserName()"<#else>"submit"</#if>>
+    <button class="btn btn-default" type="button" onclick="<#if model?? && model>doSubmitQueryWithUserName()<#else>submitQuery()</#if>">
       Submit
     </button>
   </form>
@@ -125,7 +123,8 @@
     document.getElementById('queryForm')
             .addEventListener('keydown', function(e) {
       if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
-      if (e.target.form) doSubmitQueryWithUserName();
+      if (e.target.form) 
+        <#if model?? && model>doSubmitQueryWithUserName()<#else>submitQuery()</#if>;
     });
   </script>
 

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -10,17 +10,27 @@
  *  OF ANY KIND, either express or implied. See the License for the specific
  *  language governing permissions and limitations under the License.
  */
+var userName = null;
 
+//Submit query with username
 function doSubmitQueryWithUserName() {
-    var userName = document.getElementById("userName").value;
+    userName = document.getElementById("userName").value;
     if (!userName.trim()) {
         alert("Please fill in User Name field");
         return;
     }
+    submitQuery();
+}
+
+//Submit Query (used if impersonation is not enabled)
+function submitQuery() {
+    //Submit query
     $.ajax({
         type: "POST",
         beforeSend: function (request) {
-            request.setRequestHeader("User-Name", userName);
+            if (typeof userName !== 'undefined' && userName != null && userName.length > 0) {
+              request.setRequestHeader("User-Name", userName);
+            }
         },
         url: "/query",
         data: $("#queryForm").serializeArray(),


### PR DESCRIPTION
Without impersonation, the key combination did not work because a conditional block of the FTLs skipped the Javascript functions required for submitting with the key combination.
This commit fixes that by unifying the functions that are common to both approaches of submitting a query (with and without impersoination)