### PR TITLE
DRILL-7154: TPCH query 4, 17 and 18 take longer with sf 1000 when Statistics are disabled.

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DefaultQueryParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DefaultQueryParallelizer.java
@@ -55,7 +55,7 @@ public class DefaultQueryParallelizer extends SimpleParallelizer {
     if (planHasMemory) {
       return;
     }
-    List<PhysicalOperator> bufferedOpers = planningSet.getRootWrapper().getNode().getBufferedOperators();
+    List<PhysicalOperator> bufferedOpers = planningSet.getRootWrapper().getNode().getBufferedOperators(queryContext);
     MemoryAllocationUtilities.setupBufferedOpsMemoryAllocations(planHasMemory, bufferedOpers, queryContext);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Fragment.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Fragment.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.base.AbstractPhysicalVisitor;
 import org.apache.drill.exec.physical.base.Exchange;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
@@ -165,17 +166,23 @@ public class Fragment implements Iterable<Fragment.ExchangeFragmentPair> {
     return true;
   }
 
-  public List<PhysicalOperator> getBufferedOperators() {
+  public List<PhysicalOperator> getBufferedOperators(QueryContext queryContext) {
     List<PhysicalOperator> bufferedOps = new ArrayList<>();
-    root.accept(new BufferedOpFinder(), bufferedOps);
+    root.accept(new BufferedOpFinder(queryContext), bufferedOps);
     return bufferedOps;
   }
 
   protected static class BufferedOpFinder extends AbstractPhysicalVisitor<Void, List<PhysicalOperator>, RuntimeException> {
+    private final QueryContext context;
+
+    public BufferedOpFinder(QueryContext queryContext) {
+      this.context = queryContext;
+    }
+
     @Override
     public Void visitOp(PhysicalOperator op, List<PhysicalOperator> value)
       throws RuntimeException {
-      if (op.isBufferedOperator(null)) {
+      if (op.isBufferedOperator(context)) {
         value.add(op);
       }
       visitChildren(op, value);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Materializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Materializer.java
@@ -196,7 +196,9 @@ public class Materializer extends AbstractPhysicalVisitor<PhysicalOperator, Mate
 
     public void addAllocation(PhysicalOperator pop) {
       info.addInitialAllocation(pop.getInitialAllocation());
-      info.addMaxAllocation(memoryPerOperPerDrillbit.apply(this.endpoint.apply(info, minorFragmentId), pop));
+      long maxAllocation = memoryPerOperPerDrillbit.apply(this.endpoint.apply(info, minorFragmentId), pop);
+      info.addMaxAllocation(maxAllocation);
+      pop.setMaxAllocation(maxAllocation);
     }
 
     public void addUnnest(UnnestPOP unnest) {


### PR DESCRIPTION
Buffered operator list changes depending upon the options being set. For a code path previous code is not checking the options and all the regular buffered operators are considered during the memory estimation. This results in underestimating the memory for the operators in general and performance is degrading.

This fix passes the queryContext to the BufferedOperator finder to report the buffered operator accurately.
 