### PR TITLE
DRILL-7118: Filter not getting pushed down on MapR-DB tables.

### DIFF
--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/CompareFunctionsProcessor.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/CompareFunctionsProcessor.java
@@ -107,13 +107,13 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
     LogicalExpression nameArg = call.args.get(0);
     LogicalExpression valueArg = call.args.size() >= 2 ? call.args.get(1) : null;
 
-    if (valueArg != null) {
-      if (VALUE_EXPRESSION_CLASSES.contains(nameArg.getClass())) {
-        LogicalExpression swapArg = valueArg;
-        valueArg = nameArg;
-        nameArg = swapArg;
-        evaluator.functionName = COMPARE_FUNCTIONS_TRANSPOSE_MAP.get(functionName);
-      }
+    if (VALUE_EXPRESSION_CLASSES.contains(nameArg.getClass())) {
+      LogicalExpression swapArg = valueArg;
+      valueArg = nameArg;
+      nameArg = swapArg;
+      evaluator.functionName = COMPARE_FUNCTIONS_TRANSPOSE_MAP.get(functionName);
+    }
+    if (nameArg != null) {
       evaluator.success = nameArg.accept(evaluator, valueArg);
     }
 


### PR DESCRIPTION
The code changes here reverts back to the old behavior of pushing the predicate (is null) to the maprdb scan. The code is inadvertently removed during other changes that went in. 
The JIRA which changed the code in this file is DRILL-6969: Fix inconsistency of reading MaprDB JSON tables using hive

@amansinha100  please review this PR.