### PR TITLE
 DRILL-7081: Upgrade GlassFish Jersey and Javax Servlet dependecies 

### DIFF
--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -235,7 +235,6 @@
       <id>mapr</id>
       <properties>
         <alt-hadoop>mapr</alt-hadoop>
-        <rat.excludeSubprojects>true</rat.excludeSubprojects>
       </properties>
       <dependencies>
         <dependency>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -171,17 +171,14 @@
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-servlet</artifactId>
-      <version>2.8</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.8</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.8</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -205,13 +202,16 @@
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>
       <artifactId>jersey-mvc-freemarker</artifactId>
-      <version>2.8</version>
       <exclusions>
           <exclusion>
             <artifactId>servlet-api</artifactId>
             <groupId>javax.servlet</groupId>
           </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>
@@ -293,11 +293,6 @@
       <artifactId>vector</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- <dependency> -->
-    <!-- <groupId>org.apache.drill.exec</groupId> -->
-    <!-- <version>${project.version}</version> -->
-    <!-- <artifactId>drill-buffers</artifactId> -->
-    <!-- </dependency> -->
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -81,12 +81,24 @@
           <artifactId>commons-codec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
+          <groupId>org.glassfish.jersey.containers</groupId>
+          <artifactId>jersey-container-jetty-servlet</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>jersey-container-jetty-servlet</artifactId>
-          <groupId>org.glassfish.jersey.containers</groupId>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-multipart</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-mvc-freemarker</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jackson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
         </exclusion>
         <exclusion>
           <artifactId>jetty-server</artifactId>
@@ -99,14 +111,6 @@
         <exclusion>
           <groupId>org.apache.avro</groupId>
           <artifactId>avro-mapred</artifactId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jersey-media-multipart</artifactId>
-          <groupId>org.glassfish.jersey.media</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jersey-mvc-freemarker</artifactId>
-          <groupId>org.glassfish.jersey.ext</groupId>
         </exclusion>
         <exclusion>
           <artifactId>jetty-servlet</artifactId>
@@ -157,10 +161,6 @@
           <artifactId>httpdlog-parser</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.jersey.media</groupId>
-          <artifactId>jersey-media-json-jackson</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.kohsuke</groupId>
           <artifactId>libpam4j</artifactId>
         </exclusion>
@@ -175,6 +175,10 @@
         <exclusion>
           <artifactId>stream</artifactId>
           <groupId>com.clearspring.analytics</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.honton.chas.hocon</groupId>
+          <artifactId>jackson-dataformat-hocon</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -245,7 +249,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.0</version>
         <executions>
           <execution>
             <goals>
@@ -338,7 +341,6 @@
               <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
               <exclude>io.netty:netty-tcnative:jar:*</exclude>
-              <exclude>org.honton.chas.hocon:jackson-dataformat-hocon:*</exclude>
             </excludes>
           </artifactSet>
           <relocations>
@@ -654,7 +656,6 @@
                     <exclude>commons-io:commons-io</exclude>
                     <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
                     <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
-                    <exclude>org.honton.chas.hocon:jackson-dataformat-hocon:*</exclude>
                   </excludes>
                 </artifactSet>
                 <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.8.2</avro.version>
     <metrics.version>4.0.2</metrics.version>
+    <jersey.version>2.28</jersey.version>
     <asm.version>7.0</asm.version>
     <excludedGroups />
     <memoryMb>4096</memoryMb>
@@ -334,7 +335,6 @@
           </execution>
         </executions>
         <configuration>
-          <excludeSubprojects>false</excludeSubprojects>
           <excludes>
             <!-- Types log1, log2, sqllog and sqllog2 are used to test he logRegex format plugin. -->
             <exclude>**/*.log1</exclude>
@@ -2450,6 +2450,65 @@
             <version>1.60</version>
           </dependency>
 
+          <!--GlassFish Jersey dependecies-->
+          <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-mvc-freemarker</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-jetty-servlet</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+          </dependency>
+          <!--/GlassFish Jersey dependecies-->
+
+          <!--Javax Servlet dependecies-->
+          <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>2.3.3</version>
+            <scope>provided</scope>
+          </dependency>
+          <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
+          </dependency>
+          <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+          </dependency>
+          <!--/Javax Servlet dependecies-->
+
           <!-- Test Dependencies -->
           <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -2474,8 +2533,8 @@
                 <artifactId>netty-all</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -2524,7 +2583,6 @@
       <id>mapr</id>
       <properties>
         <alt-hadoop>mapr</alt-hadoop>
-        <rat.excludeSubprojects>true</rat.excludeSubprojects>
         <hive.version>2.3.3-mapr-1808</hive.version>
         <hbase.version>1.1.1-mapr-1602-m7-5.2.0</hbase.version>
         <hadoop.version>2.7.0-mapr-1808</hadoop.version>


### PR DESCRIPTION
- Update dependencies versions
     * update GlassFish Jersey and Javax Servlet dependecies versions
     * add `org.glassfish.jersey.inject:jersey-hk2`, since hard dependency was removed from Jersey, starting from [Jersey 2.26](https://jersey.github.io/release-notes/2.26.html).
- Exclude dependency from jdbc-all
- Removal redundant "bcpkix-jdk15on" exclusion
     * it is mentioned twice in the code
- Proper exclusion of "jackson-dataformat-hocon" dependency
     * since it is direct dependency of `java-exec` it should be excluded from `java-exec` directly, not in maven-shade-plugin
- Removal redundant "excludeSubprojects" config property for Maven Rat Plugin
    * `excludeSubprojects` name is invalid, the proper one is [`excludeSubProjects`](http://creadur.apache.org/rat/apache-rat-plugin/rat-mojo.html#excludeSubProjects) with capital `P`. Since it is not valid it is ignored by Maven Rat Plugin (true is default value). If it is false, all exclusions from license check should be specified in root POM file. But currently in Drill different exclusions are specified in different modules. So the proper value is `true` (default value). So the property can be removed.
    * `rat.excludeSubprojects` properties are removed too, since `true` is the default value.