### PR TITLE
DRILL-7307: casthigh for decimal type can lead to the issues with VarDecimalHolder

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFuncHolder.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFuncHolder.java
@@ -145,7 +145,7 @@ public class HiveFuncHolder extends AbstractFuncHolder {
 
   @Override
   public HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
-                                    JVar[] workspaceJVars, FieldReference fieldReference) {
+                                    JVar[] workspaceJVars, FunctionHolderExpression holderExpr) {
     generateSetup(classGenerator, workspaceJVars);
     return generateEval(classGenerator, inputVariables, workspaceJVars);
   }

--- a/exec/java-exec/src/main/codegen/templates/CastHigh.java
+++ b/exec/java-exec/src/main/codegen/templates/CastHigh.java
@@ -60,11 +60,17 @@ public class CastHighFunctions {
     public void setup() {}
 
     public void eval() {
-      <#if type.value>
+    <#if type.from.contains("VarDecimal")>
+      out.buffer = (DrillBuf) in.buffer;
+      out.start = (int) in.start;
+      out.scale = (int) in.scale;
+      out.precision = (int) in.precision;
+      out.end = (int) in.end;
+    <#elseif type.value>
       out.value = (double) in.value;
       <#else>
       out = in;
-      </#if>
+    </#if>
     }
   }
 </#list>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/AbstractFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/AbstractFuncHolder.java
@@ -44,11 +44,11 @@ public abstract class AbstractFuncHolder implements FuncHolder {
    * @param classGenerator the class responsible for code generation
    * @param inputVariables the source of the vector holders
    * @param workspaceJVars class fields
-   * @param fieldReference reference of the output field
+   * @param holderExpr holder for the function expression
    * @return HoldingContainer for return value
    */
   public abstract HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
-                                             JVar[] workspaceJVars, FieldReference fieldReference);
+                                             JVar[] workspaceJVars, FunctionHolderExpression holderExpr);
 
   public boolean isNested() {
     return false;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
@@ -21,6 +21,7 @@ import static org.apache.drill.shaded.guava.com.google.common.base.Preconditions
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
@@ -127,7 +128,7 @@ class DrillAggFuncHolder extends DrillFuncHolder {
 
   @Override
   public HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
-                                    JVar[] workspaceJVars, FieldReference fieldReference) {
+                                    JVar[] workspaceJVars, FunctionHolderExpression holderExpr) {
     HoldingContainer out = null;
     JVar internalOutput = null;
     if (getReturnType().getMinorType() != TypeProtos.MinorType.LATE) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterAggFuncHolder.java
@@ -19,6 +19,7 @@
 package org.apache.drill.exec.expr.fn;
 
 import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.expr.ClassGenerator;
 import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
@@ -111,7 +112,7 @@ public class DrillComplexWriterAggFuncHolder extends DrillAggFuncHolder {
 
   @Override
   public HoldingContainer renderEnd(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables,
-                                    JVar[] workspaceJVars, FieldReference fieldReference) {
+                                    JVar[] workspaceJVars, FunctionHolderExpression holderExpr) {
     HoldingContainer out = null;
     JVar internalOutput = null;
     if (getReturnType().getMinorType() != TypeProtos.MinorType.LATE) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterFuncHolder.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.expr.fn;
 
 import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.exec.expr.ClassGenerator;
 import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
@@ -47,8 +48,9 @@ public class DrillComplexWriterFuncHolder extends DrillSimpleFuncHolder {
 
   @Override
   protected HoldingContainer generateEvalBody(ClassGenerator<?> classGenerator, HoldingContainer[] inputVariables, String body,
-                                              JVar[] workspaceJVars, FieldReference fieldReference) {
+                                              JVar[] workspaceJVars, FunctionHolderExpression holderExpr) {
 
+    FieldReference fieldReference = holderExpr.getFieldReference();
     classGenerator.getEvalBlock().directStatement(String.format("//---- start of eval portion of %s function. ----//", getRegisteredNames()[0]));
 
     JBlock sub = new JBlock(true, true);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/output/DecimalReturnTypeInference.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/output/DecimalReturnTypeInference.java
@@ -88,6 +88,7 @@ public class DecimalReturnTypeInference {
     public TypeProtos.MajorType getType(List<LogicalExpression> logicalExpressions, FunctionAttributes attributes) {
       int scale = 0;
       int precision = 0;
+      TypeProtos.DataMode mode = FunctionUtils.getReturnTypeDataMode(logicalExpressions, attributes);
 
       // Get the max scale and precision from the inputs
       for (LogicalExpression e : logicalExpressions) {
@@ -99,7 +100,7 @@ public class DecimalReturnTypeInference {
           .setMinorType(attributes.getReturnValue().getType().getMinorType())
           .setScale(scale)
           .setPrecision(precision)
-          .setMode(TypeProtos.DataMode.OPTIONAL)
+          .setMode(mode)
           .build();
     }
   }
@@ -295,6 +296,7 @@ public class DecimalReturnTypeInference {
     @Override
     public TypeProtos.MajorType getType(List<LogicalExpression> logicalExpressions, FunctionAttributes attributes) {
       int scale = 0;
+      TypeProtos.DataMode mode = FunctionUtils.getReturnTypeDataMode(logicalExpressions, attributes);
 
       // Get the max scale and precision from the inputs
       for (LogicalExpression e : logicalExpressions) {
@@ -305,7 +307,7 @@ public class DecimalReturnTypeInference {
           .setMinorType(TypeProtos.MinorType.VARDECIMAL)
           .setScale(scale)
           .setPrecision(DRILL_REL_DATATYPE_SYSTEM.getMaxNumericPrecision())
-          .setMode(TypeProtos.DataMode.OPTIONAL)
+          .setMode(mode)
           .build();
     }
   }
@@ -323,6 +325,7 @@ public class DecimalReturnTypeInference {
     @Override
     public TypeProtos.MajorType getType(List<LogicalExpression> logicalExpressions, FunctionAttributes attributes) {
       int scale = 0;
+      TypeProtos.DataMode mode = FunctionUtils.getReturnTypeDataMode(logicalExpressions, attributes);
 
       // Get the max scale and precision from the inputs
       for (LogicalExpression e : logicalExpressions) {
@@ -334,7 +337,7 @@ public class DecimalReturnTypeInference {
           .setScale(Math.min(Math.max(6, scale),
               DRILL_REL_DATATYPE_SYSTEM.getMaxNumericScale()))
           .setPrecision(DRILL_REL_DATATYPE_SYSTEM.getMaxNumericPrecision())
-          .setMode(TypeProtos.DataMode.OPTIONAL)
+          .setMode(mode)
           .build();
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestSimpleCastFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestSimpleCastFunctions.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
@@ -158,6 +159,39 @@ public class TestSimpleCastFunctions extends BaseTestQuery {
       assertThat(e.getMessage(), containsString("Invalid value for boolean: 123"));
       throw e;
     }
+  }
+
+  @Test
+  public void testDecimalConstantCast() throws Exception {
+    testBuilder()
+        .sqlQuery("select casthigh(cast(1025.0 as decimal(28,8))) a")
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(BigDecimal.valueOf(102500000000L, 8))
+        .go();
+  }
+
+  @Test
+  public void testNullableDecimalConstantCast() throws Exception {
+    testBuilder()
+        .sqlQuery("select casthigh(case when true then cast(1025.0 as decimal(28,8)) else null end) a")
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(BigDecimal.valueOf(102500000000L, 8))
+        .go();
+
+  }
+
+  @Test
+  public void testDecimalCastAsVariable() throws Exception {
+    testBuilder()
+        .sqlQuery("select casthigh(cast(a as decimal(28,8))) a from (VALUES (1.0), (2.0), (3.0)) as t1(a)")
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(BigDecimal.valueOf(100000000, 8))
+        .baselineValues(BigDecimal.valueOf(200000000, 8))
+        .baselineValues(BigDecimal.valueOf(300000000, 8))
+        .go();
   }
 
 }


### PR DESCRIPTION
For problem description please see: [DRILL-7307](https://issues.apache.org/jira/browse/DRILL-7307)

- Fixed code-gen render for nullable constants
- Fixed code-gen issue with nullable holders for simple cast functions
with passed constants as arguments.
- Code-gen now honnoring DataType.Optional type defined by UDF for
NULL-IF-NULL functions.