### PR TITLE
DRILL-7079: Drill can't query views from the S3 storage when plain authentication is enabled

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/dotdrill/DotDrillFile.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/dotdrill/DotDrillFile.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.dotdrill;
 
 import org.apache.drill.common.config.LogicalPlanPersistence;
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.hadoop.fs.FileStatus;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
@@ -55,6 +56,13 @@ public class DotDrillFile {
    * @return Return owner of the file in underlying file system.
    */
   public String getOwner() {
+    if (type == DotDrillType.VIEW && status.getOwner().isEmpty()) {
+      // Drill view S3AFileStatus is not populated with owner (it has default value of "").
+      // This empty String causes IllegalArgumentException to be thrown (if impersonation is enabled) in
+      // SchemaTreeProvider#createRootSchema(String, SchemaConfigInfoProvider). To work-around the issue
+      // we can return current user as if they were the owner of the file (since they have access to it).
+      return ImpersonationUtil.getProcessUserName();
+    }
     return status.getOwner();
   }
 


### PR DESCRIPTION
Please see [DRILL-7079](https://issues.apache.org/jira/browse/DRILL-7079) for more info.