### PR TITLE
DRILL-7153: Drill Fails to Build using JDK 1.8.0_65

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
@@ -54,9 +54,12 @@ public class FilterEvaluatorUtils {
   private FilterEvaluatorUtils() {
   }
 
+  @SuppressWarnings("RedundantTypeArguments")
   public static RowsMatch evalFilter(LogicalExpression expr, MetadataBase.ParquetTableMetadataBase footer,
                                      int rowGroupIndex, OptionManager options, FragmentContext fragmentContext) {
-    List<SchemaPath> schemaPathsInExpr = new ArrayList<>(expr.accept(new FieldReferenceFinder(), null));
+    // Specifies type arguments explicitly to avoid compilation error caused by JDK-8066974
+    List<SchemaPath> schemaPathsInExpr = new ArrayList<>(
+            expr.<Set<SchemaPath>, Void, RuntimeException>accept(new FieldReferenceFinder(), null));
 
     RowGroupMetadata rowGroupMetadata = new ArrayList<>(ParquetTableMetadataUtils.getRowGroupsMetadata(footer).values()).get(rowGroupIndex);
     Map<SchemaPath, ColumnStatistics> columnsStatistics = rowGroupMetadata.getColumnsStatistics();


### PR DESCRIPTION
This PR fixes a bug in which building Drill using JDK 1.8.0_65 results in the following error. 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project drill-java-exec: Compilation failure
[ERROR] /Users/cgivre/github/drill-dev/drill/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java:[59,68] error: unreported exception E; must be caught or declared to be thrown
[ERROR]   where E,T,V are type-variables:
[ERROR]     E extends Exception declared in method <T,V,E>accept(ExprVisitor<T,V,E>,V)
[ERROR]     T extends Object declared in method <T,V,E>accept(ExprVisitor<T,V,E>,V)
[ERROR]     V extends Object declared in method <T,V,E>accept(ExprVisitor<T,V,E>,V)
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :drill-java-exec
```