### PR TITLE
DRILL-7143: Support default value for empty columns

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/BooleanType.java
+++ b/common/src/main/java/org/apache/drill/common/types/BooleanType.java
@@ -15,13 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.expr;
+package org.apache.drill.common.types;
+
+import java.util.Map;
 
 import org.apache.drill.common.map.CaseInsensitiveMap;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Enum that contains two boolean types: TRUE and FALSE.
@@ -30,30 +28,26 @@ import java.util.Map;
  * {@link <a href="https://www.postgresql.org/docs/9.6/static/datatype-boolean.html">Postgre Documentation</a>}
  */
 public enum BooleanType {
-  TRUE(1, Arrays.asList("t", "true", "y", "yes", "on", "1")),
-  FALSE(0, Arrays.asList("f", "false", "n", "no", "off", "0"));
+  TRUE(1, new String [] {"true", "1", "t", "y", "yes", "on",}),
+  FALSE(0, new String [] {"false", "0", "f", "n", "no", "off"});
 
   private final int numericValue;
-  private final List<String> literals;
+  private final String[] literals;
 
-  BooleanType(int numericValue, List<String> literals) {
+  BooleanType(int numericValue, String[] literals) {
     this.numericValue = numericValue;
     this.literals = literals;
   }
 
-  public int getNumericValue() {
-    return numericValue;
-  }
+  public int getNumericValue() { return numericValue; }
 
-  public List<String> getLiterals() {
-    return literals;
-  }
+  public String[] getLiterals() { return literals; }
 
   /** Contains all literals that are allowed to represent boolean type. */
   private static final Map<String, BooleanType> allLiterals = CaseInsensitiveMap.newHashMap();
   static {
-    for (BooleanType booleanType : BooleanType.values()) {
-      for (String literal : booleanType.getLiterals()) {
+    for (final BooleanType booleanType : BooleanType.values()) {
+      for (final String literal : booleanType.getLiterals()) {
         allLiterals.put(literal, booleanType);
       }
     }
@@ -76,4 +70,23 @@ public enum BooleanType {
     return booleanType;
   }
 
+  /**
+   * Runtime form of Boolean conversion: allows any of the valid "true" values;
+   * assumes all other values are false. Does case-insensitive comparisons.
+   * If the string must be trimmed, the caller should do it.
+   *
+   * @param value non-null string value
+   * @return true (if one of the TRUE literals), else false
+   */
+
+  public static boolean fromString(final String value) {
+    // Optimized for runtime speed
+    final String lower = value.toLowerCase();
+    for (int i = 0; i < TRUE.literals.length; i++) {
+      if (TRUE.literals[i].equals(lower)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -30,7 +30,6 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 
 import com.google.protobuf.TextFormat;
 
-@SuppressWarnings("WeakerAccess")
 public class Types {
 
   public static final int MAX_VARCHAR_LENGTH = 65535;
@@ -64,8 +63,11 @@ public class Types {
     if (type.getMode() == REPEATED) {
       return false;
     }
+    return isNumericType(type.getMinorType());
+  }
 
-    switch(type.getMinorType()) {
+  public static boolean isNumericType(final MinorType type) {
+    switch (type) {
     case BIGINT:
     case VARDECIMAL:
     case DECIMAL38SPARSE:
@@ -463,22 +465,28 @@ public class Types {
     default:
       return true;
     }
-
   }
 
   public static boolean isFixedWidthType(final MajorType type) {
-    switch(type.getMinorType()) {
+    return isFixedWidthType(type.getMinorType());
+  }
+
+  public static boolean isFixedWidthType(final MinorType type) {
+    return ! isVarWidthType(type);
+  }
+
+  public static boolean isVarWidthType(final MinorType type) {
+    switch (type) {
     case VARBINARY:
     case VAR16CHAR:
     case VARCHAR:
     case UNION:
     case VARDECIMAL:
-      return false;
-    default:
       return true;
+    default:
+      return false;
     }
   }
-
 
   /**
    * Checks if given major type is string scalar type.
@@ -490,7 +498,7 @@ public class Types {
     if (type.getMode() == REPEATED) {
       return false;
     }
-    switch(type.getMinorType()) {
+    switch (type.getMinorType()) {
     case FIXEDCHAR:
     case FIXED16CHAR:
     case VARCHAR:
@@ -736,8 +744,8 @@ public class Types {
    */
   public static MajorType.Builder calculateTypePrecisionAndScale(MajorType leftType, MajorType rightType, MajorType.Builder typeBuilder) {
     if (leftType.getMinorType().equals(rightType.getMinorType())) {
-      boolean isScalarString = Types.isScalarStringType(leftType) && Types.isScalarStringType(rightType);
-      boolean isDecimal = isDecimalType(leftType);
+      final boolean isScalarString = Types.isScalarStringType(leftType) && Types.isScalarStringType(rightType);
+      final boolean isDecimal = isDecimalType(leftType);
 
       if ((isScalarString || isDecimal) && leftType.hasPrecision() && rightType.hasPrecision()) {
         typeBuilder.setPrecision(Math.max(leftType.getPrecision(), rightType.getPrecision()));
@@ -769,8 +777,8 @@ public class Types {
       return true;
     }
 
-    List<MinorType> subtypes1 = type1.getSubTypeList();
-    List<MinorType> subtypes2 = type2.getSubTypeList();
+    final List<MinorType> subtypes1 = type1.getSubTypeList();
+    final List<MinorType> subtypes2 = type2.getSubTypeList();
     if (subtypes1 == subtypes2) { // Only occurs if both are null
       return true;
     }
@@ -783,8 +791,8 @@ public class Types {
 
     // Now it gets slow because subtype lists are not ordered.
 
-    List<MinorType> copy1 = new ArrayList<>(subtypes1);
-    List<MinorType> copy2 = new ArrayList<>(subtypes2);
+    final List<MinorType> copy1 = new ArrayList<>(subtypes1);
+    final List<MinorType> copy2 = new ArrayList<>(subtypes2);
     Collections.sort(copy1);
     Collections.sort(copy2);
     return copy1.equals(copy2);
@@ -802,5 +810,24 @@ public class Types {
 
   public static String typeKey(MinorType type) {
     return type.name().toLowerCase();
+  }
+
+  public static int maxPrecision(MinorType type) {
+    switch (type) {
+    case DECIMAL18:
+      return 18;
+    case DECIMAL28DENSE:
+    case DECIMAL28SPARSE:
+      return 28;
+    case DECIMAL38DENSE:
+    case DECIMAL38SPARSE:
+      return 38;
+    case DECIMAL9:
+      return 9;
+    case VARDECIMAL:
+      return 38;
+    default:
+      return 0;
+    }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SimpleCastFunctions.java
@@ -47,7 +47,7 @@ public class SimpleCastFunctions {
       byte[] buf = new byte[in.end - in.start];
       in.buffer.getBytes(in.start, buf, 0, in.end - in.start);
       String input = new String(buf, com.google.common.base.Charsets.UTF_8);
-      out.value = org.apache.drill.exec.expr.BooleanType.get(input).getNumericValue();
+      out.value = org.apache.drill.common.types.BooleanType.get(input).getNumericValue();
     }
   }
 
@@ -66,7 +66,7 @@ public class SimpleCastFunctions {
     public void setup() {}
 
     public void eval() {
-      byte[] outB = org.apache.drill.exec.expr.BooleanType.get(String.valueOf(in.value)).name().toLowerCase().getBytes();
+      byte[] outB = org.apache.drill.common.types.BooleanType.get(String.valueOf(in.value)).name().toLowerCase().getBytes();
       buffer.setBytes(0, outB);
       out.buffer = buffer;
       out.start = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsScanFramework.java
@@ -87,11 +87,6 @@ public class ColumnsScanFramework extends FileScanFramework {
        ((ColumnsScanBuilder) builder).requireColumnsArray);
     builder.addParser(columnsArrayManager.projectionParser());
     builder.addResolver(columnsArrayManager.resolver());
-
-    // This framework is (at present) used only for the text readers
-    // which use required Varchar columns to represent null columns.
-
-    builder.allowRequiredNullColumns(true);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/NullColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/NullColumnBuilder.java
@@ -137,7 +137,7 @@ public class NullColumnBuilder implements VectorSource {
           // use the default value from the output schema.
 
           col = new ResolvedNullColumn(name, type,
-              outputCol.decodeDefaultValue(), this, nullCols.size());
+              outputCol.defaultValue(), this, nullCols.size());
         } else {
 
           // Type and modes matches, just the output column

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ResolvedNullColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ResolvedNullColumn.java
@@ -32,9 +32,9 @@ public class ResolvedNullColumn extends ResolvedColumn implements NullColumnSpec
 
   private final String name;
   private MajorType type;
-  private Object defaultValue;
+  private String defaultValue;
 
-  public ResolvedNullColumn(String name, MajorType type, Object defaultValue,
+  public ResolvedNullColumn(String name, MajorType type, String defaultValue,
       VectorSource source, int sourceIndex) {
     super(source, sourceIndex);
     this.name = name;
@@ -47,7 +47,7 @@ public class ResolvedNullColumn extends ResolvedColumn implements NullColumnSpec
     super(colDefn, source, sourceIndex);
     this.name = colDefn.name();
     this.type = colDefn.majorType();
-    this.defaultValue = colDefn.decodeDefaultValue();
+    this.defaultValue = colDefn.defaultValue();
   }
 
   @Override
@@ -77,5 +77,5 @@ public class ResolvedNullColumn extends ResolvedColumn implements NullColumnSpec
   }
 
   @Override
-  public Object defaultValue() { return defaultValue; }
+  public String defaultValue() { return defaultValue; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ColumnBuilder.java
@@ -238,8 +238,7 @@ public class ColumnBuilder {
       vectorState = new RepeatedVectorState(colWriter.array(), (RepeatedValueVector) vector);
     } else if (columnSchema.isNullable()) {
       vectorState = new NullableVectorState(
-          colWriter,
-          (NullableVector) vector);
+          colWriter, (NullableVector) vector);
     } else {
       vectorState = SimpleVectorState.vectorState(columnSchema,
             colWriter.events(), vector);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
@@ -45,13 +45,13 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
    */
 
   public static class ResultSetOptions {
-    public final int vectorSizeLimit;
-    public final int rowCountLimit;
-    public final ResultVectorCache vectorCache;
-    public final RequestedTuple projectionSet;
-    public final TupleMetadata schema;
-    public final long maxBatchSize;
-    public final SchemaTransformer schemaTransformer;
+    protected final int vectorSizeLimit;
+    protected final int rowCountLimit;
+    protected final ResultVectorCache vectorCache;
+    protected final RequestedTuple projectionSet;
+    protected final TupleMetadata schema;
+    protected final long maxBatchSize;
+    protected final SchemaTransformer schemaTransformer;
 
     public ResultSetOptions() {
       vectorSizeLimit = ValueVector.MAX_BUFFER_SIZE;
@@ -87,7 +87,6 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
         .startObject(this)
         .attribute("vectorSizeLimit", vectorSizeLimit)
         .attribute("rowCountLimit", rowCountLimit)
-//        .attribute("projection", projection)
         .endObject();
     }
   }
@@ -167,7 +166,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
     CLOSED
   }
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ResultSetLoaderImpl.class);
+  protected static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ResultSetLoaderImpl.class);
 
   /**
    * Options provided to this loader.
@@ -179,20 +178,20 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
    * Allocator for vectors created by this loader.
    */
 
-  final BufferAllocator allocator;
+  private final BufferAllocator allocator;
 
   /**
    * Builds columns (vector, writer, state).
    */
 
-  final ColumnBuilder columnBuilder;
+  private final ColumnBuilder columnBuilder;
 
   /**
    * Internal structure used to work with the vectors (real or dummy) used
    * by this loader.
    */
 
-  final RowState rootState;
+  private final RowState rootState;
 
   /**
    * Top-level writer index that steps through the rows as they are written.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/TupleState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/TupleState.java
@@ -231,7 +231,7 @@ public abstract class TupleState extends ContainerState
 
     @Override
     public void dump(HierarchicalFormatter format) {
-      // TODO Auto-generated method stub
+      // TODO
     }
   }
 
@@ -390,7 +390,7 @@ public abstract class TupleState extends ContainerState
         ResultVectorCache vectorCache,
         RequestedTuple projectionSet) {
       super(events, vectorCache, projectionSet);
-     }
+    }
 
     /**
      * Return the tuple writer for the map. If this is a single

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
@@ -139,6 +139,11 @@ public abstract class SchemaHandler extends DefaultSqlHandler {
           .message(e.getMessage())
           .addContext("Error while preparing / creating schema for [%s]", schemaSource)
           .build(logger);
+      } catch (IllegalArgumentException e) {
+        throw UserException.validationError(e)
+          .message(e.getMessage())
+          .addContext("Error while preparing / creating schema for [%s]", schemaSource)
+          .build(logger);
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
 import org.joda.time.format.DateTimeFormatter;
@@ -75,8 +76,11 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
   }
 
   public AbstractColumnMetadata(MaterializedField schema) {
-    name = schema.getName();
-    final MajorType majorType = schema.getType();
+    this(schema.getName(), schema.getType());
+  }
+
+  public AbstractColumnMetadata(String name, MajorType majorType) {
+    this.name = name;
     type = majorType.getMinorType();
     mode = majorType.getMode();
     precision = majorType.getPrecision();
@@ -151,8 +155,7 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
 
   @Override
   public boolean isVariableWidth() {
-    final MinorType type = type();
-    return type == MinorType.VARCHAR || type == MinorType.VAR16CHAR || type == MinorType.VARBINARY;
+    return Types.isVarWidthType(type());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapBuilder.java
@@ -78,6 +78,10 @@ public class MapBuilder implements SchemaContainer {
     return this;
   }
 
+  public MapBuilder add(String name, MinorType type, int precision, int scale) {
+    return addDecimal(name, type, DataMode.REQUIRED, precision, scale);
+  }
+
   public MapBuilder addNullable(String name, MinorType type) {
     tupleBuilder.addNullable(name,  type);
     return this;
@@ -88,6 +92,10 @@ public class MapBuilder implements SchemaContainer {
     return this;
   }
 
+  public MapBuilder addNullable(String name, MinorType type, int precision, int scale) {
+    return addDecimal(name, type, DataMode.OPTIONAL, precision, scale);
+  }
+
   public MapBuilder addArray(String name, MinorType type) {
     tupleBuilder.addArray(name, type);
     return this;
@@ -96,6 +104,10 @@ public class MapBuilder implements SchemaContainer {
   public MapBuilder addArray(String name, MinorType type, int dims) {
     tupleBuilder.addArray(name,  type, dims);
     return this;
+  }
+
+  public MapBuilder addArray(String name, MinorType type, int precision, int scale) {
+    return addDecimal(name, type, DataMode.REPEATED, precision, scale);
   }
 
   public MapBuilder addDecimal(String name, MinorType type,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.record.metadata;
 
+import org.apache.drill.common.types.BooleanType;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -53,6 +54,10 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
 
   public PrimitiveColumnMetadata(MaterializedField schema) {
     super(schema);
+  }
+
+  public PrimitiveColumnMetadata(String name, MajorType type) {
+    super(name, type);
   }
 
   public PrimitiveColumnMetadata(String name, MinorType type, DataMode mode) {
@@ -241,13 +246,13 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
         case BIGINT:
           return Long.parseLong(value);
         case FLOAT4:
-          return Float.parseFloat(value);
+          return (double) Float.parseFloat(value);
         case FLOAT8:
           return Double.parseDouble(value);
         case VARDECIMAL:
           return new BigDecimal(value);
         case BIT:
-          return Boolean.parseBoolean(value);
+          return BooleanType.fromString(value);
         case VARCHAR:
         case VARBINARY:
           return value;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/SchemaBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/SchemaBuilder.java
@@ -134,8 +134,7 @@ public class SchemaBuilder implements SchemaContainer {
   }
 
   public SchemaBuilder add(String name, MinorType type, int precision, int scale) {
-    tupleBuilder.addDecimal(name, type, DataMode.REQUIRED, precision, scale);
-    return this;
+    return addDecimal(name, type, DataMode.REQUIRED, precision, scale);
   }
 
   public SchemaBuilder addNullable(String name, MinorType type) {
@@ -149,13 +148,16 @@ public class SchemaBuilder implements SchemaContainer {
   }
 
   public SchemaBuilder addNullable(String name, MinorType type, int precision, int scale) {
-    tupleBuilder.addDecimal(name, type, DataMode.OPTIONAL, precision, scale);
-    return this;
+    return addDecimal(name, type, DataMode.OPTIONAL, precision, scale);
   }
 
   public SchemaBuilder addArray(String name, MinorType type) {
     tupleBuilder.addArray(name, type);
     return this;
+  }
+
+  public SchemaBuilder addArray(String name, MinorType type, int precision, int scale) {
+    return addDecimal(name, type, DataMode.REPEATED, precision, scale);
   }
 
   public SchemaBuilder addDecimal(String name, MinorType type, DataMode mode, int precision, int scale) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -248,6 +248,10 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
         builder.setProjection(scan.getColumns());
         builder.setFiles(scan.getWorkUnits());
         builder.setConfig(plugin.easyConfig().fsConf);
+
+        // The text readers use required Varchar columns to represent null columns.
+
+        builder.allowRequiredNullColumns(true);
         final Path selectionRoot = scan.getSelectionRoot();
         if (selectionRoot != null) {
           builder.metadataOptions().setSelectionRoot(selectionRoot);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -62,6 +62,7 @@ import org.apache.drill.exec.store.easy.text.compliant.v3.TextParsingSettingsV3;
 import org.apache.drill.exec.store.schedule.CompleteFileWork;
 import org.apache.drill.exec.store.text.DrillTextRecordReader;
 import org.apache.drill.exec.store.text.DrillTextRecordWriter;
+import org.apache.drill.exec.vector.accessor.convert.AbstractConvertFromString;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -236,6 +237,12 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
       // Pass along the output schema, if any
 
       builder.setOutputSchema(scan.getSchema());
+
+      // CSV maps blank columns to nulls (for nullable non-string columns),
+      // or to the default value (for non-nullable non-string columns.)
+
+      builder.setConversionProperty(AbstractConvertFromString.BLANK_ACTION_PROP,
+          AbstractConvertFromString.BLANK_AS_NULL);
 
       return builder;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/foreman/Foreman.java
@@ -293,7 +293,8 @@ public class Foreman implements Runnable {
          */
         FailureUtils.unrecoverableFailure(e, "Unable to handle out of memory condition in Foreman.", EXIT_CODE_HEAP_OOM);
       }
-
+    } catch (UserException e) {
+      queryStateProcessor.moveToState(QueryState.FAILED, e);
     } catch (AssertionError | Exception ex) {
       queryStateProcessor.moveToState(QueryState.FAILED,
           new ForemanException("Unexpected exception during fragment initialization: " + ex.getMessage(), ex));
@@ -777,7 +778,11 @@ public class Foreman implements Runnable {
       final UserException uex;
       if (resultException != null) {
         final boolean verbose = queryContext.getOptions().getOption(ExecConstants.ENABLE_VERBOSE_ERRORS_KEY).bool_val;
-        uex = UserException.systemError(resultException).addIdentity(queryContext.getCurrentEndpoint()).build(logger);
+        if (resultException instanceof UserException) {
+          uex = (UserException) resultException;
+        } else {
+          uex = UserException.systemError(resultException).addIdentity(queryContext.getCurrentEndpoint()).build(logger);
+        }
         resultBuilder.addError(uex.getOrCreatePBError(verbose));
       } else {
         uex = null;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestByteComparisonFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestByteComparisonFunctions.java
@@ -36,7 +36,6 @@ import org.junit.experimental.categories.Category;
 
 @Category({UnlikelyTest.class, VectorTest.class})
 public class TestByteComparisonFunctions extends ExecTest {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestByteComparisonFunctions.class);
 
   private static BufferAllocator allocator;
   private static VarCharHolder hello;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/TestTupleSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/TestTupleSchema.java
@@ -326,6 +326,7 @@ public class TestTupleSchema extends SubOperatorTest {
     MaterializedField field = SchemaBuilder.columnSchema("u", MinorType.UNION, DataMode.OPTIONAL);
     ColumnMetadata col = MetadataUtils.fromField(field);
     assertFalse(col.isArray());
+    assertTrue(col.isVariableWidth());
     doVariantTest(col);
   }
 
@@ -339,6 +340,7 @@ public class TestTupleSchema extends SubOperatorTest {
     // List modeled as a repeated element. Implementation is a bit
     // more complex, but does not affect this abstract description.
 
+    assertFalse(col.isVariableWidth());
     doVariantTest(col);
   }
 
@@ -347,7 +349,6 @@ public class TestTupleSchema extends SubOperatorTest {
     assertTrue(col instanceof VariantColumnMetadata);
 
     assertTrue(col.isNullable());
-    assertFalse(col.isVariableWidth());
     assertFalse(col.isMap());
     assertTrue(col.isVariant());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/BaseCsvTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/BaseCsvTest.java
@@ -99,6 +99,14 @@ public class BaseCsvTest extends ClusterTest {
     client.resetSession(ExecConstants.MIN_READER_WIDTH_KEY);
   }
 
+  protected void enableSchema(boolean enable) {
+    client.alterSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE, enable);
+  }
+
+  protected void resetSchema() {
+    client.resetSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE);
+  }
+
   protected static void buildFile(String fileName, String[] data) throws IOException {
     buildFile(new File(testDir, fileName), data);
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
@@ -19,6 +19,8 @@ package org.apache.drill.exec.store.easy.text.compliant;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.apache.drill.test.rowSet.RowSetUtilities.dec;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +29,6 @@ import java.util.Iterator;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.rpc.RpcException;
@@ -37,7 +38,10 @@ import org.apache.drill.test.rowSet.RowSetBuilder;
 import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.drill.test.rowSet.RowSetReader;
 import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.joda.time.Instant;
 import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
+import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -54,56 +58,51 @@ public class TestCsvWithSchema extends BaseCsvTest {
   protected static final String FILE1_NAME = "file1.csv";
   protected static final String FILE_N_NAME = "file%d.csv";
 
-  protected static String basicFileContents[] = {
-      "intcol,datecol,str,dub",
-      "10,2019-03-20,it works!,1234.5"
+  private static String basicFileContents[] = {
+    "intcol,datecol,str,dub",
+    "10,2019-03-20,it works!,1234.5"
   };
 
-  public static final String raggedMulti1Contents[] = {
-      "id,name,date,gender",
-      "1,wilma,2019-01-18,female",
-      "2,fred,2019-01-19,male",
-      "4,betty,2019-05-04"
+  private static final String raggedMulti1Contents[] = {
+    "id,name,date,gender",
+    "1,wilma,2019-01-18,female",
+    "2,fred,2019-01-19,male",
+    "4,betty,2019-05-04"
   };
 
-  public static final String multi1Contents[] = {
-      "id,name,date,gender",
-      "1,wilma,2019-01-18,female",
-      "2,fred,2019-01-19,male",
-      "4,betty,2019-05-04,NA"
+  private static final String multi1Contents[] = {
+    "id,name,date,gender",
+    "1,wilma,2019-01-18,female",
+    "2,fred,2019-01-19,male",
+    "4,betty,2019-05-04,NA"
   };
 
-  public static final String multi2Contents[] = {
-      "id,name,date",
-      "3,barney,2001-01-16"
+  private static final String multi2FullContents[] = {
+    "id,name,date",
+    "3,barney,2001-01-16,NA"
   };
 
-  public static final String multi2FullContents[] = {
-      "id,name,date",
-      "3,barney,2001-01-16,NA"
+  private static final String reordered2Contents[] = {
+    "name,id,date",
+    "barney,3,2001-01-16"
   };
 
-  public static final String reordered2Contents[] = {
-      "name,id,date",
-      "barney,3,2001-01-16"
+  private static final String multi3Contents[] = {
+    "name,date",
+    "dino,2018-09-01"
   };
 
-  public static final String multi3Contents[] = {
-      "name,date",
-      "dino,2018-09-01"
+  private static final String nameOnlyContents[] = {
+    "name",
+    "dino"
   };
 
-  public static final String nameOnlyContents[] = {
-      "name",
-      "dino"
-  };
-
-  public static final String SCHEMA_SQL = "create or replace schema (" +
-      "id int not null, " +
-      "`date` date format 'yyyy-MM-dd', " +
-      "gender varchar not null default 'NA', " +
-      "comment varchar not null default 'ABC') " +
-      "for table %s";
+  private static final String SCHEMA_SQL = "create or replace schema (" +
+    "id int not null, " +
+    "`date` date format 'yyyy-MM-dd', " +
+    "gender varchar not null default 'NA', " +
+    "comment varchar not null default 'ABC') " +
+    "for table %s";
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -120,12 +119,14 @@ public class TestCsvWithSchema extends BaseCsvTest {
     return "`dfs.data`.`" + tableName + "`";
   }
 
-  private void enableSchema(boolean enable) {
-    client.alterSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE, enable);
+  private void enableSchemaSupport() {
+    enableV3(true);
+    enableSchema(true);
   }
 
-  private void resetSchema() {
-    client.resetSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE);
+  private void resetSchemaSupport() {
+    resetV3();
+    resetSchema();
   }
 
   /**
@@ -142,8 +143,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
     String tablePath = buildTable("basic", basicFileContents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       String schemaSql = "create schema (intcol int not null, datecol date not null, " +
           "`dub` double not null, `extra` bigint not null default '20') " +
           "for table " + tablePath;
@@ -164,8 +164,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
@@ -181,8 +180,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
     String tablePath = buildTable(tableName, multi3Contents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       run(SCHEMA_SQL, tablePath);
       String sql = "SELECT id, `name` FROM " + tablePath;
       RowSet actual = client.queryBuilder().sql(sql).rowSet();
@@ -196,8 +194,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
@@ -210,8 +207,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
     String tablePath = buildTable(tableName, multi3Contents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       String schemaSql = SCHEMA_SQL.replace("id int not null", "id int not null default '-1'");
       run(schemaSql, tablePath);
       String sql = "SELECT id, `name`, `date` FROM " + tablePath;
@@ -227,8 +223,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
@@ -241,10 +236,9 @@ public class TestCsvWithSchema extends BaseCsvTest {
     String tablePath = buildTable(tableName, nameOnlyContents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       String schemaSql = SCHEMA_SQL.replace("`date` date format 'yyyy-MM-dd'",
-          "`date` date format 'yyyy-MM-dd' default '2001-02-03'");
+          "`date` date not null format 'yyyy-MM-dd' default '2001-02-03'");
       run(schemaSql, tablePath);
       String sql = "SELECT id, `name`, `date` FROM " + tablePath;
       RowSet actual = client.queryBuilder().sql(sql).rowSet();
@@ -252,15 +246,14 @@ public class TestCsvWithSchema extends BaseCsvTest {
       TupleMetadata expectedSchema = new SchemaBuilder()
           .add("id", MinorType.INT)
           .add("name", MinorType.VARCHAR)
-          .addNullable("date", MinorType.DATE)
+          .add("date", MinorType.DATE)
           .buildSchema();
       RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
           .addRow(0, "dino", new LocalDate(2001, 2, 3))
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
@@ -277,8 +270,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
     RowSet expected1 = null;
     RowSet expected2 = null;
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       enableMultiScan();
       String tablePath = buildTable("multiFileSchema", raggedMulti1Contents, reordered2Contents);
       run(SCHEMA_SQL, tablePath);
@@ -298,7 +290,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
       expected1 = new RowSetBuilder(client.allocator(), expectedSchema)
           .addRow(1, "wilma", new LocalDate(2019, 1, 18), "female", "ABC")
           .addRow(2, "fred", new LocalDate(2019, 1, 19), "male", "ABC")
-          .addRow(4, "betty", new LocalDate(2019, 5, 4), "", "ABC")
+          .addRow(4, "betty", new LocalDate(2019, 5, 4), "NA", "ABC")
           .build();
       expected2 = new RowSetBuilder(client.allocator(), expectedSchema)
           .addRow(3, "barney", new LocalDate(2001, 1, 16), "NA", "ABC")
@@ -333,11 +325,11 @@ public class TestCsvWithSchema extends BaseCsvTest {
     } finally {
       expected1.clear();
       expected2.clear();
-      client.resetSession(ExecConstants.ENABLE_V3_TEXT_READER_KEY);
-      client.resetSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE);
-      client.resetSession(ExecConstants.MIN_READER_WIDTH_KEY);
+      resetSchemaSupport();
+      resetMultiScan();
     }
   }
+
   /**
    * Test the schema we get in V2 when the table read order is random.
    * Worst-case: the two files have different column counts and
@@ -575,9 +567,8 @@ public class TestCsvWithSchema extends BaseCsvTest {
   @Test
   public void testSchemaExplicitSort() throws Exception {
     try {
-      enableSchema(true);
+      enableSchemaSupport();
       enableMultiScan();
-      enableV3(true);
       // V3 handles ragged columns
       String tablePath = buildTable("v3ExplictSort", raggedMulti1Contents, reordered2Contents);
       run(SCHEMA_SQL, tablePath);
@@ -591,7 +582,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .addRow(1, "wilma", "female")
           .addRow(2, "fred", "male")
           .addRow(3, "barney", "NA")
-          .addRow(4, "betty", "")
+          .addRow(4, "betty", "NA")
           .build();
       for (int i = 0; i < 10; i++) {
         RowSet result = client.queryBuilder().sql(sql).rowSet();
@@ -599,8 +590,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
       }
       expected.clear();
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
       resetMultiScan();
     }
   }
@@ -624,8 +614,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
   public void testMultiFileSchemaMissingCol() throws Exception {
     RowSet expected = null;
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       enableMultiScan();
       String tablePath = buildTable("schemaMissingCols", raggedMulti1Contents,
           reordered2Contents, multi3Contents);
@@ -649,7 +638,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .addRow(1, "wilma", new LocalDate(2019, 1, 18), "female", "ABC")
           .addRow(2, "fred", new LocalDate(2019, 1, 19), "male", "ABC")
           .addRow(3, "barney", new LocalDate(2001, 1, 16), "NA", "ABC")
-          .addRow(4, "betty", new LocalDate(2019, 5, 4), "", "ABC")
+          .addRow(4, "betty", new LocalDate(2019, 5, 4), "NA", "ABC")
           .build();
 
       // Loop 10 times so that, as the two reader fragments read the two
@@ -662,9 +651,8 @@ public class TestCsvWithSchema extends BaseCsvTest {
       }
     } finally {
       expected.clear();
-      resetV3();
+      resetSchemaSupport();
       resetMultiScan();
-      resetSchema();
     }
   }
 
@@ -682,8 +670,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
         reordered2Contents, nameOnlyContents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       run(SCHEMA_SQL, tablePath);
       String sql = "SELECT * FROM " + tablePath + "ORDER BY id";
       RowSet actual = client.queryBuilder().sql(sql).rowSet();
@@ -704,8 +691,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
@@ -720,8 +706,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
         reordered2Contents, nameOnlyContents);
 
     try {
-      enableV3(true);
-      enableSchema(true);
+      enableSchemaSupport();
       String sql = SCHEMA_SQL +
           " PROPERTIES ('" + TupleMetadata.IS_STRICT_SCHEMA_PROP + "'='true')";
       run(sql, tablePath);
@@ -743,14 +728,13 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
-      resetSchema();
+      resetSchemaSupport();
     }
   }
 
   /**
    * Test a strict schema where it is needed most: in a scan with multiple
-   * fragments, each of which sees a diffrent reader schema. The output schema
+   * fragments, each of which sees a different reader schema. The output schema
    * ensures that each scan independently reports the same schema, so that the
    * downstream sort operator gets a single consistent batch schema.
    */
@@ -761,9 +745,8 @@ public class TestCsvWithSchema extends BaseCsvTest {
         reordered2Contents, nameOnlyContents);
 
     try {
-      enableV3(true);
+      enableSchemaSupport();
       enableMultiScan();
-      enableSchema(true);
       String sql = SCHEMA_SQL +
           " PROPERTIES ('" + TupleMetadata.IS_STRICT_SCHEMA_PROP + "'='true')";
       run(sql, tablePath);
@@ -785,9 +768,671 @@ public class TestCsvWithSchema extends BaseCsvTest {
           .build();
       RowSetUtilities.verify(expected, actual);
     } finally {
-      resetV3();
+      resetSchemaSupport();
       resetMultiScan();
+    }
+  }
+
+  private static final String boolContents[] = {
+    "id,bool_col",
+    "1,true",
+    "2,false",
+    "3,TRUE",
+    "4,FALSE",
+    "5,t",
+    "6,T",
+    "7,1",
+    "8,0",
+    "9",
+    "10,y",
+    "11,Y",
+    "12,yes",
+    "13,yEs",
+    "14,on",
+    "15,ON",
+    "16,foo"
+  };
+
+  /**
+   * Test the many ways to specify True for boolean columns. Anything that
+   * is not true is false.
+   */
+  @Test
+  public void testBool() throws Exception {
+    String tableName = "bool";
+    String tablePath = buildTable(tableName, boolContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "bool_col boolean not null default `true` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("bool_col", MinorType.BIT)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow( 1, true)
+          .addRow( 2, false)
+          .addRow( 3, true)
+          .addRow( 4, false)
+          .addRow( 5, true)
+          .addRow( 6, true)
+          .addRow( 7, true)
+          .addRow( 8, false)
+          .addRow( 9, true)
+          .addRow(10, true)
+          .addRow(11, true)
+          .addRow(12, true)
+          .addRow(13, true)
+          .addRow(14, true)
+          .addRow(15, true)
+          .addRow(16, false)
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String decimalContents[] = {
+    "id,decimal_col",
+    "1,12.34",
+    "2,-56.789",
+    "3,0",
+    "4,8",
+    "5",
+    "6,0.00",
+    "7,-0.00",
+  };
+
+  /**
+   * Basic decimal sanity test showing rounding, using default values,
+   * and so on.
+   */
+  @Test
+  public void testDecimal() throws Exception {
+    String tableName = "decimal";
+    String tablePath = buildTable(tableName, decimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(5,2) not null default `100.00` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("decimal_col", MinorType.VARDECIMAL, 5, 2)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, dec("12.34"))
+          .addRow(2, dec("-56.79"))
+          .addRow(3, dec("0"))
+          .addRow(4, dec("8"))
+          .addRow(5, dec("100.00"))
+          .addRow(6, dec("0.00"))
+          .addRow(7, dec("0.00"))
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * Verify that a decimal type without precision or scale defaults
+   * to precision of 38, scale of 0.
+   */
+  @Test
+  public void testDecimalNoPrecOrScale() throws Exception {
+    String tableName = "noPrecOrScale";
+    String tablePath = buildTable(tableName, decimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal not null default `100.00` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("decimal_col", MinorType.VARDECIMAL, 38, 0)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, dec("12"))
+          .addRow(2, dec("-57"))
+          .addRow(3, dec("0"))
+          .addRow(4, dec("8"))
+          .addRow(5, dec("100"))
+          .addRow(6, dec("0"))
+          .addRow(7, dec("0"))
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * Verify that a decimal type with no scale defaults to a scale of 0.
+   */
+  @Test
+  public void testDecimalNoScale() throws Exception {
+    String tableName = "noScale";
+    String tablePath = buildTable(tableName, decimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(5) not null default `100.00` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("decimal_col", MinorType.VARDECIMAL, 5, 0)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, dec("12"))
+          .addRow(2, dec("-57"))
+          .addRow(3, dec("0"))
+          .addRow(4, dec("8"))
+          .addRow(5, dec("100"))
+          .addRow(6, dec("0"))
+          .addRow(7, dec("0"))
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String raggedDecimalContents[] = {
+    "id,decimal_col",
+    "1,1234.5678",
+    "2",
+    "3,-12.345"
+  };
+
+  /**
+   * Verify that the decimal default value is rounded according
+   * to the scale specified in the decimal type.
+   */
+  @Test
+  public void testDecimalDefaultRound() throws Exception {
+    String tableName = "defaultRound";
+    String tablePath = buildTable(tableName, raggedDecimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(5) not null default `1111.56789` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("decimal_col", MinorType.VARDECIMAL, 5, 0)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, dec("1235"))
+          .addRow(2, dec("1112"))
+          .addRow(3, dec("-12"))
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String decimalOverflowContents[] = {
+    "id,decimal_col",
+    "1,99999.9",
+  };
+
+  /**
+   * Test decimal overflow during data reads. The overflow occurs after
+   * rounding the data value of 99999.9 to 100000.
+  */
+  @Test
+  public void testDecimalOverflow() throws Exception {
+    String tableName = "decimalOverflow";
+    String tablePath = buildTable(tableName, decimalOverflowContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(5) not null" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      try {
+        client.queryBuilder().sql(sql).run();
+        fail();
+      } catch (UserRemoteException e) {
+        assertTrue(e.getMessage().contains("VALIDATION ERROR"));
+        assertTrue(e.getMessage().contains("Value 100000 overflows specified precision 5 with scale 0"));
+      }
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * Test proper handling of overflow for a default value. In this case,
+   * the overflow occurs after rounding.
+   */
+  @Test
+  public void testDecimalDefaultOverflow() throws Exception {
+    String tableName = "decimalDefaultOverflow";
+    String tablePath = buildTable(tableName, raggedDecimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(5) not null default `99999.9` " +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      try {
+        client.queryBuilder().sql(sql).run();
+        fail();
+      } catch (UserRemoteException e) {
+        assertTrue(e.getMessage().contains("VALIDATION ERROR"));
+        assertTrue(e.getMessage().contains("Value 100000 overflows specified precision 5 with scale 0"));
+      }
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  @Test
+  public void testInvalidDecimalSchema() throws Exception {
+    String tableName = "invalidDecimal";
+    String tablePath = buildTable(tableName, raggedDecimalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, " +
+          "decimal_col decimal(39) not null" +
+          ") for table %s";
+      try {
+        run(sql, tablePath);
+        fail();
+      } catch (UserRemoteException e) {
+        assertTrue(e.getMessage().contains("VALIDATION ERROR"));
+        assertTrue(e.getMessage().contains("VARDECIMAL(39, 0) exceeds maximum suppored precision of 38"));
+      }
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String trivalContents[] = {
+    "id",
+    "1"
+  };
+
+  @Test
+  public void testMissingCols() throws Exception {
+    String tableName = "missingCols";
+    String tablePath = buildTable(tableName, trivalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "col_int integer, " +
+          "col_bigint bigint, " +
+          "col_double double, " +
+          "col_float float, " +
+          "col_var varchar, " +
+          "col_boolean boolean, " +
+          "col_interval interval, " +
+          "col_time time, " +
+          "col_date date, " +
+          "col_timestamp timestamp" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .addNullable("col_int", MinorType.INT)
+          .addNullable("col_bigint", MinorType.BIGINT)
+          .addNullable("col_double", MinorType.FLOAT8)
+          .addNullable("col_float", MinorType.FLOAT4)
+          .addNullable("col_var", MinorType.VARCHAR)
+          .addNullable("col_boolean", MinorType.BIT)
+          .addNullable("col_interval", MinorType.INTERVAL)
+          .addNullable("col_time", MinorType.TIME)
+          .addNullable("col_date", MinorType.DATE)
+          .addNullable("col_timestamp", MinorType.TIMESTAMP)
+          .add("id", MinorType.VARCHAR)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(null, null, null, null, null, null, null, null, null, null, "1")
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetV3();
       resetSchema();
+    }
+  }
+
+  /**
+   * Verify that, if a schema is provided, a column is missing,
+   * and there is no default, that the mode is left at required and
+   * the column is filled with zeros. Note that this behavior is
+   * specific to the text readers: if have no schema, even an missing
+   * VARCHAR column will be REQUIRED and set to an empty string
+   * (reason: if the column does appear it will be a required VARCHAR,
+   * so, to be consistent, missing columns are also required.)
+   */
+  @Test
+  public void testMissingColsReq() throws Exception {
+    String tableName = "missingColsStrict";
+    String tablePath = buildTable(tableName, trivalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "col_int integer not null, " +
+          "col_bigint bigint not null, " +
+          "col_double double not null, " +
+          "col_float float not null, " +
+          "col_var varchar not null, " +
+          "col_boolean boolean not null, " +
+          "col_interval interval not null, " +
+          "col_time time not null, " +
+          "col_date date not null, " +
+          "col_timestamp timestamp not null" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("col_int", MinorType.INT)
+          .add("col_bigint", MinorType.BIGINT)
+          .add("col_double", MinorType.FLOAT8)
+          .add("col_float", MinorType.FLOAT4)
+          .add("col_var", MinorType.VARCHAR)
+          .add("col_boolean", MinorType.BIT)
+          .add("col_interval", MinorType.INTERVAL)
+          .add("col_time", MinorType.TIME)
+          .add("col_date", MinorType.DATE)
+          .add("col_timestamp", MinorType.TIMESTAMP)
+          .add("id", MinorType.VARCHAR)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(0, 0L, 0.0, 0D, "", false, new Period(0), 0, 0L, 0L, "1")
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * Verify the behavior of missing columns, not null mode, with
+   * a default value.
+   */
+  @Test
+  public void testMissingColsReqDefault() throws Exception {
+    String tableName = "missingColsDefault";
+    String tablePath = buildTable(tableName, trivalContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "col_int integer not null default '10', " +
+          "col_bigint bigint not null default '10', " +
+          "col_double double not null default '10.5', " +
+          "col_float float not null default '10.5', " +
+          "col_var varchar not null default 'foo', " +
+          "col_boolean boolean not null default '1', " +
+          "col_interval interval not null default 'P10D', " +
+          "col_time time not null default '12:34:56', " +
+          "col_date date not null default '2019-03-28', " +
+          "col_timestamp timestamp not null format 'yyyy-MM-dd HH:mm:ss' default '2019-03-28 12:34:56'" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("col_int", MinorType.INT)
+          .add("col_bigint", MinorType.BIGINT)
+          .add("col_double", MinorType.FLOAT8)
+          .add("col_float", MinorType.FLOAT4)
+          .add("col_var", MinorType.VARCHAR)
+          .add("col_boolean", MinorType.BIT)
+          .add("col_interval", MinorType.INTERVAL)
+          .add("col_time", MinorType.TIME)
+          .add("col_date", MinorType.DATE)
+          .add("col_timestamp", MinorType.TIMESTAMP)
+          .add("id", MinorType.VARCHAR)
+          .buildSchema();
+      LocalTime lt = new LocalTime(12, 34, 56);
+      LocalDate ld = new LocalDate(2019, 3, 28);
+      Instant ts = ld.toDateTime(lt).toInstant();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(10, 10L, 10.5, 10.5D, "foo", true, new Period(0).plusDays(10),
+              lt, ld, ts, "1")
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String missingColContents[] = {
+    "id,amount,start_date",
+    "1,20,2019-01-01",
+    "2",
+    "3,30"
+  };
+
+  /**
+   * Demonstrate that CSV works for a schema with nullable types when columns
+   * are missing (there is no comma to introduce an empty field in the data.)
+   */
+  @Test
+  public void testMissingColsNullable() throws Exception {
+    String tableName = "missingColsNullable";
+    String tablePath = buildTable(tableName, missingColContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, amount int, start_date date" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .addNullable("amount", MinorType.INT)
+          .addNullable("start_date", MinorType.DATE)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, 20, new LocalDate(2019, 1, 1))
+          .addRow(2, null, null)
+          .addRow(3, 30, null)
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  private static final String blankColContents[] = {
+    "id,amount,start_date",
+    "1,20,2019-01-01",
+    "2, ,",    // Spaces intentional
+    "3, 30 ,"  // Spaces intentional
+  };
+
+  /**
+   * Demonstrate that CSV uses a comma to introduce a column,
+   * even if that column has no data. In this case, CSV assumes the
+   * value of the column is a blank string.
+   * <p>
+   * Such a schema cannot be converted to a number or date column,
+   * even nullable, because a blank string is neither a valid number nor
+   * a valid date.
+   */
+
+  @Test
+  public void testBlankCols() throws Exception {
+    String tableName = "blankCols";
+    String tablePath = buildTable(tableName, blankColContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.VARCHAR)
+          .add("amount", MinorType.VARCHAR)
+          .add("start_date", MinorType.VARCHAR)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow("1", "20", "2019-01-01")
+          .addRow("2", " ", "")
+          .addRow("3", " 30 ", "")
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * Use the same data set as above tests, but use a schema to do type
+   * conversion. Blank columns become 0 for numeric non-nullable, nulls for
+   * nullable non-numeric.
+   */
+  @Test
+  public void testBlankColsWithSchema() throws Exception {
+    String tableName = "blankColsSchema";
+    String tablePath = buildTable(tableName, blankColContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, amount int not null, start_date date" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("amount", MinorType.INT)
+          .addNullable("start_date", MinorType.DATE)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, 20, new LocalDate(2019, 1, 1))
+          .addRow(2, 0, null)
+          .addRow(3, 30, null)
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * As above, but with a nullable numeric column. Here, by default,
+   * blank values become nulls.
+   */
+  @Test
+  public void testBlankColsWithNullableSchema() throws Exception {
+    String tableName = "blankColsNullableSchema";
+    String tablePath = buildTable(tableName, blankColContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, amount int, start_date date" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .addNullable("amount", MinorType.INT)
+          .addNullable("start_date", MinorType.DATE)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, 20, new LocalDate(2019, 1, 1))
+          .addRow(2, null, null)
+          .addRow(3, 30, null)
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
+    }
+  }
+
+  /**
+   * As above, but with a non-nullable numeric column with a default
+   * value.
+   */
+  @Test
+  public void testBlankColsWithNDefaultValue() throws Exception {
+    String tableName = "blankColsNullableSchema";
+    String tablePath = buildTable(tableName, blankColContents);
+
+    try {
+      enableSchemaSupport();
+      String sql = "create or replace schema (" +
+          "id int not null, amount int not null default '-1', start_date date" +
+          ") for table %s";
+      run(sql, tablePath);
+      sql = "SELECT * FROM " + tablePath + "ORDER BY id";
+      RowSet actual = client.queryBuilder().sql(sql).rowSet();
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .add("id", MinorType.INT)
+          .add("amount", MinorType.INT)
+          .addNullable("start_date", MinorType.DATE)
+          .buildSchema();
+      RowSet expected = new RowSetBuilder(client.allocator(), expectedSchema)
+          .addRow(1, 20, new LocalDate(2019, 1, 1))
+          .addRow(2, -1, null)
+          .addRow(3, 30, null)
+          .build();
+      RowSetUtilities.verify(expected, actual);
+    } finally {
+      resetSchemaSupport();
     }
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterTest.java
@@ -118,7 +118,7 @@ public class ClusterTest extends DrillTest {
   }
 
   public static void run(String query, Object... args) throws Exception {
-    client.queryBuilder().sql(query, args).run( );
+    client.queryBuilder().sql(query, args).run();
   }
 
   public QueryBuilder queryBuilder( ) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
@@ -83,6 +83,7 @@ public final class RowSetBuilder {
    * set as <br><tt>add(10, "foo");</tt><br> Values of arrays can be expressed as a Java
    * array. A schema of (a:int, b:int[]) can be set as<br>
    * <tt>add(10, new int[] {100, 200});</tt><br>
+   *
    * @param values column values in column index order
    * @return this builder
    * @throws IllegalStateException if the batch, or any vector in the batch,

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
@@ -30,6 +30,9 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.ValueType;
 import org.bouncycastle.util.Arrays;
 import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.joda.time.Period;
 
 /**
@@ -73,6 +76,10 @@ public class RowSetUtilities {
     writer.setObject(testDataFromInt(writer.valueType(), field.getType(), value));
   }
 
+  /**
+   * Create a test value that can be passed to setObject(). This value matches the
+   * value type for a writer.
+   */
   public static Object testDataFromInt(ValueType valueType, MajorType dataType, int value) {
     switch (valueType) {
     case BYTES:
@@ -102,6 +109,12 @@ public class RowSetUtilities {
       return BigDecimal.valueOf(value, dataType.getScale());
     case PERIOD:
       return periodFromInt(dataType.getMinorType(), value);
+    case DATE:
+      return new LocalDate(value);
+    case TIME:
+      return new LocalTime(value);
+    case TIMESTAMP:
+      return new Instant(value);
     default:
       throw new IllegalStateException("Unknown writer type: " + valueType);
     }
@@ -158,6 +171,9 @@ public class RowSetUtilities {
      case LONG:
      case STRING:
      case DECIMAL:
+     case DATE:
+     case TIME:
+     case TIMESTAMP:
        assertEquals(msg, expectedObj, actualObj);
        break;
      case PERIOD: {
@@ -243,6 +259,10 @@ public class RowSetUtilities {
    */
   public static void verify(RowSet expected, RowSet actual) {
     new RowSetComparison(expected).verifyAndClearAll(actual);
+  }
+
+  public static BigDecimal dec(String value) {
+    return new BigDecimal(value);
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestDummyWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestDummyWriter.java
@@ -34,7 +34,7 @@ import org.apache.drill.exec.vector.accessor.writer.MapWriter;
 import org.apache.drill.test.SubOperatorTest;
 import org.junit.Test;
 
-public class DummyWriterTest extends SubOperatorTest {
+public class TestDummyWriter extends SubOperatorTest {
 
   /**
    * Test only, bare-bones tuple writer used to gather the dummy

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestIdMap.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RequestIdMap.java
@@ -22,10 +22,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.procedures.IntObjectProcedure;
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
@@ -74,11 +74,10 @@ class RequestIdMap {
     public void apply(int key, RpcOutcome<?> value) {
       try{
         value.setException(exception);
-      }catch(Exception e){
+      }catch (final Exception e){
         logger.warn("Failure while attempting to fail rpc response.", e);
       }
     }
-
   }
 
   public <V> ChannelListenerWithCoordinationId createNewRpcListener(RpcOutcomeListener<V> handler, Class<V> clazz,
@@ -101,6 +100,7 @@ class RequestIdMap {
     final RpcOutcomeListener<T> handler;
     final Class<T> clazz;
     final int coordinationId;
+    @SuppressWarnings("unused")
     final RemoteConnection connection;
 
     public RpcListener(RpcOutcomeListener<T> handler, Class<T> clazz, int coordinationId, RemoteConnection connection) {
@@ -140,15 +140,10 @@ class RequestIdMap {
     }
 
     @Override
-    public Class<T> getOutcomeType() {
-      return clazz;
-    }
+    public Class<T> getOutcomeType() { return clazz; }
 
     @Override
-    public int getCoordinationId() {
-      return coordinationId;
-    }
-
+    public int getCoordinationId() { return coordinationId; }
   }
 
   private RpcOutcome<?> removeFromMap(int coordinationId) {
@@ -165,9 +160,9 @@ class RequestIdMap {
 
   public <V> RpcOutcome<V> getAndRemoveRpcOutcome(int rpcType, int coordinationId, Class<V> clazz) {
 
-    RpcOutcome<?> rpc = removeFromMap(coordinationId);
+    final RpcOutcome<?> rpc = removeFromMap(coordinationId);
     // logger.debug("Got rpc from map {}", rpc);
-    Class<?> outcomeClass = rpc.getOutcomeType();
+    final Class<?> outcomeClass = rpc.getOutcomeType();
 
     if (outcomeClass != clazz) {
       throw new IllegalStateException(String.format(
@@ -178,6 +173,7 @@ class RequestIdMap {
     }
 
     @SuppressWarnings("unchecked")
+    final
     RpcOutcome<V> crpc = (RpcOutcome<V>) rpc;
 
     // logger.debug("Returning casted future");
@@ -187,11 +183,10 @@ class RequestIdMap {
   public void recordRemoteFailure(int coordinationId, DrillPBError failure) {
     // logger.debug("Updating failed future.");
     try {
-      RpcOutcome<?> rpc = removeFromMap(coordinationId);
+      final RpcOutcome<?> rpc = removeFromMap(coordinationId);
       rpc.setException(new UserRemoteException(failure));
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       logger.warn("Failed to remove from map.  Not a problem since we were updating on failed future.", ex);
     }
   }
-
 }

--- a/exec/vector/src/main/codegen/templates/ColumnAccessors.java
+++ b/exec/vector/src/main/codegen/templates/ColumnAccessors.java
@@ -34,15 +34,14 @@
       return ValueType.${label?upper_case};
   </#if>
     }
-</#macro>
-<#macro extendedType drillType>
-  <#if drillType == "Time" || drillType == "Date" || drillType == "TimeStamp">
+  <#if drillType == "Date" || drillType == "Time" || drillType == "TimeStamp">
+
     @Override
     public ValueType extendedType() {
-    <#if drillType == "Time">
-      return ValueType.TIME;
-    <#elseif drillType == "Date">
+    <#if drillType == "Date">
       return ValueType.DATE;
+    <#elseif drillType == "Time">
+      return ValueType.TIME;
     <#elseif drillType == "TimeStamp">
       return ValueType.TIMESTAMP;
     <#else>
@@ -50,7 +49,6 @@
       return valueType();
     </#if>
     }
-
   </#if>
 </#macro>
 <#macro build types vectorType accessorType>
@@ -80,14 +78,55 @@
   </#list>
   }
 </#macro>
+<#macro writeBuf buffer drillType minor putType doCast >
+  <#if varWidth>
+      ${buffer}.setBytes(offset, value, 0, len);
+  <#elseif drillType == "Decimal9">
+      ${buffer}.setInt(offset,
+        DecimalUtility.getDecimal9FromBigDecimal(value,
+            type.getScale()));
+  <#elseif drillType == "Decimal18">
+      ${buffer}.setLong(offset,
+          DecimalUtility.getDecimal18FromBigDecimal(value,
+              type.getScale()));
+  <#elseif drillType == "Decimal38Sparse">
+      <#-- Hard to optimize this case. Just use the available tools. -->
+      DecimalUtility.getSparseFromBigDecimal(value, ${buffer},
+          offset, type.getScale(), 6);
+  <#elseif drillType == "Decimal28Sparse">
+      <#-- Hard to optimize this case. Just use the available tools. -->
+      DecimalUtility.getSparseFromBigDecimal(value, ${buffer},
+          offset, type.getScale(), 5);
+  <#elseif drillType == "IntervalYear">
+      ${buffer}.setInt(offset,
+          value.getYears() * 12 + value.getMonths());
+  <#elseif drillType == "IntervalDay">
+      ${buffer}.setInt(offset, value.getDays());
+      ${buffer}.setInt(offset + ${minor.millisecondsOffset}, DateUtilities.periodToMillis(value));
+  <#elseif drillType == "Interval">
+      ${buffer}.setInt(offset, DateUtilities.periodToMonths(value));
+      ${buffer}.setInt(offset + ${minor.daysOffset}, value.getDays());
+      ${buffer}.setInt(offset + ${minor.millisecondsOffset}, DateUtilities.periodToMillis(value));
+  <#elseif drillType == "Float4">
+      ${buffer}.setInt(offset, Float.floatToRawIntBits((float) value));
+  <#elseif drillType == "Float8">
+      ${buffer}.setLong(offset, Double.doubleToRawLongBits(value));
+  <#elseif drillType == "Bit">
+      ${buffer}.setByte(offset, (byte)(value & 0x01));
+  <#else>
+      ${buffer}.set${putType?cap_first}(offset, <#if doCast>(${putType}) </#if>value);
+  </#if>
+</#macro>
 <@copyright />
 
 package org.apache.drill.exec.vector.accessor;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 
 import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.vector.DateUtilities;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.*;
@@ -96,6 +135,7 @@ import org.apache.drill.exec.vector.accessor.reader.BaseScalarReader.BaseVarWidt
 import org.apache.drill.exec.vector.accessor.reader.BaseScalarReader.BaseFixedWidthReader;
 import org.apache.drill.exec.vector.accessor.reader.VectorAccessor;
 import org.apache.drill.exec.vector.accessor.writer.AbstractFixedWidthWriter.BaseFixedWidthWriter;
+import org.apache.drill.exec.vector.accessor.writer.AbstractFixedWidthWriter.BaseIntWriter;
 import org.apache.drill.exec.vector.accessor.writer.BaseVarWidthWriter;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
@@ -127,22 +167,33 @@ public class ColumnAccessors {
 <#list vv.types as type>
   <#list type.minor as minor>
     <#assign drillType=minor.class>
+    <#if drillType == "Bit">
+      <#-- Bit is special, handled outside of codegen. -->
+      <#continue>
+    </#if>
     <#assign javaType=minor.javaType!type.javaType>
     <#assign accessorType=minor.accessorType!type.accessorType!minor.friendlyType!javaType>
     <#assign label=minor.accessorLabel!type.accessorLabel!accessorType?capitalize>
     <#assign notyet=minor.accessorDisabled!type.accessorDisabled!false>
-    <#assign cast=minor.accessorCast!minor.accessorCast!type.accessorCast!"none">
+    <#if notyet>
+      <#continue>
+    </#if>
+   <#assign cast=minor.accessorCast!minor.accessorCast!type.accessorCast!"none">
     <#assign friendlyType=minor.friendlyType!"">
     <#if accessorType=="BigDecimal">
       <#assign label="Decimal">
     </#if>
-    <#assign varWidth = drillType == "VarChar" || drillType == "Var16Char" || drillType == "VarBinary"  || drillType == "VarDecimal"/>
+    <#assign varWidth = drillType == "VarChar" || drillType == "Var16Char" ||
+                        drillType == "VarBinary" || drillType == "VarDecimal" />
     <#assign decimal = drillType == "Decimal9" || drillType == "Decimal18" ||
-                       drillType == "Decimal28Sparse" || drillType == "Decimal38Sparse" || drillType == "VarDecimal"/>
+                       drillType == "Decimal28Sparse" || drillType == "Decimal38Sparse" ||
+                       drillType == "VarDecimal" />
+    <#assign intType = drillType == "TinyInt" || drillType == "SmallInt" || drillType == "Int" ||
+                       drillType == "Bit" || drillType == "UInt1" || drillType = "UInt2" />
     <#if varWidth>
       <#assign accessorType = "byte[]">
       <#assign label = "Bytes">
-      <#assign putArgs = ", int len">
+      <#assign putArgs = ", final int len">
     <#else>
       <#assign putArgs = "">
     </#if>
@@ -153,7 +204,6 @@ public class ColumnAccessors {
       <#assign putType = javaType />
       <#assign doCast = (cast == "set") />
     </#if>
-    <#if ! notyet>
   //------------------------------------------------------------------------
   // ${drillType} readers and writers
 
@@ -179,12 +229,11 @@ public class ColumnAccessors {
 
     </#if>
     <@getType drillType label />
-
-    <@extendedType drillType />
     <#if ! varWidth>
-    @Override public int width() { return VALUE_WIDTH; }
 
+    @Override public int width() { return VALUE_WIDTH; }
     </#if>
+
     @Override
     public ${accessorType} get${label}() {
     <#assign getObject ="getObject"/>
@@ -302,97 +351,70 @@ public class ColumnAccessors {
     <#if varWidth>
   public static class ${drillType}ColumnWriter extends BaseVarWidthWriter {
     <#else>
+      <#if intType>
+  public static class ${drillType}ColumnWriter extends BaseIntWriter {
+      <#else>
   public static class ${drillType}ColumnWriter extends BaseFixedWidthWriter {
+      </#if>
 
     private static final int VALUE_WIDTH = ${drillType}Vector.VALUE_WIDTH;
     </#if>
 
     private final ${drillType}Vector vector;
     <#if drillType == "VarDecimal">
+    private int precision;
     private int scale;
     <#elseif decimal>
     private MajorType type;
     </#if>
 
     public ${drillType}ColumnWriter(final ValueVector vector) {
-      <#if varWidth>
+    <#if varWidth>
       super(((${drillType}Vector) vector).getOffsetVector());
-      <#else>
-      </#if>
-      <#if drillType == "VarDecimal">
+    </#if>
+    <#if drillType == "VarDecimal">
       // VarDecimal requires a scale. If not set, assume 0
       MajorType type = vector.getField().getType();
+      precision = type.hasPrecision() ? type.getPrecision() : Types.maxPrecision(type.getMinorType());
       scale = type.hasScale() ? type.getScale() : 0;
-      <#elseif decimal>
+    <#elseif decimal>
       type = vector.getField().getType();
-      </#if>
+    </#if>
       this.vector = (${drillType}Vector) vector;
     }
 
     @Override public BaseDataValueVector vector() { return vector; }
 
-       <#if ! varWidth>
+     <#if ! varWidth>
     @Override public int width() { return VALUE_WIDTH; }
 
-      </#if>
-      <@getType drillType label />
-      <#if ! varWidth>
     </#if>
+      <@getType drillType label />
 
     @Override
     public final void set${label}(final ${accessorType} value${putArgs}) {
-      <#-- Must compute the write offset first; can't be inline because the
-           writeOffset() function has a side effect of possibly changing the buffer
-           address (bufAddr). -->
-      <#if ! varWidth>
-      final int writeOffset = prepareWrite();
-      <#assign putOffset = "writeOffset * VALUE_WIDTH">
-      </#if>
-      <#if varWidth>
+    <#-- Must compute the write offset first; can't be inline because the
+         writeOffset() function has a side effect of possibly changing the buffer
+         address (bufAddr). -->
+    <#if varWidth>
       final int offset = prepareWrite(len);
-      drillBuf.setBytes(offset, value, 0, len);
+    <#else>
+      final int offset = prepareWrite() * VALUE_WIDTH;
+    </#if>
+      <@writeBuf "drillBuf", drillType minor putType doCast />
+    <#if varWidth>
       offsetsWriter.setNextOffset(offset + len);
-      <#elseif drillType == "Decimal9">
-      drillBuf.setInt(${putOffset},
-          DecimalUtility.getDecimal9FromBigDecimal(value,
-              type.getScale()));
-      <#elseif drillType == "Decimal18">
-      drillBuf.setLong(${putOffset},
-          DecimalUtility.getDecimal18FromBigDecimal(value,
-              type.getScale()));
-      <#elseif drillType == "Decimal38Sparse">
-      <#-- Hard to optimize this case. Just use the available tools. -->
-      DecimalUtility.getSparseFromBigDecimal(value, drillBuf,
-          ${putOffset},
-          type.getScale(), 6);
-      <#elseif drillType == "Decimal28Sparse">
-      <#-- Hard to optimize this case. Just use the available tools. -->
-      DecimalUtility.getSparseFromBigDecimal(value, drillBuf,
-          ${putOffset},
-          type.getScale(), 5);
-      <#elseif drillType == "IntervalYear">
-      drillBuf.setInt(${putOffset},
-          value.getYears() * 12 + value.getMonths());
-      <#elseif drillType == "IntervalDay">
-      final int offset = ${putOffset};
-      drillBuf.setInt(offset, value.getDays());
-      drillBuf.setInt(offset + ${minor.millisecondsOffset}, DateUtilities.periodToMillis(value));
-      <#elseif drillType == "Interval">
-      final int offset = ${putOffset};
-      drillBuf.setInt(offset, DateUtilities.periodToMonths(value));
-      drillBuf.setInt(offset + ${minor.daysOffset}, value.getDays());
-      drillBuf.setInt(offset + ${minor.millisecondsOffset}, DateUtilities.periodToMillis(value));
-      <#elseif drillType == "Float4">
-      drillBuf.setInt(${putOffset}, Float.floatToRawIntBits((float) value));
-      <#elseif drillType == "Float8">
-      drillBuf.setLong(${putOffset}, Double.doubleToRawLongBits(value));
-      <#elseif drillType == "Bit">
-      drillBuf.setByte(writeOffset, (byte)(value & 0x01));
-      <#else>
-      drillBuf.set${putType?cap_first}(${putOffset}, <#if doCast>(${putType}) </#if>value);
-      </#if>
+    </#if>
       vectorIndex.nextElement();
     }
+    <#if ! varWidth>
+
+    public final void write${label}(final DrillBuf buf, final ${accessorType} value) {
+      final int offset = 0;
+      <@writeBuf "buf", drillType minor putType doCast />
+      buf.writerIndex(VALUE_WIDTH);
+    }
+    </#if>
     <#if drillType == "VarChar">
 
     @Override
@@ -406,39 +428,6 @@ public class ColumnAccessors {
     public final void setString(final String value) {
       final byte bytes[] = value.getBytes(Charsets.UTF_16);
       setBytes(bytes, bytes.length);
-    }
-
-    <#elseif drillType == "TinyInt" || drillType == "SmallInt" || drillType == "Int">
-
-    @Override
-    public final void setLong(final long value) {
-      try {
-        // Catches int overflow. Does not catch overflow for smaller types.
-        setInt(Math.toIntExact(value));
-      } catch (ArithmeticException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
-    }
-
-    @Override
-    public final void setDouble(final double value) {
-      try {
-        // Catches int overflow. Does not catch overflow from
-        // double. See Math.round for details.
-        setInt(Math.toIntExact(Math.round(value)));
-      } catch (ArithmeticException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
-    }
-
-    @Override
-    public final void setDecimal(final BigDecimal value) {
-      try {
-        // Catches int overflow.
-        setInt(value.intValueExact());
-      } catch (ArithmeticException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
     }
     <#elseif drillType == "BigInt">
 
@@ -499,8 +488,14 @@ public class ColumnAccessors {
 
     @Override
     public final void setDecimal(final BigDecimal value) {
-      final byte[] barr = value.setScale(scale).unscaledValue().toByteArray();
-      setBytes(barr,  barr.length);
+      try {
+        final BigDecimal rounded = value.setScale(scale, RoundingMode.HALF_UP);
+        DecimalUtility.checkValueOverflow(rounded, precision, scale);
+        final byte[] barr = rounded.unscaledValue().toByteArray();
+        setBytes(barr,  barr.length);
+      } catch (ArithmeticException e) {
+        throw new InvalidConversionError("Decimal conversion failed for " + value, e);
+      }
     }
       </#if>
     <#elseif drillType == "Date">
@@ -528,6 +523,7 @@ public class ColumnAccessors {
       setLong(value.getMillis());
     }
     </#if>
+    <#if ! intType>
 
     @Override
     public final void setValue(final Object value) {
@@ -537,20 +533,56 @@ public class ColumnAccessors {
       setDate((LocalDate) value);
       <#elseif drillType = "Time">
       setTime((LocalTime) value);
-      <#elseif drillType = "Timestamp">
+      <#elseif drillType = "TimeStamp">
       setTimestamp((Instant) value);
       <#elseif putArgs != "">
       throw new InvalidConversionError("Generic object not supported for type ${drillType}, "
           + "set${label}(${accessorType}${putArgs})");
       <#else>
       if (value != null) {
-        set${label}((${accessorType}${putArgs}) value);
+        set${label}((${accessorType}) value);
       }
       </#if>
     }
+    </#if>
+
+    <#-- Default value logic is a bit convoluted because we want to reuse the same
+         (complex) template here to generate both the set-value code and the set-default
+         code. This means we need a (temporary) DrillBuf for most cases except those
+         where a byte array value is directly available. -->
+    @Override
+    public final void setDefaultValue(final Object value) {
+    <#if drillType == "VarBinary">
+      emptyValue = (byte[]) value;
+    <#elseif drillType == "VarChar">
+      emptyValue = ((String) value).getBytes(Charsets.UTF_8);
+    <#elseif drillType == "Var16Char">
+      emptyValue = ((String) value).getBytes(Charsets.UTF_16);
+    <#elseif drillType == "VarDecimal">
+      final BigDecimal rounded = ((BigDecimal) value).setScale(scale, RoundingMode.HALF_UP);
+      DecimalUtility.checkValueOverflow(rounded, precision, scale);
+      emptyValue = rounded.unscaledValue().toByteArray();
+    <#else>
+      try (DrillBuf buf = vector.getAllocator().buffer(VALUE_WIDTH)) {
+      <#if drillType = "Date">
+        writeLong(buf, ((LocalDate) value).toDateTimeAtStartOfDay(DateTimeZone.UTC).toInstant().getMillis());
+      <#elseif drillType = "Time">
+        writeInt(buf, ((LocalTime) value).getMillisOfDay());
+      <#elseif drillType = "TimeStamp">
+        writeLong(buf, ((Instant) value).getMillis());
+      <#elseif putArgs != "">
+        throw new InvalidConversionError("Generic object not supported for type ${drillType}, "
+            + "set${label}(${accessorType}${putArgs})");
+      <#else>
+        write${label}(buf, (${accessorType}) value);
+      </#if>
+        emptyValue = new byte[VALUE_WIDTH];
+        buf.getBytes(0, emptyValue);
+      }
+    </#if>
+    }
   }
 
-    </#if>
   </#list>
 </#list>
 }
@@ -562,7 +594,9 @@ package org.apache.drill.exec.vector.accessor;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.vector.accessor.ColumnAccessors.*;
 import org.apache.drill.exec.vector.accessor.reader.BaseScalarReader;
+import org.apache.drill.exec.vector.accessor.reader.BitColumnReader;
 import org.apache.drill.exec.vector.accessor.writer.BaseScalarWriter;
+import org.apache.drill.exec.vector.accessor.writer.BitColumnWriter;
 
 public class ColumnAccessorUtils {
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnMetadata.java
@@ -34,28 +34,35 @@ public interface ColumnMetadata extends Propertied {
    * Predicted number of elements per array entry. Default is
    * taken from the often hard-coded value of 10.
    */
-  public static final String EXPECTED_CARDINALITY_PROP = DRILL_PROP_PREFIX + "cardinality";
+  String EXPECTED_CARDINALITY_PROP = DRILL_PROP_PREFIX + "cardinality";
 
   /**
    * Default value represented as a string.
    */
-  public static final String DEFAULT_VALUE_PROP = DRILL_PROP_PREFIX + "default";
+  String DEFAULT_VALUE_PROP = DRILL_PROP_PREFIX + "default";
 
   /**
    * Expected (average) width for variable-width columns.
    */
-  public static final String EXPECTED_WIDTH_PROP = DRILL_PROP_PREFIX + "width";
+  String EXPECTED_WIDTH_PROP = DRILL_PROP_PREFIX + "width";
 
   /**
    * Optional format to use when converting to/from string values.
    */
-  public static final String FORMAT_PROP = DRILL_PROP_PREFIX + "format";
+  String FORMAT_PROP = DRILL_PROP_PREFIX + "format";
 
   /**
    * Indicates if the column is projected. Used only for internal
    * reader-provided schemas.
    */
-  public static final String PROJECTED_PROP = DRILL_PROP_PREFIX + "projected";
+  String PROJECTED_PROP = DRILL_PROP_PREFIX + "projected";
+
+  /**
+   * Indicates how to handle blanks. Must be one of the valid values defined
+   * in AbstractConvertFromString. Normally set on the converter by the plugin
+   * rather than by the user in the schema.
+   */
+  String BLANK_AS_PROP = DRILL_PROP_PREFIX + "blank-as";
 
   /**
    * Rough characterization of Drill types into metadata categories.

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarReader.java
@@ -76,7 +76,9 @@ public interface ScalarReader extends ColumnReader {
    */
 
   ValueType extendedType();
+
   int getInt();
+  boolean getBoolean();
   long getLong();
   double getDouble();
   String getString();
@@ -86,4 +88,9 @@ public interface ScalarReader extends ColumnReader {
   LocalDate getDate();
   LocalTime getTime();
   Instant getTimestamp();
+
+  /**
+   * Return the value of the object using the extended type.
+   */
+  Object getValue();
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ScalarWriter.java
@@ -56,6 +56,15 @@ public interface ScalarWriter extends ColumnWriter {
    */
 
   ValueType valueType();
+
+  /**
+   * The extended type of the value, describes the secondary type
+   * for DATE, TIME and TIMESTAMP for which the value type is
+   * int or long.
+   */
+
+  ValueType extendedType();
+  void setBoolean(boolean value);
   void setInt(int value);
   void setLong(long value);
   void setDouble(double value);
@@ -81,4 +90,15 @@ public interface ScalarWriter extends ColumnWriter {
    */
 
   void setValue(Object value);
+
+  /**
+   * Set the default value to be used to fill empties for this writer.
+   * Only valid for required writers: null writers set this is-set bit
+   * to 0 and set the data value to 0.
+   *
+   * @param value the value to set. Cannot be null. The type of the value
+   * must match that legal for {@link #setValue(Object)}
+   */
+
+  void setDefaultValue(Object value);
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ValueType.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ValueType.java
@@ -29,6 +29,12 @@ package org.apache.drill.exec.vector.accessor;
 public enum ValueType {
 
   /**
+   * The value is set from a boolean: BIT.
+   */
+
+  BOOLEAN,
+
+  /**
    * The value is set from an integer: TINYINT,
    * SMALLINT, INT, UINT1, and UINT2.
    */

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/AbstractConvertFromString.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/AbstractConvertFromString.java
@@ -17,6 +17,11 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 
@@ -26,9 +31,214 @@ import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
  */
 public abstract class AbstractConvertFromString extends AbstractWriteConverter {
 
+  /**
+   * Property to control how the conversion handles blanks. Blanks are
+   * zero-length text fields (after triming whitespace.)
+   */
+  public static final String BLANK_ACTION_PROP = "blank-as";
+
+  /**
+   * Convert blanks to null values (if the column is nullable), or
+   * fill with the default value (non-nullable.)
+   */
+  public static final String BLANK_AS_NULL = "null";
+
+  /**
+   * Convert blanks for numeric fields to 0. For non-numeric
+   * fields, convert to null (for nullable) or the default value
+   * (for non-nullable). Works best if non-numeric fields are declared
+   * as nullable.
+   */
+  public static final String BLANK_AS_ZERO = "0";
+
+  /**
+   * Skip blank values. This will result in the column being set to null for
+   * nullable columns, and to the default value (else 0 for numeric columns)
+   * for non-nullable columns.
+   */
+  public static final String BLANK_AS_SKIP = "skip";
+
+  protected static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(AbstractConvertFromString.class);
+
+  protected final Function<String,String> prepare;
 
   public AbstractConvertFromString(ScalarWriter baseWriter) {
+    this(baseWriter, null);
+  }
+
+  public AbstractConvertFromString(ScalarWriter baseWriter, Map<String, String> properties) {
     super(baseWriter);
+    this.prepare = buildPrepare(baseWriter.schema(), properties);
+  }
+
+  /**
+   * Create a function to prepare the string. This turns out to be surprisingly
+   * complex. Behavior is determined by a property which can be:
+   * <p>
+   * <ul>
+   * <li>Property is set in the column schema.</li>
+   * <li>Property is set via the framework to a plugin-specific value.</li>
+   * <li>Properties are provided but the blank property is not set.</li>
+   * <li>No framework properties provided.</li>
+   * </ul>
+   *
+   * In the last two cases, no special handling is done for blank properties.
+   * <p>
+   * In all cases, nulls:
+   * <p>
+   * <ul>
+   * <li>Cause the column to be set to null, if the column is nullable. (This step
+   * is actually optional, but is done explicitly to allow a column to be rewritten.)</li>
+   * <li>Cause the column to be skipped, if the column is not nullable.</li>
+   * </ul>
+   *
+   * In all cases, the (non-null) string value is trimmed. Next, there are
+   * multiple ways to handle nulls, depending on context:
+   *
+   * <ul>
+   * <li>Leave nulls unchanged (default if no property is set.)</li>
+   * <li>{@link #BLANK_AS_DEFAULT}: skip the value for the row, letting the
+   * fill-empties logic fill in the default value.</li>
+   * <li>{@link #BLANK_AS_ZERO}: for numeric types, replace the null value with
+   * "0", which will then be parsed to a numeric zero.</li>
+   * <li>{@link #BLANK_AS_NULL}: for nullable modes, set the column to null
+   * and ignore the value.</li>
+   * </ul>
+   * <p>
+   * The preparation function handles setting the column to null if needed.
+   * The function returns a non-null string if the converter should handle it,
+   * or null if the converter should do nothing.
+   * <p>
+   * The logic is handled as a lambda function for two reasons:
+   * <p>
+   * <ul>
+   * <li>Perform all column-wide conditional checks once on writer creation
+   * rather than on every row.</li>
+   * <li>Allow the function to call this writers {@link #setNull()} method.</li>
+   * </ul>
+   *
+   * @param schema the output schema, with user properties optionally set
+   * @param properties optional framework-specific properties
+   * @return a function to call to prepare each string value for conversion
+   */
+
+  private Function<String,String> buildPrepare(ColumnMetadata schema,
+      Map<String, String> properties) {
+
+    String blankProp = schema.property(ColumnMetadata.BLANK_AS_PROP);
+    if (blankProp == null && properties != null) {
+      blankProp = properties.get(BLANK_ACTION_PROP);
+    }
+
+    if (blankProp != null) {
+      switch (blankProp.toLowerCase()) {
+      case BLANK_AS_NULL:
+        return skipBlankFn(schema);
+      case BLANK_AS_ZERO:
+        return blankAsZeroFn(schema);
+     case BLANK_AS_SKIP:
+        if (schema.isNullable()) {
+          return blankToNullFn();
+        } else {
+          return blankAsZeroFn(schema);
+        }
+      default:
+        // Silently ignore invalid values
+        logger.warn("Invalid conversion option '{}', skipping", blankProp);
+        break;
+      }
+    }
+
+    // Else, if the mode, then if the string is null, set the
+    // column to null, else trim the string.
+
+    if (schema.isNullable()) {
+      return nullableStrFn();
+    }
+
+    // Otherwise, trim the string, but have the converter skip this row if the
+    // string is blank. The column loader will then fill in the default value.
+
+    return skipBlanksFn();
+  }
+
+  private Function<String, String> blankAsZeroFn(ColumnMetadata schema) {
+    if (! Types.isNumericType(schema.type())) {
+      return skipBlankFn(schema);
+    } else if (schema.isNullable()) {
+      return nullableBlankToZeroFn();
+    } else {
+      return blankToZeroFn();
+    }
+  }
+
+  private Function<String, String> skipBlankFn(ColumnMetadata schema) {
+    if (schema.isNullable()) {
+      return blankToNullFn();
+    } else {
+      return skipBlankFn();
+    }
+  }
+
+  private static Function<String, String> skipBlanksFn() {
+     return (String s) -> s == null ? s : s.trim();
+  }
+
+  private Function<String, String> nullableStrFn() {
+    return (String s) -> {
+      if (s == null) {
+        setNull();
+        return null;
+      }
+      return s.trim();
+     };
+  }
+
+  private Function<String, String> blankToNullFn() {
+    return (String s) -> {
+      if (s == null) {
+        setNull();
+        return null;
+      }
+      s = s.trim();
+      if (s.isEmpty()) {
+        setNull();
+        return null;
+      }
+      return s;
+    };
+  }
+
+  private Function<String, String> skipBlankFn() {
+    return (String s) -> {
+      if (s == null) {
+        return null;
+      }
+      s = s.trim();
+      return s.isEmpty() ? null : s;
+    };
+  }
+
+  private Function<String, String> nullableBlankToZeroFn() {
+    return (String s) -> {
+      if (s == null) {
+        setNull();
+        return null;
+      }
+      s = s.trim();
+      return s.isEmpty() ? "0" : s;
+    };
+  }
+
+  private Function<String, String> blankToZeroFn() {
+    return (String s) -> {
+      if (s == null) {
+        return null;
+      }
+      s = s.trim();
+      return s.isEmpty() ? "0" : s;
+    };
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/AbstractWriteConverter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/AbstractWriteConverter.java
@@ -69,8 +69,19 @@ public abstract class AbstractWriteConverter extends AbstractScalarWriter {
   }
 
   @Override
+  public void setDefaultValue(Object value) {
+    throw new IllegalStateException(
+        "Cannot set a default value through a shim; types conflict: " + value);
+  }
+
+  @Override
   public void setNull() {
     baseWriter.setNull();
+  }
+
+  @Override
+  public void setBoolean(boolean value) {
+    baseWriter.setBoolean(value);
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertBooleanToString.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertBooleanToString.java
@@ -26,8 +26,8 @@ public class ConvertBooleanToString extends AbstractWriteConverter {
   }
 
   @Override
-  public void setInt(int value) {
-    baseWriter.setString(Boolean.toString(value != 0));
+  public void setBoolean(boolean value) {
+    baseWriter.setString(Boolean.toString(value));
   }
 
   @Override
@@ -35,7 +35,7 @@ public class ConvertBooleanToString extends AbstractWriteConverter {
     if (value == null) {
       setNull();
     } else {
-      setInt((int) value);
+      setBoolean((boolean) value);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToBoolean.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToBoolean.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
+import org.apache.drill.common.types.BooleanType;
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
@@ -27,21 +30,22 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  */
 public class ConvertStringToBoolean extends AbstractConvertFromString {
 
-  public ConvertStringToBoolean(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToBoolean(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setInt(Boolean.parseBoolean(value) ? 1 : 0);
-      }
-      catch (final NumberFormatException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setBoolean(BooleanType.fromString(prepared));
+    }
+    catch (final NumberFormatException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDate.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDate.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.joda.time.LocalDate;
@@ -31,22 +33,23 @@ public class ConvertStringToDate extends AbstractConvertFromString {
 
   private final DateTimeFormatter dateTimeFormatter;
 
-  public ConvertStringToDate(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToDate(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
     dateTimeFormatter = baseWriter.schema().dateTimeFormatter();
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setDate(LocalDate.parse(value, dateTimeFormatter));
-      }
-      catch (final IllegalStateException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setDate(LocalDate.parse(prepared, dateTimeFormatter));
+    }
+    catch (final IllegalStateException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDecimal.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDecimal.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.vector.accessor.convert;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
@@ -30,21 +31,22 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  */
 public class ConvertStringToDecimal extends AbstractConvertFromString {
 
-  public ConvertStringToDecimal(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToDecimal(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setDecimal(new BigDecimal(value));
-      }
-      catch (final NumberFormatException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setDecimal(new BigDecimal(prepared));
+    }
+    catch (final NumberFormatException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDouble.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToDouble.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
@@ -26,21 +28,22 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  */
 public class ConvertStringToDouble extends AbstractConvertFromString {
 
-  public ConvertStringToDouble(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToDouble(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setDouble(Double.parseDouble(value));
-      }
-      catch (final NumberFormatException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setDouble(Double.parseDouble(prepared));
+    }
+    catch (final NumberFormatException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToInt.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToInt.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
@@ -27,21 +29,22 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  */
 public class ConvertStringToInt extends AbstractConvertFromString {
 
-  public ConvertStringToInt(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToInt(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setInt(Integer.parseInt(value));
-      }
-      catch (final NumberFormatException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setInt(Integer.parseInt(prepared));
+    }
+    catch (final NumberFormatException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToInterval.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToInterval.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.vector.accessor.convert;
 
 import java.time.format.DateTimeParseException;
+import java.util.Map;
 
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
@@ -29,21 +30,22 @@ import org.joda.time.Period;
  */
 public class ConvertStringToInterval extends AbstractConvertFromString {
 
-  public ConvertStringToInterval(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToInterval(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setPeriod(Period.parse(value));
-      }
-      catch (final DateTimeParseException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setPeriod(Period.parse(prepared));
+    }
+    catch (final DateTimeParseException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToLong.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToLong.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
@@ -26,21 +28,22 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  */
 public class ConvertStringToLong extends AbstractConvertFromString {
 
-  public ConvertStringToLong(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToLong(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setLong(Long.parseLong(value));
-      }
-      catch (final NumberFormatException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setLong(Long.parseLong(prepared));
+    }
+    catch (final NumberFormatException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToTime.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToTime.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.joda.time.LocalTime;
@@ -31,22 +33,23 @@ public class ConvertStringToTime extends AbstractConvertFromString {
 
   private final DateTimeFormatter dateTimeFormatter;
 
-  public ConvertStringToTime(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToTime(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
     dateTimeFormatter = baseWriter.schema().dateTimeFormatter();
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setTime(LocalTime.parse(value, dateTimeFormatter));
-      }
-      catch (final IllegalStateException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setTime(LocalTime.parse(prepared, dateTimeFormatter));
+    }
+    catch (final IllegalStateException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToTimeStamp.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/convert/ConvertStringToTimeStamp.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.vector.accessor.convert;
 
+import java.util.Map;
+
 import org.apache.drill.exec.vector.accessor.InvalidConversionError;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.joda.time.Instant;
@@ -31,22 +33,23 @@ public class ConvertStringToTimeStamp extends AbstractConvertFromString {
 
   private final DateTimeFormatter dateTimeFormatter;
 
-  public ConvertStringToTimeStamp(ScalarWriter baseWriter) {
-    super(baseWriter);
+  public ConvertStringToTimeStamp(ScalarWriter baseWriter,
+      Map<String, String> properties) {
+    super(baseWriter, properties);
     dateTimeFormatter = baseWriter.schema().dateTimeFormatter();
   }
 
   @Override
   public void setString(final String value) {
-    if (value == null) {
-      baseWriter.setNull();
-    } else {
-      try {
-        baseWriter.setTimestamp(Instant.parse(value, dateTimeFormatter));
-      }
-      catch (final IllegalStateException e) {
-        throw InvalidConversionError.writeError(schema(), value, e);
-      }
+    final String prepared = prepare.apply(value);
+    if (prepared == null) {
+      return;
+    }
+    try {
+      baseWriter.setTimestamp(Instant.parse(prepared, dateTimeFormatter));
+    }
+    catch (final IllegalStateException e) {
+      throw InvalidConversionError.writeError(schema(), value, e);
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.vector.accessor.impl;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
-
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 
 /**
@@ -33,7 +32,10 @@ public class VectorPrinter {
   public static void printOffsets(UInt4Vector vector, int start, int length) {
     header(vector, start, length);
     for (int i = start, j = 0; j < length; i++, j++) {
-      if (j > 0) {
+      if (j % 40 == 0) {
+        System.out.print("\n          ");
+      }
+      else if (j > 0) {
         System.out.print(" ");
       }
       System.out.print(vector.getAccessor().get(i));
@@ -68,5 +70,4 @@ public class VectorPrinter {
   public static String stringAt(VarCharVector vector, int i) {
     return new String(vector.getAccessor().get(i), Charsets.UTF_8);
   }
-
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractScalarReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractScalarReader.java
@@ -125,6 +125,11 @@ public abstract class AbstractScalarReader implements ScalarReader, ReaderEvents
   }
 
   @Override
+  public boolean getBoolean() {
+    throw conversionError("boolean");
+  }
+
+  @Override
   public int getInt() {
     throw conversionError("int");
   }
@@ -180,6 +185,8 @@ public abstract class AbstractScalarReader implements ScalarReader, ReaderEvents
       return null;
     }
     switch (valueType()) {
+    case BOOLEAN:
+      return getBoolean();
     case BYTES:
       return getBytes();
     case DECIMAL:
@@ -202,6 +209,23 @@ public abstract class AbstractScalarReader implements ScalarReader, ReaderEvents
       return getTimestamp();
     default:
       throw new IllegalStateException("Unexpected type: " + valueType());
+    }
+  }
+
+  @Override
+  public Object getValue() {
+    if (isNull()) {
+      return null;
+    }
+    switch (extendedType()) {
+    case DATE:
+      return getDate();
+    case TIME:
+      return getTime();
+    case TIMESTAMP:
+      return getTimestamp();
+    default:
+      return getObject();
     }
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/BitColumnReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/BitColumnReader.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.reader;
+
+import org.apache.drill.exec.vector.BitVector;
+import org.apache.drill.exec.vector.accessor.ValueType;
+import org.apache.drill.exec.vector.accessor.reader.BaseScalarReader.BaseFixedWidthReader;
+
+/**
+ * Specialized reader for bit columns. Bits are packed 8 per byte.
+ * Rather than duplicate that logic here, this reader just delegates
+ * to the vector's own accessor.
+ */
+public class BitColumnReader extends BaseFixedWidthReader {
+
+  @Override
+  public ValueType valueType() {
+    return ValueType.BOOLEAN;
+  }
+
+  @Override public int width() { return BitVector.VALUE_WIDTH; }
+
+  @Override
+  public boolean getBoolean() {
+    final BitVector.Accessor accessor = ((BitVector) vectorAccessor.vector()).getAccessor();
+    final int readOffset = vectorIndex.offset();
+    return accessor.get(readOffset) != 0;
+  }
+
+  @Override
+  public int getInt() {
+    return getBoolean() ? 1 : 0;
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractArrayWriter.java
@@ -257,13 +257,14 @@ public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
     }
   }
 
-  protected final ColumnMetadata schema;
+  private final ColumnMetadata schema;
   protected AbstractObjectWriter elementObjWriter;
   protected final OffsetVectorWriter offsetsWriter;
   protected ColumnWriterIndex outerIndex;
   protected ArrayElementWriterIndex elementIndex;
 
-  public AbstractArrayWriter(ColumnMetadata schema, AbstractObjectWriter elementObjWriter, OffsetVectorWriter offsetVectorWriter) {
+  public AbstractArrayWriter(ColumnMetadata schema, AbstractObjectWriter elementObjWriter,
+      OffsetVectorWriter offsetVectorWriter) {
     this.schema = schema;
     this.elementObjWriter = elementObjWriter;
     this.offsetsWriter = offsetVectorWriter;
@@ -337,7 +338,7 @@ public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
 
   @Override
   public void setNull(boolean isNull) {
-    if (isNull == true) {
+    if (isNull) {
       throw new UnsupportedOperationException();
     }
   }
@@ -357,7 +358,7 @@ public abstract class AbstractArrayWriter implements ArrayWriter, WriterEvents {
     format
       .startObject(this)
       .attribute("elementObjWriter");
-      elementObjWriter.dump(format);
+    elementObjWriter.dump(format);
     format.endObject();
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractObjectWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractObjectWriter.java
@@ -88,9 +88,6 @@ public abstract class AbstractObjectWriter implements ObjectWriter {
       return baseWriter;
     }
     final AbstractWriteConverter shim = conversionFactory.newWriter(baseWriter);
-    if (shim == null) {
-      return baseWriter;
-    }
-    return shim;
+    return shim == null ? baseWriter : shim;
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractScalarWriter.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+import org.apache.drill.exec.vector.accessor.ValueType;
 import org.apache.drill.exec.vector.accessor.writer.WriterEvents.ColumnWriterListener;
 import org.joda.time.Instant;
 import org.joda.time.LocalDate;
@@ -33,6 +34,9 @@ import org.joda.time.Period;
  */
 
 public abstract class AbstractScalarWriter implements ScalarWriter {
+
+  @Override
+  public ValueType extendedType() { return valueType(); }
 
   @Override
   public void setObject(Object value) {
@@ -66,7 +70,7 @@ public abstract class AbstractScalarWriter implements ScalarWriter {
     } else if (value instanceof Short) {
       setInt((Short) value);
     } else if (value instanceof Boolean) {
-      setInt(((boolean) value) ? 1 : 0);
+      setBoolean((boolean) value);
     } else {
       throw conversionError(value.getClass().getSimpleName());
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
@@ -248,7 +248,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   public void startWrite() {
     assert state == State.IDLE;
     state = State.IN_WRITE;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().startWrite();
     }
   }
@@ -260,7 +260,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
 
     assert state == State.IN_WRITE;
     state = State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().startRow();
     }
   }
@@ -268,7 +268,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   @Override
   public void endArrayValue() {
     assert state == State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().endArrayValue();
     }
   }
@@ -285,7 +285,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
     // the current row.
 
     assert state == State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().restartRow();
     }
   }
@@ -293,7 +293,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   @Override
   public void saveRow() {
     assert state == State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().saveRow();
     }
     state = State.IN_WRITE;
@@ -305,7 +305,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
     // Rollover can only happen while a row is in progress.
 
     assert state == State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().preRollover();
     }
   }
@@ -316,7 +316,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
     // Rollover can only happen while a row is in progress.
 
     assert state == State.IN_ROW;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().postRollover();
     }
   }
@@ -324,7 +324,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   @Override
   public void endWrite() {
     assert state != State.IDLE;
-    for (int i = 0; i < writers.size();  i++) {
+    for (int i = 0; i < writers.size(); i++) {
       writers.get(i).events().endWrite();
     }
     state = State.IDLE;

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BaseScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BaseScalarWriter.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.vector.accessor.writer;
 
 import java.math.BigDecimal;
 
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
 import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
 import org.joda.time.Instant;
@@ -143,6 +144,13 @@ public abstract class BaseScalarWriter extends AbstractScalarWriterImpl {
 
   protected ColumnWriterListener listener;
 
+  /**
+   * Value to use to fill empties. Must be at least as wide as each
+   * value.
+   */
+
+  protected byte emptyValue[];
+
   protected DrillBuf drillBuf;
 
   /**
@@ -156,6 +164,18 @@ public abstract class BaseScalarWriter extends AbstractScalarWriterImpl {
   @Override
   public void bindListener(ColumnWriterListener listener) {
     this.listener = listener;
+  }
+
+  @Override
+  public void bindSchema(ColumnMetadata schema) {
+    super.bindSchema(schema);
+
+    // Set the default value, if any, from the schema.
+
+    final Object defaultValue = schema.decodeDefaultValue();
+    if (defaultValue != null) {
+      setDefaultValue(defaultValue);
+    }
   }
 
   /**
@@ -211,6 +231,11 @@ public abstract class BaseScalarWriter extends AbstractScalarWriterImpl {
   @Override
   public void setNull() {
     throw UnsupportedConversionError.nullError(schema());
+  }
+
+  @Override
+  public void setBoolean(boolean value) {
+    throw conversionError("boolean");
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BaseVarWidthWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BaseVarWidthWriter.java
@@ -33,6 +33,13 @@ import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
  * vector.
  * <p>
  * Most and value events are forwarded to the offset vector.
+ * <p>
+ * This class handles filling empty values with a default value.
+ * Doing so is trick as we must coordinate both this vector and
+ * the offset vector; checking for resize and overflow on each step.
+ * Also, when filling empties, we cannot use the normal "set" functions
+ * as they are what trigger the empty filling. Instead, we have to
+ * write to the "last write" position, not the current row positon.
  */
 
 public abstract class BaseVarWidthWriter extends BaseScalarWriter {
@@ -60,14 +67,22 @@ public abstract class BaseVarWidthWriter extends BaseScalarWriter {
   protected final int prepareWrite(final int width) {
 
     // This is performance critical code; every operation counts.
-    // Please be thoughtful when changing the code.
+    // Please be thoughtful when making changes.
 
-    int writeOffset = offsetsWriter.nextOffset();
+    fillEmpties();
+    return writeOffset(width);
+  }
+
+  private final int writeOffset(final int width) {
+    final int writeOffset = offsetsWriter.nextOffset;
     if (writeOffset + width < capacity) {
       return writeOffset;
     }
     resize(writeOffset + width);
-    return offsetsWriter.nextOffset();
+
+    // Offset will change if overflow occurred on resize.
+
+    return offsetsWriter.nextOffset;
   }
 
   @Override
@@ -128,6 +143,31 @@ public abstract class BaseVarWidthWriter extends BaseScalarWriter {
   @Override
   public int lastWriteIndex() { return offsetsWriter.lastWriteIndex(); }
 
+  /**
+   * Fill an empty slot with the default value set via a call to
+   * {@link #setDefaultValue(Object)}. This is an implementation of the
+   * {@link EmptyValueFiller} interface and is registered with the offset
+   * writer when setting the default value. The offset vector writer calls
+   * this method for each value that is to be filled. Note that the value
+   * being filled is <b>earlier</b> in the vector than the current row
+   * position: that is the very nature of empty filling.
+   */
+  private void fillEmpties() {
+    if (emptyValue == null) {
+      return;
+    }
+    final int fillCount = offsetsWriter.prepareFill() - offsetsWriter.lastWriteIndex - 1;
+    if (fillCount == 0) {
+      return;
+    }
+    final int len = emptyValue.length;
+    for (int i = 0; i < fillCount; i++) {
+      final int writeOffset = writeOffset(len);
+      drillBuf.setBytes(writeOffset, emptyValue, 0, len);
+      offsetsWriter.fillOffset(writeOffset + len);
+    }
+  }
+
   @Override
   public final void preRollover() {
     vector().getBuffer().writerIndex(offsetsWriter.rowStartOffset());
@@ -142,6 +182,7 @@ public abstract class BaseVarWidthWriter extends BaseScalarWriter {
 
   @Override
   public final void endWrite() {
+    fillEmpties();
     vector().getBuffer().writerIndex(offsetsWriter.nextOffset());
     offsetsWriter.endWrite();
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BitColumnWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/BitColumnWriter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.vector.accessor.writer;
+
+import org.apache.drill.exec.vector.BaseDataValueVector;
+import org.apache.drill.exec.vector.BitVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.accessor.ValueType;
+
+/**
+ * Specialized writer for bit columns. Bits are packed 8 per byte.
+ * Rather than duplicate that logic here, this writer just delegates
+ * to the vector's own mutator.
+ */
+
+public class BitColumnWriter extends AbstractFixedWidthWriter {
+
+  private final BitVector vector;
+  private final BitVector.Mutator mutator;
+  private int defaultValue;
+
+  public BitColumnWriter(final ValueVector vector) {
+    this.vector = (BitVector) vector;
+    mutator = this.vector.getMutator();
+  }
+
+  @Override public BaseDataValueVector vector() { return vector; }
+
+  @Override public int width() { return BitVector.VALUE_WIDTH; }
+
+  @Override
+  public ValueType valueType() {
+    return ValueType.BOOLEAN;
+  }
+
+  protected int prepareWrite() {
+
+    // "Fast path" for the normal case of no fills, no overflow.
+    // This is the only bounds check we want to do for the entire
+    // set operation.
+
+    // This is performance critical code; every operation counts.
+    // Please be thoughtful when changing the code.
+
+    final int writeIndex = vectorIndex.vectorIndex();
+    prepareWrite(writeIndex);
+
+    // Track the last write location for zero-fill use next time around.
+
+    lastWriteIndex = writeIndex;
+    return writeIndex;
+  }
+
+  private void prepareWrite(int writeIndex) {
+    final int byteIndex = writeIndex >> 3;
+    if (byteIndex >= capacity) {
+
+      // Bit vector can never overflow
+
+      resize(byteIndex);
+    }
+    if (lastWriteIndex + 1 < writeIndex) {
+      fillEmpties(writeIndex);
+    }
+    lastWriteIndex = writeIndex;
+  }
+
+  @Override
+  public void setValueCount(int valueCount) {
+    prepareWrite(valueCount);
+    mutator.setValueCount(valueCount);
+  }
+
+  /**
+   * Fill empties. This is required because the allocated memory is not
+   * zero-filled.
+   */
+
+  @Override
+  protected final void fillEmpties(final int writeIndex) {
+    for (int dest = lastWriteIndex + 1; dest < writeIndex; dest++) {
+      mutator.set(dest, defaultValue);
+    }
+  }
+
+  @Override
+  public final void setBoolean(final boolean value) {
+    mutator.set(prepareWrite(), value ? 1 : 0);
+    vectorIndex.nextElement();
+  }
+
+  @Override
+  public void setInt(final int value) {
+    setBoolean(value != 0);
+  }
+
+  @Override
+  public void setValue(Object value) {
+    setInt((Integer) value);
+  }
+
+  @Override
+  public final void setDefaultValue(final Object value) {
+    defaultValue = ((Boolean) value) ? 1 : 0;
+  }
+}

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/NullableScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/NullableScalarWriter.java
@@ -131,6 +131,13 @@ public class NullableScalarWriter extends AbstractScalarWriterImpl {
   }
 
   @Override
+  public void setBoolean(boolean value) {
+    baseWriter.setBoolean(value);
+    isSetWriter.setInt(1);
+    writerIndex.nextElement();
+  }
+
+  @Override
   public void setInt(int value) {
     baseWriter.setInt(value);
     isSetWriter.setInt(1);
@@ -277,5 +284,11 @@ public class NullableScalarWriter extends AbstractScalarWriterImpl {
     format.attribute("baseWriter");
     baseWriter.dump(format);
     format.endObject();
+  }
+
+  @Override
+  public void setDefaultValue(Object value) {
+    throw new UnsupportedOperationException(
+        "Default values not supported for nullable types:" + value);
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
@@ -117,6 +117,24 @@ import org.apache.drill.exec.vector.accessor.impl.HierarchicalFormatter;
  * <p>
  * See {@link ObjectArrayWriter} for information about arrays of
  * maps (arrays of multiple columns.)
+ *
+ * <h4>Empty Slots</h4>
+ *
+ * The offset vector writer handles empty slots in two distinct ways.
+ * First, the writer handles its own empties. Suppose that this is the offset
+ * vector for a VarChar column. Suppose we write "Foo" in the first slot. Now
+ * we have an offset vector with the values <tt>[ 0 3 ]</tt>. Suppose the client
+ * skips several rows and next writes at slot 5. We must copy the latest
+ * offset (3) into all the skipped slots: <tt>[ 0 3 3 3 3 3 ]</tt>. The result
+ * is a set of four empty VarChars in positions 1, 2, 3 and 4. (Here, remember
+ * that the offset vector always has one more value than the the number of rows.)
+ * <p>
+ * The second way to fill empties is in the data vector. The data vector may choose
+ * to fill the four "empty" slots with a value, say "X". In this case, it is up to
+ * the data vector to fill in the values, calling into this vector to set each
+ * offset. Note that when doing this, the calls are a bit different than for writing
+ * a regular value because we want to write at the "last write position", not the
+ * current row position. See {@link BaseVarWidthWriter} for an example.
  */
 
 public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements OffsetVectorWriter {
@@ -140,7 +158,7 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
    * committed in {@link @endValue()}.
    */
 
-  private int nextOffset;
+  protected int nextOffset;
 
   public OffsetVectorWriterImpl(UInt4Vector vector) {
     this.vector = vector;
@@ -176,7 +194,7 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
   }
 
   @Override
-  public int nextOffset() { return nextOffset; }
+  public int nextOffset() {return nextOffset; }
 
   @Override
   public int rowStartOffset() { return rowStartOffset; }
@@ -194,48 +212,37 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
 
   protected final int prepareWrite() {
 
-    // "Fast path" for the normal case of no fills, no overflow.
-    // This is the only bounds check we want to do for the entire
-    // set operation.
-
     // This is performance critical code; every operation counts.
     // Please be thoughtful when changing the code.
 
-    final int valueIndex = vectorIndex.vectorIndex();
-    int writeIndex = valueIndex + 1;
-    if (lastWriteIndex + 1 < valueIndex || writeIndex >= capacity) {
-      writeIndex =  prepareWrite(writeIndex);
+    final int valueIndex = prepareFill();
+    final int fillCount = valueIndex - lastWriteIndex - 1;
+    if (fillCount > 0) {
+      fillEmpties(fillCount);
     }
 
     // Track the last write location for zero-fill use next time around.
 
     lastWriteIndex = valueIndex;
-    return writeIndex;
-  }
-
-  protected int prepareWrite(int writeIndex) {
-
-    // Either empties must be filed or the vector is full.
-
-    resize(writeIndex);
-
-    // Call to resize may cause rollover, so reset write index
-    // afterwards.
-
-    final int valueIndex = vectorIndex.vectorIndex();
-
-    // Fill empties to the write position.
-    // Fill empties works of the row index, not the write
-    // index. (Yes, this is complex...)
-
-    fillEmpties(valueIndex);
     return valueIndex + 1;
   }
 
+  public final int prepareFill() {
+    final int valueIndex = vectorIndex.vectorIndex();
+    if (valueIndex + 1 < capacity) {
+      return valueIndex;
+    }
+    resize(valueIndex + 1);
+
+    // Call to resize may cause rollover, so get new write index afterwards.
+
+    return vectorIndex.vectorIndex();
+  }
+
   @Override
-  protected final void fillEmpties(final int valueIndex) {
-    while (lastWriteIndex < valueIndex - 1) {
-      drillBuf.setInt((++lastWriteIndex + 1) * VALUE_WIDTH, nextOffset);
+  protected final void fillEmpties(final int fillCount) {
+    for (int i = 0; i < fillCount; i++) {
+      fillOffset(nextOffset);
     }
   }
 
@@ -246,16 +253,21 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
     nextOffset = newOffset;
   }
 
+  public final void fillOffset(final int newOffset) {
+    drillBuf.setInt((++lastWriteIndex + 1) * VALUE_WIDTH, newOffset);
+    nextOffset = newOffset;
+  }
+
   @Override
   public final void setValue(final Object value) {
-    throw new InvalidConversionError("setValue() not supported for the offset vector writer");
+    throw new InvalidConversionError(
+        "setValue() not supported for the offset vector writer: " + value);
   }
 
   @Override
   public void skipNulls() {
 
-    // Nothing to do. Fill empties logic will fill in missing
-    // offsets.
+    // Nothing to do. Fill empties logic will fill in missing offsets.
   }
 
   @Override
@@ -286,10 +298,9 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
   public void setValueCount(int valueCount) {
     mandatoryResize(valueCount);
 
-    // Value count are in offset vector positions. Fill empties
-    // works in row positions.
+    // Value count is in row positions.
 
-    fillEmpties(valueCount);
+    fillEmpties(valueCount - lastWriteIndex - 1);
     vector().getBuffer().writerIndex((valueCount + 1) * VALUE_WIDTH);
   }
 
@@ -301,5 +312,10 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
       .attribute("lastWriteIndex", lastWriteIndex)
       .attribute("nextOffset", nextOffset)
       .endObject();
+  }
+
+  @Override
+  public void setDefaultValue(Object value) {
+    throw new UnsupportedOperationException("Encoding not supported for offset vectors");
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ScalarArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ScalarArrayWriter.java
@@ -122,7 +122,7 @@ public class ScalarArrayWriter extends BaseArrayWriter {
     if (! objClass.startsWith("[")) {
       throw new IllegalArgumentException(
           String.format("Argument must be an array. Column `%s`, value = %s",
-              schema.name(), array.toString()));
+              schema().name(), array.toString()));
     }
 
     // Figure out type
@@ -140,7 +140,7 @@ public class ScalarArrayWriter extends BaseArrayWriter {
       default:
         throw new IllegalArgumentException(
             String.format("Unknown Java array type: %s, for column `%s`",
-                objClass, schema.name()));
+                objClass, schema().name()));
       }
       break;
     case  'B':

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/dummy/DummyScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/dummy/DummyScalarWriter.java
@@ -54,6 +54,9 @@ public class DummyScalarWriter extends AbstractScalarWriterImpl {
   public void setNull() { }
 
   @Override
+  public void setBoolean(boolean value) { }
+
+  @Override
   public void setInt(int value) { }
 
   @Override
@@ -109,4 +112,7 @@ public class DummyScalarWriter extends AbstractScalarWriterImpl {
 
   @Override
   public void setValue(Object value) { }
+
+  @Override
+  public void setDefaultValue(Object value) { }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <hadoop.version>2.7.4</hadoop.version>
     <hbase.version>2.1.1</hbase.version>
     <fmpp.version>1.0</fmpp.version>
-    <freemarker.version>2.3.26-incubating</freemarker.version>
+    <freemarker.version>2.3.28</freemarker.version>
     <javassist.version>3.24.0-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>


### PR DESCRIPTION
Modifies the prior work to add default values for columns. The prior work added defaults
when the entire column is missing from a reader (the old Nullable Int column). The Row
Set mechanism now will also "fill empty" slots with the default value.

Added default support for the column writers. The writers automatically obtain the
default value from the column schema. The default can also be set explicitly on
the column writer.

Updated the null column mechanism to use this feature rather than the ad-hoc
implemention in the prior commit.

Semantics changed a bit. Only Required columns take a default. The default value
is ignored or nullable columns since nullable columns already have a file default: NULL.

Updated the CSV-with-schema tests to illustrate the new behavior.