### PR TITLE
DRILL-6707: Join Batch Memory Manager to resize current outgoing batch no larger than current batch size

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -587,7 +587,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
           // Allocate the memory for the vectors in the output container
           batchMemoryManager.allocateVectors(container);
 
-          hashJoinProbe.setTargetOutputCount(batchMemoryManager.getCurrentOutgoingMaxRowCount());
+          hashJoinProbe.setTargetOutputCount(batchMemoryManager.getOutputRowCount());
 
           outputRecords = hashJoinProbe.probeAndProject();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -587,7 +587,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
           // Allocate the memory for the vectors in the output container
           batchMemoryManager.allocateVectors(container);
 
-          hashJoinProbe.setTargetOutputCount(batchMemoryManager.getOutputRowCount());
+          hashJoinProbe.setTargetOutputCount(batchMemoryManager.getCurrentOutgoingMaxRowCount());
 
           outputRecords = hashJoinProbe.probeAndProject();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -271,7 +271,8 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
                 probeBatch.getSchema());
             }
           case OK:
-            setTargetOutputCount(outgoingJoinBatch.getBatchMemoryManager().update(probeBatch, LEFT_INDEX,outputRecords));
+            outgoingJoinBatch.getBatchMemoryManager().update(probeBatch, LEFT_INDEX,outputRecords);
+            setTargetOutputCount(outgoingJoinBatch.getBatchMemoryManager().getCurrentOutgoingTargetOutputRowCount()); // calculated by update()
             recordsToProcess = probeBatch.getRecordCount();
             recordsProcessed = 0;
             // If we received an empty batch do nothing

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -272,7 +272,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
             }
           case OK:
             outgoingJoinBatch.getBatchMemoryManager().update(probeBatch, LEFT_INDEX,outputRecords);
-            setTargetOutputCount(outgoingJoinBatch.getBatchMemoryManager().getCurrentOutgoingTargetOutputRowCount()); // calculated by update()
+            setTargetOutputCount(outgoingJoinBatch.getBatchMemoryManager().getCurrentOutgoingMaxRowCount()); // calculated by update()
             recordsToProcess = probeBatch.getRecordCount();
             recordsProcessed = 0;
             // If we received an empty batch do nothing

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
@@ -232,6 +232,14 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
     // vectors and throws NPE. The actual checks are done in updateMemoryManager
     updateMemoryManager(RIGHT_INDEX);
 
+    if (outputIndex > 0) {
+      // this means batch is already allocated but because of new incoming the width and output row count might have
+      // changed. So update the maxOutputRowCount with new value
+      if (useMemoryManager) {
+        setMaxOutputRowCount(batchMemoryManager.getCurrentOutgoingMaxRowCount());
+      }
+    }
+    // if output is not allocated then maxRowCount will be set correctly below
     // allocate space for the outgoing batch
     allocateVectors();
 
@@ -700,6 +708,12 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
           }
           // Since schema has change so we have new empty vectors in output container hence allocateMemory for them
           allocateVectors();
+        } else {
+          // means we are using already allocated output batch so row count may have changed based on new incoming
+          // batch hence update it
+          if (useMemoryManager) {
+            setMaxOutputRowCount(batchMemoryManager.getCurrentOutgoingMaxRowCount());
+          }
         }
       }
     } // output batch is full to its max capacity
@@ -882,9 +896,17 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
    * Simple method to allocate space for all the vectors in the container.
    */
   private void allocateVectors() {
+    // This check is here and will be true only in case of left join where the pending rows from previous left batch is
+    // copied to the new output batch. Then same output batch is used to fill remaining memory using new left & right
+    // batches.
     if (outputIndex > 0) {
       logger.trace("Allocation is already done for output container vectors since it already holds some record");
       return;
+    }
+
+    // Set this as max output rows to be filled in output batch since memory for that many rows are allocated
+    if (useMemoryManager) {
+      setMaxOutputRowCount(batchMemoryManager.getOutputRowCount());
     }
 
     for (VectorWrapper w : container) {
@@ -1153,6 +1175,10 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
    */
   @VisibleForTesting
   public void setMaxOutputRowCount(int outputRowCount) {
+    if (isRecordBatchStatsLoggingEnabled()) {
+      RecordBatchStats.logRecordBatchStats(getRecordBatchStatsContext(),
+        "Previous OutputRowCount: %d, New OutputRowCount: %d", maxOutputRowCount, outputRowCount);
+    }
     maxOutputRowCount = outputRowCount;
   }
 
@@ -1183,18 +1209,11 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
     // For cases where all the previous input were consumed and send with previous output batch. But now we are building
     // a new output batch with new incoming then it will not cause any problem since outputIndex will be 0
     batchMemoryManager.update(inputIndex, outputIndex);
-    final int newOutputRowCount = batchMemoryManager.getCurrentOutgoingMaxRowCount();
-
 
     if (isRecordBatchStatsLoggingEnabled()) {
       RecordBatchIOType type = inputIndex == LEFT_INDEX ? RecordBatchIOType.INPUT_LEFT : RecordBatchIOType.INPUT_RIGHT;
-      RecordBatchStats.logRecordBatchStats(type, batchMemoryManager.getRecordBatchSizer(inputIndex), getRecordBatchStatsContext());
-      RecordBatchStats.logRecordBatchStats(getRecordBatchStatsContext(),
-        "Previous OutputRowCount: %d, New OutputRowCount: %d", maxOutputRowCount, newOutputRowCount);
-    }
-
-    if (useMemoryManager) {
-      maxOutputRowCount = newOutputRowCount;
+      RecordBatchStats.logRecordBatchStats(type, batchMemoryManager.getRecordBatchSizer(inputIndex),
+        getRecordBatchStatsContext());
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
@@ -1183,7 +1183,7 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
     // For cases where all the previous input were consumed and send with previous output batch. But now we are building
     // a new output batch with new incoming then it will not cause any problem since outputIndex will be 0
     batchMemoryManager.update(inputIndex, outputIndex);
-    final int newOutputRowCount = batchMemoryManager.getCurrentOutgoingTargetOutputRowCount();
+    final int newOutputRowCount = batchMemoryManager.getCurrentOutgoingMaxRowCount();
 
 
     if (isRecordBatchStatsLoggingEnabled()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
@@ -1182,7 +1182,9 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
 
     // For cases where all the previous input were consumed and send with previous output batch. But now we are building
     // a new output batch with new incoming then it will not cause any problem since outputIndex will be 0
-    final int newOutputRowCount = batchMemoryManager.update(inputIndex, outputIndex);
+    batchMemoryManager.update(inputIndex, outputIndex);
+    final int newOutputRowCount = batchMemoryManager.getCurrentOutgoingTargetOutputRowCount();
+
 
     if (isRecordBatchStatsLoggingEnabled()) {
       RecordBatchIOType type = inputIndex == LEFT_INDEX ? RecordBatchIOType.INPUT_LEFT : RecordBatchIOType.INPUT_RIGHT;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
@@ -125,7 +125,7 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
     @Override
     public void update(int inputIndex) {
       super.update(inputIndex, status.getOutPosition());
-      status.setTargetOutputRowCount(super.getCurrentOutgoingTargetOutputRowCount());
+      status.setTargetOutputRowCount(super.getCurrentOutgoingMaxRowCount());
       RecordBatchIOType type = inputIndex == 0 ? RecordBatchIOType.INPUT_LEFT : RecordBatchIOType.INPUT_RIGHT;
       RecordBatchStats.logRecordBatchStats(type, getRecordBatchSizer(inputIndex), getRecordBatchStatsContext());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
@@ -125,7 +125,7 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
     @Override
     public void update(int inputIndex) {
       super.update(inputIndex, status.getOutPosition());
-      status.setTargetOutputRowCount(super.getCurrentOutgoingMaxRowCount());
+      status.setTargetOutputRowCount(super.getCurrentOutgoingMaxRowCount()); // calculated by update()
       RecordBatchIOType type = inputIndex == 0 ? RecordBatchIOType.INPUT_LEFT : RecordBatchIOType.INPUT_RIGHT;
       RecordBatchStats.logRecordBatchStats(type, getRecordBatchSizer(inputIndex), getRecordBatchStatsContext());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
@@ -124,7 +124,8 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
      */
     @Override
     public void update(int inputIndex) {
-      status.setTargetOutputRowCount(super.update(inputIndex, status.getOutPosition()));
+      super.update(inputIndex, status.getOutPosition());
+      status.setTargetOutputRowCount(super.getCurrentOutgoingTargetOutputRowCount());
       RecordBatchIOType type = inputIndex == 0 ? RecordBatchIOType.INPUT_LEFT : RecordBatchIOType.INPUT_RIGHT;
       RecordBatchStats.logRecordBatchStats(type, getRecordBatchSizer(inputIndex), getRecordBatchStatsContext());
     }
@@ -184,15 +185,13 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
     status.prepare();
     // loop so we can start over again if we find a new batch was created.
     while (true) {
+      boolean isNewSchema = false;
       // Check result of last iteration.
       switch (status.getOutcome()) {
-        case BATCH_RETURNED:
-          allocateBatch(false);
-          status.resetOutputPos();
-          status.setTargetOutputRowCount(batchMemoryManager.getOutputRowCount());
-          break;
         case SCHEMA_CHANGED:
-          allocateBatch(true);
+          isNewSchema = true;
+        case BATCH_RETURNED:
+          allocateBatch(isNewSchema);
           status.resetOutputPos();
           status.setTargetOutputRowCount(batchMemoryManager.getOutputRowCount());
           break;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinTemplate.java
@@ -193,7 +193,7 @@ public abstract class NestedLoopJoinTemplate implements NestedLoopJoin {
         break;
       case OK:
         outgoing.getBatchMemoryManager().update(left, LEFT_INDEX,outputIndex);
-        setTargetOutputCount(outgoing.getBatchMemoryManager().getCurrentOutgoingTargetOutputRowCount()); // calculated by update()
+        setTargetOutputCount(outgoing.getBatchMemoryManager().getCurrentOutgoingMaxRowCount()); // calculated by update()
         RecordBatchStats.logRecordBatchStats(RecordBatchIOType.INPUT_LEFT,
           outgoing.getBatchMemoryManager().getRecordBatchSizer(LEFT_INDEX),
           outgoing.getRecordBatchStatsContext());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinTemplate.java
@@ -192,7 +192,8 @@ public abstract class NestedLoopJoinTemplate implements NestedLoopJoin {
         leftRecordCount = 0;
         break;
       case OK:
-        setTargetOutputCount(outgoing.getBatchMemoryManager().update(left, LEFT_INDEX,outputIndex));
+        outgoing.getBatchMemoryManager().update(left, LEFT_INDEX,outputIndex);
+        setTargetOutputCount(outgoing.getBatchMemoryManager().getCurrentOutgoingTargetOutputRowCount()); // calculated by update()
         RecordBatchStats.logRecordBatchStats(RecordBatchIOType.INPUT_LEFT,
           outgoing.getBatchMemoryManager().getRecordBatchSizer(LEFT_INDEX),
           outgoing.getRecordBatchStatsContext());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
@@ -54,7 +54,7 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
    *     in that batch (i.e., outputPosition). (Need not be a power of two; e.g., 7983).
    *
    *  After every call to update() while the outgoing batch is active, the current target should be updated with (3) by
-   *  calling getCurrentOutgoingTargetOutputRowCount() .
+   *  calling getCurrentOutgoingMaxRowCount() .
    *
    * @param inputIndex  Left (0) or Right (1)
    * @param outputPosition  Position (i.e. number of inserted rows) in the current output batch
@@ -112,7 +112,7 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
     // The current outgoing batch target count (i.e., max number of rows to put there) is modified to be the current number of rows there
     // plus as many of the future new rows that would fit in the remaining memory (e.g., if the new rows are wider, fewer would fit), but
     // in any case no larger than the size the batch was allocated for (to avoid IOOB on the allocated vectors)
-    setCurrentOutgoingTargetOutputRowCount(Math.min(currentOutputBatchRowCount, outputPosition + numOutputRowsRemaining ));
+    setCurrentOutgoingMaxRowCount(Math.min(currentOutputBatchRowCount, outputPosition + numOutputRowsRemaining ));
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
@@ -56,6 +56,9 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
    *  After every call to update() while the outgoing batch is active, the current target should be updated with (3) by
    *  calling getCurrentOutgoingMaxRowCount() .
    *
+   *  Comment: The "power of 2" in the above (1) and (2) is actually "power of 2 minus 1" (e.g. 65535, or 8191) in order
+   *  to avoid memory waste in case offset vectors are used (see DRILL-5446)
+   *
    * @param inputIndex  Left (0) or Right (1)
    * @param outputPosition  Position (i.e. number of inserted rows) in the current output batch
    * @param useAggregate If true, compute using average row width (else based on allocated sizes)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/JoinBatchMemoryManager.java
@@ -40,7 +40,27 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
     this.columnsToExclude = excludedColumns;
   }
 
-  private int updateInternal(int inputIndex, int outputPosition,  boolean useAggregate) {
+  /**
+   * Update the memory manager parameters based on the new incoming batch
+   *
+   * Notice three (possibly) different "row counts" for the outgoing batches:
+   *
+   *  1. The rowCount that the current outgoing batch was allocated with (always a power of 2; e.g. 8192)
+   *  2. The new rowCount computed based on the newly seen input rows (always a power of 2); may be bigger than (1) if the
+   *     new input rows are much smaller than before (e.g. 16384), or smaller (e.g. 4096) if the new rows are much wider.
+   *     Subsequent outgoing batches would be allocated based on this (2) new rowCount.
+   *  3. The target rowCount for the current outgoing batch. While initially (1), it may be resized down if the new rows
+   *     are getting bigger. In any case it won't be resized above (1) (to avoid IOOB) or below the current number of rows
+   *     in that batch (i.e., outputPosition). (Need not be a power of two; e.g., 7983).
+   *
+   *  After every call to update() while the outgoing batch is active, the current target should be updated with (3) by
+   *  calling getCurrentOutgoingTargetOutputRowCount() .
+   *
+   * @param inputIndex  Left (0) or Right (1)
+   * @param outputPosition  Position (i.e. number of inserted rows) in the current output batch
+   * @param useAggregate If true, compute using average row width (else based on allocated sizes)
+   */
+  private void updateInternal(int inputIndex, int outputPosition,  boolean useAggregate) {
     updateIncomingStats(inputIndex);
     rowWidth[inputIndex] = useAggregate ? (int) getAvgInputRowWidth(inputIndex) : getRecordBatchSizer(inputIndex).getRowAllocWidth();
 
@@ -60,7 +80,7 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
     // This is possible for empty batches or
     // when first set of batches come with OK_NEW_SCHEMA and no data.
     if (newOutgoingRowWidth == 0 || newOutgoingRowWidth == getOutgoingRowWidth()) {
-      return getOutputRowCount();
+      return;
     }
 
     // Adjust for the current batch.
@@ -75,34 +95,73 @@ public class JoinBatchMemoryManager extends RecordBatchMemoryManager {
     // These are number of rows we can fit in remaining memory based on new outgoing row width.
     final int numOutputRowsRemaining = RecordBatchSizer.safeDivide(remainingMemory, newOutgoingRowWidth);
 
+    final int currentOutputBatchRowCount = getOutputRowCount();
+
     // update the value to be used for next batch(es)
     setOutputRowCount(configOutputBatchSize, newOutgoingRowWidth);
 
     // set the new row width
     setOutgoingRowWidth(newOutgoingRowWidth);
 
-    return adjustOutputRowCount(outputPosition + numOutputRowsRemaining);
+    int newOutputRowCount = getOutputRowCount();
+
+    if ( currentOutputBatchRowCount != newOutputRowCount ) {
+      logger.debug("Memory manager update changed the output row count from {} to {}",currentOutputBatchRowCount,newOutputRowCount);
+    }
+
+    // The current outgoing batch target count (i.e., max number of rows to put there) is modified to be the current number of rows there
+    // plus as many of the future new rows that would fit in the remaining memory (e.g., if the new rows are wider, fewer would fit), but
+    // in any case no larger than the size the batch was allocated for (to avoid IOOB on the allocated vectors)
+    setCurrentOutgoingTargetOutputRowCount(Math.min(currentOutputBatchRowCount, outputPosition + numOutputRowsRemaining ));
   }
 
+  /**
+   * Update the memory manager parameters based on the new incoming batch
+   *
+   * @param inputIndex Left (0) or Right (1)
+   * @param outputPosition Position (i.e. number of inserted rows) in the output batch
+   * @param useAggregate Compute using average row width (else based on allocated sizes)
+   */
   @Override
-  public int update(int inputIndex, int outputPosition, boolean useAggregate) {
+  public void update(int inputIndex, int outputPosition, boolean useAggregate) {
     setRecordBatchSizer(inputIndex, new RecordBatchSizer(recordBatch[inputIndex]));
-    return updateInternal(inputIndex, outputPosition, useAggregate);
+    updateInternal(inputIndex, outputPosition, useAggregate);
   }
 
+  /**
+   * Update the memory manager parameters based on the new incoming batch (based on allocated sizes, not average row size)
+   *
+   * @param inputIndex Left (0) or Right (1)
+   * @param outputPosition Position (i.e. number of inserted rows) in the output batch
+   */
   @Override
-  public int update(int inputIndex, int outputPosition) {
-    return update(inputIndex, outputPosition, false);
+  public void update(int inputIndex, int outputPosition) {
+    update(inputIndex, outputPosition, false);
   }
 
+  /**
+   * Update the memory manager parameters based on the given (incoming) batch
+   *
+   * @param batch Update based on the data in this batch
+   * @param inputIndex Left (0) or Right (1)
+   * @param outputPosition Position (i.e. number of inserted rows) in the output batch
+   * @param useAggregate Compute using average row width (else based on allocated sizes)
+   */
   @Override
-  public int update(RecordBatch batch, int inputIndex, int outputPosition, boolean useAggregate) {
+  public void update(RecordBatch batch, int inputIndex, int outputPosition, boolean useAggregate) {
     setRecordBatchSizer(inputIndex, new RecordBatchSizer(batch));
-    return updateInternal(inputIndex, outputPosition, useAggregate);
+    updateInternal(inputIndex, outputPosition, useAggregate);
   }
 
+  /**
+   * Update the memory manager parameters based on the given (incoming) batch (based on allocated sizes, not average row size)
+   *
+   * @param batch Update based on the data in this batch
+   * @param inputIndex Left (0) or Right (1)
+   * @param outputPosition Position (i.e. number of inserted rows) in the output batch
+   */
   @Override
-  public int update(RecordBatch batch, int inputIndex, int outputPosition) {
-    return update(batch, inputIndex, outputPosition, false);
+  public void update(RecordBatch batch, int inputIndex, int outputPosition) {
+    update(batch, inputIndex, outputPosition, false);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
@@ -28,6 +28,7 @@ public class RecordBatchMemoryManager {
   protected static final int MIN_NUM_ROWS = 1;
   protected static final int DEFAULT_INPUT_INDEX = 0;
   private int outputRowCount = MAX_NUM_ROWS;
+  private int currentOutgoingTargetOutputRowCount = MAX_NUM_ROWS; // target row count only for the current output batch
   private int outgoingRowWidth;
   private int outputBatchSize;
   private RecordBatchSizer[] sizer;
@@ -144,11 +145,6 @@ public class RecordBatchMemoryManager {
     outputBatchStats = new BatchStats();
   }
 
-  public int update(int inputIndex, int outputPosition) {
-    // by default just return the outputRowCount
-    return getOutputRowCount();
-  }
-
   public void update(int inputIndex) {
   }
 
@@ -166,17 +162,20 @@ public class RecordBatchMemoryManager {
     updateIncomingStats(index);
   }
 
-  public int update(int inputIndex, int outputPosition, boolean useAggregate) {
-    // by default just return the outputRowCount
-    return getOutputRowCount();
+  public void update(int inputIndex, int outputPosition, boolean useAggregate) {
+    throw new IllegalStateException("Should only be called on JoinBatchMemoryManager");
   }
 
-  public int update(RecordBatch batch, int inputIndex, int outputPosition) {
-    return getOutputRowCount();
+  public void update(int inputIndex, int outputPosition) {
+    throw new IllegalStateException("Should only be called on JoinBatchMemoryManager");
   }
 
-  public int update(RecordBatch batch, int inputIndex, int outputPosition, boolean useAggregate) {
-    return getOutputRowCount();
+  public void update(RecordBatch batch, int inputIndex, int outputPosition) {
+    throw new IllegalStateException("Should only be called on JoinBatchMemoryManager");
+  }
+
+  public void update(RecordBatch batch, int inputIndex, int outputPosition, boolean useAggregate) {
+    throw new IllegalStateException("Should only be called on JoinBatchMemoryManager");
   }
 
   public boolean updateIfNeeded(int newOutgoingRowWidth) {
@@ -199,6 +198,9 @@ public class RecordBatchMemoryManager {
     return outputRowCount;
   }
 
+  public int getCurrentOutgoingTargetOutputRowCount() {
+    return currentOutgoingTargetOutputRowCount;
+  }
   /**
    * Given batchSize and rowWidth, this will set output rowCount taking into account
    * the min and max that is allowed.
@@ -209,6 +211,13 @@ public class RecordBatchMemoryManager {
 
   public void setOutputRowCount(int outputRowCount) {
     this.outputRowCount = outputRowCount;
+  }
+
+  public void setCurrentOutgoingTargetOutputRowCount(int newTargetOutputCount) {
+    this.currentOutgoingTargetOutputRowCount = newTargetOutputCount;
+    if ( Integer.highestOneBit(newTargetOutputCount) == newTargetOutputCount ) {
+      this.currentOutgoingTargetOutputRowCount--; // to match the allocation size
+    }
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchMemoryManager.java
@@ -199,10 +199,19 @@ public class RecordBatchMemoryManager {
     return true;
   }
 
+  /**
+   * Should be used as maximum output row count that can be filled in output batch when a new output batch is
+   * allocated after calling update on BatchMemoryManager.
+   * @return outputRowCount max output row count
+   */
   public int getOutputRowCount() {
     return outputRowCount;
   }
 
+  /**
+   * Should be used as maximum output row count that can be filled in output batch which is already allocated.
+   * @return currentOutgoingMaxRowCount max output row count for current output batch
+   */
   public int getCurrentOutgoingMaxRowCount() { return currentOutgoingMaxRowCount; }
   /**
    * Given batchSize and rowWidth, this will set output rowCount taking into account
@@ -213,13 +222,18 @@ public class RecordBatchMemoryManager {
   }
 
   public void setOutputRowCount(int outputRowCount) {
+    Preconditions.checkArgument(outputRowCount <= MAX_NUM_ROWS);
     this.outputRowCount = outputRowCount;
-    if ( outputRowCount > MIN_NUM_ROWS &&  Integer.highestOneBit(outputRowCount) == outputRowCount ) {
-      this.outputRowCount--;
-    }
   }
 
-  public void setCurrentOutgoingMaxRowCount(int newTargetOutputCount) { this.currentOutgoingMaxRowCount = newTargetOutputCount; }
+  /**
+   * Set the max row count which the current output batch (already allocated) can contain. Since this setter doesn't
+   * adjust the input value we make sure it doesn't go above MAX_NUM_ROWS
+   * @param newTargetOutputCount
+   */
+  public void setCurrentOutgoingMaxRowCount(int newTargetOutputCount) {
+    this.currentOutgoingMaxRowCount = Math.min(MAX_NUM_ROWS, newTargetOutputCount);
+  }
 
   /**
    * This will adjust rowCount taking into account the min and max that is allowed.


### PR DESCRIPTION
    The source of the bug was retaining a checkArgument, which originally did a sanity check that 64K (the old batch size) was not exceeded.  When batch resizing was implemented for Merge-Join, that checkArgument was kept (with the new target size).
    So when the batch was resized while the outgoing already had more rows than the new target, the next check for a full outgoing hit that checkArgument and caused this failure.

The fix: Remove that checkArgument.  (The other code changes are for debug or cosmetics).
