### PR TITLE
DRILL-7051: Upgrade to Jetty 9.3 

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -126,17 +126,14 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.1.5.v20140505</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.1.5.v20140505</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.1.5.v20140505</version>
       <exclusions>
         <exclusion>
           <artifactId>jetty-continuation</artifactId>
@@ -359,12 +356,12 @@
           <artifactId>commons-codec</artifactId>
         </exclusion>
         <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -207,10 +207,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
     </dependency>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -86,8 +86,9 @@ public class StorageResources {
             .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s_storage_plugins.%s\"",
                 pluginGroup, format))
             .build()
-        : Response.status(Response.Status.NOT_FOUND.getStatusCode(),
-              String.format("Unknown file type %s for %s Storage Plugin Configs", format, pluginGroup))
+        : Response.status(Response.Status.NOT_FOUND.getStatusCode())
+            .entity(String.format("Unknown \"%s\" file format for \"%s\" Storage Plugin configs group",
+                    format, pluginGroup))
             .build();
   }
 
@@ -147,8 +148,8 @@ public class StorageResources {
         ? Response.ok(getPluginConfig(name))
             .header(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment;filename=\"%s.%s\"", name, format))
             .build()
-        : Response.status(Response.Status.NOT_FOUND.getStatusCode(),
-               String.format("Unknown file type %s for Storage Plugin Config: %s", format, name))
+        : Response.status(Response.Status.NOT_FOUND.getStatusCode())
+            .entity(String.format("Unknown \"%s\" file format for \"%s\" Storage Plugin config", format, name))
             .build();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -57,8 +57,10 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -267,18 +269,17 @@ public class WebServer implements AutoCloseable {
   }
 
   /**
-   * It creates {@link SessionHandler} instead of jetty-9.3 SessionManager
-   * @see <a href="https://www.eclipse.org/jetty/documentation/9.4.x/upgrading-jetty.html">Session Management</a>
+   * It creates A {@link SessionHandler} which contains a {@link HashSessionManager}
    *
    * @param securityHandler Set of initparameters that are used by the Authentication
    * @return session handler
    */
   private SessionHandler createSessionHandler(final SecurityHandler securityHandler) {
-    SessionHandler sessionHandler = new SessionHandler();
-    sessionHandler.setMaxInactiveInterval(config.getInt(ExecConstants.HTTP_SESSION_MAX_IDLE_SECS));
+    SessionManager sessionManager = new HashSessionManager();
+    sessionManager.setMaxInactiveInterval(config.getInt(ExecConstants.HTTP_SESSION_MAX_IDLE_SECS));
     // response cookie will be returned with HttpOnly flag
-    sessionHandler.getSessionCookieConfig().setHttpOnly(true);
-    sessionHandler.addEventListener(new HttpSessionListener() {
+    sessionManager.getSessionCookieConfig().setHttpOnly(true);
+    sessionManager.addEventListener(new HttpSessionListener() {
       @Override
       public void sessionCreated(HttpSessionEvent se) {
 
@@ -310,7 +311,7 @@ public class WebServer implements AutoCloseable {
       }
     });
 
-    return sessionHandler;
+    return new SessionHandler(sessionManager);
   }
 
   public int getPort() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillRestLoginService.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.server.UserIdentity;
 
 import javax.security.auth.Subject;
+import javax.servlet.ServletRequest;
 import java.security.Principal;
 
 /**
@@ -62,7 +63,7 @@ public class DrillRestLoginService implements LoginService {
   }
 
   @Override
-  public UserIdentity login(String username, Object credentials) {
+  public UserIdentity login(String username, Object credentials, ServletRequest request) {
     if (!(credentials instanceof String)) {
       return null;
     }
@@ -126,7 +127,7 @@ public class DrillRestLoginService implements LoginService {
   @Override
   public void logout(UserIdentity user) {
     // no-op
-    if(logger.isTraceEnabled()) {
+    if (logger.isTraceEnabled()) {
       logger.trace("Web user {} logged out.", user.getUserPrincipal().getName());
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoAuthenticator.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.security.authentication.SessionAuthentication;
 import org.eclipse.jetty.security.authentication.SpnegoAuthenticator;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.UserIdentity;
@@ -152,7 +153,7 @@ public class DrillSpnegoAuthenticator extends SpnegoAuthenticator {
         }
 
         response.setContentLength(0);
-        final HttpChannel channel = HttpChannel.getCurrentHttpChannel();
+        final HttpChannel channel = HttpConnection.getCurrentConnection().getHttpChannel();
         final Response base_response = channel.getResponse();
         final Request base_request = channel.getRequest();
         final int redirectCode =

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoAuthenticator.java
@@ -28,10 +28,7 @@ import org.eclipse.jetty.security.authentication.DeferredAuthentication;
 import org.eclipse.jetty.security.authentication.SessionAuthentication;
 import org.eclipse.jetty.security.authentication.SpnegoAuthenticator;
 import org.eclipse.jetty.server.Authentication;
-import org.eclipse.jetty.server.HttpChannel;
-import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.UserIdentity;
 
 import javax.servlet.ServletRequest;
@@ -151,15 +148,12 @@ public class DrillSpnegoAuthenticator extends SpnegoAuthenticator {
             newUri = WebServerConstants.WEBSERVER_ROOT_PATH;
           }
         }
-
         response.setContentLength(0);
-        final HttpChannel channel = HttpConnection.getCurrentConnection().getHttpChannel();
-        final Response base_response = channel.getResponse();
-        final Request base_request = channel.getRequest();
-        final int redirectCode =
-            base_request.getHttpVersion().getVersion() < HttpVersion.HTTP_1_1.getVersion() ? 302 : 303;
+        Request baseRequest = Request.getBaseRequest(req);
+        int redirectCode =
+            baseRequest.getHttpVersion().getVersion() < HttpVersion.HTTP_1_1.getVersion() ? 302 : 303;
         try {
-          base_response.sendRedirect(redirectCode, res.encodeRedirectURL(newUri));
+          baseRequest.getResponse().sendRedirect(redirectCode, res.encodeRedirectURL(newUri));
         } catch (IOException e) {
           logger.error("DrillSpnegoAuthenticator: Failed while using the redirect URL {} from client {}", newUri,
               req.getRemoteAddr(), e);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoLoginService.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillSpnegoLoginService.java
@@ -37,6 +37,7 @@ import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 
 import javax.security.auth.Subject;
+import javax.servlet.ServletRequest;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.security.Principal;
@@ -78,16 +79,11 @@ public class DrillSpnegoLoginService extends SpnegoLoginService {
   }
 
   @Override
-  public UserIdentity login(final String username, final Object credentials) {
+  public UserIdentity login(final String username, final Object credentials, ServletRequest request) {
 
     UserIdentity identity = null;
     try {
-      identity = loggedInUgi.doAs(new PrivilegedExceptionAction<UserIdentity>() {
-        @Override
-        public UserIdentity run() {
-          return spnegoLogin(credentials);
-        }
-      });
+      identity = loggedInUgi.doAs((PrivilegedExceptionAction<UserIdentity>) () -> spnegoLogin(credentials));
     } catch (Exception e) {
       logger.error("Failed to login using SPNEGO", e);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.server.rest.auth;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
-import org.eclipse.jetty.security.MappedLoginService.RolePrincipal;
+import org.eclipse.jetty.security.AbstractLoginService;
 
 import java.security.Principal;
 import java.util.List;
@@ -38,11 +38,12 @@ public class DrillUserPrincipal implements Principal {
 
   public static final String[] NON_ADMIN_USER_ROLES = new String[]{AUTHENTICATED_ROLE};
 
-  public static final List<RolePrincipal> ADMIN_PRINCIPALS =
-      ImmutableList.of(new RolePrincipal(AUTHENTICATED_ROLE), new RolePrincipal(ADMIN_ROLE));
+  public static final List<AbstractLoginService.RolePrincipal> ADMIN_PRINCIPALS =
+      ImmutableList.of(new AbstractLoginService.RolePrincipal(AUTHENTICATED_ROLE),
+          new AbstractLoginService.RolePrincipal(ADMIN_ROLE));
 
-  public static final List<RolePrincipal> NON_ADMIN_PRINCIPALS =
-      ImmutableList.of(new RolePrincipal(AUTHENTICATED_ROLE));
+  public static final List<AbstractLoginService.RolePrincipal> NON_ADMIN_PRINCIPALS =
+      ImmutableList.of(new AbstractLoginService.RolePrincipal(AUTHENTICATED_ROLE));
 
   private final String userName;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillUserPrincipal.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.server.rest.auth;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
-import org.eclipse.jetty.security.AbstractLoginService;
+import org.eclipse.jetty.security.MappedLoginService.RolePrincipal;
 
 import java.security.Principal;
 import java.util.List;
@@ -38,12 +38,11 @@ public class DrillUserPrincipal implements Principal {
 
   public static final String[] NON_ADMIN_USER_ROLES = new String[]{AUTHENTICATED_ROLE};
 
-  public static final List<AbstractLoginService.RolePrincipal> ADMIN_PRINCIPALS =
-      ImmutableList.of(new AbstractLoginService.RolePrincipal(AUTHENTICATED_ROLE),
-          new AbstractLoginService.RolePrincipal(ADMIN_ROLE));
+  public static final List<RolePrincipal> ADMIN_PRINCIPALS =
+      ImmutableList.of(new RolePrincipal(AUTHENTICATED_ROLE), new RolePrincipal(ADMIN_ROLE));
 
-  public static final List<AbstractLoginService.RolePrincipal> NON_ADMIN_PRINCIPALS =
-      ImmutableList.of(new AbstractLoginService.RolePrincipal(AUTHENTICATED_ROLE));
+  public static final List<RolePrincipal> NON_ADMIN_PRINCIPALS =
+      ImmutableList.of(new RolePrincipal(AUTHENTICATED_ROLE));
 
   private final String userName;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
@@ -56,6 +56,8 @@ import java.lang.reflect.Field;
 import java.security.PrivilegedExceptionAction;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -88,7 +90,6 @@ public class TestSpnegoAuthentication {
   /**
    * Both SPNEGO and FORM mechanism is enabled for WebServer in configuration. Test to see if the respective security
    * handlers are created successfully or not.
-   * @throws Exception
    */
   @Test
   public void testSPNEGOAndFORMEnabled() throws Exception {
@@ -119,7 +120,6 @@ public class TestSpnegoAuthentication {
 
   /**
    * Validate if FORM security handler is created successfully when only form is configured as auth mechanism
-   * @throws Exception
    */
   @Test
   public void testOnlyFORMEnabled() throws Exception {
@@ -151,7 +151,6 @@ public class TestSpnegoAuthentication {
   /**
    * Validate failure in creating FORM security handler when PAM authenticator is absent. PAM authenticator is provided
    * via {@link PlainFactory#getAuthenticator()}
-   * @throws Exception
    */
   @Test
   public void testFORMEnabledWithPlainDisabled() throws Exception {
@@ -185,7 +184,6 @@ public class TestSpnegoAuthentication {
 
   /**
    * Validate only SPNEGO security handler is configured properly when enabled via configuration
-   * @throws Exception
    */
   @Test
   public void testOnlySPNEGOEnabled() throws Exception {
@@ -219,7 +217,6 @@ public class TestSpnegoAuthentication {
    * Validate when none of the security mechanism is specified in the
    * {@link ExecConstants#HTTP_AUTHENTICATION_MECHANISMS}, FORM security handler is still configured correctly when
    * authentication is enabled along with PAM authenticator module.
-   * @throws Exception
    */
   @Test
   public void testConfigBackwardCompatibility() throws Exception {
@@ -244,9 +241,8 @@ public class TestSpnegoAuthentication {
   }
 
   /**
-   * Validate successful {@link DrillSpnegoLoginService#login(String, Object)} when provided with client token for a
-   * configured service principal.
-   * @throws Exception
+   * Validate successful {@link DrillSpnegoLoginService#login(String, Object, javax.servlet.ServletRequest)}
+   * when provided with client token for a configured service principal.
    */
   @Test
   public void testDrillSpnegoLoginService() throws Exception {
@@ -305,11 +301,11 @@ public class TestSpnegoAuthentication {
     final DrillSpnegoLoginService loginService = new DrillSpnegoLoginService(drillbitContext);
 
     // Authenticate the client using its SPNEGO token
-    final UserIdentity user = loginService.login(null, token);
+    final UserIdentity user = loginService.login(null, token, null);
 
     // Validate the UserIdentity of authenticated client
-    assertTrue(user != null);
-    assertTrue(user.getUserPrincipal().getName().equals(spnegoHelper.CLIENT_SHORT_NAME));
+    assertNotNull(user);
+    assertEquals(user.getUserPrincipal().getName(), spnegoHelper.CLIENT_SHORT_NAME);
     assertTrue(user.isUserInRole("authenticated", null));
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -243,8 +243,7 @@ public class TestGracefulShutdown extends BaseTestQuery {
   private File getWebServerTempDirPath(Drillbit drillbit) throws IllegalAccessException {
     Field webServerField = FieldUtils.getField(drillbit.getClass(), "webServer", true);
     WebServer webServerHandle = (WebServer) FieldUtils.readField(webServerField, drillbit, true);
-    File webServerTempDirPath = webServerHandle.getOrCreateTmpJavaScriptDir();
-    return webServerTempDirPath;
+    return webServerHandle.getOrCreateTmpJavaScriptDir();
   }
 
   private boolean waitAndAssertDrillbitCount(ClusterFixture cluster, int zkRefresh, int bitsNum)

--- a/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/TestGracefulShutdown.java
@@ -140,7 +140,7 @@ public class TestGracefulShutdown extends BaseTestQuery {
         Thread.sleep(100L);
       }
 
-      if (waitAndAssertDrillbitCount(cluster, zkRefresh)) {
+      if (waitAndAssertDrillbitCount(cluster, zkRefresh, drillbits.length)) {
         return;
       }
       Assert.fail("Timed out");
@@ -178,7 +178,7 @@ public class TestGracefulShutdown extends BaseTestQuery {
         throw new RuntimeException("Failed : HTTP error code : "
                 + conn.getResponseCode());
       }
-      if (waitAndAssertDrillbitCount(cluster, zkRefresh)) {
+      if (waitAndAssertDrillbitCount(cluster, zkRefresh, drillbits.length)) {
         return;
       }
       Assert.fail("Timed out");
@@ -240,24 +240,24 @@ public class TestGracefulShutdown extends BaseTestQuery {
     assertFalse("First drillbit instance should have a temporary Javascript dir deleted", originalDrillbitTempDir.exists());
   }
 
-  private static File getWebServerTempDirPath(Drillbit drillbit) throws IllegalAccessException {
+  private File getWebServerTempDirPath(Drillbit drillbit) throws IllegalAccessException {
     Field webServerField = FieldUtils.getField(drillbit.getClass(), "webServer", true);
     WebServer webServerHandle = (WebServer) FieldUtils.readField(webServerField, drillbit, true);
     File webServerTempDirPath = webServerHandle.getOrCreateTmpJavaScriptDir();
     return webServerTempDirPath;
   }
 
-  private static boolean waitAndAssertDrillbitCount(ClusterFixture cluster, int zkRefresh) throws InterruptedException {
+  private boolean waitAndAssertDrillbitCount(ClusterFixture cluster, int zkRefresh, int bitsNum)
+      throws InterruptedException {
 
     while (true) {
       Collection<DrillbitEndpoint> drillbitEndpoints = cluster.drillbit()
               .getContext()
               .getClusterCoordinator()
               .getAvailableEndpoints();
-      if (drillbitEndpoints.size() == 2) {
+      if (drillbitEndpoints.size() == bitsNum - 1) {
         return true;
       }
-
       Thread.sleep(zkRefresh);
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -2529,33 +2529,6 @@
           </dependency>
           <!--/GlassFish Jersey dependecies-->
 
-          <!--Javax dependecies-->
-          <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <version>2.3.3</version>
-            <scope>provided</scope>
-          </dependency>
-          <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <version>2.2</version>
-            <scope>provided</scope>
-          </dependency>
-          <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-          </dependency>
-
-          <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
-          </dependency>
-          <!--/Javax dependecies-->
-
           <!-- Test Dependencies -->
           <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2453,6 +2453,7 @@
             <version>1.60</version>
           </dependency>
 
+          <!--Eclipse Jetty dependecies-->
           <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -2483,6 +2484,17 @@
             <artifactId>jetty-io</artifactId>
             <version>${jetty.version}</version>
           </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-xml</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <!--Eclipse Jetty dependecies-->
 
           <!--GlassFish Jersey dependecies-->
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.8.2</avro.version>
     <metrics.version>4.0.2</metrics.version>
+    <jetty.version>9.4.15.v20190215</jetty.version>
     <jersey.version>2.28</jersey.version>
     <asm.version>7.0</asm.version>
     <excludedGroups />
@@ -2450,6 +2451,37 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>1.60</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>${jetty.version}</version>
           </dependency>
 
           <!--GlassFish Jersey dependecies-->

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.8.2</avro.version>
     <metrics.version>4.0.2</metrics.version>
-    <jetty.version>9.4.15.v20190215</jetty.version>
-    <jersey.version>2.28</jersey.version>
+    <jetty.version>9.3.25.v20180904</jetty.version>
+    <jersey.version>2.25.1</jersey.version>
     <asm.version>7.0</asm.version>
     <excludedGroups />
     <memoryMb>4096</memoryMb>
@@ -2527,14 +2527,9 @@
             <artifactId>jersey-container-servlet</artifactId>
             <version>${jersey.version}</version>
           </dependency>
-          <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-          </dependency>
           <!--/GlassFish Jersey dependecies-->
 
-          <!--Javax Servlet dependecies-->
+          <!--Javax dependecies-->
           <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>javax.servlet.jsp-api</artifactId>
@@ -2553,7 +2548,13 @@
             <version>4.0.1</version>
             <scope>provided</scope>
           </dependency>
-          <!--/Javax Servlet dependecies-->
+
+          <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+          </dependency>
+          <!--/Javax dependecies-->
 
           <!-- Test Dependencies -->
           <dependency>


### PR DESCRIPTION
- upgrade Jetty dependencies to 9.3 version
- downgrade Jersey dependencies to 2.25.1 version
- add JavaDocs and code refactoring
- adaptation to the new Jetty API - SessionHandler, LoginService, AbstractLoginService (jetty 9.4 only).
For Jetty and Jersey versions update to the latest versions [DRILL-7135](https://issues.apache.org/jira/browse/DRILL-7135) is created.