### PR TITLE
DRILL-7250: Query with CTE fails when its name matches to the table name without access

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -61,6 +61,8 @@ public class DynamicRootSchema extends DynamicSchema {
   @Override
   protected CalciteSchema getImplicitSubSchema(String schemaName,
                                                boolean caseSensitive) {
+    // Drill registers schemas in lower case, see AbstractSchema constructor
+    schemaName = schemaName == null ? null : schemaName.toLowerCase();
     CalciteSchema retSchema = getSubSchemaMap().get(schemaName);
     if (retSchema != null) {
       return retSchema;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/impersonation/TestImpersonationQueries.java
@@ -291,8 +291,22 @@ public class TestImpersonationQueries extends BaseTestImpersonation {
     }
   }
 
+  @Test // DRILL-7250
+  public void testCTEWithImpersonation() throws Exception {
+    // Table lineitem is owned by "user0_1:group0_1" with permissions 750. "user2_1" doesn't have access to it,
+    // but query uses CTE with the same name as the table, so query shouldn't look for lineitem table
+    updateClient(org1Users[2]);
+    test("use %s", getWSSchema(org1Users[0]));
+    testBuilder()
+        .sqlQuery("with lineitem as (SELECT 1 as a) select * from lineitem")
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(1)
+        .go();
+  }
+
   @AfterClass
-  public static void removeMiniDfsBasedStorage() throws Exception {
+  public static void removeMiniDfsBasedStorage() {
     getDrillbitContext().getStorage().deletePlugin(MINI_DFS_STORAGE_PLUGIN_NAME);
     stopMiniDfsCluster();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <guava.version>19.0</guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.10.0</parquet.version>
-    <calcite.version>1.18.0-drill-r1</calcite.version>
+    <calcite.version>1.18.0-drill-r2</calcite.version>
     <avatica.version>1.13.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.7.0</sqlline.version>


### PR DESCRIPTION
- Removed `catalogReader.getTable(tempNode.names)` call since it does not resolve table names correctly using provided scope.
- Reworked `catalogReader.isValidSchema()` method to follow logic on how Calcite determines whether the table is present: it uses schemas from `CatalogReader` and resolves specified schema among them.
- Updated Calcite version to use the fix for `CALCITE-3061`.
- Added unit test.

For problem description please see [DRILL-7250](https://issues.apache.org/jira/browse/DRILL-7250).