### PR TITLE
DRILL-6711: Use jitpack repository for Drill Calcite project artifacts instead of repository.mapr.com

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.calcite</groupId>
+      <groupId>com.github.vvysotskyi.drill-calcite</groupId>
       <artifactId>calcite-core</artifactId>
     </dependency>
 

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -96,7 +96,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.calcite</groupId>
+      <groupId>com.github.vvysotskyi.drill-calcite</groupId>
       <artifactId>calcite-core</artifactId>
     </dependency>
     <dependency>
@@ -149,6 +149,18 @@
       <version>2.3.2</version>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-linq4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-druid</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -65,8 +65,8 @@
           <artifactId>calcite-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.calcite</groupId>
-          <artifactId>calcite-avatica</artifactId>
+          <groupId>org.apache.calcite.avatica</groupId>
+          <artifactId>avatica</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.calcite</groupId>

--- a/docs/dev/Calcite.md
+++ b/docs/dev/Calcite.md
@@ -1,0 +1,26 @@
+# Drill-specific commits in Apache Calcite
+
+Currently, Drill uses Apache Calcite with additional changes, required for Drill. All the commits were left after 
+update from Calcite `1.4.0` to Calcite `1.15.0` and weren't merged to the Calcite's master yet since there is no consensus on them in Calcite community.
+
+List of Jiras with Drill-specific commits:
+
+|Jira|Summary|The reason why it wasn't merged|
+|----|-------|-------------------------------|
+|[CALCITE-2018](https://issues.apache.org/jira/browse/CALCITE-2018)|Queries failed with AssertionError: rel has lower cost than best cost of subset|Pull request with the fix was created ([PR-552](https://github.com/apache/calcite/pull/552)), but [CALCITE-2166](https://issues.apache.org/jira/browse/CALCITE-2166) which blocks it was found and is not resolved yet.|
+|[CALCITE-2087](https://issues.apache.org/jira/browse/CALCITE-2087)|Add new method to ViewExpander interface to allow passing SchemaPlus.|Pull request into Apache Calcite was created, but it was declined. See conversation in Jira.|
+|[CALCITE-1178](https://issues.apache.org/jira/browse/CALCITE-1178)|Allow SqlBetweenOperator to compare DATE and TIMESTAMP|SQL spec does not allow to compare datetime types if they have different `<primary datetime field>`s. Therefore Calcite community won’t accept these changes. Similar issues were reported in [CALCITE-2829](https://issues.apache.org/jira/browse/CALCITE-2829) and in [CALCITE-2745](https://issues.apache.org/jira/browse/CALCITE-2745).|
+
+# Drill-Calcite repository
+
+Repository with source code is placed [here](https://github.com/vvysotskyi/drill-calcite). For backward 
+compatibility, a couple of previous Drill Calcite branches were pushed into this repo.
+
+Drill committers who need write permissions to the repository, should notify its owner.
+
+# Process of updating Calcite version
+
+- Push required changes to the existing branch, or create new branch. *Though this repository contains Drill specific commits, it is forbidden to add additional specific commits which were not merged to Apache Calcite master if it wasn't discussed in Drill community first.*
+- The last commit must be a commit which updates the version number.
+- Create and push tag for commit with the version update. Tag name should match the version, for example, `1.18.0-drill-r0`, `1.18.0-drill-r1`, `1.18.0-drill-r2` and so on.
+- Bump-up Drill Calcite version in Drill pom.xml file.

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -207,7 +207,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.calcite</groupId>
+      <groupId>com.github.vvysotskyi.drill-calcite</groupId>
       <artifactId>calcite-core</artifactId>
     </dependency>
     <dependency>
@@ -677,7 +677,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.apache.calcite</groupId>
+                  <groupId>com.github.vvysotskyi.drill-calcite</groupId>
                   <artifactId>calcite-core</artifactId>
                   <type>jar</type>
                   <overWrite>true</overWrite>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -300,8 +300,8 @@
             </includes>
             <excludes>
               <exclude>io.protostuff:*</exclude>
-              <exclude>org.apache.calcite:calcite-core</exclude>
-              <exclude>org.apache.calcite:calcite-linq4j</exclude>
+              <exclude>com.github.vvysotskyi.drill-calcite:calcite-core</exclude>
+              <exclude>com.github.vvysotskyi.drill-calcite:calcite-linq4j</exclude>
               <exclude>org.pentaho:*</exclude>
               <exclude>org.msgpack:*</exclude>
               <exclude>xerces:*</exclude>
@@ -615,8 +615,8 @@
                   <excludes>
                     <exclude>org.slf4j:jcl-over-slf4j</exclude>
                     <exclude>io.protostuff:*</exclude>
-                    <exclude>org.apache.calcite:calcite-core</exclude>
-                    <exclude>org.apache.calcite:calcite-linq4j</exclude>
+                    <exclude>com.github.vvysotskyi.drill-calcite:calcite-core</exclude>
+                    <exclude>com.github.vvysotskyi.drill-calcite:calcite-linq4j</exclude>
                     <exclude>org.pentaho:*</exclude>
                     <exclude>org.msgpack:*</exclude>
                     <exclude>xerces:*</exclude>

--- a/logical/pom.xml
+++ b/logical/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.calcite</groupId>
+      <groupId>com.github.vvysotskyi.drill-calcite</groupId>
       <artifactId>calcite-core</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
   </properties>
 
   <scm>
-    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/drill.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/drill.git</developerConnection>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/drill.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/drill.git</developerConnection>
     <url>https://github.com/apache/drill</url>
     <tag>HEAD</tag>
   </scm>
@@ -167,31 +167,6 @@
     </repository>
 
     <repository>
-      <!-- Keep until we move back to released calcite versions. -->
-      <id>mapr-drill-optiq-snapshots</id>
-      <name>MapR Drill Optiq Snapshots</name>
-      <url>http://repository.mapr.com/nexus/content/repositories/drill-optiq/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
-      <id>mapr-drill-thirdparty</id>
-      <name>MapR Drill Third Party Artifacts</name>
-      <url>http://repository.mapr.com/nexus/content/repositories/drill/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
       <id>sonatype-nexus-snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
@@ -200,6 +175,11 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+    </repository>
+
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
     </repository>
   </repositories>
 
@@ -527,6 +507,7 @@
                     <exclude>jdk.tools:jdk.tools</exclude>
                     <exclude>org.json:json</exclude>
                     <exclude>org.beanshell:bsh</exclude>
+                    <exclude>org.apache.calcite:*</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>
@@ -1058,7 +1039,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.calcite</groupId>
+        <groupId>com.github.vvysotskyi.drill-calcite</groupId>
         <artifactId>calcite-core</artifactId>
         <version>${calcite.version}</version>
         <exclusions>


### PR DESCRIPTION
For details please see [DRILL-6711](https://issues.apache.org/jira/browse/DRILL-6711).