### PR TITLE
DRILL-7203: Back button not working 

### DIFF
--- a/exec/java-exec/src/main/resources/rest/errorMessage.ftl
+++ b/exec/java-exec/src/main/resources/rest/errorMessage.ftl
@@ -20,12 +20,10 @@
 <#include "*/generic.ftl">
 <#macro page_head>
 <script>
+  //Hack to mimic browser back button
   function goToPreviousPage() {
-    console.log("Going back from "+location.pathname + " to " +  document.referrer + "( "+window.history.state+" )");
-    //window.history.go(-1);
-	sessionStorage.useCachedQuery = true;
-	console.log("Reloading with query: " + sessionStorage.cachedQuery)
-	location.reload();
+    sessionStorage.useCachedQuery = true;
+    location.reload();
   }
 </script>
 </#macro>
@@ -40,7 +38,7 @@
     </div>
     <div class="panel-body"><span style="font-family:courier,monospace;white-space:pre-wrap">${model}</span></div>
   </div>
-  <button type="reset" class="btn btn-default" id="backBtn" style="display:inline" Xonclick="window.history.back()" onclick="goToPreviousPage()"><span class="glyphicon glyphicon-step-backward"></span> Back</button>
+  <button type="reset" class="btn btn-default" id="backBtn" style="display:inline" onclick="goToPreviousPage()"><span class="glyphicon glyphicon-step-backward"></span> Back</button>
 </#macro>
 
 <@page_html/>

--- a/exec/java-exec/src/main/resources/rest/errorMessage.ftl
+++ b/exec/java-exec/src/main/resources/rest/errorMessage.ftl
@@ -19,6 +19,15 @@
 -->
 <#include "*/generic.ftl">
 <#macro page_head>
+<script>
+  function goToPreviousPage() {
+    console.log("Going back from "+location.pathname + " to " +  document.referrer + "( "+window.history.state+" )");
+    //window.history.go(-1);
+	sessionStorage.useCachedQuery = true;
+	console.log("Reloading with query: " + sessionStorage.cachedQuery)
+	location.reload();
+  }
+</script>
 </#macro>
 
 <#macro page_body>
@@ -31,7 +40,7 @@
     </div>
     <div class="panel-body"><span style="font-family:courier,monospace;white-space:pre-wrap">${model}</span></div>
   </div>
-  <a class="btn btn-default" id="backBtn" style="display:inline" onclick="window.history.back()"><span class="glyphicon glyphicon-step-backward"></span> Back</a>
+  <button type="reset" class="btn btn-default" id="backBtn" style="display:inline" Xonclick="window.history.back()" onclick="goToPreviousPage()"><span class="glyphicon glyphicon-step-backward"></span> Back</button>
 </#macro>
 
 <@page_html/>

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -104,17 +104,14 @@
     editor.getSession().setUseSoftTabs(true);
     editor.setTheme("ace/theme/sqlserver");
     editor.$blockScrolling = "Infinity";
-	var retrievedQuery = sessionStorage.getItem("cachedQuery");
-	var useCachedQuery = sessionStorage.getItem("useCachedQuery");
-	console.log("Checking cQ : " + retrievedQuery);
-	var referingUrl = document.referrer;
-	console.log("Checking dR: " + referingUrl);
-	if (useCachedQuery !== null && (typeof useCachedQuery !== 'undefined')) {
+    var retrievedQuery = sessionStorage.getItem("cachedQuery");
+    var useCachedQuery = sessionStorage.getItem("useCachedQuery");
+    if (useCachedQuery !== null && retrievedQuery !== null) {
       editor.setValue(retrievedQuery);
       editor.clearSelection(); // This will remove the highlight over the text
-	}
-	sessionStorage.removeItem("useCachedQuery");
-	sessionStorage.removeItem("cachedQuery");
+    }
+    sessionStorage.removeItem("useCachedQuery");
+    sessionStorage.removeItem("cachedQuery");
     editor.setOptions({
       enableSnippets: true,
       enableBasicAutocompletion: true,
@@ -143,17 +140,6 @@
       if (e.target.form) //Submit [Wrapped] Query 
         <#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>;
     });
-
-	/*
-    $(document).ready(function() {
-	  console.log("Populating with : " + sessionStorage.cachedQuery);
-	  if (sessionStorage.getItem("cachedQuery") !== null) {
-	    var retrievedQuery = sessionStorage.removeItem("cachedQuery");
-        ace.edit("query-editor-format").setValue(sessionStorage.cachedQuery);
-        $('#query').attr('value',retrievedQuery);
-	  }
-	});
-	*/
   </script>
 </#macro>
 

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -104,6 +104,22 @@
     editor.getSession().setUseSoftTabs(true);
     editor.setTheme("ace/theme/sqlserver");
     editor.$blockScrolling = "Infinity";
+	var retrievedQuery = sessionStorage.getItem("cachedQuery");
+	var useCachedQuery = sessionStorage.getItem("useCachedQuery");
+	console.log("Checking cQ : " + retrievedQuery);
+	var referingUrl = document.referrer;
+	console.log("Checking dR: " + referingUrl);
+	if (useCachedQuery !== null && (typeof useCachedQuery !== 'undefined')) {
+      editor.setValue(retrievedQuery);
+      editor.clearSelection(); // This will remove the highlight over the text
+	}
+	sessionStorage.removeItem("useCachedQuery");
+	sessionStorage.removeItem("cachedQuery");
+    editor.setOptions({
+      enableSnippets: true,
+      enableBasicAutocompletion: true,
+      enableLiveAutocompletion: false
+    });
     editor.focus();
     //CSS Formatting
     document.getElementById('query-editor-format').style.fontSize='13px';
@@ -111,11 +127,6 @@
     document.getElementById('query-editor-format').style.lineHeight='1.5';
     document.getElementById('query-editor-format').style.width='98%';
     document.getElementById('query-editor-format').style.margin='auto';
-    editor.setOptions({
-      enableSnippets: true,
-      enableBasicAutocompletion: true,
-      enableLiveAutocompletion: false
-    });
 
     //Provides hint based on OS
     var browserOS = navigator.platform.toLowerCase();
@@ -132,6 +143,17 @@
       if (e.target.form) //Submit [Wrapped] Query 
         <#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>;
     });
+
+	/*
+    $(document).ready(function() {
+	  console.log("Populating with : " + sessionStorage.cachedQuery);
+	  if (sessionStorage.getItem("cachedQuery") !== null) {
+	    var retrievedQuery = sessionStorage.removeItem("cachedQuery");
+        ace.edit("query-editor-format").setValue(sessionStorage.cachedQuery);
+        $('#query').attr('value',retrievedQuery);
+	  }
+	});
+	*/
   </script>
 </#macro>
 

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -90,14 +90,25 @@ function submitQuery() {
             if (typeof userName !== 'undefined' && userName !== null && userName.length > 0) {
               request.setRequestHeader("User-Name", userName);
             }
+			//TODO if this works, should I store other params too? most likely no, as quey is sufficient
+			sessionStorage.cachedQuery = $("#query").attr('value');
+			console.log("Cached :: " + sessionStorage.cachedQuery);
         },
         url: "/query",
         data: $("#queryForm").serializeArray(),
         success: function (response) {
             closePopup();
-            var newDoc = document.open("text/html", "replace");
+			/*
+			Check if exception? Clear
+			*/
+            //
+            //var newDoc = document.open();
+			var newDoc = document.open("text/html", "replace");
             newDoc.write(response);
             newDoc.close();
+			//1stNull: Reference Link in sessionStorage=location.pathname, and query
+			//window.history.pushState(null, null, '/result');
+			//TODO Ingres
         },
         error: function (request, textStatus, errorThrown) {
             closePopup();

--- a/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/querySubmission.js
@@ -90,25 +90,16 @@ function submitQuery() {
             if (typeof userName !== 'undefined' && userName !== null && userName.length > 0) {
               request.setRequestHeader("User-Name", userName);
             }
-			//TODO if this works, should I store other params too? most likely no, as quey is sufficient
-			sessionStorage.cachedQuery = $("#query").attr('value');
-			console.log("Cached :: " + sessionStorage.cachedQuery);
+            //Storing query for injection if navigating back to previous page
+            sessionStorage.cachedQuery = $("#query").attr('value');
         },
         url: "/query",
         data: $("#queryForm").serializeArray(),
         success: function (response) {
             closePopup();
-			/*
-			Check if exception? Clear
-			*/
-            //
-            //var newDoc = document.open();
-			var newDoc = document.open("text/html", "replace");
+            var newDoc = document.open("text/html", "replace");
             newDoc.write(response);
             newDoc.close();
-			//1stNull: Reference Link in sessionStorage=location.pathname, and query
-			//window.history.pushState(null, null, '/result');
-			//TODO Ingres
         },
         error: function (request, textStatus, errorThrown) {
             closePopup();


### PR DESCRIPTION
The root cause of this bug is that when a form is submitted, Drill uses the POST mechanism via an AJAX call. The response is then used to swap the existing `/query` page's DOM. This means that the browser history does not capture the change because the URL has never changed. As a result, when the user hits the `[BACK]` button, the call is made to the browser which redirects to the last page visited just before `/query`. 
Changing the AJAX call mechanism is risky, so the workaround was to leverage the `sessionStorage` feature supported by most modern (and secure) browsers. When a query is submitted, `sessionStorage`  is used to cache the submitted query (like a session/cookie). If the back button on the page is hit, an additional flag is set, telling the Javascript to revisit the submission page and use the _cached_ query. If the submission page is revisited via any other mechanism, it is assumed that the `[BACK]` button was not pressed (since the additional flag is not set), and the cached query is cleared from the browser memory.
