### PR TITLE
DRILL-6947: fix RuntimeFilter memory leak

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -213,6 +213,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
   private Map<BloomFilter, Integer> bloomFilter2buildId = new HashMap<>();
   private Map<BloomFilterDef, Integer> bloomFilterDef2buildId = new HashMap<>();
   private List<BloomFilter> bloomFilters = new ArrayList<>();
+  private boolean bloomFiltersGenerated = false;
 
   /**
    * This holds information about the spilled partitions for the build and probe side.
@@ -818,8 +819,12 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
 
   }
 
+  /**
+   * Note:
+   * This method can not be called again as part of recursive call of executeBuildPhase() to handle spilled build partitions.
+   */
   private void initializeRuntimeFilter() {
-    if (!enableRuntimeFilter) {
+    if (!enableRuntimeFilter || bloomFiltersGenerated) {
       return;
     }
     runtimeFilterReporter = new RuntimeFilterReporter((ExecutorFragmentContext) context);
@@ -838,6 +843,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
         bloomFilter2buildId.put(bloomFilter, buildFieldId);
       }
     }
+    bloomFiltersGenerated = true;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/filter/RuntimeFilterWritable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/filter/RuntimeFilterWritable.java
@@ -50,24 +50,6 @@ public class RuntimeFilterWritable implements AutoCloseables.Closeable{
       + ", srcOperatorId:" + runtimeFilterBDef.getHjOpId();
   }
 
-  public RuntimeFilterWritable(BitData.RuntimeFilterBDef runtimeFilterBDef, DrillBuf data) {
-    this.runtimeFilterBDef = runtimeFilterBDef;
-    List<Integer> bfSizeInBytes = runtimeFilterBDef.getBloomFilterSizeInBytesList();
-    int boomFilterNum = bfSizeInBytes.size();
-    this.data = new DrillBuf[boomFilterNum];
-    int index = 0;
-    for (int i = 0; i < boomFilterNum; i++) {
-      int length = bfSizeInBytes.get(i);
-      this.data[i] = data.slice(index, length);
-      index = index + length;
-    }
-
-    this.identifier = "majorFragmentId:" + runtimeFilterBDef.getMajorFragmentId()
-                      + ",minorFragmentId:" + runtimeFilterBDef.getMinorFragmentId()
-                      + ", srcOperatorId:" + runtimeFilterBDef.getHjOpId();
-  }
-
-
   public BitData.RuntimeFilterBDef getRuntimeFilterBDef() {
     return runtimeFilterBDef;
   }


### PR DESCRIPTION
This is a first step to fix the RuntimeFilter memory leak at the HashToRandomExchange case. Still has the BroadcastExchange case to solve.