### PR TITLE
DRILL-7201: Strange symbols in error window (Windows)

### DIFF
--- a/exec/java-exec/src/main/resources/rest/alertModals.ftl
+++ b/exec/java-exec/src/main/resources/rest/alertModals.ftl
@@ -33,8 +33,8 @@
       <!-- Modal content-->
       <div class="modal-content">
         <div class="modal-header modalHeaderAlert">
-          <button type="button" class="close closeX" data-dismiss="modal" style="color:red;font-size:200%">×</button>
-          <h4 class="modal-title"><span class="glyphicon glyphicon-alert" style="font-size:125%"></span><span id="modalHeader" style="font-family:Helvetica Neue,Helvetica,Arial,sans-serif;white-space:pre">~ErrorMessage~ Title</span></h4>
+          <button type="button" class="close closeX" data-dismiss="modal"><span class="glyphicon glyphicon-remove" style="color:red;font-size:125%"></span></button>
+          <h4 class="modal-title"><span class="glyphicon glyphicon-alert" style="font-size:125%">&#xe209;</span><span id="modalHeader" style="font-family:Helvetica Neue,Helvetica,Arial,sans-serif;white-space:pre">~ErrorMessage~ Title</span></h4>
         </div>
         <div class="modal-body" id="modalBody" style="line-height:3">
         ~ErrorMessage Details~


### PR DESCRIPTION
Looks like some unicode characters creeped in, causing the rendering to be messed up ONLY for Windows OS. This PR patches that issue and ensures that the Alert symbol also appears correctly.