### PR TITLE
DRILL-6780: Caching dependencies for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,14 @@ jobs:
       image: circleci/classic:latest
     parallelism: 1 # TODO: 1. Configuring Parallel Jobs for Running Tests https://circleci.com/docs/2.0/parallelism-faster-jobs/
 
-
     working_directory: ~/drill
 
     steps:
     - checkout
-
+    - restore_cache:
+        keys:
+        - m2-{{ checksum "pom.xml" }}
+        - m2- # used if checksum fails
     - run:
         name: Update maven version
         # TODO: Could be removed, once Machine Executor image is updated https://github.com/circleci/image-builder/issues/140
@@ -45,10 +47,13 @@ jobs:
     - run:
         name: Drill project build
         # TODO: 2. Optimizing Maven Builds on CircleCI - https://circleci.com/blog/optimizing-maven-builds-on-circleci/
-        # TODO: 3. Caching Dependencies - https://circleci.com/docs/2.0/caching/
-        # TODO: 4. Resolving memory issues without "SlowTest" and "UnlikelyTest" excludedGroups in the build
+        # TODO: 3. Resolving memory issues without "SlowTest" and "UnlikelyTest" excludedGroups in the build
         command:
           mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608 -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest"
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: m2-{{ checksum "pom.xml" }}
 
   build_jdk9:
     machine:
@@ -60,27 +65,26 @@ jobs:
 
     steps:
     - checkout
-
+    - restore_cache:
+        keys:
+        - m2-{{ checksum "pom.xml" }}
+        - m2- # used if checksum fails
     - run:
         name: Update packages list
         command:
           sudo apt-get update
-
     - run:
         name: Install java 9
         command:
           sudo apt-get -y install openjdk-9-jdk
-
     - run:
         name: Set default java 9
         command:
           sudo update-java-alternatives --set java-1.9.0-openjdk-amd64
-
     - run:
         name: Update maven version
         command:
           curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-
     - run:
         name: Install libaio1.so library for MySQL integration tests
         command:
@@ -89,6 +93,10 @@ jobs:
         name: Drill project build
         command:
           mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608 -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest"
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: m2-{{ checksum "pom.xml" }}
 
   build_jdk10:
     machine:
@@ -100,27 +108,26 @@ jobs:
 
     steps:
     - checkout
-
+    - restore_cache:
+        keys:
+        - m2-{{ checksum "pom.xml" }}
+        - m2- # used if checksum fails
     - run:
         name: Update packages list
         command:
           sudo apt-get update
-
     - run:
         name: Install java 10
         command:
           sudo apt-get -y install openjdk-10-jdk
-
     - run:
         name: Set default java 10
         command:
           sudo update-java-alternatives --set java-1.10.0-openjdk-amd64
-
     - run:
         name: Update maven version
         command:
           curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-
     - run:
         name: Install libaio1.so library for MySQL integration tests
         command:
@@ -129,6 +136,10 @@ jobs:
         name: Drill project build
         command:
           mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608 -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest"
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: m2-{{ checksum "pom.xml" }}
 
   build_jdk11:
     machine:
@@ -140,27 +151,26 @@ jobs:
 
     steps:
     - checkout
-
+    - restore_cache:
+        keys:
+        - m2-{{ checksum "pom.xml" }}
+        - m2- # used if checksum fails
     - run:
         name: Update packages list
         command:
           sudo apt-get update
-
     - run:
         name: Install java 11
         command:
           sudo apt-get -y install openjdk-11-jdk
-
     - run:
         name: Set default java 11
         command:
           sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-
     - run:
         name: Update maven version
         command:
           curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-
     - run:
         name: Install libaio1.so library for MySQL integration tests
         command:
@@ -171,6 +181,10 @@ jobs:
         # for default value of forkCount.
         command:
           mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608 -DforkCount=1 -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest"
+    - save_cache:
+        paths:
+          - ~/.m2
+        key: m2-{{ checksum "pom.xml" }}
 
 workflows:
   version: 2


### PR DESCRIPTION
Cache `~/.m2` folder to avoid downloading project dependencies for every build. The same cache instance is used for every build, so used pom.xml checksum to handle the case of updating dependencies versions or introducing new dependencies since by default cache is stored for 30 days.

The average time of run is reduced by 6-8 minutes for every build.

Link to the successful CircleCI build (first run): https://circleci.com/workflow-run/f26e0bef-9e1c-4f20-8375-77b59774a143.
Second run (with cache usage): https://circleci.com/workflow-run/b9ec2974-85c9-4b30-a499-4e95a1152278 

For details please see [DRILL-6780](https://issues.apache.org/jira/browse/DRILL-6780).