### PR TITLE
DRILL-7199: Optimize population of metadata for non-interesting columns

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
@@ -26,6 +26,7 @@ import org.apache.drill.metastore.ColumnStatistics;
 import org.apache.drill.metastore.ColumnStatisticsImpl;
 import org.apache.drill.metastore.FileMetadata;
 import org.apache.drill.metastore.FileTableMetadata;
+import org.apache.drill.metastore.NonInterestingColumnsMetadata;
 import org.apache.drill.metastore.PartitionMetadata;
 import org.apache.drill.metastore.TableMetadata;
 import org.apache.hadoop.fs.Path;
@@ -83,6 +84,11 @@ public class SimpleFileTableMetadataProvider implements TableMetadataProvider {
 
   @Override
   public List<FileMetadata> getFilesForPartition(PartitionMetadata partition) {
+    return null;
+  }
+
+  @Override
+  public NonInterestingColumnsMetadata getNonInterestingColumnsMeta() {
     return null;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/AbstractParquetGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/AbstractParquetGroupScan.java
@@ -290,6 +290,7 @@ public abstract class AbstractParquetGroupScan extends AbstractGroupScanWithMeta
       builder.withRowGroups(rowGroupsMap)
           .withTable(getTableMetadata())
           .withPartitions(getNextOrEmpty(getPartitionsMetadata()))
+          .withNonInterestingColumns(getNonInterestingColumnsMetadata())
           .withFiles(filesMap)
           .withMatching(false);
     }
@@ -363,6 +364,7 @@ public abstract class AbstractParquetGroupScan extends AbstractGroupScanWithMeta
         .withTable(getTableMetadata())
         .withPartitions(getPartitionsMetadata())
         .withFiles(qualifiedFiles)
+        .withNonInterestingColumns(getNonInterestingColumnsMetadata())
         .withMatching(matchAllMetadata)
         .build();
   }
@@ -500,6 +502,7 @@ public abstract class AbstractParquetGroupScan extends AbstractGroupScanWithMeta
       newScan.files = files;
       newScan.rowGroups = rowGroups;
       newScan.matchAllMetadata = matchAllMetadata;
+      newScan.nonInterestingColumnsMetadata = nonInterestingColumnsMetadata;
       // since builder is used when pruning happens, entries and fileSet should be expanded
       if (!newScan.getFilesMetadata().isEmpty()) {
         newScan.entries = newScan.getFilesMetadata().keySet().stream()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
@@ -21,6 +21,7 @@ import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaPathUtils;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.parquet.metadata.MetadataBase;
+import org.apache.drill.metastore.NonInterestingColumnsMetadata;
 import org.apache.drill.metastore.RowGroupMetadata;
 import org.apache.drill.metastore.TableStatisticsKind;
 import org.apache.drill.exec.expr.FilterBuilder;
@@ -62,7 +63,14 @@ public class FilterEvaluatorUtils {
             expr.<Set<SchemaPath>, Void, RuntimeException>accept(new FieldReferenceFinder(), null));
 
     RowGroupMetadata rowGroupMetadata = new ArrayList<>(ParquetTableMetadataUtils.getRowGroupsMetadata(footer).values()).get(rowGroupIndex);
+    NonInterestingColumnsMetadata nonInterestingColumnsMetadata = ParquetTableMetadataUtils.getNonInterestingColumnsMeta(footer);
     Map<SchemaPath, ColumnStatistics> columnsStatistics = rowGroupMetadata.getColumnsStatistics();
+
+    // Add column statistics of non-interesting columns if there are any
+    if (nonInterestingColumnsMetadata != null) {
+      columnsStatistics.putAll(nonInterestingColumnsMetadata.getColumnsStatistics());
+    }
+
     columnsStatistics = ParquetTableMetadataUtils.addImplicitColumnsStatistics(columnsStatistics,
         schemaPathsInExpr, Collections.emptyList(), options, rowGroupMetadata.getLocation(), true);
 

--- a/metastore/file-metadata/src/main/java/org/apache/drill/exec/physical/base/TableMetadataProvider.java
+++ b/metastore/file-metadata/src/main/java/org/apache/drill/exec/physical/base/TableMetadataProvider.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.base;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.metastore.FileMetadata;
+import org.apache.drill.metastore.NonInterestingColumnsMetadata;
 import org.apache.drill.metastore.PartitionMetadata;
 import org.apache.drill.metastore.TableMetadata;
 import org.apache.hadoop.fs.Path;
@@ -85,4 +86,10 @@ public interface TableMetadataProvider {
    * @return list of {@link FileMetadata} instances which belongs to specified partitions
    */
   List<FileMetadata> getFilesForPartition(PartitionMetadata partition);
+
+  /**
+   * Returns {@link NonInterestingColumnsMetadata} instance which provides metadata for non-interesting columns.
+   * @return {@link NonInterestingColumnsMetadata} instance
+   */
+  NonInterestingColumnsMetadata getNonInterestingColumnsMeta();
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/NonInterestingColumnsMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/NonInterestingColumnsMetadata.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import java.util.Map;
+
+/**
+ * Represents a metadata for the non-interesting columns. Since the refresh command doesn't store the non-interesting
+ * columns stats in the cache file, there is a need to mark column statistics of non-interesting as unknown to
+ * differentiate the non-interesting columns from non-existent columns. Since the sole purpose of this class is to store
+ * column statistics for non-interesting columns, some methods like getSchema, getStatistic, getColumn are not applicable
+ * to NonInterestingColumnsMetadata.
+ */
+public class NonInterestingColumnsMetadata implements BaseMetadata {
+  private final Map<SchemaPath, ColumnStatistics> columnsStatistics;
+
+  public NonInterestingColumnsMetadata(
+                           Map<SchemaPath, ColumnStatistics> columnsStatistics) {
+    this.columnsStatistics = columnsStatistics;
+  }
+
+  @Override
+  public Map<SchemaPath, ColumnStatistics> getColumnsStatistics() {
+    return columnsStatistics;
+  }
+
+  @Override
+  public ColumnStatistics getColumnStatistics(SchemaPath columnName) {
+    return columnsStatistics.get(columnName);
+  }
+
+  @Override
+  public TupleMetadata getSchema() {
+    return null;
+  }
+
+  @Override
+  public Object getStatistic(StatisticsKind statisticsKind) {
+    return null;
+  }
+
+  @Override
+  public boolean containsExactStatistics(StatisticsKind statisticsKind) {
+    return false;
+  }
+
+  @Override
+  public Object getStatisticsForColumn(SchemaPath columnName, StatisticsKind statisticsKind) {
+    return columnsStatistics.get(columnName).getStatistic(statisticsKind);
+  }
+
+  @Override
+  public ColumnMetadata getColumn(SchemaPath name) {
+    return null;
+  }
+}


### PR DESCRIPTION
Currently the non-interesting column metadata is populated for all types of metadata including rowgroup metadata. It's a huge overkill if there are large number of row groups. With this PR, non-interesting column metadata is populated only once when all the other types of metadata is populated in the BaseParquetMetadataProvider.java. This optimization reduced the planning time from 17 sec to 5 sec when there are 35000 row groups. 