### PR TITLE
DRILL-6734: JDBC storage plugin returns null for fields without aliases

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcBatchCreator.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcBatchCreator.java
@@ -35,7 +35,8 @@ public class JdbcBatchCreator implements BatchCreator<JdbcSubScan> {
       List<RecordBatch> children) throws ExecutionSetupException {
     Preconditions.checkArgument(children.isEmpty());
     JdbcStoragePlugin plugin = config.getPlugin();
-    RecordReader reader = new JdbcRecordReader(plugin.getSource(), config.getSql(), plugin.getName());
+    RecordReader reader = new JdbcRecordReader(plugin.getSource(),
+        config.getSql(), plugin.getName(), config.getColumns());
     return new ScanBatch(config, context, Collections.singletonList(reader));
   }
 }

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcPrel.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcPrel.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.jdbc;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -91,8 +90,8 @@ public class JdbcPrel extends AbstractRelNode implements Prel {
   }
 
   @Override
-  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
-    JdbcGroupScan output = new JdbcGroupScan(sql, convention.getPlugin(), rows);
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) {
+    JdbcGroupScan output = new JdbcGroupScan(sql, rowType.getFieldNames(), convention.getPlugin(), rows);
     return creator.addMetadata(this, output);
   }
 

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
@@ -29,25 +29,31 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.util.List;
+
 @JsonTypeName("jdbc-sub-scan")
 public class JdbcSubScan extends AbstractSubScan {
 
   private final String sql;
   private final JdbcStoragePlugin plugin;
+  private final List<String> columns;
 
   @JsonCreator
   public JdbcSubScan(
       @JsonProperty("sql") String sql,
+      @JsonProperty("columns") List<String> columns,
       @JsonProperty("config") StoragePluginConfig config,
       @JacksonInject StoragePluginRegistry plugins) throws ExecutionSetupException {
     super("");
     this.sql = sql;
+    this.columns = columns;
     this.plugin = (JdbcStoragePlugin) plugins.getPlugin(config);
   }
 
-  JdbcSubScan(String sql, JdbcStoragePlugin plugin) {
+  JdbcSubScan(String sql, List<String> columns, JdbcStoragePlugin plugin) {
     super("");
     this.sql = sql;
+    this.columns = columns;
     this.plugin = plugin;
   }
 
@@ -60,6 +66,10 @@ public class JdbcSubScan extends AbstractSubScan {
     return sql;
   }
 
+  public List<String> getColumns() {
+    return columns;
+  }
+
   public StoragePluginConfig getConfig() {
     return plugin.getConfig();
   }
@@ -68,5 +78,4 @@ public class JdbcSubScan extends AbstractSubScan {
   public JdbcStoragePlugin getPlugin() {
     return plugin;
   }
-
 }

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
@@ -63,7 +63,9 @@ public class TestJdbcPluginWithH2IT extends ClusterTest {
       URL scriptFile = TestJdbcPluginWithH2IT.class.getClassLoader().getResource("h2-test-data.sql");
       Assert.assertNotNull("Script for test tables generation 'h2-test-data.sql' " +
           "cannot be found in test resources", scriptFile);
-      RunScript.execute(connection, new FileReader(scriptFile.getFile()));
+      try (FileReader fileReader = new FileReader(scriptFile.getFile())) {
+        RunScript.execute(connection, fileReader);
+      }
     }
 
     startCluster(ClusterFixture.builder(dirTestWatcher));


### PR DESCRIPTION
- Added changes to pass output column names taken from row type to JdbcRecordReader and use them for storing the results since column names in the result set may differ when aliases aren't specified and it causes problems for Drill operators like Project which rely on field names during the execution.

For problem description please see [DRILL-6734](https://issues.apache.org/jira/browse/DRILL-6734).