### PR TITLE
DRILL-7035: Drill C++ Client crashes on multiple SaslAuthenticatorImpl destruction due to communication error

### DIFF
--- a/contrib/native/client/src/clientlib/drillClientImpl.cpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.cpp
@@ -2311,9 +2311,14 @@ void DrillClientImpl::shutdownSocket(){
 
     // Delete the saslAuthenticatorImpl instance since connection is broken. It will recreated on next
     // call to connect.
-    if(m_saslAuthenticator != NULL) {
-        delete m_saslAuthenticator;
-        m_saslAuthenticator = NULL;
+    if (m_saslAuthenticator != NULL) {
+        {
+            boost::mutex::scoped_lock lock(m_sasl_dispose_mutex);
+            if (m_saslAuthenticator != NULL) {
+                delete m_saslAuthenticator;
+                m_saslAuthenticator = NULL;
+            }
+        }
     }
 
     // Reset the SASL states.

--- a/contrib/native/client/src/clientlib/drillClientImpl.hpp
+++ b/contrib/native/client/src/clientlib/drillClientImpl.hpp
@@ -582,6 +582,8 @@ class DrillClientImpl : public DrillClientImplBase{
         int m_saslResultCode;
         bool m_saslDone;
         boost::mutex m_saslMutex; // mutex to protect m_saslDone
+        // mutex to protect deallocation of sasl connection
+        boost::mutex m_sasl_dispose_mutex;
         boost::condition_variable m_saslCv; // to signal completion of SASL exchange
 
         // Used for encryption and is set when server notifies in first handshake response.


### PR DESCRIPTION
The fix for this is essentially ensuring that the null check and delete of SaslAuthenticatorImpl object is atomic and thread safe.