### PR TITLE
DRILL-7164: KafkaFilterPushdownTest is sometimes failing to pattern match correctly

### DIFF
--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaFilterPushdownTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/KafkaFilterPushdownTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -32,10 +33,8 @@ import static org.junit.Assert.assertTrue;
 @Category({KafkaStorageTest.class, SlowTest.class})
 public class KafkaFilterPushdownTest extends KafkaTestBase {
   private static final int NUM_PARTITIONS = 5;
-  private static final String expectedSubStr = "    \"kafkaScanSpec\" : {\n" +
-                                                   "      \"topicName\" : \"drill-pushdown-topic\"\n" +
-                                                   "    },\n" +
-                                                   "    \"cost\"";
+  private static final String expectedPattern = "KafkaGroupScan.*KafkaScanSpec=KafkaScanSpec.*" +
+                                                   "topicName=drill-pushdown-topic.*rowcount.*=.*%s";
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -63,7 +62,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -79,7 +80,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -95,7 +98,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -112,7 +117,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowInPlan));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowInPlan)},
+        new String[]{});
   }
 
   /**
@@ -128,7 +135,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -144,7 +153,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -161,7 +172,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -178,42 +191,54 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = 10");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"equal" such that value < startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = -1");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"greater_than" such that value = endOffset-1
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset > 9");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"greater_than_or_equal" such that value = endOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset >= 10");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"less_than" such that value = startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset < 0");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"less_than_or_equal" such that value < startOffset
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset <= -1");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -230,21 +255,27 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset = 9");
 
     runKafkaSQLVerifyCount(queryString, expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"greater_than" such that value = endOffset-2
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset > 8");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
 
     //"greater_than_or_equal" such that value = endOffset-1
     queryString = String.format(TestQueryConstants.QUERY_TEMPLATE_BASIC,
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, "kafkaMsgOffset >= 9");
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -262,7 +293,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -280,7 +313,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowInPlan));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowInPlan)},
+        new String[]{});
   }
 
   /**
@@ -299,7 +334,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCount));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -319,7 +356,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3, predicate4);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCountInPlan));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCount)},
+        new String[]{});
   }
 
   /**
@@ -338,7 +377,9 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCountInPlan));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCountInPlan)},
+        new String[]{});
   }
 
   /**
@@ -358,7 +399,8 @@ public class KafkaFilterPushdownTest extends KafkaTestBase {
         TestQueryConstants.JSON_PUSHDOWN_TOPIC, predicate1, predicate2, predicate3);
 
     runKafkaSQLVerifyCount(queryString,expectedRowCount);
-    testPhysicalPlan(queryString, String.format(expectedSubStr, expectedRowCountInPlan));
+    PlanTestBase.testPlanWithAttributesMatchingPatterns(queryString,
+        new String[] {String.format(expectedPattern, expectedRowCountInPlan)},
+        new String[]{});
   }
-
 }


### PR DESCRIPTION
- The structure of "cost" in JSON plan changed as a part of #1677 and cost validation was accidentally.
- While correcting the cost validation, the substring validation is changed to regex validation to make it more robust.