### PR TITLE
DRILL-7095: Expose table schema (TupleMetadata) to physical operator (EasySubScan)

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -972,4 +972,8 @@ public final class ExecConstants {
   public static final String NDV_BLOOM_FILTER_FPOS_PROB = "exec.statistics.ndv_extrapolation_bf_fpprobability";
   public static final LongValidator NDV_BLOOM_FILTER_FPOS_PROB_VALIDATOR = new PositiveLongValidator(NDV_BLOOM_FILTER_FPOS_PROB,
           100, new OptionDescription("Controls trade-off between NDV statistic computation memory cost and sampling extrapolation accuracy"));
+
+  public static final String STORE_TABLE_USE_SCHEMA_FILE = "store.table.use_schema_file";
+  public static final BooleanValidator STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR = new BooleanValidator(STORE_TABLE_USE_SCHEMA_FILE,
+    new OptionDescription("Controls if schema file stored in table root directory will be used during query execution. (Drill 1.16+)"));
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -450,6 +450,10 @@ public final class ExecConstants {
   public static final BooleanValidator JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR = new BooleanValidator(JSON_READER_ESCAPE_ANY_CHAR,
     new OptionDescription("Enables the JSON record reader in Drill to escape any character. Default is false. (Drill 1.16+)"));
 
+  public static final String STORE_TABLE_USE_SCHEMA_FILE = "store.table.use_schema_file";
+  public static final BooleanValidator STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR = new BooleanValidator(STORE_TABLE_USE_SCHEMA_FILE,
+    new OptionDescription("Controls if schema file stored in table root directory will be used during query execution. (Drill 1.16+)"));
+
   /**
    * The column label (for directory levels) in results when querying files in a directory
    * E.g.  labels: dir0   dir1<pre>
@@ -972,8 +976,4 @@ public final class ExecConstants {
   public static final String NDV_BLOOM_FILTER_FPOS_PROB = "exec.statistics.ndv_extrapolation_bf_fpprobability";
   public static final LongValidator NDV_BLOOM_FILTER_FPOS_PROB_VALIDATOR = new PositiveLongValidator(NDV_BLOOM_FILTER_FPOS_PROB,
           100, new OptionDescription("Controls trade-off between NDV statistic computation memory cost and sampling extrapolation accuracy"));
-
-  public static final String STORE_TABLE_USE_SCHEMA_FILE = "store.table.use_schema_file";
-  public static final BooleanValidator STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR = new BooleanValidator(STORE_TABLE_USE_SCHEMA_FILE,
-    new OptionDescription("Controls if schema file stored in table root directory will be used during query execution. (Drill 1.16+)"));
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -33,6 +33,7 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.planner.common.DrillStatsTable;
 import org.apache.drill.exec.physical.base.SchemalessScan;
 import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.dfs.FileSelection;
@@ -50,6 +51,7 @@ public abstract class DrillTable implements Table {
   private SessionOptionManager options;
   // Stores the statistics(rowcount, NDV etc.) associated with the table
   private DrillStatsTable statsTable;
+  private TupleMetadata schema;
 
   /**
    * Creates a DrillTable instance for a @{code TableType#Table} table.
@@ -94,6 +96,10 @@ public abstract class DrillTable implements Table {
     this.options = options;
   }
 
+  public void setSchema(TupleMetadata schema) {
+    this.schema = schema;
+  }
+
   public void setGroupScan(GroupScan scan) {
     this.scan = scan;
   }
@@ -103,7 +109,7 @@ public abstract class DrillTable implements Table {
       if (selection instanceof FileSelection && ((FileSelection) selection).isEmptyDirectory()) {
         this.scan = new SchemalessScan(userName, ((FileSelection) selection).getSelectionRoot());
       } else {
-        this.scan = plugin.getPhysicalScan(userName, new JSONOptions(selection), options);
+        this.scan = plugin.getPhysicalScan(userName, new JSONOptions(selection), options, schema);
       }
     }
     return scan;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -182,6 +182,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.JSON_WRITER_NAN_INF_NUMBERS_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR_VALIDATOR),
+      new OptionDefinition(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR),
       new OptionDefinition(ExecConstants.ENABLE_UNION_TYPE),
       new OptionDefinition(ExecConstants.TEXT_ESTIMATED_ROW_SIZE),
       new OptionDefinition(ExecConstants.JSON_EXTENDED_TYPES),
@@ -281,8 +282,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.NDV_BLOOM_FILTER_FPOS_PROB_VALIDATOR),
       new OptionDefinition(ExecConstants.RM_QUERY_TAGS_VALIDATOR,
         new OptionMetaData(OptionValue.AccessibleScopes.SESSION_AND_QUERY, false, false)),
-      new OptionDefinition(ExecConstants.RM_QUEUES_WAIT_FOR_PREFERRED_NODES_VALIDATOR),
-      new OptionDefinition(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR)
+      new OptionDefinition(ExecConstants.RM_QUEUES_WAIT_FOR_PREFERRED_NODES_VALIDATOR)
     };
 
     CaseInsensitiveMap<OptionDefinition> map = Arrays.stream(definitions)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -281,7 +281,8 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.NDV_BLOOM_FILTER_FPOS_PROB_VALIDATOR),
       new OptionDefinition(ExecConstants.RM_QUERY_TAGS_VALIDATOR,
         new OptionMetaData(OptionValue.AccessibleScopes.SESSION_AND_QUERY, false, false)),
-      new OptionDefinition(ExecConstants.RM_QUEUES_WAIT_FOR_PREFERRED_NODES_VALIDATOR)
+      new OptionDefinition(ExecConstants.RM_QUEUES_WAIT_FOR_PREFERRED_NODES_VALIDATOR),
+      new OptionDefinition(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR)
     };
 
     CaseInsensitiveMap<OptionDefinition> map = Arrays.stream(definitions)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.planner.PlannerPhase;
 
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SessionOptionManager;
@@ -106,10 +107,14 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
     }
   }
 
-
   @Override
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options) throws IOException {
     return getPhysicalScan(userName, selection);
+  }
+
+  @Override
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException {
+    return getPhysicalScan(userName, selection, options);
   }
 
   @Override
@@ -120,6 +125,11 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
   @Override
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options) throws IOException {
     return getPhysicalScan(userName, selection, columns);
+  }
+
+  @Override
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException {
+    return getPhysicalScan(userName, selection, columns, options);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -28,6 +28,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.dfs.FormatPlugin;
 
@@ -76,6 +77,17 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
    *
    * @param userName User whom to impersonate when when reading the contents as part of Scan.
    * @param selection The configured storage engine specific selection.
+   * @param options (optional) session options
+   * @param schema (optional) table schema
+   * @return The physical scan operator for the particular GroupScan (read) node.
+   */
+  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException;
+
+  /**
+   * Get the physical scan operator for the particular GroupScan (read) node.
+   *
+   * @param userName User whom to impersonate when when reading the contents as part of Scan.
+   * @param selection The configured storage engine specific selection.
    * @param columns (optional) The list of column names to scan from the data source.
    * @return The physical scan operator for the particular GroupScan (read) node.
   */
@@ -91,6 +103,18 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
    * @return The physical scan operator for the particular GroupScan (read) node.
    */
   AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options) throws IOException;
+
+  /**
+   * Get the physical scan operator for the particular GroupScan (read) node.
+   *
+   * @param userName User whom to impersonate when when reading the contents as part of Scan.
+   * @param selection The configured storage engine specific selection.
+   * @param columns (optional) The list of column names to scan from the data source.
+   * @param options (optional) session options
+   * @param schema (optional) table schema
+   * @return The physical scan operator for the particular GroupScan (read) node.
+   */
+  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException;
 
   /**
    * Method returns a Jackson serializable object that extends a StoragePluginConfig.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -35,6 +35,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
@@ -163,18 +164,24 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
 
   @Override
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options) throws IOException {
-    return getPhysicalScan(userName, selection, AbstractGroupScan.ALL_COLUMNS, options);
+    return getPhysicalScan(userName, selection, AbstractGroupScan.ALL_COLUMNS, options, null);
+  }
+
+  @Override
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException {
+    return getPhysicalScan(userName, selection, AbstractGroupScan.ALL_COLUMNS, options, schema);
   }
 
   @Override
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns) throws IOException {
-    return getPhysicalScan(userName, selection, columns, null);
+    return getPhysicalScan(userName, selection, columns, null, null);
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options) throws IOException {
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException {
     FormatSelection formatSelection = selection.getWith(lpPersistance, FormatSelection.class);
     FormatPlugin plugin = getFormatPlugin(formatSelection.getFormat());
+    plugin.setSchema(schema);
     return plugin.getGroupScan(userName, formatSelection.getSelection(), columns, options);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -181,8 +181,7 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException {
     FormatSelection formatSelection = selection.getWith(lpPersistance, FormatSelection.class);
     FormatPlugin plugin = getFormatPlugin(formatSelection.getFormat());
-    plugin.setSchema(schema);
-    return plugin.getGroupScan(userName, formatSelection.getSelection(), columns, options);
+    return plugin.getGroupScan(userName, formatSelection.getSelection(), columns, options, schema);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -63,6 +63,14 @@ public interface FormatPlugin {
     return getGroupScan(userName, selection, columns);
   }
 
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, TupleMetadata schema) throws IOException {
+    return getGroupScan(userName, selection, columns);
+  }
+
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options, TupleMetadata schema) throws IOException {
+    return getGroupScan(userName, selection, columns, options);
+  }
+
   boolean supportsStatistics();
 
   TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException;
@@ -74,18 +82,4 @@ public interface FormatPlugin {
   Configuration getFsConf();
   DrillbitContext getContext();
   String getName();
-
-  /**
-   * Sets table schema that will be used during data read.
-   *
-   * @param schema table schema
-   */
-  default void setSchema(TupleMetadata schema) { }
-
-  /**
-   * Returns table schema to be used during data read.
-   *
-   * @return table schema
-   */
-  default TupleMetadata getSchema() { return null; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.AbstractWriter;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
@@ -52,7 +53,7 @@ public interface FormatPlugin {
 
   FormatMatcher getMatcher();
 
-  public AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) throws IOException;
+  AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) throws IOException;
 
   Set<StoragePluginOptimizerRule> getOptimizerRules();
 
@@ -62,15 +63,29 @@ public interface FormatPlugin {
     return getGroupScan(userName, selection, columns);
   }
 
-  public boolean supportsStatistics();
+  boolean supportsStatistics();
 
-  public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException;
+  TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException;
 
-  public void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) throws IOException;
+  void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) throws IOException;
 
   FormatPluginConfig getConfig();
   StoragePluginConfig getStorageConfig();
   Configuration getFsConf();
   DrillbitContext getContext();
   String getName();
+
+  /**
+   * Sets table schema that will be used during data read.
+   *
+   * @param schema table schema
+   */
+  default void setSchema(TupleMetadata schema) { }
+
+  /**
+   * Returns table schema to be used during data read.
+   *
+   * @return table schema
+   */
+  default TupleMetadata getSchema() { return null; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -143,7 +143,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
 
       if (! columnExplorer.isStarQuery()) {
         scan = new EasySubScan(scan.getUserName(), scan.getWorkUnits(), scan.getFormatPlugin(),
-            columnExplorer.getTableColumns(), scan.getSelectionRoot(), scan.getPartitionDepth());
+            columnExplorer.getTableColumns(), scan.getSelectionRoot(), scan.getPartitionDepth(), scan.getSchema());
         scan.setOperatorId(scan.getOperatorId());
       }
 
@@ -296,8 +296,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
     }
 
     @Override
-    protected FileScanFramework buildFramework(
-        EasySubScan scan) throws ExecutionSetupException {
+    protected FileScanFramework buildFramework(EasySubScan scan) {
 
       final FileScanFramework framework = new FileScanFramework(
               scan.getColumns(),
@@ -471,14 +470,14 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   }
 
   @Override
-  public AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) throws IOException {
+  public AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) {
     return new EasyWriter(child, location, partitionColumns, this);
   }
 
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns)
       throws IOException {
-    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot);
+    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, null);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
@@ -45,6 +45,7 @@ public class EasySubScan extends AbstractSubScan {
   private final List<SchemaPath> columns;
   private final Path selectionRoot;
   private final int partitionDepth;
+  private final TupleMetadata schema;
 
   @JsonCreator
   public EasySubScan(
@@ -61,21 +62,22 @@ public class EasySubScan extends AbstractSubScan {
     super(userName);
     this.formatPlugin = (EasyFormatPlugin<?>) engineRegistry.getFormatPlugin(storageConfig, formatConfig);
     Preconditions.checkNotNull(this.formatPlugin);
-    this.formatPlugin.setSchema(schema);
     this.files = files;
     this.columns = columns;
     this.selectionRoot = selectionRoot;
     this.partitionDepth = partitionDepth;
+    this.schema = schema;
   }
 
   public EasySubScan(String userName, List<FileWorkImpl> files, EasyFormatPlugin<?> plugin,
-      List<SchemaPath> columns, Path selectionRoot, int partitionDepth) {
+      List<SchemaPath> columns, Path selectionRoot, int partitionDepth, TupleMetadata schema) {
     super(userName);
     this.formatPlugin = plugin;
     this.files = files;
     this.columns = columns;
     this.selectionRoot = selectionRoot;
     this.partitionDepth = partitionDepth;
+    this.schema = schema;
   }
 
   @JsonProperty
@@ -100,7 +102,7 @@ public class EasySubScan extends AbstractSubScan {
   public List<SchemaPath> getColumns() { return columns; }
 
   @JsonProperty("schema")
-  public TupleMetadata getSchema() { return formatPlugin.getSchema(); }
+  public TupleMetadata getSchema() { return schema; }
 
   @Override
   public int getOperatorType() { return formatPlugin.getReaderOperatorType(); }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
@@ -63,7 +63,7 @@ public class SequenceFileFormatPlugin extends EasyFormatPlugin<SequenceFileForma
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns)
     throws IOException {
-    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot);
+    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, null);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -190,8 +189,7 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
     }
 
     @Override
-    protected ColumnsScanFramework buildFramework(
-        EasySubScan scan) throws ExecutionSetupException {
+    protected ColumnsScanFramework buildFramework(EasySubScan scan) {
       ColumnsScanFramework framework = new ColumnsScanFramework(
               scan.getColumns(),
               scan.getWorkUnits(),
@@ -220,8 +218,6 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
     }
   }
 
-  private TupleMetadata schema;
-
   public TextFormatPlugin(String name, DrillbitContext context, Configuration fsConf, StoragePluginConfig storageConfig) {
      this(name, context, fsConf, storageConfig, new TextFormatConfig());
   }
@@ -247,14 +243,14 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
   }
 
   @Override
-  public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns)
+  public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, TupleMetadata schema)
       throws IOException {
     return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, schema);
   }
 
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection,
-      List<SchemaPath> columns, OptionManager options) throws IOException {
+      List<SchemaPath> columns, OptionManager options, TupleMetadata schema) throws IOException {
     return new EasyGroupScan(userName, selection, this, columns,
         selection.selectionRoot,
         // Some paths provide a null option manager. In that case, default to a
@@ -343,15 +339,5 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
     final double estimatedRowSize = settings.getOptions().getOption(ExecConstants.TEXT_ESTIMATED_ROW_SIZE);
     final double estRowCount = data / estimatedRowSize;
     return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, (long) estRowCount, 1, data);
-  }
-
-  @Override
-  public void setSchema(TupleMetadata schema) {
-    this.schema = schema;
-  }
-
-  @Override
-  public TupleMetadata getSchema() {
-    return schema;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
@@ -181,7 +181,7 @@ public class ParquetFormatPlugin implements FormatPlugin {
 
   @Override
   public AbstractFileGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns) throws IOException {
-    return getGroupScan(userName, selection, columns, null);
+    return getGroupScan(userName, selection, columns, (OptionManager) null);
   }
 
   @Override

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -683,5 +683,6 @@ drill.exec.options: {
     exec.query.return_result_set_for_ddl: true,
     # ========= rm related options ===========
     exec.rm.queryTags: "",
-    exec.rm.queues.wait_for_preferred_nodes: true
+    exec.rm.queues.wait_for_preferred_nodes: true,
+    store.table.use_schema_file: false
 }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -646,6 +646,7 @@ drill.exec.options: {
     # Using common operators batch configuration unless the Parquet specific
     # configuration is used
     store.parquet.flat.batch.memory_size: 0,
+    store.table.use_schema_file: false,
     store.partition.hash_distribute: false,
     store.text.estimated_row_size_bytes: 100.0,
     store.kafka.all_text_mode: false,
@@ -683,6 +684,5 @@ drill.exec.options: {
     exec.query.return_result_set_for_ddl: true,
     # ========= rm related options ===========
     exec.rm.queryTags: "",
-    exec.rm.queues.wait_for_preferred_nodes: true,
-    store.table.use_schema_file: false
+    exec.rm.queues.wait_for_preferred_nodes: true
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanningBase.java
@@ -61,6 +61,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.io.Resources;
 import org.mockito.Matchers;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -134,6 +135,7 @@ public class PlanningBase extends ExecTest {
         eq(TypeProtos.MinorType.VARDECIMAL),
         Matchers.<Function<DrillBuf, ValueHolder>>any()))
       .thenReturn(ValueHolderHelper.getVarDecimalHolder(allocator.buffer(4), "0.01"));
+    when(context.getOption(anyString())).thenCallRealMethod();
 
 
     for (final String sql : sqlStrings) {


### PR DESCRIPTION
1. Add system / session option `store.table.use_schema_file` to control if file schema can be used during query execution. False by default.
2. Added methods in StoragePlugin interface which allow to create Group Scan with provided table schema.
3. EasyGroupScan and EasySubScan now contain table schema, also they are able to serialize / deserialize it along with other scan properties.
4. DrillTable which is the main entry point for schema provisioning, has method to store schema and later uses it to create physical scan.
5. WorkspaceSchema when returning Drill table instance will get table schema from table root if available and if `store.table.use_schema_file` is set to true.

This PR is the next step for Schema Provisioning project which currently exposes schema only for text reader.

Jira: [DRILL-7095](https://issues.apache.org/jira/browse/DRILL-7095).