### PR TITLE
DRILL-7166: Count query with wildcard should skip reading of metadata summary file

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
@@ -138,8 +138,14 @@ public class ConvertCountToDirectScanRule extends RelOptRule {
 
     //  Rule is applicable only if the statistics for row count and null count are available from the metadata,
     FormatSelection formatSelection = (FormatSelection) selection;
-    Pair<Boolean, Metadata_V4.MetadataSummary> status = checkMetadataForScanStats(settings, drillTable, formatSelection);
 
+    // Rule cannot be applied if the selection had wildcard since the totalrowcount cannot be read from the parent directory
+    if (formatSelection.getSelection().hadWildcard()) {
+      logger.debug("Rule does not apply when there is a wild card since the COUNT could not be determined from metadata.");
+      return;
+    }
+
+    Pair<Boolean, Metadata_V4.MetadataSummary> status = checkMetadataForScanStats(settings, drillTable, formatSelection);
     if (!status.getLeft()) {
       logger.debug("Rule does not apply since MetadataSummary metadata was not found.");
       return;


### PR DESCRIPTION
Count(*) or Count(column) queries use the aggregated row count and null count from the metadata summary file without reading the large file metadata. When the directory filter has a wildcard, count cannot be fetched from the metadata summary file since the summary file contains count of all the children underneath that and there is no way to filter using wild card. The ConvertCountToDirectScan physical rule will be applied to these cases.