### PR TITLE
DRILL-6910: Allow applying DrillPushProjectIntoScanRule at physical phase

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -447,7 +447,8 @@ public enum PlannerPhase {
             // estimation of filter operator, after filter is pushed down to scan.
 
             ParquetPushDownFilter.getFilterOnProject(optimizerRulesContext),
-            ParquetPushDownFilter.getFilterOnScan(optimizerRulesContext)
+            ParquetPushDownFilter.getFilterOnScan(optimizerRulesContext),
+            DrillPushProjectIntoScanRule.DRILL_PHYSICAL_INSTANCE
         )
         .build();
 


### PR DESCRIPTION
- Enhance `DrillPushProjectIntoScanRule` to be applied at the physical stage;
- Avoid recreating `TableScan` rel nodes with the same columns during applying `DrillPushProjectIntoScanRule`;
- Add unit test;
- Enable tests for [DRILL-912](https://issues.apache.org/jira/browse/DRILL-912) (the reason why they were disabled was fixed a long time ago).

For problem description please see [DRILL-6910](https://issues.apache.org/jira/browse/DRILL-6910).