### PR TITLE
DRILL-7159: Fix typeString method to return correct name for MAP (aka STRUCT)

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/SchemaHandler.java
@@ -295,7 +295,7 @@ public abstract class SchemaHandler extends DefaultSqlHandler {
       } catch (IOException e) {
         throw UserException.resourceError(e)
           .message(e.getMessage())
-          .addContext("Error while accessing table location for [%s]", sqlCall.getTable())
+          .addContext("Error while accessing schema for table [%s]", sqlCall.getTable())
           .build(logger);
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/MapColumnMetadata.java
@@ -127,7 +127,7 @@ public class MapColumnMetadata extends AbstractColumnMetadata {
     if (isArray()) {
       builder.append("ARRAY<");
     }
-    builder.append("MAP<");
+    builder.append("STRUCT<");
     builder.append(mapSchema().toMetadataList().stream()
       .map(ColumnMetadata::columnString)
       .collect(Collectors.joining(", ")));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/TestSchemaProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/TestSchemaProvider.java
@@ -132,7 +132,7 @@ public class TestSchemaProvider {
     properties.put("k2", "v2");
 
     assertFalse(provider.exists());
-    provider.store("i int, v varchar(10)", properties, StorageStrategy.DEFAULT);
+    provider.store("i int, v varchar(10), s struct<s1 int, s2 varchar>", properties, StorageStrategy.DEFAULT);
     assertTrue(provider.exists());
 
     String expectedContent = "{\n"
@@ -147,6 +147,11 @@ public class TestSchemaProvider {
       + "        \"name\" : \"v\",\n"
       + "        \"type\" : \"VARCHAR(10)\",\n"
       + "        \"mode\" : \"OPTIONAL\"\n"
+      + "      },\n"
+      + "      {\n"
+      + "        \"name\" : \"s\",\n"
+      + "        \"type\" : \"STRUCT<`s1` INT, `s2` VARCHAR>\",\n"
+      + "        \"mode\" : \"REQUIRED\"\n"
       + "      }\n"
       + "    ],\n"
       + "    \"properties\" : {\n"


### PR DESCRIPTION
Jira [DRILL-7159](https://issues.apache.org/jira/browse/DRILL-7159).