### PR TITLE
DRILL-7317: Close ClassLoaders used for udf jars uploading when closing FunctionImplementationRegistry

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -455,7 +455,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
           return RunTimeScan.dynamicPackageScan(drillConfig, Sets.newHashSet(urls));
         } finally {
           if (markerFileConnection instanceof JarURLConnection) {
-            ((JarURLConnection) markerFile.openConnection()).getJarFile().close();
+            ((JarURLConnection) markerFileConnection).getJarFile().close();
           }
         }
       }
@@ -592,6 +592,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
    */
   @Override
   public void close() {
+    localFunctionRegistry.close();
     if (deleteTmpDir) {
       FileUtils.deleteQuietly(tmpDir);
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/LocalFunctionRegistry.java
@@ -53,7 +53,7 @@ import org.apache.drill.exec.planner.sql.DrillSqlOperatorWithoutInference;
 /**
  * Registry of Drill functions.
  */
-public class LocalFunctionRegistry {
+public class LocalFunctionRegistry implements AutoCloseable {
 
   public static final String BUILT_IN = "built-in";
 
@@ -355,5 +355,10 @@ public class LocalFunctionRegistry {
         }
       }
     }
+  }
+
+  @Override
+  public void close() {
+    registryHolder.close();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillMergeProjectRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillMergeProjectRule.java
@@ -47,15 +47,11 @@ import java.util.List;
 public class DrillMergeProjectRule extends RelOptRule {
 
   private FunctionImplementationRegistry functionRegistry;
-  private static DrillMergeProjectRule INSTANCE = null;
   private final boolean force;
 
   public static DrillMergeProjectRule getInstance(boolean force, ProjectFactory pFactory,
       FunctionImplementationRegistry functionRegistry) {
-    if (INSTANCE == null) {
-      INSTANCE = new DrillMergeProjectRule(force, pFactory, functionRegistry);
-    }
-    return INSTANCE;
+    return new DrillMergeProjectRule(force, pFactory, functionRegistry);
   }
 
   private DrillMergeProjectRule(boolean force, ProjectFactory pFactory,


### PR DESCRIPTION
Please see [DRILL-7317](https://issues.apache.org/jira/browse/DRILL-7317) for problem description.