### PR TITLE
DRILL-7093 Batch Sizing in SingleSender

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -73,6 +73,12 @@ public final class ExecConstants {
   public static final String TEMP_DIRECTORIES = "drill.exec.tmp.directories";
   public static final String TEMP_FILESYSTEM = "drill.exec.tmp.filesystem";
   public static final String INCOMING_BUFFER_IMPL = "drill.exec.buffer.impl";
+
+  public static final String EXCHANGE_BATCH_SIZE = "drill.exec.memory.operator.exchange_batch_size";
+  // Exchange Batch Size in Bytes.
+  public static final LongValidator EXCHANGE_BATCH_SIZE_VALIDATOR = new RangeLongValidator(EXCHANGE_BATCH_SIZE, 1024, 10 * 1024 * 1024,
+          new OptionDescription("Limit, in bytes, of the outgoing batch sent by an Exchange Sender."));
+
   /** incoming buffer size (number of batches) */
   public static final String INCOMING_BUFFER_SIZE = "drill.exec.buffer.size";
   public static final String SPOOLING_BUFFER_DELETE = "drill.exec.buffer.spooling.delete";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashPartitionSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashPartitionSender.java
@@ -66,9 +66,6 @@ public class HashPartitionSender extends AbstractSender {
     return expr;
   }
 
-  public int getOutgoingBatchSize() {
-    return outgoingBatchSize;
-  }
 
   @Override
   public <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -583,6 +583,15 @@ public class ScanBatch implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    VectorContainer partialContainer = new VectorContainer(context.getAllocator(), getSchema());
+    container.transferOut(partialContainer, startIndex, length);
+    partialContainer.setRecordCount(length);
+    final WritableBatch batch = WritableBatch.get(partialContainer);
+    return batch;
+  }
+
+  @Override
   public void close() throws Exception {
     container.clear();
     mutator.clear();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/SenderMemoryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/SenderMemoryManager.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl;
+
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.RecordBatchMemoryManager;
+import org.apache.drill.exec.record.RecordBatchSizer;
+
+public class SenderMemoryManager extends RecordBatchMemoryManager {
+  private RecordBatch incomingBatch;
+  private int batchSizeLimit;
+
+  public SenderMemoryManager(int batchSizeLimit, RecordBatch incomingBatch) {
+    super(batchSizeLimit);
+    this.batchSizeLimit = batchSizeLimit;
+    this.incomingBatch = incomingBatch;
+  }
+
+  public void update() {
+    RecordBatchSizer batchSizer = new RecordBatchSizer(incomingBatch);
+    setRecordBatchSizer(batchSizer);
+    int outputRowCount = computeOutputRowCount(batchSizeLimit, batchSizer.getNetRowWidth());
+    outputRowCount = Math.min(outputRowCount, batchSizer.rowCount());
+    setOutputRowCount(outputRowCount);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
@@ -108,6 +108,15 @@ public class SpilledRecordbatch implements CloseableRecordBatch {
   public BatchSchema getSchema() { return schema; }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    VectorContainer partialContainer = new VectorContainer(context.getAllocator(), getSchema());
+    container.transferOut(partialContainer, startIndex, length);
+    partialContainer.setRecordCount(length);
+    final WritableBatch batch = WritableBatch.get(partialContainer);
+    return batch;
+  }
+
+  @Override
   public WritableBatch getWritableBatch() {
     return WritableBatch.get(this);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/mergereceiver/MergingRecordBatch.java
@@ -838,4 +838,13 @@ public class MergingRecordBatch extends AbstractRecordBatch<MergingReceiverPOP> 
         container, outgoingPosition, Arrays.toString(incomingBatches), Arrays.toString(batchOffsets),
         Arrays.toString(tempBatchHolder), Arrays.toString(inputCounts), Arrays.toString(outputCounts));
   }
+
+  @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    VectorContainer partialContainer = new VectorContainer(context.getAllocator(), getSchema());
+    outgoingContainer.transferOut(partialContainer, startIndex, length);
+    partialContainer.setRecordCount(length);
+    final WritableBatch batch = WritableBatch.get(partialContainer);
+    return batch;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
@@ -116,6 +116,11 @@ public class OperatorRecordBatch implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public WritableBatch getWritableBatch() {
     return batchAccessor.getWritableBatch();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -219,6 +219,11 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    return batchLoader.getWritableBatch(startIndex, length);
+  }
+
+  @Override
   public WritableBatch getWritableBatch() {
     return batchLoader.getWritableBatch();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
@@ -354,6 +354,13 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    validateReadState("getWritableBatch()");
+    return incoming.getWritableBatch(startIndex, length);
+  }
+
+
+  @Override
   public void close() {
     // (Log construction and close() calls at same logging level to bracket
     // instance's activity.)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -253,6 +253,15 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
   }
 
   @Override
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    VectorContainer partialContainer = new VectorContainer(context.getAllocator(), getSchema());
+    container.transferOut(partialContainer, startIndex, length);
+    partialContainer.setRecordCount(length);
+    final WritableBatch batch = WritableBatch.get(partialContainer);
+    return batch;
+  }
+
+  @Override
   public VectorContainer getOutgoingContainer() {
     throw new UnsupportedOperationException(String.format(" You should not call getOutgoingContainer() for class %s", this.getClass().getCanonicalName()));
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/HyperVectorWrapper.java
@@ -160,6 +160,23 @@ public class HyperVectorWrapper<T extends ValueVector> implements VectorWrapper<
   }
 
   /**
+   * Transfer vectors to destination HyperVectorWrapper.
+   * Both this and destination must be of same type and have same number of vectors.
+   * @param destination destination HyperVectorWrapper.
+   */
+  @Override
+  public void transferPartial(VectorWrapper<?> destination, int startIndex, int length) {
+    Preconditions.checkArgument(destination instanceof HyperVectorWrapper);
+    Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
+    Preconditions.checkArgument(vectors.length == ((HyperVectorWrapper<?>)destination).vectors.length);
+
+    final ValueVector[] destionationVectors = ((HyperVectorWrapper<?>)destination).vectors;
+    for (int i = 0; i < vectors.length; ++i) {
+      vectors[i].makeTransferPair(destionationVectors[i]).splitAndTransfer(startIndex, length);
+    }
+  }
+
+  /**
    * Method to replace existing list of vectors with the newly provided ValueVectors list in this HyperVectorWrapper
    * @param vv - New list of ValueVectors to be stored
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -322,6 +322,12 @@ public interface RecordBatch extends VectorAccessible {
   WritableBatch getWritableBatch();
 
   /**
+   * Gets a writable version of this batch.  Takes over ownership of existing
+   * buffers.
+   */
+  WritableBatch getWritableBatch(int startIndex, int length);
+
+  /**
    * Perform dump of this batch's state to logs.
    */
   void dump();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
@@ -262,6 +262,14 @@ public class RecordBatchLoader implements VectorAccessible, Iterable<VectorWrapp
     return WritableBatch.getBatchNoHVWrap(valueCount, container, isSV2);
   }
 
+  public WritableBatch getWritableBatch(int startIndex, int length) {
+    VectorContainer partialContainer = new VectorContainer(allocator, getSchema());
+    container.transferOut(partialContainer, startIndex, length);
+    partialContainer.setRecordCount(length);
+    final WritableBatch batch = WritableBatch.get(partialContainer);
+    return batch;
+  }
+
   @Override
   public Iterator<VectorWrapper<?>> iterator() {
     return this.container.iterator();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SchemalessBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SchemalessBatch.java
@@ -96,6 +96,12 @@ public class SchemalessBatch implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int start, int length) {
+    throw new UnsupportedOperationException(String.format("You should not call getWritableBatch() for class %s",
+            this.getClass().getCanonicalName()));
+  }
+
+  @Override
   public Iterator<VectorWrapper<?>> iterator() {
     return null;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleRecordBatch.java
@@ -89,6 +89,11 @@ public class SimpleRecordBatch implements RecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int start, int length) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Iterator<VectorWrapper<?>> iterator() {
     return container.iterator();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleVectorWrapper.java
@@ -110,6 +110,13 @@ public class SimpleVectorWrapper<T extends ValueVector> implements VectorWrapper
   }
 
   @Override
+  public void transferPartial(VectorWrapper<?> destination, int startIndex, int length) {
+    Preconditions.checkArgument(destination instanceof SimpleVectorWrapper);
+    Preconditions.checkArgument(getField().getType().equals(destination.getField().getType()));
+    vector.makeTransferPair(((SimpleVectorWrapper<?>)destination).vector).splitAndTransfer(startIndex, length);
+  }
+
+  @Override
   public String toString() {
     if (vector == null) {
       return "null";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -131,6 +131,16 @@ public class VectorContainer implements VectorAccessible {
     }
   }
 
+  /**
+   * Transfer vectors from this to containerOut
+   */
+  public void transferOut(VectorContainer containerOut, int startIndex, int length) {
+    Preconditions.checkArgument(this.wrappers.size() == containerOut.wrappers.size());
+    for (int i = 0; i < this.wrappers.size(); ++i) {
+      this.wrappers.get(i).transferPartial(containerOut.wrappers.get(i), startIndex, length);
+    }
+  }
+
   public <T extends ValueVector> T addOrGet(MaterializedField field) {
     return addOrGet(field, null);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorWrapper.java
@@ -35,6 +35,8 @@ public interface VectorWrapper<T extends ValueVector> {
   public VectorWrapper<T> cloneAndTransfer(BufferAllocator allocator);
   public VectorWrapper<?> getChildWrapper(int[] ids);
   public void transfer(VectorWrapper<?> destination);
+  public void transferPartial(VectorWrapper<?> destination, int startIndex, int length);
+
 
   /**
    * Traverse the object graph and determine whether the provided SchemaPath matches data within the Wrapper.  If so, return a TypedFieldId associated with this path.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -266,6 +266,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.CPU_LOAD_AVERAGE),
       new OptionDefinition(ExecConstants.ENABLE_VECTOR_VALIDATOR),
       new OptionDefinition(ExecConstants.ENABLE_ITERATOR_VALIDATOR),
+      new OptionDefinition(ExecConstants.EXCHANGE_BATCH_SIZE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
       new OptionDefinition(ExecConstants.OUTPUT_BATCH_SIZE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
       new OptionDefinition(ExecConstants.STATS_LOGGING_BATCH_SIZE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, true, true)),
       new OptionDefinition(ExecConstants.STATS_LOGGING_BATCH_FG_SIZE_VALIDATOR,new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, true, true)),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/BaseRawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/BaseRawBatchBuffer.java
@@ -36,11 +36,9 @@ public abstract class BaseRawBatchBuffer<T> implements RawBatchBuffer {
   }
 
   protected interface BufferQueue<T> {
-    void addOomBatch(RawFragmentBatch batch);
     RawFragmentBatch poll() throws IOException, InterruptedException;
     RawFragmentBatch take() throws IOException, InterruptedException;
     RawFragmentBatch poll(long timeout, TimeUnit timeUnit) throws InterruptedException, IOException;
-    boolean checkForOutOfMemory();
     int size();
     boolean isEmpty();
     void add(T obj);
@@ -56,7 +54,6 @@ public abstract class BaseRawBatchBuffer<T> implements RawBatchBuffer {
 
   public BaseRawBatchBuffer(final FragmentContext context, final int fragmentCount) {
     bufferSizePerSocket = context.getConfig().getInt(ExecConstants.INCOMING_BUFFER_SIZE);
-
     this.fragmentCount = fragmentCount;
     this.streamCounter = fragmentCount;
     this.context = context;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/SpoolingRawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/SpoolingRawBatchBuffer.java
@@ -95,13 +95,6 @@ public class SpoolingRawBatchBuffer extends BaseRawBatchBuffer<SpoolingRawBatchB
     private final LinkedBlockingDeque<RawFragmentBatchWrapper> buffer = Queues.newLinkedBlockingDeque();
 
     @Override
-    public void addOomBatch(RawFragmentBatch batch) {
-      RawFragmentBatchWrapper batchWrapper = new RawFragmentBatchWrapper(batch, true);
-      batchWrapper.setOutOfMemory(true);
-      buffer.addFirst(batchWrapper);
-    }
-
-    @Override
     public RawFragmentBatch poll() throws IOException, InterruptedException {
       RawFragmentBatchWrapper batchWrapper = buffer.poll();
       if (batchWrapper != null) {
@@ -122,11 +115,6 @@ public class SpoolingRawBatchBuffer extends BaseRawBatchBuffer<SpoolingRawBatchB
         return batchWrapper.get();
       }
       return null;
-    }
-
-    @Override
-    public boolean checkForOutOfMemory() {
-      return buffer.peek().isOutOfMemory();
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/UnlimitedRawBatchBuffer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/batch/UnlimitedRawBatchBuffer.java
@@ -30,23 +30,16 @@ public class UnlimitedRawBatchBuffer extends BaseRawBatchBuffer<RawFragmentBatch
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnlimitedRawBatchBuffer.class);
 
   private final int softlimit;
-  private final int startlimit;
 
   public UnlimitedRawBatchBuffer(FragmentContext context, int fragmentCount) {
     super(context, fragmentCount);
     this.softlimit = bufferSizePerSocket * fragmentCount;
-    this.startlimit = Math.max(softlimit/2, 1);
-    logger.trace("softLimit: {}, startLimit: {}", softlimit, startlimit);
+    logger.trace("softLimit: {}, startLimit: {}", softlimit);
     this.bufferQueue = new UnlimitedBufferQueue();
   }
 
   private class UnlimitedBufferQueue implements BufferQueue<RawFragmentBatch> {
     private final LinkedBlockingDeque<RawFragmentBatch> buffer = Queues.newLinkedBlockingDeque();
-
-    @Override
-    public void addOomBatch(RawFragmentBatch batch) {
-      buffer.addFirst(batch);
-    }
 
     @Override
     public RawFragmentBatch poll() throws IOException {
@@ -71,11 +64,6 @@ public class UnlimitedRawBatchBuffer extends BaseRawBatchBuffer<RawFragmentBatch
         batch.sendOk();
       }
       return batch;
-    }
-
-    @Override
-    public boolean checkForOutOfMemory() {
-      return context.getAllocator().isOverLimit();
     }
 
     @Override

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -474,6 +474,7 @@ drill.exec.options: {
     drill.exec.storage.implicit.fqn.column.label: "fqn",
     drill.exec.storage.implicit.suffix.column.label: "suffix",
     drill.exec.testing.controls: "{}",
+    drill.exec.memory.operator.exchange_batch_size : 1048576, # 512 KB (524288)
     drill.exec.memory.operator.output_batch_size : 16777216, # 16 MB
     drill.exec.memory.operator.output_batch_size_avail_mem_factor : 0.1,
     exec.bulk_load_table_list.bulk_size: 1000,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -273,6 +273,11 @@ public class MockRecordBatch implements CloseableRecordBatch {
   }
 
   @Override
+  public WritableBatch getWritableBatch(int start, int length) {
+    throw new UnsupportedOperationException("MockRecordBatch doesn't support gettingWritableBatch yet");
+  }
+
+  @Override
   public Iterator<VectorWrapper<?>> iterator() {
     return container.iterator();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestUnionExchange.java
@@ -18,16 +18,23 @@
 package org.apache.drill.exec.physical.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
 import org.apache.drill.categories.OperatorTest;
 import org.apache.drill.common.util.DrillFileUtils;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.pop.PopUnitTestBase;
+import org.apache.drill.exec.record.RecordBatchLoader;
+import org.apache.drill.exec.record.RecordBatchSizer;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
+import org.apache.drill.exec.vector.BigIntVector;
 import org.junit.Test;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
@@ -43,15 +50,15 @@ public class TestUnionExchange extends PopUnitTestBase {
     RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
 
     try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
-        Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
-        DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+         Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
       bit1.run();
       bit2.run();
       client.connect();
       List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-          Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/union_exchange.json"),
-              Charsets.UTF_8).read());
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/union_exchange.json"),
+                      Charsets.UTF_8).read());
       int count = 0;
       for (QueryDataBatch b : results) {
         if (b.getHeader().getRowCount() != 0) {
@@ -63,4 +70,76 @@ public class TestUnionExchange extends PopUnitTestBase {
     }
   }
 
+  // Test UnionExchange BatchSizing
+  @Test
+  public void twoBitUnionExchangeRunBatchSizing() throws Exception {
+    twoBitUnionExchangeRunBatchSizingImpl(64 * 1024);
+    twoBitUnionExchangeRunBatchSizingImpl(512 * 1024);
+    twoBitUnionExchangeRunBatchSizingImpl(1024 * 1024);
+  }
+
+  /**
+   * This function takes in the batchSizeLimit and configures two Drillbits with that batch limit.
+   * Then runs a plan that includes a UnionExchange over some mock data.
+   * The test checks for exchange batch size conformity and also checks the integrity of the exchanged data.
+   * @param batchSizeLimit
+   * @throws Exception
+   */
+  public void twoBitUnionExchangeRunBatchSizingImpl(int batchSizeLimit) throws Exception {
+    RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+    try (Drillbit bit1 = new Drillbit(CONFIG, serviceSet);
+         Drillbit bit2 = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+
+      bit1.run();
+      bit2.run();
+      client.connect();
+      bit1.getContext().getOptionManager().setLocalOption(ExecConstants.EXCHANGE_BATCH_SIZE, batchSizeLimit);
+      bit2.getContext().getOptionManager().setLocalOption(ExecConstants.EXCHANGE_BATCH_SIZE, batchSizeLimit);
+
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/sender/union_exchange_batch_sizing.json"),
+                      Charsets.UTF_8).read());
+      int count = 0;
+      final RecordBatchLoader loader = new RecordBatchLoader(client.getAllocator());
+      boolean even = true;
+      for (QueryDataBatch b : results) { //iterate over each incoming batch
+        int recordCount = b.getHeader().getRowCount();
+        if (recordCount != 0) {
+          // convert QueryDataBatch to a VectorContainer
+          loader.load(b.getHeader().getDef(), b.getData());
+          final VectorContainer container = loader.getContainer();
+          container.setRecordCount(recordCount);
+          // check if the size is within the batchSizeLimit
+          RecordBatchSizer recordBatchSizer = new RecordBatchSizer(container);
+          assertTrue(recordBatchSizer.getNetBatchSize() <= batchSizeLimit);
+          // get col 1 vector. This is a mocked BigInt, as defined in the json file.
+          // this col has Long.MIN_VALUE for even rows and Long.MAX_VALUE for odd rows
+          VectorWrapper wrapper = container.getValueVector(1);
+          BigIntVector bigIntVector = (BigIntVector) (wrapper.getValueVector());
+          for (int i = 0; i < recordCount; i++) {
+            long value = bigIntVector.getAccessor().get(i);
+            // row0 is guaranteed to be Long.MIN_VALUE (even) only in the original mock data
+            // batch splitting can cause row0 to be Long.MAX_VALUE, so it has to be checked
+            if (i == 0) {
+              even = (value == Long.MIN_VALUE);
+            }
+            // check if the values alternate
+            if (even) {
+              assertEquals(value, Long.MIN_VALUE);
+            } else {
+              assertEquals(value, Long.MAX_VALUE);
+            }
+            even = !even;
+          }
+          count += recordCount;
+          loader.clear();
+        }
+        b.release();
+      }
+      // check if total row count received is the same as the
+      // count in the mock definition
+      assertEquals(300000, count);
+    }
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/MockLateralJoinBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/MockLateralJoinBatch.java
@@ -153,6 +153,10 @@ public class MockLateralJoinBatch implements LateralContract, CloseableRecordBat
     return null;
   }
 
+  @Override public WritableBatch getWritableBatch(int start, int length) {
+    return null;
+  }
+
   public List<ValueVector> getResultList() {
     return resultList;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestSimpleExternalSort.java
@@ -45,7 +45,7 @@ import org.junit.rules.TestRule;
 @Category({SlowTest.class})
 public class TestSimpleExternalSort extends DrillTest {
   @Rule
-  public final TestRule TIMEOUT = TestTools.getTimeoutRule(160_000);
+  public final TestRule TIMEOUT = TestTools.getTimeoutRule(180_000);
 
   @Rule
   public final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
@@ -118,6 +118,11 @@ public class BloomFilterTest {
     }
 
     @Override
+    public WritableBatch getWritableBatch(int start, int length) {
+      return null;
+    }
+
+    @Override
     public Iterator<VectorWrapper<?>> iterator() {
       return null;
     }

--- a/exec/java-exec/src/test/resources/sender/union_exchange_batch_sizing.json
+++ b/exec/java-exec/src/test/resources/sender/union_exchange_batch_sizing.json
@@ -1,0 +1,32 @@
+{
+    head:{
+        type:"APACHE_DRILL_PHYSICAL",
+        version:"1",
+        generator:{
+            type:"manual"
+        }
+    },
+    graph:[
+        {
+            @id:1,
+            pop:"mock-scan",
+            url: "http://apache.org",
+            entries:[
+              {records: 300000, types: [
+                {name: "blue", type: "INT", mode: "REQUIRED"},
+                {name: "red", type: "BIGINT", mode: "REQUIRED"}
+              ]}
+            ]
+        },
+        {
+            @id: 2,
+            child: 1,
+            pop: "union-exchange"
+        },
+        {
+            @id: 3,
+            child: 2,
+            pop: "screen"
+        }
+    ]
+}


### PR DESCRIPTION
This PR contains changes for implementing batch sizing in SingleSender. The sizing is done by using the RecordBatchSizer. 