### PR TITLE
DRILL-6918: Querying empty topics fails with "NumberFormatException"

### DIFF
--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaRecordReader.java
@@ -119,7 +119,9 @@ public class KafkaRecordReader extends AbstractRecordReader {
         }
       }
 
-      messageReader.ensureAtLeastOneField();
+      if (currentMessageCount > 0) {
+        messageReader.ensureAtLeastOneField();
+      }
       writer.setValueCount(currentMessageCount);
       logger.debug("Took {} ms to process {} records.", watch.elapsed(TimeUnit.MILLISECONDS), currentMessageCount);
       logger.debug("Last offset consumed for {}:{} is {}", subScanSpec.getTopicName(), subScanSpec.getPartitionId(),


### PR DESCRIPTION
If none of the project / filter columns, exist in the records, `ensureAtLeastOneField` (or the Scan operator) adds at least one field as nullable integer (or nullable varchar if `allTextmode` is enabled).

The downstream Filter operator would then go on to fail with `NumberFormatException` because it tries to convert empty fields to integers.

Since `ensureAtLeastOneField` is called after reading all the messages in a batch, it can be skipped if the batch is empty.