### PR TITLE
DRILL-7063: Seperate metadata cache file into summary, file metadata

### DIFF
--- a/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
+++ b/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
@@ -472,14 +472,14 @@ SqlNode SqlRefreshMetadata() :
     SqlIdentifier tblName;
     SqlNodeList fieldList = null;
     SqlNode query;
-    boolean allColumns = true;
+    boolean allColumnsInteresting = true;
 }
 {
     <REFRESH> { pos = getPos(); }
     <TABLE>
     <METADATA>
     [
-        <COLUMNS> { allColumns = false; }
+        <COLUMNS> { allColumnsInteresting = false; }
         (   fieldList = ParseRequiredFieldList("Table")
             |
             <NONE>
@@ -487,7 +487,7 @@ SqlNode SqlRefreshMetadata() :
     ]
     tblName = CompoundIdentifier()
     {
-        return new SqlRefreshMetadata(pos, tblName, SqlLiteral.createBoolean(allColumns, getPos()), fieldList);
+        return new SqlRefreshMetadata(pos, tblName, SqlLiteral.createBoolean(allColumnsInteresting, getPos()), fieldList);
     }
 }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
@@ -161,7 +161,7 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
    */
   private SqlNodeList getColumnList(final SqlRefreshMetadata sqlrefreshMetadata) {
     SqlNodeList columnList = sqlrefreshMetadata.getFieldList();
-    if (columnList == null || !SqlNodeList.isEmptyList(columnList)) {
+    if (SqlNodeList.isEmptyList(columnList)) {
       columnList = new SqlNodeList(SqlParserPos.ZERO);
       columnList.add(new SqlIdentifier(SchemaPath.STAR_COLUMN.rootName(), SqlParserPos.ZERO));
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataBase.java
@@ -33,6 +33,7 @@ import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Const
 import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Constants.V3_1;
 import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Constants.V3_2;
 import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Constants.V3_3;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Constants.V4;
 
 public class MetadataBase {
 
@@ -53,7 +54,9 @@ public class MetadataBase {
       @JsonSubTypes.Type(value = Metadata_V3.ParquetTableMetadata_v3.class, name = V3),
       @JsonSubTypes.Type(value = Metadata_V3.ParquetTableMetadata_v3.class, name = V3_1),
       @JsonSubTypes.Type(value = Metadata_V3.ParquetTableMetadata_v3.class, name = V3_2),
-      @JsonSubTypes.Type(value = Metadata_V3.ParquetTableMetadata_v3.class, name = V3_3)
+      @JsonSubTypes.Type(value = Metadata_V3.ParquetTableMetadata_v3.class, name = V3_3),
+      @JsonSubTypes.Type(value = Metadata_V4.ParquetTableMetadata_v4.class, name = V4),
+
   })
   public static abstract class ParquetTableMetadataBase {
 
@@ -74,6 +77,10 @@ public class MetadataBase {
 
     @JsonIgnore public abstract Integer getDefinitionLevel(String[] columnName);
 
+    @JsonIgnore public abstract Integer getScale(String[] columnName);
+
+    @JsonIgnore public abstract Integer getPrecision(String[] columnName);
+
     @JsonIgnore public abstract boolean isRowGroupPrunable();
 
     @JsonIgnore public abstract ParquetTableMetadataBase clone();
@@ -81,6 +88,8 @@ public class MetadataBase {
     @JsonIgnore public abstract String getDrillVersion();
 
     @JsonIgnore public abstract String getMetadataVersion();
+
+    @JsonIgnore  public abstract List<? extends ColumnTypeMetadata> getColumnTypeInfoList();
   }
 
   public static abstract class ParquetFileMetadata {
@@ -103,7 +112,6 @@ public class MetadataBase {
 
     @JsonIgnore public abstract List<? extends ColumnMetadata> getColumns();
   }
-
 
   public static abstract class ColumnMetadata {
 
@@ -147,6 +155,14 @@ public class MetadataBase {
     public abstract PrimitiveType.PrimitiveTypeName getPrimitiveType();
 
     public abstract OriginalType getOriginalType();
+
   }
 
+  public static abstract class ColumnTypeMetadata {
+
+    public abstract PrimitiveType.PrimitiveTypeName getPrimitiveType();
+
+    public abstract String[] getName();
+
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataVersion.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/MetadataVersion.java
@@ -145,6 +145,11 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
      */
     public static final String V3_3 = "3.3";
 
+  /**
+   *  Version 4.0: Split the metadata cache file into summary and file metadata
+   */
+  public static final String V4 = "4.0";
+
     /**
      * All historical versions of the Drill metadata cache files. In case of introducing a new parquet metadata version
      * please follow the {@link MetadataVersion#FORMAT}.
@@ -155,7 +160,8 @@ public class MetadataVersion implements Comparable<MetadataVersion> {
         new MetadataVersion(V3),
         new MetadataVersion(V3_1),
         new MetadataVersion(V3_2),
-        new MetadataVersion(V3_3)
+        new MetadataVersion(V3_3),
+        new MetadataVersion(V4)
     );
 
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V1.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V1.java
@@ -60,11 +60,13 @@ public class Metadata_V1 {
       return directories;
     }
 
-    @JsonIgnore @Override public List<? extends ParquetFileMetadata> getFiles() {
+    @JsonIgnore
+    @Override public List<? extends ParquetFileMetadata> getFiles() {
       return files;
     }
 
-    @JsonIgnore @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
+    @JsonIgnore
+    @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
       this.files = (List<ParquetFileMetadata_v1>) newFiles;
     }
 
@@ -72,40 +74,66 @@ public class Metadata_V1 {
       return false;
     }
 
-    @JsonIgnore @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
+    @JsonIgnore
+    @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override public OriginalType getOriginalType(String[] columnName) {
+    @JsonIgnore
+    @Override public OriginalType getOriginalType(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getRepetitionLevel(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getDefinitionLevel(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
+    public Integer getScale(String[] columnName) {
+      return null;
+    }
+
+    @JsonIgnore
+    @Override
+    public Integer getPrecision(String[] columnName) {
+      return null;
+    }
+
+    @JsonIgnore
+    @Override
     public boolean isRowGroupPrunable() {
       return false;
     }
 
-    @JsonIgnore @Override public MetadataBase.ParquetTableMetadataBase clone() {
+    @JsonIgnore
+    @Override public MetadataBase.ParquetTableMetadataBase clone() {
       return new ParquetTableMetadata_v1(metadataVersion, files, directories);
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public String getDrillVersion() {
       return null;
     }
 
-    @JsonIgnore @Override public String getMetadataVersion() {
+    @JsonIgnore
+    @Override public String getMetadataVersion() {
       return metadataVersion;
+    }
+
+    @JsonIgnore
+    @Override
+    public List<? extends MetadataBase.ColumnTypeMetadata> getColumnTypeInfoList() {
+      return null;
     }
   }
 
@@ -135,15 +163,18 @@ public class Metadata_V1 {
       return String.format("path: %s rowGroups: %s", path, rowGroups);
     }
 
-    @JsonIgnore @Override public Path getPath() {
+    @JsonIgnore
+    @Override public Path getPath() {
       return path;
     }
 
-    @JsonIgnore @Override public Long getLength() {
+    @JsonIgnore
+    @Override public Long getLength() {
       return length;
     }
 
-    @JsonIgnore @Override public List<? extends RowGroupMetadata> getRowGroups() {
+    @JsonIgnore
+    @Override public List<? extends RowGroupMetadata> getRowGroups() {
       return rowGroups;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V2.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V2.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import java.util.ArrayList;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.OriginalType;
@@ -98,11 +99,13 @@ public class Metadata_V2 {
       return directories;
     }
 
-    @JsonIgnore @Override public List<? extends ParquetFileMetadata> getFiles() {
+    @JsonIgnore
+    @Override public List<? extends ParquetFileMetadata> getFiles() {
       return files;
     }
 
-    @JsonIgnore @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
+    @JsonIgnore
+    @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
       this.files = (List<ParquetFileMetadata_v2>) newFiles;
     }
 
@@ -110,40 +113,70 @@ public class Metadata_V2 {
       return true;
     }
 
-    @JsonIgnore @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
+    @JsonIgnore
+    @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
       return getColumnTypeInfo(columnName).primitiveType;
     }
 
-    @JsonIgnore @Override public OriginalType getOriginalType(String[] columnName) {
+    @JsonIgnore
+    @Override public OriginalType getOriginalType(String[] columnName) {
       return getColumnTypeInfo(columnName).originalType;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getRepetitionLevel(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getDefinitionLevel(String[] columnName) {
       return null;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
+    public Integer getScale(String[] columnName) {
+      return null;
+    }
+
+    @JsonIgnore
+    @Override
+    public Integer getPrecision(String[] columnName) {
+      return null;
+    }
+
+    @JsonIgnore
+    @Override
     public boolean isRowGroupPrunable() {
       return false;
     }
 
-    @JsonIgnore @Override public ParquetTableMetadataBase clone() {
+    @JsonIgnore
+    @Override public ParquetTableMetadataBase clone() {
       return new ParquetTableMetadata_v2(metadataVersion, files, directories, columnTypeInfo, drillVersion);
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public String getDrillVersion() {
       return drillVersion;
     }
 
-    @JsonIgnore @Override public String getMetadataVersion() {
+    @JsonIgnore
+    @Override public String getMetadataVersion() {
       return metadataVersion;
+    }
+
+    @JsonIgnore
+    public ConcurrentHashMap<ColumnTypeMetadata_v2.Key, ColumnTypeMetadata_v2> getColumnTypeInfoMap() {
+      return this.columnTypeInfo;
+    }
+
+    @Override
+    public List<? extends MetadataBase.ColumnTypeMetadata> getColumnTypeInfoList() {
+      return new ArrayList<>(this.columnTypeInfo.values());
     }
 
   }
@@ -170,15 +203,18 @@ public class Metadata_V2 {
       return String.format("path: %s rowGroups: %s", path, rowGroups);
     }
 
-    @JsonIgnore @Override public Path getPath() {
+    @JsonIgnore
+    @Override public Path getPath() {
       return path;
     }
 
-    @JsonIgnore @Override public Long getLength() {
+    @JsonIgnore
+    @Override public Long getLength() {
       return length;
     }
 
-    @JsonIgnore @Override public List<? extends RowGroupMetadata> getRowGroups() {
+    @JsonIgnore
+    @Override public List<? extends RowGroupMetadata> getRowGroups() {
       return rowGroups;
     }
   }
@@ -228,7 +264,7 @@ public class Metadata_V2 {
   }
 
 
-  public static class ColumnTypeMetadata_v2 {
+  public static class ColumnTypeMetadata_v2 extends MetadataBase.ColumnTypeMetadata {
     @JsonProperty public String[] name;
     @JsonProperty public PrimitiveType.PrimitiveTypeName primitiveType;
     @JsonProperty public OriginalType originalType;
@@ -300,6 +336,15 @@ public class Metadata_V2 {
           return new Key(key.split("\\."));
         }
       }
+    }
+
+    @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType() {
+      return primitiveType;
+    }
+
+    @Override
+    public String[] getName() {
+      return name;
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V3.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V3.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import java.util.ArrayList;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.io.api.Binary;
@@ -103,7 +104,8 @@ public class Metadata_V3 {
       return directories;
     }
 
-    @JsonIgnore @Override public String getMetadataVersion() {
+    @JsonIgnore
+    @Override public String getMetadataVersion() {
       return metadataVersion;
     }
 
@@ -116,14 +118,16 @@ public class Metadata_V3 {
       this.directories = MetadataPathUtils.convertToAbsolutePaths(directories, baseDir);
 
       // update files paths to absolute ones
-      this.files = MetadataPathUtils.convertToFilesWithAbsolutePaths(files, baseDir);
+      this.files = (List<ParquetFileMetadata_v3>) MetadataPathUtils.convertToFilesWithAbsolutePaths(files, baseDir);
     }
 
-    @JsonIgnore @Override public List<? extends ParquetFileMetadata> getFiles() {
+    @JsonIgnore
+    @Override public List<? extends ParquetFileMetadata> getFiles() {
       return files;
     }
 
-    @JsonIgnore @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
+    @JsonIgnore
+    @Override public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
       this.files = (List<ParquetFileMetadata_v3>) newFiles;
     }
 
@@ -131,38 +135,66 @@ public class Metadata_V3 {
       return true;
     }
 
-    @JsonIgnore @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
+    @JsonIgnore
+    @Override public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
       return getColumnTypeInfo(columnName).primitiveType;
     }
 
-    @JsonIgnore @Override public OriginalType getOriginalType(String[] columnName) {
+    @JsonIgnore
+    @Override public OriginalType getOriginalType(String[] columnName) {
       return getColumnTypeInfo(columnName).originalType;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getRepetitionLevel(String[] columnName) {
       return getColumnTypeInfo(columnName).repetitionLevel;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public Integer getDefinitionLevel(String[] columnName) {
       return getColumnTypeInfo(columnName).definitionLevel;
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
+    public Integer getScale(String[] columnName) {
+      return getColumnTypeInfo(columnName).scale;
+    }
+
+    @JsonIgnore
+    @Override
+    public Integer getPrecision(String[] columnName) {
+      return getColumnTypeInfo(columnName).precision;
+    }
+
+    @JsonIgnore
+    @Override
     public boolean isRowGroupPrunable() {
       return true;
     }
 
-    @JsonIgnore @Override public ParquetTableMetadataBase clone() {
+    @JsonIgnore
+    @Override public ParquetTableMetadataBase clone() {
       return new ParquetTableMetadata_v3(metadataVersion, files, directories, columnTypeInfo, drillVersion);
     }
 
-    @JsonIgnore @Override
+    @JsonIgnore
+    @Override
     public String getDrillVersion() {
       return drillVersion;
     }
 
+    @JsonIgnore
+    public ConcurrentHashMap<Metadata_V3.ColumnTypeMetadata_v3.Key, Metadata_V3.ColumnTypeMetadata_v3> getColumnTypeInfoMap() {
+      return this.columnTypeInfo;
+    }
+
+    @Override
+    public List<? extends MetadataBase.ColumnTypeMetadata> getColumnTypeInfoList() {
+      return new ArrayList<>(this.columnTypeInfo.values());
+    }
   }
 
 
@@ -187,15 +219,18 @@ public class Metadata_V3 {
       return String.format("path: %s rowGroups: %s", path, rowGroups);
     }
 
-    @JsonIgnore @Override public Path getPath() {
+    @JsonIgnore
+    @Override public Path getPath() {
       return path;
     }
 
-    @JsonIgnore @Override public Long getLength() {
+    @JsonIgnore
+    @Override public Long getLength() {
       return length;
     }
 
-    @JsonIgnore @Override public List<? extends RowGroupMetadata> getRowGroups() {
+    @JsonIgnore
+    @Override public List<? extends RowGroupMetadata> getRowGroups() {
       return rowGroups;
     }
   }
@@ -244,8 +279,7 @@ public class Metadata_V3 {
     }
   }
 
-
-  public static class ColumnTypeMetadata_v3 {
+  public static class ColumnTypeMetadata_v3 extends MetadataBase.ColumnTypeMetadata {
     @JsonProperty public String[] name;
     @JsonProperty public PrimitiveType.PrimitiveTypeName primitiveType;
     @JsonProperty public OriginalType originalType;
@@ -323,6 +357,16 @@ public class Metadata_V3 {
           return new Key(key.split("\\."));
         }
       }
+    }
+
+    @Override
+    public PrimitiveType.PrimitiveTypeName getPrimitiveType() {
+      return primitiveType;
+    }
+
+    @Override
+    public String[] getName() {
+      return name;
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V4.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V4.java
@@ -1,0 +1,540 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.drill.common.expression.SchemaPath;
+
+import static org.apache.drill.exec.store.parquet.metadata.MetadataBase.ColumnMetadata;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataBase.ParquetFileMetadata;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataBase.ParquetTableMetadataBase;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataBase.RowGroupMetadata;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataBase.ColumnTypeMetadata;
+import static org.apache.drill.exec.store.parquet.metadata.MetadataVersion.Constants.V4;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+
+public class Metadata_V4 {
+
+  public static class ParquetTableMetadata_v4 extends ParquetTableMetadataBase {
+
+    MetadataSummary metadataSummary = new MetadataSummary();
+    FileMetadata fileMetadata = new FileMetadata();
+
+    public ParquetTableMetadata_v4(MetadataSummary metadataSummary) {
+      this.metadataSummary = metadataSummary;
+    }
+
+    public ParquetTableMetadata_v4(MetadataSummary metadataSummary, FileMetadata fileMetadata) {
+      this.metadataSummary = metadataSummary;
+      this.fileMetadata = fileMetadata;
+    }
+
+    public ParquetTableMetadata_v4(String metadataVersion, ParquetTableMetadataBase parquetTableMetadata,
+                                   List<ParquetFileMetadata_v4> files, List<Path> directories, String drillVersion, long totalRowCount, boolean allColumnsInteresting) {
+      this.metadataSummary.metadataVersion = metadataVersion;
+      this.fileMetadata.files = files;
+      this.metadataSummary.directories = directories;
+      this.metadataSummary.columnTypeInfo = ((ParquetTableMetadata_v4) parquetTableMetadata).metadataSummary.columnTypeInfo;
+      this.metadataSummary.drillVersion = drillVersion;
+      this.metadataSummary.totalRowCount = totalRowCount;
+      this.metadataSummary.allColumnsInteresting = allColumnsInteresting;
+    }
+
+    public ColumnTypeMetadata_v4 getColumnTypeInfo(String[] name) {
+      return metadataSummary.getColumnTypeInfo(name);
+    }
+
+    @Override
+    public List<Path> getDirectories() {
+      return metadataSummary.getDirectories();
+    }
+
+    @Override
+    public List<? extends ParquetFileMetadata> getFiles() {
+      return fileMetadata.getFiles();
+    }
+
+    @Override
+    public String getMetadataVersion() {
+      return metadataSummary.getMetadataVersion();
+    }
+
+    /**
+     * If directories list and file metadata list contain relative paths, update it to absolute ones
+     *
+     * @param baseDir base parent directory
+     */
+    public void updateRelativePaths(String baseDir) {
+      // update directories paths to absolute ones
+      this.metadataSummary.directories = MetadataPathUtils.convertToAbsolutePaths(metadataSummary.directories, baseDir);
+
+      // update files paths to absolute ones
+      this.fileMetadata.files = (List<ParquetFileMetadata_v4>) MetadataPathUtils.convertToFilesWithAbsolutePaths(fileMetadata.files, baseDir);
+    }
+
+    @Override
+    public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
+      this.fileMetadata.assignFiles(newFiles);
+    }
+
+    @Override
+    public boolean hasColumnMetadata() {
+      return true;
+    }
+
+    @Override
+    public PrimitiveType.PrimitiveTypeName getPrimitiveType(String[] columnName) {
+      return getColumnTypeInfo(columnName).primitiveType;
+    }
+
+    @Override
+    public OriginalType getOriginalType(String[] columnName) {
+      return getColumnTypeInfo(columnName).originalType;
+    }
+
+    @Override
+    public Integer getRepetitionLevel(String[] columnName) {
+      return getColumnTypeInfo(columnName).repetitionLevel;
+    }
+
+    @Override
+    public Integer getDefinitionLevel(String[] columnName) {
+      return getColumnTypeInfo(columnName).definitionLevel;
+    }
+
+    @Override
+    public Integer getScale(String[] columnName) {
+      return getColumnTypeInfo(columnName).scale;
+    }
+
+    @Override
+    public Integer getPrecision(String[] columnName) {
+      return getColumnTypeInfo(columnName).precision;
+    }
+
+    @Override
+    public boolean isRowGroupPrunable() {
+      return true;
+    }
+
+    @Override
+    public ParquetTableMetadataBase clone() {
+      return new ParquetTableMetadata_v4(metadataSummary, fileMetadata);
+    }
+
+    @Override
+    public String getDrillVersion() {
+      return metadataSummary.drillVersion;
+    }
+
+    public MetadataSummary getSummary() {
+      return metadataSummary;
+    }
+
+    public long getTotalRowCount() {
+      return metadataSummary.getTotalRowCount();
+    }
+
+    public long getTotalNullCount(String[] columnName) {
+      return getColumnTypeInfo(columnName).totalNullCount;
+    }
+
+    public boolean isAllColumnsInteresting() {
+      return metadataSummary.isAllColumnsInteresting();
+    }
+
+    public ConcurrentHashMap<ColumnTypeMetadata_v4.Key, ColumnTypeMetadata_v4> getColumnTypeInfoMap() {
+      return metadataSummary.columnTypeInfo;
+    }
+
+    @Override
+    public List<? extends MetadataBase.ColumnTypeMetadata> getColumnTypeInfoList() {
+      return new ArrayList<>(metadataSummary.columnTypeInfo.values());
+    }
+
+    public void setTotalRowCount(long totalRowCount) {
+      metadataSummary.setTotalRowCount(totalRowCount);
+    }
+
+    public void setAllColumnsInteresting(boolean allColumnsInteresting) {
+      metadataSummary.allColumnsInteresting = allColumnsInteresting;
+    }
+  }
+
+  /**
+   * Struct which contains the metadata for a single parquet file
+   */
+  public static class ParquetFileMetadata_v4 extends ParquetFileMetadata {
+    @JsonProperty
+    public Path path;
+    @JsonProperty
+    public Long length;
+    @JsonProperty
+    public List<RowGroupMetadata_v4> rowGroups;
+
+    public ParquetFileMetadata_v4() {
+
+    }
+
+    public ParquetFileMetadata_v4(Path path, Long length, List<RowGroupMetadata_v4> rowGroups) {
+      this.path = path;
+      this.length = length;
+      this.rowGroups = rowGroups;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("path: %s rowGroups: %s", path, rowGroups);
+    }
+
+    @JsonIgnore
+    @Override
+    public Path getPath() {
+      return path;
+    }
+
+    @JsonIgnore
+    @Override
+    public Long getLength() {
+      return length;
+    }
+
+    @JsonIgnore
+    @Override
+    public List<? extends RowGroupMetadata> getRowGroups() {
+      return rowGroups;
+    }
+  }
+
+
+  /**
+   * A struct that contains the metadata for a parquet row group
+   */
+  public static class RowGroupMetadata_v4 extends RowGroupMetadata {
+    @JsonProperty
+    public Long start;
+    @JsonProperty
+    public Long length;
+    @JsonProperty
+    public Long rowCount;
+    @JsonProperty
+    public Map<String, Float> hostAffinity;
+    @JsonProperty
+    public List<ColumnMetadata_v4> columns;
+
+    public RowGroupMetadata_v4() {
+    }
+
+    public RowGroupMetadata_v4(Long start, Long length, Long rowCount, Map<String, Float> hostAffinity,
+                               List<ColumnMetadata_v4> columns) {
+      this.start = start;
+      this.length = length;
+      this.rowCount = rowCount;
+      this.hostAffinity = hostAffinity;
+      this.columns = columns;
+    }
+
+    @Override
+    public Long getStart() {
+      return start;
+    }
+
+    @Override
+    public Long getLength() {
+      return length;
+    }
+
+    @Override
+    public Long getRowCount() {
+      return rowCount;
+    }
+
+    @Override
+    public Map<String, Float> getHostAffinity() {
+      return hostAffinity;
+    }
+
+    @Override
+    public List<? extends ColumnMetadata> getColumns() {
+      return columns;
+    }
+  }
+
+
+  public static class ColumnTypeMetadata_v4 extends ColumnTypeMetadata {
+    @JsonProperty
+    public String[] name;
+    @JsonProperty
+    public PrimitiveType.PrimitiveTypeName primitiveType;
+    @JsonProperty
+    public OriginalType originalType;
+    @JsonProperty
+    public int precision;
+    @JsonProperty
+    public int scale;
+    @JsonProperty
+    public int repetitionLevel;
+    @JsonProperty
+    public int definitionLevel;
+    @JsonProperty
+    public long totalNullCount = 0;
+    @JsonProperty
+    public boolean isInteresting = false;
+
+    // Key to find by name only
+    @JsonIgnore
+    private Key key;
+
+    public ColumnTypeMetadata_v4() {
+    }
+
+    public ColumnTypeMetadata_v4(String[] name, PrimitiveType.PrimitiveTypeName primitiveType, OriginalType originalType, int precision, int scale, int repetitionLevel, int definitionLevel, long totalNullCount, boolean isInteresting) {
+      this.name = name;
+      this.primitiveType = primitiveType;
+      this.originalType = originalType;
+      this.precision = precision;
+      this.scale = scale;
+      this.repetitionLevel = repetitionLevel;
+      this.definitionLevel = definitionLevel;
+      this.key = new Key(name);
+      this.totalNullCount = totalNullCount;
+      this.isInteresting = isInteresting;
+    }
+
+    @JsonIgnore
+    private Key key() {
+      return this.key;
+    }
+
+    public static class Key {
+      private SchemaPath name;
+      private int hashCode = 0;
+
+      public Key(String[] name) {
+        this.name = SchemaPath.getCompoundPath(name);
+      }
+
+      public Key(SchemaPath name) {
+        this.name = new SchemaPath(name);
+      }
+
+      @Override
+      public int hashCode() {
+        if (hashCode == 0) {
+          hashCode = name.hashCode();
+        }
+        return hashCode;
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj == null) {
+          return false;
+        }
+        if (getClass() != obj.getClass()) {
+          return false;
+        }
+        final Key other = (Key) obj;
+        return this.name.equals(other.name);
+      }
+
+      @Override
+      public String toString() {
+        return name.toString();
+      }
+
+      public static class DeSerializer extends KeyDeserializer {
+
+        public DeSerializer() {
+        }
+
+        @Override
+        public Object deserializeKey(String key, com.fasterxml.jackson.databind.DeserializationContext ctxt) {
+          // key string should contain '`' char if the field was serialized as SchemaPath object
+          if (key.contains("`")) {
+            return new Key(SchemaPath.parseFromString(key));
+          }
+          return new Key(key.split("\\."));
+        }
+      }
+    }
+
+    @JsonIgnore
+    @Override
+    public PrimitiveType.PrimitiveTypeName getPrimitiveType() {
+      return primitiveType;
+    }
+
+    @JsonIgnore
+    @Override
+    public String[] getName() {
+      return name;
+    }
+  }
+
+  /**
+   * A struct that contains the metadata for a column in a parquet file.
+   * Note: Since the structure of column metadata hasn't changes from v3, ColumnMetadata_v4 extends ColumnMetadata_v3
+   */
+  public static class ColumnMetadata_v4 extends Metadata_V3.ColumnMetadata_v3 {
+    public ColumnMetadata_v4() {
+    }
+
+    public ColumnMetadata_v4(String[] name, PrimitiveType.PrimitiveTypeName primitiveType, Object minValue, Object maxValue, Long nulls) {
+      super(name, primitiveType, minValue, maxValue, nulls);
+    }
+  }
+
+  @JsonTypeName(V4)
+  public static class MetadataSummary {
+
+    @JsonProperty(value = "metadata_version")
+    private String metadataVersion;
+    /*
+     ColumnTypeInfo is schema information from all the files and row groups, merged into
+     one. To get this info, we pass the ParquetTableMetadata object all the way down to the
+     RowGroup and the column type is built there as it is read from the footer.
+     */
+    @JsonProperty
+    public ConcurrentHashMap<ColumnTypeMetadata_v4.Key, ColumnTypeMetadata_v4> columnTypeInfo;
+    @JsonProperty
+    List<Path> directories;
+    @JsonProperty
+    String drillVersion;
+    @JsonProperty
+    long totalRowCount = 0;
+    @JsonProperty
+    boolean allColumnsInteresting = false;
+
+    public MetadataSummary() {
+
+    }
+
+    public MetadataSummary(String metadataVersion, String drillVersion) {
+      this.metadataVersion = metadataVersion;
+      this.drillVersion = drillVersion;
+    }
+
+    public MetadataSummary(String metadataVersion, String drillVersion, List<Path> directories) {
+      this.metadataVersion = metadataVersion;
+      this.drillVersion = drillVersion;
+      this.directories = directories;
+    }
+
+    @JsonIgnore
+    public ColumnTypeMetadata_v4 getColumnTypeInfo(String[] name) {
+      return columnTypeInfo.get(new ColumnTypeMetadata_v4.Key(name));
+    }
+
+    @JsonIgnore
+    public ColumnTypeMetadata_v4 getColumnTypeInfo(ColumnTypeMetadata_v4.Key key) {
+      return columnTypeInfo.get(key);
+    }
+
+    @JsonIgnore
+    public List<Path> getDirectories() {
+      return directories;
+    }
+
+    @JsonIgnore
+    public String getMetadataVersion() {
+      return metadataVersion;
+    }
+
+    @JsonIgnore
+    public boolean isAllColumnsInteresting() {
+      return allColumnsInteresting;
+    }
+
+    @JsonIgnore
+    public void setAllColumnsInteresting(boolean allColumnsInteresting) {
+      this.allColumnsInteresting = allColumnsInteresting;
+    }
+
+    @JsonIgnore
+    public void setTotalRowCount(Long totalRowCount) {
+      this.totalRowCount = totalRowCount;
+    }
+
+    @JsonIgnore
+    public Long getTotalRowCount() {
+      return this.totalRowCount;
+    }
+  }
+
+  /*
+   * A struct that holds list of file metadata in a directory
+   */
+  public static class FileMetadata {
+
+    @JsonProperty
+    List<ParquetFileMetadata_v4> files;
+
+    public FileMetadata() {
+    }
+
+    @JsonIgnore
+    public List<ParquetFileMetadata_v4> getFiles() {
+      return files;
+    }
+
+    @JsonIgnore
+    public void assignFiles(List<? extends ParquetFileMetadata> newFiles) {
+      this.files = (List<ParquetFileMetadata_v4>) newFiles;
+    }
+  }
+
+  /*
+   * A struct that holds file metadata and row count and null count of a single file
+   */
+  public static class ParquetFileAndRowCountMetadata {
+    ParquetFileMetadata_v4 fileMetadata;
+    Map<ColumnTypeMetadata_v4.Key, Long> totalNullCountMap;
+    long fileRowCount;
+
+    public ParquetFileAndRowCountMetadata() {
+    }
+
+    public ParquetFileAndRowCountMetadata(ParquetFileMetadata_v4 fileMetadata, Map<ColumnTypeMetadata_v4.Key, Long> totalNullCountMap, long fileRowCount) {
+      this.fileMetadata = fileMetadata;
+      this.totalNullCountMap = totalNullCountMap;
+      this.fileRowCount = fileRowCount;
+    }
+
+    public ParquetFileMetadata_v4 getFileMetadata() {
+      return this.fileMetadata;
+    }
+
+    public long getFileRowCount() {
+      return this.fileRowCount;
+    }
+
+    public Map<ColumnTypeMetadata_v4.Key, Long> getTotalNullCountMap() {
+      return totalNullCountMap;
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/PlanTestBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill;
 
+import java.nio.file.Paths;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -336,10 +337,13 @@ public class PlanTestBase extends BaseTestQuery {
       throw new RuntimeException(e);
     }
 
-    File metaFile = table.startsWith(tmpDir) ? FileUtils.getFile(table, Metadata.METADATA_FILENAME)
-        : FileUtils.getFile(tmpDir, table, Metadata.METADATA_FILENAME);
-    assertTrue(String.format("There is no metadata cache file for the %s table", table),
-        Files.exists(metaFile.toPath()));
+    for (String filename: Metadata.CURRENT_METADATA_FILENAMES) {
+      File metaFile = table.startsWith(tmpDir) ? FileUtils.getFile(table, filename)
+              : FileUtils.getFile(tmpDir, table, filename);
+      assertTrue(String.format("There is no metadata cache file for the %s table", table),
+              Files.exists(metaFile.toPath()));
+    }
+
   }
 
   /*
@@ -464,5 +468,26 @@ public class PlanTestBase extends BaseTestQuery {
     }
 
     return builder.toString();
+  }
+
+  /**
+   * Create a temp metadata directory to query the metadata summary cache file
+   * @param table table name or table path
+   */
+  public static void createMetadataDir(String table) throws IOException {
+    final String tmpDir;
+    try {
+      tmpDir = dirTestWatcher.getRootDir().getCanonicalPath();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    File metadataDir = dirTestWatcher.makeRootSubDir(Paths.get(tmpDir, table, "metadataDir"));
+    File metaFile, newFile;
+    metaFile = table.startsWith(tmpDir) ? FileUtils.getFile(table, Metadata.METADATA_SUMMARY_FILENAME)
+            : FileUtils.getFile(tmpDir, table, Metadata.METADATA_SUMMARY_FILENAME);
+    File tablefile = new File(tmpDir, table);
+    newFile = new File(tablefile, "summary_meta.json");
+    FileUtils.copyFile(metaFile, newFile);
+    FileUtils.copyFileToDirectory(newFile, metadataDir);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestCorruptParquetDateCorrection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestCorruptParquetDateCorrection.java
@@ -111,7 +111,7 @@ public class TestCorruptParquetDateCorrection extends PlanTestBase {
     dirTestWatcher.copyResourceToRoot(CORRECT_PARTITIONED_DATES_1_9_PATH, MIXED_CORRUPTED_AND_CORRECT_PARTITIONED_FOLDER.resolve(PARTITIONED_1_9_FOLDER));
     dirTestWatcher.copyResourceToRoot(CORRUPTED_PARTITIONED_DATES_1_4_0_PATH, MIXED_CORRUPTED_AND_CORRECT_PARTITIONED_FOLDER.resolve(PARTITIONED_1_4_FOLDER));
     File metaData = dirTestWatcher.copyResourceToRoot(PARQUET_4203.resolve("drill.parquet.metadata_1_2.requires_replace.txt"),
-      PARTITIONED_1_2_FOLDER.resolve(Metadata.METADATA_FILENAME));
+      PARTITIONED_1_2_FOLDER.resolve(Metadata.OLD_METADATA_FILENAME));
     dirTestWatcher.replaceMetaDataContents(metaData, dirTestWatcher.getRootDir(), null);
   }
 
@@ -344,7 +344,7 @@ public class TestCorruptParquetDateCorrection extends PlanTestBase {
   public void testReadNewMetadataCacheFileOverOldAndNewFiles() throws Exception {
     File meta = dirTestWatcher.copyResourceToRoot(
        PARQUET_4203.resolve("mixed_version_partitioned_metadata.requires_replace.txt"),
-       MIXED_CORRUPTED_AND_CORRECT_PARTITIONED_FOLDER.resolve(Metadata.METADATA_FILENAME));
+       MIXED_CORRUPTED_AND_CORRECT_PARTITIONED_FOLDER.resolve(Metadata.OLD_METADATA_FILENAME));
     dirTestWatcher.replaceMetaDataContents(meta, dirTestWatcher.getRootDir(), null);
     // for sanity, try reading all partitions without a filter
     TestBuilder builder = testBuilder()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -138,18 +138,22 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     testParquetRowGroupFilterEval(footer, "intCol = 50 or intCol = 160", RowsMatch.SOME);
 
     //"nonExistCol" does not exist in the table. "AND" with a filter on exist column
+
     testParquetRowGroupFilterEval(footer, "intCol > 100 and nonExistCol = 100", RowsMatch.NONE);
     testParquetRowGroupFilterEval(footer, "intCol > 50 and nonExistCol = 100", RowsMatch.NONE); // since nonExistCol = 100 -> Unknown -> could drop.
     testParquetRowGroupFilterEval(footer, "nonExistCol = 100 and intCol > 50", RowsMatch.NONE); // since nonExistCol = 100 -> Unknown -> could drop.
     testParquetRowGroupFilterEval(footer, "intCol > 100 and nonExistCol < 'abc'", RowsMatch.NONE);
     testParquetRowGroupFilterEval(footer, "nonExistCol < 'abc' and intCol > 100", RowsMatch.NONE); // nonExistCol < 'abc' hit NumberException and is ignored, but intCol >100 will
+
     // say "drop".
     testParquetRowGroupFilterEval(footer, "intCol > 50 and nonExistCol < 'abc'", RowsMatch.SOME); // because nonExistCol < 'abc' hit NumberException and
     // is ignored.
 
     //"nonExistCol" does not exist in the table. "OR" with a filter on exist column
+
     testParquetRowGroupFilterEval(footer, "intCol > 100 or nonExistCol = 100", RowsMatch.NONE); // nonExistCol = 100 -> could drop.
     testParquetRowGroupFilterEval(footer, "nonExistCol = 100 or intCol > 100", RowsMatch.NONE); // nonExistCol = 100 -> could drop.
+
     testParquetRowGroupFilterEval(footer, "intCol > 50 or nonExistCol < 100", RowsMatch.SOME);
     testParquetRowGroupFilterEval(footer, "nonExistCol < 100 or intCol > 50", RowsMatch.SOME);
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataCache.java
@@ -481,17 +481,17 @@ public class TestParquetMetadataCache extends PlanTestBase {
           null);
         metaFile = dirTestWatcher.copyResourceToTestTmp(
           relativePath.resolve("metadata_table.requires_replace.txt"),
-          tablePath.resolve(Metadata.METADATA_FILENAME));
+          tablePath.resolve(Metadata.OLD_METADATA_FILENAME));
         dirTestWatcher.replaceMetaDataContents(metaFile, dirTestWatcher.getDfsTestTmpDir(),
           null);
         metaFile = dirTestWatcher.copyResourceToTestTmp(
           relativePath.resolve("metadata_table_t1.requires_replace.txt"),
-          absolutePathsMetadataT1.resolve(Metadata.METADATA_FILENAME));
+          absolutePathsMetadataT1.resolve(Metadata.OLD_METADATA_FILENAME));
         dirTestWatcher.replaceMetaDataContents(metaFile, dirTestWatcher.getDfsTestTmpDir(),
           null);
         metaFile = dirTestWatcher.copyResourceToTestTmp(
           relativePath.resolve("metadata_table_t2.requires_replace.txt"),
-          absolutePathsMetadataT2.resolve(Metadata.METADATA_FILENAME));
+          absolutePathsMetadataT2.resolve(Metadata.OLD_METADATA_FILENAME));
         dirTestWatcher.replaceMetaDataContents(metaFile, dirTestWatcher.getDfsTestTmpDir(),
           null);
         String query = String.format("select * from %s", tablePath);
@@ -548,7 +548,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
       String futureVersion = new MetadataVersion(lastVersion.getMajor() + 1, 0).toString();
       File metaDataFile = dirTestWatcher.copyResourceToTestTmp(
         Paths.get("parquet", "unsupported_metadata", "unsupported_metadata_version.requires_replace.txt"),
-        Paths.get(unsupportedMetadataVersion, Metadata.METADATA_FILENAME));
+        Paths.get(unsupportedMetadataVersion, Metadata.OLD_METADATA_FILENAME));
       dirTestWatcher.replaceMetaDataContents(metaDataFile, dirTestWatcher.getDfsTestTmpDir(), futureVersion);
       String query = String.format("select * from %s", unsupportedMetadataVersion);
       int expectedRowCount = 25;
@@ -573,7 +573,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
       test("create table `%s` as select * from cp.`tpch/nation.parquet`", corruptedMetadata);
       dirTestWatcher.copyResourceToTestTmp(
         Paths.get("parquet", "unsupported_metadata", "corrupted_metadata.requires_replace.txt"),
-        Paths.get(corruptedMetadata, Metadata.METADATA_FILENAME));
+        Paths.get(corruptedMetadata, Metadata.OLD_METADATA_FILENAME));
       String query = String.format("select * from %s", corruptedMetadata);
       int expectedRowCount = 25;
       int expectedNumFiles = 1;
@@ -597,7 +597,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
       test("create table `%s` as select * from cp.`tpch/nation.parquet`", emptyMetadataFile);
       dirTestWatcher.copyResourceToTestTmp(
         Paths.get("parquet", "unsupported_metadata", "empty_metadata_file.requires_replace.txt"),
-        Paths.get(emptyMetadataFile, Metadata.METADATA_FILENAME));
+        Paths.get(emptyMetadataFile, Metadata.OLD_METADATA_FILENAME));
       String query = String.format("select * from %s", emptyMetadataFile);
       int expectedRowCount = 25;
       int expectedNumFiles = 1;
@@ -872,7 +872,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
     dirTestWatcher.makeTestTmpSubDir(Paths.get(emptyDirNameWithMetadataFile));
     dirTestWatcher.copyResourceToTestTmp(
         Paths.get("parquet", "metadata_files_with_old_versions", "v3_1", "metadata_table.requires_replace.txt"),
-        Paths.get(emptyDirNameWithMetadataFile, Metadata.METADATA_FILENAME));
+        Paths.get(emptyDirNameWithMetadataFile, Metadata.OLD_METADATA_FILENAME));
 
     final BatchSchema expectedSchema = new SchemaBuilder().build();
 
@@ -913,7 +913,7 @@ public class TestParquetMetadataCache extends PlanTestBase {
 
     // sets last-modified time of directory greater than the time of cache file to force metadata cache file auto-refresh
     assertTrue("Unable to change the last-modified time of table directory",
-        ordersTable.setLastModified(new File(ordersTable, Metadata.METADATA_FILENAME).lastModified() + 100500));
+        ordersTable.setLastModified(new File(ordersTable, Metadata.OLD_METADATA_FILENAME).lastModified() + 100500));
 
     String query = "select * from dfs.tmp.`orders`\n" +
         "where o_orderstatus = 'O' and o_orderdate < '1995-03-10'";
@@ -956,4 +956,433 @@ public class TestParquetMetadataCache extends PlanTestBase {
     int actualRowCount = testSql(query);
     assertEquals(expectedRowCount, actualRowCount);
   }
+
+  @Test // Test total rowcount from the summary file
+  public void testTotalRowCount() throws Exception {
+    String tableName = "nation_ctas_rowcount";
+    test("use dfs");
+    test("create table `%s/t1` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    String query = String.format("select * from `%s`", tableName);
+    long rowCount = testSql(query);
+    test("refresh table metadata %s", tableName);
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+
+    testBuilder()
+        .sqlQuery("select t.totalRowCount as rowCount from `%s/metadataDir/summary_meta.json` as t", tableName)
+        .unOrdered()
+        .baselineColumns("rowCount")
+        .baselineValues(rowCount)
+        .go();
+  }
+
+  @Test // Test total row count of sub-dir in te summary file.
+  public void testTotalRowCountSubDir() throws Exception {
+    String tableName = "nation_ctas_rowcount_subdir";
+    test("use dfs");
+    test("create table `%s/t1` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    String query = String.format("select * from `%s/t1`", tableName);
+    long rowCount = testSql(query);
+    test("refresh table metadata %s", tableName);
+    tableName = tableName + "/t1";
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+    testBuilder()
+        .sqlQuery("select t.totalRowCount as rowCount from `%s/metadataDir/summary_meta.json` as t", tableName)
+        .unOrdered()
+        .baselineColumns("rowCount")
+        .baselineValues(rowCount)
+        .go();
+  }
+
+
+  @Test //Test total row count after adding a directory post refresh
+  public void testTotalRowCountAddDirectory() throws Exception {
+    String tableName = "nation_ctas_rowcount_add_dir";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    test("refresh table metadata %s", tableName);
+    Thread.sleep(1000);
+    test("create table `%s/t5` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    String query = String.format("select count(*) as count from `%s`", tableName);
+    String rowCountQuery = String.format("select t.totalRowCount as rowCount from `%s/metadataDir/summary_meta.json` as t", tableName);
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("count")
+        .baselineValues(125L)
+        .go();
+
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("rowCount")
+        .baselineValues(125L)
+        .go();
+  }
+
+
+  @Test //Test total row count after adding a directory under sub-dir post refresh
+  public void testTotalRowCountAddSubDir() throws Exception {
+    String tableName = "nation_ctas_rowcount_add_subdir";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/nation.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    test("refresh table metadata %s", tableName);
+    Thread.sleep(1000);
+    tableName = tableName + "/t1";
+    test("create table `%s/t5` as select * from cp.`tpch/nation.parquet`", tableName);
+
+    String query = String.format("select count(*) as count from `%s`", tableName);
+    String rowCountQuery = String.format("select t.totalRowCount as rowCount from `%s/metadataDir/summary_meta.json` as t", tableName);
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("count")
+        .baselineValues(50L)
+        .go();
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("rowCount")
+        .baselineValues(50L)
+        .go();
+  }
+
+  @Test
+  public void testTotalRowCountAddFile() throws Exception {
+    String tableName = "orders_ctas_refresh_add_file";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+    Thread.sleep(1000);
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet/1994/Q1/orders_94_q1.parquet"), Paths.get("orders_ctas_refresh_add_file/t1/q1.parquet"));
+    tableName = tableName + "/t1";
+    String query = String.format("select count(*) as count from `%s`", tableName);
+    String rowCountQuery = String.format("select t.totalRowCount as rowCount from `%s/metadataDir/summary_meta.json` as t", tableName);
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("count")
+        .baselineValues(15010L)
+        .go();
+
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("rowCount")
+        .baselineValues(15010L)
+        .go();
+  }
+
+  @Test
+  public void testRefreshWithInterestingColumn() throws Exception {
+    String tableName = "orders_ctas_refresh_interesting_col";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+    Thread.sleep(1000);
+
+    String rowCountQuery = String.format("select t.allColumnsInteresting as allColumnsInteresting from `%s/metadataDir/summary_meta.json` as t", tableName);
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("allColumnsInteresting")
+        .baselineValues(false)
+        .go();
+  }
+
+  @Test
+  public void testDefaultRefresh() throws Exception {
+    String tableName = "orders_ctas_refresh_default";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata %s", tableName);
+    Thread.sleep(1000);
+
+    String rowCountQuery = String.format("select t.allColumnsInteresting as allColumnsInteresting from `%s/metadataDir/summary_meta.json` as t", tableName);
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("allColumnsInteresting")
+        .baselineValues(true)
+        .go();
+  }
+
+  @Test
+  public void testAutoRefreshWithInterestingColumn() throws Exception {
+    String tableName = "orders_ctas_autorefresh_int_col";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+    Thread.sleep(1000);
+    test("create table `%s/t5` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("Select count(*) from `%s`", tableName);
+    tableName = tableName + "/t5";
+
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+
+    String rowCountQuery = String.format("select t.allColumnsInteresting as allColumnsInteresting from `%s/metadataDir/summary_meta.json` as t", tableName);
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("allColumnsInteresting")
+        .baselineValues(false)
+        .go();
+  }
+
+
+  @Test
+  public void testAutoRefreshWithInterestingColumnFile() throws Exception {
+    String tableName = "orders_ctas_autorefresh_add_file";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+    Thread.sleep(1000);
+    test("create table `%s/t5` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("Select count(*) from `%s`", tableName);
+    tableName = tableName + "/t5";
+
+    checkForMetadataFile(tableName);
+    createMetadataDir(tableName);
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet/1994/Q1/orders_94_q1.parquet"), Paths.get("orders_ctas_refresh3/t5/q1.parquet"));
+    String rowCountQuery = String.format("select t.allColumnsInteresting as allColumnsInteresting from `%s/metadataDir/summary_meta.json` as t", tableName);
+    testBuilder()
+        .sqlQuery(rowCountQuery)
+        .unOrdered()
+        .baselineColumns("allColumnsInteresting")
+        .baselineValues(false)
+        .go();
+}
+
+
+  @Test
+  public void testRefreshWithIsNull() throws Exception {
+    String tableName = "orders_ctas_refresh_not_null";
+    test("use dfs");
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+    String query = String.format("Select count(*) as cnt from `%s` where o_orderpriority is not null", tableName);
+
+    checkForMetadataFile(tableName);
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(15000L)
+        .go();
+  }
+
+  @Test
+  public void testRefreshExistentColumns() throws Exception {
+    String tableName = "orders_ctas_ex";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+
+    String query = String.format("select count(*) as cnt from `%s` where o_orderdate is not null", tableName);
+
+    int expectedNumFiles = 1;
+    int expectedNumRowGroups = 4;
+    String numFilesPattern = "numFiles=" + expectedNumFiles;
+    String numRowGroupsPattern ="numRowGroups=" + expectedNumRowGroups;
+    String usedMetaPattern = "usedMetadataFile=true";
+
+    testPlanMatchingPatterns(query, new String[]{numFilesPattern, numRowGroupsPattern, usedMetaPattern}, new String[]{"Filter"});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(60000L)
+        .go();
+  }
+
+
+  @Test
+  public void testRefreshNonExistentColumns() throws Exception {
+    String tableName = "orders_ctas_nonex";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+
+    String query = String.format("select count(*) as cnt from `%s` where random is not null", tableName);
+
+    int expectedNumFiles = 1;
+    int expectedNumRowGroups = 1;
+    String numFilesPattern = "numFiles=" + expectedNumFiles;
+    String numRowGroupsPattern ="numRowGroups=" + expectedNumRowGroups;
+    String usedMetaPattern = "usedMetadataFile=true";
+
+    testPlanMatchingPatterns(query, new String[]{numFilesPattern, numRowGroupsPattern, usedMetaPattern});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(0L)
+        .go();
+  }
+
+  @Test
+  public void testRefreshNonExistentColumnFilter() throws Exception {
+    String tableName = "orders_ctas_nonex_filter";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+
+    String query = String.format("select count(o_orderdate) as cnt from `%s` where random > 10", tableName);
+
+    int expectedNumFiles = 1;
+    int expectedNumRowGroups = 1;
+    String numFilesPattern = "numFiles=" + expectedNumFiles;
+    String numRowGroupsPattern ="numRowGroups=" + expectedNumRowGroups;
+    String usedMetaPattern = "usedMetadataFile=true";
+
+    testPlanMatchingPatterns(query, new String[]{numFilesPattern, numRowGroupsPattern, usedMetaPattern});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(0L)
+        .go();
+  }
+
+  @Test
+  public void testRefreshNonExAndNonIntColumnFilter() throws Exception {
+    String tableName = "orders_ctas_nonex_nonint";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+
+    String query = String.format("select count(o_orderdate) as cnt from `%s` where random > 10 and o_orderpriority = '1_URGENT'", tableName);
+
+    int expectedNumFiles = 1;
+    int expectedNumRowGroups = 1;
+    String numFilesPattern = "numFiles=" + expectedNumFiles;
+    String numRowGroupsPattern ="numRowGroups=" + expectedNumRowGroups;
+    String usedMetaPattern = "usedMetadataFile=true";
+
+    testPlanMatchingPatterns(query, new String[]{numFilesPattern, numRowGroupsPattern, usedMetaPattern});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(0L)
+        .go();
+  }
+
+
+  @Test
+  public void testRefreshNonInterestingColumns() throws Exception {
+    String tableName = "orders_ctas_nonint";
+    test("use dfs");
+
+    test("create table `%s/t1` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t2` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t3` as select * from cp.`tpch/orders.parquet`", tableName);
+    test("create table `%s/t4` as select * from cp.`tpch/orders.parquet`", tableName);
+
+    test("refresh table metadata COLUMNS (o_orderdate) %s", tableName);
+
+    String query = String.format("select count(*) as cnt from `%s` where o_orderpriority is not null", tableName);
+
+    int expectedNumFiles = 1;
+    int expectedNumRowGroups = 4;
+    String numFilesPattern = "numFiles=" + expectedNumFiles;
+    String numRowGroupsPattern ="numRowGroups=" + expectedNumRowGroups;
+    String usedMetaPattern = "usedMetadataFile=true";
+
+    testPlanMatchingPatterns(query, new String[]{numFilesPattern, numRowGroupsPattern, usedMetaPattern});
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(60000L)
+        .go();
+  }
+
 }


### PR DESCRIPTION
DRILL-7065: Added backward compatibility to be able to fall back to read previous versions of metadata cache files if current version is not available.

Drill-7066: Auto-refresh to pick up interesting columns from the existing columns and create metadata only for the existing interesting columns

Ignored few tests in testParquetRowGroupFilterEval which have filters on non-existent columns. These will be enabled once run-time row group pruning is enabled.