### PR TITLE
DRILL-6988: Utility of the too long error message when syntax error

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/DrillParserUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/DrillParserUtil.java
@@ -32,6 +32,11 @@ public class DrillParserUtil {
 
   private static final int CONDITION_LIST_CAPACITY = 3;
 
+  /**
+   * System-depended end of line character
+   */
+  public static final String EOL = System.lineSeparator();
+
   public static SqlNode createCondition(SqlNode left, SqlOperator op, SqlNode right) {
 
     // if one of the operands is null, return the other

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/impl/DrillSqlParseException.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/impl/DrillSqlParseException.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser.impl;
+
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/**
+ * Customized {@link SqlParseException} class
+ */
+public class DrillSqlParseException extends SqlParseException {
+  private final ParseException parseException;
+
+  public DrillSqlParseException(String message, SqlParserPos pos, int[][] expectedTokenSequences,
+                                String[] tokenImages, Throwable ex) {
+    super(message, pos, expectedTokenSequences, tokenImages, ex);
+
+    parseException = (ex instanceof ParseException) ? (ParseException) ex : null;
+  }
+
+  public DrillSqlParseException(SqlParseException sqlParseException) {
+    this(sqlParseException.getMessage(), sqlParseException.getPos(), sqlParseException.getExpectedTokenSequences(),
+        sqlParseException.getTokenImages(), sqlParseException.getCause());
+  }
+
+  /**
+   * Builds error message just like the original {@link SqlParseException}
+   * with special handling for {@link ParseException} class.
+   * <p>
+   * This is customized implementation of the original {@link ParseException#getMessage()}.
+   * Any other underlying {@link SqlParseException} exception messages goes through without changes
+   * <p>
+   * <p>
+   * Example:
+   * <pre>
+   *
+   *   Given query: SELECT FROM (VALUES(1));
+   *
+   *   Generated message for the unsupported FROM token after SELECT would look like:
+   *
+   *       Encountered "FROM" at line 1, column 8.
+   *</pre>
+   * @return formatted string representation of {@link DrillSqlParseException}
+   */
+  @Override
+  public String getMessage() {
+    // proxy the original message if exception does not belongs
+    // to ParseException or no current token passed
+    if (parseException == null || parseException.currentToken == null) {
+      return super.getMessage();
+    }
+
+    int[][] expectedTokenSequences = getExpectedTokenSequences();
+    String[] tokenImage = getTokenImages();
+
+    int maxSize = 0;  // holds max possible length of the token sequence
+    for (int[] expectedTokenSequence : expectedTokenSequences) {
+      if (maxSize < expectedTokenSequence.length) {
+        maxSize = expectedTokenSequence.length;
+      }
+    }
+
+    // parseException.currentToken points to the last successfully parsed token, next one is considered as fail reason
+    Token tok = parseException.currentToken.next;
+    StringBuilder sb = new StringBuilder("Encountered \"");
+
+    // Adds unknown token sequences to the message
+    for (int i = 0; i < maxSize; i++) {
+      if (i != 0) {
+        sb.append(" ");
+      }
+
+      if (tok.kind == DrillParserImplConstants.EOF) {
+        sb.append(tokenImage[0]);
+        break;
+      }
+      sb.append(parseException.add_escapes(tok.image));
+      tok = tok.next;
+    }
+
+    sb
+        .append("\" at line ")
+        .append(parseException.currentToken.beginLine)
+        .append(", column ")
+        .append(parseException.currentToken.next.beginColumn)
+        .append(".");
+
+    return sb.toString();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/sql/TestDrillSQLWorker.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.calcite.avatica.util.Quoting;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.planner.sql.parser.impl.DrillSqlParseException;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.SqlTest;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
@@ -31,28 +32,30 @@ import org.junit.experimental.categories.Category;
 public class TestDrillSQLWorker extends BaseTestQuery {
 
   private void validateFormattedIs(String sql, SqlParserPos pos, String expected) {
-    String formatted = SqlConverter.formatSQLParsingError(sql, pos);
+    DrillSqlParseException ex = new DrillSqlParseException(null, pos, null, null, null);
+    String formatted = SqlConverter.formatSQLParsingError(sql, ex);
     assertEquals(expected, formatted);
   }
 
   @Test
-  public void testErrorFormating() {
-    String sql = "Select * from Foo\nwhere tadadidada;\n";
+  public void testErrorFormatting() {
+    String sql = "Select * from Foo\n"
+        + "where tadadidada;\n";
     validateFormattedIs(sql, new SqlParserPos(1, 2),
-        "Select * from Foo\n"
-      + " ^\n"
-      + "where tadadidada;\n");
+        "SQL Query: Select * from Foo\n"
+            + "            ^\n"
+            + "where tadadidada;");
     validateFormattedIs(sql, new SqlParserPos(2, 2),
-        "Select * from Foo\n"
-      + "where tadadidada;\n"
-      + " ^\n" );
+        "SQL Query: Select * from Foo\n"
+            + "where tadadidada;\n"
+            + " ^" );
     validateFormattedIs(sql, new SqlParserPos(1, 10),
-        "Select * from Foo\n"
-      + "         ^\n"
-      + "where tadadidada;\n");
-    validateFormattedIs(sql, new SqlParserPos(-11, -10), sql);
-    validateFormattedIs(sql, new SqlParserPos(0, 10), sql);
-    validateFormattedIs(sql, new SqlParserPos(100, 10), sql);
+        "SQL Query: Select * from Foo\n"
+            + "                    ^\n"
+            + "where tadadidada;");
+    validateFormattedIs(sql, new SqlParserPos(-11, -10), "SQL Query: Select * from Foo\nwhere tadadidada;");
+    validateFormattedIs(sql, new SqlParserPos(0, 10), "SQL Query: Select * from Foo\nwhere tadadidada;");
+    validateFormattedIs(sql, new SqlParserPos(100, 10), "SQL Query: Select * from Foo\nwhere tadadidada;");
   }
 
   @Test


### PR DESCRIPTION
JIRA [DRILL-6988](https://issues.apache.org/jira/browse/DRILL-6988)

- Adding Drill wrapper around SqlparseException to customize produced by Calcite messages
- Fix Drill SQL parse exception formatter to calculate proper position for "^" character