### PR TITLE
DRILL-7048: Implement JDBC Statement.setMaxRows() with System Option

### DIFF
--- a/contrib/native/client/src/protobuf/User.pb.cc
+++ b/contrib/native/client/src/protobuf/User.pb.cc
@@ -1210,11 +1210,13 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::user::RunQuery, plan_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::user::RunQuery, fragments_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::user::RunQuery, prepared_statement_handle_),
-  2,
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::user::RunQuery, autolimit_rowcount_),
   3,
+  4,
   0,
   ~0u,
   1,
+  2,
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 7, sizeof(::exec::user::Property)},
@@ -1247,7 +1249,7 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 371, 378, sizeof(::exec::user::ConvertSupport)},
   { 380, 388, sizeof(::exec::user::GetServerMetaResp)},
   { 391, 446, sizeof(::exec::user::ServerMeta)},
-  { 496, 506, sizeof(::exec::user::RunQuery)},
+  { 496, 507, sizeof(::exec::user::RunQuery)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -1464,73 +1466,74 @@ void AddDescriptorsImpl() {
       "ySupport\022\030\n\020system_functions\030. \003(\t\022\022\n\nta"
       "ble_term\030/ \001(\t\022\035\n\025transaction_supported\030"
       "0 \001(\010\022.\n\runion_support\0301 \003(\0162\027.exec.user"
-      ".UnionSupport\022\026\n\016current_schema\0302 \001(\t\"\353\001"
+      ".UnionSupport\022\026\n\016current_schema\0302 \001(\t\"\207\002"
       "\n\010RunQuery\0221\n\014results_mode\030\001 \001(\0162\033.exec."
       "user.QueryResultsMode\022$\n\004type\030\002 \001(\0162\026.ex"
       "ec.shared.QueryType\022\014\n\004plan\030\003 \001(\t\0221\n\tfra"
       "gments\030\004 \003(\0132\036.exec.bit.control.PlanFrag"
       "ment\022E\n\031prepared_statement_handle\030\005 \001(\0132"
-      "\".exec.user.PreparedStatementHandle*\320\003\n\007"
-      "RpcType\022\r\n\tHANDSHAKE\020\000\022\007\n\003ACK\020\001\022\013\n\007GOODB"
-      "YE\020\002\022\r\n\tRUN_QUERY\020\003\022\020\n\014CANCEL_QUERY\020\004\022\023\n"
-      "\017REQUEST_RESULTS\020\005\022\027\n\023RESUME_PAUSED_QUER"
-      "Y\020\013\022\034\n\030GET_QUERY_PLAN_FRAGMENTS\020\014\022\020\n\014GET"
-      "_CATALOGS\020\016\022\017\n\013GET_SCHEMAS\020\017\022\016\n\nGET_TABL"
-      "ES\020\020\022\017\n\013GET_COLUMNS\020\021\022\035\n\031CREATE_PREPARED"
-      "_STATEMENT\020\026\022\023\n\017GET_SERVER_META\020\010\022\016\n\nQUE"
-      "RY_DATA\020\006\022\020\n\014QUERY_HANDLE\020\007\022\030\n\024QUERY_PLA"
-      "N_FRAGMENTS\020\r\022\014\n\010CATALOGS\020\022\022\013\n\007SCHEMAS\020\023"
-      "\022\n\n\006TABLES\020\024\022\013\n\007COLUMNS\020\025\022\026\n\022PREPARED_ST"
-      "ATEMENT\020\027\022\017\n\013SERVER_META\020\t\022\020\n\014QUERY_RESU"
-      "LT\020\n\022\020\n\014SASL_MESSAGE\020\030*H\n\013SaslSupport\022\030\n"
-      "\024UNKNOWN_SASL_SUPPORT\020\000\022\r\n\tSASL_AUTH\020\001\022\020"
-      "\n\014SASL_PRIVACY\020\002*#\n\020QueryResultsMode\022\017\n\013"
-      "STREAM_FULL\020\001*q\n\017HandshakeStatus\022\013\n\007SUCC"
-      "ESS\020\001\022\030\n\024RPC_VERSION_MISMATCH\020\002\022\017\n\013AUTH_"
-      "FAILED\020\003\022\023\n\017UNKNOWN_FAILURE\020\004\022\021\n\rAUTH_RE"
-      "QUIRED\020\005*D\n\rRequestStatus\022\022\n\016UNKNOWN_STA"
-      "TUS\020\000\022\006\n\002OK\020\001\022\n\n\006FAILED\020\002\022\013\n\007TIMEOUT\020\003*Y"
-      "\n\023ColumnSearchability\022\031\n\025UNKNOWN_SEARCHA"
-      "BILITY\020\000\022\010\n\004NONE\020\001\022\010\n\004CHAR\020\002\022\n\n\006NUMBER\020\003"
-      "\022\007\n\003ALL\020\004*K\n\022ColumnUpdatability\022\030\n\024UNKNO"
-      "WN_UPDATABILITY\020\000\022\r\n\tREAD_ONLY\020\001\022\014\n\010WRIT"
-      "ABLE\020\002*1\n\016CollateSupport\022\016\n\nCS_UNKNOWN\020\000"
-      "\022\017\n\013CS_GROUP_BY\020\001*J\n\027CorrelationNamesSup"
-      "port\022\013\n\007CN_NONE\020\001\022\026\n\022CN_DIFFERENT_NAMES\020"
-      "\002\022\n\n\006CN_ANY\020\003*\271\003\n\027DateTimeLiteralsSuppor"
-      "t\022\016\n\nDL_UNKNOWN\020\000\022\013\n\007DL_DATE\020\001\022\013\n\007DL_TIM"
-      "E\020\002\022\020\n\014DL_TIMESTAMP\020\003\022\024\n\020DL_INTERVAL_YEA"
-      "R\020\004\022\025\n\021DL_INTERVAL_MONTH\020\005\022\023\n\017DL_INTERVA"
-      "L_DAY\020\006\022\024\n\020DL_INTERVAL_HOUR\020\007\022\026\n\022DL_INTE"
-      "RVAL_MINUTE\020\010\022\026\n\022DL_INTERVAL_SECOND\020\t\022\035\n"
-      "\031DL_INTERVAL_YEAR_TO_MONTH\020\n\022\033\n\027DL_INTER"
-      "VAL_DAY_TO_HOUR\020\013\022\035\n\031DL_INTERVAL_DAY_TO_"
-      "MINUTE\020\014\022\035\n\031DL_INTERVAL_DAY_TO_SECOND\020\r\022"
-      "\036\n\032DL_INTERVAL_HOUR_TO_MINUTE\020\016\022\036\n\032DL_IN"
-      "TERVAL_HOUR_TO_SECOND\020\017\022 \n\034DL_INTERVAL_M"
-      "INUTE_TO_SECOND\020\020*Y\n\016GroupBySupport\022\013\n\007G"
-      "B_NONE\020\001\022\022\n\016GB_SELECT_ONLY\020\002\022\024\n\020GB_BEYON"
-      "D_SELECT\020\003\022\020\n\014GB_UNRELATED\020\004*x\n\020Identifi"
-      "erCasing\022\016\n\nIC_UNKNOWN\020\000\022\023\n\017IC_STORES_LO"
-      "WER\020\001\022\023\n\017IC_STORES_MIXED\020\002\022\023\n\017IC_STORES_"
-      "UPPER\020\003\022\025\n\021IC_SUPPORTS_MIXED\020\004*X\n\rNullCo"
-      "llation\022\016\n\nNC_UNKNOWN\020\000\022\017\n\013NC_AT_START\020\001"
-      "\022\r\n\tNC_AT_END\020\002\022\013\n\007NC_HIGH\020\003\022\n\n\006NC_LOW\020\004"
-      "*E\n\016OrderBySupport\022\016\n\nOB_UNKNOWN\020\000\022\020\n\014OB"
-      "_UNRELATED\020\001\022\021\n\rOB_EXPRESSION\020\002*\226\001\n\020Oute"
-      "rJoinSupport\022\016\n\nOJ_UNKNOWN\020\000\022\013\n\007OJ_LEFT\020"
-      "\001\022\014\n\010OJ_RIGHT\020\002\022\013\n\007OJ_FULL\020\003\022\r\n\tOJ_NESTE"
-      "D\020\004\022\022\n\016OJ_NOT_ORDERED\020\005\022\014\n\010OJ_INNER\020\006\022\031\n"
-      "\025OJ_ALL_COMPARISON_OPS\020\007*\204\001\n\017SubQuerySup"
-      "port\022\016\n\nSQ_UNKNOWN\020\000\022\021\n\rSQ_CORRELATED\020\001\022"
-      "\024\n\020SQ_IN_COMPARISON\020\002\022\020\n\014SQ_IN_EXISTS\020\003\022"
-      "\020\n\014SQ_IN_INSERT\020\004\022\024\n\020SQ_IN_QUANTIFIED\020\005*"
-      ";\n\014UnionSupport\022\r\n\tU_UNKNOWN\020\000\022\013\n\007U_UNIO"
-      "N\020\001\022\017\n\013U_UNION_ALL\020\002B+\n\033org.apache.drill"
-      ".exec.protoB\nUserProtosH\001"
+      "\".exec.user.PreparedStatementHandle\022\032\n\022a"
+      "utolimit_rowcount\030\006 \001(\005*\320\003\n\007RpcType\022\r\n\tH"
+      "ANDSHAKE\020\000\022\007\n\003ACK\020\001\022\013\n\007GOODBYE\020\002\022\r\n\tRUN_"
+      "QUERY\020\003\022\020\n\014CANCEL_QUERY\020\004\022\023\n\017REQUEST_RES"
+      "ULTS\020\005\022\027\n\023RESUME_PAUSED_QUERY\020\013\022\034\n\030GET_Q"
+      "UERY_PLAN_FRAGMENTS\020\014\022\020\n\014GET_CATALOGS\020\016\022"
+      "\017\n\013GET_SCHEMAS\020\017\022\016\n\nGET_TABLES\020\020\022\017\n\013GET_"
+      "COLUMNS\020\021\022\035\n\031CREATE_PREPARED_STATEMENT\020\026"
+      "\022\023\n\017GET_SERVER_META\020\010\022\016\n\nQUERY_DATA\020\006\022\020\n"
+      "\014QUERY_HANDLE\020\007\022\030\n\024QUERY_PLAN_FRAGMENTS\020"
+      "\r\022\014\n\010CATALOGS\020\022\022\013\n\007SCHEMAS\020\023\022\n\n\006TABLES\020\024"
+      "\022\013\n\007COLUMNS\020\025\022\026\n\022PREPARED_STATEMENT\020\027\022\017\n"
+      "\013SERVER_META\020\t\022\020\n\014QUERY_RESULT\020\n\022\020\n\014SASL"
+      "_MESSAGE\020\030*H\n\013SaslSupport\022\030\n\024UNKNOWN_SAS"
+      "L_SUPPORT\020\000\022\r\n\tSASL_AUTH\020\001\022\020\n\014SASL_PRIVA"
+      "CY\020\002*#\n\020QueryResultsMode\022\017\n\013STREAM_FULL\020"
+      "\001*q\n\017HandshakeStatus\022\013\n\007SUCCESS\020\001\022\030\n\024RPC"
+      "_VERSION_MISMATCH\020\002\022\017\n\013AUTH_FAILED\020\003\022\023\n\017"
+      "UNKNOWN_FAILURE\020\004\022\021\n\rAUTH_REQUIRED\020\005*D\n\r"
+      "RequestStatus\022\022\n\016UNKNOWN_STATUS\020\000\022\006\n\002OK\020"
+      "\001\022\n\n\006FAILED\020\002\022\013\n\007TIMEOUT\020\003*Y\n\023ColumnSear"
+      "chability\022\031\n\025UNKNOWN_SEARCHABILITY\020\000\022\010\n\004"
+      "NONE\020\001\022\010\n\004CHAR\020\002\022\n\n\006NUMBER\020\003\022\007\n\003ALL\020\004*K\n"
+      "\022ColumnUpdatability\022\030\n\024UNKNOWN_UPDATABIL"
+      "ITY\020\000\022\r\n\tREAD_ONLY\020\001\022\014\n\010WRITABLE\020\002*1\n\016Co"
+      "llateSupport\022\016\n\nCS_UNKNOWN\020\000\022\017\n\013CS_GROUP"
+      "_BY\020\001*J\n\027CorrelationNamesSupport\022\013\n\007CN_N"
+      "ONE\020\001\022\026\n\022CN_DIFFERENT_NAMES\020\002\022\n\n\006CN_ANY\020"
+      "\003*\271\003\n\027DateTimeLiteralsSupport\022\016\n\nDL_UNKN"
+      "OWN\020\000\022\013\n\007DL_DATE\020\001\022\013\n\007DL_TIME\020\002\022\020\n\014DL_TI"
+      "MESTAMP\020\003\022\024\n\020DL_INTERVAL_YEAR\020\004\022\025\n\021DL_IN"
+      "TERVAL_MONTH\020\005\022\023\n\017DL_INTERVAL_DAY\020\006\022\024\n\020D"
+      "L_INTERVAL_HOUR\020\007\022\026\n\022DL_INTERVAL_MINUTE\020"
+      "\010\022\026\n\022DL_INTERVAL_SECOND\020\t\022\035\n\031DL_INTERVAL"
+      "_YEAR_TO_MONTH\020\n\022\033\n\027DL_INTERVAL_DAY_TO_H"
+      "OUR\020\013\022\035\n\031DL_INTERVAL_DAY_TO_MINUTE\020\014\022\035\n\031"
+      "DL_INTERVAL_DAY_TO_SECOND\020\r\022\036\n\032DL_INTERV"
+      "AL_HOUR_TO_MINUTE\020\016\022\036\n\032DL_INTERVAL_HOUR_"
+      "TO_SECOND\020\017\022 \n\034DL_INTERVAL_MINUTE_TO_SEC"
+      "OND\020\020*Y\n\016GroupBySupport\022\013\n\007GB_NONE\020\001\022\022\n\016"
+      "GB_SELECT_ONLY\020\002\022\024\n\020GB_BEYOND_SELECT\020\003\022\020"
+      "\n\014GB_UNRELATED\020\004*x\n\020IdentifierCasing\022\016\n\n"
+      "IC_UNKNOWN\020\000\022\023\n\017IC_STORES_LOWER\020\001\022\023\n\017IC_"
+      "STORES_MIXED\020\002\022\023\n\017IC_STORES_UPPER\020\003\022\025\n\021I"
+      "C_SUPPORTS_MIXED\020\004*X\n\rNullCollation\022\016\n\nN"
+      "C_UNKNOWN\020\000\022\017\n\013NC_AT_START\020\001\022\r\n\tNC_AT_EN"
+      "D\020\002\022\013\n\007NC_HIGH\020\003\022\n\n\006NC_LOW\020\004*E\n\016OrderByS"
+      "upport\022\016\n\nOB_UNKNOWN\020\000\022\020\n\014OB_UNRELATED\020\001"
+      "\022\021\n\rOB_EXPRESSION\020\002*\226\001\n\020OuterJoinSupport"
+      "\022\016\n\nOJ_UNKNOWN\020\000\022\013\n\007OJ_LEFT\020\001\022\014\n\010OJ_RIGH"
+      "T\020\002\022\013\n\007OJ_FULL\020\003\022\r\n\tOJ_NESTED\020\004\022\022\n\016OJ_NO"
+      "T_ORDERED\020\005\022\014\n\010OJ_INNER\020\006\022\031\n\025OJ_ALL_COMP"
+      "ARISON_OPS\020\007*\204\001\n\017SubQuerySupport\022\016\n\nSQ_U"
+      "NKNOWN\020\000\022\021\n\rSQ_CORRELATED\020\001\022\024\n\020SQ_IN_COM"
+      "PARISON\020\002\022\020\n\014SQ_IN_EXISTS\020\003\022\020\n\014SQ_IN_INS"
+      "ERT\020\004\022\024\n\020SQ_IN_QUANTIFIED\020\005*;\n\014UnionSupp"
+      "ort\022\r\n\tU_UNKNOWN\020\000\022\013\n\007U_UNION\020\001\022\017\n\013U_UNI"
+      "ON_ALL\020\002B+\n\033org.apache.drill.exec.protoB"
+      "\nUserProtosH\001"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 8905);
+      descriptor, 8933);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "User.proto", &protobuf_RegisterTypes);
   ::protobuf_SchemaDef_2eproto::AddDescriptors();
@@ -16121,6 +16124,7 @@ const int RunQuery::kTypeFieldNumber;
 const int RunQuery::kPlanFieldNumber;
 const int RunQuery::kFragmentsFieldNumber;
 const int RunQuery::kPreparedStatementHandleFieldNumber;
+const int RunQuery::kAutolimitRowcountFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 RunQuery::RunQuery()
@@ -16145,15 +16149,17 @@ RunQuery::RunQuery(const RunQuery& from)
   } else {
     prepared_statement_handle_ = NULL;
   }
-  ::memcpy(&results_mode_, &from.results_mode_,
+  ::memcpy(&autolimit_rowcount_, &from.autolimit_rowcount_,
     static_cast<size_t>(reinterpret_cast<char*>(&type_) -
-    reinterpret_cast<char*>(&results_mode_)) + sizeof(type_));
+    reinterpret_cast<char*>(&autolimit_rowcount_)) + sizeof(type_));
   // @@protoc_insertion_point(copy_constructor:exec.user.RunQuery)
 }
 
 void RunQuery::SharedCtor() {
   plan_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  prepared_statement_handle_ = NULL;
+  ::memset(&prepared_statement_handle_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&autolimit_rowcount_) -
+      reinterpret_cast<char*>(&prepared_statement_handle_)) + sizeof(autolimit_rowcount_));
   results_mode_ = 1;
   type_ = 1;
 }
@@ -16190,7 +16196,7 @@ void RunQuery::Clear() {
 
   fragments_.Clear();
   cached_has_bits = _has_bits_[0];
-  if (cached_has_bits & 15u) {
+  if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
       plan_.ClearNonDefaultToEmptyNoArena();
     }
@@ -16198,6 +16204,9 @@ void RunQuery::Clear() {
       GOOGLE_DCHECK(prepared_statement_handle_ != NULL);
       prepared_statement_handle_->Clear();
     }
+  }
+  if (cached_has_bits & 28u) {
+    autolimit_rowcount_ = 0;
     results_mode_ = 1;
     type_ = 1;
   }
@@ -16295,6 +16304,20 @@ bool RunQuery::MergePartialFromCodedStream(
         break;
       }
 
+      // optional int32 autolimit_rowcount = 6;
+      case 6: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(48u /* 48 & 0xFF */)) {
+          set_has_autolimit_rowcount();
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &autolimit_rowcount_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -16323,13 +16346,13 @@ void RunQuery::SerializeWithCachedSizes(
 
   cached_has_bits = _has_bits_[0];
   // optional .exec.user.QueryResultsMode results_mode = 1;
-  if (cached_has_bits & 0x00000004u) {
+  if (cached_has_bits & 0x00000008u) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       1, this->results_mode(), output);
   }
 
   // optional .exec.shared.QueryType type = 2;
-  if (cached_has_bits & 0x00000008u) {
+  if (cached_has_bits & 0x00000010u) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       2, this->type(), output);
   }
@@ -16359,6 +16382,11 @@ void RunQuery::SerializeWithCachedSizes(
       5, this->_internal_prepared_statement_handle(), output);
   }
 
+  // optional int32 autolimit_rowcount = 6;
+  if (cached_has_bits & 0x00000004u) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(6, this->autolimit_rowcount(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         _internal_metadata_.unknown_fields(), output);
@@ -16375,13 +16403,13 @@ void RunQuery::SerializeWithCachedSizes(
 
   cached_has_bits = _has_bits_[0];
   // optional .exec.user.QueryResultsMode results_mode = 1;
-  if (cached_has_bits & 0x00000004u) {
+  if (cached_has_bits & 0x00000008u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       1, this->results_mode(), target);
   }
 
   // optional .exec.shared.QueryType type = 2;
-  if (cached_has_bits & 0x00000008u) {
+  if (cached_has_bits & 0x00000010u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       2, this->type(), target);
   }
@@ -16412,6 +16440,11 @@ void RunQuery::SerializeWithCachedSizes(
         5, this->_internal_prepared_statement_handle(), deterministic, target);
   }
 
+  // optional int32 autolimit_rowcount = 6;
+  if (cached_has_bits & 0x00000004u) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(6, this->autolimit_rowcount(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields(), target);
@@ -16440,7 +16473,7 @@ size_t RunQuery::ByteSizeLong() const {
     }
   }
 
-  if (_has_bits_[0 / 32] & 15u) {
+  if (_has_bits_[0 / 32] & 31u) {
     // optional string plan = 3;
     if (has_plan()) {
       total_size += 1 +
@@ -16453,6 +16486,13 @@ size_t RunQuery::ByteSizeLong() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSize(
           *prepared_statement_handle_);
+    }
+
+    // optional int32 autolimit_rowcount = 6;
+    if (has_autolimit_rowcount()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->autolimit_rowcount());
     }
 
     // optional .exec.user.QueryResultsMode results_mode = 1;
@@ -16497,7 +16537,7 @@ void RunQuery::MergeFrom(const RunQuery& from) {
 
   fragments_.MergeFrom(from.fragments_);
   cached_has_bits = from._has_bits_[0];
-  if (cached_has_bits & 15u) {
+  if (cached_has_bits & 31u) {
     if (cached_has_bits & 0x00000001u) {
       set_has_plan();
       plan_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.plan_);
@@ -16506,9 +16546,12 @@ void RunQuery::MergeFrom(const RunQuery& from) {
       mutable_prepared_statement_handle()->::exec::user::PreparedStatementHandle::MergeFrom(from.prepared_statement_handle());
     }
     if (cached_has_bits & 0x00000004u) {
-      results_mode_ = from.results_mode_;
+      autolimit_rowcount_ = from.autolimit_rowcount_;
     }
     if (cached_has_bits & 0x00000008u) {
+      results_mode_ = from.results_mode_;
+    }
+    if (cached_has_bits & 0x00000010u) {
       type_ = from.type_;
     }
     _has_bits_[0] |= cached_has_bits;
@@ -16543,6 +16586,7 @@ void RunQuery::InternalSwap(RunQuery* other) {
   plan_.Swap(&other->plan_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   swap(prepared_statement_handle_, other->prepared_statement_handle_);
+  swap(autolimit_rowcount_, other->autolimit_rowcount_);
   swap(results_mode_, other->results_mode_);
   swap(type_, other->type_);
   swap(_has_bits_[0], other->_has_bits_[0]);

--- a/contrib/native/client/src/protobuf/User.pb.h
+++ b/contrib/native/client/src/protobuf/User.pb.h
@@ -6197,6 +6197,13 @@ class RunQuery : public ::google::protobuf::Message /* @@protoc_insertion_point(
   ::exec::user::PreparedStatementHandle* mutable_prepared_statement_handle();
   void set_allocated_prepared_statement_handle(::exec::user::PreparedStatementHandle* prepared_statement_handle);
 
+  // optional int32 autolimit_rowcount = 6;
+  bool has_autolimit_rowcount() const;
+  void clear_autolimit_rowcount();
+  static const int kAutolimitRowcountFieldNumber = 6;
+  ::google::protobuf::int32 autolimit_rowcount() const;
+  void set_autolimit_rowcount(::google::protobuf::int32 value);
+
   // optional .exec.user.QueryResultsMode results_mode = 1;
   bool has_results_mode() const;
   void clear_results_mode();
@@ -6221,6 +6228,8 @@ class RunQuery : public ::google::protobuf::Message /* @@protoc_insertion_point(
   void clear_has_plan();
   void set_has_prepared_statement_handle();
   void clear_has_prepared_statement_handle();
+  void set_has_autolimit_rowcount();
+  void clear_has_autolimit_rowcount();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::HasBits<1> _has_bits_;
@@ -6228,6 +6237,7 @@ class RunQuery : public ::google::protobuf::Message /* @@protoc_insertion_point(
   ::google::protobuf::RepeatedPtrField< ::exec::bit::control::PlanFragment > fragments_;
   ::google::protobuf::internal::ArenaStringPtr plan_;
   ::exec::user::PreparedStatementHandle* prepared_statement_handle_;
+  ::google::protobuf::int32 autolimit_rowcount_;
   int results_mode_;
   int type_;
   friend struct ::protobuf_User_2eproto::TableStruct;
@@ -13771,13 +13781,13 @@ inline void ServerMeta::set_allocated_current_schema(::std::string* current_sche
 
 // optional .exec.user.QueryResultsMode results_mode = 1;
 inline bool RunQuery::has_results_mode() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void RunQuery::set_has_results_mode() {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void RunQuery::clear_has_results_mode() {
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void RunQuery::clear_results_mode() {
   results_mode_ = 1;
@@ -13796,13 +13806,13 @@ inline void RunQuery::set_results_mode(::exec::user::QueryResultsMode value) {
 
 // optional .exec.shared.QueryType type = 2;
 inline bool RunQuery::has_type() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void RunQuery::set_has_type() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void RunQuery::clear_has_type() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void RunQuery::clear_type() {
   type_ = 1;
@@ -13968,6 +13978,30 @@ inline void RunQuery::set_allocated_prepared_statement_handle(::exec::user::Prep
   }
   prepared_statement_handle_ = prepared_statement_handle;
   // @@protoc_insertion_point(field_set_allocated:exec.user.RunQuery.prepared_statement_handle)
+}
+
+// optional int32 autolimit_rowcount = 6;
+inline bool RunQuery::has_autolimit_rowcount() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void RunQuery::set_has_autolimit_rowcount() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void RunQuery::clear_has_autolimit_rowcount() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void RunQuery::clear_autolimit_rowcount() {
+  autolimit_rowcount_ = 0;
+  clear_has_autolimit_rowcount();
+}
+inline ::google::protobuf::int32 RunQuery::autolimit_rowcount() const {
+  // @@protoc_insertion_point(field_get:exec.user.RunQuery.autolimit_rowcount)
+  return autolimit_rowcount_;
+}
+inline void RunQuery::set_autolimit_rowcount(::google::protobuf::int32 value) {
+  set_has_autolimit_rowcount();
+  autolimit_rowcount_ = value;
+  // @@protoc_insertion_point(field_set:exec.user.RunQuery.autolimit_rowcount)
 }
 
 #ifdef __GNUC__

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -727,8 +727,9 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::QueryProfile, total_cost_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::QueryProfile, queue_name_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::QueryProfile, queryid_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::QueryProfile, autolimit_),
   10,
-  20,
+  21,
   12,
   13,
   0,
@@ -736,7 +737,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   11,
   14,
   15,
-  19,
+  16,
   ~0u,
   2,
   3,
@@ -744,11 +745,12 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   5,
   6,
   7,
-  16,
-  17,
   18,
+  19,
+  20,
   8,
   9,
+  17,
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::MajorFragmentProfile, _has_bits_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::exec::shared::MajorFragmentProfile, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -870,15 +872,15 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 124, 132, sizeof(::exec::shared::QueryResult)},
   { 135, 144, sizeof(::exec::shared::QueryData)},
   { 148, 161, sizeof(::exec::shared::QueryInfo)},
-  { 169, 196, sizeof(::exec::shared::QueryProfile)},
-  { 218, 225, sizeof(::exec::shared::MajorFragmentProfile)},
-  { 227, 243, sizeof(::exec::shared::MinorFragmentProfile)},
-  { 254, 267, sizeof(::exec::shared::OperatorProfile)},
-  { 275, 283, sizeof(::exec::shared::StreamProfile)},
-  { 286, 294, sizeof(::exec::shared::MetricValue)},
-  { 297, 303, sizeof(::exec::shared::Registry)},
-  { 304, 311, sizeof(::exec::shared::Jar)},
-  { 313, 321, sizeof(::exec::shared::SaslMessage)},
+  { 169, 197, sizeof(::exec::shared::QueryProfile)},
+  { 220, 227, sizeof(::exec::shared::MajorFragmentProfile)},
+  { 229, 245, sizeof(::exec::shared::MinorFragmentProfile)},
+  { 256, 269, sizeof(::exec::shared::OperatorProfile)},
+  { 277, 285, sizeof(::exec::shared::StreamProfile)},
+  { 288, 296, sizeof(::exec::shared::MetricValue)},
+  { 299, 305, sizeof(::exec::shared::Registry)},
+  { 306, 313, sizeof(::exec::shared::Jar)},
+  { 315, 323, sizeof(::exec::shared::SaslMessage)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -984,7 +986,7 @@ void AddDescriptorsImpl() {
       "ult.QueryState\022\017\n\004user\030\004 \001(\t:\001-\022\'\n\007forem"
       "an\030\005 \001(\0132\026.exec.DrillbitEndpoint\022\024\n\014opti"
       "ons_json\030\006 \001(\t\022\022\n\ntotal_cost\030\007 \001(\001\022\025\n\nqu"
-      "eue_name\030\010 \001(\t:\001-\"\263\004\n\014QueryProfile\022 \n\002id"
+      "eue_name\030\010 \001(\t:\001-\"\306\004\n\014QueryProfile\022 \n\002id"
       "\030\001 \001(\0132\024.exec.shared.QueryId\022$\n\004type\030\002 \001"
       "(\0162\026.exec.shared.QueryType\022\r\n\005start\030\003 \001("
       "\003\022\013\n\003end\030\004 \001(\003\022\r\n\005query\030\005 \001(\t\022\014\n\004plan\030\006 "
@@ -998,79 +1000,80 @@ void AddDescriptorsImpl() {
       "(\t\022\022\n\nerror_node\030\020 \001(\t\022\024\n\014options_json\030\021"
       " \001(\t\022\017\n\007planEnd\030\022 \001(\003\022\024\n\014queueWaitEnd\030\023 "
       "\001(\003\022\022\n\ntotal_cost\030\024 \001(\001\022\025\n\nqueue_name\030\025 "
-      "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\"t\n\024MajorFragment"
-      "Profile\022\031\n\021major_fragment_id\030\001 \001(\005\022A\n\026mi"
-      "nor_fragment_profile\030\002 \003(\0132!.exec.shared"
-      ".MinorFragmentProfile\"\350\002\n\024MinorFragmentP"
-      "rofile\022)\n\005state\030\001 \001(\0162\032.exec.shared.Frag"
-      "mentState\022(\n\005error\030\002 \001(\0132\031.exec.shared.D"
-      "rillPBError\022\031\n\021minor_fragment_id\030\003 \001(\005\0226"
-      "\n\020operator_profile\030\004 \003(\0132\034.exec.shared.O"
-      "peratorProfile\022\022\n\nstart_time\030\005 \001(\003\022\020\n\010en"
-      "d_time\030\006 \001(\003\022\023\n\013memory_used\030\007 \001(\003\022\027\n\017max"
-      "_memory_used\030\010 \001(\003\022(\n\010endpoint\030\t \001(\0132\026.e"
-      "xec.DrillbitEndpoint\022\023\n\013last_update\030\n \001("
-      "\003\022\025\n\rlast_progress\030\013 \001(\003\"\377\001\n\017OperatorPro"
-      "file\0221\n\rinput_profile\030\001 \003(\0132\032.exec.share"
-      "d.StreamProfile\022\023\n\013operator_id\030\003 \001(\005\022\025\n\r"
-      "operator_type\030\004 \001(\005\022\023\n\013setup_nanos\030\005 \001(\003"
-      "\022\025\n\rprocess_nanos\030\006 \001(\003\022#\n\033peak_local_me"
-      "mory_allocated\030\007 \001(\003\022(\n\006metric\030\010 \003(\0132\030.e"
-      "xec.shared.MetricValue\022\022\n\nwait_nanos\030\t \001"
-      "(\003\"B\n\rStreamProfile\022\017\n\007records\030\001 \001(\003\022\017\n\007"
-      "batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001(\003\"J\n\013Metric"
-      "Value\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nlong_value\030\002"
-      " \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n\010Registry\022\035"
-      "\n\003jar\030\001 \003(\0132\020.exec.shared.Jar\"/\n\003Jar\022\014\n\004"
-      "name\030\001 \001(\t\022\032\n\022function_signature\030\002 \003(\t\"W"
-      "\n\013SaslMessage\022\021\n\tmechanism\030\001 \001(\t\022\014\n\004data"
-      "\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec.shared.Sas"
-      "lStatus*5\n\nRpcChannel\022\017\n\013BIT_CONTROL\020\000\022\014"
-      "\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQueryType\022\007\n\003S"
-      "QL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL\020\003\022\r\n\tEXECU"
-      "TION\020\004\022\026\n\022PREPARED_STATEMENT\020\005*\207\001\n\rFragm"
-      "entState\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALLOCA"
-      "TION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\tCAN"
-      "CELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_REQ"
-      "UESTED\020\006*\374\t\n\020CoreOperatorType\022\021\n\rSINGLE_"
-      "SENDER\020\000\022\024\n\020BROADCAST_SENDER\020\001\022\n\n\006FILTER"
-      "\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n\tHASH_JOIN\020\004\022\016\n"
-      "\nMERGE_JOIN\020\005\022\031\n\025HASH_PARTITION_SENDER\020\006"
-      "\022\t\n\005LIMIT\020\007\022\024\n\020MERGING_RECEIVER\020\010\022\034\n\030ORD"
-      "ERED_PARTITION_SENDER\020\t\022\013\n\007PROJECT\020\n\022\026\n\022"
-      "UNORDERED_RECEIVER\020\013\022\032\n\026RANGE_PARTITION_"
-      "SENDER\020\014\022\n\n\006SCREEN\020\r\022\034\n\030SELECTION_VECTOR"
-      "_REMOVER\020\016\022\027\n\023STREAMING_AGGREGATE\020\017\022\016\n\nT"
-      "OP_N_SORT\020\020\022\021\n\rEXTERNAL_SORT\020\021\022\t\n\005TRACE\020"
-      "\022\022\t\n\005UNION\020\023\022\014\n\010OLD_SORT\020\024\022\032\n\026PARQUET_RO"
-      "W_GROUP_SCAN\020\025\022\021\n\rHIVE_SUB_SCAN\020\026\022\025\n\021SYS"
-      "TEM_TABLE_SCAN\020\027\022\021\n\rMOCK_SUB_SCAN\020\030\022\022\n\016P"
-      "ARQUET_WRITER\020\031\022\023\n\017DIRECT_SUB_SCAN\020\032\022\017\n\013"
-      "TEXT_WRITER\020\033\022\021\n\rTEXT_SUB_SCAN\020\034\022\021\n\rJSON"
-      "_SUB_SCAN\020\035\022\030\n\024INFO_SCHEMA_SUB_SCAN\020\036\022\023\n"
-      "\017COMPLEX_TO_JSON\020\037\022\025\n\021PRODUCER_CONSUMER\020"
-      " \022\022\n\016HBASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024\n\020NES"
-      "TED_LOOP_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$\022\021\n\rPC"
-      "AP_SUB_SCAN\020%\022\022\n\016KAFKA_SUB_SCAN\020&\022\021\n\rKUD"
-      "U_SUB_SCAN\020\'\022\013\n\007FLATTEN\020(\022\020\n\014LATERAL_JOI"
-      "N\020)\022\n\n\006UNNEST\020*\022,\n(HIVE_DRILL_NATIVE_PAR"
-      "QUET_ROW_GROUP_SCAN\020+\022\r\n\tJDBC_SCAN\020,\022\022\n\016"
-      "REGEX_SUB_SCAN\020-\022\023\n\017MAPRDB_SUB_SCAN\020.\022\022\n"
-      "\016MONGO_SUB_SCAN\020/\022\017\n\013KUDU_WRITER\0200\022\026\n\022OP"
-      "EN_TSDB_SUB_SCAN\0201\022\017\n\013JSON_WRITER\0202\022\026\n\022H"
-      "TPPD_LOG_SUB_SCAN\0203\022\022\n\016IMAGE_SUB_SCAN\0204\022"
-      "\025\n\021SEQUENCE_SUB_SCAN\0205\022\023\n\017PARTITION_LIMI"
-      "T\0206\022\023\n\017PCAPNG_SUB_SCAN\0207\022\022\n\016RUNTIME_FILT"
-      "ER\0208\022\017\n\013ROWKEY_JOIN\0209\022\023\n\017SYSLOG_SUB_SCAN"
-      "\020:\022\030\n\024STATISTICS_AGGREGATE\020;\022\020\n\014UNPIVOT_"
-      "MAPS\020<\022\024\n\020STATISTICS_MERGE\020=\022\021\n\rLTSV_SUB"
-      "_SCAN\020>*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022"
-      "\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n"
-      "\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org."
-      "apache.drill.exec.protoB\rUserBitSharedH\001"
+      "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\022\021\n\tautoLimit\030\027 \001"
+      "(\005\"t\n\024MajorFragmentProfile\022\031\n\021major_frag"
+      "ment_id\030\001 \001(\005\022A\n\026minor_fragment_profile\030"
+      "\002 \003(\0132!.exec.shared.MinorFragmentProfile"
+      "\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030\001 \001(\016"
+      "2\032.exec.shared.FragmentState\022(\n\005error\030\002 "
+      "\001(\0132\031.exec.shared.DrillPBError\022\031\n\021minor_"
+      "fragment_id\030\003 \001(\005\0226\n\020operator_profile\030\004 "
+      "\003(\0132\034.exec.shared.OperatorProfile\022\022\n\nsta"
+      "rt_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013memor"
+      "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n"
+      "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022"
+      "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 "
+      "\001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_profile"
+      "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op"
+      "erator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 \001(\005\022\023"
+      "\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001"
+      "(\003\022#\n\033peak_local_memory_allocated\030\007 \001(\003\022"
+      "(\n\006metric\030\010 \003(\0132\030.exec.shared.MetricValu"
+      "e\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProfile\022\017"
+      "\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007sche"
+      "mas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 "
+      "\001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_value\030"
+      "\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.sh"
+      "ared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022functio"
+      "n_signature\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmech"
+      "anism\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001("
+      "\0162\027.exec.shared.SaslStatus*5\n\nRpcChannel"
+      "\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020"
+      "\002*V\n\tQueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010"
+      "PHYSICAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_ST"
+      "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000"
+      "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014"
+      "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022"
+      "\032\n\026CANCELLATION_REQUESTED\020\006*\374\t\n\020CoreOper"
+      "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST"
+      "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020"
+      "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH"
+      "_PARTITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGIN"
+      "G_RECEIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER"
+      "\020\t\022\013\n\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022"
+      "\032\n\026RANGE_PARTITION_SENDER\020\014\022\n\n\006SCREEN\020\r\022"
+      "\034\n\030SELECTION_VECTOR_REMOVER\020\016\022\027\n\023STREAMI"
+      "NG_AGGREGATE\020\017\022\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERN"
+      "AL_SORT\020\021\022\t\n\005TRACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_S"
+      "ORT\020\024\022\032\n\026PARQUET_ROW_GROUP_SCAN\020\025\022\021\n\rHIV"
+      "E_SUB_SCAN\020\026\022\025\n\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rM"
+      "OCK_SUB_SCAN\020\030\022\022\n\016PARQUET_WRITER\020\031\022\023\n\017DI"
+      "RECT_SUB_SCAN\020\032\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT"
+      "_SUB_SCAN\020\034\022\021\n\rJSON_SUB_SCAN\020\035\022\030\n\024INFO_S"
+      "CHEMA_SUB_SCAN\020\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n"
+      "\021PRODUCER_CONSUMER\020 \022\022\n\016HBASE_SUB_SCAN\020!"
+      "\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOOP_JOIN\020#\022\021\n\rAV"
+      "RO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFK"
+      "A_SUB_SCAN\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATT"
+      "EN\020(\022\020\n\014LATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HI"
+      "VE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN\020+"
+      "\022\r\n\tJDBC_SCAN\020,\022\022\n\016REGEX_SUB_SCAN\020-\022\023\n\017M"
+      "APRDB_SUB_SCAN\020.\022\022\n\016MONGO_SUB_SCAN\020/\022\017\n\013"
+      "KUDU_WRITER\0200\022\026\n\022OPEN_TSDB_SUB_SCAN\0201\022\017\n"
+      "\013JSON_WRITER\0202\022\026\n\022HTPPD_LOG_SUB_SCAN\0203\022\022"
+      "\n\016IMAGE_SUB_SCAN\0204\022\025\n\021SEQUENCE_SUB_SCAN\020"
+      "5\022\023\n\017PARTITION_LIMIT\0206\022\023\n\017PCAPNG_SUB_SCA"
+      "N\0207\022\022\n\016RUNTIME_FILTER\0208\022\017\n\013ROWKEY_JOIN\0209"
+      "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR"
+      "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_"
+      "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>*g\n\nSaslStatus"
+      "\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SA"
+      "SL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SA"
+      "SL_FAILED\020\004B.\n\033org.apache.drill.exec.pro"
+      "toB\rUserBitSharedH\001"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 5640);
+      descriptor, 5659);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "UserBitShared.proto", &protobuf_RegisterTypes);
   ::protobuf_Types_2eproto::AddDescriptors();
@@ -6423,6 +6426,7 @@ const int QueryProfile::kQueueWaitEndFieldNumber;
 const int QueryProfile::kTotalCostFieldNumber;
 const int QueryProfile::kQueueNameFieldNumber;
 const int QueryProfile::kQueryIdFieldNumber;
+const int QueryProfile::kAutoLimitFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 QueryProfile::QueryProfile()
@@ -6506,8 +6510,8 @@ void QueryProfile::SharedCtor() {
   queue_name_.UnsafeSetDefault(&::exec::shared::QueryProfile::_i_give_permission_to_break_this_code_default_queue_name_.get());
   queryid_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   ::memset(&id_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&finished_fragments_) -
-      reinterpret_cast<char*>(&id_)) + sizeof(finished_fragments_));
+      reinterpret_cast<char*>(&total_cost_) -
+      reinterpret_cast<char*>(&id_)) + sizeof(total_cost_));
   type_ = 1;
 }
 
@@ -6600,10 +6604,10 @@ void QueryProfile::Clear() {
         reinterpret_cast<char*>(&total_fragments_) -
         reinterpret_cast<char*>(&start_)) + sizeof(total_fragments_));
   }
-  if (cached_has_bits & 2031616u) {
-    ::memset(&planend_, 0, static_cast<size_t>(
-        reinterpret_cast<char*>(&finished_fragments_) -
-        reinterpret_cast<char*>(&planend_)) + sizeof(finished_fragments_));
+  if (cached_has_bits & 4128768u) {
+    ::memset(&finished_fragments_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&total_cost_) -
+        reinterpret_cast<char*>(&finished_fragments_)) + sizeof(total_cost_));
     type_ = 1;
   }
   _has_bits_.Clear();
@@ -6954,6 +6958,20 @@ bool QueryProfile::MergePartialFromCodedStream(
         break;
       }
 
+      // optional int32 autoLimit = 23;
+      case 23: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(184u /* 184 & 0xFF */)) {
+          set_has_autolimit();
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &autolimit_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -6988,7 +7006,7 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional .exec.shared.QueryType type = 2;
-  if (cached_has_bits & 0x00100000u) {
+  if (cached_has_bits & 0x00200000u) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       2, this->type(), output);
   }
@@ -7041,7 +7059,7 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional int32 finished_fragments = 10;
-  if (cached_has_bits & 0x00080000u) {
+  if (cached_has_bits & 0x00010000u) {
     ::google::protobuf::internal::WireFormatLite::WriteInt32(10, this->finished_fragments(), output);
   }
 
@@ -7115,17 +7133,17 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional int64 planEnd = 18;
-  if (cached_has_bits & 0x00010000u) {
+  if (cached_has_bits & 0x00040000u) {
     ::google::protobuf::internal::WireFormatLite::WriteInt64(18, this->planend(), output);
   }
 
   // optional int64 queueWaitEnd = 19;
-  if (cached_has_bits & 0x00020000u) {
+  if (cached_has_bits & 0x00080000u) {
     ::google::protobuf::internal::WireFormatLite::WriteInt64(19, this->queuewaitend(), output);
   }
 
   // optional double total_cost = 20;
-  if (cached_has_bits & 0x00040000u) {
+  if (cached_has_bits & 0x00100000u) {
     ::google::protobuf::internal::WireFormatLite::WriteDouble(20, this->total_cost(), output);
   }
 
@@ -7147,6 +7165,11 @@ void QueryProfile::SerializeWithCachedSizes(
       "exec.shared.QueryProfile.queryId");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       22, this->queryid(), output);
+  }
+
+  // optional int32 autoLimit = 23;
+  if (cached_has_bits & 0x00020000u) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(23, this->autolimit(), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7172,7 +7195,7 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional .exec.shared.QueryType type = 2;
-  if (cached_has_bits & 0x00100000u) {
+  if (cached_has_bits & 0x00200000u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       2, this->type(), target);
   }
@@ -7228,7 +7251,7 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional int32 finished_fragments = 10;
-  if (cached_has_bits & 0x00080000u) {
+  if (cached_has_bits & 0x00010000u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(10, this->finished_fragments(), target);
   }
 
@@ -7307,17 +7330,17 @@ void QueryProfile::SerializeWithCachedSizes(
   }
 
   // optional int64 planEnd = 18;
-  if (cached_has_bits & 0x00010000u) {
+  if (cached_has_bits & 0x00040000u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(18, this->planend(), target);
   }
 
   // optional int64 queueWaitEnd = 19;
-  if (cached_has_bits & 0x00020000u) {
+  if (cached_has_bits & 0x00080000u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(19, this->queuewaitend(), target);
   }
 
   // optional double total_cost = 20;
-  if (cached_has_bits & 0x00040000u) {
+  if (cached_has_bits & 0x00100000u) {
     target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(20, this->total_cost(), target);
   }
 
@@ -7341,6 +7364,11 @@ void QueryProfile::SerializeWithCachedSizes(
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         22, this->queryid(), target);
+  }
+
+  // optional int32 autoLimit = 23;
+  if (cached_has_bits & 0x00020000u) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(23, this->autolimit(), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -7486,7 +7514,21 @@ size_t QueryProfile::ByteSizeLong() const {
     }
 
   }
-  if (_has_bits_[16 / 32] & 2031616u) {
+  if (_has_bits_[16 / 32] & 4128768u) {
+    // optional int32 finished_fragments = 10;
+    if (has_finished_fragments()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->finished_fragments());
+    }
+
+    // optional int32 autoLimit = 23;
+    if (has_autolimit()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->autolimit());
+    }
+
     // optional int64 planEnd = 18;
     if (has_planend()) {
       total_size += 2 +
@@ -7504,13 +7546,6 @@ size_t QueryProfile::ByteSizeLong() const {
     // optional double total_cost = 20;
     if (has_total_cost()) {
       total_size += 2 + 8;
-    }
-
-    // optional int32 finished_fragments = 10;
-    if (has_finished_fragments()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->finished_fragments());
     }
 
     // optional .exec.shared.QueryType type = 2;
@@ -7612,20 +7647,23 @@ void QueryProfile::MergeFrom(const QueryProfile& from) {
     }
     _has_bits_[0] |= cached_has_bits;
   }
-  if (cached_has_bits & 2031616u) {
+  if (cached_has_bits & 4128768u) {
     if (cached_has_bits & 0x00010000u) {
-      planend_ = from.planend_;
-    }
-    if (cached_has_bits & 0x00020000u) {
-      queuewaitend_ = from.queuewaitend_;
-    }
-    if (cached_has_bits & 0x00040000u) {
-      total_cost_ = from.total_cost_;
-    }
-    if (cached_has_bits & 0x00080000u) {
       finished_fragments_ = from.finished_fragments_;
     }
+    if (cached_has_bits & 0x00020000u) {
+      autolimit_ = from.autolimit_;
+    }
+    if (cached_has_bits & 0x00040000u) {
+      planend_ = from.planend_;
+    }
+    if (cached_has_bits & 0x00080000u) {
+      queuewaitend_ = from.queuewaitend_;
+    }
     if (cached_has_bits & 0x00100000u) {
+      total_cost_ = from.total_cost_;
+    }
+    if (cached_has_bits & 0x00200000u) {
       type_ = from.type_;
     }
     _has_bits_[0] |= cached_has_bits;
@@ -7683,10 +7721,11 @@ void QueryProfile::InternalSwap(QueryProfile* other) {
   swap(end_, other->end_);
   swap(state_, other->state_);
   swap(total_fragments_, other->total_fragments_);
+  swap(finished_fragments_, other->finished_fragments_);
+  swap(autolimit_, other->autolimit_);
   swap(planend_, other->planend_);
   swap(queuewaitend_, other->queuewaitend_);
   swap(total_cost_, other->total_cost_);
-  swap(finished_fragments_, other->finished_fragments_);
   swap(type_, other->type_);
   swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -2865,6 +2865,20 @@ class QueryProfile : public ::google::protobuf::Message /* @@protoc_insertion_po
   ::google::protobuf::int32 total_fragments() const;
   void set_total_fragments(::google::protobuf::int32 value);
 
+  // optional int32 finished_fragments = 10;
+  bool has_finished_fragments() const;
+  void clear_finished_fragments();
+  static const int kFinishedFragmentsFieldNumber = 10;
+  ::google::protobuf::int32 finished_fragments() const;
+  void set_finished_fragments(::google::protobuf::int32 value);
+
+  // optional int32 autoLimit = 23;
+  bool has_autolimit() const;
+  void clear_autolimit();
+  static const int kAutoLimitFieldNumber = 23;
+  ::google::protobuf::int32 autolimit() const;
+  void set_autolimit(::google::protobuf::int32 value);
+
   // optional int64 planEnd = 18;
   bool has_planend() const;
   void clear_planend();
@@ -2885,13 +2899,6 @@ class QueryProfile : public ::google::protobuf::Message /* @@protoc_insertion_po
   static const int kTotalCostFieldNumber = 20;
   double total_cost() const;
   void set_total_cost(double value);
-
-  // optional int32 finished_fragments = 10;
-  bool has_finished_fragments() const;
-  void clear_finished_fragments();
-  static const int kFinishedFragmentsFieldNumber = 10;
-  ::google::protobuf::int32 finished_fragments() const;
-  void set_finished_fragments(::google::protobuf::int32 value);
 
   // optional .exec.shared.QueryType type = 2;
   bool has_type() const;
@@ -2944,6 +2951,8 @@ class QueryProfile : public ::google::protobuf::Message /* @@protoc_insertion_po
   void clear_has_queue_name();
   void set_has_queryid();
   void clear_has_queryid();
+  void set_has_autolimit();
+  void clear_has_autolimit();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::HasBits<1> _has_bits_;
@@ -2971,10 +2980,11 @@ class QueryProfile : public ::google::protobuf::Message /* @@protoc_insertion_po
   ::google::protobuf::int64 end_;
   int state_;
   ::google::protobuf::int32 total_fragments_;
+  ::google::protobuf::int32 finished_fragments_;
+  ::google::protobuf::int32 autolimit_;
   ::google::protobuf::int64 planend_;
   ::google::protobuf::int64 queuewaitend_;
   double total_cost_;
-  ::google::protobuf::int32 finished_fragments_;
   int type_;
   friend struct ::protobuf_UserBitShared_2eproto::TableStruct;
 };
@@ -6481,13 +6491,13 @@ inline void QueryProfile::set_allocated_id(::exec::shared::QueryId* id) {
 
 // optional .exec.shared.QueryType type = 2;
 inline bool QueryProfile::has_type() const {
-  return (_has_bits_[0] & 0x00100000u) != 0;
+  return (_has_bits_[0] & 0x00200000u) != 0;
 }
 inline void QueryProfile::set_has_type() {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
 }
 inline void QueryProfile::clear_has_type() {
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 inline void QueryProfile::clear_type() {
   type_ = 1;
@@ -6789,13 +6799,13 @@ inline void QueryProfile::set_total_fragments(::google::protobuf::int32 value) {
 
 // optional int32 finished_fragments = 10;
 inline bool QueryProfile::has_finished_fragments() const {
-  return (_has_bits_[0] & 0x00080000u) != 0;
+  return (_has_bits_[0] & 0x00010000u) != 0;
 }
 inline void QueryProfile::set_has_finished_fragments() {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00010000u;
 }
 inline void QueryProfile::clear_has_finished_fragments() {
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 inline void QueryProfile::clear_finished_fragments() {
   finished_fragments_ = 0;
@@ -7239,13 +7249,13 @@ inline void QueryProfile::set_allocated_options_json(::std::string* options_json
 
 // optional int64 planEnd = 18;
 inline bool QueryProfile::has_planend() const {
-  return (_has_bits_[0] & 0x00010000u) != 0;
+  return (_has_bits_[0] & 0x00040000u) != 0;
 }
 inline void QueryProfile::set_has_planend() {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00040000u;
 }
 inline void QueryProfile::clear_has_planend() {
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 inline void QueryProfile::clear_planend() {
   planend_ = GOOGLE_LONGLONG(0);
@@ -7263,13 +7273,13 @@ inline void QueryProfile::set_planend(::google::protobuf::int64 value) {
 
 // optional int64 queueWaitEnd = 19;
 inline bool QueryProfile::has_queuewaitend() const {
-  return (_has_bits_[0] & 0x00020000u) != 0;
+  return (_has_bits_[0] & 0x00080000u) != 0;
 }
 inline void QueryProfile::set_has_queuewaitend() {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00080000u;
 }
 inline void QueryProfile::clear_has_queuewaitend() {
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 inline void QueryProfile::clear_queuewaitend() {
   queuewaitend_ = GOOGLE_LONGLONG(0);
@@ -7287,13 +7297,13 @@ inline void QueryProfile::set_queuewaitend(::google::protobuf::int64 value) {
 
 // optional double total_cost = 20;
 inline bool QueryProfile::has_total_cost() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
+  return (_has_bits_[0] & 0x00100000u) != 0;
 }
 inline void QueryProfile::set_has_total_cost() {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00100000u;
 }
 inline void QueryProfile::clear_has_total_cost() {
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 inline void QueryProfile::clear_total_cost() {
   total_cost_ = 0;
@@ -7439,6 +7449,30 @@ inline void QueryProfile::set_allocated_queryid(::std::string* queryid) {
   }
   queryid_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), queryid);
   // @@protoc_insertion_point(field_set_allocated:exec.shared.QueryProfile.queryId)
+}
+
+// optional int32 autoLimit = 23;
+inline bool QueryProfile::has_autolimit() const {
+  return (_has_bits_[0] & 0x00020000u) != 0;
+}
+inline void QueryProfile::set_has_autolimit() {
+  _has_bits_[0] |= 0x00020000u;
+}
+inline void QueryProfile::clear_has_autolimit() {
+  _has_bits_[0] &= ~0x00020000u;
+}
+inline void QueryProfile::clear_autolimit() {
+  autolimit_ = 0;
+  clear_has_autolimit();
+}
+inline ::google::protobuf::int32 QueryProfile::autolimit() const {
+  // @@protoc_insertion_point(field_get:exec.shared.QueryProfile.autoLimit)
+  return autolimit_;
+}
+inline void QueryProfile::set_autolimit(::google::protobuf::int32 value) {
+  set_has_autolimit();
+  autolimit_ = value;
+  // @@protoc_insertion_point(field_set:exec.shared.QueryProfile.autoLimit)
 }
 
 // -------------------------------------------------------------------

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -987,4 +987,12 @@ public final class ExecConstants {
   public static final LongValidator TDIGEST_COMPRESSION_VALIDATOR = new PositiveLongValidator(TDIGEST_COMPRESSION, 10000,
     new OptionDescription("Controls trade-off between t-digest quantile statistic storage cost and accuracy. " +
       "Higher values use more groups (clusters) for the t-digest and improve accuracy at the expense of extra storage. "));
+
+  /**
+   * Options that have a JDBC Statement implementation already in place
+   */
+  public static final String QUERY_MAX_ROWS = "exec.query.max_rows";
+  public static final RangeLongValidator QUERY_MAX_ROWS_VALIDATOR = new RangeLongValidator(QUERY_MAX_ROWS, 0, Integer.MAX_VALUE,
+      new OptionDescription("The maximum number of rows that the query will return. This can be only set at a SYSTEM level by an admin. (Drill 1.16+)"));
+
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -281,10 +281,10 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.DETERMINISTIC_SAMPLING_VALIDATOR),
       new OptionDefinition(ExecConstants.NDV_BLOOM_FILTER_ELEMENTS_VALIDATOR),
       new OptionDefinition(ExecConstants.NDV_BLOOM_FILTER_FPOS_PROB_VALIDATOR),
-      new OptionDefinition(ExecConstants.RM_QUERY_TAGS_VALIDATOR,
-        new OptionMetaData(OptionValue.AccessibleScopes.SESSION_AND_QUERY, false, false)),
+      new OptionDefinition(ExecConstants.RM_QUERY_TAGS_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SESSION_AND_QUERY, false, false)),
       new OptionDefinition(ExecConstants.RM_QUEUES_WAIT_FOR_PREFERRED_NODES_VALIDATOR),
-      new OptionDefinition(ExecConstants.TDIGEST_COMPRESSION_VALIDATOR)
+      new OptionDefinition(ExecConstants.TDIGEST_COMPRESSION_VALIDATOR),
+      new OptionDefinition(ExecConstants.QUERY_MAX_ROWS_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.ALL, true, false))
     };
 
     CaseInsensitiveMap<OptionDefinition> map = Arrays.stream(definitions)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
@@ -68,6 +68,8 @@ public class WebUserConnection extends AbstractDisposableUserClientConnection im
 
   public final List<String> metadata = new ArrayList<>();
 
+  private int autoLimitRowCount;
+
   WebUserConnection(WebSessionResources webSessionResources) {
     this.webSessionResources = webSessionResources;
   }
@@ -195,5 +197,21 @@ public class WebUserConnection extends AbstractDisposableUserClientConnection im
     public void cleanupSession() {
       webSessionResources.close();
     }
+  }
+
+  /**
+   * Sets an autolimit on the size of records to be sent back on the connection
+   * @param autoLimitRowCount Max number of records to be sent back to WebServer
+   */
+  void setAutoLimitRowCount(int autoLimitRowCount) {
+    this.autoLimitRowCount = autoLimitRowCount;
+  }
+
+  /**
+   * Gets the max size of records to be sent back by the query
+   * @return Max number of records to be sent back to WebServer
+   */
+  public int getAutoLimitRowCount() {
+    return this.autoLimitRowCount;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -64,10 +64,12 @@ public class ProfileWrapper {
   private final boolean onlyImpersonationEnabled;
   private Map<String, String> physicalOperatorMap;
   private final String noProgressWarningThreshold;
+  private final int defaultAutoLimit;
 
   public ProfileWrapper(final QueryProfile profile, DrillConfig drillConfig) {
     this.profile = profile;
     this.id = profile.hasQueryId() ? profile.getQueryId() : QueryIdHelper.getQueryId(profile.getId());
+    this.defaultAutoLimit = drillConfig.getInt(ExecConstants.HTTP_WEB_CLIENT_RESULTSET_AUTOLIMIT_ROWS);
     //Generating Operator Name map (DRILL-6140)
     String profileTextPlan = profile.hasPlan()? profile.getPlan(): "";
     generateOpMap(profileTextPlan);
@@ -148,6 +150,18 @@ public class ProfileWrapper {
       globalProcessNanos += processNanos;
     }
     return globalProcessNanos;
+  }
+
+  public boolean hasAutoLimit() {
+    return profile.hasAutoLimit();
+  }
+
+  public int getAutoLimit() {
+    return profile.getAutoLimit();
+  }
+
+  public int getDefaultAutoLimit() {
+    return defaultAutoLimit;
   }
 
   public boolean hasError() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -143,6 +143,11 @@ public class Foreman implements Runnable {
     this.closeFuture = initiatingClient.getChannelClosureFuture();
     closeFuture.addListener(closeListener);
 
+    // Apply AutoLimit on resultSet (Usually received via REST APIs)
+    final int autoLimit = queryRequest.getAutolimitRowcount();
+    if (autoLimit > 0) {
+      connection.getSession().getOptions().setLocalOption(ExecConstants.QUERY_MAX_ROWS, autoLimit);
+    }
     this.queryContext = new QueryContext(connection.getSession(), drillbitContext, queryId);
     this.queryManager = new QueryManager(queryId, queryRequest, drillbitContext.getStoreProvider(),
         drillbitContext.getClusterCoordinator(), this);
@@ -239,7 +244,7 @@ public class Foreman implements Runnable {
     try {
       /*
        Check if the foreman is ONLINE. If not don't accept any new queries.
-      */
+       */
       if (!drillbitContext.isForemanOnline()) {
         throw new ForemanException("Query submission failed since Foreman is shutting down.");
       }
@@ -504,7 +509,7 @@ public class Foreman implements Runnable {
     } catch (Exception e) {
       queryStateProcessor.moveToState(QueryState.FAILED, e);
     } finally {
-       /*
+      /*
        * Begin accepting external events.
        *
        * Doing this here in the finally clause will guarantee that it occurs. Otherwise, if there

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/QueryManager.java
@@ -377,6 +377,12 @@ public class QueryManager implements AutoCloseable {
       profileBuilder.setQuery(queryText);
     }
 
+    int autoLimitRowCount = foreman.getQueryContext().getOptions().getOption(ExecConstants.QUERY_MAX_ROWS).num_val.intValue();
+    if (autoLimitRowCount > 0) {
+      profileBuilder.setAutoLimit(autoLimitRowCount);
+      logger.debug("The query's resultset was limited to {} rows", autoLimitRowCount);
+    }
+
     fragmentDataMap.forEach(new OuterIter(profileBuilder));
 
     return profileBuilder.build();

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -675,7 +675,8 @@ drill.exec.options: {
     planner.index.prefer_intersect_plans: false,
     planner.index.max_indexes_to_intersect: 5,
     exec.query.rowkeyjoin_batchsize: 128,
-    exec.query.return_result_set_for_ddl: true
+    exec.query.return_result_set_for_ddl: true,
+    exec.query.max_rows: 0,
     exec.return_result_set_for_ddl: true,
     storage.list_files_recursively: false,
     exec.statistics.ndv_accuracy: 20,

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -114,8 +114,16 @@
     </#if>
   </ul>
   <div id="query-content" class="tab-content">
-    <div id="query-query" class="tab-pane">
-      <p><pre id="query-text" name="query-text"  style="background-color: #f5f5f5;">${model.getProfile().query}</pre></p>
+    <div id="query-query" class="tab-pane" style="background-color: #ffffff">
+      <p><pre id="query-text" name="query-text"  style="background-color: #f5f5f5; font-family:courier,monospace">${model.getProfile().query}</pre></p>
+      <#if model.hasAutoLimit()>
+          <div name="autoLimitWarning" style="cursor:help" class="panel panel-warning" title="WebUI Queries allow restricting the number of rows returned to avoid the server to hold excessive number of results rows in memory.&#10;This helps maintain server stability with faster response if the entire resultset will not be visualized in the browser">
+            <div class="panel-heading">
+            <span class="glyphicon glyphicon-pushpin" style="font-size:125%"></span>
+            <b>WARNING:</b> Query result was <b>automatically</b> limited to <span style="font-style:italic;font-weight:bold">${model.getAutoLimit()} rows</span>
+            </div>
+          </div>
+      </#if>
     </div>
     <div id="query-physical" class="tab-pane">
       <p><pre>${model.profile.plan}</pre></p>
@@ -162,9 +170,12 @@
               </label>
             </div>
             </div>
-            <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
+            <div>
+              <button class="btn btn-default" type="button" id="rerunButton" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
             Re-run query
-            </button>
+              </button>
+              <input type="checkbox" name="forceLimit" value="limit" <#if model.hasAutoLimit()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="<#if model.hasAutoLimit()>${model.getAutoLimit()?c}<#else>${model.getDefaultAutoLimit()?c}</#if>" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
+            </div>
           </form>
       </p>
 
@@ -178,6 +189,7 @@
         </div>
       </form>
         </p>
+       <#include "*/runningQuery.ftl">
     </div>
     <#if model.hasError()>
       <div id="query-error" class="tab-pane fade">
@@ -388,6 +400,14 @@
       </div>
       <div id="operator-overview" class="panel-collapse collapse">
         <div class="panel-body">
+      <#if model.hasAutoLimit()>
+          <div name="autoLimitWarning" style="cursor:help" class="panel panel-warning" title="WebUI Queries allow restricting the number of rows returned to avoid the server to hold excessive number of results rows in memory.&#10;This helps maintain server stability with faster response if the entire resultset will not be visualized in the browser">
+            <div class="panel-heading">
+            <span class="glyphicon glyphicon-pushpin" style="font-size:125%"></span>
+            <b>WARNING:</b> Query result was <b>automatically</b> limited to <span style="font-style:italic;font-weight:bold">${model.getAutoLimit()} rows</span>
+            </div>
+          </div>
+      </#if>
           <div id="spillToDiskWarning" style="display:none;cursor:help" class="panel panel-warning" title="Spills occur because a buffered operator didn't get enough memory to hold data in memory. Increase the memory or ensure that number of spills &lt; 2">
             <div class="panel-heading"><span class="glyphicon glyphicon-alert" style="font-size:125%">&#xe209;</span> <b>WARNING:</b> Some operators have data spilled to disk. This will result in performance loss. (See <span style="font-style:italic;font-weight:bold">Avg Peak Memory</span> and <span style="font-style:italic;font-weight:bold">Max Peak Memory</span> below)
             <button type="button" class="close" onclick="closeWarning('spillToDiskWarning')" style="font-size:180%">&times;</button>
@@ -494,11 +514,10 @@
     viewer.setTheme("ace/theme/sqlserver");
     //CSS Formatting
     document.getElementById('query-query').style.fontSize='13px';
-    document.getElementById('query-query').style.fontFamily='courier';
+    document.getElementById('query-query').style.fontFamily='courier,monospace';
     document.getElementById('query-query').style.lineHeight='1.5';
     document.getElementById('query-query').style.width='98%';
     document.getElementById('query-query').style.margin='auto';
-    document.getElementById('query-query').style.backgroundColor='#f5f5f5';
     viewer.resize();
     viewer.setReadOnly(true);
     viewer.setOptions({
@@ -531,7 +550,7 @@
     editor.$blockScrolling = "Infinity";
     //CSS Formatting
     document.getElementById('query-editor').style.fontSize='13px';
-    document.getElementById('query-editor').style.fontFamily='courier';
+    document.getElementById('query-editor').style.fontFamily='courier,monospace';
     document.getElementById('query-editor').style.lineHeight='1.5';
     document.getElementById('query-editor').style.width='98%';
     document.getElementById('query-editor').style.margin='auto';

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -34,7 +34,7 @@
 <#macro page_body>
   <div class="page-header">
   </div>
-  <div id="message" class="alert alert-info alert-dismissable" style="font-family: Courier;">
+  <div id="message" class="alert alert-info alert-dismissable" style="font-family: courier,monospace;">
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
     Sample SQL query: <strong>SELECT * FROM cp.`employee.json` LIMIT 20</strong>
   </div>
@@ -82,8 +82,7 @@
     <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
       Submit
     </button>
-    <!--  DISABLED: See DRILL-7061 (PR #1689) -->
-    <!--input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="queryLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" onclick="alert('Limits the number of records retrieved in the query')" style="cursor:pointer"></span -->
+    <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
   </form>
 
   <script>

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -90,7 +90,11 @@
         "lengthMenu": [[${model.getRowsPerPageValues()},-1], [${model.getRowsPerPageValues()},"ALL"]],
         "lengthChange": true,
         "dom": '<"H"lCfr>t<"F"ip>',
-        "jQueryUI" : true
+        "jQueryUI" : true,
+        "language": {
+              "infoEmpty": "No records to show <#if model.isResultSetAutoLimited()> [NOTE: Results are auto-limited to max ${model.getAutoLimitedRowCount()} rows]</#if>",
+              "info": "Showing _START_ to _END_ of _TOTAL_ entries <#if model.isResultSetAutoLimited()>[<b>NOTE:</b> Results are auto-limited to max ${model.getAutoLimitedRowCount()} rows]</#if>"
+        }
       } );
     } );
 

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -59,25 +59,23 @@ function doSubmitQueryWithAutoLimit() {
         $("#query").focus();
         return;
     }
-    /** DISABLED : See DRILL-7061 (PR #1689)
     //Wrap if required
     let mustWrapWithLimit = $('input[name="forceLimit"]:checked').length > 0;
     //Clear field when submitting if not mustWrapWithLimit
     if (!mustWrapWithLimit) {
       //Wipe out any numeric entry in the field before
-      $('#queryLimit').attr('value', '');
+      $('#autoLimit').attr('value', '');
     } else {
-      let autoLimitValue=document.getElementById('queryLimit').value;
+      let autoLimitValue=document.getElementById('autoLimit').value;
       let positiveIntRegex = new RegExp("^[1-9]\\d*$");
-      let isValidRowCount = positiveIntRegex.test(autoLimitValue);
+      let isValidRowCount = positiveIntRegex.test(autoLimitValue.trim());
       if (!isValidRowCount) {
-        let alertValues = {'_autoLimitValue_': autoLimitValue };
+        let alertValues = {'_autoLimitValue_': autoLimitValue.trim() };
         populateAndShowAlert("invalidRowCount", alertValues);
-        $('#queryLimit').focus();
+        $('#autoLimit').focus();
         return;
       }
     }
-    */
     //Submit query
     submitQuery();
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillPreparedStatement.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/DrillPreparedStatement.java
@@ -31,5 +31,4 @@ import java.sql.PreparedStatement;
  * @see #unwrap
  */
 public interface DrillPreparedStatement extends PreparedStatement {
-
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
@@ -361,6 +361,9 @@ public class DrillCursor implements Cursor {
             ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
     resultsListener = new ResultsListener(this, batchQueueThrottlingThreshold);
     currentBatchHolder = new RecordBatchLoader(client.getAllocator());
+
+    // Set Query Timeout
+    logger.debug("Setting timeout as {}", this.statement.getQueryTimeout());
     setTimeout(this.statement.getQueryTimeout());
   }
 

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillPreparedStatementImpl.java
@@ -21,11 +21,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLType;
+import java.sql.Statement;
 
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.AvaticaPreparedStatement;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.Meta.StatementHandle;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserProtos.PreparedStatement;
 import org.apache.drill.jdbc.AlreadyClosedSqlException;
 import org.apache.drill.jdbc.DrillPreparedStatement;
@@ -258,5 +260,13 @@ abstract class DrillPreparedStatementImpl extends AvaticaPreparedStatement
   public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
     checkOpen();
     super.setObject(parameterIndex, x, targetSqlType);
+  }
+
+  @Override
+  public void setLargeMaxRows(long maxRowCount) throws SQLException {
+    super.setLargeMaxRows(maxRowCount);
+    try (Statement statement = this.connection.createStatement()) {
+      statement.execute("ALTER SESSION SET `" + ExecConstants.QUERY_MAX_ROWS + "`=" + maxRowCount);
+    }
   }
 }

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillStatementImpl.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillStatementImpl.java
@@ -25,6 +25,7 @@ import org.apache.calcite.avatica.AvaticaResultSet;
 import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta.StatementHandle;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.jdbc.AlreadyClosedSqlException;
 import org.apache.drill.jdbc.DrillStatement;
 
@@ -269,5 +270,11 @@ public class DrillStatementImpl extends AvaticaStatement implements DrillStateme
   @Override
   public void setUpdateCount(int value) {
     updateCount = value;
+  }
+
+  @Override
+  public void setLargeMaxRows(long maxRowCount) throws SQLException {
+    super.setLargeMaxRows(maxRowCount);
+    execute("ALTER SESSION SET `" + ExecConstants.QUERY_MAX_ROWS + "`=" + maxRowCount);
   }
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementMaxRowsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementMaxRowsTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.jdbc;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.Semaphore;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.categories.JdbcTest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test for Drill's implementation of PreparedStatement's get/setMaxRows methods
+ */
+@Category(JdbcTest.class)
+public class PreparedStatementMaxRowsTest extends JdbcTestBase {
+
+  private static final Random RANDOMIZER = new Random(20150304);
+
+  private static final String SYS_OPTIONS_SQL = "SELECT * FROM sys.options";
+  private static final String SYS_OPTIONS_SQL_LIMIT_10 = "SELECT * FROM sys.options LIMIT 12";
+  private static final String ALTER_SYS_OPTIONS_MAX_ROWS_LIMIT_X = "ALTER SYSTEM SET `" + ExecConstants.QUERY_MAX_ROWS + "`=";
+  // Lock used by all tests to avoid corrupting test scenario
+  private static final Semaphore maxRowsSysOptionLock = new Semaphore(1);
+
+  private static Connection connection;
+
+
+  @BeforeClass
+  public static void setUpConnection() throws SQLException {
+    Driver.load();
+    Properties properties = new Properties();
+    // Increased prepared statement creation timeout to avoid timeout failures
+    properties.setProperty(ExecConstants.bootDefaultFor(ExecConstants.CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS), "30000");
+    connection = DriverManager.getConnection("jdbc:drill:zk=local", properties);
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute(String.format("alter session set `%s` = true", PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY));
+    }
+  }
+
+  @AfterClass
+  public static void tearDownConnection() throws SQLException {
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  @Before
+  public void getExclusiveLock() {
+    // Acquire lock
+    maxRowsSysOptionLock.acquireUninterruptibly();
+  }
+
+  @After
+  public void releaseExclusiveLock() {
+    // Release lock either way
+    maxRowsSysOptionLock.release();
+  }
+
+  ////////////////////////////////////////
+  // Query maxRows methods:
+
+  /**
+   * Test for reading of default max rows
+   */
+  @Test
+  public void testDefaultGetMaxRows() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      int maxRowsValue = pStmt.getMaxRows();
+      assertEquals(0, maxRowsValue);
+    }
+  }
+
+  /**
+   * Test Invalid parameter by giving negative maxRows value
+   */
+  @Test
+  public void testInvalidSetMaxRows() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      //Setting negative value
+      int valueToSet = -10;
+      int origMaxRows = pStmt.getMaxRows();
+      try {
+        pStmt.setMaxRows(valueToSet);
+      } catch (final SQLException e) {
+        assertThat(e.getMessage(), containsString("illegal maxRows value: " + valueToSet));
+      }
+      // Confirm no change
+      assertEquals(origMaxRows, pStmt.getMaxRows());
+    }
+  }
+
+  /**
+   * Test setting a valid maxRows value
+   */
+  @Test
+  public void testValidSetMaxRows() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      //Setting positive value
+      int valueToSet = RANDOMIZER.nextInt(59) + 1;
+      pStmt.setMaxRows(valueToSet);
+      assertEquals(valueToSet, pStmt.getMaxRows());
+    }
+  }
+
+  /**
+   * Test setting maxSize as zero (i.e. no Limit)
+   */
+  @Test
+  public void testSetMaxRowsAsZero() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      pStmt.setMaxRows(0);
+      pStmt.execute();
+      ResultSet rs = pStmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertTrue(rowCount > 0);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value lower than existing query limit
+   */
+  @Test
+  public void testSetMaxRowsLowerThanQueryLimit() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL_LIMIT_10)) {
+      int valueToSet = RANDOMIZER.nextInt(9) + 1; // range: [1-9]
+      pStmt.setMaxRows(valueToSet);
+      pStmt.executeQuery();
+      ResultSet rs = pStmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(valueToSet, rowCount);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value higher than existing query limit
+   */
+  @Test
+  public void testSetMaxRowsHigherThanQueryLimit() throws SQLException {
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL_LIMIT_10)) {
+      int valueToSet = RANDOMIZER.nextInt(10) + 11; // range: [11-20]
+      pStmt.setMaxRows(valueToSet);
+      pStmt.executeQuery();
+      ResultSet rs = pStmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertTrue(valueToSet > rowCount);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value lower than existing SYSTEM limit
+   */
+  @Test
+  public void testSetMaxRowsLowerThanSystemLimit() throws SQLException {
+    int sysValueToSet = RANDOMIZER.nextInt(5) + 6; // range: [6-10]
+    setSystemMaxRows(sysValueToSet);
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      int valueToSet = RANDOMIZER.nextInt(5) + 1; // range: [1-5]
+      pStmt.setMaxRows(valueToSet);
+      pStmt.executeQuery();
+      ResultSet rs = pStmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(valueToSet, rowCount);
+    }
+    setSystemMaxRows(0); //RESET
+  }
+
+  /**
+   * Test setting maxSize at a value higher than existing SYSTEM limit
+   */
+  @Test
+  public void testSetMaxRowsHigherThanSystemLimit() throws SQLException {
+    int sysValueToSet = RANDOMIZER.nextInt(5) + 6; // range: [6-10]
+    setSystemMaxRows(sysValueToSet);
+    try (PreparedStatement pStmt = connection.prepareStatement(SYS_OPTIONS_SQL)) {
+      int valueToSet = RANDOMIZER.nextInt(5) + 11; // range: [11-15]
+      pStmt.setMaxRows(valueToSet);
+      pStmt.executeQuery();
+      ResultSet rs = pStmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(sysValueToSet, rowCount);
+    }
+    setSystemMaxRows(0); //RESET
+  }
+
+
+  //////////
+  // Parameters-not-implemented tests:
+
+  // Sets the SystemMaxRows option
+  private void setSystemMaxRows(int sysValueToSet) throws SQLException {
+    // Setting the value
+    try (Statement stmt = connection.createStatement()) {
+      stmt.executeQuery(ALTER_SYS_OPTIONS_MAX_ROWS_LIMIT_X + sysValueToSet);
+      ResultSet rs = stmt.getResultSet();
+      while (rs.next()) { /*Do Nothing*/ }
+      rs.close();
+    } catch (SQLException e) {
+      throw e;
+    }
+  }
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/PreparedStatementTest.java
@@ -72,6 +72,7 @@ import org.junit.experimental.categories.Category;
 public class PreparedStatementTest extends JdbcTestBase {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PreparedStatementTest.class);
+  private static final Random RANDOMIZER = new Random(20150304);
 
   private static final String SYS_VERSION_SQL = "select * from sys.version";
   private static final String SYS_RANDOM_SQL =
@@ -272,8 +273,8 @@ public class PreparedStatementTest extends JdbcTestBase {
       int valueToSet = -10;
       try {
         stmt.setQueryTimeout(valueToSet);
-      } catch ( final SQLException e) {
-        assertThat( e.getMessage(), containsString( "illegal timeout value") );
+      } catch (final SQLException e) {
+        assertThat(e.getMessage(), containsString( "illegal timeout value") );
       }
     }
   }
@@ -285,7 +286,7 @@ public class PreparedStatementTest extends JdbcTestBase {
   public void testValidSetQueryTimeout() throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(SYS_VERSION_SQL)) {
       //Setting positive value
-      int valueToSet = new Random(20150304).nextInt(59)+1;
+      int valueToSet = RANDOMIZER.nextInt(59) + 1;
       logger.info("Setting timeout as {} seconds", valueToSet);
       stmt.setQueryTimeout(valueToSet);
       assertEquals(valueToSet, stmt.getQueryTimeout());
@@ -461,5 +462,4 @@ public class PreparedStatementTest extends JdbcTestBase {
       }
     }
   }
-
 }

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementMaxRowsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/StatementMaxRowsTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.jdbc;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.exec.ExecConstants;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Random;
+import java.util.concurrent.Semaphore;
+import java.sql.SQLException;
+
+/**
+ * Test for Drill's implementation of Statement's get/setMaxRows methods
+ */
+@Category(JdbcTest.class)
+public class StatementMaxRowsTest extends JdbcTestBase {
+
+  private static final Random RANDOMIZER = new Random(20150304);
+
+  private static final String SYS_OPTIONS_SQL = "SELECT * FROM sys.options";
+  private static final String SYS_OPTIONS_SQL_LIMIT_10 = "SELECT * FROM sys.options LIMIT 12";
+  private static final String ALTER_SYS_OPTIONS_MAX_ROWS_LIMIT_X = "ALTER SYSTEM SET `" + ExecConstants.QUERY_MAX_ROWS + "`=";
+  // Lock used by all tests to avoid corrupting test scenario
+  private static final Semaphore maxRowsSysOptionLock = new Semaphore(1);
+
+  private static Connection connection;
+
+  @BeforeClass
+  public static void setUpStatement() throws SQLException {
+    // (Note: Can't use JdbcTest's connect(...) because JdbcTest closes
+    // Connection--and other JDBC objects--on test method failure, but this test
+    // class uses some objects across methods.)
+    connection = new Driver().connect("jdbc:drill:zk=local", null);
+  }
+
+  @AfterClass
+  public static void tearDownStatement() throws SQLException {
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  @Before
+  public void getExclusiveLock() {
+    // Acquire lock
+    maxRowsSysOptionLock.acquireUninterruptibly();
+  }
+
+  @After
+  public void releaseExclusiveLock() {
+    // Release lock either way
+    maxRowsSysOptionLock.release();
+  }
+
+  ////////////////////////////////////////
+  // Query maxRows methods:
+
+  /**
+   * Test for reading of default max rows
+   */
+  @Test
+  public void testDefaultGetMaxRows() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      int maxRowsValue = stmt.getMaxRows();
+      assertEquals(0, maxRowsValue);
+    }
+  }
+
+  /**
+   * Test Invalid parameter by giving negative maxRows value
+   */
+  @Test
+  public void testInvalidSetMaxRows() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      // Setting negative value
+      int valueToSet = -10;
+      int origMaxRows = stmt.getMaxRows();
+      try {
+        stmt.setMaxRows(valueToSet);
+      } catch (final SQLException e) {
+        assertThat(e.getMessage(), containsString("illegal maxRows value: " + valueToSet));
+      }
+      // Confirm no change
+      assertEquals(origMaxRows, stmt.getMaxRows());
+    }
+  }
+
+  /**
+   * Test setting a valid maxRows value
+   */
+  @Test
+  public void testValidSetMaxRows() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      // Setting positive value
+      int valueToSet = RANDOMIZER.nextInt(59) + 1;
+      stmt.setMaxRows(valueToSet);
+      assertEquals(valueToSet, stmt.getMaxRows());
+    }
+  }
+
+  /**
+   * Test setting maxSize as zero (i.e. no Limit)
+   */
+  @Test
+  public void testSetMaxRowsAsZero() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.setMaxRows(0);
+      stmt.executeQuery(SYS_OPTIONS_SQL);
+      ResultSet rs = stmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertTrue(rowCount > 0);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value lower than existing query limit
+   */
+  @Test
+  public void testSetMaxRowsLowerThanQueryLimit() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      int valueToSet = RANDOMIZER.nextInt(9) + 1; // range: [1-9]
+      stmt.setMaxRows(valueToSet);
+      stmt.executeQuery(SYS_OPTIONS_SQL_LIMIT_10);
+      ResultSet rs = stmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(valueToSet, rowCount);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value higher than existing query limit
+   */
+  @Test
+  public void testSetMaxRowsHigherThanQueryLimit() throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      int valueToSet = RANDOMIZER.nextInt(10) + 11; // range: [11-20]
+      stmt.setMaxRows(valueToSet);
+      stmt.executeQuery(SYS_OPTIONS_SQL_LIMIT_10);
+      ResultSet rs = stmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertTrue(valueToSet > rowCount);
+    }
+  }
+
+  /**
+   * Test setting maxSize at a value lower than existing SYSTEM limit
+   */
+  @Test
+  public void testSetMaxRowsLowerThanSystemLimit() throws SQLException {
+    int sysValueToSet = RANDOMIZER.nextInt(5) + 6; // range: [6-10]
+    setSystemMaxRows(sysValueToSet);
+    try (Statement stmt = connection.createStatement()) {
+      int valueToSet = RANDOMIZER.nextInt(5) + 1; // range: [1-5]
+      stmt.setMaxRows(valueToSet);
+      stmt.executeQuery(SYS_OPTIONS_SQL);
+      ResultSet rs = stmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(valueToSet, rowCount);
+    }
+    setSystemMaxRows(0); // Reset value
+  }
+
+  /**
+   * Test setting maxSize at a value higher than existing SYSTEM limit
+   */
+  @Test
+  public void testSetMaxRowsHigherThanSystemLimit() throws SQLException {
+    int sysValueToSet = RANDOMIZER.nextInt(5) + 6; // range: [6-10]
+    setSystemMaxRows(sysValueToSet);
+    try (Statement stmt = connection.createStatement()) {
+      int valueToSet = RANDOMIZER.nextInt(5) + 11; // range: [11-15]
+      stmt.setMaxRows(valueToSet);
+      stmt.executeQuery(SYS_OPTIONS_SQL);
+      ResultSet rs = stmt.getResultSet();
+      int rowCount = 0;
+      while (rs.next()) {
+        rs.getBytes(1);
+        rowCount++;
+      }
+      rs.close();
+      assertEquals(sysValueToSet, rowCount);
+    }
+    setSystemMaxRows(0); // Reset value
+  }
+
+
+  // Sets the SystemMaxRows option
+  private void setSystemMaxRows(int sysValueToSet) throws SQLException {
+    // Setting the value
+    try (Statement stmt = connection.createStatement()) {
+      stmt.executeQuery(ALTER_SYS_OPTIONS_MAX_ROWS_LIMIT_X + sysValueToSet);
+      ResultSet rs = stmt.getResultSet();
+      while (rs.next()) { /*Do Nothing*/ }
+      rs.close();
+    } catch (SQLException e) {
+      throw e;
+    }
+  }
+}

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
@@ -1828,6 +1828,8 @@ public final class SchemaUserBitShared
                     output.writeString(21, message.getQueueName(), false);
                 if(message.hasQueryId())
                     output.writeString(22, message.getQueryId(), false);
+                if(message.hasAutoLimit())
+                    output.writeInt32(23, message.getAutoLimit(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserBitShared.QueryProfile message)
             {
@@ -1936,6 +1938,9 @@ public final class SchemaUserBitShared
                         case 22:
                             builder.setQueryId(input.readString());
                             break;
+                        case 23:
+                            builder.setAutoLimit(input.readInt32());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -1998,6 +2003,7 @@ public final class SchemaUserBitShared
                 case 20: return "totalCost";
                 case 21: return "queueName";
                 case 22: return "queryId";
+                case 23: return "autoLimit";
                 default: return null;
             }
         }
@@ -2031,6 +2037,7 @@ public final class SchemaUserBitShared
             fieldMap.put("totalCost", 20);
             fieldMap.put("queueName", 21);
             fieldMap.put("queryId", 22);
+            fieldMap.put("autoLimit", 23);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserProtos.java
@@ -4447,6 +4447,8 @@ public final class SchemaUserProtos
                 if(message.hasPreparedStatementHandle())
                     output.writeObject(5, message.getPreparedStatementHandle(), org.apache.drill.exec.proto.SchemaUserProtos.PreparedStatementHandle.WRITE, false);
 
+                if(message.hasAutolimitRowcount())
+                    output.writeInt32(6, message.getAutolimitRowcount(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserProtos.RunQuery message)
             {
@@ -4503,6 +4505,9 @@ public final class SchemaUserProtos
                             builder.setPreparedStatementHandle(input.mergeObject(org.apache.drill.exec.proto.UserProtos.PreparedStatementHandle.newBuilder(), org.apache.drill.exec.proto.SchemaUserProtos.PreparedStatementHandle.MERGE));
 
                             break;
+                        case 6:
+                            builder.setAutolimitRowcount(input.readInt32());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -4548,6 +4553,7 @@ public final class SchemaUserProtos
                 case 3: return "plan";
                 case 4: return "fragments";
                 case 5: return "preparedStatementHandle";
+                case 6: return "autolimitRowcount";
                 default: return null;
             }
         }
@@ -4564,6 +4570,7 @@ public final class SchemaUserProtos
             fieldMap.put("plan", 3);
             fieldMap.put("fragments", 4);
             fieldMap.put("preparedStatementHandle", 5);
+            fieldMap.put("autolimitRowcount", 6);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -16026,6 +16026,15 @@ public final class UserBitShared {
      */
     com.google.protobuf.ByteString
         getQueryIdBytes();
+
+    /**
+     * <code>optional int32 autoLimit = 23;</code>
+     */
+    boolean hasAutoLimit();
+    /**
+     * <code>optional int32 autoLimit = 23;</code>
+     */
+    int getAutoLimit();
   }
   /**
    * Protobuf type {@code exec.shared.QueryProfile}
@@ -16060,6 +16069,7 @@ public final class UserBitShared {
       totalCost_ = 0D;
       queueName_ = "-";
       queryId_ = "";
+      autoLimit_ = 0;
     }
 
     @java.lang.Override
@@ -16238,6 +16248,11 @@ public final class UserBitShared {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00100000;
               queryId_ = bs;
+              break;
+            }
+            case 184: {
+              bitField0_ |= 0x00200000;
+              autoLimit_ = input.readInt32();
               break;
             }
             default: {
@@ -16912,6 +16927,21 @@ public final class UserBitShared {
       }
     }
 
+    public static final int AUTOLIMIT_FIELD_NUMBER = 23;
+    private int autoLimit_;
+    /**
+     * <code>optional int32 autoLimit = 23;</code>
+     */
+    public boolean hasAutoLimit() {
+      return ((bitField0_ & 0x00200000) == 0x00200000);
+    }
+    /**
+     * <code>optional int32 autoLimit = 23;</code>
+     */
+    public int getAutoLimit() {
+      return autoLimit_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -16991,6 +17021,9 @@ public final class UserBitShared {
       }
       if (((bitField0_ & 0x00100000) == 0x00100000)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 22, queryId_);
+      }
+      if (((bitField0_ & 0x00200000) == 0x00200000)) {
+        output.writeInt32(23, autoLimit_);
       }
       unknownFields.writeTo(output);
     }
@@ -17078,6 +17111,10 @@ public final class UserBitShared {
       }
       if (((bitField0_ & 0x00100000) == 0x00100000)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(22, queryId_);
+      }
+      if (((bitField0_ & 0x00200000) == 0x00200000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(23, autoLimit_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -17202,6 +17239,11 @@ public final class UserBitShared {
         result = result && getQueryId()
             .equals(other.getQueryId());
       }
+      result = result && (hasAutoLimit() == other.hasAutoLimit());
+      if (hasAutoLimit()) {
+        result = result && (getAutoLimit()
+            == other.getAutoLimit());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -17305,6 +17347,10 @@ public final class UserBitShared {
       if (hasQueryId()) {
         hash = (37 * hash) + QUERYID_FIELD_NUMBER;
         hash = (53 * hash) + getQueryId().hashCode();
+      }
+      if (hasAutoLimit()) {
+        hash = (37 * hash) + AUTOLIMIT_FIELD_NUMBER;
+        hash = (53 * hash) + getAutoLimit();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -17498,6 +17544,8 @@ public final class UserBitShared {
         bitField0_ = (bitField0_ & ~0x00100000);
         queryId_ = "";
         bitField0_ = (bitField0_ & ~0x00200000);
+        autoLimit_ = 0;
+        bitField0_ = (bitField0_ & ~0x00400000);
         return this;
       }
 
@@ -17627,6 +17675,10 @@ public final class UserBitShared {
           to_bitField0_ |= 0x00100000;
         }
         result.queryId_ = queryId_;
+        if (((from_bitField0_ & 0x00400000) == 0x00400000)) {
+          to_bitField0_ |= 0x00200000;
+        }
+        result.autoLimit_ = autoLimit_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -17784,6 +17836,9 @@ public final class UserBitShared {
           bitField0_ |= 0x00200000;
           queryId_ = other.queryId_;
           onChanged();
+        }
+        if (other.hasAutoLimit()) {
+          setAutoLimit(other.getAutoLimit());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -19345,6 +19400,38 @@ public final class UserBitShared {
   }
   bitField0_ |= 0x00200000;
         queryId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int autoLimit_ ;
+      /**
+       * <code>optional int32 autoLimit = 23;</code>
+       */
+      public boolean hasAutoLimit() {
+        return ((bitField0_ & 0x00400000) == 0x00400000);
+      }
+      /**
+       * <code>optional int32 autoLimit = 23;</code>
+       */
+      public int getAutoLimit() {
+        return autoLimit_;
+      }
+      /**
+       * <code>optional int32 autoLimit = 23;</code>
+       */
+      public Builder setAutoLimit(int value) {
+        bitField0_ |= 0x00400000;
+        autoLimit_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 autoLimit = 23;</code>
+       */
+      public Builder clearAutoLimit() {
+        bitField0_ = (bitField0_ & ~0x00400000);
+        autoLimit_ = 0;
         onChanged();
         return this;
       }
@@ -27744,7 +27831,7 @@ public final class UserBitShared {
       "ult.QueryState\022\017\n\004user\030\004 \001(\t:\001-\022\'\n\007forem" +
       "an\030\005 \001(\0132\026.exec.DrillbitEndpoint\022\024\n\014opti" +
       "ons_json\030\006 \001(\t\022\022\n\ntotal_cost\030\007 \001(\001\022\025\n\nqu" +
-      "eue_name\030\010 \001(\t:\001-\"\263\004\n\014QueryProfile\022 \n\002id" +
+      "eue_name\030\010 \001(\t:\001-\"\306\004\n\014QueryProfile\022 \n\002id" +
       "\030\001 \001(\0132\024.exec.shared.QueryId\022$\n\004type\030\002 \001" +
       "(\0162\026.exec.shared.QueryType\022\r\n\005start\030\003 \001(" +
       "\003\022\013\n\003end\030\004 \001(\003\022\r\n\005query\030\005 \001(\t\022\014\n\004plan\030\006 " +
@@ -27758,76 +27845,77 @@ public final class UserBitShared {
       "(\t\022\022\n\nerror_node\030\020 \001(\t\022\024\n\014options_json\030\021" +
       " \001(\t\022\017\n\007planEnd\030\022 \001(\003\022\024\n\014queueWaitEnd\030\023 " +
       "\001(\003\022\022\n\ntotal_cost\030\024 \001(\001\022\025\n\nqueue_name\030\025 " +
-      "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\"t\n\024MajorFragment" +
-      "Profile\022\031\n\021major_fragment_id\030\001 \001(\005\022A\n\026mi" +
-      "nor_fragment_profile\030\002 \003(\0132!.exec.shared" +
-      ".MinorFragmentProfile\"\350\002\n\024MinorFragmentP" +
-      "rofile\022)\n\005state\030\001 \001(\0162\032.exec.shared.Frag" +
-      "mentState\022(\n\005error\030\002 \001(\0132\031.exec.shared.D" +
-      "rillPBError\022\031\n\021minor_fragment_id\030\003 \001(\005\0226" +
-      "\n\020operator_profile\030\004 \003(\0132\034.exec.shared.O" +
-      "peratorProfile\022\022\n\nstart_time\030\005 \001(\003\022\020\n\010en" +
-      "d_time\030\006 \001(\003\022\023\n\013memory_used\030\007 \001(\003\022\027\n\017max" +
-      "_memory_used\030\010 \001(\003\022(\n\010endpoint\030\t \001(\0132\026.e" +
-      "xec.DrillbitEndpoint\022\023\n\013last_update\030\n \001(" +
-      "\003\022\025\n\rlast_progress\030\013 \001(\003\"\377\001\n\017OperatorPro" +
-      "file\0221\n\rinput_profile\030\001 \003(\0132\032.exec.share" +
-      "d.StreamProfile\022\023\n\013operator_id\030\003 \001(\005\022\025\n\r" +
-      "operator_type\030\004 \001(\005\022\023\n\013setup_nanos\030\005 \001(\003" +
-      "\022\025\n\rprocess_nanos\030\006 \001(\003\022#\n\033peak_local_me" +
-      "mory_allocated\030\007 \001(\003\022(\n\006metric\030\010 \003(\0132\030.e" +
-      "xec.shared.MetricValue\022\022\n\nwait_nanos\030\t \001" +
-      "(\003\"B\n\rStreamProfile\022\017\n\007records\030\001 \001(\003\022\017\n\007" +
-      "batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001(\003\"J\n\013Metric" +
-      "Value\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nlong_value\030\002" +
-      " \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n\010Registry\022\035" +
-      "\n\003jar\030\001 \003(\0132\020.exec.shared.Jar\"/\n\003Jar\022\014\n\004" +
-      "name\030\001 \001(\t\022\032\n\022function_signature\030\002 \003(\t\"W" +
-      "\n\013SaslMessage\022\021\n\tmechanism\030\001 \001(\t\022\014\n\004data" +
-      "\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec.shared.Sas" +
-      "lStatus*5\n\nRpcChannel\022\017\n\013BIT_CONTROL\020\000\022\014" +
-      "\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQueryType\022\007\n\003S" +
-      "QL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL\020\003\022\r\n\tEXECU" +
-      "TION\020\004\022\026\n\022PREPARED_STATEMENT\020\005*\207\001\n\rFragm" +
-      "entState\022\013\n\007SENDING\020\000\022\027\n\023AWAITING_ALLOCA" +
-      "TION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISHED\020\003\022\r\n\tCAN" +
-      "CELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCELLATION_REQ" +
-      "UESTED\020\006*\374\t\n\020CoreOperatorType\022\021\n\rSINGLE_" +
-      "SENDER\020\000\022\024\n\020BROADCAST_SENDER\020\001\022\n\n\006FILTER" +
-      "\020\002\022\022\n\016HASH_AGGREGATE\020\003\022\r\n\tHASH_JOIN\020\004\022\016\n" +
-      "\nMERGE_JOIN\020\005\022\031\n\025HASH_PARTITION_SENDER\020\006" +
-      "\022\t\n\005LIMIT\020\007\022\024\n\020MERGING_RECEIVER\020\010\022\034\n\030ORD" +
-      "ERED_PARTITION_SENDER\020\t\022\013\n\007PROJECT\020\n\022\026\n\022" +
-      "UNORDERED_RECEIVER\020\013\022\032\n\026RANGE_PARTITION_" +
-      "SENDER\020\014\022\n\n\006SCREEN\020\r\022\034\n\030SELECTION_VECTOR" +
-      "_REMOVER\020\016\022\027\n\023STREAMING_AGGREGATE\020\017\022\016\n\nT" +
-      "OP_N_SORT\020\020\022\021\n\rEXTERNAL_SORT\020\021\022\t\n\005TRACE\020" +
-      "\022\022\t\n\005UNION\020\023\022\014\n\010OLD_SORT\020\024\022\032\n\026PARQUET_RO" +
-      "W_GROUP_SCAN\020\025\022\021\n\rHIVE_SUB_SCAN\020\026\022\025\n\021SYS" +
-      "TEM_TABLE_SCAN\020\027\022\021\n\rMOCK_SUB_SCAN\020\030\022\022\n\016P" +
-      "ARQUET_WRITER\020\031\022\023\n\017DIRECT_SUB_SCAN\020\032\022\017\n\013" +
-      "TEXT_WRITER\020\033\022\021\n\rTEXT_SUB_SCAN\020\034\022\021\n\rJSON" +
-      "_SUB_SCAN\020\035\022\030\n\024INFO_SCHEMA_SUB_SCAN\020\036\022\023\n" +
-      "\017COMPLEX_TO_JSON\020\037\022\025\n\021PRODUCER_CONSUMER\020" +
-      " \022\022\n\016HBASE_SUB_SCAN\020!\022\n\n\006WINDOW\020\"\022\024\n\020NES" +
-      "TED_LOOP_JOIN\020#\022\021\n\rAVRO_SUB_SCAN\020$\022\021\n\rPC" +
-      "AP_SUB_SCAN\020%\022\022\n\016KAFKA_SUB_SCAN\020&\022\021\n\rKUD" +
-      "U_SUB_SCAN\020\'\022\013\n\007FLATTEN\020(\022\020\n\014LATERAL_JOI" +
-      "N\020)\022\n\n\006UNNEST\020*\022,\n(HIVE_DRILL_NATIVE_PAR" +
-      "QUET_ROW_GROUP_SCAN\020+\022\r\n\tJDBC_SCAN\020,\022\022\n\016" +
-      "REGEX_SUB_SCAN\020-\022\023\n\017MAPRDB_SUB_SCAN\020.\022\022\n" +
-      "\016MONGO_SUB_SCAN\020/\022\017\n\013KUDU_WRITER\0200\022\026\n\022OP" +
-      "EN_TSDB_SUB_SCAN\0201\022\017\n\013JSON_WRITER\0202\022\026\n\022H" +
-      "TPPD_LOG_SUB_SCAN\0203\022\022\n\016IMAGE_SUB_SCAN\0204\022" +
-      "\025\n\021SEQUENCE_SUB_SCAN\0205\022\023\n\017PARTITION_LIMI" +
-      "T\0206\022\023\n\017PCAPNG_SUB_SCAN\0207\022\022\n\016RUNTIME_FILT" +
-      "ER\0208\022\017\n\013ROWKEY_JOIN\0209\022\023\n\017SYSLOG_SUB_SCAN" +
-      "\020:\022\030\n\024STATISTICS_AGGREGATE\020;\022\020\n\014UNPIVOT_" +
-      "MAPS\020<\022\024\n\020STATISTICS_MERGE\020=\022\021\n\rLTSV_SUB" +
-      "_SCAN\020>*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022" +
-      "\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n" +
-      "\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org." +
-      "apache.drill.exec.protoB\rUserBitSharedH\001"
+      "\001(\t:\001-\022\017\n\007queryId\030\026 \001(\t\022\021\n\tautoLimit\030\027 \001" +
+      "(\005\"t\n\024MajorFragmentProfile\022\031\n\021major_frag" +
+      "ment_id\030\001 \001(\005\022A\n\026minor_fragment_profile\030" +
+      "\002 \003(\0132!.exec.shared.MinorFragmentProfile" +
+      "\"\350\002\n\024MinorFragmentProfile\022)\n\005state\030\001 \001(\016" +
+      "2\032.exec.shared.FragmentState\022(\n\005error\030\002 " +
+      "\001(\0132\031.exec.shared.DrillPBError\022\031\n\021minor_" +
+      "fragment_id\030\003 \001(\005\0226\n\020operator_profile\030\004 " +
+      "\003(\0132\034.exec.shared.OperatorProfile\022\022\n\nsta" +
+      "rt_time\030\005 \001(\003\022\020\n\010end_time\030\006 \001(\003\022\023\n\013memor" +
+      "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n" +
+      "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022" +
+      "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 " +
+      "\001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_profile" +
+      "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op" +
+      "erator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 \001(\005\022\023" +
+      "\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001" +
+      "(\003\022#\n\033peak_local_memory_allocated\030\007 \001(\003\022" +
+      "(\n\006metric\030\010 \003(\0132\030.exec.shared.MetricValu" +
+      "e\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProfile\022\017" +
+      "\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007sche" +
+      "mas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 " +
+      "\001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_value\030" +
+      "\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.sh" +
+      "ared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022functio" +
+      "n_signature\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmech" +
+      "anism\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(" +
+      "\0162\027.exec.shared.SaslStatus*5\n\nRpcChannel" +
+      "\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020" +
+      "\002*V\n\tQueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010" +
+      "PHYSICAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_ST" +
+      "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000" +
+      "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014" +
+      "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022" +
+      "\032\n\026CANCELLATION_REQUESTED\020\006*\374\t\n\020CoreOper" +
+      "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST" +
+      "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020" +
+      "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH" +
+      "_PARTITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGIN" +
+      "G_RECEIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER" +
+      "\020\t\022\013\n\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022" +
+      "\032\n\026RANGE_PARTITION_SENDER\020\014\022\n\n\006SCREEN\020\r\022" +
+      "\034\n\030SELECTION_VECTOR_REMOVER\020\016\022\027\n\023STREAMI" +
+      "NG_AGGREGATE\020\017\022\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERN" +
+      "AL_SORT\020\021\022\t\n\005TRACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_S" +
+      "ORT\020\024\022\032\n\026PARQUET_ROW_GROUP_SCAN\020\025\022\021\n\rHIV" +
+      "E_SUB_SCAN\020\026\022\025\n\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rM" +
+      "OCK_SUB_SCAN\020\030\022\022\n\016PARQUET_WRITER\020\031\022\023\n\017DI" +
+      "RECT_SUB_SCAN\020\032\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT" +
+      "_SUB_SCAN\020\034\022\021\n\rJSON_SUB_SCAN\020\035\022\030\n\024INFO_S" +
+      "CHEMA_SUB_SCAN\020\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n" +
+      "\021PRODUCER_CONSUMER\020 \022\022\n\016HBASE_SUB_SCAN\020!" +
+      "\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOOP_JOIN\020#\022\021\n\rAV" +
+      "RO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFK" +
+      "A_SUB_SCAN\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATT" +
+      "EN\020(\022\020\n\014LATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HI" +
+      "VE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN\020+" +
+      "\022\r\n\tJDBC_SCAN\020,\022\022\n\016REGEX_SUB_SCAN\020-\022\023\n\017M" +
+      "APRDB_SUB_SCAN\020.\022\022\n\016MONGO_SUB_SCAN\020/\022\017\n\013" +
+      "KUDU_WRITER\0200\022\026\n\022OPEN_TSDB_SUB_SCAN\0201\022\017\n" +
+      "\013JSON_WRITER\0202\022\026\n\022HTPPD_LOG_SUB_SCAN\0203\022\022" +
+      "\n\016IMAGE_SUB_SCAN\0204\022\025\n\021SEQUENCE_SUB_SCAN\020" +
+      "5\022\023\n\017PARTITION_LIMIT\0206\022\023\n\017PCAPNG_SUB_SCA" +
+      "N\0207\022\022\n\016RUNTIME_FILTER\0208\022\017\n\013ROWKEY_JOIN\0209" +
+      "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR" +
+      "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_" +
+      "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>*g\n\nSaslStatus" +
+      "\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SA" +
+      "SL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SA" +
+      "SL_FAILED\020\004B.\n\033org.apache.drill.exec.pro" +
+      "toB\rUserBitSharedH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -27927,7 +28015,7 @@ public final class UserBitShared {
     internal_static_exec_shared_QueryProfile_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_exec_shared_QueryProfile_descriptor,
-        new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", "PlanEnd", "QueueWaitEnd", "TotalCost", "QueueName", "QueryId", });
+        new java.lang.String[] { "Id", "Type", "Start", "End", "Query", "Plan", "Foreman", "State", "TotalFragments", "FinishedFragments", "FragmentProfile", "User", "Error", "VerboseError", "ErrorId", "ErrorNode", "OptionsJson", "PlanEnd", "QueueWaitEnd", "TotalCost", "QueueName", "QueryId", "AutoLimit", });
     internal_static_exec_shared_MajorFragmentProfile_descriptor =
       getDescriptor().getMessageTypes().get(14);
     internal_static_exec_shared_MajorFragmentProfile_fieldAccessorTable = new

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserProtos.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserProtos.java
@@ -44832,6 +44832,23 @@ public final class UserProtos {
      * <code>optional .exec.user.PreparedStatementHandle prepared_statement_handle = 5;</code>
      */
     org.apache.drill.exec.proto.UserProtos.PreparedStatementHandleOrBuilder getPreparedStatementHandleOrBuilder();
+
+    /**
+     * <pre>
+     * Input for indicating the limit on a query's result set.
+     * </pre>
+     *
+     * <code>optional int32 autolimit_rowcount = 6;</code>
+     */
+    boolean hasAutolimitRowcount();
+    /**
+     * <pre>
+     * Input for indicating the limit on a query's result set.
+     * </pre>
+     *
+     * <code>optional int32 autolimit_rowcount = 6;</code>
+     */
+    int getAutolimitRowcount();
   }
   /**
    * <pre>
@@ -44854,6 +44871,7 @@ public final class UserProtos {
       type_ = 1;
       plan_ = "";
       fragments_ = java.util.Collections.emptyList();
+      autolimitRowcount_ = 0;
     }
 
     @java.lang.Override
@@ -44930,6 +44948,11 @@ public final class UserProtos {
                 preparedStatementHandle_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000008;
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000010;
+              autolimitRowcount_ = input.readInt32();
               break;
             }
             default: {
@@ -45147,6 +45170,29 @@ public final class UserProtos {
       return preparedStatementHandle_ == null ? org.apache.drill.exec.proto.UserProtos.PreparedStatementHandle.getDefaultInstance() : preparedStatementHandle_;
     }
 
+    public static final int AUTOLIMIT_ROWCOUNT_FIELD_NUMBER = 6;
+    private int autolimitRowcount_;
+    /**
+     * <pre>
+     * Input for indicating the limit on a query's result set.
+     * </pre>
+     *
+     * <code>optional int32 autolimit_rowcount = 6;</code>
+     */
+    public boolean hasAutolimitRowcount() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <pre>
+     * Input for indicating the limit on a query's result set.
+     * </pre>
+     *
+     * <code>optional int32 autolimit_rowcount = 6;</code>
+     */
+    public int getAutolimitRowcount() {
+      return autolimitRowcount_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -45176,6 +45222,9 @@ public final class UserProtos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(5, getPreparedStatementHandle());
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeInt32(6, autolimitRowcount_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -45203,6 +45252,10 @@ public final class UserProtos {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, getPreparedStatementHandle());
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(6, autolimitRowcount_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -45240,6 +45293,11 @@ public final class UserProtos {
         result = result && getPreparedStatementHandle()
             .equals(other.getPreparedStatementHandle());
       }
+      result = result && (hasAutolimitRowcount() == other.hasAutolimitRowcount());
+      if (hasAutolimitRowcount()) {
+        result = result && (getAutolimitRowcount()
+            == other.getAutolimitRowcount());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -45270,6 +45328,10 @@ public final class UserProtos {
       if (hasPreparedStatementHandle()) {
         hash = (37 * hash) + PREPARED_STATEMENT_HANDLE_FIELD_NUMBER;
         hash = (53 * hash) + getPreparedStatementHandle().hashCode();
+      }
+      if (hasAutolimitRowcount()) {
+        hash = (37 * hash) + AUTOLIMIT_ROWCOUNT_FIELD_NUMBER;
+        hash = (53 * hash) + getAutolimitRowcount();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -45428,6 +45490,8 @@ public final class UserProtos {
           preparedStatementHandleBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000010);
+        autolimitRowcount_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -45485,6 +45549,10 @@ public final class UserProtos {
         } else {
           result.preparedStatementHandle_ = preparedStatementHandleBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.autolimitRowcount_ = autolimitRowcount_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -45573,6 +45641,9 @@ public final class UserProtos {
         }
         if (other.hasPreparedStatementHandle()) {
           mergePreparedStatementHandle(other.getPreparedStatementHandle());
+        }
+        if (other.hasAutolimitRowcount()) {
+          setAutolimitRowcount(other.getAutolimitRowcount());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -46252,6 +46323,54 @@ public final class UserProtos {
         }
         return preparedStatementHandleBuilder_;
       }
+
+      private int autolimitRowcount_ ;
+      /**
+       * <pre>
+       * Input for indicating the limit on a query's result set.
+       * </pre>
+       *
+       * <code>optional int32 autolimit_rowcount = 6;</code>
+       */
+      public boolean hasAutolimitRowcount() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <pre>
+       * Input for indicating the limit on a query's result set.
+       * </pre>
+       *
+       * <code>optional int32 autolimit_rowcount = 6;</code>
+       */
+      public int getAutolimitRowcount() {
+        return autolimitRowcount_;
+      }
+      /**
+       * <pre>
+       * Input for indicating the limit on a query's result set.
+       * </pre>
+       *
+       * <code>optional int32 autolimit_rowcount = 6;</code>
+       */
+      public Builder setAutolimitRowcount(int value) {
+        bitField0_ |= 0x00000020;
+        autolimitRowcount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Input for indicating the limit on a query's result set.
+       * </pre>
+       *
+       * <code>optional int32 autolimit_rowcount = 6;</code>
+       */
+      public Builder clearAutolimitRowcount() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        autolimitRowcount_ = 0;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -46628,70 +46747,71 @@ public final class UserProtos {
       "ySupport\022\030\n\020system_functions\030. \003(\t\022\022\n\nta" +
       "ble_term\030/ \001(\t\022\035\n\025transaction_supported\030" +
       "0 \001(\010\022.\n\runion_support\0301 \003(\0162\027.exec.user" +
-      ".UnionSupport\022\026\n\016current_schema\0302 \001(\t\"\353\001" +
+      ".UnionSupport\022\026\n\016current_schema\0302 \001(\t\"\207\002" +
       "\n\010RunQuery\0221\n\014results_mode\030\001 \001(\0162\033.exec." +
       "user.QueryResultsMode\022$\n\004type\030\002 \001(\0162\026.ex" +
       "ec.shared.QueryType\022\014\n\004plan\030\003 \001(\t\0221\n\tfra" +
       "gments\030\004 \003(\0132\036.exec.bit.control.PlanFrag" +
       "ment\022E\n\031prepared_statement_handle\030\005 \001(\0132" +
-      "\".exec.user.PreparedStatementHandle*\320\003\n\007" +
-      "RpcType\022\r\n\tHANDSHAKE\020\000\022\007\n\003ACK\020\001\022\013\n\007GOODB" +
-      "YE\020\002\022\r\n\tRUN_QUERY\020\003\022\020\n\014CANCEL_QUERY\020\004\022\023\n" +
-      "\017REQUEST_RESULTS\020\005\022\027\n\023RESUME_PAUSED_QUER" +
-      "Y\020\013\022\034\n\030GET_QUERY_PLAN_FRAGMENTS\020\014\022\020\n\014GET" +
-      "_CATALOGS\020\016\022\017\n\013GET_SCHEMAS\020\017\022\016\n\nGET_TABL" +
-      "ES\020\020\022\017\n\013GET_COLUMNS\020\021\022\035\n\031CREATE_PREPARED" +
-      "_STATEMENT\020\026\022\023\n\017GET_SERVER_META\020\010\022\016\n\nQUE" +
-      "RY_DATA\020\006\022\020\n\014QUERY_HANDLE\020\007\022\030\n\024QUERY_PLA" +
-      "N_FRAGMENTS\020\r\022\014\n\010CATALOGS\020\022\022\013\n\007SCHEMAS\020\023" +
-      "\022\n\n\006TABLES\020\024\022\013\n\007COLUMNS\020\025\022\026\n\022PREPARED_ST" +
-      "ATEMENT\020\027\022\017\n\013SERVER_META\020\t\022\020\n\014QUERY_RESU" +
-      "LT\020\n\022\020\n\014SASL_MESSAGE\020\030*H\n\013SaslSupport\022\030\n" +
-      "\024UNKNOWN_SASL_SUPPORT\020\000\022\r\n\tSASL_AUTH\020\001\022\020" +
-      "\n\014SASL_PRIVACY\020\002*#\n\020QueryResultsMode\022\017\n\013" +
-      "STREAM_FULL\020\001*q\n\017HandshakeStatus\022\013\n\007SUCC" +
-      "ESS\020\001\022\030\n\024RPC_VERSION_MISMATCH\020\002\022\017\n\013AUTH_" +
-      "FAILED\020\003\022\023\n\017UNKNOWN_FAILURE\020\004\022\021\n\rAUTH_RE" +
-      "QUIRED\020\005*D\n\rRequestStatus\022\022\n\016UNKNOWN_STA" +
-      "TUS\020\000\022\006\n\002OK\020\001\022\n\n\006FAILED\020\002\022\013\n\007TIMEOUT\020\003*Y" +
-      "\n\023ColumnSearchability\022\031\n\025UNKNOWN_SEARCHA" +
-      "BILITY\020\000\022\010\n\004NONE\020\001\022\010\n\004CHAR\020\002\022\n\n\006NUMBER\020\003" +
-      "\022\007\n\003ALL\020\004*K\n\022ColumnUpdatability\022\030\n\024UNKNO" +
-      "WN_UPDATABILITY\020\000\022\r\n\tREAD_ONLY\020\001\022\014\n\010WRIT" +
-      "ABLE\020\002*1\n\016CollateSupport\022\016\n\nCS_UNKNOWN\020\000" +
-      "\022\017\n\013CS_GROUP_BY\020\001*J\n\027CorrelationNamesSup" +
-      "port\022\013\n\007CN_NONE\020\001\022\026\n\022CN_DIFFERENT_NAMES\020" +
-      "\002\022\n\n\006CN_ANY\020\003*\271\003\n\027DateTimeLiteralsSuppor" +
-      "t\022\016\n\nDL_UNKNOWN\020\000\022\013\n\007DL_DATE\020\001\022\013\n\007DL_TIM" +
-      "E\020\002\022\020\n\014DL_TIMESTAMP\020\003\022\024\n\020DL_INTERVAL_YEA" +
-      "R\020\004\022\025\n\021DL_INTERVAL_MONTH\020\005\022\023\n\017DL_INTERVA" +
-      "L_DAY\020\006\022\024\n\020DL_INTERVAL_HOUR\020\007\022\026\n\022DL_INTE" +
-      "RVAL_MINUTE\020\010\022\026\n\022DL_INTERVAL_SECOND\020\t\022\035\n" +
-      "\031DL_INTERVAL_YEAR_TO_MONTH\020\n\022\033\n\027DL_INTER" +
-      "VAL_DAY_TO_HOUR\020\013\022\035\n\031DL_INTERVAL_DAY_TO_" +
-      "MINUTE\020\014\022\035\n\031DL_INTERVAL_DAY_TO_SECOND\020\r\022" +
-      "\036\n\032DL_INTERVAL_HOUR_TO_MINUTE\020\016\022\036\n\032DL_IN" +
-      "TERVAL_HOUR_TO_SECOND\020\017\022 \n\034DL_INTERVAL_M" +
-      "INUTE_TO_SECOND\020\020*Y\n\016GroupBySupport\022\013\n\007G" +
-      "B_NONE\020\001\022\022\n\016GB_SELECT_ONLY\020\002\022\024\n\020GB_BEYON" +
-      "D_SELECT\020\003\022\020\n\014GB_UNRELATED\020\004*x\n\020Identifi" +
-      "erCasing\022\016\n\nIC_UNKNOWN\020\000\022\023\n\017IC_STORES_LO" +
-      "WER\020\001\022\023\n\017IC_STORES_MIXED\020\002\022\023\n\017IC_STORES_" +
-      "UPPER\020\003\022\025\n\021IC_SUPPORTS_MIXED\020\004*X\n\rNullCo" +
-      "llation\022\016\n\nNC_UNKNOWN\020\000\022\017\n\013NC_AT_START\020\001" +
-      "\022\r\n\tNC_AT_END\020\002\022\013\n\007NC_HIGH\020\003\022\n\n\006NC_LOW\020\004" +
-      "*E\n\016OrderBySupport\022\016\n\nOB_UNKNOWN\020\000\022\020\n\014OB" +
-      "_UNRELATED\020\001\022\021\n\rOB_EXPRESSION\020\002*\226\001\n\020Oute" +
-      "rJoinSupport\022\016\n\nOJ_UNKNOWN\020\000\022\013\n\007OJ_LEFT\020" +
-      "\001\022\014\n\010OJ_RIGHT\020\002\022\013\n\007OJ_FULL\020\003\022\r\n\tOJ_NESTE" +
-      "D\020\004\022\022\n\016OJ_NOT_ORDERED\020\005\022\014\n\010OJ_INNER\020\006\022\031\n" +
-      "\025OJ_ALL_COMPARISON_OPS\020\007*\204\001\n\017SubQuerySup" +
-      "port\022\016\n\nSQ_UNKNOWN\020\000\022\021\n\rSQ_CORRELATED\020\001\022" +
-      "\024\n\020SQ_IN_COMPARISON\020\002\022\020\n\014SQ_IN_EXISTS\020\003\022" +
-      "\020\n\014SQ_IN_INSERT\020\004\022\024\n\020SQ_IN_QUANTIFIED\020\005*" +
-      ";\n\014UnionSupport\022\r\n\tU_UNKNOWN\020\000\022\013\n\007U_UNIO" +
-      "N\020\001\022\017\n\013U_UNION_ALL\020\002B+\n\033org.apache.drill" +
-      ".exec.protoB\nUserProtosH\001"
+      "\".exec.user.PreparedStatementHandle\022\032\n\022a" +
+      "utolimit_rowcount\030\006 \001(\005*\320\003\n\007RpcType\022\r\n\tH" +
+      "ANDSHAKE\020\000\022\007\n\003ACK\020\001\022\013\n\007GOODBYE\020\002\022\r\n\tRUN_" +
+      "QUERY\020\003\022\020\n\014CANCEL_QUERY\020\004\022\023\n\017REQUEST_RES" +
+      "ULTS\020\005\022\027\n\023RESUME_PAUSED_QUERY\020\013\022\034\n\030GET_Q" +
+      "UERY_PLAN_FRAGMENTS\020\014\022\020\n\014GET_CATALOGS\020\016\022" +
+      "\017\n\013GET_SCHEMAS\020\017\022\016\n\nGET_TABLES\020\020\022\017\n\013GET_" +
+      "COLUMNS\020\021\022\035\n\031CREATE_PREPARED_STATEMENT\020\026" +
+      "\022\023\n\017GET_SERVER_META\020\010\022\016\n\nQUERY_DATA\020\006\022\020\n" +
+      "\014QUERY_HANDLE\020\007\022\030\n\024QUERY_PLAN_FRAGMENTS\020" +
+      "\r\022\014\n\010CATALOGS\020\022\022\013\n\007SCHEMAS\020\023\022\n\n\006TABLES\020\024" +
+      "\022\013\n\007COLUMNS\020\025\022\026\n\022PREPARED_STATEMENT\020\027\022\017\n" +
+      "\013SERVER_META\020\t\022\020\n\014QUERY_RESULT\020\n\022\020\n\014SASL" +
+      "_MESSAGE\020\030*H\n\013SaslSupport\022\030\n\024UNKNOWN_SAS" +
+      "L_SUPPORT\020\000\022\r\n\tSASL_AUTH\020\001\022\020\n\014SASL_PRIVA" +
+      "CY\020\002*#\n\020QueryResultsMode\022\017\n\013STREAM_FULL\020" +
+      "\001*q\n\017HandshakeStatus\022\013\n\007SUCCESS\020\001\022\030\n\024RPC" +
+      "_VERSION_MISMATCH\020\002\022\017\n\013AUTH_FAILED\020\003\022\023\n\017" +
+      "UNKNOWN_FAILURE\020\004\022\021\n\rAUTH_REQUIRED\020\005*D\n\r" +
+      "RequestStatus\022\022\n\016UNKNOWN_STATUS\020\000\022\006\n\002OK\020" +
+      "\001\022\n\n\006FAILED\020\002\022\013\n\007TIMEOUT\020\003*Y\n\023ColumnSear" +
+      "chability\022\031\n\025UNKNOWN_SEARCHABILITY\020\000\022\010\n\004" +
+      "NONE\020\001\022\010\n\004CHAR\020\002\022\n\n\006NUMBER\020\003\022\007\n\003ALL\020\004*K\n" +
+      "\022ColumnUpdatability\022\030\n\024UNKNOWN_UPDATABIL" +
+      "ITY\020\000\022\r\n\tREAD_ONLY\020\001\022\014\n\010WRITABLE\020\002*1\n\016Co" +
+      "llateSupport\022\016\n\nCS_UNKNOWN\020\000\022\017\n\013CS_GROUP" +
+      "_BY\020\001*J\n\027CorrelationNamesSupport\022\013\n\007CN_N" +
+      "ONE\020\001\022\026\n\022CN_DIFFERENT_NAMES\020\002\022\n\n\006CN_ANY\020" +
+      "\003*\271\003\n\027DateTimeLiteralsSupport\022\016\n\nDL_UNKN" +
+      "OWN\020\000\022\013\n\007DL_DATE\020\001\022\013\n\007DL_TIME\020\002\022\020\n\014DL_TI" +
+      "MESTAMP\020\003\022\024\n\020DL_INTERVAL_YEAR\020\004\022\025\n\021DL_IN" +
+      "TERVAL_MONTH\020\005\022\023\n\017DL_INTERVAL_DAY\020\006\022\024\n\020D" +
+      "L_INTERVAL_HOUR\020\007\022\026\n\022DL_INTERVAL_MINUTE\020" +
+      "\010\022\026\n\022DL_INTERVAL_SECOND\020\t\022\035\n\031DL_INTERVAL" +
+      "_YEAR_TO_MONTH\020\n\022\033\n\027DL_INTERVAL_DAY_TO_H" +
+      "OUR\020\013\022\035\n\031DL_INTERVAL_DAY_TO_MINUTE\020\014\022\035\n\031" +
+      "DL_INTERVAL_DAY_TO_SECOND\020\r\022\036\n\032DL_INTERV" +
+      "AL_HOUR_TO_MINUTE\020\016\022\036\n\032DL_INTERVAL_HOUR_" +
+      "TO_SECOND\020\017\022 \n\034DL_INTERVAL_MINUTE_TO_SEC" +
+      "OND\020\020*Y\n\016GroupBySupport\022\013\n\007GB_NONE\020\001\022\022\n\016" +
+      "GB_SELECT_ONLY\020\002\022\024\n\020GB_BEYOND_SELECT\020\003\022\020" +
+      "\n\014GB_UNRELATED\020\004*x\n\020IdentifierCasing\022\016\n\n" +
+      "IC_UNKNOWN\020\000\022\023\n\017IC_STORES_LOWER\020\001\022\023\n\017IC_" +
+      "STORES_MIXED\020\002\022\023\n\017IC_STORES_UPPER\020\003\022\025\n\021I" +
+      "C_SUPPORTS_MIXED\020\004*X\n\rNullCollation\022\016\n\nN" +
+      "C_UNKNOWN\020\000\022\017\n\013NC_AT_START\020\001\022\r\n\tNC_AT_EN" +
+      "D\020\002\022\013\n\007NC_HIGH\020\003\022\n\n\006NC_LOW\020\004*E\n\016OrderByS" +
+      "upport\022\016\n\nOB_UNKNOWN\020\000\022\020\n\014OB_UNRELATED\020\001" +
+      "\022\021\n\rOB_EXPRESSION\020\002*\226\001\n\020OuterJoinSupport" +
+      "\022\016\n\nOJ_UNKNOWN\020\000\022\013\n\007OJ_LEFT\020\001\022\014\n\010OJ_RIGH" +
+      "T\020\002\022\013\n\007OJ_FULL\020\003\022\r\n\tOJ_NESTED\020\004\022\022\n\016OJ_NO" +
+      "T_ORDERED\020\005\022\014\n\010OJ_INNER\020\006\022\031\n\025OJ_ALL_COMP" +
+      "ARISON_OPS\020\007*\204\001\n\017SubQuerySupport\022\016\n\nSQ_U" +
+      "NKNOWN\020\000\022\021\n\rSQ_CORRELATED\020\001\022\024\n\020SQ_IN_COM" +
+      "PARISON\020\002\022\020\n\014SQ_IN_EXISTS\020\003\022\020\n\014SQ_IN_INS" +
+      "ERT\020\004\022\024\n\020SQ_IN_QUANTIFIED\020\005*;\n\014UnionSupp" +
+      "ort\022\r\n\tU_UNKNOWN\020\000\022\013\n\007U_UNION\020\001\022\017\n\013U_UNI" +
+      "ON_ALL\020\002B+\n\033org.apache.drill.exec.protoB" +
+      "\nUserProtosH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -46896,7 +47016,7 @@ public final class UserProtos {
     internal_static_exec_user_RunQuery_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_exec_user_RunQuery_descriptor,
-        new java.lang.String[] { "ResultsMode", "Type", "Plan", "Fragments", "PreparedStatementHandle", });
+        new java.lang.String[] { "ResultsMode", "Type", "Plan", "Fragments", "PreparedStatementHandle", "AutolimitRowcount", });
     org.apache.drill.exec.proto.SchemaDefProtos.getDescriptor();
     org.apache.drill.common.types.TypeProtos.getDescriptor();
     org.apache.drill.exec.proto.UserBitShared.getDescriptor();

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/QueryProfile.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/QueryProfile.java
@@ -74,6 +74,7 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
     private double totalCost;
     private String queueName = DEFAULT_QUEUE_NAME;
     private String queryId;
+    private int autoLimit;
 
     public QueryProfile()
     {
@@ -368,6 +369,19 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
         return this;
     }
 
+    // autoLimit
+
+    public int getAutoLimit()
+    {
+        return autoLimit;
+    }
+
+    public QueryProfile setAutoLimit(int autoLimit)
+    {
+        this.autoLimit = autoLimit;
+        return this;
+    }
+
     // java serialization
 
     public void readExternal(ObjectInput in) throws IOException
@@ -493,6 +507,9 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
                 case 22:
                     message.queryId = input.readString();
                     break;
+                case 23:
+                    message.autoLimit = input.readInt32();
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -576,6 +593,9 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
 
         if(message.queryId != null)
             output.writeString(22, message.queryId, false);
+
+        if(message.autoLimit != 0)
+            output.writeInt32(23, message.autoLimit, false);
     }
 
     public String getFieldName(int number)
@@ -604,6 +624,7 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
             case 20: return "totalCost";
             case 21: return "queueName";
             case 22: return "queryId";
+            case 23: return "autoLimit";
             default: return null;
         }
     }
@@ -639,6 +660,7 @@ public final class QueryProfile implements Externalizable, Message<QueryProfile>
         __fieldMap.put("totalCost", 20);
         __fieldMap.put("queueName", 21);
         __fieldMap.put("queryId", 22);
+        __fieldMap.put("autoLimit", 23);
     }
     
 }

--- a/protocol/src/main/java/org/apache/drill/exec/proto/beans/RunQuery.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/beans/RunQuery.java
@@ -54,6 +54,7 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
     private String plan;
     private List<PlanFragment> fragments;
     private PreparedStatementHandle preparedStatementHandle;
+    private int autolimitRowcount;
 
     public RunQuery()
     {
@@ -124,6 +125,19 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
     public RunQuery setPreparedStatementHandle(PreparedStatementHandle preparedStatementHandle)
     {
         this.preparedStatementHandle = preparedStatementHandle;
+        return this;
+    }
+
+    // autolimitRowcount
+
+    public int getAutolimitRowcount()
+    {
+        return autolimitRowcount;
+    }
+
+    public RunQuery setAutolimitRowcount(int autolimitRowcount)
+    {
+        this.autolimitRowcount = autolimitRowcount;
         return this;
     }
 
@@ -200,6 +214,9 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
                     message.preparedStatementHandle = input.mergeObject(message.preparedStatementHandle, PreparedStatementHandle.getSchema());
                     break;
 
+                case 6:
+                    message.autolimitRowcount = input.readInt32();
+                    break;
                 default:
                     input.handleUnknownField(number, this);
             }   
@@ -231,6 +248,9 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
         if(message.preparedStatementHandle != null)
              output.writeObject(5, message.preparedStatementHandle, PreparedStatementHandle.getSchema(), false);
 
+
+        if(message.autolimitRowcount != 0)
+            output.writeInt32(6, message.autolimitRowcount, false);
     }
 
     public String getFieldName(int number)
@@ -242,6 +262,7 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
             case 3: return "plan";
             case 4: return "fragments";
             case 5: return "preparedStatementHandle";
+            case 6: return "autolimitRowcount";
             default: return null;
         }
     }
@@ -260,6 +281,7 @@ public final class RunQuery implements Externalizable, Message<RunQuery>, Schema
         __fieldMap.put("plan", 3);
         __fieldMap.put("fragments", 4);
         __fieldMap.put("preparedStatementHandle", 5);
+        __fieldMap.put("autolimitRowcount", 6);
     }
     
 }

--- a/protocol/src/main/protobuf/User.proto
+++ b/protocol/src/main/protobuf/User.proto
@@ -678,4 +678,9 @@ message RunQuery {
    * to state on server side which is returned in response to CreatePreparedStatementReq.
    */
   optional PreparedStatementHandle prepared_statement_handle = 5;
+
+  /*
+   * Input for indicating the limit on a query's result set.
+   */
+  optional int32 autolimit_rowcount = 6;
 }

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -237,6 +237,7 @@ message QueryProfile {
   optional double total_cost = 20;
   optional string queue_name = 21 [default = "-"];
   optional string queryId = 22;
+  optional int32 autoLimit = 23;
 }
 
 message MajorFragmentProfile {


### PR DESCRIPTION
This is a rework of #1608 with complete JDBC support. All the issues in #1608 have been addressed here as this PR is a superset of #1608 and #1593 
This introduces support for JDBC's Statement.setMaxRows(int) API, which can help Drill execute a query much faster if it knows that not ALL the records in the resultset will be consumed upfront.
This PR is broken into 4 commits
1. Introduces the core changes to support the feature within Drill's execution engine.
2. Has corresponding Protobuf changes
3. Support for REST API
4. Support for JDBC API