### PR TITLE
DRILL-7103: Incorrect conversion to integer in BsonRecordReader#writeTimeStamp

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/bson/BsonRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/bson/BsonRecordReader.java
@@ -255,7 +255,7 @@ public class BsonRecordReader {
     } else {
       t = writer.list.timeStamp();
     }
-    t.writeTimeStamp((int) (dateTime.withZoneRetainFields(org.joda.time.DateTimeZone.UTC).getMillis()));
+    t.writeTimeStamp(dateTime.withZoneRetainFields(org.joda.time.DateTimeZone.UTC).getMillis());
   }
 
   private void writeString(String readString, final MapOrListWriterImpl writer, String fieldName, boolean isList) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
@@ -75,17 +75,19 @@ public class TestBsonRecordReader {
     writer.reset();
     bsonReader.write(writer, new BsonDocumentReader(bsonDoc));
     SingleMapReaderImpl mapReader = (SingleMapReaderImpl) writer.getMapVector().getReader();
-    assertEquals(10l, mapReader.reader("seqNo").readLong().longValue());
+    assertEquals(10L, mapReader.reader("seqNo").readLong().longValue());
   }
 
   @Test
   public void testTimeStampType() throws IOException {
     BsonDocument bsonDoc = new BsonDocument();
-    bsonDoc.append("ts", new BsonTimestamp(1000, 10));
+    bsonDoc.append("ts_small", new BsonTimestamp(1000, 10));
+    bsonDoc.append("ts_large", new BsonTimestamp(1000000000, 10));
     writer.reset();
     bsonReader.write(writer, new BsonDocumentReader(bsonDoc));
     SingleMapReaderImpl mapReader = (SingleMapReaderImpl) writer.getMapVector().getReader();
-    assertEquals(1000000l, mapReader.reader("ts").readLocalDateTime().atZone(ZoneOffset.systemDefault()).toInstant().toEpochMilli());
+    assertEquals(1000000L, mapReader.reader("ts_small").readLocalDateTime().atZone(ZoneOffset.systemDefault()).toInstant().toEpochMilli());
+    assertEquals(1000000000000L, mapReader.reader("ts_large").readLocalDateTime().atZone(ZoneOffset.systemDefault()).toInstant().toEpochMilli());
   }
 
   @Test


### PR DESCRIPTION
Fix for DRILL-7103:
Incorrect conversion to integer in BsonRecordReader#writeTimeStamp