### PR TITLE
DRILL-7187: Improve selectivity estimation of BETWEEN predicates and …

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
@@ -120,7 +120,7 @@ public class DrillStatsTable {
     Long ndvCol = ndv.get(col);
     // Ndv estimation techniques like HLL may over-estimate, hence cap it at rowCount
     if (ndvCol != null) {
-      return Math.min(ndvCol, rowCount);
+      return (double) Math.min(ndvCol, rowCount);
     }
     return null;
   }
@@ -184,7 +184,6 @@ public class DrillStatsTable {
     }
     return histogram.get(column);
   }
-
 
   /**
    * Read the stats from storage and keep them in memory.
@@ -337,7 +336,7 @@ public class DrillStatsTable {
       this.type = type;
     }
     @JsonGetter ("schema")
-    public double getSchema() {
+    public long getSchema() {
       return this.schema;
     }
     @JsonSetter ("schema")
@@ -493,6 +492,10 @@ public class DrillStatsTable {
       Histogram histogram = statsProvider.getHistogram(fieldName);
       if (histogram != null) {
         statisticsValues.put(ColumnStatisticsKind.HISTOGRAM, histogram);
+      }
+      Double rowcount = statsProvider.getRowCount();
+      if (rowcount != null) {
+        statisticsValues.put(ColumnStatisticsKind.ROWCOUNT, rowcount);
       }
       return statisticsValues;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/Histogram.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/Histogram.java
@@ -35,7 +35,8 @@ public interface Histogram {
   /**
    * For a filter condition, estimate the selectivity (matching rows/total rows) for this histogram
    * @param filter
+   * @param totalRowCount
    * @return estimated selectivity or NULL if it could not be estimated for any reason
    */
-  Double estimatedSelectivity(final RexNode filter);
+  Double estimatedSelectivity(final RexNode filter, final long totalRowCount);
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/ColumnStatisticsKind.java
@@ -126,6 +126,23 @@ public enum ColumnStatisticsKind implements CollectableColumnStatisticsKind {
   },
 
   /**
+   * Column statistics kind which represents total row count for the specific column.
+   */
+  ROWCOUNT(Statistic.ROWCOUNT) {
+    @Override
+    public Double mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+      double rowCount = 0;
+      for (ColumnStatistics statistics : statisticsList) {
+        Double count = (Double) statistics.getStatistic(this);
+        if (count != null) {
+          rowCount += count;
+        }
+      }
+      return rowCount;
+    }
+  },
+
+  /**
    * Column statistics kind which represents number of distinct values for the specific column.
    */
   NVD(Statistic.NDV) {


### PR DESCRIPTION
…arbitrary combination of range predicates.

- Also, propagate the totalRowCount to the histogram selectivity estimation and use it instead of the nonNullCount. 
- Before and after estimates for the following predicate: 
    `where o.o_orderdate >= date '1996-10-01' and o.o_orderdate < date '1996-10-01' + interval '3' month`
BEFORE this PR:  estimated filter row count = **3206**
AFTER this PR:     estimated filter row count = **601**
ACTUAL row count                                           = **561**
