### PR TITLE
DRILL-7073: CREATE SCHEMA command / TupleSchema / ColumnMetadata improvements

### DIFF
--- a/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaLexer.g4
+++ b/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaLexer.g4
@@ -64,10 +64,18 @@ LEFT_PAREN: '(';
 RIGHT_PAREN: ')';
 LEFT_ANGLE_BRACKET: '<';
 RIGHT_ANGLE_BRACKET: '>';
+SINGLE_QUOTE: '\'';
+DOUBLE_QUOTE: '"';
+LEFT_BRACE: '{';
+RIGHT_BRACE: '}';
+EQUALS_SIGN: '=';
 
 NOT: 'NOT';
 NULL: 'NULL';
 AS: 'AS';
+FORMAT: 'FORMAT';
+DEFAULT: 'DEFAULT';
+PROPERTIES: 'PROPERTIES';
 
 NUMBER: [1-9] DIGIT* | '0';
 fragment DIGIT: [0-9];
@@ -83,6 +91,8 @@ ID: ([A-Z$_]) ([A-Z$_] | DIGIT)*;
 // if contains backtick, it should be escaped with backslash (`a\\`b` -> a`b)
 // if contains backslash, it should be escaped as well (`a\\\\b` -> a\b)
 QUOTED_ID: REVERSE_QUOTE (~[`\\] | '\\' [`\\])* REVERSE_QUOTE;
+SINGLE_QUOTED_STRING: SINGLE_QUOTE (~['\\] | '\\' ['\\])* SINGLE_QUOTE;
+DOUBLE_QUOTED_STRING: DOUBLE_QUOTE (~["\\] | '\\' ["\\])* DOUBLE_QUOTE;
 
 // skip
 LINE_COMMENT:  '//' ~[\r\n]* -> skip;

--- a/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
+++ b/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
@@ -27,11 +27,13 @@ options {
 
 schema: (columns | LEFT_PAREN columns RIGHT_PAREN) EOF;
 
-columns: column (COMMA column)*;
+columns: column_def  (COMMA column_def)*;
+
+column_def: column property_values?;
 
 column: (primitive_column | map_column | simple_array_column | complex_array_column);
 
-primitive_column: column_id simple_type nullability?;
+primitive_column: column_id simple_type nullability? format_value? default_value?;
 
 simple_array_column: column_id simple_array_type nullability?;
 
@@ -70,3 +72,13 @@ complex_array_type: ARRAY LEFT_ANGLE_BRACKET complex_type RIGHT_ANGLE_BRACKET;
 map_type: MAP LEFT_ANGLE_BRACKET columns RIGHT_ANGLE_BRACKET;
 
 nullability: NOT NULL;
+
+format_value: FORMAT string_value;
+
+default_value: DEFAULT string_value;
+
+property_values: PROPERTIES LEFT_BRACE property_pair (COMMA property_pair)* RIGHT_BRACE;
+
+property_pair: string_value EQUALS_SIGN string_value;
+
+string_value: (QUOTED_ID | SINGLE_QUOTED_STRING | DOUBLE_QUOTED_STRING);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -30,7 +30,7 @@ import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
 import org.apache.drill.exec.vector.accessor.ColumnConversionFactory;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -72,7 +72,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
    */
 
   protected int expectedElementCount = 1;
-  protected Map<String, String> properties = new HashMap<>();
+  protected final Map<String, String> properties = new LinkedHashMap<>();
 
   @JsonCreator
   public static AbstractColumnMetadata createColumnMetadata(@JsonProperty("name") String name,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -17,12 +17,22 @@
  */
 package org.apache.drill.exec.record.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
 import org.apache.drill.exec.vector.accessor.ColumnConversionFactory;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Abstract definition of column metadata. Allows applications to create
@@ -36,6 +46,13 @@ import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
  * since maps (and the row itself) will, by definition, differ between
  * the two views.
  */
+@JsonAutoDetect(
+  fieldVisibility = JsonAutoDetect.Visibility.NONE,
+  getterVisibility = JsonAutoDetect.Visibility.NONE,
+  isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+  setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"name", "type", "mode", "format", "default", "properties"})
 public abstract class AbstractColumnMetadata implements ColumnMetadata {
 
   // Capture the key schema information. We cannot use the MaterializedField
@@ -55,6 +72,21 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
    */
 
   protected int expectedElementCount = 1;
+  protected Map<String, String> properties = new HashMap<>();
+
+  @JsonCreator
+  public static AbstractColumnMetadata createColumnMetadata(@JsonProperty("name") String name,
+                                                            @JsonProperty("type") String type,
+                                                            @JsonProperty("mode") DataMode mode,
+                                                            @JsonProperty("format") String formatValue,
+                                                            @JsonProperty("default") String defaultValue,
+                                                            @JsonProperty("properties") Map<String, String> properties) {
+    ColumnMetadata columnMetadata = SchemaExprParser.parseColumn(name, type, mode);
+    columnMetadata.setFormatValue(formatValue);
+    columnMetadata.setDefaultFromString(defaultValue);
+    columnMetadata.setProperties(properties);
+    return (AbstractColumnMetadata) columnMetadata;
+  }
 
   public AbstractColumnMetadata(MaterializedField schema) {
     name = schema.getName();
@@ -91,6 +123,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
   @Override
   public void bind(TupleMetadata parentTuple) { }
 
+  @JsonProperty("name")
   @Override
   public String name() { return name; }
 
@@ -105,6 +138,7 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
         .build();
   }
 
+  @JsonProperty("mode")
   @Override
   public DataMode mode() { return mode; }
 
@@ -186,10 +220,26 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
   public boolean isProjected() { return projected; }
 
   @Override
+  public void setFormatValue(String value) { }
+
+  @JsonProperty("format")
+  @Override
+  public String formatValue() { return null; }
+
+  @Override
   public void setDefaultValue(Object value) { }
 
   @Override
   public Object defaultValue() { return null; }
+
+  @Override
+  public void setDefaultFromString(String value) { }
+
+  @JsonProperty("default")
+  @Override
+  public String defaultStringValue() {
+    return null;
+  }
 
   @Override
   public void setTypeConverter(ColumnConversionFactory factory) {
@@ -198,6 +248,20 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
 
   @Override
   public ColumnConversionFactory typeConverter() { return null; }
+
+  @Override
+  public void setProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return;
+    }
+    this.properties.putAll(properties);
+  }
+
+  @JsonProperty("properties")
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
 
   @Override
   public String toString() {
@@ -221,11 +285,24 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
       buf.append(", schema: ")
          .append(mapSchema().toString());
     }
+    if (formatValue() != null) {
+      buf.append(", format: ")
+        .append(formatValue());
+    }
+    if (defaultValue() != null) {
+      buf.append(", default: ")
+        .append(defaultStringValue());
+    }
+    if (!properties().isEmpty()) {
+      buf.append(", properties: ")
+        .append(properties());
+    }
     return buf
         .append("]")
         .toString();
   }
 
+  @JsonProperty("type")
   @Override
   public String typeString() {
     return majorType().toString();
@@ -241,6 +318,23 @@ public abstract class AbstractColumnMetadata implements ColumnMetadata {
     // Drill does not have nullability notion for complex types
     if (!isNullable() && !isArray() && !isMap()) {
       builder.append(" NOT NULL");
+    }
+
+    if (formatValue() != null) {
+      builder.append(" FORMAT '").append(formatValue()).append("'");
+    }
+
+    if (defaultValue() != null) {
+      builder.append(" DEFAULT '").append(defaultStringValue()).append("'");
+    }
+
+    if (!properties().isEmpty()) {
+      builder.append(" PROPERTIES { ");
+      builder.append(properties().entrySet()
+        .stream()
+        .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
+        .collect(Collectors.joining(", ")));
+      builder.append(" }");
     }
 
     return builder.toString();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
@@ -22,6 +22,8 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
 
+import java.util.stream.Collectors;
+
 /**
  * Describes a map and repeated map. Both are tuples that have a tuple
  * schema as part of the column definition.
@@ -125,7 +127,11 @@ public class MapColumnMetadata extends AbstractColumnMetadata {
     if (isArray()) {
       builder.append("ARRAY<");
     }
-    builder.append("MAP<").append(mapSchema.schemaString()).append(">");
+    builder.append("MAP<");
+    builder.append(mapSchema().toMetadataList().stream()
+      .map(ColumnMetadata::columnString)
+      .collect(Collectors.joining(", ")));
+    builder.append(">");
     if (isArray()) {
       builder.append(">");
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
@@ -167,83 +167,12 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
 
   @Override
   public void setDefaultFromString(String value) {
-    if (value == null) {
-      return;
-    }
-    Object objectValue = null;
-    try {
-      switch (type) {
-        case INT:
-          objectValue = Integer.parseInt(value);
-          break;
-        case BIGINT:
-          objectValue = Long.parseLong(value);
-          break;
-        case FLOAT4:
-          objectValue = Float.parseFloat(value);
-          break;
-        case FLOAT8:
-          objectValue = Double.parseDouble(value);
-          break;
-        case VARDECIMAL:
-          objectValue = new BigDecimal(value);
-          break;
-        case BIT:
-          objectValue = Boolean.parseBoolean(value);
-          break;
-        case VARCHAR:
-        case VARBINARY:
-          objectValue = value;
-          break;
-        case TIME:
-          DateTimeFormatter timeFormatter = formatValue == null
-            ? DateTimeFormatter.ISO_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-          objectValue = LocalTime.parse(value, timeFormatter);
-          break;
-        case DATE:
-          DateTimeFormatter dateFormatter = formatValue == null
-            ? DateTimeFormatter.ISO_DATE.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-          objectValue = LocalDate.parse(value, dateFormatter);
-          break;
-        case TIMESTAMP:
-          DateTimeFormatter dateTimeFormatter = formatValue == null
-            ? DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-          objectValue = ZonedDateTime.parse(value, dateTimeFormatter);
-          break;
-        case INTERVAL:
-        case INTERVALDAY:
-        case INTERVALYEAR:
-          objectValue = Period.parse(value);
-          break;
-      }
-    } catch (IllegalArgumentException | DateTimeParseException e) {
-      logger.warn("Error while parsing type {} default value {}", type, value, e);
-    }
-
-    this.defaultValue = objectValue;
+    this.defaultValue = valueFromString(value);
   }
 
   @Override
   public String defaultStringValue() {
-    if (defaultValue == null) {
-      return null;
-    }
-    switch (type) {
-      case TIME:
-        DateTimeFormatter timeFormatter = formatValue == null
-          ? DateTimeFormatter.ISO_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-        return timeFormatter.format((LocalTime) defaultValue);
-      case DATE:
-        DateTimeFormatter dateFormatter = formatValue == null
-          ? DateTimeFormatter.ISO_DATE.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-        return dateFormatter.format((LocalDate) defaultValue);
-      case TIMESTAMP:
-        DateTimeFormatter dateTimeFormatter = formatValue == null
-          ? DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
-        return dateTimeFormatter.format((ZonedDateTime) defaultValue);
-      default:
-       return defaultValue.toString();
-    }
+    return valueToString(defaultValue);
   }
 
   @Override
@@ -328,6 +257,88 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
       builder.append(">");
     }
     return builder.toString();
+  }
+
+  /**
+   * Converts value in string literal form into Object instance based on {@link MinorType} value.
+   * Returns null in case of error during parsing or unsupported type.
+   *
+   * @param value value in string literal form
+   * @return Object instance
+   */
+  private Object valueFromString(String value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      switch (type) {
+        case INT:
+          return Integer.parseInt(value);
+        case BIGINT:
+          return Long.parseLong(value);
+        case FLOAT4:
+          return Float.parseFloat(value);
+        case FLOAT8:
+          return Double.parseDouble(value);
+        case VARDECIMAL:
+          return new BigDecimal(value);
+        case BIT:
+          return Boolean.parseBoolean(value);
+        case VARCHAR:
+        case VARBINARY:
+          return value;
+        case TIME:
+          DateTimeFormatter timeFormatter = formatValue == null
+            ? DateTimeFormatter.ISO_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+          return LocalTime.parse(value, timeFormatter);
+        case DATE:
+          DateTimeFormatter dateFormatter = formatValue == null
+            ? DateTimeFormatter.ISO_DATE.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+          return LocalDate.parse(value, dateFormatter);
+        case TIMESTAMP:
+          DateTimeFormatter dateTimeFormatter = formatValue == null
+            ? DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+          return ZonedDateTime.parse(value, dateTimeFormatter);
+        case INTERVAL:
+        case INTERVALDAY:
+        case INTERVALYEAR:
+          return Period.parse(value);
+        default:
+          logger.warn("Unsupported type {} for default value {}, ignore and return null", type, value);
+          return null;
+      }
+    } catch (IllegalArgumentException | DateTimeParseException e) {
+      logger.warn("Error while parsing type {} default value {}, ignore and return null", type, value, e);
+      return null;
+    }
+  }
+
+  /**
+   * Converts given value instance into String literal representation based on column metadata type.
+   *
+   * @param value value instance
+   * @return value in string literal representation
+   */
+  private String valueToString(Object value) {
+    if (value == null) {
+      return null;
+    }
+    switch (type) {
+      case TIME:
+        DateTimeFormatter timeFormatter = formatValue == null
+          ? DateTimeFormatter.ISO_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+        return timeFormatter.format((LocalTime) value);
+      case DATE:
+        DateTimeFormatter dateFormatter = formatValue == null
+          ? DateTimeFormatter.ISO_DATE.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+        return dateFormatter.format((LocalDate) value);
+      case TIMESTAMP:
+        DateTimeFormatter dateTimeFormatter = formatValue == null
+          ? DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC) : DateTimeFormatter.ofPattern(formatValue);
+        return dateTimeFormatter.format((ZonedDateTime) value);
+      default:
+        return value.toString();
+    }
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
@@ -27,8 +27,8 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.MaterializedField;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,10 +51,9 @@ public class TupleSchema implements TupleMetadata {
 
   private MapColumnMetadata parentMap;
   private final TupleNameSpace<ColumnMetadata> nameSpace = new TupleNameSpace<>();
-  private final Map<String, String> properties = new HashMap<>();
+  private final Map<String, String> properties = new LinkedHashMap<>();
 
   public TupleSchema() {
-
   }
 
   @JsonCreator

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
@@ -17,14 +17,21 @@
  */
 package org.apache.drill.exec.record.metadata;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
+import org.apache.drill.exec.record.MaterializedField;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.drill.exec.record.BatchSchema;
-import org.apache.drill.exec.record.MaterializedField;
-import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 /**
  * Defines the schema of a tuple: either the top-level row or a nested
@@ -33,11 +40,29 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
  * index. New columns may be added at any time; the new column takes the
  * next available index.
  */
-
+@JsonAutoDetect(
+  fieldVisibility = JsonAutoDetect.Visibility.NONE,
+  getterVisibility = JsonAutoDetect.Visibility.NONE,
+  isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+  setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"columns", "properties"})
 public class TupleSchema implements TupleMetadata {
 
   private MapColumnMetadata parentMap;
   private final TupleNameSpace<ColumnMetadata> nameSpace = new TupleNameSpace<>();
+  private final Map<String, String> properties = new HashMap<>();
+
+  public TupleSchema() {
+
+  }
+
+  @JsonCreator
+  public TupleSchema(@JsonProperty("columns") List<AbstractColumnMetadata> columns,
+                     @JsonProperty("properties") Map<String, String> properties) {
+    columns.forEach(this::addColumn);
+    setProperties(properties);
+  }
 
   public void bind(MapColumnMetadata parentMap) {
     this.parentMap = parentMap;
@@ -145,6 +170,7 @@ public class TupleSchema implements TupleMetadata {
     return cols;
   }
 
+  @JsonProperty("columns")
   @Override
   public List<ColumnMetadata> toMetadataList() {
     return new ArrayList<>(nameSpace.entries());
@@ -183,13 +209,6 @@ public class TupleSchema implements TupleMetadata {
   public boolean isRoot() { return parentMap == null; }
 
   @Override
-  public String schemaString() {
-    return nameSpace.entries().stream()
-      .map(ColumnMetadata::columnString)
-      .collect(Collectors.joining(", "));
-  }
-
-  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder()
         .append("[")
@@ -200,7 +219,28 @@ public class TupleSchema implements TupleMetadata {
       .map(ColumnMetadata::toString)
       .collect(Collectors.joining(", ")));
 
+    if (!properties.isEmpty()) {
+      if (!nameSpace.entries().isEmpty()) {
+        builder.append(", ");
+      }
+      builder.append("properties: ").append(properties);
+    }
+
     builder.append("]");
     return builder.toString();
+  }
+
+  @Override
+  public void setProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return;
+    }
+    this.properties.putAll(properties);
+  }
+
+  @JsonProperty("properties")
+  @Override
+  public Map<String, String> properties() {
+    return properties;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaContainer.java
@@ -21,34 +21,29 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
 import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
 
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
- * Holder class that contains table name, schema definition
- * and properties passed in schema file or using table function.
+ * Holder class that contains table name, schema definition and current schema container version.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class SchemaContainer {
 
   private final String table;
   private final TupleMetadata schema;
-  // preserve properties order
-  private final Map<String, String> properties = new LinkedHashMap<>();
   private final Version version;
 
   @JsonCreator
   public SchemaContainer(@JsonProperty("table") String table,
-                         @JsonProperty("schema") List<String> schema,
-                         @JsonProperty("properties") LinkedHashMap<String, String> properties,
+                         @JsonProperty("schema") TupleSchema schema,
                          @JsonProperty("version") Integer version) {
-    this(table, schema == null ? null : String.join(", ", schema), properties, version);
+    this.table = table;
+    this.schema = schema;
+    this.version = new Version(version);
   }
 
   public SchemaContainer(String table, String schema, Map<String, String> properties) {
@@ -57,10 +52,7 @@ public class SchemaContainer {
 
   public SchemaContainer(String table, String schema, Map<String, String> properties, Integer version) {
     this.table = table;
-    this.schema = schema == null ? null : convert(schema);
-    if (properties != null) {
-      this.properties.putAll(properties);
-    }
+    this.schema = schema == null ? null : convert(schema, properties);
     this.version = new Version(version);
   }
 
@@ -70,15 +62,8 @@ public class SchemaContainer {
   }
 
   @JsonProperty("schema")
-  public List<String> getSchemaList() {
-    return schema == null ? null : schema.toMetadataList().stream()
-      .map(ColumnMetadata::columnString)
-      .collect(Collectors.toList());
-  }
-
-  @JsonProperty("properties")
-  public Map<String, String> getProperties() {
-    return properties;
+  public TupleMetadata getSchema() {
+    return schema;
   }
 
   @JsonProperty("version")
@@ -87,23 +72,21 @@ public class SchemaContainer {
   }
 
   @JsonIgnore
-  public TupleMetadata getSchema() {
-    return schema;
-  }
-
-  @JsonIgnore
   public Version getVersion() {
     return version;
   }
 
-  private TupleMetadata convert(String schema) {
-    return SchemaExprParser.parseSchema(schema);
+  private TupleMetadata convert(String schemaString, Map<String, String> properties) {
+    TupleMetadata schema = SchemaExprParser.parseSchema(schemaString);
+    if (properties != null) {
+      schema.setProperties(properties);
+    }
+    return schema;
   }
 
   @Override
   public String toString() {
-    return "SchemaContainer{" + "table='" + table + '\'' + ", schema=" + schema +
-      ", properties=" + properties + ", version=" + version + '}';
+    return "SchemaContainer{" + "table='" + table + '\'' + ", schema=" + schema + ", version=" + version + '}';
   }
 
   /**
@@ -114,6 +97,7 @@ public class SchemaContainer {
   public static class Version {
 
     public static final int UNDEFINED_VERSION = -1;
+
     public static final int VERSION_1 = 1;
 
     // is used for testing

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaExprParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaExprParser.java
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.CodePointCharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 
@@ -38,6 +39,21 @@ public class SchemaExprParser {
   public static TupleMetadata parseSchema(String schema) {
     SchemaVisitor visitor = new SchemaVisitor();
     return visitor.visit(initParser(schema).schema());
+  }
+
+  /**
+   * Parses given column name, type and mode into {@link ColumnMetadata} instance.
+   *
+   * @param name column name
+   * @param type column type
+   * @param mode column mode
+   * @return column metadata
+   */
+  public static ColumnMetadata parseColumn(String name, String type, TypeProtos.DataMode mode) {
+    return parseColumn(String.format("`%s` %s %s",
+      name.replaceAll("(\\\\)|(`)", "\\\\$0"),
+      type,
+      TypeProtos.DataMode.REQUIRED == mode ? "not null" : ""));
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaVisitor.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.RepeatedListBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -70,7 +71,7 @@ public class SchemaVisitor extends SchemaParserBaseVisitor<TupleMetadata> {
             List<String> pairValues = pair.string_value().stream()
               .map(stringValueVisitor::visit)
               .collect(Collectors.toList());
-            assert pairValues.size() == 2;
+            Preconditions.checkState(pairValues.size() == 2);
             columnProperties.put(pairValues.get(0), pairValues.get(1));
           }
         );

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaVisitor.java
@@ -28,7 +28,10 @@ import org.apache.drill.exec.record.metadata.RepeatedListBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Visits schema and stores metadata about its columns into {@link TupleMetadata} class.
@@ -43,11 +46,39 @@ public class SchemaVisitor extends SchemaParserBaseVisitor<TupleMetadata> {
   @Override
   public TupleMetadata visitColumns(SchemaParser.ColumnsContext ctx) {
     TupleMetadata schema = new TupleSchema();
-    ColumnVisitor columnVisitor = new ColumnVisitor();
-    ctx.column().forEach(
-      c -> schema.addColumn(c.accept(columnVisitor))
+    ColumnDefVisitor columnDefVisitor = new ColumnDefVisitor();
+    ctx.column_def().forEach(
+      columnDef -> schema.addColumn(columnDef.accept(columnDefVisitor))
     );
     return schema;
+  }
+
+  /**
+   * Visits column definition, adds column properties to {@link ColumnMetadata} if present.
+   */
+  public static class ColumnDefVisitor extends SchemaParserBaseVisitor<ColumnMetadata> {
+
+    @Override
+    public ColumnMetadata visitColumn_def(SchemaParser.Column_defContext ctx) {
+      ColumnVisitor columnVisitor = new ColumnVisitor();
+      ColumnMetadata columnMetadata = ctx.column().accept(columnVisitor);
+      if (ctx.property_values() != null) {
+        StringValueVisitor stringValueVisitor = new StringValueVisitor();
+        Map<String, String> columnProperties = new LinkedHashMap<>();
+        ctx.property_values().property_pair().forEach(
+          pair -> {
+            List<String> pairValues = pair.string_value().stream()
+              .map(stringValueVisitor::visit)
+              .collect(Collectors.toList());
+            assert pairValues.size() == 2;
+            columnProperties.put(pairValues.get(0), pairValues.get(1));
+          }
+        );
+        columnMetadata.setProperties(columnProperties);
+      }
+      return columnMetadata;
+    }
+
   }
 
   /**
@@ -60,7 +91,15 @@ public class SchemaVisitor extends SchemaParserBaseVisitor<TupleMetadata> {
     public ColumnMetadata visitPrimitive_column(SchemaParser.Primitive_columnContext ctx) {
       String name = ctx.column_id().accept(new IdVisitor());
       TypeProtos.DataMode mode = ctx.nullability() == null ? TypeProtos.DataMode.OPTIONAL : TypeProtos.DataMode.REQUIRED;
-      return ctx.simple_type().accept(new TypeVisitor(name, mode));
+      ColumnMetadata columnMetadata = ctx.simple_type().accept(new TypeVisitor(name, mode));
+      StringValueVisitor stringValueVisitor = new StringValueVisitor();
+      if (ctx.format_value() != null) {
+        columnMetadata.setFormatValue(stringValueVisitor.visit(ctx.format_value().string_value()));
+      }
+      if (ctx.default_value() != null) {
+        columnMetadata.setDefaultFromString(stringValueVisitor.visit(ctx.default_value().string_value()));
+      }
+      return columnMetadata;
     }
 
     @Override
@@ -85,6 +124,20 @@ public class SchemaVisitor extends SchemaParserBaseVisitor<TupleMetadata> {
       return builder.buildColumn();
     }
 
+  }
+
+  /**
+   * Visits quoted string, strips backticks, single quotes or double quotes and returns bare string value.
+   */
+  private static class StringValueVisitor extends SchemaParserBaseVisitor<String> {
+
+    @Override
+    public String visitString_value(SchemaParser.String_valueContext ctx) {
+      String text = ctx.getText();
+      // first substring first and last symbols (backticks, single quotes, double quotes)
+      // then find all chars that are preceding with the backslash and remove the backslash
+      return text.substring(1, text.length() -1).replaceAll("\\\\(.)", "$1");
+    }
   }
 
   /**
@@ -225,8 +278,8 @@ public class SchemaVisitor extends SchemaParserBaseVisitor<TupleMetadata> {
     @Override
     public ColumnMetadata visitMap_type(SchemaParser.Map_typeContext ctx) {
       MapBuilder builder = new MapBuilder(null, name, mode);
-      ColumnVisitor visitor = new ColumnVisitor();
-      ctx.columns().column().forEach(
+      ColumnDefVisitor visitor = new ColumnDefVisitor();
+      ctx.columns().column_def().forEach(
         c -> builder.addColumn(c.accept(visitor))
       );
       return builder.buildColumn();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
@@ -30,7 +30,6 @@ public class TestParserErrorHandling {
   public void testUnsupportedType() {
     String schema = "col unk_type";
     thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("offending symbol [@1,4:11='unk_type',<38>,1:4]: no viable alternative at input");
     SchemaExprParser.parseSchema(schema);
   }
 
@@ -54,7 +53,6 @@ public class TestParserErrorHandling {
   public void testUnquotedId() {
     String schema = "id with space varchar";
     thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("offending symbol [@1,3:6='with',<38>,1:3]: no viable alternative at input");
     SchemaExprParser.parseSchema(schema);
   }
 
@@ -62,7 +60,6 @@ public class TestParserErrorHandling {
   public void testUnescapedBackTick() {
     String schema = "`c`o`l` varchar";
     thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("offending symbol [@1,3:3='o',<38>,1:3]: no viable alternative at input");
     SchemaExprParser.parseSchema(schema);
   }
 
@@ -78,7 +75,6 @@ public class TestParserErrorHandling {
   public void testMissingType() {
     String schema = "col not null";
     thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("offending symbol [@1,4:6='not',<34>,1:4]: no viable alternative at input");
     SchemaExprParser.parseSchema(schema);
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
@@ -23,6 +23,8 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.accessor.ColumnConversionFactory;
 
+import java.util.Map;
+
 /**
  * Metadata description of a column including names, types and structure
  * information.
@@ -182,6 +184,10 @@ public interface ColumnMetadata {
 
   int expectedElementCount();
 
+  void setFormatValue(String value);
+
+  String formatValue();
+
   /**
    * Set the default value to use for filling a vector when no real data is
    * available, such as for columns added in new files but which does not
@@ -199,6 +205,21 @@ public interface ColumnMetadata {
    * @return the default value, or null if no default value has been set
    */
   Object defaultValue();
+
+  /**
+   * Parses default value from String based on literal value into Object instance based on {@link MinorType} value.
+   * Sets default value to use for filling a vector when no real data is available.
+   *
+   * @param value the default value in String representation
+   */
+  void setDefaultFromString(String value);
+
+  /**
+   * Returns the default value for this column in String literal representation.
+   *
+   * @return the default value in String literal representation, or null if no default value has been set
+   */
+  String defaultStringValue();
 
   /**
    * Set the factory for an optional shim writer that translates from the type of
@@ -230,6 +251,15 @@ public interface ColumnMetadata {
    */
 
   ColumnMetadata cloneEmpty();
+
+  /**
+   * Sets column properties if not null.
+   *
+   * @param properties column properties
+   */
+  void setProperties(Map<String, String> properties);
+
+  Map<String, String> properties();
 
   /**
    * Reports whether, in this context, the column is projected outside

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleMetadata.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.record.metadata;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.drill.exec.record.MaterializedField;
 
@@ -95,10 +96,12 @@ public interface TupleMetadata extends Iterable<ColumnMetadata> {
   String fullName(int index);
 
   /**
-   * Converts schema metadata into string representation
-   * accepted by the table schema parser.
+   * Sets schema properties if not null.
    *
-   * @return schema metadata string representation
+   * @param properties schema properties
    */
-  String schemaString();
+  void setProperties(Map<String, String> properties);
+
+  Map<String, String> properties();
+
 }


### PR DESCRIPTION
1. Add format, default, column properties logic.
2. Changed schema JSON after serialization.
3. Added appropriate unit tests.

Details in [DRILL-7073](https://issues.apache.org/jira/browse/DRILL-7073).