### PR TITLE
DRILL-7047: Drill C++ Client crash due to Dangling stack ptr to sasl_callback_t

### DIFF
--- a/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
+++ b/contrib/native/client/src/clientlib/saslAuthenticatorImpl.hpp
@@ -71,6 +71,7 @@ private:
 
     const DrillUserProperties *const m_pUserProperties;
     sasl_conn_t *m_pConnection;
+    std::vector<sasl_callback_t> m_callbacks;
     std::string m_username;
     sasl_secret_t *m_ppwdSecret;
     EncryptionContext *m_pEncryptCtxt;


### PR DESCRIPTION
The fix moves the callback from being allocated on the stack as a local variable to a member variable. This ensures that the callback vector has the same lifetime as the sasl connection object.  