### PR TITLE
DRILL-7236: SqlLine 1.8 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <calcite.version>1.18.0-drill-r2</calcite.version>
     <avatica.version>1.13.0</avatica.version>
     <janino.version>3.0.11</janino.version>
-    <sqlline.version>1.7.0</sqlline.version>
+    <sqlline.version>1.8.0</sqlline.version>
     <jackson.version>2.9.5</jackson.version>
     <jackson.databind.version>2.9.5</jackson.databind.version>
     <zookeeper.version>3.4.12</zookeeper.version>


### PR DESCRIPTION
Jira - [DRILL-7236](https://issues.apache.org/jira/browse/DRILL-7236).