### PR TITLE
DRILL-7146: Query failing with NPE when ZK queue is enabled.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/QueueQueryParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/QueueQueryParallelizer.java
@@ -55,7 +55,7 @@ public class QueueQueryParallelizer extends SimpleParallelizer {
   // return the memory computed for a physical operator on a drillbitendpoint.
   public BiFunction<DrillbitEndpoint, PhysicalOperator, Long> getMemory() {
     return (endpoint, operator) -> {
-      if (planHasMemory) {
+      if (!planHasMemory) {
         return operators.get(endpoint).get(operator);
       }
       else {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/rm/TestMemoryCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/rm/TestMemoryCalculator.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserProtos;
 import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.work.foreman.rm.EmbeddedQueryQueue;
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
@@ -223,5 +224,19 @@ public class TestMemoryCalculator extends PlanTestBase {
     PlanningSet planningSet = preparePlanningSet(activeEndpoints, 2, resources, sql, parallelizer);
     parallelizer.adjustMemory(planningSet, createSet(planningSet.getRootWrapper()), activeEndpoints);
     assertTrue("memory requirement is different", Iterables.all(resources.entrySet(), (e) -> e.getValue().getMemory() == 481490));
+  }
+
+  @Test
+  public void TestZKBasedQueue() throws Exception {
+    String sql = "select * from cp.`employee.json`";
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher).configProperty(EmbeddedQueryQueue.ENABLED, true);
+
+    try (ClusterFixture cluster = builder.build();
+         ClientFixture client = cluster.clientFixture()) {
+      client
+        .queryBuilder()
+        .sql(sql)
+        .run();
+    }
   }
 }


### PR DESCRIPTION
This PR fixes the issue to not look for physical operator in memory adjusted operators of the QueueQueryParallelizer when planHasMemory is set to true.

@sohami  can you please review this fix.