### PR TITLE
DRILL-7202: Failed query shows warning that fragments made no progress

### DIFF
--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -57,7 +57,9 @@
       //No Progress Warning
       let noProgressFragmentCount = document.querySelectorAll('td[class=no-progress-tag]').length;
       let majorFragmentCount = document.querySelectorAll('#fragment-overview table tbody tr').length;
-      toggleWarning("noProgressWarning", majorFragmentCount, noProgressFragmentCount);
+      if (majorFragmentCount > 0) { // For fast-failed queries majorFragmentCount=0
+        toggleWarning("noProgressWarning", majorFragmentCount, noProgressFragmentCount);
+      }
 
       //Spill To Disk Warnings
       let spillCount = document.querySelectorAll('td[class=spill-tag]').length;


### PR DESCRIPTION
This bug arises because of the `toggleWarning()` javascript function that shows the warning if the number of slow major fragments matches the number of major fragments.
For failed queries, the number of major fragments = 0; and that matches the number of tags (which is also zero for a non-running query). Hence the warning shows.