### PR TITLE
DRILL-7007: Use verify method in row set tests

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/cache/TestBatchSerialization.java
@@ -42,7 +42,6 @@ import org.apache.drill.test.OperatorFixture;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.ExtendableRowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.drill.test.rowSet.RowSetWriter;
 import org.junit.AfterClass;
@@ -149,8 +148,7 @@ public class TestBatchSerialization extends DrillTest {
       result = fixture.wrap(reader.read(), reader.sv2());
     }
 
-    new RowSetComparison(expected)
-      .verifyAndClearAll(result);
+    RowSetUtilities.verify(expected, result);
     outFile.delete();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/SortTestUtilities.java
@@ -39,8 +39,7 @@ import org.apache.drill.test.OperatorFixture;
 import org.apache.drill.test.rowSet.DirectRowSet;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
-
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class SortTestUtilities {
@@ -126,8 +125,7 @@ public class SortTestUtilities {
       for (RowSet expectedSet : expected) {
         assertTrue(merger.next());
         RowSet rowSet = DirectRowSet.fromContainer(dest);
-        new RowSetComparison(expectedSet)
-              .verifyAndClearAll(rowSet);
+        RowSetUtilities.verify(expectedSet, rowSet);
       }
       assertFalse(merger.next());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSorter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/managed/TestSorter.java
@@ -93,8 +93,7 @@ public class TestSorter extends DrillTest {
     try {
       sorter.sortBatch(rowSet.container(), rowSet.getSv2());
 
-      new RowSetComparison(expected)
-          .verifyAndClearAll(rowSet);
+      RowSetUtilities.verify(expected, rowSet);
       sorter.close();
     } finally {
       opContext.close();
@@ -240,8 +239,7 @@ public class TestSorter extends DrillTest {
     }
 
     protected void doVerify(DataItem[] expected, RowSet expectedRows, RowSet actual) {
-      new RowSetComparison(expectedRows)
-            .verifyAndClearAll(actual);
+      RowSetUtilities.verify(expectedRows, actual);
     }
 
     protected abstract void doSort(DataItem[] expected);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderEmptyProject.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderEmptyProject.java
@@ -34,7 +34,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSetBuilder;
-import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -156,8 +156,7 @@ public class TestResultSetLoaderEmptyProject extends SubOperatorTest {
     for (int i = 0; i < rowCount; i++) {
       builder.addRow(0, 0);
     }
-    new RowSetComparison(builder.build())
-        .verifyAndClearAll(fixture.wrap(rsLoader.harvest()));
+    RowSetUtilities.verify(builder.build(), fixture.wrap(rsLoader.harvest()));
 
     rsLoader.close();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderOmittedValues.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderOmittedValues.java
@@ -34,8 +34,8 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 
 
@@ -158,8 +158,7 @@ public class TestResultSetLoaderOmittedValues extends SubOperatorTest {
         .addRow( 10, "",    null,    0, null, strArray())
         .build();
 
-    new RowSetComparison(expected)
-        .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
     rsLoader.close();
   }
 
@@ -321,8 +320,7 @@ public class TestResultSetLoaderOmittedValues extends SubOperatorTest {
         .addRow(13, null)
         .build();
 //    expected.print();
-    new RowSetComparison(expected)
-      .verifyAndClearAll(result);
+    RowSetUtilities.verify(expected, result);
 
     rsLoader.close();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderProjection.java
@@ -40,7 +40,7 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 
 /**
@@ -136,8 +136,7 @@ public class TestResultSetLoaderProjection extends SubOperatorTest {
         .build();
     RowSet actual = fixture.wrap(rsLoader.harvest());
 //    actual.print();
-    new RowSetComparison(expected)
-        .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
     rsLoader.close();
   }
 
@@ -212,8 +211,7 @@ public class TestResultSetLoaderProjection extends SubOperatorTest {
       .addRow(mapValue( 1,  2), mapValue( 4))
       .addRow(mapValue(11, 12), mapValue(14))
       .build();
-    new RowSetComparison(expected)
-        .verifyAndClearAll(fixture.wrap(rsLoader.harvest()));
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
     rsLoader.close();
   }
 
@@ -258,8 +256,7 @@ public class TestResultSetLoaderProjection extends SubOperatorTest {
       .addSingleCol(mapValue( 1,  2))
       .addSingleCol(mapValue(11, 12))
       .build();
-    new RowSetComparison(expected)
-        .verifyAndClearAll(fixture.wrap(rsLoader.harvest()));
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
     rsLoader.close();
   }
 
@@ -324,8 +321,7 @@ public class TestResultSetLoaderProjection extends SubOperatorTest {
           objArray(objArray(110, 120), objArray(111, 121)),
           objArray(objArray(140), objArray(142)))
       .build();
-    new RowSetComparison(expected)
-        .verifyAndClearAll(fixture.wrap(rsLoader.harvest()));
+    RowSetUtilities.verify(expected, fixture.wrap(rsLoader.harvest()));
     rsLoader.close();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetSchemaChange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetSchemaChange.java
@@ -35,8 +35,8 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 
 public class TestResultSetSchemaChange extends SubOperatorTest {
@@ -149,8 +149,7 @@ public class TestResultSetSchemaChange extends SubOperatorTest {
         .addRow("a_10",  10, "c_10", "d_10", 100, strArray("f_10-1", "f_10-2"))
         .build();
 
-    new RowSetComparison(expected)
-        .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
     rsLoader.close();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsv.java
@@ -33,7 +33,7 @@ import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSetBuilder;
-import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -98,8 +98,7 @@ public class TestCsv extends ClusterTest {
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
         .addRow("10", "foo", "bar")
         .build();
-    new RowSetComparison(expected)
-      .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
   }
 
   String invalidHeaders[] = {
@@ -124,8 +123,7 @@ public class TestCsv extends ClusterTest {
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
         .addRow("10", "foo", "bar", "fourth", "fifth", "sixth")
         .build();
-    new RowSetComparison(expected)
-      .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
   }
 
   // Test fix for DRILL-5590
@@ -146,8 +144,7 @@ public class TestCsv extends ClusterTest {
     RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
         .addRow("10", "foo", "bar")
         .build();
-    new RowSetComparison(expected)
-      .verifyAndClearAll(actual);
+    RowSetUtilities.verify(expected, actual);
   }
 
   private String makeStatement(String fileName) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
@@ -30,7 +30,7 @@ import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.rowSet.RowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -119,7 +119,6 @@ public class TestLogReader extends ClusterTest {
     pluginConfig.getFormats().put("date-log",logDateConfig);
     pluginConfig.getFormats().put( "mysql-log", mysqlLogConfig);
     pluginRegistry.createOrUpdate("cp", pluginConfig, false);
-
   }
 
   @Test
@@ -139,7 +138,7 @@ public class TestLogReader extends ClusterTest {
         .addRow(2017, 12, 19)
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -160,7 +159,7 @@ public class TestLogReader extends ClusterTest {
 
 //    results.print();
 //    expected.print();
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -182,7 +181,7 @@ public class TestLogReader extends ClusterTest {
 
 //    results.print();
 //    expected.print();
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -199,7 +198,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("2017-12-18 10:52:37,652 [main] INFO  o.a.drill.common.config.DrillConfig - Configuration and plugin file(s) identified in 115ms.")
         .addRow("2017-12-19 11:12:27,278 [main] ERROR o.apache.drill.exec.server.Drillbit - Failure during initial startup of Drillbit.")
         .build();
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
 
@@ -216,7 +215,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("TIMESTAMP")
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
 
   }
 
@@ -257,7 +256,7 @@ public class TestLogReader extends ClusterTest {
 
     //results.print();
     //expected.print();
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -281,7 +280,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("070917", "16:29:12", "21", "Query","select * from location where id = 1 LIMIT 1" )
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -302,7 +301,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("070917", "select * from location where id = 1 LIMIT 1" )
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -322,7 +321,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("070917 16:29:12      21 Query       select * from location where id = 1 LIMIT 1" )
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -338,7 +337,7 @@ public class TestLogReader extends ClusterTest {
         .addRow("dfadkfjaldkjafsdfjlksdjflksjdlkfjsldkfjslkjl")
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
 
   @Test
@@ -360,7 +359,6 @@ public class TestLogReader extends ClusterTest {
         .addRow( null, "dfadkfjaldkjafsdfjlksdjflksjdlkfjsldkfjslkjl")
         .build();
 
-    new RowSetComparison(expected).verifyAndClearAll(results);
+    RowSetUtilities.verify(expected, results);
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestIndirectReaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestIndirectReaders.java
@@ -29,8 +29,8 @@ import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSetWriter;
 import org.apache.drill.test.rowSet.RowSet.ExtendableRowSet;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.drill.test.rowSet.RowSetReader;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -100,8 +100,7 @@ public class TestIndirectReaders extends SubOperatorTest {
         .addRow(0)
         .build();
 
-    new RowSetComparison(expected)
-      .verifyAndClearAll(result);
+    RowSetUtilities.verify(expected, result);
   }
 
   /**


### PR DESCRIPTION
Many of the early RowSet-based tests used the pattern:

```
    new RowSetComparison(expected)
      .verifyAndClearAll(result);
```

Revise this to use the simplified form:

```
    RowSetUtilities.verify(expected, result);
```

The original form is retained when tests use additional functionality, such as the ability to perform multiple verifications on the same expected batch.