### PR TITLE
Drill 7148 - Join order, multi-col ndv and aggregate rowcount fixes for TPCH queries

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillJoinRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillJoinRelBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.common;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -33,6 +34,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.expr.holders.IntHolder;
 import org.apache.drill.exec.physical.impl.join.JoinUtils;
@@ -102,26 +104,32 @@ public abstract class DrillJoinRelBase extends Join implements DrillJoin {
       return joinRowFactor * this.getLeft().estimateRowCount(mq) * this.getRight().estimateRowCount(mq);
     }
 
-    int[] joinFields = new int[2];
-
     LogicalJoin jr = LogicalJoin.create(this.getLeft(), this.getRight(), this.getCondition(),
             this.getVariablesSet(), this.getJoinType());
 
     if (!DrillRelOptUtil.guessRows(this)         //Statistics present for left and right side of the join
-        && jr.getJoinType() == JoinRelType.INNER
-        && DrillRelOptUtil.analyzeSimpleEquiJoin((Join)jr, joinFields)) {
-      ImmutableBitSet leq = ImmutableBitSet.of(joinFields[0]);
-      ImmutableBitSet req = ImmutableBitSet.of(joinFields[1]);
+        && jr.getJoinType() == JoinRelType.INNER) {
+      List<Pair<Integer, Integer>> joinConditions = DrillRelOptUtil.analyzeSimpleEquiJoin((Join)jr);
+      if (joinConditions.size() > 0) {
+        List<Integer> leftSide =  new ArrayList<>();
+        List<Integer> rightSide = new ArrayList<>();
+        for (Pair<Integer, Integer> condition : joinConditions) {
+          leftSide.add(condition.left);
+          rightSide.add(condition.right);
+        }
+        ImmutableBitSet leq = ImmutableBitSet.of(leftSide);
+        ImmutableBitSet req = ImmutableBitSet.of(rightSide);
 
-      Double ldrc = mq.getDistinctRowCount(this.getLeft(), leq, null);
-      Double rdrc = mq.getDistinctRowCount(this.getRight(), req, null);
+        Double ldrc = mq.getDistinctRowCount(this.getLeft(), leq, null);
+        Double rdrc = mq.getDistinctRowCount(this.getRight(), req, null);
 
-      Double lrc = mq.getRowCount(this.getLeft());
-      Double rrc = mq.getRowCount(this.getRight());
+        Double lrc = mq.getRowCount(this.getLeft());
+        Double rrc = mq.getRowCount(this.getRight());
 
-      if (ldrc != null && rdrc != null && lrc != null && rrc != null) {
-        // Join cardinality = (lrc * rrc) / Math.max(ldrc, rdrc). Avoid overflow by dividing earlier
-        return (lrc / Math.max(ldrc, rdrc)) * rrc;
+        if (ldrc != null && rdrc != null && lrc != null && rrc != null) {
+          // Join cardinality = (lrc * rrc) / Math.max(ldrc, rdrc). Avoid overflow by dividing earlier
+          return (lrc / Math.max(ldrc, rdrc)) * rrc;
+        }
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
@@ -483,7 +483,7 @@ public class DrillStatsTable {
       Map<StatisticsKind, Object> statisticsValues = new HashMap<>();
       Double ndv = statsProvider.getNdv(fieldName);
       if (ndv != null) {
-        statisticsValues.put(ColumnStatisticsKind.NVD, ndv);
+        statisticsValues.put(ColumnStatisticsKind.NDV, ndv);
       }
       Double nonNullCount = statsProvider.getNNRowCount(fieldName);
       if (nonNullCount != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PlannerSettings.java
@@ -231,6 +231,8 @@ public class PlannerSettings implements Context{
 
   public static final BooleanValidator STATISTICS_USE = new BooleanValidator("planner.statistics.use", null);
 
+  public static final RangeDoubleValidator STATISTICS_MULTICOL_NDV_ADJUST_FACTOR = new RangeDoubleValidator("planner.statistics.multicol_ndv_adjustment_factor", 0.0, 1.0, null);
+
   public OptionManager options = null;
   public FunctionImplementationRegistry functionImplementationRegistry = null;
 
@@ -473,6 +475,10 @@ public class PlannerSettings implements Context{
 
   public boolean useStatistics() {
     return options.getOption(STATISTICS_USE);
+  }
+
+  public double getStatisticsMultiColNdvAdjustmentFactor() {
+    return options.getOption(STATISTICS_MULTICOL_NDV_ADJUST_FACTOR);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -121,6 +121,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(PlannerSettings.ENABLE_UNNEST_LATERAL),
       new OptionDefinition(PlannerSettings.FORCE_2PHASE_AGGR), // for testing
       new OptionDefinition(PlannerSettings.STATISTICS_USE),
+      new OptionDefinition(PlannerSettings.STATISTICS_MULTICOL_NDV_ADJUST_FACTOR),
       new OptionDefinition(ExecConstants.HASHJOIN_NUM_PARTITIONS_VALIDATOR),
       new OptionDefinition(ExecConstants.HASHJOIN_MAX_MEMORY_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, true)),
       new OptionDefinition(ExecConstants.HASHJOIN_NUM_ROWS_IN_BATCH_VALIDATOR),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/Utilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/Utilities.java
@@ -105,7 +105,7 @@ public class Utilities {
    */
   public static DrillTable getDrillTable(RelOptTable table) {
     DrillTable drillTable = table.unwrap(DrillTable.class);
-    if (drillTable == null) {
+    if (drillTable == null && table.unwrap(DrillTranslatableTable.class) != null) {
       drillTable = table.unwrap(DrillTranslatableTable.class).getDrillTable();
     }
     return drillTable;

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -591,6 +591,7 @@ drill.exec.options: {
     planner.producer_consumer_queue_size: 10,
     planner.slice_target: 100000,
     planner.statistics.use: false,
+    planner.statistics.multicol_ndv_adjustment_factor: 1.0,
     planner.store.parquet.rowgroup.filter.pushdown.enabled: true,
     planner.store.parquet.rowgroup.filter.pushdown.threshold: 10000,
     # Max per node should always be configured as zero and

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -258,14 +258,14 @@ public class TestAnalyze extends BaseTestQuery {
 
     query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
         + " on emp.department_id = dept.department_id";
-    String[] expectedPlan4 = {"HashJoin\\(condition.*\\).*rowcount = 1154.9999999999995,.*",
+    String[] expectedPlan4 = {"HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
             "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
             "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
     PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan4, new String[]{});
 
     query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
             + " on emp.department_id = dept.department_id where dept.department_id = 5";
-    String[] expectedPlan5 = {"HashJoin\\(condition.*\\).*rowcount = 96.24999999999997,.*",
+    String[] expectedPlan5 = {"HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
             "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
             "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
     PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan5, new String[]{});
@@ -290,8 +290,8 @@ public class TestAnalyze extends BaseTestQuery {
     query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
             + " on emp.department_id = dept.department_id "
             + " group by emp.employee_id";
-    String[] expectedPlan8 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 730.0992454469839,.*",
-            "HashJoin\\(condition.*\\).*rowcount = 1154.9999999999995,.*",
+    String[] expectedPlan8 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 115.49475630811243,.*",
+            "HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
             "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
             "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
     PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan8, new String[]{});
@@ -301,8 +301,8 @@ public class TestAnalyze extends BaseTestQuery {
             + " on emp.department_id = dept.department_id "
             + " group by emp.employee_id, emp.store_id, dept.department_description "
             + " having dept.department_description = 'FINANCE'";
-    String[] expectedPlan9 = {"HashAgg\\(group=\\[\\{0, 1, 2\\}\\]\\).*rowcount = 92.3487011031316.*",
-            "HashJoin\\(condition.*\\).*rowcount = 96.24999999999997,.*",
+    String[] expectedPlan9 = {"HashAgg\\(group=\\[\\{0, 1, 2\\}\\]\\).*rowcount = 60.84160378724867.*",
+            "HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
             "Scan.*columns=\\[`department_id`, `employee_id`, `store_id`\\].*rowcount = 1155.0.*",
             "Filter\\(condition=\\[=\\(\\$1, 'FINANCE'\\)\\]\\).*rowcount = 1.0,.*",
             "Scan.*columns=\\[`department_id`, `department_description`\\].*rowcount = 12.0.*"};

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
@@ -145,7 +145,7 @@ public enum ColumnStatisticsKind implements CollectableColumnStatisticsKind {
   /**
    * Column statistics kind which represents number of distinct values for the specific column.
    */
-  NVD(Statistic.NDV) {
+  NDV(Statistic.NDV) {
     @Override
     public Object mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
       throw new UnsupportedOperationException("Cannot merge statistics for NDV");


### PR DESCRIPTION
@amansinha100 can you please do an initial review of the proposed fixes. @rhou1 can you please run perf tests with this branch. Here is a description of each commit:

DRILL-7148: Use different join cardinality and ndv estimation
Enable using the new formula which had the limitation of less accurate ndv computation. That has been addressed as part of this fix. Also, earlier multi-col ndv computation does not seem as accurate which has been fixed.

DRILL-7148: Additional performance fixes
HashAgg rowcount was underestimated for the first phase of a two-phase hash agg. This has been addressed.

DRILL-7148: Fix statistics row count
There was a bug which did not result in using correct rowcount for EnumerableTableScan which was affecting initial join ordering.