### PR TITLE
DRILL-6855: Query from non-existent proxy user fails with "No default schema selected" when impersonation is enabled

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionUtils.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionUtils.java
@@ -1,0 +1,27 @@
+package org.apache.drill.common.exceptions;
+
+/**
+ * Provides utilities (such as retrieving hints) to add more context to UserExceptions.
+ */
+public class UserExceptionUtils {
+  public static final String USER_DOES_NOT_EXIST =
+      "Username is absent in connection URL or doesn't exist on Drillbit node." +
+          " Please specify a username in connection URL which is present on Drillbit node.";
+
+  private UserExceptionUtils() {
+    //Restrict instantiation
+  }
+
+  private static String decorateHint(final String text) {
+    return String.format("[Hint: %s]", text);
+  }
+  public static String getUserHint(final Throwable ex) {
+    if (ex.getMessage().startsWith("Error getting user info for current user")) {
+      //User does not exist hint
+      return decorateHint(USER_DOES_NOT_EXIST);
+    } else {
+      //No hint can be provided
+      return "";
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -25,6 +25,8 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.exceptions.UserExceptionUtils;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePlugin;
@@ -117,6 +119,14 @@ public class DynamicRootSchema extends DynamicSchema {
       }
     } catch(ExecutionSetupException | IOException ex) {
       logger.warn("Failed to load schema for \"" + schemaName + "\"!", ex);
+      // We can't proceed further without a schema, throw a runtime exception.
+      UserException.Builder exceptBuilder =
+          UserException
+              .resourceError(ex)
+              .message("Failed to load schema for \"" + schemaName + "\"!")
+              .addContext(ex.getClass().getName() + ": " + ex.getMessage())
+              .addContext(UserExceptionUtils.getUserHint(ex)); //Provide hint if it exists
+      throw exceptBuilder.build(logger);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestSchema.java
@@ -54,7 +54,7 @@ public class TestSchema extends DrillTest {
     try {
       client.queryBuilder().sql(sql).run();
     } catch (Exception ex) {
-      assertTrue(ex.getMessage().contains("VALIDATION ERROR: Schema"));
+      assertTrue(ex.getMessage().contains("RESOURCE ERROR: Failed to load schema"));
       throw ex;
     }
   }
@@ -79,7 +79,7 @@ public class TestSchema extends DrillTest {
       String use_dfs = "use mock_broken";
       client.queryBuilder().sql(use_dfs).run();
     } catch(Exception ex) {
-      assertTrue(ex.getMessage().contains("VALIDATION ERROR: Schema"));
+      assertTrue(ex.getMessage().contains("RESOURCE ERROR: Failed to load schema"));
       throw ex;
     }
   }


### PR DESCRIPTION
This PR intends to throw an error immediately when `UserSession.getDefaultSchema` fails with an `IOException`. Similar changes were done as a part of [DRILL-5704](https://github.com/apache/drill/pull/895). However, with [dynamic loading of schema](https://issues.apache.org/jira/browse/DRILL-5089), the previous fix is no more relevant. This PR tries to resolve the issue on similar lines.