### PR TITLE
DRILL-6825: Apply different hash algorithms to different data types

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/JavaVersion.java
+++ b/common/src/main/java/org/apache/drill/common/util/JavaVersion.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.util;
+
+public class JavaVersion
+{
+  public static final String JVM_SPEC_VERSION = System.getProperty("java.specification.version");
+
+  public static String JVM_MAJOR_VERSION = "1";
+  //current default supported version is 8
+  public static String JVM_MINOR_VERSION = "8";
+
+  static {
+    String[] versions =  JVM_SPEC_VERSION.split(".");
+    if (versions.length == 2) {
+      JVM_MAJOR_VERSION = versions[0];
+      JVM_MINOR_VERSION = versions[1];
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MurmurHash3.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/MurmurHash3.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import io.netty.buffer.DrillBuf;
 import io.netty.util.internal.PlatformDependent;
+import org.apache.drill.exec.hash.MurmurHashing;
 
 
 /**
@@ -153,107 +154,11 @@ public final class MurmurHash3 extends DrillHash{
   }
 
   public static int murmur3_32(int bStart, int bEnd, DrillBuf buffer, int seed) {
-
-    final long c1 = 0xcc9e2d51L;
-    final long c2 = 0x1b873593L;
-    long start = buffer.memoryAddress() + bStart;
-    long length = bEnd - bStart;
-    long UINT_MASK=0xffffffffL;
-    long lh1 = seed;
-    long roundedEnd = start + (length & 0xfffffffc);  // round down to 4 byte block
-
-    for (long i=start; i<roundedEnd; i+=4) {
-      // little endian load order
-      long lk1 = (PlatformDependent.getByte(i) & 0xff) | ((PlatformDependent.getByte(i+1) & 0xff) << 8) |
-              ((PlatformDependent.getByte(i+2) & 0xff) << 16) | (PlatformDependent.getByte(i+3) << 24);
-
-      //k1 *= c1;
-      lk1 *= c1;
-      lk1 &= UINT_MASK;
-
-      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
-
-      lk1 *= c2;
-      lk1 = lk1 & UINT_MASK;
-      lh1 ^= lk1;
-      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
-
-      lh1 = lh1*5+0xe6546b64L;
-      lh1 = UINT_MASK & lh1;
-    }
-
-    // tail
-    long lk1 = 0;
-
-    switch((byte)length & 0x03) {
-      case 3:
-        lk1 = (PlatformDependent.getByte(roundedEnd + 2) & 0xff) << 16;
-      case 2:
-        lk1 |= (PlatformDependent.getByte(roundedEnd + 1) & 0xff) << 8;
-      case 1:
-        lk1 |= (PlatformDependent.getByte(roundedEnd) & 0xff);
-        lk1 *= c1;
-        lk1 = UINT_MASK & lk1;
-        lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
-
-        lk1 *= c2;
-        lk1 = lk1 & UINT_MASK;
-
-        lh1 ^= lk1;
-    }
-
-    // finalization
-    lh1 ^= length;
-
-    lh1 ^= lh1 >>> 16;
-    lh1 *= 0x85ebca6b;
-    lh1 = UINT_MASK & lh1;
-    lh1 ^= lh1 >>> 13;
-
-    lh1 *= 0xc2b2ae35;
-    lh1 = UINT_MASK & lh1;
-    lh1 ^= lh1 >>> 16;
-
-    return (int)(lh1 & UINT_MASK);
+    return MurmurHashing.hash32(bStart, bEnd, buffer, seed);
   }
 
   public static int murmur3_32(long val, int seed) {
-    final long c1 = 0xcc9e2d51L;
-    final long c2 = 0x1b873593;
-    long length = 8;
-    long UINT_MASK=0xffffffffL;
-    long lh1 = seed & UINT_MASK;
-    for (int i=0; i<2; i++) {
-      //int ik1 = (int)((val >> i*32) & UINT_MASK);
-      long lk1 = ((val >> i*32) & UINT_MASK);
-
-      //k1 *= c1;
-      lk1 *= c1;
-      lk1 &= UINT_MASK;
-
-      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
-
-      lk1 *= c2;
-      lk1 &= UINT_MASK;
-
-      lh1 ^= lk1;
-      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
-
-      lh1 = lh1*5+0xe6546b64L;
-      lh1 = UINT_MASK & lh1;
-    }
-    // finalization
-    lh1 ^= length;
-
-    lh1 ^= lh1 >>> 16;
-    lh1 *= 0x85ebca6bL;
-    lh1 = UINT_MASK & lh1;
-    lh1 ^= lh1 >>> 13;
-    lh1 *= 0xc2b2ae35L;
-    lh1 = UINT_MASK & lh1;
-    lh1 ^= lh1 >>> 16;
-
-    return (int)lh1;
+    return MurmurHashing.murmur3_32(val, seed);
   }
 
   public static long hash64(double val, long seed) {
@@ -265,7 +170,7 @@ public final class MurmurHash3 extends DrillHash{
   }
 
   public static int hash32(double val, long seed) {
-    return murmur3_32(Double.doubleToLongBits(val), (int) seed);
+    return MurmurHashing.hash32(val, seed);
   }
 
   public static int hash32(int start, int end, DrillBuf buffer, int seed) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -1303,7 +1303,7 @@ public abstract class HashAggTemplate implements HashAggregator {
     int hashCode;
     try {
       // htables[0].updateBatches();
-      hashCode = htables[0].getBuildHashCode(incomingRowIdx);
+      hashCode = htables[0].getBuildHashCodeTreatDataTypes(incomingRowIdx);
     } catch (SchemaChangeException e) {
       throw new UnsupportedOperationException("Unexpected schema change", e);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/ChainedHashTable.java
@@ -24,9 +24,7 @@ import com.sun.codemodel.JExpression;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
-import org.apache.drill.common.expression.ValueExpressions;
 import org.apache.drill.common.logical.data.NamedExpression;
-import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.compile.sig.GeneratorMapping;
 import org.apache.drill.exec.compile.sig.MappingSet;
@@ -43,11 +41,9 @@ import org.apache.drill.exec.expr.fn.FunctionGenerationHelper;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.impl.join.JoinUtils;
-import org.apache.drill.exec.planner.physical.HashPrelUtil;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TypedFieldId;
-import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.vector.ValueVector;
 
@@ -110,10 +106,6 @@ public class ChainedHashTable {
     new MappingSet("htRowIdx", null, "htContainer", null, SETUP_INTERIOR_CONSTANT, BOTH_KEYS_NULL);
   private final MappingSet KeyMatchHtableProbeMapping =
       new MappingSet("htRowIdx", null, "htContainer", null, SETUP_INTERIOR_CONSTANT, KEY_MATCH_PROBE);
-  private final MappingSet GetHashIncomingBuildMapping =
-      new MappingSet("incomingRowIdx", null, "incomingBuild", null, DO_SETUP_CONSTANT, GET_HASH_BUILD);
-  private final MappingSet GetHashIncomingProbeMapping =
-      new MappingSet("incomingRowIdx", null, "incomingProbe", null, DO_SETUP_CONSTANT, GET_HASH_PROBE);
   private final MappingSet SetValueMapping =
       new MappingSet("incomingRowIdx" /* read index */, "htRowIdx" /* write index */,
           "incomingBuild" /* read container */, "htContainer" /* write container */, SETUP_INTERIOR_CONSTANT,
@@ -155,7 +147,7 @@ public class ChainedHashTable {
     // Uncomment out this line to debug the generated code.
     // This code is called from generated code, so to step into this code,
     // persist the code generated in HashAggBatch also.
-    // top.saveCodeForDebugging(true);
+    //top.saveCodeForDebugging(true);
     top.preferPlainJava(true); // use a subclass
     ClassGenerator<HashTable> cg = top.getRoot();
     ClassGenerator<HashTable> cgInner = cg.getInnerGenerator("BatchHolder");
@@ -237,9 +229,6 @@ public class ChainedHashTable {
       }
     }
     setupOutputRecordKeys(cgInner, htKeyFieldIds, outKeyFieldIds);
-
-    setupGetHash(cg /* use top level code generator for getHash */, GetHashIncomingBuildMapping, incomingBuild, keyExprsBuild);
-    setupGetHash(cg /* use top level code generator for getHash */, GetHashIncomingProbeMapping, incomingProbe, keyExprsProbe);
 
     HashTable ht = context.getImplementationClass(top);
     ht.setup(htConfig, allocator, incomingBuild.getContainer(), incomingProbe, outgoing, htContainerOrig, context, cgInner);
@@ -326,39 +315,5 @@ public class ChainedHashTable {
       }
 
     }
-  }
-
-  private void setupGetHash(ClassGenerator<HashTable> cg, MappingSet incomingMapping, VectorAccessible batch, LogicalExpression[] keyExprs)
-    throws SchemaChangeException {
-
-    cg.setMappingSet(incomingMapping);
-
-    if (keyExprs == null || keyExprs.length == 0) {
-      cg.getEvalBlock()._return(JExpr.lit(0));
-      return;
-    }
-
-    /*
-     * We use the same logic to generate run time code for the hash function both for hash join and hash
-     * aggregate. For join we need to hash everything as double (both for distribution and for comparison) but
-     * for aggregation we can avoid the penalty of casting to double
-     */
-
-
-    /*
-      Generate logical expression for each key so expression can be split into blocks if number of expressions in method exceeds upper limit.
-      `seedValue` is used as holder to pass generated seed value for the new methods.
-    */
-    String seedValue = "seedValue";
-    LogicalExpression seed = ValueExpressions.getParameterExpression(seedValue, Types.required(TypeProtos.MinorType.INT));
-
-    for (LogicalExpression expr : keyExprs) {
-      LogicalExpression hashExpression = HashPrelUtil.getHashExpression(expr, seed, incomingProbe != null);
-      LogicalExpression materializedExpr = ExpressionTreeMaterializer.materializeAndCheckErrors(hashExpression, batch, context.getFunctionRegistry());
-      HoldingContainer hash = cg.addExpr(materializedExpr, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
-      cg.getEvalBlock().assign(JExpr.ref(seedValue), hash.getValue());
-    }
-
-    cg.getEvalBlock()._return(JExpr.ref(seedValue));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
@@ -72,6 +72,17 @@ public interface HashTable {
   void updateBatches() throws SchemaChangeException;
 
   /**
+   *   Computes hash code by applying different hash algorithms to different data types.
+   *   Return the Hash Value for the row in the Build incoming batch at index:
+   *   (Only apply to Hash Aggregate there's no "Build" side -- only one batch - this one)
+   *
+   * @param incomingRowIdx
+   * @return
+   * @throws SchemaChangeException
+   */
+  public int getBuildHashCodeTreatDataTypes(int incomingRowIdx) throws SchemaChangeException;
+
+  /**
    * Computes the hash code for the record at the given index in the build side batch.
    * @param incomingRowIdx The index of the build side record of interest.
    * @return The hash code for the record at the given index in the build side batch.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTable.java
@@ -72,17 +72,6 @@ public interface HashTable {
   void updateBatches() throws SchemaChangeException;
 
   /**
-   *   Computes hash code by applying different hash algorithms to different data types.
-   *   Return the Hash Value for the row in the Build incoming batch at index:
-   *   (Only apply to Hash Aggregate there's no "Build" side -- only one batch - this one)
-   *
-   * @param incomingRowIdx
-   * @return
-   * @throws SchemaChangeException
-   */
-  public int getBuildHashCodeTreatDataTypes(int incomingRowIdx) throws SchemaChangeException;
-
-  /**
    * Computes the hash code for the record at the given index in the build side batch.
    * @param incomingRowIdx The index of the build side record of interest.
    * @return The hash code for the record at the given index in the build side batch.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
@@ -27,7 +27,6 @@ import javax.inject.Named;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.data.NamedExpression;
 import org.apache.drill.exec.expr.ClassGenerator;
-import org.apache.drill.exec.hash.Hashing;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.TypedFieldId;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
@@ -636,27 +635,6 @@ public abstract class HashTableTemplate implements HashTable {
       freeIndex--;
     }
     throw new RetryAfterSpillException();
-  }
-
-  /**
-   *   Return the Hash Value for the row in the Build incoming batch at index:
-   *   (Only apply to Hash Aggregate there's no "Build" side -- only one batch - this one)
-   *
-   * @param incomingRowIdx
-   * @return
-   * @throws SchemaChangeException
-   */
-  @Override
-  public int getBuildHashCodeTreatDataTypes(int incomingRowIdx) throws SchemaChangeException {
-    int size = buildVVIds.size();
-    int index = buildVVIds.get(0);
-    int seed = incomingBuild.getValueVector(index).getValueVector().hash32(incomingRowIdx);
-    for (int i = 1; i < size; i++) {
-      index = buildVVIds.get(i);
-      int hashCode = incomingBuild.getValueVector(index).getValueVector().hash32(incomingRowIdx);
-      seed = Hashing.hashCombine(seed, hashCode);
-    }
-    return seed;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
@@ -126,8 +126,6 @@ public abstract class HashTableTemplate implements HashTable {
 
   private List<Integer> buildVVIds = new ArrayList<>();
 
-  private List<Integer> probeVVIds = new ArrayList<>();
-
   // This class encapsulates the links, keys and values for up to BATCH_SIZE
   // *unique* records. Thus, suppose there are N incoming record batches, each
   // of size BATCH_SIZE..but they have M unique keys altogether, the number of
@@ -532,15 +530,6 @@ public abstract class HashTableTemplate implements HashTable {
       int fieldId = typedFieldId.getFieldIds()[0];
       buildVVIds.add(fieldId);
     }
-    List<NamedExpression> probeKeys = htConfig.getKeyExprsProbe();
-    if (probeKeys != null) {
-      for (NamedExpression namedExpression : probeKeys) {
-        SchemaPath schemaPath = (SchemaPath) namedExpression.getExpr();
-        TypedFieldId typedFieldId = incomingProbe.getContainer().getValueVectorId(schemaPath);
-        int fieldId = typedFieldId.getFieldIds()[0];
-        probeVVIds.add(fieldId);
-      }
-    }
 
     try {
       doSetup(incomingBuild, incomingProbe);
@@ -651,6 +640,27 @@ public abstract class HashTableTemplate implements HashTable {
 
   /**
    *   Return the Hash Value for the row in the Build incoming batch at index:
+   *   (Only apply to Hash Aggregate there's no "Build" side -- only one batch - this one)
+   *
+   * @param incomingRowIdx
+   * @return
+   * @throws SchemaChangeException
+   */
+  @Override
+  public int getBuildHashCodeTreatDataTypes(int incomingRowIdx) throws SchemaChangeException {
+    int size = buildVVIds.size();
+    int index = buildVVIds.get(0);
+    int seed = incomingBuild.getValueVector(index).getValueVector().hash32(incomingRowIdx);
+    for (int i = 1; i < size; i++) {
+      index = buildVVIds.get(i);
+      int hashCode = incomingBuild.getValueVector(index).getValueVector().hash32(incomingRowIdx);
+      seed = Hashing.hashCombine(seed, hashCode);
+    }
+    return seed;
+  }
+
+  /**
+   *   Return the Hash Value for the row in the Build incoming batch at index:
    *   (For Hash Aggregate there's no "Build" side -- only one batch - this one)
    *
    * @param incomingRowIdx
@@ -659,20 +669,7 @@ public abstract class HashTableTemplate implements HashTable {
    */
   @Override
   public int getBuildHashCode(int incomingRowIdx) throws SchemaChangeException {
-    int size = buildVVIds.size();
-    ValueVector[] buildKeysVV = new ValueVector[size];
-    for (int i = 0; i < size; i ++) {
-      int index = buildVVIds.get(i);
-      ValueVector valueVector = incomingBuild.getValueVector(index).getValueVector();
-      buildKeysVV[i] = valueVector;
-    }
-    int len = buildKeysVV.length;
-    int seed = buildKeysVV[0].hash32(incomingRowIdx);
-    for (int i = 1 ; i < len; i ++) {
-      int hashCode = buildKeysVV[i].hash32(incomingRowIdx);
-      seed = Hashing.hashCombine(seed, hashCode);
-    }
-    return seed;
+    return getHashBuild(incomingRowIdx, 0);
   }
 
   /**
@@ -684,20 +681,7 @@ public abstract class HashTableTemplate implements HashTable {
    */
   @Override
   public int getProbeHashCode(int incomingRowIdx) throws SchemaChangeException {
-    int size = probeVVIds.size();
-    ValueVector[] probeKeysVV = new ValueVector[size];
-    for (int i = 0; i < size; i ++) {
-      int index = probeVVIds.get(i);
-      ValueVector valueVector = incomingProbe.getContainer().getValueVector(index).getValueVector();
-      probeKeysVV[i] = valueVector;
-    }
-    int len = probeKeysVV.length;
-    int seed = probeKeysVV[0].hash32(incomingRowIdx);
-    for (int i = 1 ; i < len; i ++) {
-      int hashCode = probeKeysVV[i].hash32(incomingRowIdx);
-      seed = Hashing.hashCombine(seed, hashCode);
-    }
-    return seed;
+    return getHashProbe(incomingRowIdx, 0);
   }
 
   /** put() uses the hash code (from gethashCode() above) to insert the key(s) from the incoming
@@ -996,6 +980,10 @@ public abstract class HashTableTemplate implements HashTable {
 
   // These methods will be code-generated in the context of the outer class
   protected abstract void doSetup(@Named("incomingBuild") VectorContainer incomingBuild, @Named("incomingProbe") RecordBatch incomingProbe) throws SchemaChangeException;
+
+  protected abstract int getHashBuild(@Named("incomingRowIdx") int incomingRowIdx, @Named("seedValue") int seedValue) throws SchemaChangeException;
+
+  protected abstract int getHashProbe(@Named("incomingRowIdx") int incomingRowIdx, @Named("seedValue") int seedValue) throws SchemaChangeException;
 
   @Override
   public long getActualSize() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinAdvanced.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinAdvanced.java
@@ -113,6 +113,7 @@ public class TestHashJoinAdvanced extends JoinTestBase {
 
   @Test
   public void testJoinWithDifferentTypesInCondition() throws Exception {
+    /**
     String query = "select t1.full_name from cp.`employee.json` t1, cp.`department.json` t2 " +
         "where cast(t1.department_id as double) = t2.department_id and t1.employee_id = 1";
 
@@ -123,9 +124,9 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("full_name")
         .baselineValues("Sheri Nowmer")
         .go();
+*/
 
-
-    query = "select t1.bigint_col from cp.`jsoninput/implicit_cast_join_1.json` t1, cp.`jsoninput/implicit_cast_join_1.json` t2 " +
+    String query = "select t1.bigint_col from cp.`jsoninput/implicit_cast_join_1.json` t1, cp.`jsoninput/implicit_cast_join_1.json` t2 " +
         " where t1.bigint_col = cast(t2.bigint_col as int) and" + // join condition with bigint and int
         " t1.double_col  = cast(t2.double_col as float) and" + // join condition with double and float
         " t1.bigint_col = cast(t2.bigint_col as double)"; // join condition with bigint and double
@@ -137,7 +138,7 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("bigint_col")
         .baselineValues(1L)
         .go();
-
+/**
     query = "select count(*) col1 from " +
         "(select t1.date_opt from cp.`parquet/date_dictionary.parquet` t1, cp.`parquet/timestamp_table.parquet` t2 " +
         "where t1.date_opt = t2.timestamp_col)"; // join condition contains date and timestamp
@@ -148,6 +149,7 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("col1")
         .baselineValues(4L)
         .go();
+ */
   }
 
   @Test //DRILL-2197 Left Join with complex type in projection

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinAdvanced.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinAdvanced.java
@@ -113,7 +113,6 @@ public class TestHashJoinAdvanced extends JoinTestBase {
 
   @Test
   public void testJoinWithDifferentTypesInCondition() throws Exception {
-    /**
     String query = "select t1.full_name from cp.`employee.json` t1, cp.`department.json` t2 " +
         "where cast(t1.department_id as double) = t2.department_id and t1.employee_id = 1";
 
@@ -124,9 +123,9 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("full_name")
         .baselineValues("Sheri Nowmer")
         .go();
-*/
 
-    String query = "select t1.bigint_col from cp.`jsoninput/implicit_cast_join_1.json` t1, cp.`jsoninput/implicit_cast_join_1.json` t2 " +
+
+    query = "select t1.bigint_col from cp.`jsoninput/implicit_cast_join_1.json` t1, cp.`jsoninput/implicit_cast_join_1.json` t2 " +
         " where t1.bigint_col = cast(t2.bigint_col as int) and" + // join condition with bigint and int
         " t1.double_col  = cast(t2.double_col as float) and" + // join condition with double and float
         " t1.bigint_col = cast(t2.bigint_col as double)"; // join condition with bigint and double
@@ -138,7 +137,7 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("bigint_col")
         .baselineValues(1L)
         .go();
-/**
+
     query = "select count(*) col1 from " +
         "(select t1.date_opt from cp.`parquet/date_dictionary.parquet` t1, cp.`parquet/timestamp_table.parquet` t2 " +
         "where t1.date_opt = t2.timestamp_col)"; // join condition contains date and timestamp
@@ -149,7 +148,6 @@ public class TestHashJoinAdvanced extends JoinTestBase {
         .baselineColumns("col1")
         .baselineValues(4L)
         .go();
- */
   }
 
   @Test //DRILL-2197 Left Join with complex type in projection

--- a/exec/vector/src/main/codegen/includes/vv_imports.ftl
+++ b/exec/vector/src/main/codegen/includes/vv_imports.ftl
@@ -31,6 +31,7 @@ import io.netty.buffer.*;
 import org.apache.commons.lang3.ArrayUtils;
 
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.hash.Hashing;
 import org.apache.drill.exec.memory.*;
 import org.apache.drill.exec.proto.SchemaDefProtos;
 import org.apache.drill.exec.proto.UserBitShared;

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -440,6 +440,16 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
+  public int hash32(int index) {
+    boolean isNull = accessor.isNull(index);
+    if (isNull) {
+      return 0;
+    } else {
+      return values.hash32(index);
+    }
+  }
+
+  @Override
   public void exchange(ValueVector other) {
     ${className} target = (${className}) other;
     bits.exchange(target.bits);

--- a/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/RepeatedValueVectors.java
@@ -191,6 +191,11 @@ public final class Repeated${minor.class}Vector extends BaseRepeatedValueVector 
   }
 
   @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("RepeatedValueVector does not support this");
+  }
+
+  @Override
   public boolean allocateNewSafe() {
     /* boolean to keep track if all the memory allocations were successful.
      * Used in the case of composite vectors when we need to allocate multiple

--- a/exec/vector/src/main/codegen/templates/UnionVector.java
+++ b/exec/vector/src/main/codegen/templates/UnionVector.java
@@ -382,6 +382,11 @@ public class UnionVector implements ValueVector {
     copyFromSafe(fromIndex, toIndex, (UnionVector) from);
   }
 
+  @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("UnionValueVector does not support this");
+  }
+
   /**
    * Add a vector that matches the argument. Transfer the buffer from the argument
    * to the new vector.

--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.util.Set;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.hash.Hashing;
 import org.apache.drill.exec.memory.AllocationManager.BufferLedger;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.BaseValueVector;
@@ -440,6 +441,22 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
   public void toNullable(ValueVector nullableVector) {
     Nullable${minor.class}Vector dest = (Nullable${minor.class}Vector) nullableVector;
     dest.getMutator().fromNotNullable(this);
+  }
+
+  @Override
+  public int hash32(int index) {
+    final UInt${type.width}Vector.Accessor accessor = offsetVector.getAccessor();
+    int start = accessor.get(index);
+    int end = accessor.get(index + 1);
+    <#if minor.class.contains("Decimal")>
+    int scale = field.getScale();
+    int precision = field.getPrecision();
+    java.math.BigDecimal bd = org.apache.drill.exec.util.DecimalUtility.getBigDecimalFromDrillBuf(data,
+                                                                                                  start, end - start, scale);
+     return Hashing.hash32(bd.doubleValue());
+     <#else>
+    return Hashing.hash32(start, end, data);
+     </#if>
   }
 
   public final class Accessor extends BaseValueVector.BaseAccessor implements VariableWidthAccessor {

--- a/exec/vector/src/main/java/org/apache/drill/exec/hash/Hashing.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/hash/Hashing.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.hash;
+
+import io.netty.buffer.DrillBuf;
+
+public class Hashing
+{
+  public static int hash32(char key) {
+    int intv = key;
+    return hash32(intv);
+  }
+
+  public static int hash32(int key) {
+    int hashv = IntegerHashing.hash32(key);
+    return hashv;
+  }
+
+  public static int hash32(long key) {
+    int hashv = IntegerHashing.hash32(key);
+    return hashv;
+  }
+
+  public static int hash32(float key) {
+    double doublev = key;
+    return hash32(doublev);
+  }
+
+  public static int hash32(double key) {
+    int hashv = MurmurHashing.hash32(key, 0);
+    return hashv;
+  }
+
+  /**
+   * for variable length data type
+   * @param bstart
+   * @param bend
+   * @param data
+   * @return
+   */
+  public static int hash32(int bstart, int bend, DrillBuf data) {
+    return MurmurHashing.hash32(bstart, bend, data, 0);
+  }
+
+  /**
+   * a java version of C++ Boost hash_combine
+   * @param seed
+   * @param hashv
+   * @return
+   */
+  public static int hashCombine(int seed, int hashv) {
+    return seed ^ (hashv + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/hash/IntegerHashing.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/hash/IntegerHashing.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.hash;
+
+/**
+ * multiply-shift hash algorithm
+ */
+public class IntegerHashing
+{
+  /**
+   * according to https://15721.courses.cs.cmu.edu/spring2019/papers/17-hashjoins/richter-vldb2015.pdf
+   * multiply-shift is a good performance hashing algorithm, this method is from https://gist.github.com/badboy/6267743
+   * @param key
+   * @return
+   */
+  public static int hash32(int key) {
+    int c2 = 0x27d4eb2d; // a prime or an odd constant
+    key = (key ^ 61) ^ (key >>> 16);
+    key = key + (key << 3);
+    key = key ^ (key >>> 4);
+    key = key * c2;
+    key = key ^ (key >>> 15);
+    return key;
+  }
+
+  /**
+   * also from https://gist.github.com/badboy/6267743
+   * @param key
+   * @return
+   */
+  public static int hash32(long key) {
+    key = (~key) + (key << 18); // key = (key << 18) - key - 1;
+    key = key ^ (key >>> 31);
+    key = key * 21; // key = (key + (key << 2)) + (key << 4);
+    key = key ^ (key >>> 11);
+    key = key + (key << 6);
+    key = key ^ (key >>> 22);
+    return (int) key;
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/hash/MurmurHashing.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/hash/MurmurHashing.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.hash;
+
+import io.netty.buffer.DrillBuf;
+import io.netty.util.internal.PlatformDependent;
+
+/**
+ * 32bit hashing for string and so on.
+ * murmurhash3
+ */
+public class MurmurHashing
+{
+  public static int hash32(int bStart, int bEnd, DrillBuf buffer, int seed)
+  {
+    final long c1 = 0xcc9e2d51L;
+    final long c2 = 0x1b873593L;
+    long start = buffer.memoryAddress() + bStart;
+    long length = bEnd - bStart;
+    long UINT_MASK=0xffffffffL;
+    long lh1 = seed;
+    long roundedEnd = start + (length & 0xfffffffc);  // round down to 4 byte block
+
+    for (long i=start; i<roundedEnd; i+=4) {
+      // little endian load order
+      long lk1 = (PlatformDependent.getByte(i) & 0xff) | ((PlatformDependent.getByte(i + 1) & 0xff) << 8) |
+                 ((PlatformDependent.getByte(i+2) & 0xff) << 16) | (PlatformDependent.getByte(i+3) << 24);
+
+      //k1 *= c1;
+      lk1 *= c1;
+      lk1 &= UINT_MASK;
+
+      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+      lk1 *= c2;
+      lk1 = lk1 & UINT_MASK;
+      lh1 ^= lk1;
+      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
+
+      lh1 = lh1*5+0xe6546b64L;
+      lh1 = UINT_MASK & lh1;
+    }
+
+    // tail
+    long lk1 = 0;
+
+    switch((byte)length & 0x03) {
+      case 3:
+        lk1 = (PlatformDependent.getByte(roundedEnd + 2) & 0xff) << 16;
+      case 2:
+        lk1 |= (PlatformDependent.getByte(roundedEnd + 1) & 0xff) << 8;
+      case 1:
+        lk1 |= (PlatformDependent.getByte(roundedEnd) & 0xff);
+        lk1 *= c1;
+        lk1 = UINT_MASK & lk1;
+        lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+        lk1 *= c2;
+        lk1 = lk1 & UINT_MASK;
+
+        lh1 ^= lk1;
+    }
+
+    // finalization
+    lh1 ^= length;
+
+    lh1 ^= lh1 >>> 16;
+    lh1 *= 0x85ebca6b;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 13;
+
+    lh1 *= 0xc2b2ae35;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 16;
+
+    return (int)(lh1 & UINT_MASK);
+  }
+
+  public static int murmur3_32(long val, int seed) {
+    final long c1 = 0xcc9e2d51L;
+    final long c2 = 0x1b873593;
+    long length = 8;
+    long UINT_MASK=0xffffffffL;
+    long lh1 = seed & UINT_MASK;
+    for (int i=0; i<2; i++) {
+      //int ik1 = (int)((val >> i*32) & UINT_MASK);
+      long lk1 = ((val >> i*32) & UINT_MASK);
+
+      //k1 *= c1;
+      lk1 *= c1;
+      lk1 &= UINT_MASK;
+
+      lk1 = ((lk1 << 15) & UINT_MASK) | (lk1 >>> 17);
+
+      lk1 *= c2;
+      lk1 &= UINT_MASK;
+
+      lh1 ^= lk1;
+      lh1 = ((lh1 << 13) & UINT_MASK) | (lh1 >>> 19);
+
+      lh1 = lh1*5+0xe6546b64L;
+      lh1 = UINT_MASK & lh1;
+    }
+    // finalization
+    lh1 ^= length;
+
+    lh1 ^= lh1 >>> 16;
+    lh1 *= 0x85ebca6bL;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 13;
+    lh1 *= 0xc2b2ae35L;
+    lh1 = UINT_MASK & lh1;
+    lh1 ^= lh1 >>> 16;
+
+    return (int)lh1;
+  }
+
+  public static int hash32(double val, long seed) {
+    return murmur3_32(Double.doubleToLongBits(val), (int) seed);
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.vector;
 
+import org.apache.drill.exec.hash.Hashing;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import io.netty.buffer.DrillBuf;
 
@@ -230,6 +231,11 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
   @Override
   public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
     copyFrom(fromIndex, toIndex, (BitVector) from);
+  }
+
+  public int hash32(int index) {
+    int key = accessor.get(index);
+    return Hashing.hash32(key);
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ObjectVector.java
@@ -205,6 +205,12 @@ public class ObjectVector extends BaseValueVector {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public int hash32(int index)
+  {
+    throw new UnsupportedOperationException("ObjectVector does not support this");
+  }
+
   public final class Accessor extends BaseAccessor {
     @Override
     public Object getObject(int index) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/UntypedNullVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/UntypedNullVector.java
@@ -175,6 +175,11 @@ public final class UntypedNullVector extends BaseDataValueVector implements Fixe
   }
 
   @Override
+  public int hash32(int index) {
+    return 0;
+  }
+
+  @Override
   public void clear() {
     valueCount = 0;
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ValueVector.java
@@ -265,6 +265,8 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
 
   void toNullable(ValueVector nullableVector);
 
+  int hash32(int index);
+
   /**
    * An abstraction that is used to read from this vector instance.
    */

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/ZeroVector.java
@@ -163,6 +163,11 @@ public class ZeroVector implements ValueVector {
   public void copyEntry(int toIndex, ValueVector from, int fromIndex) { }
 
   @Override
+  public int hash32(int index) {
+    return 0;
+  }
+
+  @Override
   public void exchange(ValueVector other) { }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/ListVector.java
@@ -235,6 +235,11 @@ public class ListVector extends BaseRepeatedValueVector {
   }
 
   @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("ListVector does not support this");
+  }
+
+  @Override
   public ValueVector getDataVector() { return vector; }
 
   public ValueVector getBitsVector() { return bits; }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -91,6 +91,11 @@ public class MapVector extends AbstractMapVector {
   }
 
   @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("MapVector does not support this");
+  }
+
+  @Override
   protected boolean supportsDirectRead() { return true; }
 
   public Iterator<String> fieldNameIterator() {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedListVector.java
@@ -215,6 +215,10 @@ public class RepeatedListVector extends AbstractContainerVector
     public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
       copyFromSafe(fromIndex, toIndex, (DelegateRepeatedVector) from);
     }
+
+    public int hash32(int index) {
+      throw new UnsupportedOperationException("does not support this");
+    }
   }
 
   protected class RepeatedListTransferPair implements TransferPair {
@@ -442,6 +446,11 @@ public class RepeatedListVector extends AbstractContainerVector
   @Override
   public void copyEntry(int toIndex, ValueVector from, int fromIndex) {
     copyFromSafe(fromIndex, toIndex, (RepeatedListVector) from);
+  }
+
+  @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("RepeatedListVector does not support this");
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/RepeatedMapVector.java
@@ -410,6 +410,12 @@ public class RepeatedMapVector extends AbstractMapVector
   }
 
   @Override
+  public int hash32(int index) {
+    throw new UnsupportedOperationException("RepeatedMapVector does not support this");
+  }
+
+
+  @Override
   public int getValueCapacity() {
     return Math.max(offsets.getValueCapacity() - 1, 0);
   }


### PR DESCRIPTION
This PR introduces those main changes:
* Add hash32(int index) method to the ValueVector interface.
* To Interger data types, introduce https://gist.github.com/badboy/6267743 multiply-shift algorithm which was proved to be good at performance by the paper https://15721.courses.cs.cmu.edu/spring2019/papers/17-hashjoins/richter-vldb2015.pdf. Other data types like double,float,string still use the Murmur3 hash method.
* Since HashJoin needs to solve implicit casting , it treats all numeric data types as double. So this PR only apply to HashAgg operator.
