### PR TITLE
DRILL-7061: Setting limit results to 1000 on web UI causes parse error

### DIFF
--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -82,7 +82,8 @@
     <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
       Submit
     </button>
-    <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="queryLimit" min="0" value="${model.getDefaultRowsAutoLimited()}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" onclick="alert('Limits the number of records retrieved in the query')" style="cursor:pointer"></span>
+    <!--  DISABLED: See DRILL-7061 (PR #1689) -->
+    <!--input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="queryLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" onclick="alert('Limits the number of records retrieved in the query')" style="cursor:pointer"></span -->
   </form>
 
   <script>

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -59,6 +59,7 @@ function doSubmitQueryWithAutoLimit() {
         $("#query").focus();
         return;
     }
+    /** DISABLED : See DRILL-7061 (PR #1689)
     //Wrap if required
     let mustWrapWithLimit = $('input[name="forceLimit"]:checked').length > 0;
     //Clear field when submitting if not mustWrapWithLimit
@@ -76,6 +77,7 @@ function doSubmitQueryWithAutoLimit() {
         return;
       }
     }
+    */
     //Submit query
     submitQuery();
 }


### PR DESCRIPTION
Freemarker by default introduces a comma in numeric values greater than 999. This corrects that by removing the ',' in the default limit size