### PR TITLE
DRILL-7110: Skip writing profile when an ALTER SESSION is executed

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -842,7 +842,10 @@ public final class ExecConstants {
    * for any query.
    */
   public static final String ENABLE_QUERY_PROFILE_OPTION = "exec.query_profile.save";
-  public static final BooleanValidator ENABLE_QUERY_PROFILE_VALIDATOR = new BooleanValidator(ENABLE_QUERY_PROFILE_OPTION, null);
+  public static final BooleanValidator ENABLE_QUERY_PROFILE_VALIDATOR = new BooleanValidator(ENABLE_QUERY_PROFILE_OPTION, new OptionDescription("Save completed profiles to the persistent store"));
+  //Allow to skip writing Alter Session profiles
+  public static final String SKIP_ALTER_SESSION_QUERY_PROFILE = "exec.query_profile.alter_session.skip";
+  public static final BooleanValidator SKIP_SESSION_QUERY_PROFILE_VALIDATOR = new BooleanValidator(SKIP_ALTER_SESSION_QUERY_PROFILE, new OptionDescription("Skip saving ALTER SESSION profiles"));
 
   /**
    * Profiles are normally written after the last client message to reduce latency.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -77,6 +77,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
   private final QueryContextInformation queryContextInfo;
   private final ViewExpansionContext viewExpansionContext;
   private final SchemaTreeProvider schemaTreeProvider;
+  private boolean skipProfileWrite;
   /** Stores constants and their holders by type */
   private final Map<String, Map<MinorType, ValueHolder>> constantValueHolderCache;
   private SqlStatementType stmtType;
@@ -92,6 +93,7 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     this.drillbitContext = drillbitContext;
     this.session = session;
     this.queryId = queryId;
+    this.skipProfileWrite = false;
     queryOptions = new QueryOptionManager(session.getOptions());
     executionControls = new ExecutionControls(queryOptions, drillbitContext.getEndpoint());
     plannerSettings = new PlannerSettings(queryOptions, getFunctionRegistry());
@@ -354,5 +356,20 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    */
   public SqlStatementType getSQLStatementType() {
     return stmtType;
+  }
+
+  /**
+   * Skip writing profile
+   * @param skipWriting
+   */
+  public void skipWritingProfile(boolean skipWriting) {
+    this.skipProfileWrite = skipWriting;
+  }
+
+  /**
+   * @return Check if to skip writing
+   */
+  public boolean isSkipProfileWrite() {
+    return skipProfileWrite;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SetOptionHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SetOptionHandler.java
@@ -63,6 +63,7 @@ public class SetOptionHandler extends AbstractSqlHandler {
           .build(logger);
     }
 
+    final QueryOptionManager options = context.getOptions();
     final String scope = option.getScope();
     final OptionValue.OptionScope optionScope;
     if (scope == null) { // No scope mentioned assumed SESSION
@@ -71,6 +72,11 @@ public class SetOptionHandler extends AbstractSqlHandler {
       switch (scope.toLowerCase()) {
       case "session":
         optionScope = OptionScope.SESSION;
+        // Skip writing profiles for "ALTER SESSION SET" queries
+        if (options.getBoolean(ExecConstants.SKIP_ALTER_SESSION_QUERY_PROFILE)) {
+          logger.debug("Will not write profile for ALTER SESSION SET ... ");
+          context.skipWritingProfile(true);
+        }
         break;
       case "system":
         optionScope = OptionScope.SYSTEM;
@@ -82,7 +88,6 @@ public class SetOptionHandler extends AbstractSqlHandler {
       }
     }
 
-    final QueryOptionManager options = context.getOptions();
     if (optionScope == OptionScope.SYSTEM) {
       // If the user authentication is enabled, make sure the user who is trying to change the system option has
       // administrative privileges.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -260,6 +260,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR,  new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
       new OptionDefinition(ExecConstants.EXTERNAL_SORT_DISABLE_MANAGED_OPTION),
       new OptionDefinition(ExecConstants.ENABLE_QUERY_PROFILE_VALIDATOR),
+      new OptionDefinition(ExecConstants.SKIP_SESSION_QUERY_PROFILE_VALIDATOR),
       new OptionDefinition(ExecConstants.QUERY_PROFILE_DEBUG_VALIDATOR),
       new OptionDefinition(ExecConstants.USE_DYNAMIC_UDFS),
       new OptionDefinition(ExecConstants.QUERY_TRANSIENT_STATE_UPDATE),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -785,8 +785,8 @@ public class Foreman implements Runnable {
 
       // Debug option: write query profile before sending final results so that
       // the client can be certain the profile exists.
-
-      if (profileOption == ProfileOption.SYNC) {
+      final boolean skipProfileWrite = queryContext.isSkipProfileWrite();
+      if (profileOption == ProfileOption.SYNC && !skipProfileWrite) {
         queryManager.writeFinalProfile(uex);
       }
 
@@ -816,7 +816,7 @@ public class Foreman implements Runnable {
       // storage write; query completion occurs in parallel with profile
       // persistence.
 
-      if (profileOption == ProfileOption.ASYNC) {
+      if (profileOption == ProfileOption.ASYNC && !skipProfileWrite) {
         queryManager.writeFinalProfile(uex);
       }
 
@@ -857,7 +857,7 @@ public class Foreman implements Runnable {
     @Override
     public void failed(final RpcException ex) {
       logger.info("Failure while trying communicate query result to initiating client. " +
-              "This would happen if a client is disconnected before response notice can be sent.", ex);
+          "This would happen if a client is disconnected before response notice can be sent.", ex);
     }
 
     @Override

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -510,6 +510,7 @@ drill.exec.options: {
     exec.query.progress.update: true,
     exec.query_profile.debug_mode: false,
     exec.query_profile.save: true,
+    exec.query_profile.alter_session.skip: true,
     exec.queue.enable: false,
     # Default queue values for an 8 GB direct memory default
     # Drill install. Users are expected to adjust these based


### PR DESCRIPTION
Allows (by default) for `ALTER SESSION SET <option>=<value>` queries to NOT be writen to the profile store. This would avoid the risk of potentially adding up to a lot of profiles being written unnecessarily, since those changes are also reflected on the queries that follow.