### PR TITLE
DRILL-5270: Improve loading of profiles listing in the WebUI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -236,6 +236,7 @@ public final class ExecConstants {
   public static final String SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE = "drill.exec.sys.store.provider.local.write";
   public static final String PROFILES_STORE_INMEMORY = "drill.exec.profiles.store.inmemory";
   public static final String PROFILES_STORE_CAPACITY = "drill.exec.profiles.store.capacity";
+  public static final String PROFILES_STORE_CACHE_SIZE = "drill.exec.profiles.store.cache.size";
   public static final String IMPERSONATION_ENABLED = "drill.exec.impersonation.enabled";
   public static final String IMPERSONATION_MAX_CHAINED_USER_HOPS = "drill.exec.impersonation.max_chained_user_hops";
   public static final String AUTHENTICATION_MECHANISMS = "drill.exec.security.auth.mechanisms";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/BasePersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/BasePersistentStore.java
@@ -27,4 +27,9 @@ public abstract class BasePersistentStore<V> implements PersistentStore<V> {
     return getRange(0, Integer.MAX_VALUE);
   }
 
+  @Override
+  public Iterator<Map.Entry<String, V>> getRange(int skip, int take, boolean useCache) {
+    //No implicit cache implemented by default
+    return getRange(skip, take, false);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/CaseInsensitivePersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/CaseInsensitivePersistentStore.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.sys;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Wrapper around {@link PersistentStore} to ensure all passed keys are converted to lower case and stored this way.
@@ -70,6 +71,11 @@ public class CaseInsensitivePersistentStore<V> implements PersistentStore<V> {
   @Override
   public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
     return underlyingStore.getRange(skip, take);
+  }
+
+  @Override
+  public Iterator<Entry<String, V>> getRange(int skip, int take, boolean useCache) {
+    return underlyingStore.getRange(skip, take, useCache);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/PersistentStore.java
@@ -54,4 +54,13 @@ public interface PersistentStore<V> extends Store<V> {
    */
   Iterator<Map.Entry<String, V>> getAll();
 
+  /**
+   * Returns, from a possible cache, an iterator of desired number of entries offsetting by the skip value.
+   *
+   * @param skip  number of records to skip from beginning
+   * @param take  max number of records to return
+   * @param useCache  use cache if available
+   */
+  Iterator<Map.Entry<String, V>> getRange(int skip, int take, boolean useCache);
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/DrillSysFilePathFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import static org.apache.drill.exec.ExecConstants.DRILL_SYS_FILE_SUFFIX;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+/**
+ * Filter for Drill System Files
+ */
+public class DrillSysFilePathFilter implements PathFilter {
+
+  //NOTE: The filename is a combination of query ID (which is monotonically
+  //decreasing value derived off epoch timestamp) and a random value. This
+  //filter helps eliminate that list
+  String cutoffFileName = null;
+  public DrillSysFilePathFilter() {}
+
+  public DrillSysFilePathFilter(String cutoffSysFileName) {
+    if (cutoffSysFileName != null) {
+      this.cutoffFileName = cutoffSysFileName + DRILL_SYS_FILE_SUFFIX;
+    }
+  }
+
+  /* (non-Javadoc)
+   * @see org.apache.hadoop.fs.PathFilter#accept(org.apache.hadoop.fs.Path)
+   */
+  @Override
+  public boolean accept(Path file){
+    if (file.getName().endsWith(DRILL_SYS_FILE_SUFFIX)) {
+      if (cutoffFileName != null) {
+        return (file.getName().compareTo(cutoffFileName) <= 0);
+      } else {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/LocalPersistentStore.java
@@ -24,45 +24,134 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.drill.common.AutoCloseables.Closeable;
 import org.apache.drill.common.collections.ImmutableEntry;
+import org.apache.drill.common.concurrent.AutoCloseableLock;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
-import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.exec.store.sys.BasePersistentStore;
 import org.apache.drill.exec.store.sys.PersistentStoreConfig;
 import org.apache.drill.exec.store.sys.PersistentStoreMode;
+import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
-import org.apache.drill.shaded.guava.com.google.common.base.Function;
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.hadoop.fs.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
+import org.apache.drill.shaded.guava.com.google.common.cache.CacheBuilder;
+import org.apache.drill.shaded.guava.com.google.common.cache.CacheLoader;
+import org.apache.drill.shaded.guava.com.google.common.cache.LoadingCache;
+import org.apache.drill.shaded.guava.com.google.common.base.Function;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+
 public class LocalPersistentStore<V> extends BasePersistentStore<V> {
   private static final Logger logger = LoggerFactory.getLogger(LocalPersistentStore.class);
 
+  //Provides a threshold above which we report an event's time
+  private static final long RESPONSE_TIME_THRESHOLD_MSEC = /*200*/0L;
+
+  private static final int DRILL_SYS_FILE_EXT_SIZE = DRILL_SYS_FILE_SUFFIX.length();
   private final Path basePath;
   private final PersistentStoreConfig<V> config;
   private final DrillFileSystem fs;
+  private final AutoCloseableLock profileStoreLock;
+  private Function<String, Entry<String, V>> stringTransformer;
+  private Function<FileStatus, Entry<String, V>> fileStatusTransformer;
 
-  public LocalPersistentStore(DrillFileSystem fs, Path base, PersistentStoreConfig<V> config) {
+  private ProfileSet profilesSet;
+  private PathFilter sysFileSuffixFilter;
+  //  private String mostRecentProfile;
+  private long basePathLastModified;
+  private long lastKnownFileCount;
+  private int maxSetCapacity;
+  private Stopwatch listAndBuildWatch;
+  private Stopwatch transformWatch;
+
+  private Iterable<Entry<String, V>> iterableProfileSet;
+
+  private CacheLoader<String, V> cacheLoader;
+  private LoadingCache<String, V> deserializedVCache;
+
+  public LocalPersistentStore(DrillFileSystem fs, Path base, PersistentStoreConfig<V> config, DrillConfig drillConfig) {
     this.basePath = new Path(base, config.getName());
+    logger.info("basePath = {}", basePath);
     this.config = config;
     this.fs = fs;
+
+    //Initialize Lock for profileStore
+    ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    profileStoreLock = new AutoCloseableLock(readWriteLock.writeLock());
+
+    //MRU Profile Cache
+    int cacheCapacity = drillConfig.getInt(ExecConstants.HTTP_MAX_PROFILES);
+    int deserializedCacheCapacity = drillConfig.getInt(ExecConstants.PROFILES_STORE_CACHE_SIZE);
+    this.profilesSet = new ProfileSet(cacheCapacity);
+    this.basePathLastModified = 0L;
+    this.lastKnownFileCount = 0L;
+    this.sysFileSuffixFilter = new DrillSysFilePathFilter();
+    //this.mostRecentProfile = null;
+
+    //Defining Cache loader for handling missing entries
+    this.cacheLoader = new CacheLoader<String, V>() {
+      @Override
+      public V load(String srcPathAsStr) {
+        //Cache miss to force loading from FS
+        return deserializeFromFileSystem(srcPathAsStr);
+      }
+    };
+
+    //Creating the cache
+    this.deserializedVCache = CacheBuilder.newBuilder()
+        .initialCapacity(Math.max(deserializedCacheCapacity/5, 20)) //startingCapacity: 20% or 20
+        .maximumSize(deserializedCacheCapacity)
+        .recordStats()
+        .build(cacheLoader);
+
+    //Timing
+    this.listAndBuildWatch = Stopwatch.createUnstarted();
+    this.transformWatch = Stopwatch.createUnstarted();
+
+    // Transformer function to extract profile based on query ID String
+    this.stringTransformer = new Function<String, Entry<String, V>>() {
+      @Nullable
+      @Override
+      public Entry<String, V> apply(String key) {
+        return new ImmutableEntry<>(key, get(key));
+      }
+    };
+
+    // Transformer function to extract profile based on FileStatus
+    this.fileStatusTransformer = new Function<FileStatus, Entry<String, V>>() {
+      @Nullable
+      @Override
+      public Entry<String, V> apply(FileStatus fStatus) {
+        Path fPath = fStatus.getPath();
+        String sanSuffixName = fPath.getName().substring(0, fPath.getName().length() - DRILL_SYS_FILE_EXT_SIZE);
+        return new ImmutableEntry<>(sanSuffixName, get(fStatus));
+      }
+    };
+
+    //Base Dir
     try {
       mkdirs(getBasePath());
     } catch (IOException e) {
@@ -107,47 +196,132 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     return fs;
   }
 
+  //Get an iterator based on the current state of the contents on the FileSystem
   @Override
   public Iterator<Map.Entry<String, V>> getRange(int skip, int take) {
     try {
-      // list only files with sys file suffix
-      PathFilter sysFileSuffixFilter = new PathFilter() {
-        @Override
-        public boolean accept(Path path) {
-          return path.getName().endsWith(DRILL_SYS_FILE_SUFFIX);
-        }
-      };
-
-      List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, false, sysFileSuffixFilter);
+      //Recursively look for files (can't apply filename filters, or else sub-directories get excluded)
+      List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, true);
       if (fileStatuses.isEmpty()) {
         return Collections.emptyIterator();
       }
 
-      List<String> files = Lists.newArrayList();
-      for (FileStatus stat : fileStatuses) {
-        String s = stat.getPath().getName();
-        files.add(s.substring(0, s.length() - DRILL_SYS_FILE_SUFFIX.length()));
+      List<FileStatus> files = Lists.newArrayList(); //TODO switch to regular ArrayList
+      for (FileStatus fileStatus : fileStatuses) {
+        if (fileStatus.getPath().getName().endsWith(DRILL_SYS_FILE_SUFFIX)) {
+          files.add(fileStatus);
+        }
       }
 
-      Collections.sort(files);
+      //Sort files
+      List<FileStatus> sortedFiles = files.stream().sorted(
+          new Comparator<FileStatus>() {
+            @Override
+            public int compare(FileStatus fs1, FileStatus fs2) {
+              return fs1.getPath().getName().compareTo(fs2.getPath().getName());
+            }
+          }).collect(Collectors.toList());
 
-      return Iterables.transform(Iterables.limit(Iterables.skip(files, skip), take), new Function<String, Entry<String, V>>() {
-        @Nullable
-        @Override
-        public Entry<String, V> apply(String key) {
-          return new ImmutableEntry<>(key, get(key));
-        }
-      }).iterator();
+      return Iterables.transform(Iterables.limit(Iterables.skip(sortedFiles, skip), take), fileStatusTransformer).iterator();
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get range of potentially cached list of object (primary usecase is for the WebServer that relies on listing cache)
+   * @param skip
+   * @param take
+   * @return iterator of V object
+   */
+  @Override
+  public Iterator<Map.Entry<String, V>> getRange(int skip, int take, boolean useCache) {
+    if (!useCache) {
+      return getRange(skip, take);
+    }
+
+    //Marking currently seen modification time
+    long currBasePathModified = 0L;
+    try {
+      currBasePathModified = fs.getFileStatus(basePath).getModificationTime();
+    } catch (IOException e) {
+      logger.error("Failed to get FileStatus for {}", basePath, e);
+      throw new RuntimeException(e);
+    }
+    //Need to acquire lock since incoming non-web requests are not guaranteed to be synchronized
+    try (Closeable lock = profileStoreLock.open()) {
+      try {
+        long expectedFileCount = fs.getFileStatus(basePath).getLen();
+        logger.info/*debug*/("Current ModTime: {} (Last known ModTime: {})", currBasePathModified, basePathLastModified);
+        logger.info/*debug*/("Expected {} files (Last known {} files)", expectedFileCount, lastKnownFileCount);
+
+        //Force-read list of profiles based on change of any of the 3 states
+        if (this.basePathLastModified < currBasePathModified  //Has ModificationTime changed?
+            || this.lastKnownFileCount != expectedFileCount   //Has Profile Count changed?
+            || (skip + take) > maxSetCapacity ) {             //Does requestSize exceed current cached size
+
+          if (maxSetCapacity < (skip + take)) {
+            logger.info/*debug*/("Updating last Max Capacity from {} to {}", maxSetCapacity, (skip + take) );
+            maxSetCapacity = skip + take;
+          }
+          //Mark Start Time
+          listAndBuildWatch.reset().start();
+
+          //[2Do]
+          //Listing ALL DrillSysFiles
+          //Can apply MostRecentProfile name as filter. Unfortunately, Hadoop (2.7.1) currently doesn't leverage this to speed up
+          List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, basePath, false, //Not performing recursive search of profiles
+              sysFileSuffixFilter /*TODO: Use MostRecentProfile */
+              );
+          //Checking if empty
+          if (fileStatuses.isEmpty()) {
+            return Collections.emptyIterator();
+          }
+
+          //Force a reload of the profile.
+          //Note: We shouldn't need to do this if the load is incremental (i.e. using mostRecentProfile)
+          profilesSet.clear(maxSetCapacity);
+          int numProfilesInStore = 0;
+
+          //Populating cache with profiles
+          for (FileStatus stat : fileStatuses) {
+            String profileName = stat.getPath().getName();
+            //Strip extension and store only query ID
+            profilesSet.add(profileName.substring(0, profileName.length() - DRILL_SYS_FILE_EXT_SIZE));
+            numProfilesInStore++;
+          }
+
+          //Report Lag
+          if (listAndBuildWatch.stop().elapsed(TimeUnit.MILLISECONDS) >= RESPONSE_TIME_THRESHOLD_MSEC) {
+            logger.info/*warn*/("Took {} ms to list & map {} profiles (out of {} profiles in store)", listAndBuildWatch.elapsed(TimeUnit.MILLISECONDS),
+                profilesSet.size(), numProfilesInStore);
+          }
+          //Recording last checked modified time and the most recent profile
+          basePathLastModified = currBasePathModified;
+          /*TODO: mostRecentProfile = profilesSet.getYoungest();*/
+          lastKnownFileCount = expectedFileCount;
+
+          //Transform profileSet for consumption
+          logger.info("profilesSetSize? {}", profilesSet.size());
+          transformWatch.start();
+          iterableProfileSet = Iterables.transform(profilesSet, stringTransformer);
+          if (transformWatch.stop().elapsed(TimeUnit.MILLISECONDS) >= RESPONSE_TIME_THRESHOLD_MSEC) {
+            logger.info/*warn*/("Took {} ms to transform {} profiles", transformWatch.elapsed(TimeUnit.MILLISECONDS), profilesSet.size());
+          }
+        }
+        logger.info("getRange DeSerCacheStats:: {}", this.deserializedVCache.stats().toString());
+        return iterableProfileSet.iterator();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 
   private Path makePath(String name) {
     Preconditions.checkArgument(
         !name.contains("/") &&
-            !name.contains(":") &&
-            !name.contains(".."));
+        !name.contains(":") &&
+        !name.contains(".."));
     return new Path(basePath, name + DRILL_SYS_FILE_SUFFIX);
   }
 
@@ -160,22 +334,50 @@ public class LocalPersistentStore<V> extends BasePersistentStore<V> {
     }
   }
 
+  //TODO | FIXME: Guava to Handle RuntimeException by
+  //Deserialize path's contents (leveraged by Guava Cache)
+  private V deserializeFromFileSystem(String srcPath) {
+    final Path path = new Path(srcPath);
+    try (InputStream is = fs.open(path)) {
+      return config.getSerializer().deserialize(IOUtils.toByteArray(is));
+    } catch (IOException e) {
+      logger.info("Unable to deserialize {}\n{}", path, e);
+      throw new RuntimeException("Unable to deserialize \"" + path, e);
+    }
+  }
+
   @Override
   public V get(String key) {
+    Path path = null;
     try {
-      Path path = makePath(key);
+      path = makePath(key);
+      //logger.info("makePath({}) = {}", key, path);
       if (!fs.exists(path)) {
         return null;
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    final Path path = makePath(key);
-    try (InputStream is = fs.open(path)) {
-      return config.getSerializer().deserialize(IOUtils.toByteArray(is));
+    V payload = deserializedVCache.getUnchecked(path.toString());//deserialize(path.toString());
+    //logger.info("postGetString[{}] :: {}", path, deserializedProfileCache.stats().toString());
+    return payload;
+  }
+
+  //For profiles not on basePath
+  public V get(FileStatus fStat) {
+    Path path = null;
+    try {
+      path = fStat.getPath();
+      //logger.info("{}.getPath() = {}", fStat, path);
+      if (!fs.exists(path)) {
+        return null;
+      }
     } catch (IOException e) {
-      throw new RuntimeException("Unable to deserialize \"" + path + "\"", e);
+      throw new RuntimeException(e);
     }
+    V payload = deserializedVCache.getUnchecked(path.toString());//deserialize(path.toString());
+    //logger.info("postGetFileStatus[{}] :: {}", path, deserializedProfileCache.stats().toString());
+    return payload;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/ProfileSet.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys.store;
+
+import java.util.Iterator;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Wrapper around TreeSet to mimic a size-bound set ordered by name (implicitly the profiles' age)
+ */
+public class ProfileSet implements Iterable<String> {
+  private TreeSet<String> store;
+  private int maxCapacity;
+  //Using a dedicated counter to avoid
+  private AtomicInteger size;
+
+  @SuppressWarnings("unused")
+  @Deprecated
+  private ProfileSet() {}
+
+  public ProfileSet(int capacity) {
+    this.store = new TreeSet<String>();
+    this.maxCapacity = capacity;
+    this.size = new AtomicInteger();
+  }
+
+  public int size() {
+    return size.get();
+  }
+
+  /**
+   * Get max capacity of the profile set
+   * @return max capacity
+   */
+  public int capacity() {
+    return maxCapacity;
+  }
+
+  /**
+   * Add a profile name to the set, while removing the oldest, if exceeding capacity
+   * @param profile
+   * @return oldest profile
+   */
+  public String add(String profile) {
+    return add(profile, false);
+  }
+
+  /**
+   * Add a profile name to the set, while removing the oldest or youngest, based on flag
+   * @param profile
+   * @param retainOldest indicate retaining policy as oldest
+   * @return youngest/oldest profile
+   */
+  public String add(String profile, boolean retainOldest) {
+    store.add(profile);
+    if (size.incrementAndGet() > maxCapacity) {
+      if (retainOldest) {
+        return removeYoungest();
+      } else {
+        return removeOldest();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Remove the oldest profile
+   * @return oldest profile
+   */
+  public String removeOldest() {
+    size.decrementAndGet();
+    return store.pollLast();
+  }
+
+  /**
+   * Remove the youngest profile
+   * @return youngest profile
+   */
+  public String removeYoungest() {
+    size.decrementAndGet();
+    return store.pollFirst();
+  }
+
+  /**
+   * Retrieve the oldest profile without removal
+   * @return oldest profile
+   */
+  public String getOldest() {
+    return store.last();
+  }
+
+  /**
+   * Retrieve the youngest profile without removal
+   * @return youngest profile
+   */
+  public String getYoungest() {
+    return store.first();
+  }
+
+  /**
+   * Clear the set
+   */
+  public void clear() {
+    size.set(0);
+    store.clear();
+  }
+
+  /**
+   * Clear the set with the initial capacity
+   * @param capacity
+   */
+  public void clear(int capacity) {
+    clear(maxCapacity, false);
+  }
+
+  /**
+   * Clear the set with the initial capacity
+   * @param capacity
+   * @param forceResize
+   */
+  public void clear(int capacity, boolean forceResize) {
+    clear();
+    if (forceResize || capacity > maxCapacity) {
+      maxCapacity = capacity;
+    }
+  }
+
+  public boolean isEmpty() {
+    return store.isEmpty();
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    return store.iterator();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/store/provider/LocalPersistentStoreProvider.java
@@ -43,6 +43,8 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
   // This flag is used in testing. Ideally, tests should use a specific PersistentStoreProvider that knows
   // how to handle this flag.
   private final boolean enableWrite;
+  //Config reference for archiving
+  private final DrillConfig drillConfig;
 
   public LocalPersistentStoreProvider(final PersistentStoreRegistry<?> registry) throws StoreException {
     this(registry.getConfig());
@@ -50,6 +52,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
 
   public LocalPersistentStoreProvider(final DrillConfig config) throws StoreException {
     this.path = new Path(config.getString(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH));
+    this.drillConfig = config;
     this.enableWrite = config.getBoolean(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE);
     try {
       this.fs = LocalPersistentStore.getFileSystem(config, path);
@@ -64,7 +67,7 @@ public class LocalPersistentStoreProvider extends BasePersistentStoreProvider {
     case BLOB_PERSISTENT:
     case PERSISTENT:
       if (enableWrite) {
-        return new LocalPersistentStore<>(fs, path, storeConfig);
+        return new LocalPersistentStore<>(fs, path, storeConfig, drillConfig);
       }
       return new NoWriteLocalStore<>();
     default:

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -209,7 +209,8 @@ drill.exec: {
   },
   profiles.store: {
     inmemory: false,
-    capacity: 1000
+    capacity: 1000,
+    cache.size: 100
   },
   impersonation: {
     enabled: false,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/sys/TestProfileSet.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.sys;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.exec.store.sys.store.ProfileSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test the size-constrained ProfileSet for use in the webserver's '/profiles' listing
+ */
+public class TestProfileSet {
+  private final static String PROFILE_PREFIX = "t35t-pr0fil3-";
+  static int initCapacity;
+  static int finalCapacity;
+  static int storeCount;
+  static Random rand;
+  static List<String> masterList;
+
+  @BeforeClass
+  public static void setupProfileSet() {
+    initCapacity = 50;
+    finalCapacity = 70;
+    storeCount = 100;
+    rand = new Random();
+    //Generating source list of storeCount # 'profiles'
+    masterList = new LinkedList<String>();
+    for (int i = 0; i < storeCount; i++) {
+      masterList.add(PROFILE_PREFIX + StringUtils.leftPad(String.valueOf(i), String.valueOf(storeCount).length(), '0'));
+    }
+  }
+
+  @Test
+  public void testProfileOrder() throws Exception {
+    //clone initial # profiles and verify via iterator.
+    ProfileSet testSet = new ProfileSet(initCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assert (poppedProfile == null);
+      assertEquals(null, poppedProfile);
+    }
+
+    //Testing order
+    String prevProfile = null;
+    while (!testSet.isEmpty()) {
+      String currOldestProfile = testSet.removeOldest();
+      if (prevProfile != null) {
+        assertTrue( prevProfile.compareTo(currOldestProfile) > 0 );
+      }
+      prevProfile = currOldestProfile;
+    }
+  }
+
+  //Test if inserts exceeding capacity leads to eviction of oldest
+  @Test
+  public void testExcessInjection() throws Exception {
+    //clone initial # profiles and verify via iterator.
+    ProfileSet testSet = new ProfileSet(initCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    //Testing Excess by looking at oldest popped
+    for (int i = initCapacity; i < finalCapacity; i++) {
+      String toInsert = srcList.remove(rand.nextInt(storeCount - i));
+      String expectedToPop = ( toInsert.compareTo(testSet.getOldest()) > 0 ?
+          toInsert : testSet.getOldest() );
+
+      String oldestPoppedProfile = testSet.add(toInsert);
+      assertEquals(expectedToPop, oldestPoppedProfile);
+    }
+
+    assertEquals(initCapacity, testSet.size());
+  }
+
+  //Test if size internally resizes to final capacity with no evictions
+  @Test
+  public void testSetResize() throws Exception {
+    //clone initial # profiles into a 700-capacity set.
+    ProfileSet testSet = new ProfileSet(finalCapacity);
+    List<String> srcList = new LinkedList<String>(masterList);
+
+    //Loading randomly
+    for (int i = 0; i < initCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    assertEquals(initCapacity, testSet.size());
+
+    //Testing No Excess by looking at oldest popped
+    for (int i = initCapacity; i < finalCapacity; i++) {
+      String poppedProfile = testSet.add(srcList.remove(rand.nextInt(storeCount - i)));
+      assertEquals(null, poppedProfile);
+    }
+
+    assertEquals(finalCapacity, testSet.size());
+  }
+
+}


### PR DESCRIPTION
_**Note:** Closed the old PR #755 and #1250 and opening this._

When Drill is displaying profiles stored on the file system (Local or Distributed), it does so by loading the entire list of `.sys.drill` files in the profile directory, sorting and deserializing. This can get expensive, since only a single CPU thread does this.
As an example, a directory of 120K profiles, the time to just fetch the list of files alone is about 6 seconds. After that, based on the number of profiles being rendered, the time varies. An average of 30ms is needed to deserialize a standard profile, which translates to an additional 3sec for the rendering of default 100 profiles.

A user reported issue confirms just that:
[DRILL-5028](https://issues.apache.org/jira/browse/DRILL-5028) Opening profiles page from web ui gets very slow when a lot of history files have been stored in HDFS or Local FS

Additional JIRAs filed ask for managing these profiles
[DRILL-2362](https://issues.apache.org/jira/browse/DRILL-2362) Drill should manage Query Profiling archiving
[DRILL-2861](https://issues.apache.org/jira/browse/DRILL-2861) enhance drill profile file management

This PR brings the following enhancements to achieve that:

1. Improve loading times by pinning the deserialized list in memory (TreeSet; for maintaining a memory-efficient sortedness of the profiles). That way, if we do not detect any new profiles in the profileStore (i.e. profile directory) since the last time a web-request for rendering the profiles was made, we can re-serve the same listing and skip making a trip to the filesystem to re-fetch all the profiles.
2. Leverage Guava Cache to save on deserializing profiles, since the WebServer makes 2 calls to deserialize a file on disk for rendering.

Reload & reconstruction of the profiles in the Tree is done in the event of any of the following states changing:
i. Modification Time of profile dir
ii. Number of profiles in the profile dir
iii. Number of profiles requested exceeds existing the currently available list

Access to the profiles requires a lock to ensure that at any time, only one of the requesting users is able to trigger a reconstruction of the TreeSet. If reconstruction is not required, it uses the existing cache rather than attempting to read the entire profile directory's contents all over again.