### PR TITLE
DRILL-7105: Error while building the Drill native client

### DIFF
--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1.3)
+
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(drillclient)
 cmake_policy(SET CMP0043 NEW)

--- a/contrib/native/client/readme.linux
+++ b/contrib/native/client/readme.linux
@@ -24,7 +24,7 @@ Install Prerequisites
 0) Install development tools
     $>yum groupinstall 'Development Tools'
 
-1) CMAKE 3.0
+1) CMAKE 3
     $> yum install cmake3
 
 2.1) Download protobuf 3.6 from :

--- a/contrib/native/client/readme.macos
+++ b/contrib/native/client/readme.macos
@@ -28,7 +28,7 @@ Install Prerequisites
 
 0.2) Install brew following the instructions here: http://brew.sh/
 
-1) CMAKE 3.0 or above
+1) CMAKE 3.1.3 or above
   Download and install Cmake : https://cmake.org/download/
   or use brew to install 
   $> brew install cmake


### PR DESCRIPTION
Added a compiler option in CMakeLists.txt to support the ISO C++ 2011 standard.
Also, changed the CMake min version to 3.1.3 to match the min version specified in protobuf.