### PR TITLE
DRILL-7150: Fix timezone conversion for timestamp from maprdb after the transition from PDT to PST

### DIFF
--- a/exec/vector/src/main/java/org/apache/drill/exec/expr/fn/impl/DateUtility.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/expr/fn/impl/DateUtility.java
@@ -636,7 +636,6 @@ public class DateUtility {
   public static final DateTimeFormatter isoFormatTime     = buildFormatter("HH:mm:ss.SSSXX");
 
   public static final DateTimeFormatter UTC_FORMATTER = buildFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-  public static final long TIMEZONE_OFFSET_MILLIS = OffsetDateTime.now().getOffset().getTotalSeconds() * 1000;
 
   public static DateTimeFormatter dateTimeTZFormat = null;
   public static DateTimeFormatter timeFormat = null;


### PR DESCRIPTION
Used JDK classes to convert timestamp from one timezone to another one instead of adding milliseconds which corresponds to the offset.

For problem description please see [DRILL-7150](https://issues.apache.org/jira/browse/DRILL-7150).