### PR TITLE
DRILL-6956: Maintain a single entry for Drill Version in the pom file

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-common</artifactId>

--- a/contrib/data/pom.xml
+++ b/contrib/data/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.data</groupId>

--- a/contrib/data/tpch-sample-data/pom.xml
+++ b/contrib/data/tpch-sample-data/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-data-parent</artifactId>
     <groupId>org.apache.drill.contrib.data</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>tpch-sample-data</artifactId>

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-format-mapr</artifactId>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.contrib</groupId>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-storage-hbase</artifactId>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-storage-hive-core</artifactId>

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.drill.contrib.storage-hive</groupId>
     <artifactId>drill-contrib-storage-hive-parent</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-hive-exec-shaded</artifactId>

--- a/contrib/storage-hive/pom.xml
+++ b/contrib/storage-hive/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.contrib</groupId>
     <artifactId>drill-contrib-parent</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.contrib.storage-hive</groupId>

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-jdbc-storage</artifactId>

--- a/contrib/storage-kafka/pom.xml
+++ b/contrib/storage-kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-storage-kafka</artifactId>

--- a/contrib/storage-kudu/pom.xml
+++ b/contrib/storage-kudu/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-kudu-storage</artifactId>

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-mongo-storage</artifactId>

--- a/contrib/storage-opentsdb/pom.xml
+++ b/contrib/storage-opentsdb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>drill-contrib-parent</artifactId>
         <groupId>org.apache.drill.contrib</groupId>
-        <version>1.16.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>drill-opentsdb-storage</artifactId>

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -24,7 +24,7 @@
 <parent>
     <artifactId>drill-contrib-parent</artifactId>
     <groupId>org.apache.drill.contrib</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-udfs</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/drill-yarn/pom.xml
+++ b/drill-yarn/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-yarn</artifactId>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>drill-java-exec</artifactId>
   <name>exec/Java Execution Engine</name>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-jdbc-all</artifactId>

--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.drill.exec</groupId>
     <artifactId>exec-parent</artifactId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>drill-jdbc</artifactId>
   <name>exec/JDBC Driver using dependencies</name>

--- a/exec/memory/base/pom.xml
+++ b/exec/memory/base/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>memory-parent</artifactId>
     <groupId>org.apache.drill.memory</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>drill-memory-base</artifactId>
   <name>exec/memory/base</name>

--- a/exec/memory/pom.xml
+++ b/exec/memory/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.memory</groupId>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.exec</groupId>

--- a/exec/rpc/pom.xml
+++ b/exec/rpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>drill-rpc</artifactId>
   <name>exec/rpc</name>

--- a/exec/vector/pom.xml
+++ b/exec/vector/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>exec-parent</artifactId>
     <groupId>org.apache.drill.exec</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>vector</artifactId>
   <name>exec/Vectors</name>

--- a/logical/pom.xml
+++ b/logical/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-logical</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.apache.drill</groupId>
   <artifactId>drill-root</artifactId>
-  <version>1.16.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>Apache Drill Root POM</name>
@@ -38,6 +38,7 @@
   <url>http://drill.apache.org/</url>
 
   <properties>
+    <revision>1.16.0-SNAPSHOT</revision>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <sourceReleaseAssemblyDescriptor>source-release-zip-tar</sourceReleaseAssemblyDescriptor>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-protocol</artifactId>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tools-parent</artifactId>
     <groupId>org.apache.drill.tools</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>drill-fmpp-maven-plugin</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>drill-root</artifactId>
     <groupId>org.apache.drill</groupId>
-    <version>1.16.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.apache.drill.tools</groupId>


### PR DESCRIPTION
Currently, updating the version information for a Drill release involves updating 30+ pom files.
The right way would be to use the Multi Module Setup for Maven CI.
https://maven.apache.org/maven-ci-friendly.html#Multi_Module_Setup