### PR TITLE
DRILL-7127: Updating hbase version for mapr profile

### DIFF
--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -31,7 +31,7 @@
   <name>contrib/mapr-format-plugin</name>
 
   <properties>
-    <mapr-format-plugin.hbase.version>1.1.1-mapr-1602-m7-5.2.0</mapr-format-plugin.hbase.version>
+    <mapr-format-plugin.hbase.version>${hbase.version}</mapr-format-plugin.hbase.version>
     <mapr.TestSuite>**/MaprDBTestsSuite.class</mapr.TestSuite>
     <mapr.skip.tests>true</mapr.skip.tests>
   </properties>

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -31,7 +31,7 @@
   <name>contrib/mapr-format-plugin</name>
 
   <properties>
-    <mapr-format-plugin.hbase.version>${hbase.version}</mapr-format-plugin.hbase.version>
+    <mapr-format-plugin.hbase.version>1.1.8-mapr-1808</mapr-format-plugin.hbase.version>
     <mapr.TestSuite>**/MaprDBTestsSuite.class</mapr.TestSuite>
     <mapr.skip.tests>true</mapr.skip.tests>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2520,7 +2520,7 @@
         <alt-hadoop>mapr</alt-hadoop>
         <rat.excludeSubprojects>true</rat.excludeSubprojects>
         <hive.version>2.3.3-mapr-1808</hive.version>
-        <hbase.version>1.1.1-mapr-1602-m7-5.2.0</hbase.version>
+        <hbase.version>1.1.8-mapr-1808</hbase.version>
         <hadoop.version>2.7.0-mapr-1808</hadoop.version>
         <zookeeper.version>3.4.11-mapr-1808</zookeeper.version>
       </properties>


### PR DESCRIPTION
Current hbase version for mapr profile is 1.1.1-mapr-1602-m7-5.2.0 - which is over 3 years old. Needs to be updated to 1.1.8-mapr-1808