### PR TITLE
DRILL-7064: Leverage the summary metadata for plain COUNT aggregates.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -60,8 +60,9 @@ import org.apache.drill.exec.planner.logical.DrillValuesRule;
 import org.apache.drill.exec.planner.logical.DrillWindowRule;
 import org.apache.drill.exec.planner.logical.partition.ParquetPruneScanRule;
 import org.apache.drill.exec.planner.logical.partition.PruneScanRule;
+import org.apache.drill.exec.planner.logical.ConvertCountToDirectScanRule;
 import org.apache.drill.exec.planner.physical.AnalyzePrule;
-import org.apache.drill.exec.planner.physical.ConvertCountToDirectScan;
+import org.apache.drill.exec.planner.physical.ConvertCountToDirectScanPrule;
 import org.apache.drill.exec.planner.physical.LateralJoinPrule;
 import org.apache.drill.exec.planner.physical.DirectScanPrule;
 import org.apache.drill.exec.planner.physical.FilterPrule;
@@ -474,8 +475,10 @@ public enum PlannerPhase {
         .add(
             PruneScanRule.getDirFilterOnProject(optimizerRulesContext),
             PruneScanRule.getDirFilterOnScan(optimizerRulesContext),
-            PruneScanRule.getConvertAggScanToValuesRule(optimizerRulesContext)
-        )
+            PruneScanRule.getConvertAggScanToValuesRule(optimizerRulesContext),
+            ConvertCountToDirectScanRule.AGG_ON_PROJ_ON_SCAN,
+            ConvertCountToDirectScanRule.AGG_ON_SCAN
+          )
         .build();
 
     return RuleSets.ofList(pruneRules);
@@ -501,8 +504,8 @@ public enum PlannerPhase {
   static RuleSet getPhysicalRules(OptimizerRulesContext optimizerRulesContext) {
     final List<RelOptRule> ruleList = new ArrayList<>();
     final PlannerSettings ps = optimizerRulesContext.getPlannerSettings();
-    ruleList.add(ConvertCountToDirectScan.AGG_ON_PROJ_ON_SCAN);
-    ruleList.add(ConvertCountToDirectScan.AGG_ON_SCAN);
+    ruleList.add(ConvertCountToDirectScanPrule.AGG_ON_PROJ_ON_SCAN);
+    ruleList.add(ConvertCountToDirectScanPrule.AGG_ON_SCAN);
     ruleList.add(SortConvertPrule.INSTANCE);
     ruleList.add(SortPrule.INSTANCE);
     ruleList.add(ProjectPrule.INSTANCE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/CountToDirectScanUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/CountToDirectScanUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.common;
+
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+/**
+ * A utility class that contains helper functions used by rules that convert COUNT(*) and COUNT(col)
+ * aggregates (no group-by) to DirectScan
+ */
+public class CountToDirectScanUtils {
+
+  /**
+   * Checks if aggregate call contains star or non-null expression:
+   * <pre>
+   * count(*)  == >  empty arg  ==>  rowCount
+   * count(Not-null-input) ==> rowCount
+   * </pre>
+   *
+   * @param aggregateCall aggregate call
+   * @param aggregate aggregate relation expression
+   * @return true of aggregate call contains star or non-null expression
+   */
+  public static boolean containsStarOrNotNullInput(AggregateCall aggregateCall, Aggregate aggregate) {
+    return aggregateCall.getArgList().isEmpty() ||
+        (aggregateCall.getArgList().size() == 1 &&
+            !aggregate.getInput().getRowType().getFieldList().get(aggregateCall.getArgList().get(0)).getType().isNullable());
+  }
+
+  /**
+   * For each aggregate call creates field based on its name with bigint type.
+   * Constructs record type for created fields.
+   *
+   * @param aggregateRel aggregate relation expression
+   * @param fieldNames field names
+   * @return record type
+   */
+  public static RelDataType constructDataType(Aggregate aggregateRel, Collection<String> fieldNames) {
+    List<RelDataTypeField> fields = new ArrayList<>();
+    int fieldIndex = 0;
+    for (String name : fieldNames) {
+      RelDataTypeField field = new RelDataTypeFieldImpl(
+          name,
+          fieldIndex++,
+          aggregateRel.getCluster().getTypeFactory().createSqlType(SqlTypeName.BIGINT));
+      fields.add(field);
+    }
+    return new RelRecordType(fields);
+  }
+
+  /**
+   * Builds schema based on given field names.
+   * Type for each schema is set to long.class.
+   *
+   * @param fieldNames field names
+   * @return schema
+   */
+  public static LinkedHashMap<String, Class<?>> buildSchema(List<String> fieldNames) {
+    LinkedHashMap<String, Class<?>> schema = new LinkedHashMap<>();
+    for (String fieldName: fieldNames) {
+      schema.put(fieldName, long.class);
+    }
+    return schema;
+  }
+
+  /**
+   * For each field creates row expression.
+   *
+   * @param rowType row type
+   * @return list of row expressions
+   */
+  public static List<RexNode> prepareFieldExpressions(RelDataType rowType) {
+    List<RexNode> expressions = new ArrayList<>();
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      expressions.add(RexInputRef.of(i, rowType));
+    }
+    return expressions;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -56,6 +56,7 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.planner.logical.DrillRelFactories;
 import org.apache.drill.exec.planner.logical.DrillTable;
 import org.apache.drill.exec.planner.logical.FieldsReWriterUtil;
+import org.apache.drill.exec.planner.logical.DrillTranslatableTable;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.resolver.TypeCastRules;
 import org.apache.drill.exec.util.Utilities;
@@ -646,5 +647,17 @@ public abstract class DrillRelOptUtil {
         }
       }
     }
+  }
+
+  public static DrillTable getDrillTable(final TableScan scan) {
+    DrillTable drillTable = null;
+    drillTable = scan.getTable().unwrap(DrillTable.class);
+    if (drillTable == null) {
+      DrillTranslatableTable transTable = scan.getTable().unwrap(DrillTranslatableTable.class);
+      if (transTable != null) {
+        drillTable = transTable.getDrillTable();
+      }
+    }
+    return drillTable;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.logical;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.FormatPluginConfig;
+
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.physical.base.ScanStats;
+import org.apache.drill.exec.planner.common.CountToDirectScanUtils;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.store.ColumnExplorer;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.FileSystemPlugin;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.exec.store.dfs.NamedFormatPluginConfig;
+import org.apache.drill.exec.store.direct.MetadataDirectGroupScan;
+import org.apache.drill.exec.store.parquet.ParquetFormatConfig;
+import org.apache.drill.exec.store.parquet.ParquetReaderConfig;
+import org.apache.drill.exec.store.parquet.metadata.Metadata;
+import org.apache.drill.exec.store.parquet.metadata.Metadata_V4;
+import org.apache.drill.exec.store.pojo.DynamicPojoRecordReader;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.Set;
+
+/**
+ * <p> This rule is a logical planning counterpart to a corresponding <b>ConvertCountToDirectScanPrule</b>
+ * physical rule
+ * </p>
+ * <p>
+ * This rule will convert <b>" select count(*)  as mycount from table "</b>
+ * or <b>" select count(not-nullable-expr) as mycount from table "</b> into
+ * <pre>
+ *    Project(mycount)
+ *         \
+ *    DirectGroupScan ( PojoRecordReader ( rowCount ))
+ *</pre>
+ * or <b>" select count(column) as mycount from table "</b> into
+ * <pre>
+ *      Project(mycount)
+ *           \
+ *            DirectGroupScan (PojoRecordReader (columnValueCount))
+ *</pre>
+ * Rule can be applied if query contains multiple count expressions.
+ * <b>" select count(column1), count(column2), count(*) from table "</b>
+ * </p>
+ *
+ * <p>
+ * The rule utilizes the Parquet Metadata Cache's summary information to retrieve the total row count
+ * and the per-column null count.  As such, the rule is only applicable for Parquet tables and only if the
+ * metadata cache has been created with the summary information.
+ * </p>
+ */
+public class ConvertCountToDirectScanRule extends RelOptRule {
+
+  public static final RelOptRule AGG_ON_PROJ_ON_SCAN = new ConvertCountToDirectScanRule(
+      RelOptHelper.some(Aggregate.class,
+                        RelOptHelper.some(Project.class,
+                            RelOptHelper.any(TableScan.class))), "Agg_on_proj_on_scan");
+
+  public static final RelOptRule AGG_ON_SCAN = new ConvertCountToDirectScanRule(
+      RelOptHelper.some(Aggregate.class,
+                            RelOptHelper.any(TableScan.class)), "Agg_on_scan");
+
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ConvertCountToDirectScanRule.class);
+
+  protected ConvertCountToDirectScanRule(RelOptRuleOperand rule, String id) {
+    super(rule, "ConvertCountToDirectScanRule:" + id);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final Aggregate agg = (Aggregate) call.rel(0);
+    final TableScan scan = (TableScan) call.rel(call.rels.length - 1);
+    final Project project = call.rels.length == 3 ? (Project) call.rel(1) : null;
+
+    // Qualifying conditions for rule:
+    //    1) There's no GroupBY key,
+    //    2) Agg is not a DISTINCT agg
+    //    3) Additional checks are done further below ..
+    if (agg.getGroupCount() > 0 ||
+        agg.containsDistinctCall()) {
+      return;
+    }
+
+    DrillTable drillTable = DrillRelOptUtil.getDrillTable(scan);
+
+    if (drillTable == null) {
+      logger.debug("Rule does not apply since an eligible drill table instance was not found.");
+      return;
+    }
+
+    Object selection = drillTable.getSelection();
+
+    if (!(selection instanceof FormatSelection)) {
+      logger.debug("Rule does not apply since only Parquet file format is eligible.");
+      return;
+    }
+
+    PlannerSettings settings = call.getPlanner().getContext().unwrap(PlannerSettings.class);
+
+    //  Rule is applicable only if the statistics for row count and null count are available from the metadata,
+    FormatSelection formatSelection = (FormatSelection) selection;
+    Pair<Boolean, Metadata_V4.MetadataSummary> status = checkMetadataForScanStats(settings, drillTable, formatSelection);
+
+    if (!status.getLeft()) {
+      logger.debug("Rule does not apply since MetadataSummary metadata was not found.");
+      return;
+    }
+
+    Metadata_V4.MetadataSummary metadataSummary = status.getRight();
+    Map<String, Long> result = collectCounts(settings, metadataSummary, agg, scan, project);
+    logger.trace("Calculated the following aggregate counts: ", result);
+
+    // if counts could not be determined, rule won't be applied
+    if (result.isEmpty()) {
+      logger.debug("Rule does not apply since one or more COUNTs could not be determined from metadata.");
+      return;
+    }
+
+    List<Path> fileList =
+            ImmutableList.of(Metadata.getSummaryFileName(formatSelection.getSelection().getSelectionRoot()));
+
+    final RelDataType scanRowType = CountToDirectScanUtils.constructDataType(agg, result.keySet());
+
+    final DynamicPojoRecordReader<Long> reader = new DynamicPojoRecordReader<>(
+        CountToDirectScanUtils.buildSchema(scanRowType.getFieldNames()),
+        Collections.singletonList((List<Long>) new ArrayList<>(result.values())));
+
+    final ScanStats scanStats = new ScanStats(ScanStats.GroupScanProperty.EXACT_ROW_COUNT, 1, 1, scanRowType.getFieldCount());
+    final MetadataDirectGroupScan directScan = new MetadataDirectGroupScan(reader, fileList, scanStats, true);
+
+    final DrillDirectScanRel newScan = new DrillDirectScanRel(scan.getCluster(), scan.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
+      directScan, scanRowType);
+
+    final DrillProjectRel newProject = new DrillProjectRel(agg.getCluster(), agg.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
+      newScan, CountToDirectScanUtils.prepareFieldExpressions(scanRowType), agg.getRowType());
+
+    call.transformTo(newProject);
+  }
+
+  private Pair<Boolean, Metadata_V4.MetadataSummary> checkMetadataForScanStats(PlannerSettings settings, DrillTable drillTable,
+                                                                               FormatSelection formatSelection) {
+
+    // Currently only support metadata rowcount stats for Parquet tables
+    FormatPluginConfig formatConfig = formatSelection.getFormat();
+    if (!((formatConfig instanceof ParquetFormatConfig)
+      || ((formatConfig instanceof NamedFormatPluginConfig)
+      && ((NamedFormatPluginConfig) formatConfig).name.equals("parquet")))) {
+      return new ImmutablePair<Boolean, Metadata_V4.MetadataSummary>(false, null);
+    }
+
+    FileSystemPlugin plugin = (FileSystemPlugin) drillTable.getPlugin();
+    DrillFileSystem fs = null;
+    try {
+       fs = new DrillFileSystem(plugin.getFormatPlugin(formatSelection.getFormat()).getFsConf());
+    } catch (IOException e) {
+      logger.warn("Unable to create the file system object for retrieving statistics from metadata cache file ", e);
+      return new ImmutablePair<Boolean, Metadata_V4.MetadataSummary>(false, null);
+    }
+
+    // check if the cacheFileRoot has been set: this is needed because after directory pruning, the
+    // cacheFileRoot could have been changed and not be the same as the original selectionRoot
+    Path selectionRoot = formatSelection.getSelection().getCacheFileRoot() != null ?
+            formatSelection.getSelection().getCacheFileRoot() :
+            formatSelection.getSelection().getSelectionRoot();
+
+    ParquetReaderConfig parquetReaderConfig= ParquetReaderConfig.builder()
+            .withFormatConfig((ParquetFormatConfig) formatConfig)
+            .withOptions(settings.getOptions())
+            .build();
+
+    Metadata_V4.MetadataSummary metadataSummary = Metadata.getSummary(fs, selectionRoot, false, parquetReaderConfig);
+
+    return metadataSummary != null ? new ImmutablePair<Boolean, Metadata_V4.MetadataSummary>(true, metadataSummary) :
+      new ImmutablePair<Boolean, Metadata_V4.MetadataSummary>(false, null);
+  }
+
+  /**
+   * Collects counts for each aggregation call by using the metadata summary information
+   * Will return empty result map if was not able to determine count for at least one aggregation call.
+   *
+   * For each aggregate call will determine if count can be calculated. Collects counts only for COUNT function.
+   *   1. First, we get the total row count from the metadata summary.
+   *   2. For COUNT(*) and COUNT(<non null column>) and COUNT(<implicit column>), the count = total row count
+   *   3. For COUNT(nullable column), count = (total row count - column's null count)
+   *   4. Also count can not be calculated for parition columns.
+   *
+   * @param settings planner options
+   * @param metadataSummary metadata summary containing row counts and column counts
+   * @param agg aggregate relational expression
+   * @param scan scan relational expression
+   * @param project project relational expression
+   * @return result map where key is count column name, value is count value
+   */
+  private Map<String, Long> collectCounts(PlannerSettings settings, Metadata_V4.MetadataSummary metadataSummary,
+                                          Aggregate agg, TableScan scan, Project project) {
+    final Set<String> implicitColumnsNames = ColumnExplorer.initImplicitFileColumns(settings.getOptions()).keySet();
+    final long totalRecordCount = metadataSummary.getTotalRowCount();
+    final LinkedHashMap<String, Long> result = new LinkedHashMap<>();
+
+    for (int i = 0; i < agg.getAggCallList().size(); i++) {
+      AggregateCall aggCall = agg.getAggCallList().get(i);
+      long cnt;
+
+      // rule can be applied only for count function, return empty counts
+      if (!"count".equalsIgnoreCase(aggCall.getAggregation().getName()) ) {
+        return ImmutableMap.of();
+      }
+
+      if (CountToDirectScanUtils.containsStarOrNotNullInput(aggCall, agg)) {
+        cnt = totalRecordCount;
+
+      } else if (aggCall.getArgList().size() == 1) {
+        // count(columnName) ==> Agg ( Scan )) ==> columnValueCount
+        int index = aggCall.getArgList().get(0);
+
+        if (project != null) {
+          // project in the middle of Agg and Scan : Only when input of AggCall is a RexInputRef in Project, we find the index of Scan's field.
+          // For instance,
+          // Agg - count($0)
+          //  \
+          //  Proj - Exp={$1}
+          //    \
+          //   Scan (col1, col2).
+          // return count of "col2" in Scan's metadata, if found.
+          if (!(project.getProjects().get(index) instanceof RexInputRef)) {
+            return ImmutableMap.of(); // do not apply for all other cases.
+          }
+
+          index = ((RexInputRef) project.getProjects().get(index)).getIndex();
+        }
+
+        String columnName = scan.getRowType().getFieldNames().get(index).toLowerCase();
+
+        // for implicit column count will be the same as total record count
+        if (implicitColumnsNames.contains(columnName)) {
+          cnt = totalRecordCount;
+        } else {
+          SchemaPath simplePath = SchemaPath.getSimplePath(columnName);
+
+          if (ColumnExplorer.isPartitionColumn(settings.getOptions(), simplePath)) {
+            return ImmutableMap.of();
+          }
+
+          Metadata_V4.ColumnTypeMetadata_v4 columnMetadata = metadataSummary.getColumnTypeInfo(new Metadata_V4.ColumnTypeMetadata_v4.Key(simplePath));
+
+         if (columnMetadata == null || columnMetadata.totalNullCount == GroupScan.NO_COLUMN_STATS) {
+            // if column stats is not available don't apply this rule, return empty counts
+            return ImmutableMap.of();
+          } else {
+           // count of a nullable column = (total row count - column's null count)
+           cnt = totalRecordCount - columnMetadata.totalNullCount;
+         }
+
+        }
+      } else {
+        return ImmutableMap.of();
+      }
+
+      String name = "count" + i + "$" + (aggCall.getName() == null ? aggCall.toString() : aggCall.getName());
+      result.put(name, cnt);
+    }
+
+    return ImmutableMap.copyOf(result);
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/MetadataDirectGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/MetadataDirectGroupScan.java
@@ -38,21 +38,19 @@ import java.util.List;
 public class MetadataDirectGroupScan extends DirectGroupScan {
 
   private final Collection<Path> files;
+  private boolean usedMetadataSummaryFile = false;
 
-  public MetadataDirectGroupScan(RecordReader reader, Collection<Path> files) {
-    super(reader);
-    this.files = files;
-  }
-
-  public MetadataDirectGroupScan(RecordReader reader, Collection<Path> files, ScanStats stats) {
+  public MetadataDirectGroupScan(RecordReader reader, Collection<Path> files, ScanStats stats,
+                                 boolean usedMetadataSummaryFile) {
     super(reader, stats);
     this.files = files;
+    this.usedMetadataSummaryFile = usedMetadataSummaryFile;
   }
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
     assert children == null || children.isEmpty();
-    return new MetadataDirectGroupScan(reader, files, stats);
+    return new MetadataDirectGroupScan(reader, files, stats, usedMetadataSummaryFile);
   }
 
   @Override
@@ -78,6 +76,7 @@ public class MetadataDirectGroupScan extends DirectGroupScan {
       StringBuilder builder = new StringBuilder();
       builder.append("files = ").append(files).append(", ");
       builder.append("numFiles = ").append(files.size()).append(", ");
+      builder.append("usedMetadataSummaryFile = ").append(usedMetadataSummaryFile).append(", ");
       return builder.append(super.getDigest()).toString();
     }
     return super.getDigest();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata.java
@@ -796,12 +796,12 @@ public class Metadata {
     return metadataSummary.isAllColumnsInteresting();
   }
 
-  private static Path getSummaryFileName(Path metadataParentDir) {
+  public static Path getSummaryFileName(Path metadataParentDir) {
     Path summaryFile = new Path(metadataParentDir, METADATA_SUMMARY_FILENAME);
     return summaryFile;
   }
 
-  private static Path getDirFileName(Path metadataParentDir) {
+  public static Path getDirFileName(Path metadataParentDir) {
     Path metadataDirFile = new Path(metadataParentDir, METADATA_DIRECTORIES_FILENAME);
     return metadataDirFile;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/TestConvertCountToDirectScan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/TestConvertCountToDirectScan.java
@@ -163,4 +163,79 @@ public class TestConvertCountToDirectScan extends PlanTestBase {
     }
   }
 
+  @Test
+  public void testCountsWithMetadataCacheSummary() throws Exception {
+    test("use dfs.tmp");
+    String tableName = "parquet_table_counts";
+
+    try {
+      test(String.format("create table `%s/1` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/2` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/3` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/4` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+
+      test("refresh table metadata %s", tableName);
+
+      String sql = String.format("select\n" +
+              "count(*) as star_count,\n" +
+              "count(col_int) as int_column_count,\n" +
+              "count(col_vrchr) as vrchr_column_count\n" +
+              "from %s", tableName);
+
+      int expectedNumFiles = 1;
+      String numFilesPattern = "numFiles = " + expectedNumFiles;
+      String usedMetaSummaryPattern = "usedMetadataSummaryFile = true";
+      String recordReaderPattern = "DynamicPojoRecordReader";
+
+      testPlanMatchingPatterns(sql, new String[]{numFilesPattern, usedMetaSummaryPattern, recordReaderPattern});
+
+      testBuilder()
+              .sqlQuery(sql)
+              .unOrdered()
+              .baselineColumns("star_count", "int_column_count", "vrchr_column_count")
+              .baselineValues(24L, 8L, 12L)
+              .go();
+
+    } finally {
+      test("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testCountsWithMetadataCacheSummaryAndDirPruning() throws Exception {
+    test("use dfs.tmp");
+    String tableName = "parquet_table_counts";
+
+    try {
+      test(String.format("create table `%s/1` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/2` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/3` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+      test(String.format("create table `%s/4` as select * from cp.`parquet/alltypes_optional.parquet`", tableName));
+
+      test("refresh table metadata %s", tableName);
+
+      String sql = String.format("select\n" +
+              "count(*) as star_count,\n" +
+              "count(col_int) as int_column_count,\n" +
+              "count(col_vrchr) as vrchr_column_count\n" +
+              "from %s where dir0 = 1 ", tableName);
+
+      int expectedNumFiles = 1;
+      String numFilesPattern = "numFiles = " + expectedNumFiles;
+      String usedMetaSummaryPattern = "usedMetadataSummaryFile = false";
+      String recordReaderPattern = "DynamicPojoRecordReader";
+
+      testPlanMatchingPatterns(sql, new String[]{numFilesPattern, usedMetaSummaryPattern, recordReaderPattern});
+
+      testBuilder()
+              .sqlQuery(sql)
+              .unOrdered()
+              .baselineColumns("star_count", "int_column_count", "vrchr_column_count")
+              .baselineValues(6L, 2L, 3L)
+              .go();
+
+    } finally {
+      test("drop table if exists %s", tableName);
+    }
+  }
 }


### PR DESCRIPTION
Please see [DRILL-7064](https://issues.apache.org/jira/browse/DRILL-7064) for a description of this enhancement.  Please also see the design document attached to the parent JIRA for design details. 

This PR adds a logical planning rule `ConvertCountToDirectScanRule` and creates a DirectScan plan for plain COUNT(*) and COUNT(column) aggregates with no group-by.   It does this by reading the Summary metadata cache file and fetching the `totalRowCount` and `totalNullCount` per column. 

Note to reviewer:  Please review the DRILL-7064 commit here and ignore the DRILL-7063 which is the underlying metadata changes on which this PR is based.    