### PR TITLE
DRILL-7126: Contrib format-ltsv is not being included in distribution

### DIFF
--- a/contrib/format-ltsv/pom.xml
+++ b/contrib/format-ltsv/pom.xml
@@ -52,5 +52,30 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-java-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/org/apache/drill/exec/store/ltsv
+              </outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/java/org/apache/drill/exec/store/ltsv</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -289,6 +289,11 @@
           <artifactId>drill-format-syslog</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.drill.contrib</groupId>
+          <artifactId>drill-format-ltsv</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
     </profile>
 

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -41,6 +41,7 @@
         <include>org.apache.drill.contrib:drill-storage-hbase:jar</include>
         <include>org.apache.drill.contrib:drill-format-mapr:jar</include>
         <include>org.apache.drill.contrib:drill-format-syslog:jar</include>
+        <include>org.apache.drill.contrib:drill-format-ltsv:jar</include>
         <include>org.apache.drill.contrib:drill-jdbc-storage:jar</include>
         <include>org.apache.drill.contrib:drill-kudu-storage:jar</include>
         <include>org.apache.drill.contrib:drill-storage-kafka:jar</include>


### PR DESCRIPTION
With these changes, I'm now able to successfully add the `ltsv` format in the dfs storage plugin. 