### PR TITLE
DRILL-6971: Display query state in query result page

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
@@ -45,6 +45,8 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
 
   protected volatile UserException exception;
 
+  protected String queryState;
+
   /**
    * Wait until the query has completed or timeout is passed.
    *
@@ -73,6 +75,7 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
 
     // Release the wait latch if the query is terminated.
     final QueryState state = result.getQueryState();
+    queryState = state.toString();
     final QueryId queryId = result.getQueryId();
 
     if (logger.isDebugEnabled()) {
@@ -103,5 +106,9 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
    */
   public DrillPBError getError() {
     return error;
+  }
+
+  public String getQueryState() {
+    return queryState;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -134,6 +134,7 @@ public class QueryResources {
     private final List<List<String>> rows;
     private final String queryId;
     private final String rowsPerPageValues;
+    private final String queryState;
 
     public TabularResult(QueryResult result, String rowsPerPageValuesAsStr) {
       rowsPerPageValues = rowsPerPageValuesAsStr;
@@ -149,6 +150,7 @@ public class QueryResources {
 
       this.columns = ImmutableList.copyOf(result.columns);
       this.rows = rows;
+      this.queryState = result.queryState;
     }
 
     public boolean isEmpty() {
@@ -170,6 +172,10 @@ public class QueryResources {
     //Used by results.ftl to render default number of pages per row
     public String getRowsPerPageValues() {
       return rowsPerPageValues;
+    }
+
+    public String getQueryState() {
+      return queryState;
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -128,12 +128,14 @@ public class QueryWrapper {
     public final Collection<String> columns;
     public final List<Map<String, String>> rows;
     public final List<String> metadata;
+    public final String queryState;
 
     //DRILL-6847:  Modified the constructor so that the method has access to all the properties in webUserConnection
     public QueryResult(QueryId queryId, WebUserConnection webUserConnection, List<Map<String, String>> rows) {
         this.queryId = QueryIdHelper.getQueryId(queryId);
         this.columns = webUserConnection.columns;
         this.metadata = webUserConnection.metadata;
+        this.queryState = webUserConnection.getQueryState();
         this.rows = rows;
       }
 

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -33,11 +33,21 @@
   <table><tr>
     <td align='left'>
       <button type="button"  title="Open in new window" onclick="popOutProfile('${model.getQueryId()}');" class="btn btn-default btn-sm">
-      <b>Query Profile:</b> ${model.getQueryId()} <span class="glyphicon glyphicon-new-window"/></button>
+      <b>Query Profile:</b> ${model.getQueryId()} <#switch model.getQueryState()>
+        <#case "COMPLETED">
+          <span class="label label-success">
+          <#break>
+        <#case "CANCELED">
+          <span class="label label-warning">
+          <#break>
+        <#case "FAILED">
+          <span class="label label-danger">
+          <#break>
+        <#default>
+          <span class="label label-default">
+      </#switch>${model.getQueryState()}</span>&nbsp;&nbsp;&nbsp;<span class="glyphicon glyphicon-new-window"/></button>
      </td>
-     <td>
-         <span class="input-group-addon" style="font-size:95%"><b>Query State:</b> ${model.getQueryState()}</span>
-     </td><td align="right" width="100%">
+     <td align="right" width="100%">
        <div class="input-group">
          <span class="input-group-addon" style="font-size:95%">Delimiter </span>
          <input id="delimitBy" type="text" class="form-control input-sm" name="delimitBy" title="Specify delimiter" placeholder="Required" maxlength="2" size="2" value=",">

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -34,6 +34,9 @@
     <td align='left'>
       <button type="button"  title="Open in new window" onclick="popOutProfile('${model.getQueryId()}');" class="btn btn-default btn-sm">
       <b>Query Profile:</b> ${model.getQueryId()} <span class="glyphicon glyphicon-new-window"/></button>
+     </td>
+     <td>
+         <span class="input-group-addon" style="font-size:95%"><b>Query State:</b> ${model.getQueryState()}</span>
      </td><td align="right" width="100%">
        <div class="input-group">
          <span class="input-group-addon" style="font-size:95%">Delimiter </span>


### PR DESCRIPTION
With this change query state will be displayed in the query result page as below:

Example of completed query:
<img width="1277" alt="completed_example" src="https://user-images.githubusercontent.com/22159459/51067327-15811600-15c6-11e9-86fc-aeb27550732a.png">

Example of cancelled query:
<img width="652" alt="cancelled_example" src="https://user-images.githubusercontent.com/22159459/51067329-1e71e780-15c6-11e9-9b43-267652792d55.png">
