### PR TITLE
DRILL-7035: Drill C++ Client crashes on multiple SaslAuthenticatorImpl destruction due to communication error

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -2311,9 +2311,14 @@ void DrillClientImpl::shutdownSocket(){
 
     // Delete the saslAuthenticatorImpl instance since connection is broken. It will recreated on next
     // call to connect.
-    if(m_saslAuthenticator != NULL) {
-        delete m_saslAuthenticator;
-        m_saslAuthenticator = NULL;
+    if (m_saslAuthenticator != NULL) {
+        {
+            boost::mutex::scoped_lock lock(m_sasl_dispose_mutex);
+            if (m_saslAuthenticator != NULL) {
+                delete m_saslAuthenticator;
+                m_saslAuthenticator = NULL;
+            }
+        }
     }
 
     // Reset the SASL states.

--- a/contrib/native/client/src/clientlib/drillClientImpl.hpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.hpp
@@ -582,6 +582,8 @@ class DrillClientImpl : public DrillClientImplBase{
         int m_saslResultCode;
         bool m_saslDone;
         boost::mutex m_saslMutex; // mutex to protect m_saslDone
+        // mutex to protect deallocation of sasl connection
+        boost::mutex m_sasl_dispose_mutex;
         boost::condition_variable m_saslCv; // to signal completion of SASL exchange
 
         // Used for encryption and is set when server notifies in first handshake response.

--- a/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
+++ b/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
@@ -71,6 +71,7 @@ private:
 
     const DrillUserProperties *const m_pUserProperties;
     sasl_conn_t *m_pConnection;
+    std::vector<sasl_callback_t> m_callbacks;
     std::string m_username;
     sasl_secret_t *m_ppwdSecret;
     EncryptionContext *m_pEncryptCtxt;


### PR DESCRIPTION
The fix ensures that the check for  null of m_saslAuthenticator and delete of m_saslAuthenticator object are atomic and thread safe.