### PR TITLE
DRILL-7054: PCAP timestamp in milliseconds

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapRecordReader.java
@@ -242,6 +242,9 @@ public class PcapRecordReader extends AbstractRecordReader {
         case "timestamp":
           setTimestampColumnValue(packet.getTimestamp(), pci, count);
           break;
+        case "timestamp_micro":
+          setLongColumnValue(packet.getTimestampMicro(), pci, count);
+          break;
         case "network":
           setIntegerColumnValue(networkType, pci, count);
           break;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
@@ -40,6 +40,7 @@ public class Packet {
   //            guint32 orig_len;       // actual length of packet */
   //        } pcaprec_hdr_t;
   private long timestamp;
+  private long timestampMicro;
   private int originalLength;
 
   protected byte[] raw;
@@ -159,6 +160,10 @@ public class Packet {
 
   public long getTimestamp() {
     return timestamp;
+  }
+
+  public long getTimestampMicro() {
+    return timestampMicro;
   }
 
   public int getPacketLength() {
@@ -384,16 +389,17 @@ public class Packet {
   }
 
   private void decodePcapHeader(final byte[] header, final boolean byteOrder, final int maxLength, final int offset) {
-    timestamp = getTimestamp(header, byteOrder, offset);
+    timestampMicro = getTimestampMicro(header, byteOrder, offset);
+    timestamp = timestampMicro / 1000L;
     originalLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ORIGINAL_LENGTH_OFFSET);
     packetLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ACTUAL_LENGTH_OFFSET);
     Preconditions.checkState(originalLength < maxLength,
         "Packet too long (%d bytes)", originalLength);
   }
 
-  private long getTimestamp(final byte[] header, final boolean byteOrder, final int offset) {
-    return getIntFileOrder(byteOrder, header, offset + PacketConstants.TIMESTAMP_OFFSET) * 1000L +
-        getIntFileOrder(byteOrder, header, offset + PacketConstants.TIMESTAMP_MICRO_OFFSET) / 1000L;
+  private long getTimestampMicro(final byte[] header, final boolean byteOrder, final int offset) {
+    return getIntFileOrder(byteOrder, header, offset + PacketConstants.TIMESTAMP_OFFSET) * 1000000L +
+        getIntFileOrder(byteOrder, header, offset + PacketConstants.TIMESTAMP_MICRO_OFFSET);
   }
 
   private void decodeEtherPacket() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/schema/Schema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/schema/Schema.java
@@ -35,6 +35,7 @@ public class Schema {
     columns.add(new ColumnDto("type", PcapTypes.STRING));
     columns.add(new ColumnDto("network", PcapTypes.INTEGER));
     columns.add(new ColumnDto("timestamp", PcapTypes.TIMESTAMP));
+    columns.add(new ColumnDto("timestamp_micro", PcapTypes.LONG));
     columns.add(new ColumnDto("src_ip", PcapTypes.STRING));
     columns.add(new ColumnDto("dst_ip", PcapTypes.STRING));
     columns.add(new ColumnDto("src_port", PcapTypes.INTEGER));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
@@ -75,6 +75,7 @@ public class TestPcapDecoder extends BaseTestQuery {
     assertEquals("/192.168.0.2", p.getDst_ip().toString());
     assertEquals(161, p.getSrc_port());
     assertEquals(0, p.getDst_port());
+    assertEquals(0, p.getTimestampMicro());
   }
 
   private static void writeHeader(DataOutputStream out) throws IOException {


### PR DESCRIPTION
A column has been added for retrieving the timestamp in microseconds. 
The pcap provides microseconds accuracy and such a parameter is really important for getting statistics from packet captures. In the timestamp column, instead, it is exported as DATE format which has millisecond accuracy.
I could not compute many of the feature I had to work on before this patch.
