### PR TITLE
DRILL-7206: using primitive int list at right or full join case

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashPartition.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashPartition.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.common;
 
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
@@ -399,7 +400,7 @@ public class HashPartition implements HashJoinMemoryCalculator.PartitionStat {
   public boolean setRecordMatched(int compositeIndex) {
     return hjHelper.setRecordMatched(compositeIndex);
   }
-  public List<Integer> getNextUnmatchedIndex() {
+  public IntArrayList getNextUnmatchedIndex() {
     return hjHelper.getNextUnmatchedIndex();
   }
   //

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinHelper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
+import com.carrotsearch.hppc.IntArrayList;
 import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
@@ -163,8 +164,8 @@ public class HashJoinHelper {
     return info.getLinks().get(recordIdx);
   }
 
-  public List<Integer> getNextUnmatchedIndex() {
-    List<Integer> compositeIndexes = new ArrayList<>();
+  public IntArrayList getNextUnmatchedIndex() {
+    IntArrayList compositeIndexes = new IntArrayList();
 
     for (int i = 0; i < buildInfoList.size(); i++) {
       BuildInfo info = buildInfoList.get(i);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -18,8 +18,8 @@
 package org.apache.drill.exec.physical.impl.join;
 
 import java.util.ArrayList;
-import java.util.List;
 
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.physical.config.HashJoinPOP;
 import org.apache.drill.exec.physical.impl.common.HashPartition;
@@ -72,7 +72,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
   private ProbeState probeState = ProbeState.PROBE_PROJECT;
 
   // For outer or right joins, this is a list of unmatched records that needs to be projected
-  private List<Integer> unmatchedBuildIndexes = null;
+  private IntArrayList unmatchedBuildIndexes = null;
 
   private  HashPartition partitions[];
 


### PR DESCRIPTION
This change is to avoid the unneeded box ,unbox operation.