### PR TITLE
DRILL-6965: Implement schema table function parameter

### DIFF
--- a/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
+++ b/exec/java-exec/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
@@ -25,9 +25,9 @@ options {
  */
 }
 
-schema: (columns | LEFT_PAREN columns RIGHT_PAREN) EOF;
+schema: (columns | LEFT_PAREN columns? RIGHT_PAREN) property_values? EOF;
 
-columns: column_def  (COMMA column_def)*;
+columns: column_def (COMMA column_def)*;
 
 column_def: column property_values?;
 

--- a/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
+++ b/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
@@ -376,9 +376,9 @@ void addProperty(SqlNodeList properties) :
   | < NUM: <DIGIT> (" " | "\t" | "\n" | "\r")* >
     // once schema is found, switch back to initial lexical state
     // must be enclosed in the parentheses
-    // inside may have left parenthesis only if number precededs (covers cases with varchar(10)),
+    // inside may have left parenthesis only if number precedes (covers cases with varchar(10)),
     // if left parenthesis is present in column name, it must be escaped with backslash
-  | < PAREN_STRING: <LPAREN> ((~[")"]) | (<NUM> ")") | ("\\)"))+ <RPAREN> > { popState(); }
+  | < PAREN_STRING: <LPAREN> ((~[")"]) | (<NUM> ")") | ("\\)"))* <RPAREN> > { popState(); }
 }
 
 /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FileSystemMetadataProviderManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FileSystemMetadataProviderManager.java
@@ -32,13 +32,18 @@ public class FileSystemMetadataProviderManager implements MetadataProviderManage
 
   private TableMetadataProvider tableMetadataProvider;
 
-  public static MetadataProviderManager getMetadataProviderManager() {
+  public static MetadataProviderManager init() {
     return new FileSystemMetadataProviderManager();
   }
 
   @Override
   public void setSchemaProvider(SchemaProvider schemaProvider) {
     this.schemaProvider = schemaProvider;
+  }
+
+  @Override
+  public SchemaProvider getSchemaProvider() {
+    return schemaProvider;
   }
 
   @Override
@@ -49,11 +54,6 @@ public class FileSystemMetadataProviderManager implements MetadataProviderManage
   @Override
   public DrillStatsTable getStatsProvider() {
     return statsProvider;
-  }
-
-  @Override
-  public SchemaProvider getSchemaProvider() {
-    return schemaProvider;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/MetadataProviderManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/MetadataProviderManager.java
@@ -28,17 +28,17 @@ import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
  */
 public interface MetadataProviderManager {
 
-  DrillStatsTable getStatsProvider();
-
-  void setStatsProvider(DrillStatsTable statsProvider);
+  void setSchemaProvider(SchemaProvider schemaProvider);
 
   SchemaProvider getSchemaProvider();
 
-  void setSchemaProvider(SchemaProvider schemaProvider);
+  void setStatsProvider(DrillStatsTable statsProvider);
 
-  TableMetadataProvider getTableMetadataProvider();
+  DrillStatsTable getStatsProvider();
 
   void setTableMetadataProvider(TableMetadataProvider tableMetadataProvider);
+
+  TableMetadataProvider getTableMetadataProvider();
 
   /**
    * Returns builder responsible for constructing required {@link TableMetadataProvider} instances

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/SimpleFileTableMetadataProvider.java
@@ -124,7 +124,7 @@ public class SimpleFileTableMetadataProvider implements TableMetadataProvider {
 
     @Override
     @SuppressWarnings("unchecked")
-    public TableMetadataProvider build() throws IOException {
+    public TableMetadataProvider build() {
       SchemaProvider schemaProvider = metadataProviderManager.getSchemaProvider();
       TableMetadataProvider source = metadataProviderManager.getTableMetadataProvider();
       if (source == null) {
@@ -152,8 +152,9 @@ public class SimpleFileTableMetadataProvider implements TableMetadataProvider {
           } else {
             schema = schemaProvider != null ? schemaProvider.read().getSchema() : null;
           }
-        } catch (IOException e) {
-          logger.debug("Unable to deserialize schema from schema file for table: " + (tableName != null ? tableName : location), e);
+        } catch (IOException | IllegalArgumentException e) {
+          logger.debug("Unable to read schema from schema provider [{}]: {}", (tableName != null ? tableName : location), e.getMessage());
+          logger.trace("Error when reading the schema", e);
         }
         TableMetadata tableMetadata = new FileTableMetadata(tableName,
             location, schema,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -105,8 +105,8 @@ public abstract class DrillTable implements Table {
     this.scan = scan;
   }
 
-  public void setTableMetadataProviderBuilder(MetadataProviderManager metadataProviderBuilder) {
-    this.metadataProviderManager = metadataProviderBuilder;
+  public void setTableMetadataProviderManager(MetadataProviderManager metadataProviderManager) {
+    this.metadataProviderManager = metadataProviderManager;
   }
 
   public GroupScan getGroupScan() throws IOException {
@@ -121,7 +121,7 @@ public abstract class DrillTable implements Table {
   }
 
   /**
-   * Returns builder for {@link TableMetadataProvider} which may provide null for the case when scan wasn't created.
+   * Returns manager for {@link TableMetadataProvider} which may provide null for the case when scan wasn't created.
    * This method should be used only for the case when it is possible to obtain {@link TableMetadataProvider} when supplier returns null
    * or {@link TableMetadataProvider} usage may be omitted.
    *
@@ -130,7 +130,7 @@ public abstract class DrillTable implements Table {
   public MetadataProviderManager getMetadataProviderManager() {
     if (metadataProviderManager == null) {
       // for the case when scan wasn't initialized, return null to avoid reading data which may be pruned in future
-      metadataProviderManager = FileSystemMetadataProviderManager.getMetadataProviderManager();
+      metadataProviderManager = FileSystemMetadataProviderManager.init();
       if (scan != null) {
         metadataProviderManager.setTableMetadataProvider(scan.getMetadataProvider());
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SqlConverter.java
@@ -713,7 +713,7 @@ public class SqlConverter {
       if (table != null && (drillTable = table.unwrap(DrillTable.class)) != null) {
         drillTable.setOptions(session.getOptions());
 
-        drillTable.setTableMetadataProviderBuilder(tableCache.getUnchecked(
+        drillTable.setTableMetadataProviderManager(tableCache.getUnchecked(
             new DrillTableKey(SchemaPath.getCompoundPath(names.toArray(new String[0])), drillTable)));
       }
       return table;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
@@ -42,15 +42,17 @@ import java.util.Map;
 
 /**
  * Parent class for CREATE, DROP, DESCRIBE SCHEMA commands.
- * Holds logic common command property: table.
+ * Holds logic common command property: table, path.
  */
 public abstract class SqlSchema extends DrillSqlCall {
 
   protected final SqlIdentifier table;
+  protected final SqlNode path;
 
-  protected SqlSchema(SqlParserPos pos, SqlIdentifier table) {
+  protected SqlSchema(SqlParserPos pos, SqlIdentifier table, SqlNode path) {
     super(pos);
     this.table = table;
+    this.path = path;
   }
 
   @Override
@@ -84,6 +86,10 @@ public abstract class SqlSchema extends DrillSqlCall {
     return null;
   }
 
+  public String getPath() {
+    return path == null ? null : path.accept(LiteralVisitor.INSTANCE);
+  }
+
   /**
    * Visits literal and returns bare value (i.e. single quotes).
    */
@@ -105,7 +111,6 @@ public abstract class SqlSchema extends DrillSqlCall {
 
     private final SqlCharStringLiteral schema;
     private final SqlNode load;
-    private final SqlNode path;
     private final SqlNodeList properties;
     private final SqlLiteral createType;
 
@@ -124,10 +129,9 @@ public abstract class SqlSchema extends DrillSqlCall {
                   SqlNode path,
                   SqlNodeList properties,
                   SqlLiteral createType) {
-      super(pos, table);
+      super(pos, table, path);
       this.schema = schema;
       this.load = load;
-      this.path = path;
       this.properties = properties;
       this.createType = createType;
     }
@@ -200,10 +204,6 @@ public abstract class SqlSchema extends DrillSqlCall {
       return load == null ? null : load.accept(LiteralVisitor.INSTANCE);
     }
 
-    public String getPath() {
-      return path == null ? null : path.accept(LiteralVisitor.INSTANCE);
-    }
-
     public Map<String, String> getProperties() {
       if (properties == null) {
         return null;
@@ -239,7 +239,7 @@ public abstract class SqlSchema extends DrillSqlCall {
     };
 
     public Drop(SqlParserPos pos, SqlIdentifier table, SqlLiteral existenceCheck) {
-      super(pos, table);
+      super(pos, table, null);
       this.existenceCheck = existenceCheck;
     }
 
@@ -292,7 +292,7 @@ public abstract class SqlSchema extends DrillSqlCall {
     };
 
     public Describe(SqlParserPos pos, SqlIdentifier table, SqlLiteral format) {
-      super(pos, table);
+      super(pos, table, null);
       this.format = format;
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -69,7 +70,7 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
   public static AbstractColumnMetadata createColumnMetadata(@JsonProperty("name") String name,
                                                             @JsonProperty("type") String type,
                                                             @JsonProperty("mode") DataMode mode,
-                                                            @JsonProperty("properties") Map<String, String> properties) {
+                                                            @JsonProperty("properties") Map<String, String> properties) throws IOException {
     ColumnMetadata columnMetadata = SchemaExprParser.parseColumn(name, type, mode);
     columnMetadata.setProperties(properties);
     return (AbstractColumnMetadata) columnMetadata;
@@ -314,8 +315,7 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
         builder.append(" DEFAULT '").append(defaultValue()).append("'");
       }
 
-      Map<String,String> copy = new HashMap<>();
-      copy.putAll(properties());
+      Map<String, String> copy = new HashMap<>(properties());
       copy.remove(FORMAT_PROP);
       copy.remove(DEFAULT_VALUE_PROP);
       if (! copy.isEmpty()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
@@ -56,7 +56,9 @@ public class TupleSchema extends AbstractPropertied implements TupleMetadata {
   @JsonCreator
   public TupleSchema(@JsonProperty("columns") List<AbstractColumnMetadata> columns,
                      @JsonProperty("properties") Map<String, String> properties) {
-    columns.forEach(this::addColumn);
+    if (columns != null) {
+      columns.forEach(this::addColumn);
+    }
     setProperties(properties);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/FsMetastoreSchemaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/FsMetastoreSchemaProvider.java
@@ -45,7 +45,7 @@ public class FsMetastoreSchemaProvider extends PathSchemaProvider {
   }
 
   @Override
-  protected SchemaContainer createTableSchema(String schema, Map<String, String> properties) {
+  protected SchemaContainer createTableSchema(String schema, Map<String, String> properties) throws IOException {
     return new SchemaContainer(tableName, schema, properties);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/InlineSchemaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/InlineSchemaProvider.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.record.metadata.schema;
 
 import org.apache.drill.exec.store.StorageStrategy;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -27,11 +28,9 @@ import java.util.Map;
 public class InlineSchemaProvider implements SchemaProvider {
 
   private final String schema;
-  private final Map<String, String> properties;
 
-  public InlineSchemaProvider(String schema, Map<String, String> properties) {
+  public InlineSchemaProvider(String schema) {
     this.schema = schema;
-    this.properties = properties;
   }
 
   @Override
@@ -45,8 +44,8 @@ public class InlineSchemaProvider implements SchemaProvider {
   }
 
   @Override
-  public SchemaContainer read() {
-    return new SchemaContainer(null, schema, properties);
+  public SchemaContainer read() throws IOException {
+    return new SchemaContainer(null, schema, null);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/PathSchemaProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/PathSchemaProvider.java
@@ -124,7 +124,7 @@ public class PathSchemaProvider implements SchemaProvider {
     return fs.exists(path);
   }
 
-  protected SchemaContainer createTableSchema(String schema, Map<String, String> properties) {
+  protected SchemaContainer createTableSchema(String schema, Map<String, String> properties) throws IOException {
     return new SchemaContainer(null, schema, properties);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaContainer.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
 import org.apache.drill.exec.record.metadata.schema.parser.SchemaExprParser;
-
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -46,11 +46,11 @@ public class SchemaContainer {
     this.version = new Version(version);
   }
 
-  public SchemaContainer(String table, String schema, Map<String, String> properties) {
+  public SchemaContainer(String table, String schema, Map<String, String> properties) throws IOException {
     this(table, schema, properties, Version.VERSION_1); //current default version
   }
 
-  public SchemaContainer(String table, String schema, Map<String, String> properties, Integer version) {
+  public SchemaContainer(String table, String schema, Map<String, String> properties, Integer version) throws IOException {
     this.table = table;
     this.schema = schema == null ? null : convert(schema, properties);
     this.version = new Version(version);
@@ -76,7 +76,7 @@ public class SchemaContainer {
     return version;
   }
 
-  private TupleMetadata convert(String schemaString, Map<String, String> properties) {
+  private TupleMetadata convert(String schemaString, Map<String, String> properties) throws IOException {
     TupleMetadata schema = SchemaExprParser.parseSchema(schemaString);
     if (properties != null) {
       schema.setProperties(properties);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaProviderFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/SchemaProviderFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.record.metadata.schema;
+
+import org.apache.drill.exec.planner.sql.handlers.SchemaHandler;
+import org.apache.drill.exec.planner.sql.parser.SqlSchema;
+import org.apache.drill.exec.store.dfs.WorkspaceSchemaFactory;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * Factory class responsible for creating different instances of schema provider based on given parameters.
+ */
+public class SchemaProviderFactory {
+
+  /**
+   * Creates schema provider for sql schema commands.
+   *
+   * @param sqlSchema sql schema call
+   * @param schemaHandler schema handler
+   * @return schema provider instance
+   * @throws IOException if unable to init schema provider
+   */
+  public static SchemaProvider create(SqlSchema sqlSchema, SchemaHandler schemaHandler) throws IOException {
+    if (sqlSchema.hasTable()) {
+      String tableName = sqlSchema.getTableName();
+      WorkspaceSchemaFactory.WorkspaceSchema wsSchema = schemaHandler.getWorkspaceSchema(sqlSchema.getSchemaPath(), tableName);
+      return new FsMetastoreSchemaProvider(wsSchema, tableName);
+    } else {
+      return new PathSchemaProvider(new Path(sqlSchema.getPath()));
+    }
+  }
+
+  /**
+   * Creates schema provider based table function schema parameter.
+   *
+   * @param parameterValue schema parameter value
+   * @return schema provider instance
+   * @throws IOException if unable to init schema provider
+   */
+  public static SchemaProvider create(String parameterValue) throws IOException {
+    String[] split = parameterValue.split("=", 2);
+    if (split.length < 2) {
+      throw new IOException("Incorrect parameter value format: " + parameterValue);
+    }
+    ProviderType providerType = ProviderType.valueOf(split[0].trim().toUpperCase());
+    String value = split[1].trim();
+    switch (providerType) {
+      case INLINE:
+        return new InlineSchemaProvider(value);
+      case PATH:
+        char c = value.charAt(0);
+        // if path starts with any type of quotes, strip them
+        if (c == '\'' || c == '"' || c == '`') {
+          value = value.substring(1, value.length() - 1);
+        }
+        return new PathSchemaProvider(new Path(value));
+      default:
+        throw new IOException("Unexpected provider type: " + providerType);
+    }
+  }
+
+  /**
+   * Indicates provider type will be used to provide schema.
+   */
+  private enum ProviderType {
+    INLINE,
+    PATH
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaExprParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/metadata/schema/parser/SchemaExprParser.java
@@ -27,6 +27,8 @@ import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 
+import java.io.IOException;
+
 public class SchemaExprParser {
 
   /**
@@ -35,10 +37,15 @@ public class SchemaExprParser {
    *
    * @param schema schema definition
    * @return metadata description of the schema
+   * @throws IOException when unable to parse the schema
    */
-  public static TupleMetadata parseSchema(String schema) {
+  public static TupleMetadata parseSchema(String schema) throws IOException {
     SchemaVisitor visitor = new SchemaVisitor();
-    return visitor.visit(initParser(schema).schema());
+    try {
+      return visitor.visit(initParser(schema).schema());
+    } catch (SchemaParsingException e) {
+      throw new IOException(String.format("Unable to parse schema [%s]: %s", schema, e.getMessage()), e);
+    }
   }
 
   /**
@@ -48,8 +55,9 @@ public class SchemaExprParser {
    * @param type column type
    * @param mode column mode
    * @return column metadata
+   * @throws IOException when unable to parse the column
    */
-  public static ColumnMetadata parseColumn(String name, String type, TypeProtos.DataMode mode) {
+  public static ColumnMetadata parseColumn(String name, String type, TypeProtos.DataMode mode) throws IOException {
     return parseColumn(String.format("`%s` %s %s",
       name.replaceAll("(\\\\)|(`)", "\\\\$0"),
       type,
@@ -62,10 +70,15 @@ public class SchemaExprParser {
    *
    * @param column column definition
    * @return metadata description of the column
+   * @throws IOException when unable to parse the column
    */
-  public static ColumnMetadata parseColumn(String column) {
+  public static ColumnMetadata parseColumn(String column) throws IOException {
     SchemaVisitor.ColumnVisitor visitor = new SchemaVisitor.ColumnVisitor();
-    return visitor.visit(initParser(column).column());
+    try {
+      return visitor.visit(initParser(column).column());
+    } catch (SchemaParsingException e) {
+      throw new IOException(String.format("Unable to parse column [%s]: %s", column, e.getMessage()), e);
+    }
   }
 
   private static SchemaParser initParser(String value) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/TableParamDef.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/TableParamDef.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.table.function;
+
+import org.apache.drill.exec.planner.logical.DrillTable;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+/**
+ * Definition of table parameters, contains parameter name, class type, type status (optional / required).
+ * May also contain action this parameter can perform for the given value and table.
+ */
+public final class TableParamDef {
+
+  private final String name;
+  private final Class<?> type;
+  private final boolean optional;
+  private final BiConsumer<DrillTable, Object> action;
+
+  public static TableParamDef required(String name, Class<?> type, BiConsumer<DrillTable, Object> action) {
+    return new TableParamDef(name, type, false, action);
+  }
+
+  public static TableParamDef optional(String name, Class<?> type, BiConsumer<DrillTable, Object> action) {
+    return new TableParamDef(name, type, true, action);
+  }
+
+  private TableParamDef(String name, Class<?> type, boolean optional, BiConsumer<DrillTable, Object> action) {
+    this.name = name;
+    this.type = type;
+    this.optional = optional;
+    this.action = action;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Class<?> getType() {
+    return type;
+  }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  public void apply(DrillTable drillTable, Object value) {
+    if (action == null) {
+      return;
+    }
+    action.accept(drillTable, value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, optional, action);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableParamDef that = (TableParamDef) o;
+    return optional == that.optional
+      && Objects.equals(name, that.name)
+      && Objects.equals(type, that.type)
+      && Objects.equals(action, that.action);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    if (optional) {
+      builder.append("[");
+    }
+    builder.append(name).append(": ").append(type);
+    if (action != null) {
+      builder.append(" (with action)");
+    }
+    if (optional) {
+      builder.append("]");
+    }
+    return builder.toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/TableSignature.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/TableSignature.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.table.function;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Describes table and parameters that can be used during table initialization and usage.
+ * Common parameters are those that are common for all tables (ex: schema).
+ * Specific parameters are those that are specific to the schema table belongs to.
+ */
+public final class TableSignature {
+
+  private final String name;
+  private final List<TableParamDef> commonParams;
+  private final List<TableParamDef> specificParams;
+  private final List<TableParamDef> params;
+
+  public static TableSignature of(String name) {
+    return new TableSignature(name, Collections.emptyList(), Collections.emptyList());
+  }
+
+  public static TableSignature of(String name, List<TableParamDef> commonParams) {
+    return new TableSignature(name, commonParams, Collections.emptyList());
+  }
+
+  public static TableSignature of(String name, List<TableParamDef> commonParams, List<TableParamDef> specificParams) {
+    return new TableSignature(name, commonParams, specificParams);
+  }
+
+  private TableSignature(String name, List<TableParamDef> commonParams, List<TableParamDef> specificParams) {
+    this.name = name;
+    this.commonParams = Collections.unmodifiableList(commonParams);
+    this.specificParams = Collections.unmodifiableList(specificParams);
+    this.params = Stream.of(specificParams, commonParams)
+      .flatMap(Collection::stream)
+      .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<TableParamDef> getParams() {
+    return params;
+  }
+
+  public List<TableParamDef> getCommonParams() {
+    return commonParams;
+  }
+
+  public List<TableParamDef> getSpecificParams() { return specificParams; }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, params);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableSignature that = (TableSignature) o;
+    return name.equals(that.name) && params.equals(that.params);
+  }
+
+  @Override
+  public String toString() {
+    return "TableSignature{" +
+      "name='" + name + '\'' +
+      ", commonParams=" + commonParams +
+      ", specificParams=" + specificParams + '}';
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/WithOptionsTableMacro.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/table/function/WithOptionsTableMacro.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.table.function;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.FunctionParameter;
+import org.apache.calcite.schema.TableMacro;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.logical.DrillTranslatableTable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Implementation of a table macro that generates a table based on parameters.
+ */
+public class WithOptionsTableMacro implements TableMacro {
+
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WithOptionsTableMacro.class);
+
+  private final TableSignature sig;
+  private final Function<List<Object>, DrillTable> function;
+
+  public WithOptionsTableMacro(TableSignature sig, Function<List<Object>, DrillTable> function) {
+    this.sig = sig;
+    this.function = function;
+  }
+
+  @Override
+  public TranslatableTable apply(List<Object> arguments) {
+    DrillTable drillTable = function.apply(arguments);
+    if (drillTable == null) {
+      throw UserException
+        .validationError()
+        .message("Unable to find table [%s]", sig.getName())
+        .build(logger);
+    }
+    return new DrillTranslatableTable(drillTable);
+  }
+
+  @Override
+  public List<FunctionParameter> getParameters() {
+    List<FunctionParameter> result = new ArrayList<>();
+    for (int i = 0; i < sig.getParams().size(); i++) {
+      final TableParamDef p = sig.getParams().get(i);
+      final int ordinal = i;
+      FunctionParameter functionParameter = new FunctionParameter() {
+        @Override
+        public int getOrdinal() {
+          return ordinal;
+        }
+
+        @Override
+        public String getName() {
+          return p.getName();
+        }
+
+        @Override
+        public RelDataType getType(RelDataTypeFactory typeFactory) {
+          return typeFactory.createJavaType(p.getType());
+        }
+
+        @Override
+        public boolean isOptional() {
+          return p.isOptional();
+        }
+      };
+      result.add(functionParameter);
+    }
+    return result;
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/TestSchemaWithTableFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestSchemaWithTableFunction.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill;
+
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.util.StoragePluginTestUtils;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestSchemaWithTableFunction extends ClusterTest {
+
+  private static final String DATA_PATH = "store/text/data";
+  private static final String TABLE_PLACEHOLDER = "[TABLE]";
+  private static final String TABLE_NAME = String.format("%s.`%s/%s`", StoragePluginTestUtils.DFS_PLUGIN_NAME, DATA_PATH, TABLE_PLACEHOLDER);
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    dirTestWatcher.copyResourceToRoot(Paths.get(DATA_PATH));
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+    client.alterSession(ExecConstants.ENABLE_V3_TEXT_READER_KEY, true);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    client.resetSession(ExecConstants.ENABLE_V3_TEXT_READER_KEY);
+  }
+
+  @Test
+  public void testSchemaInline() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+    String query = "select Year from table(%s(schema=>'inline=(`Year` int)')) where Make = 'Ford'";
+
+    testBuilder()
+      .sqlQuery(query, table)
+      .unOrdered()
+      .baselineColumns("Year")
+      .baselineValues(1997)
+      .go();
+
+    String plan = queryBuilder().sql(query, table).explainText();
+    assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`Year` (INT(0, 0):OPTIONAL)]]]"));
+  }
+
+  @Test
+  public void testSchemaInlineWithProperties() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+    String query = "select * from table(%s(schema=>'inline=(`Year` int, `Make` varchar) " +
+      "properties {`drill.strict` = `true`}')) where Make = 'Ford'";
+
+    testBuilder()
+      .sqlQuery(query, table)
+      .unOrdered()
+      .baselineColumns("Year", "Make")
+      .baselineValues(1997, "Ford")
+      .go();
+
+    String plan = queryBuilder().sql(query, table).explainText();
+    assertFalse(plan.contains("schema=null"));
+  }
+
+  @Test
+  public void testSchemaInlineWithoutColumns() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+    String query = "select * from table(%s(schema=>'inline=() " +
+      "properties {`drill.strict` = `true`}')) where Make = 'Ford'";
+
+    String plan = queryBuilder().sql(query, table).explainText();
+    assertFalse(plan.contains("schema=null"));
+  }
+
+  @Test
+  public void testSchemaInlineWithTableProperties() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh-test");
+    String query = "select Year from table(%s(type=>'text', fieldDelimiter=>',', extractHeader=>true, " +
+      "schema=>'inline=(`Year` int)')) where Make = 'Ford'";
+
+    testBuilder()
+      .sqlQuery(query, table)
+      .unOrdered()
+      .baselineColumns("Year")
+      .baselineValues(1997)
+      .go();
+
+    String plan = queryBuilder().sql(query, table).explainText();
+    assertFalse(plan.contains("schema=null"));
+  }
+
+  @Test
+  public void testSchemaInlineWithPropertiesInDifferentOrder() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh-test");
+
+    String sqlQuery = "select Year from table(%s(schema=>'inline=(`Year` int)', fieldDelimiter=>',', extractHeader=>true, " +
+      "type=>'text'))";
+
+    String sqlBaselineQuery = "select Year from table(%s(type=>'text', fieldDelimiter=>',', schema=>'inline=(`Year` int)', " +
+      "extractHeader=>true))";
+
+    testBuilder()
+      .sqlQuery(sqlQuery, table)
+      .unOrdered()
+      .sqlBaselineQuery(sqlBaselineQuery, table)
+      .go();
+
+    String plan = queryBuilder().sql(sqlQuery, table).explainText();
+    assertFalse(plan.contains("schema=null"));
+  }
+
+  @Test
+  public void testSchemaInlineForFolder() throws Exception {
+    run("use dfs.tmp");
+
+    String table = "text_table";
+    String sourceTable = TABLE_NAME.replace(TABLE_PLACEHOLDER, "regions.csv");
+    try {
+      client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+      run("create table %s as select columns[0] as id, columns[1] as name from %s", table, sourceTable);
+
+      String query = "select * from table(%s(type=>'text', fieldDelimiter=>',', extractHeader=>true " +
+        ",schema=>'inline=(`id` int)')) where id = 1";
+
+      testBuilder()
+        .sqlQuery(query, table)
+        .unOrdered()
+        .baselineColumns("id", "name")
+        .baselineValues(1, "AMERICA")
+        .go();
+
+      String plan = queryBuilder().sql(query, table).explainText();
+      assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`id` (INT(0, 0):OPTIONAL)]]]"));
+    } finally {
+      client.resetSession(ExecConstants.OUTPUT_FORMAT_OPTION);
+      run("drop table if exists %s", table);
+    }
+  }
+
+  @Test
+  public void testInvalidSchemaParameter() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("VALIDATION ERROR");
+
+    run("select Year from table(%s(schema=>'(`Year` int)'))", table);
+  }
+
+  @Test
+  public void testInvalidSchemaProviderType() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("VALIDATION ERROR");
+
+    run("select Year from table(%s(schema=>'line=(`Year` int)'))", table);
+  }
+
+  @Test
+  public void testSchemaInlineInvalidSchemaSyntax() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("VALIDATION ERROR");
+
+    run("select Year from table(%s(schema=>'inline=(int)')) where Make = 'Ford'", table);
+  }
+
+  @Test
+  public void testSchemaPath() throws Exception {
+    File tmpDir = dirTestWatcher.getTmpDir();
+    File schemaFile = new File(tmpDir, "schema_for_path.schema");
+    assertFalse(schemaFile.exists());
+
+    try {
+      String path = schemaFile.getPath();
+      testBuilder()
+        .sqlQuery("create schema (`Year` int) path '%s'", path)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(true, String.format("Created schema for [%s]", path))
+        .go();
+
+      String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+
+      List<String> queries = Arrays.asList(
+        "select Year from table(%s(schema=>'path=%s')) where Make = 'Ford'",
+        "select Year from table(%s(schema=>'path=`%s`')) where Make = 'Ford'");
+
+      for (String query : queries) {
+        testBuilder()
+          .sqlQuery(query, table, path)
+          .unOrdered()
+          .baselineColumns("Year")
+          .baselineValues(1997)
+          .go();
+
+        String plan = queryBuilder().sql(query, table, path).explainText();
+        assertFalse(plan.contains("schema=null"));
+      }
+
+    } finally {
+      if (schemaFile.exists()) {
+        assertTrue(schemaFile.delete());
+      }
+    }
+  }
+
+  @Test
+  public void testSchemaPathInvalid() throws Exception {
+    String table = TABLE_NAME.replace(TABLE_PLACEHOLDER, "cars.csvh");
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("VALIDATION ERROR");
+
+    run("select Year from table(%s(schema=>'path=(int)')) where Make = 'Ford'", table);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/TestSelectWithOption.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestSelectWithOption.java
@@ -71,18 +71,17 @@ public class TestSelectWithOption extends BaseTestQuery {
         "\"b\"|\"1\"",
         "\"b\"|\"2\"");
 
-    String queryTemplate =
-        "select columns from table(%s (type => 'TeXT', fieldDelimiter => '%s'))";
+    String queryTemplate = "select columns from table(%s (type => 'TeXT', fieldDelimiter => '%s'))";
+
     testWithResult(format(queryTemplate, tableName, ","),
         listOf("b\"|\"0"),
         listOf("b\"|\"1"),
-        listOf("b\"|\"2")
-      );
+        listOf("b\"|\"2"));
+
     testWithResult(format(queryTemplate, tableName, "|"),
         listOf("b", "0"),
         listOf("b", "1"),
-        listOf("b", "2")
-      );
+        listOf("b", "2"));
   }
 
   @Test
@@ -163,8 +162,7 @@ public class TestSelectWithOption extends BaseTestQuery {
     testWithResult(format("select columns from table(%s(type => 'TeXT', fieldDelimiter => '|', quote => '@'))", tableName),
         listOf("\"b\"", "\"0\""),
         listOf("\"b\"", "\"1\""),
-        listOf("\"b\"", "\"2\"")
-        );
+        listOf("\"b\"", "\"2\""));
 
     String quoteTableName = genCSVTable("testTextQuote2",
         "@b@|@0@",
@@ -172,8 +170,7 @@ public class TestSelectWithOption extends BaseTestQuery {
     // It seems that a parameter can not be called "escape"
     testWithResult(format("select columns from table(%s(`escape` => '$', type => 'TeXT', fieldDelimiter => '|', quote => '@'))", quoteTableName),
         listOf("b", "0"),
-        listOf("b$@c", "1") // shouldn't $ be removed here?
-        );
+        listOf("b$@c", "1")); // shouldn't $ be removed here?
   }
 
   @Test
@@ -184,8 +181,7 @@ public class TestSelectWithOption extends BaseTestQuery {
           "b|1");
       testWithResult(format("select columns from table(%s(type => 'TeXT', fieldDelimiter => '|', comment => '@'))", commentTableName),
           listOf("b", "0"),
-          listOf("b", "1")
-          );
+          listOf("b", "1"));
   }
 
   @Test
@@ -196,8 +192,7 @@ public class TestSelectWithOption extends BaseTestQuery {
         "b|1");
     testWithResult(format("select columns from table(%s(type => 'TeXT', fieldDelimiter => '|', skipFirstLine => true))", headerTableName),
         listOf("b", "0"),
-        listOf("b", "1")
-        );
+        listOf("b", "1"));
 
     testBuilder()
         .sqlQuery(format("select a, b from table(%s(type => 'TeXT', fieldDelimiter => '|', extractHeader => true))", headerTableName))
@@ -205,7 +200,7 @@ public class TestSelectWithOption extends BaseTestQuery {
         .baselineColumns("b", "a")
         .baselineValues("b", "0")
         .baselineValues("b", "1")
-        .build().run();
+        .go();
   }
 
   @Test
@@ -214,18 +209,9 @@ public class TestSelectWithOption extends BaseTestQuery {
         "a,b",
         "c|d");
     // Using the defaults in TextFormatConfig (the field delimiter is neither "," not "|")
-    String[] csvQueries = {
-//        format("select columns from %s ('TeXT')", csvTableName),
-//        format("select columns from %s('TeXT')", csvTableName),
-        format("select columns from table(%s ('TeXT'))", csvTableName),
-        format("select columns from table(%s (type => 'TeXT'))", csvTableName),
-//        format("select columns from %s (type => 'TeXT')", csvTableName)
-    };
-    for (String csvQuery : csvQueries) {
-      testWithResult(csvQuery,
-          listOf("a,b"),
-          listOf("c|d"));
-    }
+    testWithResult(format("select columns from table(%s (type => 'TeXT'))", csvTableName),
+      listOf("a,b"),
+      listOf("c|d"));
     // the drill config file binds .csv to "," delimited
     testWithResult(format("select columns from %s", csvTableName),
           listOf("a", "b"),
@@ -248,7 +234,6 @@ public class TestSelectWithOption extends BaseTestQuery {
         listOf("{\"columns\": [\"f\"", "g\"]}\n")
         );
     String[] jsonQueries = {
-        format("select columns from table(%s ('JSON'))", jsonTableName),
         format("select columns from table(%s(type => 'JSON'))", jsonTableName),
         // we can use named format plugin configurations too!
         format("select columns from table(%s(type => 'Named', name => 'json'))", jsonTableName),
@@ -266,15 +251,8 @@ public class TestSelectWithOption extends BaseTestQuery {
     // the extension is actually csv
     test("use dfs");
     try {
-      String[] jsonQueries = {
-          format("select columns from table(%s ('JSON'))", jsonTableName),
-          format("select columns from table(%s(type => 'JSON'))", jsonTableName),
-      };
-      for (String jsonQuery : jsonQueries) {
-        testWithResult(jsonQuery, listOf("f","g"));
-      }
-
-      testWithResult(format("select length(columns[0]) as columns from table(%s ('JSON'))", jsonTableName), 1L);
+      testWithResult(format("select columns from table(%s(type => 'JSON'))", jsonTableName), listOf("f","g"));
+      testWithResult(format("select length(columns[0]) as columns from table(%s (type => 'JSON'))", jsonTableName), 1L);
     } finally {
       test("use sys");
     }
@@ -287,7 +265,7 @@ public class TestSelectWithOption extends BaseTestQuery {
     try {
       test("select * from table(`%s`.`%s`(type=>'parquet'))", schema, tableName);
     } catch (UserRemoteException e) {
-      assertThat(e.getMessage(), containsString(String.format("Unable to find table [%s] in schema [%s]", tableName, schema)));
+      assertThat(e.getMessage(), containsString(String.format("Unable to find table [%s]", tableName)));
       throw e;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
@@ -21,131 +21,133 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
+
 public class TestParserErrorHandling {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testUnsupportedType() {
+  public void testUnsupportedType() throws Exception {
     String schema = "col unk_type";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testVarcharWithScale() {
+  public void testVarcharWithScale() throws Exception {
     String schema = "col varchar(1, 2)";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("missing ')' at ','");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testUnquotedKeyword() {
+  public void testUnquotedKeyword() throws Exception {
     String schema = "int varchar";
-    thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("mismatched input 'int' expecting {'(', ID, QUOTED_ID}");
+    thrown.expect(IOException.class);
+    thrown.expectMessage("mismatched input 'int'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testUnquotedId() {
+  public void testUnquotedId() throws Exception {
     String schema = "id with space varchar";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testUnescapedBackTick() {
+  public void testUnescapedBackTick() throws Exception {
     String schema = "`c`o`l` varchar";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testUnescapedBackSlash() {
+  public void testUnescapedBackSlash() throws Exception {
     String schema = "`c\\o\\l` varchar";
-    thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("extraneous input '`' expecting {'(', ID, QUOTED_ID}");
+    thrown.expect(IOException.class);
+    thrown.expectMessage("extraneous input '`'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testMissingType() {
+  public void testMissingType() throws Exception {
     String schema = "col not null";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testIncorrectEOF() {
+  public void testIncorrectEOF() throws Exception {
     String schema = "col int not null footer";
-    thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("extraneous input 'footer' expecting <EOF>");
+    thrown.expect(IOException.class);
+    thrown.expectMessage("extraneous input 'footer'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testSchemaWithOneParen() {
+  public void testSchemaWithOneParen() throws Exception {
     String schema = "(col int not null";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("missing ')' at '<EOF>'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testMissingAngleBracket() {
+  public void testMissingAngleBracket() throws Exception {
     String schema = "col array<int not null";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("missing '>' at 'not'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testUnclosedAngleBracket() {
+  public void testUnclosedAngleBracket() throws Exception {
     String schema = "col struct<m array<int> not null";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("missing '>' at '<EOF>'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testMissingColumnNameForStruct() {
+  public void testMissingColumnNameForStruct() throws Exception {
     String schema = "col struct<int> not null";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("mismatched input 'int' expecting {ID, QUOTED_ID}");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testMissingNotBeforeNull() {
+  public void testMissingNotBeforeNull() throws Exception {
     String schema = "col int null";
-    thrown.expect(SchemaParsingException.class);
-    thrown.expectMessage("extraneous input 'null' expecting <EOF>");
+    thrown.expect(IOException.class);
+    thrown.expectMessage("extraneous input 'null'");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testExtraComma() {
+  public void testExtraComma() throws Exception {
     String schema = "id int,, name varchar";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("extraneous input ',' expecting {ID, QUOTED_ID}");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void testExtraCommaEOF() {
+  public void testExtraCommaEOF() throws Exception {
     String schema = "id int, name varchar,";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("mismatched input '<EOF>' expecting {ID, QUOTED_ID}");
     SchemaExprParser.parseSchema(schema);
   }
 
   @Test
-  public void incorrectNumber() {
+  public void incorrectNumber() throws Exception {
     String schema = "id decimal(5, 02)";
-    thrown.expect(SchemaParsingException.class);
+    thrown.expect(IOException.class);
     thrown.expectMessage("extraneous input '2' expecting ')'");
     SchemaExprParser.parseSchema(schema);
   }


### PR DESCRIPTION
1. Added common schema table function parameter with can be used as single unit or with format plugin table function parameters.
2. Allowed creating schema without columns, in case if user needs only to indicate table properties.
3. Added unit tests.

Details in Jira [DRILL-6965](https://issues.apache.org/jira/browse/DRILL-6965).