### PR TITLE
DRILL-7050: RexNode convert exception in sub-query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.calcite.sql.SqlKind;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.MetadataProviderManager;
 import org.apache.drill.exec.physical.base.TableMetadataProvider;
@@ -324,6 +325,19 @@ public class SqlConverter {
           .containsKey(SqlValidatorUtil.getAlias(exp, -1))) {
         super.addToSelectList(list, aliases, fieldList, exp, scope, includeSystemVars);
       }
+    }
+
+    @Override
+    protected void inferUnknownTypes(
+        RelDataType inferredType,
+        SqlValidatorScope scope,
+        SqlNode node) {
+      // calls validateQuery() for SqlSelect to be sure that temporary table name will be changed
+      // for the case when it is used in sub-select
+      if (node.getKind() == SqlKind.SELECT) {
+        validateQuery(node, scope, inferredType);
+      }
+      super.inferUnknownTypes(inferredType, scope, node);
     }
 
     private void changeNamesIfTableIsTemporary(SqlIdentifier tempNode) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestCTTAS.java
@@ -507,6 +507,25 @@ public class TestCTTAS extends BaseTestQuery {
     }
   }
 
+  @Test // DRILL-7050
+  public void testTemporaryTableInSubQuery() throws Exception {
+    test("create temporary table source as (select 1 as id union all select 2 as id)");
+
+    String query =
+        "select t1.id as id,\n" +
+            "(select count(t2.id)\n" +
+            "from source t2 where t2.id = t1.id) as c\n" +
+        "from source t1";
+
+    testBuilder()
+        .sqlQuery(query)
+        .ordered()
+        .baselineColumns("id", "c")
+        .baselineValues(1, 1L)
+        .baselineValues(2, 1L)
+        .go();
+  }
+
   private void expectUserRemoteExceptionWithMessage(String message) {
     thrown.expect(UserRemoteException.class);
     thrown.expectMessage(containsString(message));

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <guava.version>19.0</guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.10.0</parquet.version>
-    <calcite.version>1.18.0-drill-r0</calcite.version>
+    <calcite.version>1.18.0-drill-r1</calcite.version>
     <avatica.version>1.13.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.7.0</sqlline.version>


### PR DESCRIPTION
- Bumped up Calcite version to include a fix for CALCITE-2954;
- Added a call to validate query when `inferUnknownTypes()` is called to replace temporary table name in sub-queries from the project list;
- Added unit tests for both issues.

For problem description please see [DRILL-7050](https://issues.apache.org/jira/browse/DRILL-7050).