### PR TITLE
DRILL-6954: Move commons libs used in UDFs module to the dependency management

### DIFF
--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -40,31 +40,22 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.6</version>
     </dependency>
 
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.4</version>
     </dependency>
 
     <dependency>
       <groupId>com.esri.geometry</groupId>
       <artifactId>esri-geometry-api</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,9 @@
     <docker.repository>drill/apache-drill</docker.repository>
     <antlr.version>4.7.1</antlr.version>
     <lowestMavenVersion>3.3.3</lowestMavenVersion>
+    <commons.net.version>3.6</commons.net.version>
+    <commons.validator.version>1.6</commons.validator.version>
+    <commons.text.version>1.6</commons.text.version>
   </properties>
 
   <scm>
@@ -1702,6 +1705,32 @@
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>
       </dependency>
+      <dependency>
+        <groupId>sqlline</groupId>
+        <artifactId>sqlline</artifactId>
+        <version>${sqlline.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>${commons.net.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>${commons.validator.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commons.text.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -2349,11 +2378,6 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
             <version>2.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>sqlline</groupId>
-            <artifactId>sqlline</artifactId>
-            <version>${sqlline.version}</version>
           </dependency>
 
           <dependency>


### PR DESCRIPTION
Details in [DRILL-6954](https://issues.apache.org/jira/browse/DRILL-6954).