### PR TITLE
DRILL-7055: Revise SELECT * to exclude partitions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractSubScan.java
@@ -26,7 +26,6 @@ import org.apache.drill.common.graph.GraphVisitor;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 public abstract class AbstractSubScan extends AbstractBase implements SubScan{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractSubScan.class);
 
   public AbstractSubScan(String userName) {
     super(userName);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -499,7 +499,6 @@ public class ScanBatch implements CloseableRecordBatch {
       schemaChanged = false;
     }
 
-    @SuppressWarnings("resource")
     private <T extends ValueVector> T addField(MaterializedField field,
         Class<T> clazz, boolean isImplicitField) throws SchemaChangeException {
       Map<String, ValueVector> fieldVectorMap;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -42,7 +42,6 @@ import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.ClassGenerator;
-import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
 import org.apache.drill.exec.expr.CodeGenerator;
 import org.apache.drill.exec.expr.DrillFuncHolderExpr;
 import org.apache.drill.exec.expr.ExpressionTreeMaterializer;
@@ -77,21 +76,21 @@ import java.util.List;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
 
 public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProjectRecordBatch.class);
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProjectRecordBatch.class);
+
+  private static final String EMPTY_STRING = "";
+
   private Projector projector;
   private List<ValueVector> allocationVectors;
   private List<ComplexWriter> complexWriters;
   private List<FieldReference> complexFieldReferencesList;
   private boolean hasRemainder = false;
-  private int remainderIndex = 0;
+  private int remainderIndex;
   private int recordCount;
-
   private ProjectMemoryManager memoryManager;
-
-
-  private static final String EMPTY_STRING = "";
   private boolean first = true;
   private boolean wasNone = false; // whether a NONE iter outcome was already seen
+  private ColumnExplorer columnExplorer;
 
   private class ClassifierResult {
     public boolean isStar = false;
@@ -114,6 +113,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
   public ProjectRecordBatch(final Project pop, final RecordBatch incoming, final FragmentContext context) throws OutOfMemoryException {
     super(pop, context, incoming);
+    columnExplorer = new ColumnExplorer(context.getOptions());
   }
 
   @Override
@@ -121,13 +121,11 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     return recordCount;
   }
 
-
   @Override
   protected void killIncoming(final boolean sendUpstream) {
     super.killIncoming(sendUpstream);
     hasRemainder = false;
   }
-
 
   @Override
   public IterOutcome innerNext() {
@@ -204,21 +202,20 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
           }
           incomingRecordCount = incoming.getRecordCount();
           memoryManager.update();
-          logger.trace("doWork():[1] memMgr RC {}, incoming rc {},  incoming {}, Project {}",
+          logger.trace("doWork():[1] memMgr RC {}, incoming rc {}, incoming {}, Project {}",
                        memoryManager.getOutputRowCount(), incomingRecordCount, incoming, this);
         }
       }
     }
 
     if (complexWriters != null && getLastKnownOutcome() == EMIT) {
-      throw new UnsupportedOperationException("Currently functions producing complex types as output is not " +
+      throw new UnsupportedOperationException("Currently functions producing complex types as output are not " +
         "supported in project list for subquery between LATERAL and UNNEST. Please re-write the query using this " +
         "function in the projection list of outermost query.");
     }
 
     first = false;
     container.zeroVectors();
-
 
     int maxOuputRecordCount = memoryManager.getOutputRowCount();
     logger.trace("doWork():[2] memMgr RC {}, incoming rc {}, incoming {}, project {}",
@@ -232,7 +229,6 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     final int outputRecords = projector.projectRecords(this.incoming,0, maxOuputRecordCount, 0);
     long projectEndTime = System.currentTimeMillis();
     logger.trace("doWork(): projection: records {}, time {} ms", outputRecords, (projectEndTime - projectStartTime));
-
 
     if (outputRecords < incomingRecordCount) {
       setValueCount(outputRecords);
@@ -277,7 +273,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
     final int projRecords = projector.projectRecords(this.incoming, remainderIndex, recordsToProcess, 0);
     long projectEndTime = System.currentTimeMillis();
 
-    logger.trace("handleRemainder: projection: " + "records {}, time {} ms", projRecords,(projectEndTime - projectStartTime));
+    logger.trace("handleRemainder: projection: records {}, time {} ms", projRecords,(projectEndTime - projectStartTime));
 
     if (projRecords < remainingRecordCount) {
       setValueCount(projRecords);
@@ -463,7 +459,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
               final TypedFieldId fid = container.getValueVectorId(SchemaPath.getSimplePath(outputField.getName()));
               final ValueVectorWriteExpression write = new ValueVectorWriteExpression(fid, expr, true);
               memoryManager.addNewField(vv, write);
-              final HoldingContainer hc = cg.addExpr(write, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
+              cg.addExpr(write, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
             }
           }
           continue;
@@ -546,7 +542,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
         final TypedFieldId fid = container.getValueVectorId(SchemaPath.getSimplePath(outputField.getName()));
         final boolean useSetSafe = !(ouputVector instanceof FixedWidthVector);
         final ValueVectorWriteExpression write = new ValueVectorWriteExpression(fid, expr, useSetSafe);
-        final HoldingContainer hc = cg.addExpr(write, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
+        cg.addExpr(write, ClassGenerator.BlkCreateMode.TRUE_IF_BOUND);
         memoryManager.addNewField(ouputVector, write);
 
         // We cannot do multiple transfers from the same vector. However we still need to instantiate the output vector.
@@ -590,7 +586,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
   }
 
   private boolean isImplicitFileColumn(ValueVector vvIn) {
-    return ColumnExplorer.initImplicitFileColumns(context.getOptions()).get(vvIn.getField().getName()) != null;
+    return columnExplorer.isImplicitColumn(vvIn.getField().getName());
   }
 
   private List<NamedExpression> getExpressionList() {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
@@ -128,6 +128,7 @@ public class TestPartitionFilter extends PlanTestBase {
     String query = "select * from dfs.`multilevel/parquet` where (dir0=1994 and dir1='Q1' and o_custkey < 500) or (dir0=1995 and dir1='Q2' and o_custkey > 500)";
     testIncludeFilter(query, 2, "Filter\\(", 8);
   }
+
   @Test //Parquet: partition filters are ANDed and belong to a top-level OR
   public void testPartitionFilter3_Parquet_from_CTAS() throws Exception {
     String query = "select * from dfs.tmp.parquet where (yr=1994 and qrtr='Q1' and o_custkey < 500) or (yr=1995 and qrtr='Q2' and o_custkey > 500)";

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -435,8 +435,8 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
     .sqlQuery("select * from dfs.`multilevel/parquet` where dir0=1994 and dir1='Q1' order by dir0 limit 1")
     .ordered()
-    .baselineColumns("dir0", "dir1", "o_clerk", "o_comment", "o_custkey", "o_orderdate", "o_orderkey",  "o_orderpriority", "o_orderstatus", "o_shippriority",  "o_totalprice")
-    .baselineValues("1994", "Q1", "Clerk#000000743", "y pending requests integrate", 1292, mydate, 66, "5-LOW", "F",  0, 104190.66)
+    .baselineColumns("o_clerk", "o_comment", "o_custkey", "o_orderdate", "o_orderkey",  "o_orderpriority", "o_orderstatus", "o_shippriority",  "o_totalprice")
+    .baselineValues("Clerk#000000743", "y pending requests integrate", 1292, mydate, 66, "5-LOW", "F",  0, 104190.66)
     .build().run();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestDirectoryExplorerUDFs.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/TestDirectoryExplorerUDFs.java
@@ -121,8 +121,8 @@ public class TestDirectoryExplorerUDFs extends PlanTestBase {
     testBuilder()
         .sqlQuery(query, path, tests.get(0).funcName, path)
         .unOrdered()
-        .baselineColumns("columns", "dir0")
-        .baselineValues(list, tests.get(0).expectedFolderName)
+        .baselineColumns("columns")
+        .baselineValues(list)
         .go();
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -178,7 +178,7 @@ public class TestAnalyze extends BaseTestQuery {
       test("ALTER SESSION SET `planner.slice_target` = 1");
       test("ALTER SESSION SET `store.format` = 'parquet'");
       test("CREATE TABLE dfs.tmp.parquet1 AS SELECT * from dfs.`%s`", tmpLocation);
-      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquet1 COMPUTE STATISTICS", "11");
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquet1 COMPUTE STATISTICS", "9");
       test("SELECT * FROM dfs.tmp.`parquet1/.stats.drill`");
       test("create table dfs.tmp.flatstats4 as select flatten(`directories`[0].`columns`) as `columns` " +
            "from dfs.tmp.`parquet1/.stats.drill`");
@@ -199,8 +199,6 @@ public class TestAnalyze extends BaseTestQuery {
           .baselineValues("`o_clerk`", 120.0, 120.0, 114L, 15.0)
           .baselineValues("`o_shippriority`", 120.0, 120.0, 1L, 4.0)
           .baselineValues("`o_comment`", 120.0, 120.0, 120L, 46.333333333333336)
-          .baselineValues("`dir0`", 120.0, 120.0, 3L, 4.0)
-          .baselineValues("`dir1`", 120.0, 120.0, 4L, 2.0)
           .go();
     } finally {
       test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestImplicitFileColumns.java
@@ -76,9 +76,9 @@ public class TestImplicitFileColumns extends BaseTestQuery {
     testBuilder()
         .sqlQuery("select *, filename, suffix, fqn, filepath from dfs.`%s` order by filename", FILES)
         .ordered()
-        .baselineColumns("columns", "dir0", "filename", "suffix", "fqn", "filepath")
-        .baselineValues(mainColumnValues, null, mainFile.getName(), CSV, mainFile.getCanonicalPath(), mainFile.getParentFile().getCanonicalPath())
-        .baselineValues(nestedColumnValues, NESTED, NESTED_FILE, CSV, nestedFile.getCanonicalPath(), nestedFile.getParentFile().getCanonicalPath())
+        .baselineColumns("columns", "filename", "suffix", "fqn", "filepath")
+        .baselineValues(mainColumnValues, mainFile.getName(), CSV, mainFile.getCanonicalPath(), mainFile.getParentFile().getCanonicalPath())
+        .baselineValues(nestedColumnValues, NESTED_FILE, CSV, nestedFile.getCanonicalPath(), nestedFile.getParentFile().getCanonicalPath())
         .go();
   }
 
@@ -161,7 +161,6 @@ public class TestImplicitFileColumns extends BaseTestQuery {
   @Test
   public void testStarColumnJson() throws Exception {
     final BatchSchema expectedSchema = new SchemaBuilder()
-        .addNullable("dir0", TypeProtos.MinorType.VARCHAR)
         .addNullable("id", TypeProtos.MinorType.BIGINT)
         .addNullable("name", TypeProtos.MinorType.VARCHAR)
         .build();
@@ -176,8 +175,6 @@ public class TestImplicitFileColumns extends BaseTestQuery {
   @Test
   public void testStarColumnParquet() throws Exception {
     final BatchSchema expectedSchema = new SchemaBuilder()
-        .addNullable("dir0", TypeProtos.MinorType.VARCHAR)
-        .addNullable("dir1", TypeProtos.MinorType.VARCHAR)
         .add("o_orderkey", TypeProtos.MinorType.INT)
         .add("o_custkey", TypeProtos.MinorType.INT)
         .add("o_orderstatus", TypeProtos.MinorType.VARCHAR)
@@ -199,8 +196,6 @@ public class TestImplicitFileColumns extends BaseTestQuery {
   @Test
   public void testStarColumnCsv() throws Exception {
     final BatchSchema expectedSchema = new SchemaBuilder()
-        .addNullable("dir0", TypeProtos.MinorType.VARCHAR)
-        .addNullable("dir1", TypeProtos.MinorType.VARCHAR)
         .addArray("columns", TypeProtos.MinorType.VARCHAR)
         .build();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -366,7 +366,7 @@ public class QueryBuilder {
     }
   }
 
-  public QueryRowSetIterator rowSetIterator( ) {
+  public QueryRowSetIterator rowSetIterator() {
     return new QueryRowSetIterator(client.allocator(), withEventListener());
   }
 


### PR DESCRIPTION
Historically, a SELECT * (wildcard) query on a partitioned table included partition directory names as a set of "dir0", "dir1" columns. When used with files at differnt depths, this can lead to schema change exceptions as some readers create, say, "dir0" and "dir1", while others create just "dir0".

The result is that either 1) things just work, 2) the client gets some batches with two partition columns, others with one, or 3) a hard schema change occurs as the project operator creates missing columns as nullable int.

This change proposes to include table columns with using the wildcard and to no longer include partition columns. Partition columns will now work the way the "implicit" file columns already work, so this change improves consistency.

The partition columns are still available: they can be requested explicitly:

```
SELECT *, dir0, dir1 FROM ...
```

Both before and after this change, when including the partition columns explicitly, the nullable int issue described above will occur. However, this change positions us for the revised scan framework that will properly provide the partition columns as nullable VARCHAR whether a matching directory exists or not.

This is a potentially breaking change: any user that uses SELECT * and expects partition columns (and manages to work around the schema change issues) will see different behavior: they will have to revise queries to include partition columns.