### PR TITLE
Drill-7185: Drill Fails to Read Large Packets

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
@@ -408,7 +408,7 @@ public class Packet {
     timestamp = timestampMicro / 1000L;
     originalLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ORIGINAL_LENGTH_OFFSET);
     packetLength = getIntFileOrder(byteOrder, header, offset + PacketConstants.ACTUAL_LENGTH_OFFSET);
-    Preconditions.checkState(originalLength < maxLength,
+    Preconditions.checkState(originalLength <= maxLength,
         "Packet too long (%d bytes)", originalLength);
   }
 


### PR DESCRIPTION
If there is a packet with a length of 96, the PCAP parser crashes.  This small fix corrects that problem.