### PR TITLE
DRILL-7089: Implement caching for TableMetadataProvider at query level and adapt statistics to use Drill metastore API

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveParquetTableMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveParquetTableMetadataProvider.java
@@ -49,17 +49,17 @@ public class HiveParquetTableMetadataProvider extends BaseParquetMetadataProvide
                                          HivePartitionHolder hivePartitionHolder,
                                          HiveStoragePlugin hiveStoragePlugin,
                                          ParquetReaderConfig readerConfig) throws IOException {
-    super(entries, readerConfig, null, null);
+    super(entries, readerConfig);
     this.hiveStoragePlugin = hiveStoragePlugin;
     this.hivePartitionHolder = hivePartitionHolder;
 
-    init();
+    init(null);
   }
 
   public HiveParquetTableMetadataProvider(HiveStoragePlugin hiveStoragePlugin,
                                           List<HiveMetadataProvider.LogicalInputSplit> logicalInputSplits,
                                           ParquetReaderConfig readerConfig) throws IOException {
-    super(readerConfig, null, null, null);
+    super(null, readerConfig);
     this.hiveStoragePlugin = hiveStoragePlugin;
     this.hivePartitionHolder = new HivePartitionHolder();
 
@@ -81,7 +81,7 @@ public class HiveParquetTableMetadataProvider extends BaseParquetMetadataProvide
         hivePartitionHolder.add(pathString, partition.getValues());
       }
     }
-    init();
+    init(null);
   }
 
   public HivePartitionHolder getHivePartitionHolder() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/StatisticsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/StatisticsProvider.java
@@ -246,10 +246,10 @@ public class StatisticsProvider<T extends Comparable<T>> extends AbstractExprVis
   }
 
   public static class MinMaxStatistics<V> implements ColumnStatistics<V> {
-    private V minVal;
-    private V maxVal;
+    private final V minVal;
+    private final V maxVal;
+    private final Comparator<V> valueComparator;
     private long nullsCount;
-    private Comparator<V> valueComparator;
 
     public MinMaxStatistics(V minVal, V maxVal, Comparator<V> valueComparator) {
       this.minVal = minVal;
@@ -281,6 +281,11 @@ public class StatisticsProvider<T extends Comparable<T>> extends AbstractExprVis
         default:
           return false;
       }
+    }
+
+    @Override
+    public boolean containsExactStatistics(StatisticsKind statisticsKind) {
+      return true;
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.drill.metastore.TableMetadata;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 import org.apache.drill.common.expression.LogicalExpression;
@@ -188,6 +189,16 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
 
   @Override
   public GroupScan applyFilter(LogicalExpression filterExpr, UdfUtilities udfUtilities, FunctionImplementationRegistry functionImplementationRegistry, OptionManager optionManager) {
+    return null;
+  }
+
+  @Override
+  public TableMetadataProvider getMetadataProvider() {
+    return null;
+  }
+
+  @Override
+  public TableMetadata getTableMetadata() {
     return null;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FileSystemMetadataProviderManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FileSystemMetadataProviderManager.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.base;
+
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+import org.apache.drill.exec.store.parquet.ParquetTableMetadataProviderImpl;
+
+/**
+ * Implementation of {@link MetadataProviderManager} which uses file system providers and returns
+ * builders for file system based {@link TableMetadataProvider} instances.
+ */
+public class FileSystemMetadataProviderManager implements MetadataProviderManager {
+
+  private SchemaProvider schemaProvider;
+  private DrillStatsTable statsProvider;
+
+  private TableMetadataProvider tableMetadataProvider;
+
+  public static MetadataProviderManager getMetadataProviderManager() {
+    return new FileSystemMetadataProviderManager();
+  }
+
+  @Override
+  public void setSchemaProvider(SchemaProvider schemaProvider) {
+    this.schemaProvider = schemaProvider;
+  }
+
+  @Override
+  public void setStatsProvider(DrillStatsTable statsProvider) {
+    this.statsProvider = statsProvider;
+  }
+
+  @Override
+  public DrillStatsTable getStatsProvider() {
+    return statsProvider;
+  }
+
+  @Override
+  public SchemaProvider getSchemaProvider() {
+    return schemaProvider;
+  }
+
+  @Override
+  public void setTableMetadataProvider(TableMetadataProvider tableMetadataProvider) {
+    this.tableMetadataProvider = tableMetadataProvider;
+  }
+
+  @Override
+  public TableMetadataProvider getTableMetadataProvider() {
+    return tableMetadataProvider;
+  }
+
+  @Override
+  public TableMetadataProviderBuilder builder(MetadataProviderKind kind) {
+    switch (kind) {
+      case PARQUET_TABLE:
+        return new ParquetTableMetadataProviderImpl.Builder(this);
+      case SCHEMA_STATS_ONLY:
+        return new SimpleFileTableMetadataProvider.Builder(this);
+    }
+    return null;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.metastore.TableMetadata;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
 
@@ -154,4 +155,14 @@ public interface GroupScan extends Scan, HasAffinity {
   GroupScan applyFilter(LogicalExpression filterExpr, UdfUtilities udfUtilities,
                         FunctionImplementationRegistry functionImplementationRegistry, OptionManager optionManager);
 
+  /**
+   * Returns {@link TableMetadataProvider} instance which is used for providing metadata for current {@link GroupScan}.
+   *
+   * @return {@link TableMetadataProvider} instance the source of metadata
+   */
+  @JsonIgnore
+  TableMetadataProvider getMetadataProvider();
+
+  @JsonIgnore
+  TableMetadata getTableMetadata();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/MetadataProviderManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/MetadataProviderManager.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.base;
+
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+
+/**
+ * Base interface for passing and obtaining {@link SchemaProvider}, {@link DrillStatsTable} and
+ * {@link TableMetadataProvider}, responsible for creating required
+ * {@link TableMetadataProviderBuilder} which constructs required {@link TableMetadataProvider}
+ * based on specified providers
+ */
+public interface MetadataProviderManager {
+
+  DrillStatsTable getStatsProvider();
+
+  void setStatsProvider(DrillStatsTable statsProvider);
+
+  SchemaProvider getSchemaProvider();
+
+  void setSchemaProvider(SchemaProvider schemaProvider);
+
+  TableMetadataProvider getTableMetadataProvider();
+
+  void setTableMetadataProvider(TableMetadataProvider tableMetadataProvider);
+
+  /**
+   * Returns builder responsible for constructing required {@link TableMetadataProvider} instances
+   * based on specified providers.
+   *
+   * @param kind kind of {@link TableMetadataProvider} whose builder should be obtained
+   * @return builder responsible for constructing required {@link TableMetadataProvider}
+   */
+  TableMetadataProviderBuilder builder(MetadataProviderKind kind);
+
+  /**
+   * Kinds of {@link TableMetadataProvider} whose builder should be obtained.
+   */
+  enum MetadataProviderKind {
+    PARQUET_TABLE,
+    SCHEMA_STATS_ONLY
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ParquetMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ParquetMetadataProvider.java
@@ -47,6 +47,13 @@ public interface ParquetMetadataProvider extends TableMetadataProvider {
   List<RowGroupMetadata> getRowGroupsMeta();
 
   /**
+   * Returns list of file paths which belong to current table.
+   *
+   * @return list of file paths
+   */
+  List<Path> getLocations();
+
+  /**
    * Returns multimap of {@link RowGroupMetadata} instances which provides metadata for specific row group and its columns mapped to their locations.
    *
    * @return multimap of {@link RowGroupMetadata} instances

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.base;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+import org.apache.drill.exec.store.dfs.easy.SimpleFileTableMetadataProviderBuilder;
+import org.apache.drill.metastore.ColumnStatistics;
+import org.apache.drill.metastore.ColumnStatisticsImpl;
+import org.apache.drill.metastore.FileMetadata;
+import org.apache.drill.metastore.FileTableMetadata;
+import org.apache.drill.metastore.PartitionMetadata;
+import org.apache.drill.metastore.TableMetadata;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Metadata provider which supplies only table schema and / or table statistics if available.
+ */
+public class SimpleFileTableMetadataProvider implements TableMetadataProvider {
+  private static final Logger logger = LoggerFactory.getLogger(SimpleFileTableMetadataProvider.class);
+
+  private TableMetadata tableMetadata;
+
+  private SimpleFileTableMetadataProvider(TableMetadata tableMetadata) {
+    this.tableMetadata = tableMetadata;
+  }
+
+  @Override
+  public TableMetadata getTableMetadata() {
+    return tableMetadata;
+  }
+
+  @Override
+  public List<SchemaPath> getPartitionColumns() {
+    return null;
+  }
+
+  @Override
+  public List<PartitionMetadata> getPartitionsMetadata() {
+    return null;
+  }
+
+  @Override
+  public List<PartitionMetadata> getPartitionMetadata(SchemaPath columnName) {
+    return null;
+  }
+
+  @Override
+  public List<FileMetadata> getFilesMetadata() {
+    return null;
+  }
+
+  @Override
+  public FileMetadata getFileMetadata(Path location) {
+    return null;
+  }
+
+  @Override
+  public List<FileMetadata> getFilesForPartition(PartitionMetadata partition) {
+    return null;
+  }
+
+  public static class Builder implements SimpleFileTableMetadataProviderBuilder {
+    private String tableName;
+    private Path location;
+    private long lastModifiedTime = -1L;
+    private TupleMetadata schema;
+
+    private MetadataProviderManager metadataProviderManager;
+
+    public Builder(MetadataProviderManager source) {
+      this.metadataProviderManager = source;
+    }
+
+    @Override
+    public SimpleFileTableMetadataProviderBuilder withTableName(String tableName) {
+      this.tableName = tableName;
+      return this;
+    }
+
+    @Override
+    public SimpleFileTableMetadataProviderBuilder withLocation(Path location) {
+      this.location = location;
+      return this;
+    }
+
+    @Override
+    public SimpleFileTableMetadataProviderBuilder withLastModifiedTime(long lastModifiedTime) {
+      this.lastModifiedTime = lastModifiedTime;
+      return this;
+    }
+
+    @Override
+    public SimpleFileTableMetadataProviderBuilder withSchema(TupleMetadata schema) {
+      this.schema = schema;
+      return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TableMetadataProvider build() throws IOException {
+      SchemaProvider schemaProvider = metadataProviderManager.getSchemaProvider();
+      TableMetadataProvider source = metadataProviderManager.getTableMetadataProvider();
+      if (source == null) {
+        DrillStatsTable statsProvider = metadataProviderManager.getStatsProvider();
+        Map<SchemaPath, ColumnStatistics> columnsStatistics = new HashMap<>();
+
+        if (statsProvider != null) {
+          if (!statsProvider.isMaterialized()) {
+            statsProvider.materialize();
+          }
+          if (statsProvider.isMaterialized()) {
+            for (SchemaPath column : statsProvider.getColumns()) {
+              columnsStatistics.put(column,
+                  new ColumnStatisticsImpl(
+                      DrillStatsTable.getEstimatedColumnStats(statsProvider, column),
+                      Comparator.nullsFirst(Comparator.naturalOrder())));
+            }
+          }
+        }
+
+        TupleMetadata schema = null;
+        try {
+          if (this.schema != null) {
+            schema = this.schema;
+          } else {
+            schema = schemaProvider != null ? schemaProvider.read().getSchema() : null;
+          }
+        } catch (IOException e) {
+          logger.debug("Unable to deserialize schema from schema file for table: " + (tableName != null ? tableName : location), e);
+        }
+        TableMetadata tableMetadata = new FileTableMetadata(tableName,
+            location, schema,
+            columnsStatistics, DrillStatsTable.getEstimatedTableStats(statsProvider),
+            lastModifiedTime, "", Collections.emptySet());
+
+        source = new SimpleFileTableMetadataProvider(tableMetadata);
+        metadataProviderManager.setTableMetadataProvider(source);
+      }
+      return source;
+    }
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/TableMetadataProviderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/TableMetadataProviderBuilder.java
@@ -15,21 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.metastore;
+package org.apache.drill.exec.physical.base;
 
-import org.apache.drill.common.expression.SchemaPath;
-import org.apache.hadoop.fs.Path;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 
-import java.util.Map;
+import java.io.IOException;
 
 /**
- * Metadata which corresponds to the table level.
+ * Base interface for builders of {@link TableMetadataProvider}.
  */
-public interface TableMetadata extends BaseMetadata {
+public interface TableMetadataProviderBuilder {
 
-  String getTableName();
-  Path getLocation();
-  String getOwner();
-  long getLastModifiedTime();
-  TableMetadata cloneWithStats(Map<SchemaPath, ColumnStatistics> columnStatistics, Map<StatisticsKind, Object> tableStatistics);
+  TableMetadataProviderBuilder withSchema(TupleMetadata schema);
+
+  TableMetadataProvider build() throws IOException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
@@ -244,9 +244,8 @@ public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
       FormatSelection newFormatSelection = new FormatSelection(formatSelection.getFormat(), newFileSelection);
 
       DynamicDrillTable dynamicDrillTable = new DynamicDrillTable(table.getPlugin(), table.getStorageEngineName(),
-          table.getUserName(), newFormatSelection);
+          table.getUserName(), newFormatSelection, table.getMetadataProviderManager());
       /* Copy statistics from the original relOptTable */
-      dynamicDrillTable.setStatsTable(table.getStatsTable());
       DrillTranslatableTable newTable = new DrillTranslatableTable(dynamicDrillTable);
 
       RelOptTableImpl newOptTableImpl = RelOptTableImpl.create(relOptTable.getRelOptSchema(), relOptTable.getRowType(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DynamicDrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DynamicDrillTable.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.planner.logical;
 
+import org.apache.calcite.schema.Schema;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.planner.types.RelDataTypeDrillImpl;
 import org.apache.drill.exec.planner.types.RelDataTypeHolder;
 import org.apache.drill.exec.store.StoragePlugin;
@@ -30,6 +32,10 @@ public class DynamicDrillTable extends DrillTable{
 
   public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, String userName, Object selection) {
     super(storageEngineName, plugin, userName, selection);
+  }
+
+  public DynamicDrillTable(StoragePlugin plugin, String storageEngineName, String userName, Object selection, MetadataProviderManager metadataProviderManager) {
+    super(storageEngineName, plugin, Schema.TableType.TABLE, userName, selection, metadataProviderManager);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -73,7 +73,6 @@ import org.apache.drill.exec.physical.impl.join.JoinUtils;
 import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.planner.PlannerType;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
-import org.apache.drill.exec.planner.common.DrillStatsTable.StatsMaterializationVisitor;
 import org.apache.drill.exec.planner.cost.DrillDefaultRelMetadataProvider;
 import org.apache.drill.exec.planner.logical.DrillProjectRel;
 import org.apache.drill.exec.planner.logical.DrillRel;
@@ -231,9 +230,6 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
     }
 
     try {
-      // Materialize the statistics, if available.
-      StatsMaterializationVisitor.materialize(relNode, context);
-
       // HEP for rules, which are failed at the LOGICAL_PLANNING stage for Volcano planner
       final RelNode setOpTransposeNode = transform(PlannerType.HEP, PlannerPhase.PRE_LOGICAL_PLANNING, relNode);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractStoragePlugin.java
@@ -27,9 +27,9 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.planner.PlannerPhase;
 
-import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SessionOptionManager;
@@ -113,7 +113,7 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException {
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
     return getPhysicalScan(userName, selection, options);
   }
 
@@ -128,7 +128,7 @@ public abstract class AbstractStoragePlugin implements StoragePlugin {
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException {
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
     return getPhysicalScan(userName, selection, columns, options);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePlugin.java
@@ -28,7 +28,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
-import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.dfs.FormatPlugin;
 
@@ -75,13 +75,13 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
   /**
    * Get the physical scan operator for the particular GroupScan (read) node.
    *
-   * @param userName User whom to impersonate when when reading the contents as part of Scan.
-   * @param selection The configured storage engine specific selection.
-   * @param options (optional) session options
-   * @param schema (optional) table schema
+   * @param userName        User whom to impersonate when when reading the contents as part of Scan.
+   * @param selection       The configured storage engine specific selection.
+   * @param options         (optional) session options
+   * @param providerManager manager for handling metadata providers
    * @return The physical scan operator for the particular GroupScan (read) node.
    */
-  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException;
+  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, MetadataProviderManager providerManager) throws IOException;
 
   /**
    * Get the physical scan operator for the particular GroupScan (read) node.
@@ -107,14 +107,14 @@ public interface StoragePlugin extends SchemaFactory, AutoCloseable {
   /**
    * Get the physical scan operator for the particular GroupScan (read) node.
    *
-   * @param userName User whom to impersonate when when reading the contents as part of Scan.
-   * @param selection The configured storage engine specific selection.
-   * @param columns (optional) The list of column names to scan from the data source.
-   * @param options (optional) session options
-   * @param schema (optional) table schema
+   * @param userName        User whom to impersonate when when reading the contents as part of Scan.
+   * @param selection       The configured storage engine specific selection.
+   * @param columns         (optional) The list of column names to scan from the data source.
+   * @param options         (optional) session options
+   * @param providerManager manager for handling metadata providers
    * @return The physical scan operator for the particular GroupScan (read) node.
    */
-  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException;
+  AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, MetadataProviderManager providerManager) throws IOException;
 
   /**
    * Method returns a Jackson serializable object that extends a StoragePluginConfig.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -35,7 +35,7 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
-import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
@@ -168,8 +168,8 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, TupleMetadata schema) throws IOException {
-    return getPhysicalScan(userName, selection, AbstractGroupScan.ALL_COLUMNS, options, schema);
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
+    return getPhysicalScan(userName, selection, AbstractGroupScan.ALL_COLUMNS, options, metadataProviderManager);
   }
 
   @Override
@@ -178,10 +178,10 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
   }
 
   @Override
-  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, TupleMetadata schema) throws IOException {
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection, List<SchemaPath> columns, SessionOptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
     FormatSelection formatSelection = selection.getWith(lpPersistance, FormatSelection.class);
     FormatPlugin plugin = getFormatPlugin(formatSelection.getFormat());
-    return plugin.getGroupScan(userName, formatSelection.getSelection(), columns, options, schema);
+    return plugin.getGroupScan(userName, formatSelection.getSelection(), columns, options, metadataProviderManager);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -26,9 +26,9 @@ import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
 import org.apache.drill.exec.physical.base.AbstractWriter;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
-import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
@@ -63,12 +63,12 @@ public interface FormatPlugin {
     return getGroupScan(userName, selection, columns);
   }
 
-  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, TupleMetadata schema) throws IOException {
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, MetadataProviderManager metadataProviderManager) throws IOException {
     return getGroupScan(userName, selection, columns);
   }
 
-  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options, TupleMetadata schema) throws IOException {
-    return getGroupScan(userName, selection, columns, options);
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options, MetadataProviderManager metadataProvider) throws IOException {
+    return getGroupScan(userName, selection, columns, metadataProvider);
   }
 
   boolean supportsStatistics();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.shaded.guava.com.google.common.base.Functions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
@@ -212,8 +213,8 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   }
 
   /**
-   * Revised scanner based on the revised
-   * {@link ResultSetLoader} and {@link RowBatchReader} classes.
+   * Revised scanner based on the revised {@link org.apache.drill.exec.physical.rowSet.ResultSetLoader}
+   * and {@link org.apache.drill.exec.physical.impl.scan.RowBatchReader} classes.
    * Handles most projection tasks automatically. Able to limit
    * vector and batch sizes. Use this for new format plugins.
    */
@@ -485,6 +486,12 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns)
       throws IOException {
     return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, null);
+  }
+
+  @Override
+  public AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns, MetadataProviderManager metadataProviderManager) throws IOException {
+    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, metadataProviderManager);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/SimpleFileTableMetadataProviderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/SimpleFileTableMetadataProviderBuilder.java
@@ -15,21 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.metastore;
+package org.apache.drill.exec.store.dfs.easy;
 
-import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.base.TableMetadataProviderBuilder;
 import org.apache.hadoop.fs.Path;
 
-import java.util.Map;
-
 /**
- * Metadata which corresponds to the table level.
+ * Builder for {@link org.apache.drill.exec.physical.base.SimpleFileTableMetadataProvider}.
  */
-public interface TableMetadata extends BaseMetadata {
+public interface SimpleFileTableMetadataProviderBuilder extends TableMetadataProviderBuilder {
 
-  String getTableName();
-  Path getLocation();
-  String getOwner();
-  long getLastModifiedTime();
-  TableMetadata cloneWithStats(Map<SchemaPath, ColumnStatistics> columnStatistics, Map<StatisticsKind, Object> tableStatistics);
+  SimpleFileTableMetadataProviderBuilder withTableName(String tableName);
+
+  SimpleFileTableMetadataProviderBuilder withLocation(Path location);
+
+  SimpleFileTableMetadataProviderBuilder withLastModifiedTime(long lastModifiedTime);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonStatisticsRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonStatisticsRecordWriter.java
@@ -23,6 +23,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.exec.physical.impl.statistics.Statistic;
 import org.apache.drill.exec.planner.common.DrillStatsTable;
@@ -270,7 +272,7 @@ public class JsonStatisticsRecordWriter extends JSONBaseStatisticsRecordWriter {
         throw new IOException("Statistics writer encountered unexpected field");
       }
       if (nextField.equals(Statistic.COLNAME)) {
-        ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setName(reader.readText().toString());
+        ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setName(SchemaPath.parseFromString(reader.readText().toString()));
       } else if (nextField.equals(Statistic.COLTYPE)) {
         MajorType fieldType = DrillStatsTable.getMapper().readValue(reader.readText().toString(), MajorType.class);
         ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setType(fieldType);
@@ -278,7 +280,7 @@ public class JsonStatisticsRecordWriter extends JSONBaseStatisticsRecordWriter {
     }
 
     @Override
-    public void endField() throws IOException {
+    public void endField() {
       nextField = null;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -32,6 +32,7 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.ScanStats;
 import org.apache.drill.exec.physical.base.ScanStats.GroupScanProperty;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
@@ -43,7 +44,6 @@ import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
-import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.RecordReader;
@@ -273,19 +273,19 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
   }
 
   @Override
-  public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, TupleMetadata schema)
+  public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, MetadataProviderManager metadataProviderManager)
       throws IOException {
-    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, schema);
+    return new EasyGroupScan(userName, selection, this, columns, selection.selectionRoot, metadataProviderManager);
   }
 
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection,
-      List<SchemaPath> columns, OptionManager options, TupleMetadata schema) throws IOException {
+      List<SchemaPath> columns, OptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
     return new EasyGroupScan(userName, selection, this, columns,
         selection.selectionRoot,
         // Some paths provide a null option manager. In that case, default to a
         // min width of 1; just like the base class.
-        options == null ? 1 : (int) options.getLong(ExecConstants.MIN_READER_WIDTH_KEY), schema);
+        options == null ? 1 : (int) options.getLong(ExecConstants.MIN_READER_WIDTH_KEY), metadataProviderManager);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
@@ -19,7 +19,7 @@ package org.apache.drill.exec.store.parquet;
 
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaPathUtils;
-import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.parquet.metadata.MetadataBase;
 import org.apache.drill.metastore.RowGroupMetadata;
 import org.apache.drill.metastore.TableStatisticsKind;
@@ -71,7 +71,7 @@ public class FilterEvaluatorUtils {
   }
 
   public static RowsMatch matches(LogicalExpression expr, Map<SchemaPath, ColumnStatistics> columnsStatistics,
-      TupleSchema schema, long rowCount, UdfUtilities udfUtilities, FunctionLookupContext functionImplementationRegistry) {
+      TupleMetadata schema, long rowCount, UdfUtilities udfUtilities, FunctionLookupContext functionImplementationRegistry) {
     ErrorCollector errorCollector = new ErrorCollectorImpl();
 
     LogicalExpression materializedFilter = ExpressionTreeMaterializer.materializeFilterExpr(
@@ -94,7 +94,7 @@ public class FilterEvaluatorUtils {
 
   public static RowsMatch matches(FilterPredicate parquetPredicate,
                                   Map<SchemaPath, ColumnStatistics> columnsStatistics,
-                                  long rowCount, TupleSchema fileMetadata, Set<SchemaPath> schemaPathsInExpr) {
+                                  long rowCount, TupleMetadata fileMetadata, Set<SchemaPath> schemaPathsInExpr) {
     RowsMatch temp = matches(parquetPredicate, columnsStatistics, rowCount);
     return temp == RowsMatch.ALL && isRepeated(schemaPathsInExpr, fileMetadata) ? RowsMatch.SOME : temp;
   }
@@ -108,7 +108,7 @@ public class FilterEvaluatorUtils {
     return RowsMatch.SOME;
   }
 
-  private static boolean isRepeated(Set<SchemaPath> fields, TupleSchema fileMetadata) {
+  private static boolean isRepeated(Set<SchemaPath> fields, TupleMetadata fileMetadata) {
     for (SchemaPath field : fields) {
       ColumnMetadata columnMetadata = SchemaPathUtils.getColumnMetadata(field, fileMetadata);
       TypeProtos.MajorType fieldType = columnMetadata != null ? columnMetadata.majorType() : null;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFileTableMetadataProviderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFileTableMetadataProviderBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.parquet;
+
+import org.apache.drill.exec.physical.base.ParquetTableMetadataProvider;
+import org.apache.drill.exec.physical.base.TableMetadataProviderBuilder;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.ReadEntryWithPath;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+
+/**
+ * Builder for {@link ParquetTableMetadataProvider}.
+ */
+public interface ParquetFileTableMetadataProviderBuilder extends TableMetadataProviderBuilder {
+
+  ParquetFileTableMetadataProviderBuilder withEntries(List<ReadEntryWithPath> entries);
+
+  ParquetFileTableMetadataProviderBuilder withSelectionRoot(Path selectionRoot);
+
+  ParquetFileTableMetadataProviderBuilder withCacheFileRoot(Path cacheFileRoot);
+
+  ParquetFileTableMetadataProviderBuilder withReaderConfig(ParquetReaderConfig readerConfig);
+
+  ParquetFileTableMetadataProviderBuilder withFileSystem(DrillFileSystem fs);
+
+  ParquetFileTableMetadataProviderBuilder withCorrectCorruptedDates(boolean autoCorrectCorruptedDates);
+
+  ParquetFileTableMetadataProviderBuilder withSelection(FileSelection selection);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.AbstractFileGroupScan;
 import org.apache.drill.exec.physical.base.AbstractWriter;
+import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.SchemalessScan;
 import org.apache.drill.exec.physical.impl.WriterRecordBatch;
@@ -186,11 +187,17 @@ public class ParquetFormatPlugin implements FormatPlugin {
 
   @Override
   public AbstractFileGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options) throws IOException {
+    return getGroupScan(userName, selection, columns, options, null);
+  }
+
+  @Override
+  public AbstractFileGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns, OptionManager options, MetadataProviderManager metadataProviderManager) throws IOException {
     ParquetReaderConfig readerConfig = ParquetReaderConfig.builder()
-      .withFormatConfig(getConfig())
-      .withOptions(options)
-      .build();
-    ParquetGroupScan parquetGroupScan = new ParquetGroupScan(userName, selection, this, columns, readerConfig);
+        .withFormatConfig(getConfig())
+        .withOptions(options)
+        .build();
+    ParquetGroupScan parquetGroupScan = new ParquetGroupScan(userName, selection, this, columns, readerConfig, metadataProviderManager);
     if (parquetGroupScan.getEntries().isEmpty()) {
       // If ParquetGroupScan does not contain any entries, it means selection directories are empty and
       // metadata cache files are invalid, return schemaless scan

--- a/exec/java-exec/src/main/java/org/apache/drill/metastore/BaseMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/metastore/BaseMetadata.java
@@ -19,7 +19,7 @@ package org.apache.drill.metastore;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
-import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 
 import java.util.Map;
 
@@ -46,11 +46,11 @@ public interface BaseMetadata {
 
   /**
    * Returns schema stored in current metadata represented as
-   * {@link TupleSchema}.
+   * {@link TupleMetadata}.
    *
    * @return schema stored in current metadata
    */
-  TupleSchema getSchema();
+  TupleMetadata getSchema();
 
   /**
    * Returns value of non-column statistics which corresponds to specified {@link StatisticsKind}.
@@ -59,6 +59,15 @@ public interface BaseMetadata {
    * @return value of non-column statistics
    */
   Object getStatistic(StatisticsKind statisticsKind);
+
+  /**
+   * Checks whether specified statistics kind is set in this non-column statistics
+   * and it corresponds to the exact statistics value.
+   *
+   * @param statisticsKind statistics kind to check
+   * @return true if value which corresponds to the specified statistics kind is exact
+   */
+  boolean containsExactStatistics(StatisticsKind statisticsKind);
 
   /**
    * Returns value of column statistics which corresponds to specified {@link StatisticsKind}

--- a/exec/java-exec/src/main/java/org/apache/drill/metastore/ColumnStatistics.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/metastore/ColumnStatistics.java
@@ -43,6 +43,15 @@ public interface ColumnStatistics<T> {
   boolean containsStatistic(StatisticsKind statisticsKind);
 
   /**
+   * Checks whether specified statistics kind is set in this column statistics
+   * and it corresponds to the exact statistics value.
+   *
+   * @param statisticsKind statistics kind to check
+   * @return true if value which corresponds to the specified statistics kind is exact
+   */
+  boolean containsExactStatistics(StatisticsKind statisticsKind);
+
+  /**
    * Returns {@link Comparator} for comparing values with the same type as column values.
    *
    * @return {@link Comparator}

--- a/exec/java-exec/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
@@ -19,6 +19,7 @@ package org.apache.drill.metastore;
 
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.expr.ExactStatisticsConstants;
+import org.apache.drill.exec.physical.impl.statistics.Statistic;
 
 import java.util.List;
 
@@ -105,6 +106,53 @@ public enum ColumnStatisticsKind implements CollectableColumnStatisticsKind {
     @Override
     public boolean isExact() {
       return true;
+    }
+  },
+
+  /**
+   * Column statistics kind which represents number of non-null values for the specific column.
+   */
+  NON_NULL_COUNT(Statistic.NNROWCOUNT) {
+    @Override
+    public Double mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+      double nonNullRowCount = 0;
+      for (ColumnStatistics statistics : statisticsList) {
+        Double nnRowCount = (Double) statistics.getStatistic(this);
+        if (nnRowCount != null) {
+          nonNullRowCount += nnRowCount;
+        }
+      }
+      return nonNullRowCount;
+    }
+  },
+
+  /**
+   * Column statistics kind which represents number of distinct values for the specific column.
+   */
+  NVD(Statistic.NDV) {
+    @Override
+    public Object mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+      throw new UnsupportedOperationException("Cannot merge statistics for NDV");
+    }
+  },
+
+  /**
+   * Column statistics kind which is the width of the specific column.
+   */
+  AVG_WIDTH(Statistic.AVG_WIDTH) {
+    @Override
+    public Object mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+      throw new UnsupportedOperationException("Cannot merge statistics for avg_width");
+    }
+  },
+
+  /**
+   * Column statistics kind which is the histogram of the specific column.
+   */
+  HISTOGRAM("histogram") {
+    @Override
+    public Object mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+      throw new UnsupportedOperationException("Cannot merge statistics for histogram");
     }
   };
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestPushDownAndPruningForDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestPushDownAndPruningForDecimal.java
@@ -40,8 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestPushDownAndPruningForDecimal extends ClusterTest {
@@ -121,9 +123,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         String query = String.format("select val_int_32, val_int_64 from %s where %s = cast(1.00 as decimal(5, 2))", table, column);
 
         String plan = client.queryBuilder().sql(query).explainText();
-        assertTrue(plan.contains("numRowGroups=1"));
-        assertTrue(plan.contains("usedMetadataFile=false"));
-        assertFalse(plan.contains("Filter"));
+        assertThat(plan, containsString("numRowGroups=1"));
+        assertThat(plan, containsString("usedMetadataFile=false"));
+        assertThat(plan, not(containsString("Filter")));
 
         client.testBuilder()
           .sqlQuery(query)
@@ -155,9 +157,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         String query = String.format("select val_int_32, val_int_64 from %s where %s = cast(2.00 as decimal(5,2))", table, column);
 
         String plan = client.queryBuilder().sql(query).explainText();
-        assertTrue(plan.contains("numRowGroups=1"));
-        assertTrue(plan.contains("usedMetadataFile=true"));
-        assertFalse(plan.contains("Filter"));
+        assertThat(plan, containsString("numRowGroups=1"));
+        assertThat(plan, containsString("usedMetadataFile=true"));
+        assertThat(plan, not(containsString("Filter")));
 
         client.testBuilder()
           .sqlQuery(query)
@@ -184,8 +186,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
 
       String plan = client.queryBuilder().sql(query).explainText();
       // push down does not work for old int decimal types because stats is not read: PARQUET-1322
-      assertTrue(plan.contains("numRowGroups=2"));
-      assertTrue(plan.contains("usedMetadataFile=false"));
+      assertThat(plan, containsString("numRowGroups=2"));
+      assertThat(plan, containsString("usedMetadataFile=false"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -208,8 +210,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         table, column);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=true"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=true"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -235,8 +237,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
 
       String plan = client.queryBuilder().sql(query).explainText();
       // push down does not work for old int decimal types because stats is not read: PARQUET-1322
-      assertTrue(plan.contains("numRowGroups=2"));
-      assertTrue(plan.contains("usedMetadataFile=true"));
+      assertThat(plan, containsString("numRowGroups=2"));
+      assertThat(plan, containsString("usedMetadataFile=true"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -264,8 +266,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         table, column);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=false"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=false"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -294,8 +296,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         table, column);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=true"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=true"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -326,9 +328,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
         String query = String.format("select part_fixed, val_fixed from %s where part_fixed = cast(1.00 as decimal(5, 2))", table);
 
         String plan = client.queryBuilder().sql(query).explainText();
-        assertTrue(plan.contains("numRowGroups=1"));
-        assertTrue(plan.contains("usedMetadataFile=false"));
-        assertFalse(plan.contains("Filter"));
+        assertThat(plan, containsString("numRowGroups=1"));
+        assertThat(plan, containsString("usedMetadataFile=false"));
+        assertThat(plan, not(containsString("Filter")));
 
         client.testBuilder()
           .sqlQuery(query)
@@ -354,9 +356,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
       String query = String.format("select part_fixed, val_fixed from %s where part_fixed = cast(1.00 as decimal(5, 2))", table);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=true"));
-      assertFalse(plan.contains("Filter"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=true"));
+      assertThat(plan, not(containsString("Filter")));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -382,9 +384,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
       String query = String.format("select part_fixed, val_fixed from %s where part_fixed = cast(2.00 as decimal(5, 2))", table);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=true"));
-      assertFalse(plan.contains("Filter"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=true"));
+      assertThat(plan, not(containsString("Filter")));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -407,8 +409,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     String query = String.format("select part_fixed, val_fixed from %s where val_fixed = cast(1.05 as decimal(5, 2))", table);
     String plan = client.queryBuilder().sql(query).explainText();
     // statistics for fixed decimal is not available for files generated prior to parquet 1.10.0 version
-    assertTrue(plan.contains("numRowGroups=2"));
-    assertTrue(plan.contains("usedMetadataFile=false"));
+    assertThat(plan, containsString("numRowGroups=2"));
+    assertThat(plan, containsString("usedMetadataFile=false"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -434,8 +436,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     for (Map.Entry<String, String> property : properties.entrySet()) {
       client.alterSession(ExecConstants.PARQUET_READER_STRINGS_SIGNED_MIN_MAX, property.getKey());
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains(property.getValue()));
-      assertTrue(plan.contains("usedMetadataFile=true"));
+      assertThat(plan, containsString(property.getValue()));
+      assertThat(plan, containsString("usedMetadataFile=true"));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -458,8 +460,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     queryBuilder().sql(String.format("refresh table metadata %s", table)).run();
 
     String plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=2"));
-    assertTrue(plan.contains("usedMetadataFile=true"));
+    assertThat(plan, containsString("numRowGroups=2"));
+    assertThat(plan, containsString("usedMetadataFile=true"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -486,8 +488,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
 
     String query = String.format("select part_fixed, val_fixed from %s where val_fixed = cast(1.05 as decimal(5, 2))", newTable);
     String plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=false"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=false"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -502,8 +504,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     // set string signed option to true since test was written on Drill 1.15.0-SNAPSHOT version
     client.alterSession(ExecConstants.PARQUET_READER_STRINGS_SIGNED_MIN_MAX, "true");
     plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=true"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=true"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -530,9 +532,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
 
     String query = String.format("select part_binary, val_binary from %s where part_binary = cast(1.00 as decimal(5, 2))", newTable);
     String plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=false"));
-    assertFalse(plan.contains("Filter"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=false"));
+    assertThat(plan, not(containsString("Filter")));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -546,9 +548,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     queryBuilder().sql(String.format("refresh table metadata %s", newTable)).run();
 
     plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=true"));
-    assertFalse(plan.contains("Filter"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=true"));
+    assertThat(plan, not(containsString("Filter")));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -577,8 +579,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
 
     String query = String.format("select part_binary, val_binary from %s where val_binary = cast(1.05 as decimal(5, 2))", newTable);
     String plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=false"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=false"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -593,8 +595,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
     // set string signed option to true, since test was written on Drill 1.15.0-SNAPSHOT version
     client.alterSession(ExecConstants.PARQUET_READER_STRINGS_SIGNED_MIN_MAX, "true");
     plan = client.queryBuilder().sql(query).explainText();
-    assertTrue(plan.contains("numRowGroups=1"));
-    assertTrue(plan.contains("usedMetadataFile=true"));
+    assertThat(plan, containsString("numRowGroups=1"));
+    assertThat(plan, containsString("usedMetadataFile=true"));
 
     client.testBuilder()
       .sqlQuery(query)
@@ -619,9 +621,9 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
       String query = String.format("select part, val from %s where part = cast(2.0 as %s)", newTable, decimalType);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=false"));
-      assertFalse(plan.contains("Filter"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=false"));
+      assertThat(plan, not(containsString("Filter")));
 
       client.testBuilder()
         .sqlQuery(query)
@@ -649,8 +651,8 @@ public class TestPushDownAndPruningForDecimal extends ClusterTest {
       String query = String.format("select part, val from %s where val = cast(20.0 as %s)", newTable, decimalType);
 
       String plan = client.queryBuilder().sql(query).explainText();
-      assertTrue(plan.contains("numRowGroups=1"));
-      assertTrue(plan.contains("usedMetadataFile=false"));
+      assertThat(plan, containsString("numRowGroups=1"));
+      assertThat(plan, containsString("usedMetadataFile=false"));
 
       client.testBuilder()
         .sqlQuery(query)

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -347,6 +347,7 @@
             <!-- Relocate Drill classes to minimize classloader hell. -->
             <relocation><pattern>org.apache.drill.exec.</pattern><shadedPattern>oadd.org.apache.drill.exec.</shadedPattern></relocation>
             <relocation><pattern>org.apache.drill.common.</pattern><shadedPattern>oadd.org.apache.drill.common.</shadedPattern></relocation>
+            <relocation><pattern>org.apache.drill.metastore.</pattern><shadedPattern>oadd.org.apache.drill.metastore.</shadedPattern></relocation>
 
             <!-- Move dependencies out of path -->
             <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>
@@ -663,6 +664,7 @@
                   <!-- Relocate Drill classes to minimize classloader hell. -->
                   <relocation><pattern>org.apache.drill.exec.</pattern><shadedPattern>oadd.org.apache.drill.exec.</shadedPattern></relocation>
                   <relocation><pattern>org.apache.drill.common.</pattern><shadedPattern>oadd.org.apache.drill.common.</shadedPattern></relocation>
+                  <relocation><pattern>org.apache.drill.metastore.</pattern><shadedPattern>oadd.org.apache.drill.metastore.</shadedPattern></relocation>
 
                   <!-- Move dependencies out of path -->
                   <relocation><pattern>antlr.</pattern><shadedPattern>oadd.antlr.</shadedPattern></relocation>


### PR DESCRIPTION
In the scope of this PR introduced caching of table metadata (schema and statistics) at the query level.
Introduced `MetadataProviderManager` which holds both `SchemaProvider` and `DrillStatsTable` and `TableMetadataProvider` if it was already created.
`MetadataProviderManager` instance will be cached and used for every `DrillTable` which corresponds to the same table.
Such an approach was used to preserve lazy initialization of group scan and `TableMetadataProvider` instances, so once the first instance of `TableMetadataProvider` is created, it will be stored in the `MetadataProviderManager` and its metadata will be reused for all further `TableMetadataProvider` instances.

Another part of this PR is connected with the adoption of statistics to use Drill Metastore API. Enhanced logic to distinguish exact and estimated metadata, and used `TableMetadata` for obtaining statistics.

Will create and attach a class diagram later.

Also, tests should be run for this PR, so for now, I'll leave it in draft state.