### PR TITLE
DRILL-7306: Disable schema-only batch for new scan framework

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterTemplate2.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterTemplate2.java
@@ -19,8 +19,8 @@ package org.apache.drill.exec.physical.impl.filter;
 
 import javax.inject.Named;
 
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.RecordBatch;
@@ -102,8 +102,8 @@ public abstract class FilterTemplate2 implements Filterer {
 
   private void filterBatchNoSV(int recordCount) throws SchemaChangeException {
     int svIndex = 0;
-    for(int i = 0; i < recordCount; i++){
-      if(doEval(i, 0)){
+    for (int i = 0; i < recordCount; i++) {
+      if (doEval(i, 0)) {
         outgoingSelectionVector.setIndex(svIndex, (char)i);
         svIndex++;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
@@ -57,7 +57,8 @@ public class OperatorRecordBatch implements CloseableRecordBatch {
   private final BatchAccessor batchAccessor;
   private IterOutcome lastOutcome;
 
-  public OperatorRecordBatch(FragmentContext context, PhysicalOperator config, OperatorExec opExec) {
+  public OperatorRecordBatch(FragmentContext context, PhysicalOperator config,
+      OperatorExec opExec, boolean enableSchemaBatch) {
     OperatorContext opContext = context.newOperatorContext(config);
     opContext.getStats().startProcessing();
 
@@ -66,7 +67,7 @@ public class OperatorRecordBatch implements CloseableRecordBatch {
 
     try {
       opExec.bind(opContext);
-      driver = new OperatorDriver(opContext, opExec);
+      driver = new OperatorDriver(opContext, opExec, enableSchemaBatch);
       batchAccessor = opExec.batchAccessor();
     } catch (UserException e) {
       opContext.close();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/SchemaTracker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/SchemaTracker.java
@@ -51,6 +51,9 @@ import org.apache.drill.exec.vector.ValueVector;
  * vector is just as serious as a change in schema. Hence, operators
  * try to use the same vectors for their entire lives. That is the change
  * tracked here.
+ * <p>
+ * Schema versions start at 1. A schema version of 0 means that no
+ * output batch was ever presented.
  */
 
 // TODO: Does not handle SV4 situations
@@ -62,7 +65,6 @@ public class SchemaTracker {
   private List<ValueVector> currentVectors = new ArrayList<>();
 
   public void trackSchema(VectorContainer newBatch) {
-
     if (! isSameSchema(newBatch)) {
       schemaVersion++;
       captureSchema(newBatch);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/VectorContainerAccessor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/VectorContainerAccessor.java
@@ -57,10 +57,26 @@ public class VectorContainerAccessor implements BatchAccessor {
 
   private VectorContainer container;
   private SchemaTracker schemaTracker = new SchemaTracker();
+  private int batchCount;
 
   /**
-   * Set the vector container. Done initially, and any time the schema of
-   * the container may have changed. May be called with the same container
+   * Define a schema that does not necessarily contain any data.
+   * Call this to declare a schema when there are no results to
+   * report.
+   */
+
+  public void setSchema(VectorContainer container) {
+    this.container = container;
+    if (container != null) {
+      schemaTracker.trackSchema(container);
+    }
+  }
+
+  /**
+   * Define an output batch. Called each time a new batch is sent
+   * downstream. Checks if the schema of this batch is the same as
+   * that of any previous batch, and updates the schema version if
+   * the schema changes. May be called with the same container
    * as the previous call, or a different one. A schema change occurs
    * unless the vectors are identical across the two containers.
    *
@@ -68,12 +84,12 @@ public class VectorContainerAccessor implements BatchAccessor {
    * downstream
    */
 
-  public void setContainer(VectorContainer container) {
-    this.container = container;
-    if (container != null) {
-      schemaTracker.trackSchema(container);
-    }
+  public void addBatch(VectorContainer container) {
+    setSchema(container);
+    batchCount++;
   }
+
+  public int batchCount() { return batchCount; }
 
   @Override
   public BatchSchema getSchema() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ScanOperatorExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/ScanOperatorExec.java
@@ -20,10 +20,10 @@ package org.apache.drill.exec.physical.impl.scan;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.ScanBatch;
 import org.apache.drill.exec.physical.impl.protocol.BatchAccessor;
 import org.apache.drill.exec.physical.impl.protocol.OperatorExec;
 import org.apache.drill.exec.physical.impl.protocol.VectorContainerAccessor;
-
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -67,6 +67,7 @@ import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTes
  * {#link ResultSetLoader} to write values into value vectors.
  *
  * <h4>Schema Versions</h4>
+ *
  * Readers may change schemas from time to time. To track such changes,
  * this implementation tracks a batch schema version, maintained by comparing
  * one schema with the next.
@@ -80,23 +81,94 @@ import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTes
  * each increasing its internal version number as work proceeds. But, at the
  * end of each batch, the schemas may (and, in fact, should) be identical,
  * which is the schema version downstream operators care about.
+ *
+ * <h4>Empty Files and/or Empty Schemas</h4>
+ *
+ * A corner case occurs if the input is empty, such as a CSV file
+ * that contains no data. The general rule is the following:
+ *
+ * <ul>
+ * <li>If the reader is "early schema" (the schema is defined at
+ * open time), then the result will be a single empty batch with
+ * the schema defined. Example: a CSV file without headers; in this case,
+ * we know the schema is always the single `columns` array.</li>
+ * <li>If the reader is "late schema" (the schema is defined while the
+ * data is read), then no batch is returned because there is no schema.
+ * Example: a JSON file. It is not helpful to return a single batch
+ * with no columns; such a batch will simply conflict with some other
+ * non-empty-schema batch. It turns out that other DBs handle this
+ * case gracefully: a query of the form<br><pre><tt>
+ * SELECT * FROM VALUES()</tt></pre><br>
+ * Will produce an empty result: no schema, no data.</li>
+ * <li>The hybrid case: the reader could provide an early schema,
+ * but cannot do so. That is, the early schema contains no columns.
+ * We treat this case identically to the late schema case. Example: a
+ * CSV file with headers in which the header line is empty.</li>
+ * </ul>
  */
 
 public class ScanOperatorExec implements OperatorExec {
 
-  private enum State { START, READER, END, FAILED, CLOSED }
+  private enum State {
+
+    /**
+     * The scan has been started, but next() has not yet been
+     * called.
+     */
+
+    START,
+
+    /**
+     * A reader is active and has more batches to deliver.
+     */
+
+    READER,
+
+    /**
+     * All readers are completed, non returned any data, but
+     * the final reader did provide a schema. An empty batch
+     * was returned from next(). The next call to next() will
+     * be the last.
+     */
+
+    EMPTY,
+
+    /**
+     * All readers are complete; no more batches to deliver.
+     * close() is not yet called.
+     */
+
+    END,
+
+    /**
+     * A fatal error occurred during the START or READER
+     * states. No further calls to next() allowed. Waiting
+     * for the call to close().
+     */
+
+    FAILED,
+
+    /**
+     * Scan operator is closed. All resources and state are
+     * released. No further calls of any kind are allowed.
+     */
+    CLOSED
+  }
 
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ScanOperatorExec.class);
 
   private final ScanOperatorEvents factory;
+  private final boolean allowEmptyResult;
   protected final VectorContainerAccessor containerAccessor = new VectorContainerAccessor();
   private State state = State.START;
   protected OperatorContext context;
   private int readerCount;
   private ReaderState readerState;
 
-  public ScanOperatorExec(ScanOperatorEvents factory) {
+  public ScanOperatorExec(ScanOperatorEvents factory,
+      boolean allowEmptyResult) {
     this.factory = factory;
+    this.allowEmptyResult = allowEmptyResult;
   }
 
   @Override
@@ -151,6 +223,7 @@ public class ScanOperatorExec implements OperatorExec {
       switch (state) {
 
       case READER:
+      case START: // Occurs if no schema batch
         // Read another batch from the list of row readers. Keeps opening,
         // reading from, and closing readers as needed to locate a batch, or
         // until all readers are exhausted. Terminates when a batch is read,
@@ -158,6 +231,10 @@ public class ScanOperatorExec implements OperatorExec {
 
         nextAction(false);
         return state != State.END;
+
+      case EMPTY:
+        state = State.END;
+        return false;
 
       case END:
         return false;
@@ -171,14 +248,14 @@ public class ScanOperatorExec implements OperatorExec {
     }
   }
 
-  private void nextAction(boolean schema) {
+  private void nextAction(boolean readSchema) {
     for (;;) {
 
       // If have a reader, read a batch
 
       if (readerState != null) {
         boolean hasData;
-        if (schema) {
+        if (readSchema) {
           hasData = readerState.buildSchema();
         } else {
           hasData = readerState.next();
@@ -192,7 +269,7 @@ public class ScanOperatorExec implements OperatorExec {
       // Another reader available?
 
       if (! nextReader()) {
-        state = State.END;
+        finalizeResults();
         return;
       }
       state = State.READER;
@@ -202,6 +279,25 @@ public class ScanOperatorExec implements OperatorExec {
       if (! readerState.open()) {
         closeReader();
       }
+    }
+  }
+
+  /**
+   * The last reader is done. Check for the special case that no reader
+   * returned any rows, but some reader provided a schema. In this case,
+   * we can return an empty result set with a schema. Otherwise, we have
+   * to return a null result set: no schema, no data. For the Volcano
+   * iterator protocol, this means no return of OK_NEW_SCHEMA, just
+   * an immediate return of NONE.
+   */
+
+  private void finalizeResults() {
+    if (allowEmptyResult &&
+        containerAccessor.batchCount() == 0 &&
+        containerAccessor.schemaVersion() > 0) {
+      state = State.EMPTY;
+    } else {
+      state = State.END;
     }
   }
 
@@ -218,7 +314,6 @@ public class ScanOperatorExec implements OperatorExec {
 
     final RowBatchReader reader = factory.nextReader();
     if (reader == null) {
-      containerAccessor.setContainer(null);
       return false;
     }
     readerCount++;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsScanFramework.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.columns;
 
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorEvents;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiatorImpl;
 
@@ -43,7 +44,7 @@ public class ColumnsScanFramework extends FileScanFramework {
     }
 
     @Override
-    public FileScanFramework buildFileFramework() {
+    public ScanOperatorEvents buildEvents() {
       return new ColumnsScanFramework(this);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/file/FileScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/file/FileScanFramework.java
@@ -26,6 +26,7 @@ import org.apache.drill.common.exceptions.ChildErrorContext;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserException.Builder;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorEvents;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
@@ -156,7 +157,8 @@ public class FileScanFramework extends ManagedScanFramework {
 
     public FileMetadataOptions metadataOptions() { return metadataOptions; }
 
-    public FileScanFramework buildFileFramework() {
+    @Override
+    public ScanOperatorEvents buildEvents() {
       return new FileScanFramework(this);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/ManagedScanFramework.java
@@ -146,6 +146,11 @@ public class ManagedScanFramework implements ScanOperatorEvents {
     public void setUserName(String userName) {
       this.userName = userName;
     }
+
+    @Override
+    public ScanOperatorEvents buildEvents() {
+      return new ManagedScanFramework(this);
+    }
   }
 
   // Inputs

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/SchemaSmoother.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/SchemaSmoother.java
@@ -87,8 +87,7 @@ public class SchemaSmoother {
   }
 
   public ReaderLevelProjection resolve(
-      TupleMetadata tableSchema,
-      ResolvedTuple outputTuple) {
+      TupleMetadata tableSchema, ResolvedTuple outputTuple) {
 
     // If a prior schema exists, try resolving the new table using the
     // prior schema. If this works, use the projection. Else, start

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -41,11 +41,11 @@ public class VectorContainer implements VectorAccessible {
   private final BufferAllocator allocator;
   protected final List<VectorWrapper<?>> wrappers = Lists.newArrayList();
   private BatchSchema schema;
-
-  private int recordCount = 0;
-  private boolean initialized = false;
+  private int recordCount;
+  private boolean initialized;
   // private BufferAllocator allocator;
-  private boolean schemaChanged = true; // Schema has changed since last built. Must rebuild schema
+  // Schema has changed since last built. Must rebuild schema
+  private boolean schemaChanged = true;
 
   public VectorContainer() {
     allocator = null;
@@ -93,8 +93,18 @@ public class VectorContainer implements VectorAccessible {
 
   public BufferAllocator getAllocator() { return allocator; }
 
-  public boolean isSchemaChanged() {
-    return schemaChanged;
+  public boolean isSchemaChanged() { return schemaChanged; }
+
+  /**
+   * Indicate the schema changed. Normally set by mutating this container.
+   * If schemas are built externally, call this if the schema contained
+   * here is different than the one provided in a previous batch. (Some
+   * operators don't trust OK_NEW_SCHEMA, and use the schema changed
+   * flag for the "real" truth.
+   */
+
+  public void schemaChanged() {
+    schemaChanged = true;
   }
 
   public void addHyperList(List<ValueVector> vectors) {
@@ -237,7 +247,7 @@ public class VectorContainer implements VectorAccessible {
     }
 
   public TypedFieldId add(ValueVector vv) {
-    schemaChanged = true;
+    schemaChanged();
     schema = null;
     int i = wrappers.size();
     wrappers.add(SimpleVectorWrapper.create(vv));
@@ -255,7 +265,7 @@ public class VectorContainer implements VectorAccessible {
 
   public void add(ValueVector[] hyperVector, boolean releasable) {
     assert hyperVector.length != 0;
-    schemaChanged = true;
+    schemaChanged();
     schema = null;
     Class<?> clazz = hyperVector[0].getClass();
     ValueVector[] c = (ValueVector[]) Array.newInstance(clazz, hyperVector.length);
@@ -266,7 +276,7 @@ public class VectorContainer implements VectorAccessible {
 
   public void remove(ValueVector v) {
     schema = null;
-    schemaChanged = true;
+    schemaChanged();
     for (Iterator<VectorWrapper<?>> iter = wrappers.iterator(); iter.hasNext();) {
       VectorWrapper<?> w = iter.next();
       if (!w.isHyper() && v == w.getValueVector()) {
@@ -280,7 +290,7 @@ public class VectorContainer implements VectorAccessible {
 
   private void replace(ValueVector old, ValueVector newVector) {
     schema = null;
-    schemaChanged = true;
+    schemaChanged();
     int i = 0;
     for (VectorWrapper<?> w : wrappers){
       if (!w.isHyper() && old == w.getValueVector()) {
@@ -355,8 +365,8 @@ public class VectorContainer implements VectorAccessible {
     for (VectorWrapper<?> v : wrappers) {
       bldr.addField(v.getField());
     }
-    this.schema = bldr.build();
-    this.schemaChanged = false;
+    schema = bldr.build();
+    schemaChanged = false;
   }
 
   @Override
@@ -500,7 +510,7 @@ public class VectorContainer implements VectorAccessible {
     String separator = "";
     sb.append("[");
 
-    for (VectorWrapper vectorWrapper: wrappers) {
+    for (VectorWrapper<?> vectorWrapper: wrappers) {
       sb.append(separator);
       separator = ", ";
       final String columnName = vectorWrapper.getField().getName();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -39,9 +39,6 @@ import org.apache.drill.exec.physical.base.ScanStats.GroupScanProperty;
 import org.apache.drill.exec.physical.impl.ScanBatch;
 import org.apache.drill.exec.physical.impl.StatisticsWriterRecordBatch;
 import org.apache.drill.exec.physical.impl.WriterRecordBatch;
-import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
-import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
-import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
@@ -348,47 +345,15 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
 
   private CloseableRecordBatch buildScan(FragmentContext context, EasySubScan scan) throws ExecutionSetupException {
 
-    // Assemble the scan operator and its wrapper.
-
     try {
       final FileScanBuilder builder = frameworkBuilder(context.getOptions(), scan);
-      builder.setProjection(scan.getColumns());
-      builder.setFiles(scan.getWorkUnits());
-      builder.setConfig(easyConfig().fsConf);
-      builder.setUserName(scan.getUserName());
-
-      // Pass along the output schema, if any
-
-      builder.typeConverterBuilder().providedSchema(scan.getSchema());
-      final Path selectionRoot = scan.getSelectionRoot();
-      if (selectionRoot != null) {
-        builder.metadataOptions().setSelectionRoot(selectionRoot);
-        builder.metadataOptions().setPartitionDepth(scan.getPartitionDepth());
-      }
 
       // Add batch reader, if none specified
 
       if (builder.readerFactory() == null) {
         builder.setReaderFactory(new EasyReaderFactory(this, scan, context));
       }
-
-      // Add error context, if none is specified
-
-      if (builder.errorContext() == null) {
-        builder.setContext(
-            new CustomErrorContext() {
-              @Override
-              public void addContext(UserException.Builder builder) {
-                builder.addContext("Format plugin:",
-                    EasyFormatPlugin.this.getClass().getSimpleName());
-                builder.addContext("Plugin config name:", getName());
-              }
-            });
-      }
-
-      FileScanFramework framework = builder.buildFileFramework();
-      return new OperatorRecordBatch(context, scan,
-          new ScanOperatorExec(framework));
+      return builder.buildScanOperator(context, scan);
     } catch (final UserException e) {
       // Rethrow user exceptions directly
       throw e;
@@ -396,6 +361,45 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
       // Wrap all others
       throw new ExecutionSetupException(e);
     }
+  }
+
+  /**
+   * Initialize the scan framework builder with standard options.
+   * Call this from the plugin-specific
+   * {@link #frameworkBuilder(OptionManager, EasySubScan)} method.
+   * The plugin can then customize/revise options as needed.
+   *
+   * @param builder the scan framework builder you create in the
+   * {@link #frameworkBuilder()} method
+   * @param scan the physical scan operator definition passed to
+   * the {@link #frameworkBuilder()} method
+   */
+
+  protected void initScanBuilder(FileScanBuilder builder, EasySubScan scan) {
+    builder.setProjection(scan.getColumns());
+    builder.setFiles(scan.getWorkUnits());
+    builder.setConfig(easyConfig().fsConf);
+    builder.setUserName(scan.getUserName());
+
+    // Pass along the output schema, if any
+
+    builder.typeConverterBuilder().providedSchema(scan.getSchema());
+    final Path selectionRoot = scan.getSelectionRoot();
+    if (selectionRoot != null) {
+      builder.metadataOptions().setSelectionRoot(selectionRoot);
+      builder.metadataOptions().setPartitionDepth(scan.getPartitionDepth());
+    }
+
+    builder.setContext(
+        new CustomErrorContext() {
+          @Override
+          public void addContext(UserException.Builder builder) {
+            builder.addContext("Format plugin:", easyConfig.defaultName);
+            builder.addContext("Format plugin:",
+                EasyFormatPlugin.this.getClass().getSimpleName());
+            builder.addContext("Plugin config name:", getName());
+          }
+        });
   }
 
   public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.ChildErrorContext;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -264,6 +264,7 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
   protected FileScanBuilder frameworkBuilder(
       OptionManager options, EasySubScan scan) throws ExecutionSetupException {
     ColumnsScanBuilder builder = new ColumnsScanBuilder();
+    initScanBuilder(builder, scan);
     TextParsingSettings settings =
         new TextParsingSettings(getConfig(), scan, options);
     builder.setReaderFactory(new ColumnsReaderFactory(settings));
@@ -293,12 +294,12 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
     builder.allowRequiredNullColumns(true);
 
     // Provide custom error context
+
     builder.setContext(
-        new CustomErrorContext() {
+        new ChildErrorContext(builder.errorContext()) {
           @Override
           public void addContext(UserException.Builder builder) {
-            builder.addContext("Format plugin:", PLUGIN_NAME);
-            builder.addContext("Plugin config name:", getName());
+            super.addContext(builder);
             builder.addContext("Extract headers:",
                 Boolean.toString(getConfig().isHeaderExtractionEnabled()));
             builder.addContext("Skip first line:",

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/CompliantTextBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/CompliantTextBatchReader.java
@@ -230,7 +230,7 @@ public class CompliantTextBatchReader implements ManagedReader<ColumnsSchemaNego
       // Return false on the batch that hits EOF. The scan operator
       // knows to process any rows in this final batch.
 
-      return more && writer.rowCount() > 0;
+      return more;
     } catch (IOException | TextParsingException e) {
       if (e.getCause() != null  && e.getCause() instanceof UserException) {
         throw (UserException) e.getCause();

--- a/exec/java-exec/src/test/java/org/apache/drill/TestSchemaWithTableFunction.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestSchemaWithTableFunction.java
@@ -23,7 +23,6 @@ import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,12 +50,6 @@ public class TestSchemaWithTableFunction extends ClusterTest {
     dirTestWatcher.copyResourceToRoot(Paths.get(DATA_PATH));
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
     startCluster(builder);
-    client.alterSession(ExecConstants.ENABLE_V3_TEXT_READER_KEY, true);
-  }
-
-  @AfterClass
-  public static void cleanUp() {
-    client.resetSession(ExecConstants.ENABLE_V3_TEXT_READER_KEY);
   }
 
   @Test
@@ -72,7 +65,7 @@ public class TestSchemaWithTableFunction extends ClusterTest {
       .go();
 
     String plan = queryBuilder().sql(query, table).explainText();
-    assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`Year` (INT(0, 0):OPTIONAL)]]]"));
+    assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`Year` (INT:OPTIONAL)]]]"));
   }
 
   @Test
@@ -160,7 +153,7 @@ public class TestSchemaWithTableFunction extends ClusterTest {
         .go();
 
       String plan = queryBuilder().sql(query, table).explainText();
-      assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`id` (INT(0, 0):OPTIONAL)]]]"));
+      assertTrue(plan.contains("schema=[TupleSchema [PrimitiveColumnMetadata [`id` (INT:OPTIONAL)]]]"));
     } finally {
       client.resetSession(ExecConstants.OUTPUT_FORMAT_OPTION);
       run("drop table if exists %s", table);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestEmptyInputSql.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestEmptyInputSql.java
@@ -49,8 +49,9 @@ public class TestEmptyInputSql extends BaseTestQuery {
   }
 
   /**
-   * Test with query against an empty file. Select clause has regular column reference, and an expression.
-   *
+   * Test with query against an empty file. Select clause has regular column
+   * reference, and an expression.
+   * <p>
    * regular column "key" is assigned with nullable-int
    * expression "key + 100" is materialized with nullable-int as output type.
    */
@@ -112,7 +113,6 @@ public class TestEmptyInputSql extends BaseTestQuery {
         .schemaBaseLine(expectedSchema)
         .build()
         .run();
-
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/protocol/TestOperatorRecordBatch.java
@@ -88,7 +88,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
 
     public MockOperatorExec(VectorContainer container) {
       batchAccessor = new VectorContainerAccessor();
-      batchAccessor.setContainer(container);
+      batchAccessor.addBatch(container);
     }
 
     public MockOperatorExec(VectorContainerAccessor accessor) {
@@ -120,7 +120,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
         newSchema.schemaBuilder()
             .add("b", MinorType.VARCHAR);
         VectorContainer newContainer = new VectorContainer(fixture.allocator(), newSchema.build());
-        batchAccessor.setContainer(newContainer);
+        batchAccessor.addBatch(newContainer);
       }
       return true;
     }
@@ -148,7 +148,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
   private OperatorRecordBatch makeOpBatch(MockOperatorExec opExec) {
     // Dummy operator definition
     PhysicalOperator popConfig = new Limit(null, 0, 100);
-    return new OperatorRecordBatch(fixture.getFragmentContext(), popConfig, opExec);
+    return new OperatorRecordBatch(fixture.getFragmentContext(), popConfig, opExec, true);
   }
 
   /**
@@ -444,7 +444,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
     // Changing data does not trigger schema change
 
     container.zeroVectors();
-    opExec.batchAccessor.setContainer(container);
+    opExec.batchAccessor.addBatch(container);
     assertEquals(schemaVersion, opExec.batchAccessor().schemaVersion());
 
     // Different container, same vectors, does not trigger a change
@@ -454,10 +454,10 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
       c2.add(vw.getValueVector());
     }
     c2.buildSchema(SelectionVectorMode.NONE);
-    opExec.batchAccessor.setContainer(c2);
+    opExec.batchAccessor.addBatch(c2);
     assertEquals(schemaVersion, opExec.batchAccessor().schemaVersion());
 
-    opExec.batchAccessor.setContainer(container);
+    opExec.batchAccessor.addBatch(container);
     assertEquals(schemaVersion, opExec.batchAccessor().schemaVersion());
 
     // Replacing a vector with another of the same type does trigger
@@ -469,13 +469,13 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
             container.getValueVector(1).getValueVector().getField(),
             fixture.allocator(), null));
     c3.buildSchema(SelectionVectorMode.NONE);
-    opExec.batchAccessor.setContainer(c3);
+    opExec.batchAccessor.addBatch(c3);
     assertEquals(schemaVersion + 1, opExec.batchAccessor().schemaVersion());
     schemaVersion = opExec.batchAccessor().schemaVersion();
 
     // No change if same schema again
 
-    opExec.batchAccessor.setContainer(c3);
+    opExec.batchAccessor.addBatch(c3);
     assertEquals(schemaVersion, opExec.batchAccessor().schemaVersion());
 
     // Adding a vector triggers a change
@@ -483,13 +483,13 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
     MaterializedField c = SchemaBuilder.columnSchema("c", MinorType.INT, DataMode.OPTIONAL);
     c3.add(TypeHelper.getNewVector(c, fixture.allocator(), null));
     c3.buildSchema(SelectionVectorMode.NONE);
-    opExec.batchAccessor.setContainer(c3);
+    opExec.batchAccessor.addBatch(c3);
     assertEquals(schemaVersion + 1, opExec.batchAccessor().schemaVersion());
     schemaVersion = opExec.batchAccessor().schemaVersion();
 
     // No change if same schema again
 
-    opExec.batchAccessor.setContainer(c3);
+    opExec.batchAccessor.addBatch(c3);
     assertEquals(schemaVersion, opExec.batchAccessor().schemaVersion());
 
     // Removing a vector triggers a change
@@ -497,7 +497,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
     c3.remove(c3.getValueVector(2).getValueVector());
     c3.buildSchema(SelectionVectorMode.NONE);
     assertEquals(2, c3.getNumberOfColumns());
-    opExec.batchAccessor.setContainer(c3);
+    opExec.batchAccessor.addBatch(c3);
     assertEquals(schemaVersion + 1, opExec.batchAccessor().schemaVersion());
     schemaVersion = opExec.batchAccessor().schemaVersion();
 
@@ -525,7 +525,7 @@ public class TestOperatorRecordBatch extends SubOperatorTest {
         .build();
 
     ContainerAndSv2Accessor accessor = new ContainerAndSv2Accessor();
-    accessor.setContainer(rs.container());
+    accessor.addBatch(rs.container());
     accessor.setSelectionVector(rs.getSv2());
 
     MockOperatorExec opExec = new MockOperatorExec(accessor);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/BaseScanOperatorExecTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/BaseScanOperatorExecTest.java
@@ -21,12 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
-import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixtureBuilder;
 import org.apache.drill.exec.physical.impl.scan.framework.BasicScanFactory;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
 import org.apache.drill.exec.physical.rowSet.RowSetLoader;
@@ -122,16 +121,19 @@ public class BaseScanOperatorExecTest extends SubOperatorTest {
     }
   }
 
+  protected TupleMetadata expectedSchema() {
+    return new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("b", MinorType.VARCHAR, 10)
+        .buildSchema();
+  }
+
   protected SingleRowSet makeExpected() {
     return makeExpected(0);
   }
 
   protected SingleRowSet makeExpected(int offset) {
-    TupleMetadata expectedSchema = new SchemaBuilder()
-        .add("a", MinorType.INT)
-        .addNullable("b", MinorType.VARCHAR, 10)
-        .buildSchema();
-    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema())
         .addRow(offset + 10, "fred")
         .addRow(offset + 20, "wilma")
         .build();
@@ -160,20 +162,24 @@ public class BaseScanOperatorExecTest extends SubOperatorTest {
     }
 
     @Override
-    protected ManagedScanFramework newFramework() {
+    public ScanFixture build() {
       builder.setReaderFactory(new BasicScanFactory(readers.iterator()));
-      return new ManagedScanFramework(builder);
+      return super.build();
     }
   }
 
   @SafeVarargs
-  public static ScanFixture simpleFixture(ManagedReader<? extends SchemaNegotiator>...readers) {
+  public static BaseScanFixtureBuilder simpleBuilder(ManagedReader<? extends SchemaNegotiator>...readers) {
     BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder();
     builder.projectAll();
     for (ManagedReader<? extends SchemaNegotiator> reader : readers) {
       builder.addReader(reader);
     }
-    return builder.build();
+    return builder;
   }
 
+  @SafeVarargs
+  public static ScanFixture simpleFixture(ManagedReader<? extends SchemaNegotiator>...readers) {
+    return simpleBuilder(readers).build();
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArray.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArray.java
@@ -25,7 +25,9 @@ import java.util.List;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.MockScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.columns.ColumnsArrayManager;
+import org.apache.drill.exec.physical.impl.scan.columns.ColumnsScanFramework.ColumnsScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
 import org.apache.drill.exec.physical.impl.scan.project.ReaderSchemaOrchestrator;
@@ -82,7 +84,7 @@ public class TestColumnsArray extends SubOperatorTest {
 
     // Configure the schema orchestrator
 
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.withMetadata(metadataManager);
     builder.addParser(colsManager.projectionParser());
     builder.addResolver(colsManager.resolver());
@@ -259,7 +261,7 @@ public class TestColumnsArray extends SubOperatorTest {
 
     // Configure the schema orchestrator
 
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new ColumnsScanBuilder();
     builder.addParser(colsManager.projectionParser());
     builder.addResolver(colsManager.resolver());
     builder.setProjection(cols);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayFramework.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestColumnsArrayFramework.java
@@ -34,13 +34,11 @@ import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixtureBuilder;
 import org.apache.drill.exec.physical.impl.scan.TestFileScanFramework.DummyFileWork;
 import org.apache.drill.exec.physical.impl.scan.columns.ColumnsArrayManager;
-import org.apache.drill.exec.physical.impl.scan.columns.ColumnsScanFramework;
 import org.apache.drill.exec.physical.impl.scan.columns.ColumnsScanFramework.ColumnsScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.columns.ColumnsSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
 import org.apache.drill.exec.physical.rowSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -95,7 +93,7 @@ public class TestColumnsArrayFramework extends SubOperatorTest {
     }
 
     @Override
-    protected ManagedScanFramework newFramework() {
+    public ScanFixture build() {
 
       // Bass-ackward construction of the list of files from
       // a set of text fixture readers. Normal implementations
@@ -109,7 +107,7 @@ public class TestColumnsArrayFramework extends SubOperatorTest {
       builder.setConfig(new Configuration());
       builder.setFiles(blocks);
       builder.setReaderFactory(new MockFileReaderFactory(readers));
-      return new ColumnsScanFramework(builder);
+      return super.build();
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileScanFramework.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestFileScanFramework.java
@@ -30,12 +30,10 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixtureBuilder;
-import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
 import org.apache.drill.exec.physical.rowSet.ResultSetLoader;
 import org.apache.drill.exec.physical.rowSet.RowSetLoader;
@@ -141,7 +139,7 @@ public class TestFileScanFramework extends SubOperatorTest {
     }
 
     @Override
-    protected ManagedScanFramework newFramework() {
+    public ScanFixture build() {
 
       // Bass-ackward construction of the list of files from
       // a set of text fixture readers. Normal implementations
@@ -155,7 +153,7 @@ public class TestFileScanFramework extends SubOperatorTest {
       builder.setConfig(new Configuration());
       builder.setFiles(blocks);
       builder.setReaderFactory(new MockFileReaderFactory(readers));
-      return new FileScanFramework(builder);
+      return super.build();
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecBasics.java
@@ -28,6 +28,7 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.record.VectorContainer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -373,6 +374,9 @@ public class TestScanOperExecBasics extends BaseScanOperatorExecTest {
 
   /**
    * Test multiple readers, all EOF on first batch.
+   * The scan will return one empty batch to declare the
+   * early schema. Results in an empty (rather than null)
+   * result set.
    */
 
   @Test
@@ -388,10 +392,15 @@ public class TestScanOperExecBasics extends BaseScanOperatorExecTest {
     // EOF
 
     assertTrue(scan.buildSchema());
-    assertFalse(scan.next());
+    assertTrue(scan.next());
+    VectorContainer container = scan.batchAccessor().getOutgoingContainer();
+    assertEquals(0, container.getRecordCount());
+    assertEquals(2, container.getNumberOfColumns());
+
     assertTrue(reader1.closeCalled);
     assertTrue(reader2.closeCalled);
     assertEquals(0, scan.batchAccessor().getRowCount());
+    assertFalse(scan.next());
 
     scanFixture.close();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecSmoothing.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOperExecSmoothing.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.BaseScanOperatorExecTest.BaseScanFixtureBuilder;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
 import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
 import org.apache.drill.exec.physical.rowSet.RowSetLoader;
@@ -124,6 +125,26 @@ public class TestScanOperExecSmoothing extends BaseScanOperatorExecTest {
     assertTrue(scan.buildSchema());
     assertEquals(1, scan.batchAccessor().schemaVersion());
     scan.batchAccessor().release();
+
+    readSchemaChangeBatches(scanFixture, reader2);
+  }
+
+  @Test
+  public void testSchemaChangeNoSchemaBatch() {
+    MockEarlySchemaReader reader1 = new MockEarlySchemaReader();
+    reader1.batchLimit = 2;
+    MockEarlySchemaReader reader2 = new MockEarlySchemaReader2();
+    reader2.batchLimit = 2;
+
+    BaseScanFixtureBuilder builder = simpleBuilder(reader1, reader2);
+    builder.enableSchemaBatch = false;
+    ScanFixture scanFixture = builder.build();
+
+    readSchemaChangeBatches(scanFixture, reader2);
+  }
+
+  private void readSchemaChangeBatches(ScanFixture scanFixture, MockEarlySchemaReader reader2) {
+    ScanOperatorExec scan = scanFixture.scanOp;
 
     // First batch
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorEarlySchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorEarlySchema.java
@@ -27,6 +27,7 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.protocol.SchemaTracker;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.MockScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.project.ReaderSchemaOrchestrator;
 import org.apache.drill.exec.physical.impl.scan.project.ScanSchemaOrchestrator;
 import org.apache.drill.exec.physical.impl.scan.project.ScanSchemaOrchestrator.ScanOrchestratorBuilder;
@@ -62,7 +63,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaWildcard() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT * ...
 
@@ -153,7 +154,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectAll() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT a, b ...
 
@@ -205,7 +206,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectAllReorder() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT b, a ...
 
@@ -260,7 +261,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectExtra() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT a, b, c ...
 
@@ -316,7 +317,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectExtraCustomType() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // Null columns of type VARCHAR
 
@@ -379,7 +380,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectSubset() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT a ...
 
@@ -437,7 +438,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEarlySchemaSelectNone() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT ...
     // (Like SELECT COUNT(*) ...
@@ -519,7 +520,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEmptySchema() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT * ...
 
@@ -566,7 +567,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testEmptySchemaExtra() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT * ...
 
@@ -623,7 +624,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testTypeSmoothingExplicit() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     TupleMetadata table1Schema = new SchemaBuilder()
         .add("A", MinorType.BIGINT)
         .addNullable("B", MinorType.VARCHAR)
@@ -736,7 +737,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testTypeSmoothing() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT a, b ...
 
@@ -838,7 +839,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
 
   @Test
   public void testModeSmoothing() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.enableSchemaSmoothing(true);
     builder.setProjection(RowSetTestUtils.projectList("a"));
     ScanSchemaOrchestrator scanner = new ScanSchemaOrchestrator(fixture.allocator(), builder);
@@ -959,7 +960,7 @@ public class TestScanOrchestratorEarlySchema extends SubOperatorTest {
   @Test
   public void testColumnReordering() {
 
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.enableSchemaSmoothing(true);
     builder.setProjection(RowSetTestUtils.projectList("a", "b", "c"));
     ScanSchemaOrchestrator scanner = new ScanSchemaOrchestrator(fixture.allocator(), builder);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorLateSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorLateSchema.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.MockScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.project.ReaderSchemaOrchestrator;
 import org.apache.drill.exec.physical.impl.scan.project.ScanSchemaOrchestrator;
 import org.apache.drill.exec.physical.impl.scan.project.ScanSchemaOrchestrator.ScanOrchestratorBuilder;
@@ -55,7 +56,7 @@ public class TestScanOrchestratorLateSchema extends SubOperatorTest {
 
   @Test
   public void testLateSchemaWildcard() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT * ...
 
@@ -111,7 +112,7 @@ public class TestScanOrchestratorLateSchema extends SubOperatorTest {
 
   @Test
   public void testLateSchemaSelectDisjoint() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
 
     // SELECT a, c ...
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorMetadata.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanOrchestratorMetadata.java
@@ -28,6 +28,7 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.protocol.SchemaTracker;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.MockScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
 import org.apache.drill.exec.physical.impl.scan.project.ReaderSchemaOrchestrator;
@@ -76,7 +77,7 @@ public class TestScanOrchestratorMetadata extends SubOperatorTest {
         fixture.getOptionManager(),
         standardOptions(filePath));
 
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.withMetadata(metadataManager);
 
     // SELECT *, filename, suffix ...
@@ -135,7 +136,7 @@ public class TestScanOrchestratorMetadata extends SubOperatorTest {
 
   @Test
   public void testSelectNone() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     Path filePath = new Path("hdfs:///w/x/y/z.csv");
     FileMetadataManager metadataManager = new FileMetadataManager(
         fixture.getOptionManager(),
@@ -203,7 +204,7 @@ public class TestScanOrchestratorMetadata extends SubOperatorTest {
         .setMode(DataMode.OPTIONAL)
         .build();
 
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.setNullType(nullType);
     Path filePath = new Path("hdfs:///w/x/y/z.csv");
     FileMetadataManager metadataManager = new FileMetadataManager(
@@ -280,7 +281,7 @@ public class TestScanOrchestratorMetadata extends SubOperatorTest {
 
   @Test
   public void testMixture() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     Path filePath = new Path("hdfs:///w/x/y/z.csv");
     FileMetadataManager metadataManager = new FileMetadataManager(
         fixture.getOptionManager(),
@@ -344,7 +345,7 @@ public class TestScanOrchestratorMetadata extends SubOperatorTest {
 
   @Test
   public void testMetadataMulti() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     Path filePathA = new Path("hdfs:///w/x/y/a.csv");
     Path filePathB = new Path("hdfs:///w/x/b.csv");
     FileMetadataManager metadataManager = new FileMetadataManager(

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestSchemaSmoothing.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestSchemaSmoothing.java
@@ -28,6 +28,7 @@ import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.protocol.SchemaTracker;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.MockScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataColumn;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager;
 import org.apache.drill.exec.physical.impl.scan.file.FileMetadataManager.FileMetadataOptions;
@@ -816,7 +817,7 @@ public class TestSchemaSmoothing extends SubOperatorTest {
 
   @Test
   public void testWildcardSmoothing() {
-    ScanOrchestratorBuilder builder = new ScanOrchestratorBuilder();
+    ScanOrchestratorBuilder builder = new MockScanBuilder();
     builder.enableSchemaSmoothing(true);
     builder.setProjection(RowSetTestUtils.projectAll());
     final ScanSchemaOrchestrator projector = new ScanSchemaOrchestrator(fixture.allocator(), builder);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/BaseCsvTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/BaseCsvTest.java
@@ -35,6 +35,17 @@ public class BaseCsvTest extends ClusterTest {
   protected static final String NESTED_DIR = "nested";
   protected static final String ROOT_FILE = "first.csv";
   protected static final String NESTED_FILE = "second.csv";
+  protected static final String EMPTY_FILE = "empty.csv";
+
+  /**
+   * The scan operator can return an empty schema batch as
+   * the first batch. But, this broke multiple operators that
+   * do not handle this case. So, it is turned off for now.
+   * Tests that verified the empty batch use this flag to
+   * disable that checking.
+   */
+
+  protected static boolean SCHEMA_BATCH_ENABLED = false;
 
   protected static String validHeaders[] = {
       "a,b,c",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvHeader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvHeader.java
@@ -17,19 +17,21 @@
  */
 package org.apache.drill.exec.store.easy.text.compliant;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.drill.test.TestBuilder;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.test.TestBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(RowSetTests.class)
 public class TestCsvHeader extends BaseTestQuery{
 
   private static final String ROOT = "store/text/data/cars.csvh";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
@@ -288,7 +288,7 @@ public class TestCsvWithSchema extends BaseCsvTest {
             sawSchema = true;
           }
         }
-        assertTrue(sawSchema);
+        assertTrue(!SCHEMA_BATCH_ENABLED || sawSchema);
         assertTrue(sawFile1);
         assertTrue(sawFile2);
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestPartitionRace.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestPartitionRace.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -35,6 +36,7 @@ import org.apache.drill.test.rowSet.RowSetReader;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Demonstrates a race condition inherent in the way that partition
@@ -52,6 +54,7 @@ import org.junit.Test;
  * current "V3" version. The tests here verify this behavior.
  */
 
+@Category(RowSetTests.class)
 public class TestPartitionRace extends BaseCsvTest {
 
   @BeforeClass
@@ -84,15 +87,16 @@ public class TestPartitionRace extends BaseCsvTest {
         .addNullable("dir0", MinorType.VARCHAR)
         .buildSchema();
 
-    // Loop to run the query 10 times to verify no race
-
-    // First batch is empty; just carries the schema.
-
     Iterator<DirectRowSet> iter = client.queryBuilder().sql(sql, PART_DIR).rowSetIterator();
-    assertTrue(iter.hasNext());
-    RowSet rowSet = iter.next();
-    assertEquals(0, rowSet.rowCount());
-    rowSet.clear();
+    RowSet rowSet;
+    if (SCHEMA_BATCH_ENABLED) {
+      // First batch is empty; just carries the schema.
+
+      assertTrue(iter.hasNext());
+      rowSet = iter.next();
+      assertEquals(0, rowSet.rowCount());
+      rowSet.clear();
+    }
 
     // Read the two batches.
 
@@ -147,13 +151,16 @@ public class TestPartitionRace extends BaseCsvTest {
       boolean sawNestedFirst = false;
       for (int i = 0; i < 10; i++) {
 
-        // First batch is empty; just carries the schema.
-
         Iterator<DirectRowSet> iter = client.queryBuilder().sql(sql, PART_DIR).rowSetIterator();
-        assertTrue(iter.hasNext());
-        RowSet rowSet = iter.next();
-        assertEquals(0, rowSet.rowCount());
-        rowSet.clear();
+        RowSet rowSet;
+        if (SCHEMA_BATCH_ENABLED) {
+          // First batch is empty; just carries the schema.
+
+          assertTrue(iter.hasNext());
+          rowSet = iter.next();
+          assertEquals(0, rowSet.rowCount());
+          rowSet.clear();
+        }
 
         // Read the two batches.
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/log/TestLogReader.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -40,10 +39,7 @@ import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-// Log reader now hosted on the row set framework
-@Category(RowSetTests.class)
 public class TestLogReader extends ClusterTest {
 
   public static final String DATE_ONLY_PATTERN = "(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d) .*";

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.drill.PlanTestBase;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -52,13 +53,12 @@ import org.apache.drill.exec.util.VectorUtil;
 import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.accessor.ScalarReader;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.test.BufferingQueryEventListener.QueryEvent;
 import org.apache.drill.test.ClientFixture.StatementParser;
 import org.apache.drill.test.rowSet.DirectRowSet;
 import org.apache.drill.test.rowSet.RowSet;
 import org.apache.drill.test.rowSet.RowSetReader;
-
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.joda.time.Period;
 
 /**
@@ -355,11 +355,17 @@ public class QueryBuilder {
   public DirectRowSet rowSet() throws RpcException {
 
     // Ignore all but the first non-empty batch.
+    // Always return the last batch, which may be empty.
 
-    QueryDataBatch dataBatch = null;
+    QueryDataBatch resultBatch = null;
     for (QueryDataBatch batch : results()) {
-      if (dataBatch == null  &&  batch.getHeader().getRowCount() != 0) {
-        dataBatch = batch;
+      if (resultBatch == null) {
+        resultBatch = batch;
+      } else if (resultBatch.getHeader().getRowCount() == 0) {
+        resultBatch.release();
+        resultBatch = batch;
+      } else if (batch.getHeader().getRowCount() > 0) {
+        throw new IllegalStateException("rowSet() returns a single batch, but this query returned multiple batches. Consider rowSetIterator() instead.");
       } else {
         batch.release();
       }
@@ -367,7 +373,7 @@ public class QueryBuilder {
 
     // No results?
 
-    if (dataBatch == null) {
+    if (resultBatch == null) {
       return null;
     }
 
@@ -375,10 +381,23 @@ public class QueryBuilder {
 
     final RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
     try {
-      loader.load(dataBatch.getHeader().getDef(), dataBatch.getData());
-      dataBatch.release();
+      loader.load(resultBatch.getHeader().getDef(), resultBatch.getData());
+      resultBatch.release();
       VectorContainer container = loader.getContainer();
       container.setRecordCount(loader.getRecordCount());
+
+      // Null results? Drill will return a single batch with no rows
+      // and no columns even if the scan (or other) operator returns
+      // no batches at all. For ease of testing, simply map this null
+      // result set to a null output row set that says "nothing at all
+      // was returned." Note that this is different than an empty result
+      // set which has a schema, but no rows.
+
+      if (container.getRecordCount() == 0 && container.getNumberOfColumns() == 0) {
+        container.clear();
+        return null;
+      }
+
       return DirectRowSet.fromContainer(container);
     } catch (SchemaChangeException e) {
       throw new IllegalStateException(e);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetBuilder.java
@@ -17,15 +17,15 @@
  */
 package org.apache.drill.test.rowSet;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+import java.util.Set;
+
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
+import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 import org.apache.drill.test.rowSet.RowSet.SingleRowSet;
-
-import java.util.Set;
 
 /**
  * Fluent builder to quickly build up an row set (record batch)
@@ -73,6 +73,10 @@ public final class RowSetBuilder {
       int capacity, ColumnConversionFactory conversionFactory) {
     rowSet = DirectRowSet.fromSchema(allocator, schema);
     writer = rowSet.writer(capacity, conversionFactory);
+  }
+
+  public static RowSet emptyBatch(BufferAllocator allocator, TupleMetadata schema) {
+    return new RowSetBuilder(allocator, schema).build();
   }
 
   public RowSetWriter writer() { return writer; }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
@@ -26,6 +26,7 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.selection.SelectionVector2;
+import org.apache.drill.exec.vector.VectorOverflowException;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.ValueType;
 import org.bouncycastle.util.Arrays;
@@ -264,5 +265,4 @@ public class RowSetUtilities {
   public static BigDecimal dec(String value) {
     return new BigDecimal(value);
   }
-
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
@@ -398,10 +398,10 @@ public class MaterializedField {
       .append("` (")
       .append(type.getMinorType().name());
 
-    if (type.hasPrecision()) {
+    if (type.hasPrecision() && (type.getPrecision() > 0 || Types.isDecimalType(type))) {
       builder.append("(");
       builder.append(type.getPrecision());
-      if (type.hasScale()) {
+      if (type.hasScale() && type.getScale() > 0) {
         builder.append(", ");
         builder.append(type.getScale());
       }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnBuilder.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/ColumnBuilder.java
@@ -50,13 +50,24 @@ public class ColumnBuilder {
   }
 
   public ColumnBuilder setPrecision(int precision) {
-    typeBuilder.setPrecision(precision);
+
+    // Set the precision only if non-zero. Some (naive) code in Drill
+    // checks if precision is set as a way to determine if the precision
+    // is non-zero. The correct pattern is to check if the precision is
+    // non-zero. This unnecessary check exists simply to avoid breaking
+    // that incorrect code.
+
+    if (precision != 0) {
+      typeBuilder.setPrecision(precision);
+    }
     return this;
   }
 
   public ColumnBuilder setPrecisionAndScale(int precision, int scale) {
-    typeBuilder.setPrecision(precision);
-    typeBuilder.setScale(scale);
+    if (precision != 0) {
+      typeBuilder.setPrecision(precision);
+      typeBuilder.setScale(scale);
+    }
     return this;
   }
 


### PR DESCRIPTION
The EVF framework is set up to return a "fast schema" empty batch with only schema as its first batch because, when the code was written, it seemed that's how we wanted operators to work. However, DRILL-7305 notes that many operators cannot handle empty batches.

Since the empty-batch bugs show that Drill does not, in fact, provide a "fast schema" batch, this ticket asks to disable the feature in the new scan framework. The feature is disabled with a config option; it can be re-enabled if ever it is needed.

Old tests validate the original schema-batch mode, new tests added to validate the no-schema-batch mode.