### PR TITLE
DRILL-7181: Improve V3 text reader (row set) error messages

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/ChildErrorContext.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/ChildErrorContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.exceptions;
+
+/**
+ * Represents an additional level of error context detail that
+ * adds to that provided by some outer context. Done via composition
+ * rather than subclassing to allow many child contexts to work with
+ * many parent contexts.
+ */
+
+public class ChildErrorContext implements CustomErrorContext {
+
+  private final CustomErrorContext parent;
+
+  public ChildErrorContext(CustomErrorContext parent) {
+    this.parent = parent;
+  }
+
+  @Override
+  public void addContext(UserException.Builder builder) {
+    if (parent != null) {
+      parent.addContext(builder);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/drill/common/exceptions/CustomErrorContext.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/CustomErrorContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.exceptions;
+
+/**
+ * Generic mechanism to pass error context throughout the row set
+ * mechanism and scan framework. The idea is to encapsulate error
+ * context information in an object that can be passed around, rather
+ * than having to pass the error information directly. In many cases, the
+ * same mechanisms are called from multiple contexts, making it hard to
+ * generalize the information that would be required. By hiding that
+ * information in an error context, the caller decides what to add to
+ * the error, the intermediate classes just pass along this opaque
+ * context.
+ * <p>
+ * In some cases, such as file scans within a scan operator, there can be
+ * multiple levels of context. A format plugin, say, can describe the
+ * plugin and any interesting options. Then, a file scan can create a child
+ * context that adds things like file name, split offset, etc.
+ * <p>
+ * If this proves useful elsewhere, it can be moved into the same
+ * package as UserError, and a new <tt>addContext()</tt> method added
+ * to the <tt>UserException.Builder</tt> to make the error context
+ * easier to use.
+ */
+
+public interface CustomErrorContext {
+  void addContext(UserException.Builder builder);
+}

--- a/common/src/main/java/org/apache/drill/common/exceptions/EmptyErrorContext.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/EmptyErrorContext.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.exceptions;
+
+import org.apache.drill.common.exceptions.UserException.Builder;
+
+public class EmptyErrorContext implements CustomErrorContext {
+
+  @Override
+  public void addContext(Builder builder) { }
+}

--- a/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
@@ -531,6 +531,13 @@ public class UserException extends DrillRuntimeException {
       return this;
     }
 
+    public Builder addContext(CustomErrorContext context) {
+      if (context != null) {
+        context.addContext(this);
+      }
+      return this;
+    }
+
     /**
      * pushes a string value to the top of the context
      *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.framework;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
 import org.apache.drill.exec.physical.impl.scan.ScanOperatorEvents;
@@ -169,6 +170,8 @@ public class ManagedScanFramework implements ScanOperatorEvents {
   public ScanSchemaOrchestrator scanOrchestrator() {
     return scanOrchestrator;
   }
+
+  public CustomErrorContext errorContext() { return builder.errorContext(); }
 
   protected void configure() { }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
@@ -17,8 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.scan.framework;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 
 /**
@@ -57,6 +59,12 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 public interface SchemaNegotiator {
 
   OperatorContext context();
+
+  /**
+   * Specify an advanced error context which allows the reader to
+   * fill in custom context values.
+   */
+  void setErrorContext(CustomErrorContext context);
 
   /**
    * Specify the table schema if this is an early-schema reader. Need
@@ -110,4 +118,12 @@ public interface SchemaNegotiator {
    */
 
   boolean isProjectionEmpty();
+
+  /**
+   * The context to use as a parent when creating a custom context.
+   * <p>
+   * (Obtain the error context for this reader from the
+   * {@link ResultSetLoader}.
+   */
+  CustomErrorContext parentErrorContext();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.framework;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -56,6 +57,7 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
 
   protected final ManagedScanFramework framework;
   private NegotiatorListener listener;
+  protected CustomErrorContext context;
   protected TupleMetadata tableSchema;
   protected boolean isSchemaComplete;
   protected int batchSize = ValueVector.MAX_ROW_COUNT;
@@ -71,6 +73,20 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
   @Override
   public OperatorContext context() {
     return framework.context();
+  }
+
+  @Override
+  public CustomErrorContext parentErrorContext() {
+    return framework.errorContext();
+  }
+
+  public CustomErrorContext errorContext() {
+    return context;
+  }
+
+  @Override
+  public void setErrorContext(CustomErrorContext context) {
+    this.context = context;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ShimBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ShimBatchReader.java
@@ -197,7 +197,8 @@ public class ShimBatchReader implements RowBatchReader, NegotiatorListener {
   public ResultSetLoader build(SchemaNegotiatorImpl schemaNegotiator) {
     this.schemaNegotiator = schemaNegotiator;
     readerOrchestrator.setBatchSize(schemaNegotiator.batchSize);
-    tableLoader = readerOrchestrator.makeTableLoader(schemaNegotiator.tableSchema);
+    tableLoader = readerOrchestrator.makeTableLoader(schemaNegotiator.errorContext(),
+        schemaNegotiator.tableSchema);
     return tableLoader;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ExplicitSchemaProjection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ExplicitSchemaProjection.java
@@ -44,16 +44,18 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 public class ExplicitSchemaProjection extends ReaderLevelProjection {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExplicitSchemaProjection.class);
 
+  private final ScanLevelProjection scanProj;
+
   public ExplicitSchemaProjection(ScanLevelProjection scanProj,
       TupleMetadata readerSchema,
       ResolvedTuple rootTuple,
       List<ReaderProjectionResolver> resolvers) {
     super(resolvers);
-    resolveRootTuple(scanProj, rootTuple, readerSchema);
+    this.scanProj = scanProj;
+    resolveRootTuple(rootTuple, readerSchema);
   }
 
-  private void resolveRootTuple(ScanLevelProjection scanProj,
-      ResolvedTuple rootTuple,
+  private void resolveRootTuple(ResolvedTuple rootTuple,
       TupleMetadata readerSchema) {
     for (ColumnProjection col : scanProj.columns()) {
       if (col instanceof UnresolvedColumn) {
@@ -117,8 +119,10 @@ public class ExplicitSchemaProjection extends ReaderLevelProjection {
       throw UserException
         .validationError()
         .message("Project list implies a map column, but actual column is not a map")
-        .addContext("Projected column", requestedCol.fullName())
-        .addContext("Actual type", column.type().name())
+        .addContext("Projected column:", requestedCol.fullName())
+        .addContext("Table column:", column.name())
+        .addContext("Type:", column.type().name())
+        .addContext(scanProj.context())
         .build(logger);
     }
 
@@ -172,8 +176,11 @@ public class ExplicitSchemaProjection extends ReaderLevelProjection {
       throw UserException
         .validationError()
         .message("Project list implies an array, but actual column is not an array")
-        .addContext("Projected column", requestedCol.fullName())
-        .addContext("Actual cardinality", column.mode().name())
+        .addContext("Projected column:", requestedCol.fullName())
+        .addContext("Table column:", column.name())
+        .addContext("Type:", column.type().name())
+        .addContext("Actual cardinality:", column.mode().name())
+        .addContext(scanProj.context())
         .build(logger);
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ReaderSchemaOrchestrator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ReaderSchemaOrchestrator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.project;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.physical.impl.scan.project.NullColumnBuilder.NullBuilderBuilder;
 import org.apache.drill.exec.physical.impl.scan.project.ResolvedTuple.ResolvedRow;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
@@ -25,6 +26,7 @@ import org.apache.drill.exec.physical.rowSet.impl.ResultSetLoaderImpl;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 
 /**
  * Orchestrates projection tasks for a single reader within the set that the
@@ -60,12 +62,18 @@ public class ReaderSchemaOrchestrator implements VectorSource {
     }
   }
 
+  @VisibleForTesting
   public ResultSetLoader makeTableLoader(TupleMetadata readerSchema) {
+    return makeTableLoader(scanOrchestrator.scanProj.context(), readerSchema);
+  }
+
+  public ResultSetLoader makeTableLoader(CustomErrorContext errorContext, TupleMetadata readerSchema) {
     OptionBuilder options = new OptionBuilder();
     options.setRowCountLimit(Math.min(readerBatchSize, scanOrchestrator.options.scanBatchRecordLimit));
     options.setVectorCache(scanOrchestrator.vectorCache);
     options.setBatchSizeLimit(scanOrchestrator.options.scanBatchByteLimit);
     options.setSchemaTransform(scanOrchestrator.options.schemaTransformer);
+    options.setContext(errorContext);
 
     // Set up a selection list if available and is a subset of
     // table columns. (Only needed for non-wildcard queries.)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/ResultSetLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/ResultSetLoader.java
@@ -17,9 +17,11 @@
  */
 package org.apache.drill.exec.physical.rowSet;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.BaseValueVector;
+import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 
 /**
  * Builds a result set (series of zero or more row sets) based on a defined
@@ -40,6 +42,12 @@ import org.apache.drill.exec.vector.BaseValueVector;
 public interface ResultSetLoader {
 
   public static final int DEFAULT_ROW_COUNT = BaseValueVector.INITIAL_VALUE_ALLOCATION;
+
+  /**
+   * Context for error messages.
+   */
+
+  CustomErrorContext context();
 
   /**
    * Current schema version. The version increments by one each time

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/OptionBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/OptionBuilder.java
@@ -19,11 +19,13 @@ package org.apache.drill.exec.physical.rowSet.impl;
 
 import java.util.Collection;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.rowSet.ResultVectorCache;
 import org.apache.drill.exec.physical.rowSet.impl.ResultSetLoaderImpl.ResultSetOptions;
 import org.apache.drill.exec.physical.rowSet.project.RequestedTuple;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.BaseValueVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
@@ -42,6 +44,11 @@ public class OptionBuilder {
   protected TupleMetadata schema;
   protected long maxBatchSize;
   protected SchemaTransformer schemaTransformer;
+
+  /**
+   * Error message context
+   */
+  protected CustomErrorContext errorContext;
 
   public OptionBuilder() {
     // Start with the default option values.
@@ -143,8 +150,13 @@ public class OptionBuilder {
     return this;
   }
 
-  // TODO: No setter for vector length yet: is hard-coded
-  // at present in the value vector.
+  /**
+   * Provides context for error messages.
+   */
+  public OptionBuilder setContext(CustomErrorContext context) {
+    this.errorContext = context;
+    return this;
+  }
 
   public ResultSetOptions build() {
     Preconditions.checkArgument(projection == null || projectionSet == null);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/ResultSetLoaderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.rowSet.impl;
 
+import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
@@ -53,6 +54,11 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
     protected final long maxBatchSize;
     protected final SchemaTransformer schemaTransformer;
 
+    /**
+     * Context for error messages.
+     */
+    protected final CustomErrorContext errorContext;
+
     public ResultSetOptions() {
       vectorSizeLimit = ValueVector.MAX_BUFFER_SIZE;
       rowCountLimit = DEFAULT_ROW_COUNT;
@@ -61,6 +67,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
       schema = null;
       maxBatchSize = -1;
       schemaTransformer = null;
+      errorContext = null;
     }
 
     public ResultSetOptions(OptionBuilder builder) {
@@ -70,6 +77,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
       schema = builder.schema;
       maxBatchSize = builder.maxBatchSize;
       schemaTransformer = builder.schemaTransformer;
+      errorContext = builder.errorContext;
 
       // If projection, build the projection map.
       // The caller might have already built the map. If so,
@@ -287,7 +295,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
     if (schemaTransformer == null) {
       schemaTransformer = new DefaultSchemaTransformer(null);
     }
-    columnBuilder = new ColumnBuilder(schemaTransformer);
+    columnBuilder = new ColumnBuilder(schemaTransformer, options.errorContext);
 
     // Set the projections
 
@@ -845,4 +853,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
 
   @Override
   public ColumnBuilder columnBuilder() { return columnBuilder; }
+
+  @Override
+  public CustomErrorContext context() { return options.errorContext; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/SchemaTransformerImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/rowSet/impl/SchemaTransformerImpl.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.rowSet.impl;
 import java.util.Map;
 
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection.ScanProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.ProjectionType;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -155,8 +156,9 @@ public class SchemaTransformerImpl implements SchemaTransformer {
         if (defn.conversionClass == null) {
           throw UserException.validationError()
             .message("Runtime type conversion not available")
-            .addContext("Input type", inputSchema.typeString())
-            .addContext("Output type", outputCol.typeString())
+            .addContext("Column:", outputCol.name())
+            .addContext("Input type:", inputSchema.typeString())
+            .addContext("Output type:", outputCol.typeString())
             .build(logger);
         }
         factory = StandardConversions.factory(defn.conversionClass, properties);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayFramework.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayFramework.java
@@ -46,13 +46,12 @@ import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileSplit;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 
 /**
@@ -72,11 +71,9 @@ public class TestColumnsArrayFramework extends SubOperatorTest {
     }
 
     @Override
-    public ManagedReader<? extends FileSchemaNegotiator> newReader(
-        FileSplit split) {
+    public ManagedReader<? extends FileSchemaNegotiator> newReader() {
       DummyColumnsReader reader = readerIter.next();
       assert reader != null;
-      assert split.getPath().equals(reader.filePath());
       return reader;
     }
   }
@@ -199,6 +196,7 @@ public class TestColumnsArrayFramework extends SubOperatorTest {
     ColumnsScanFixtureBuilder builder = new ColumnsScanFixtureBuilder();
     builder.setProjection(RowSetTestUtils.projectList(ColumnsArrayManager.COLUMNS_COL));
     builder.addReader(reader);
+    builder.builder.requireColumnsArray(true);
     ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 
@@ -234,6 +232,7 @@ public class TestColumnsArrayFramework extends SubOperatorTest {
         SchemaPath.parseFromString(ColumnsArrayManager.COLUMNS_COL + "[1]"),
         SchemaPath.parseFromString(ColumnsArrayManager.COLUMNS_COL + "[3]")));
     builder.addReader(reader);
+    builder.builder.requireColumnsArray(true);
     ScanFixture scanFixture = builder.build();
     ScanOperatorExec scan = scanFixture.scanOp;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayParser.java
@@ -34,11 +34,11 @@ import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
 import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @Category(RowSetTests.class)
 public class TestColumnsArrayParser extends SubOperatorTest {
@@ -51,9 +51,9 @@ public class TestColumnsArrayParser extends SubOperatorTest {
 
   @Test
   public void testColumnsArray() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(ColumnsArrayManager.COLUMNS_COL),
-        ScanTestUtils.parsers(new ColumnsArrayParser(false)));
+        ScanTestUtils.parsers(new ColumnsArrayParser(true)));
 
     assertFalse(scanProj.projectAll());
     assertEquals(1, scanProj.requestedCols().size());
@@ -68,7 +68,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
 
   @Test
   public void testRequiredColumnsArray() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(ColumnsArrayManager.COLUMNS_COL),
         ScanTestUtils.parsers(new ColumnsArrayParser(true)));
 
@@ -85,7 +85,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
 
   @Test
   public void testRequiredWildcard() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers(new ColumnsArrayParser(true)));
 
@@ -105,9 +105,9 @@ public class TestColumnsArrayParser extends SubOperatorTest {
 
     // Sic: case variation of standard name
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("Columns"),
-        ScanTestUtils.parsers(new ColumnsArrayParser(false)));
+        ScanTestUtils.parsers(new ColumnsArrayParser(true)));
 
     assertFalse(scanProj.projectAll());
     assertEquals(1, scanProj.requestedCols().size());
@@ -123,11 +123,11 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testColumnsElements() {
 
-   ScanLevelProjection scanProj = new ScanLevelProjection(
+   ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             ColumnsArrayManager.COLUMNS_COL + "[3]",
             ColumnsArrayManager.COLUMNS_COL + "[1]"),
-        ScanTestUtils.parsers(new ColumnsArrayParser(false)));
+        ScanTestUtils.parsers(new ColumnsArrayParser(true)));
 
     assertFalse(scanProj.projectAll());
     assertEquals(2, scanProj.requestedCols().size());
@@ -158,9 +158,9 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testErrorColumnsArrayAndColumn() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectList(ColumnsArrayManager.COLUMNS_COL, "a"),
-          ScanTestUtils.parsers(new ColumnsArrayParser(false)));
+          ScanTestUtils.parsers(new ColumnsArrayParser(true)));
       fail();
     } catch (UserException e) {
       // Expected
@@ -174,9 +174,9 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testErrorColumnAndColumnsArray() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectList("a", ColumnsArrayManager.COLUMNS_COL),
-          ScanTestUtils.parsers(new ColumnsArrayParser(false)));
+          ScanTestUtils.parsers(new ColumnsArrayParser(true)));
       fail();
     } catch (UserException e) {
       // Expected
@@ -190,7 +190,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testErrorTwoColumnsArray() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectList(ColumnsArrayManager.COLUMNS_COL, ColumnsArrayManager.COLUMNS_COL),
           ScanTestUtils.parsers(new ColumnsArrayParser(false)));
       fail();
@@ -202,7 +202,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testErrorRequiredAndExtra() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectList("a"),
           ScanTestUtils.parsers(new ColumnsArrayParser(true)));
       fail();
@@ -214,7 +214,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testColumnsIndexTooLarge() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectCols(SchemaPath.parseFromString("columns[70000]")),
           ScanTestUtils.parsers(new ColumnsArrayParser(true)));
       fail();
@@ -243,11 +243,11 @@ public class TestColumnsArrayParser extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(ScanTestUtils.FILE_NAME_COL,
             ColumnsArrayManager.COLUMNS_COL,
             ScanTestUtils.SUFFIX_COL),
-        ScanTestUtils.parsers(new ColumnsArrayParser(false),
+        ScanTestUtils.parsers(new ColumnsArrayParser(true),
             metadataManager.projectionParser()));
 
     assertFalse(scanProj.projectAll());
@@ -277,7 +277,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
 
   @Test
   public void testWildcardAndColumns() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             SchemaPath.DYNAMIC_STAR,
             ColumnsArrayManager.COLUMNS_COL),
@@ -297,7 +297,7 @@ public class TestColumnsArrayParser extends SubOperatorTest {
   @Test
   public void testColumnsAsMap() {
     try {
-        new ScanLevelProjection(
+        ScanLevelProjection.build(
           RowSetTestUtils.projectList("columns.x"),
           ScanTestUtils.parsers(new ColumnsArrayParser(true)));
         fail();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileMetadataColumnParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileMetadataColumnParser.java
@@ -20,24 +20,25 @@ package org.apache.drill.exec.physical.impl.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataColumn;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
-import org.apache.drill.exec.physical.impl.scan.file.PartitionColumn;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
-import org.apache.drill.exec.physical.impl.scan.project.ColumnProjection;
-import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection;
+import org.apache.drill.exec.physical.impl.scan.file.PartitionColumn;
 import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedColumn;
 import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedWildcardColumn;
+import org.apache.drill.exec.physical.impl.scan.project.ColumnProjection;
+import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @Category(RowSetTests.class)
 public class TestFileMetadataColumnParser extends SubOperatorTest {
@@ -63,7 +64,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
 
     // Simulate SELECT a, b, c ...
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a", "b", "c"),
         Lists.newArrayList(metadataManager.projectionParser()));
 
@@ -87,7 +88,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
 
     // Simulate SELECT a, fqn, filEPath, filename, suffix ...
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a",
             ScanTestUtils.FULLY_QUALIFIED_NAME_COL,
             "filEPath", // Sic, to test case sensitivity
@@ -133,7 +134,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
     // is preferred over "natural" name.
     String dir1 = "DIR1";
     String dir2 = ScanTestUtils.partitionColName(2);
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(dir2, dir1, dir0, "a"),
         Lists.newArrayList(metadataManager.projectionParser()));
 
@@ -159,7 +160,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         Lists.newArrayList(metadataManager.projectionParser()));
 
@@ -185,7 +186,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         Lists.newArrayList(metadataManager.projectionParser()));
 
@@ -215,7 +216,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.FILE_NAME_COL,
@@ -246,7 +247,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             ScanTestUtils.FILE_NAME_COL,
             SchemaPath.DYNAMIC_STAR,
@@ -278,7 +279,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.partitionColName(8)),
         Lists.newArrayList(metadataManager.projectionParser()));
@@ -299,7 +300,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.partitionColName(8)),
         Lists.newArrayList(metadataManager.projectionParser()));
@@ -325,7 +326,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.partitionColName(8)),
         Lists.newArrayList(metadataManager.projectionParser()));
@@ -358,7 +359,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.partitionColName(1)),
         Lists.newArrayList(metadataManager.projectionParser()));
@@ -382,7 +383,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         options);
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR,
             ScanTestUtils.partitionColName(1)),
         Lists.newArrayList(metadataManager.projectionParser()));
@@ -409,7 +410,7 @@ public class TestFileMetadataColumnParser extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             ScanTestUtils.FILE_NAME_COL + ".a",
             ScanTestUtils.FILE_PATH_COL + "[0]",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileMetadataProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileMetadataProjection.java
@@ -32,9 +32,10 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadata;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataColumn;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
+import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
 import org.apache.drill.exec.physical.impl.scan.file.MetadataColumn;
 import org.apache.drill.exec.physical.impl.scan.file.PartitionColumn;
-import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
+import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedColumn;
 import org.apache.drill.exec.physical.impl.scan.project.ColumnProjection;
 import org.apache.drill.exec.physical.impl.scan.project.ExplicitSchemaProjection;
 import org.apache.drill.exec.physical.impl.scan.project.NullColumnBuilder;
@@ -42,15 +43,14 @@ import org.apache.drill.exec.physical.impl.scan.project.NullColumnBuilder.NullBu
 import org.apache.drill.exec.physical.impl.scan.project.ResolvedColumn;
 import org.apache.drill.exec.physical.impl.scan.project.ResolvedTuple.ResolvedRow;
 import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection;
-import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedColumn;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @Category(RowSetTests.class)
 public class TestFileMetadataProjection extends SubOperatorTest {
@@ -179,7 +179,7 @@ public class TestFileMetadataProjection extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
             ScanTestUtils.FILE_NAME_COL,
             "a",
@@ -264,7 +264,7 @@ public class TestFileMetadataProjection extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(
           "a",
           ScanTestUtils.FULLY_QUALIFIED_NAME_COL,
@@ -314,7 +314,7 @@ public class TestFileMetadataProjection extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("dir11"),
         ScanTestUtils.parsers(metadataManager.projectionParser()));
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileScanFramework.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileScanFramework.java
@@ -50,7 +50,6 @@ import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileSplit;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -115,11 +114,9 @@ public class TestFileScanFramework extends SubOperatorTest {
     }
 
     @Override
-    public ManagedReader<? extends FileSchemaNegotiator> newReader(
-        FileSplit split) {
+    public ManagedReader<? extends FileSchemaNegotiator> newReader() {
       MockFileReader reader = readerIter.next();
       assert reader != null;
-      assert split.getPath().equals(reader.filePath());
       return reader;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestReaderLevelProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestReaderLevelProjection.java
@@ -30,10 +30,10 @@ import java.util.List;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils;
 import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedColumn;
 import org.apache.drill.exec.physical.impl.scan.project.NullColumnBuilder.NullBuilderBuilder;
 import org.apache.drill.exec.physical.impl.scan.project.ResolvedTuple.ResolvedRow;
-import org.apache.drill.exec.physical.impl.scan.ScanTestUtils;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -59,7 +59,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
   @Test
   public void testWildcard() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
     assertEquals(1, scanProj.columns().size());
@@ -100,7 +100,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT c, b, a ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("c", "b", "a"),
         ScanTestUtils.parsers());
     assertEquals(3, scanProj.columns().size());
@@ -144,7 +144,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT c, v, b, w ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("c", "v", "b", "w"),
         ScanTestUtils.parsers());
     assertEquals(4, scanProj.columns().size());
@@ -195,7 +195,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT c, a ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("c", "a"),
         ScanTestUtils.parsers());
     assertEquals(2, scanProj.columns().size());
@@ -236,7 +236,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT c, a ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("b"),
         ScanTestUtils.parsers());
     assertEquals(1, scanProj.columns().size());
@@ -273,7 +273,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a, b.c.d ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a", "b.c.d"),
         ScanTestUtils.parsers());
     assertEquals(2, scanProj.columns().size());
@@ -343,7 +343,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a.c, a.d, a.e.f ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("x", "a.c", "a.d", "a.e.f", "y"),
         ScanTestUtils.parsers());
     assertEquals(3, scanProj.columns().size());
@@ -444,7 +444,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a.b, a.c ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a.b", "a.c"),
         ScanTestUtils.parsers());
     assertEquals(1, scanProj.columns().size());
@@ -489,7 +489,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a.b ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a.b"),
         ScanTestUtils.parsers());
 
@@ -522,7 +522,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a[0] ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a[0]"),
         ScanTestUtils.parsers());
 
@@ -558,7 +558,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a[0] ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a[0]"),
         ScanTestUtils.parsers());
 
@@ -594,7 +594,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT * ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers(),
         outputSchema);
@@ -654,7 +654,7 @@ public class TestReaderLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT * ...
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers(),
         outputSchema);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestScanLevelProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestScanLevelProjection.java
@@ -63,7 +63,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
     // Simulate SELECT a, b, c ...
     // Build the projection plan and verify
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a", "b", "c"),
         ScanTestUtils.parsers());
 
@@ -106,7 +106,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testMap() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a.x", "b.x", "a.y", "b.y", "c"),
         ScanTestUtils.parsers());
 
@@ -155,7 +155,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testArray() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a[1]", "a[3]"),
         ScanTestUtils.parsers());
 
@@ -199,7 +199,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testWildcard() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -238,7 +238,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testEmptyProjection() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(),
         ScanTestUtils.parsers());
 
@@ -264,7 +264,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testWildcardAndColumns() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
           RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR, "a"),
           ScanTestUtils.parsers());
 
@@ -293,7 +293,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
   @Test
   public void testColumnAndWildcard() {
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
           RowSetTestUtils.projectList("a", SchemaPath.DYNAMIC_STAR),
           ScanTestUtils.parsers());
 
@@ -313,7 +313,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
   @Test
   public void testErrorTwoWildcards() {
     try {
-      new ScanLevelProjection(
+      ScanLevelProjection.build(
           RowSetTestUtils.projectList(SchemaPath.DYNAMIC_STAR, SchemaPath.DYNAMIC_STAR),
           ScanTestUtils.parsers());
       fail();
@@ -328,7 +328,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
 
     // Simulate SELECT a
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList("a"),
         ScanTestUtils.parsers(),
         outputSchema);
@@ -347,7 +347,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
         .add("b", MinorType.BIGINT)
         .buildSchema();
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers(),
         outputSchema);
@@ -378,7 +378,7 @@ public class TestScanLevelProjection extends SubOperatorTest {
         .buildSchema();
     outputSchema.setProperty(TupleMetadata.IS_STRICT_SCHEMA_PROP, Boolean.TRUE.toString());
 
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers(),
         outputSchema);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestSchemaSmoothing.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestSchemaSmoothing.java
@@ -39,13 +39,13 @@ import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
 import org.apache.drill.test.rowSet.RowSetComparison;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
  * Tests schema smoothing at the schema projection level.
@@ -117,7 +117,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
     // Set up the scan level projection
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectList(ScanTestUtils.FILE_NAME_COL, "a", "b"),
         ScanTestUtils.parsers(metadataManager.projectionParser()));
 
@@ -203,7 +203,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testSmoothingProjection() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -305,7 +305,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testSmaller() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -343,7 +343,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testDisjoint() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -380,7 +380,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testDifferentTypes() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -414,7 +414,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testSameSchemas() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -449,7 +449,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testDifferentCase() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -484,7 +484,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testRequired() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -516,7 +516,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testMissingNullableColumns() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -549,7 +549,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testReordering() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 
@@ -594,7 +594,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
     // Set up the scan level projection
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         ScanTestUtils.projectAllWithMetadata(2),
         ScanTestUtils.parsers(metadataManager.projectionParser()));
 
@@ -641,7 +641,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
     // Set up the scan level projection
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         ScanTestUtils.projectAllWithMetadata(2),
         ScanTestUtils.parsers(metadataManager.projectionParser()));
 
@@ -688,7 +688,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
     // Set up the scan level projection
 
-    ScanLevelProjection scanProj = new ScanLevelProjection(
+    ScanLevelProjection scanProj = ScanLevelProjection.build(
         ScanTestUtils.projectAllWithMetadata(2),
         ScanTestUtils.parsers(metadataManager.projectionParser()));
 
@@ -722,7 +722,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testSmoothableSchemaBatches() {
-    final ScanLevelProjection scanProj = new ScanLevelProjection(
+    final ScanLevelProjection scanProj = ScanLevelProjection.build(
         RowSetTestUtils.projectAll(),
         ScanTestUtils.parsers());
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/RowSetTestUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/RowSetTestUtils.java
@@ -55,7 +55,7 @@ public class RowSetTestUtils {
 
   public static List<SchemaPath> projectAll() {
     return Lists.newArrayList(
-        new SchemaPath[] {SchemaPath.getSimplePath(SchemaPath.DYNAMIC_STAR)});
+        new SchemaPath[] {SchemaPath.STAR_COLUMN});
   }
 
   @SafeVarargs

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTypeConversion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/rowSet/impl/TestResultSetLoaderTypeConversion.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.rowSet.impl;
 
 import static org.apache.drill.test.rowSet.RowSetUtilities.intArray;
 import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
@@ -29,8 +30,8 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.test.SubOperatorTest;
 import org.apache.drill.test.rowSet.RowSet;
-import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.apache.drill.test.rowSet.test.TestColumnConverter;
 import org.apache.drill.test.rowSet.test.TestColumnConverter.ConverterFactory;
 import org.junit.Test;

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ProjectionType.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ProjectionType.java
@@ -82,4 +82,21 @@ public enum ProjectionType {
       throw new IllegalStateException(toString());
     }
   }
+
+  public String label() {
+    switch (this) {
+    case SCALAR:
+      return "scalar (a)";
+    case ARRAY:
+      return "array (a[n])";
+    case TUPLE:
+      return "tuple (a.x)";
+    case TUPLE_ARRAY:
+      return "tuple array (a[n].x)";
+    case WILDCARD:
+      return "wildcard (*)";
+    default:
+      return name();
+    }
+  }
 }


### PR DESCRIPTION
Adds an error context to the scan framework to add plugin-specific error
context.

Refines how the `columns` column can be used with the text reader. If
headers are used, then `columns` is just another column. An error is
raised, however, if `columns[x]` is used when headers are enabled.

Added additional unit tests to fully define the `columns` column
behavior.

Added another builder abstraction where a constructor argument list
became too long.