### PR TITLE
DRILL-7222: Visualize estimated and actual row counts for a query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -875,6 +875,8 @@ public final class ExecConstants {
   public static final BooleanValidator DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR = new BooleanValidator(DYNAMIC_UDF_SUPPORT_ENABLED,
       new OptionDescription("Enables users to dynamically upload UDFs. Users must upload their UDF (source and binary) JAR files to a staging directory in the distributed file system before issuing the CREATE FUNCTION USING JAR command to register a UDF. Default is true. (Drill 1.9+)"));
 
+  //Display estimated rows in operator overview by default
+  public static final String PROFILE_STATISTICS_ESTIMATED_ROWS_SHOW = "drill.exec.http.profile.statistics.estimated_rows.show";
   //Trigger warning in UX if fragments appear to be doing no work (units are in seconds).
   public static final String PROFILE_WARNING_PROGRESS_THRESHOLD = "drill.exec.http.profile.warning.progress.threshold";
   //Trigger warning in UX if slowest fragment operator crosses min threshold and exceeds ratio with average (units are in seconds).

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/HtmlAttribute.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/HtmlAttribute.java
@@ -23,6 +23,7 @@ package org.apache.drill.exec.server.rest.profile;
 public class HtmlAttribute {
   //Attributes
   public static final String CLASS = "class";
+  public static final String KEY = "key";
   public static final String DATA_ORDER = "data-order";
   public static final String TITLE = "title";
   public static final String SPILLS = "spills";
@@ -33,5 +34,6 @@ public class HtmlAttribute {
   public static final String CLASS_VALUE_NO_PROGRESS_TAG = "no-progress-tag";
   public static final String CLASS_VALUE_TIME_SKEW_TAG = "time-skew-tag";
   public static final String CLASS_VALUE_SCAN_WAIT_TAG = "scan-wait-tag";
+  public static final String CLASS_VALUE_EST_ROWS_ANCHOR = "estRowsAnchor";
   public static final String STYLE_VALUE_CURSOR_HELP = "cursor:help;";
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/OperatorWrapper.java
@@ -143,7 +143,7 @@ public class OperatorWrapper {
       OverviewTblTxt.AVG_SETUP_TIME, OverviewTblTxt.MAX_SETUP_TIME,
       OverviewTblTxt.AVG_PROCESS_TIME, OverviewTblTxt.MAX_PROCESS_TIME,
       OverviewTblTxt.MIN_WAIT_TIME, OverviewTblTxt.AVG_WAIT_TIME, OverviewTblTxt.MAX_WAIT_TIME,
-      OverviewTblTxt.PERCENT_FRAGMENT_TIME, OverviewTblTxt.PERCENT_QUERY_TIME, OverviewTblTxt.ROWS,
+      OverviewTblTxt.PERCENT_FRAGMENT_TIME, OverviewTblTxt.PERCENT_QUERY_TIME, OverviewTblTxt.ROWS.concat(OverviewTblTxt.ESTIMATED_ROWS),
       OverviewTblTxt.AVG_PEAK_MEMORY, OverviewTblTxt.MAX_PEAK_MEMORY
   };
 
@@ -269,7 +269,10 @@ public class OperatorWrapper {
     tb.appendPercent(processSum / majorBusyNanos);
     tb.appendPercent(processSum / majorFragmentBusyTallyTotal);
 
-    tb.appendFormattedInteger(recordSum);
+    Map<String, String> estRowcountMap = new HashMap<>();
+    estRowcountMap.put(HtmlAttribute.CLASS, HtmlAttribute.CLASS_VALUE_EST_ROWS_ANCHOR);
+    estRowcountMap.put(HtmlAttribute.KEY, path.replaceAll("-xx-", "-"));
+    tb.appendFormattedInteger(recordSum, estRowcountMap);
 
     final ImmutablePair<OperatorProfile, Integer> peakMem = Collections.max(opList, Comparators.operatorPeakMemory);
 
@@ -419,6 +422,7 @@ public class OperatorWrapper {
     static final String PERCENT_FRAGMENT_TIME = "% Fragment Time";
     static final String PERCENT_QUERY_TIME = "% Query Time";
     static final String ROWS = "Rows";
+    static final String ESTIMATED_ROWS = "<div class='estRows' title='Estimated'>(Estimated)</div>";
     static final String AVG_PEAK_MEMORY = "Avg Peak Memory";
     static final String MAX_PEAK_MEMORY = "Max Peak Memory";
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -65,6 +65,7 @@ public class ProfileWrapper {
   private Map<String, String> physicalOperatorMap;
   private final String noProgressWarningThreshold;
   private final int defaultAutoLimit;
+  private boolean showEstimatedRows;
 
   public ProfileWrapper(final QueryProfile profile, DrillConfig drillConfig) {
     this.profile = profile;
@@ -134,6 +135,7 @@ public class ProfileWrapper {
 
     this.onlyImpersonationEnabled = WebServer.isOnlyImpersonationEnabled(drillConfig);
     this.noProgressWarningThreshold = String.valueOf(drillConfig.getInt(ExecConstants.PROFILE_WARNING_PROGRESS_THRESHOLD));
+    this.showEstimatedRows = drillConfig.getBoolean(ExecConstants.PROFILE_STATISTICS_ESTIMATED_ROWS_SHOW);
   }
 
   private long tallyMajorFragmentCost(List<MajorFragmentProfile> majorFragments) {
@@ -389,5 +391,9 @@ public class ProfileWrapper {
       String extractedOperatorName = CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, lineToken[1].split("\\(", 2)[0].trim());
       physicalOperatorMap.put(operatorPath, extractedOperatorName);
     }
+  }
+
+  public boolean showEstimatedRows() {
+    return showEstimatedRows;
   }
 }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -143,6 +143,7 @@ drill.exec: {
     }
     max_profiles: 100,
     profiles_per_page: [10, 25, 50, 100],
+    profile.statistics.estimated_rows.show : false,
     profile.warning: {
       progress.threshold: 300,
       time.skew: {


### PR DESCRIPTION
With statistics in place, it is useful to have the estimated rowcount along side the actual rowcount query profile's operator overview. 
We extract this from the Physical Plan section of the profile and show it in parenthesis with a toggle button to have the estimates hidden by default.
![image](https://user-images.githubusercontent.com/4335237/57106796-296e9600-6ce3-11e9-9dff-f37a647cd13a.png)
