### PR TITLE
DRILL-7327: Log Regex Plugin Won't Recognize Schema

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatConfig.java
@@ -37,6 +37,9 @@ public class LogFormatConfig implements FormatPluginConfig {
   public int maxErrors = 10;
   public List<LogFormatField> schema;
 
+  // Required to keep Jackson happy
+  public LogFormatConfig() { }
+
   public String getRegex() {
     return regex;
   }
@@ -53,7 +56,6 @@ public class LogFormatConfig implements FormatPluginConfig {
     return schema;
   }
 
-  //Setters
   public void setExtension(String ext) {
     extension = ext;
   }
@@ -66,7 +68,11 @@ public class LogFormatConfig implements FormatPluginConfig {
     this.regex = regex;
   }
 
-  public void setSchema() {
+  public void setSchema(List<LogFormatField> schema) {
+    this.schema = schema;
+  }
+
+  public void initSchema() {
     schema = new ArrayList<LogFormatField>();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
@@ -18,12 +18,12 @@
 
 package org.apache.drill.exec.store.log;
 
+import java.util.Objects;
+
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
-import jersey.repackaged.com.google.common.base.Objects;
 
 
 /**
@@ -77,7 +77,7 @@ public class LogFormatField {
     }
     LogFormatField other = (LogFormatField) o;
     return fieldName.equals(other.fieldName) &&
-           Objects.equal(fieldType, other.fieldType) &&
-           Objects.equal(format, other.format);
+           Objects.equals(fieldType, other.fieldType) &&
+           Objects.equals(format, other.format);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatField.java
@@ -23,6 +23,8 @@ import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTes
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import jersey.repackaged.com.google.common.base.Objects;
+
 
 /**
  * The three configuration options for a field are:
@@ -42,9 +44,14 @@ public class LogFormatField {
   private final String fieldType;
   private final String format;
 
+  // Required to keep Jackson happy
+  public LogFormatField() {
+    this("");
+  }
+
   @VisibleForTesting
   public LogFormatField(String fieldName) {
-    this(fieldName, null, null);
+    this(fieldName, "VARCHAR", null);
   }
 
   public LogFormatField(String fieldName, String fieldType) {
@@ -62,4 +69,15 @@ public class LogFormatField {
   public String getFieldType() { return fieldType; }
 
   public String getFormat() { return format; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || ! (o instanceof LogFormatField)) {
+      return false;
+    }
+    LogFormatField other = (LogFormatField) o;
+    return fieldName.equals(other.fieldName) &&
+           Objects.equal(fieldType, other.fieldType) &&
+           Objects.equal(format, other.format);
+  }
 }

--- a/exec/java-exec/src/test/resources/regex/firewall.ssdlog
+++ b/exec/java-exec/src/test/resources/regex/firewall.ssdlog
@@ -1,0 +1,396 @@
+Dec 12 2018 06:50:25    sshd[36669]: Failed password for root from 61.160.251.136 port 1313 ssh2
+Dec 12 2018 06:50:25    sshd[36669]: Failed password for root from 61.160.251.136 port 1313 ssh2
+Dec 12 2018 06:50:24    sshd[36669]: Failed password for root from 61.160.251.136 port 1313 ssh2
+Dec 12 2018 03:36:23    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:22    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:22    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:22    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:22    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:22    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:22    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:22    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[41875]: Failed password for root from 222.189.239.10 port 1350 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:21    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:21    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:20    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:20    sshd[42419]: Failed password for root from 222.189.239.10 port 2646 ssh2
+Dec 12 2018 03:36:20    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:20    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:20    sshlockout[15383]: Locking out 222.189.239.10 after 15 invalid attempts
+Dec 12 2018 03:36:20    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:19    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:19    sshd[41339]: Failed password for root from 222.189.239.10 port 3973 ssh2
+Dec 12 2018 03:36:18    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:17    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:17    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:16    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:16    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:16    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:16    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:16    sshd[41027]: Failed password for root from 222.189.239.10 port 1767 ssh2
+Dec 12 2018 03:36:15    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:15    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:15    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:14    sshd[40555]: Failed password for root from 222.189.239.10 port 3148 ssh2
+Dec 12 2018 03:36:13    sshd[40793]: Did not receive identification string from 222.189.239.10
+Dec 12 2018 00:48:53    sshd[47041]: Did not receive identification string from 211.118.104.11
+Dec 12 2018 00:48:53    sshd[46730]: Did not receive identification string from 211.118.104.11
+Dec 12 2018 00:48:53    sshd[46653]: Did not receive identification string from 211.118.104.11
+Dec 12 2018 00:48:53    sshd[46953]: Did not receive identification string from 211.118.104.11
+Dec 11 2018 23:00:03    sshd[72093]: Failed password for root from 211.202.2.135 port 43034 ssh2
+Dec 11 2018 23:00:03    sshd[71433]: Failed password for root from 211.202.2.135 port 51566 ssh2
+Dec 11 2018 23:00:02    sshd[71011]: Failed password for root from 211.202.2.135 port 39162 ssh2
+Dec 11 2018 23:00:02    sshd[70918]: Failed password for root from 211.202.2.135 port 36206 ssh2
+Dec 11 2018 23:00:01    sshd[69898]: Failed password for root from 211.202.2.135 port 42956 ssh2
+Dec 11 2018 23:00:00    sshd[69280]: Failed password for root from 211.202.2.135 port 51488 ssh2
+Dec 11 2018 23:00:00    sshd[69260]: Failed password for root from 211.202.2.135 port 39097 ssh2
+Dec 11 2018 23:00:00    sshd[69234]: Failed password for root from 211.202.2.135 port 36138 ssh2
+Dec 11 2018 22:59:59    sshd[68339]: Failed password for root from 211.202.2.135 port 42835 ssh2
+Dec 11 2018 22:59:58    sshd[68614]: Failed password for root from 211.202.2.135 port 51391 ssh2
+Dec 11 2018 22:59:58    sshd[68080]: Failed password for root from 211.202.2.135 port 39008 ssh2
+Dec 11 2018 22:59:58    sshd[67836]: Failed password for root from 211.202.2.135 port 36055 ssh2
+Dec 11 2018 21:40:23    sshd[76679]: Did not receive identification string from 188.190.98.6
+Dec 11 2018 20:57:00    sshlockout[15383]: Locking out 68.213.36.143 after 15 invalid attempts
+Dec 11 2018 20:57:00    sshd[17643]: Failed password for invalid user support from 68.213.36.143 port 53712 ssh2
+Dec 11 2018 20:57:00    sshd[17643]: Invalid user support from 68.213.36.143
+Dec 11 2018 20:56:59    sshd[17141]: Failed password for invalid user spam from 68.213.36.143 port 53699 ssh2
+Dec 11 2018 20:56:59    sshd[17141]: Invalid user spam from 68.213.36.143
+Dec 11 2018 20:56:58    sshd[16722]: Failed password for root from 68.213.36.143 port 53695 ssh2
+Dec 11 2018 20:56:58    sshd[16103]: Failed password for invalid user test from 68.213.36.143 port 53690 ssh2
+Dec 11 2018 20:56:58    sshd[16103]: Invalid user test from 68.213.36.143
+Dec 11 2018 20:56:57    sshd[15902]: Failed password for invalid user user from 68.213.36.143 port 53686 ssh2
+Dec 11 2018 20:56:57    sshd[15902]: Invalid user user from 68.213.36.143
+Dec 11 2018 20:56:53    sshd[15619]: Failed password for invalid user office from 68.213.36.143 port 53614 ssh2
+Dec 11 2018 20:56:53    sshd[15619]: Invalid user office from 68.213.36.143
+Dec 11 2018 20:56:50    sshd[15081]: Failed password for invalid user anonymous from 68.213.36.143 port 53596 ssh2
+Dec 11 2018 20:56:50    sshd[15081]: Invalid user anonymous from 68.213.36.143
+Dec 11 2018 20:56:47    sshd[14927]: Failed password for invalid user guest from 68.213.36.143 port 53577 ssh2
+Dec 11 2018 20:56:47    sshd[14927]: Invalid user guest from 68.213.36.143
+Dec 11 2018 20:56:47    sshd[14788]: Did not receive identification string from 68.213.36.143
+Dec 11 2018 20:28:11    sshlockout[15383]: Locking out 119.163.120.182 after 15 invalid attempts
+Dec 11 2018 20:28:11    sshd[92678]: Failed password for invalid user nagios from 119.163.120.182 port 47772 ssh2
+Dec 11 2018 20:28:11    sshlockout[15383]: Locking out 119.163.120.182 after 15 invalid attempts
+Dec 11 2018 20:28:11    sshd[92678]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:10    sshlockout[15383]: Locking out 119.163.120.182 after 15 invalid attempts
+Dec 11 2018 20:28:10    sshd[83012]: Failed password for invalid user nagios from 119.163.120.182 port 40536 ssh2
+Dec 11 2018 20:28:10    sshlockout[15383]: Locking out 119.163.120.182 after 15 invalid attempts
+Dec 11 2018 20:28:10    sshd[83012]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:09    sshd[79233]: Failed password for invalid user nagios from 119.163.120.182 port 63265 ssh2
+Dec 11 2018 20:28:09    sshd[79233]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:08    sshd[64336]: Failed password for invalid user nagios from 119.163.120.182 port 47697 ssh2
+Dec 11 2018 20:28:08    sshd[64336]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:07    sshd[63890]: Failed password for invalid user nagios from 119.163.120.182 port 40469 ssh2
+Dec 11 2018 20:28:07    sshd[63890]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:07    sshd[63413]: Failed password for invalid user nagios from 119.163.120.182 port 63175 ssh2
+Dec 11 2018 20:28:06    sshd[63413]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:05    sshd[62819]: Failed password for invalid user nagios from 119.163.120.182 port 57437 ssh2
+Dec 11 2018 20:28:05    sshd[62819]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:05    sshd[62499]: Failed password for invalid user nagios from 119.163.120.182 port 40392 ssh2
+Dec 11 2018 20:28:05    sshd[62499]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:28:02    sshd[62073]: Failed password for invalid user nagios from 119.163.120.182 port 40334 ssh2
+Dec 11 2018 20:28:02    sshd[62073]: Invalid user nagios from 119.163.120.182
+Dec 11 2018 20:21:20    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:20    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:21:20    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:20    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:21:20    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:20    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:21:19    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:19    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:21:19    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:19    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:21:18    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 11 2018 20:21:18    sshd[71646]: Failed password for root from 61.147.116.33 port 1200 ssh2
+Dec 11 2018 20:17:28    sshd[62252]: Did not receive identification string from 119.163.120.182
+Dec 11 2018 20:17:28    sshd[61949]: Did not receive identification string from 119.163.120.182
+Dec 11 2018 20:17:28    sshd[61895]: Did not receive identification string from 119.163.120.182
+Dec 11 2018 20:17:28    sshd[61648]: Did not receive identification string from 119.163.120.182
+Dec 11 2018 19:34:20    lighttpd[51153]: (connections.c.305) SSL: 1 error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
+Dec 11 2018 17:29:02    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:02    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:02    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:02    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:29:02    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:02    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:01    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:01    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:01    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:01    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:01    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:01    sshd[47253]: Failed password for root from 114.80.226.94 port 1399 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:29:00    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:29:00    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:28:59    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:28:59    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:59    sshlockout[15383]: Locking out 114.80.226.94 after 15 invalid attempts
+Dec 11 2018 17:28:59    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:28:59    sshd[46016]: Failed password for root from 114.80.226.94 port 4331 ssh2
+Dec 11 2018 17:28:59    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:59    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:28:59    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:28:59    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:59    sshd[46735]: Failed password for root from 114.80.226.94 port 4327 ssh2
+Dec 11 2018 17:28:59    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:28:58    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:58    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:28:58    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:58    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:28:58    sshd[46236]: Failed password for root from 114.80.226.94 port 4035 ssh2
+Dec 11 2018 17:28:58    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:28:58    sshd[45756]: Failed password for root from 114.80.226.94 port 1787 ssh2
+Dec 11 2018 17:10:49    sshlockout[15383]: Locking out 5.104.200.238 after 15 invalid attempts
+Dec 11 2018 17:10:49    sshd[46938]: Failed password for root from 5.104.200.238 port 48230 ssh2
+Dec 11 2018 17:10:49    sshlockout[15383]: Locking out 5.104.200.238 after 15 invalid attempts
+Dec 11 2018 17:10:49    sshd[46649]: Failed password for root from 5.104.200.238 port 49619 ssh2
+Dec 11 2018 17:10:43    sshlockout[15383]: Locking out 5.104.200.238 after 15 invalid attempts
+Dec 11 2018 17:10:43    sshd[46185]: Failed password for root from 5.104.200.238 port 60814 ssh2
+Dec 11 2018 17:10:43    sshlockout[15383]: Locking out 5.104.200.238 after 15 invalid attempts
+Dec 11 2018 17:10:43    sshd[45228]: Failed password for root from 5.104.200.238 port 59314 ssh2
+Dec 11 2018 17:10:43    sshd[44949]: Failed password for root from 5.104.200.238 port 47633 ssh2
+Dec 11 2018 17:10:43    sshd[45530]: Failed password for root from 5.104.200.238 port 49100 ssh2
+Dec 11 2018 17:10:39    sshd[44444]: Failed password for root from 5.104.200.238 port 48502 ssh2
+Dec 11 2018 17:10:39    sshd[44263]: Failed password for root from 5.104.200.238 port 47044 ssh2
+Dec 11 2018 17:10:39    sshd[44334]: Failed password for root from 5.104.200.238 port 58749 ssh2
+Dec 11 2018 17:10:39    sshd[44321]: Failed password for root from 5.104.200.238 port 60279 ssh2
+Dec 11 2018 17:10:36    sshd[42544]: Failed password for root from 5.104.200.238 port 48036 ssh2
+Dec 11 2018 17:10:36    sshd[42764]: Failed password for root from 5.104.200.238 port 58293 ssh2
+Dec 11 2018 17:10:36    sshd[43337]: Failed password for root from 5.104.200.238 port 59841 ssh2
+Dec 11 2018 17:10:35    sshd[43090]: Failed password for root from 5.104.200.238 port 46634 ssh2
+Dec 11 2018 17:10:33    sshd[41206]: Failed password for root from 5.104.200.238 port 59296 ssh2
+Dec 11 2018 17:10:33    sshd[40921]: Failed password for root from 5.104.200.238 port 46091 ssh2
+Dec 11 2018 17:10:33    sshd[42243]: Failed password for root from 5.104.200.238 port 57803 ssh2
+Dec 11 2018 17:10:33    sshd[40809]: Failed password for root from 5.104.200.238 port 47499 ssh2
+Dec 11 2018 16:38:46    lighttpd[51153]: (connections.c.305) SSL: 1 error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
+Dec 11 2018 16:30:16    sshd[52346]: Failed password for root from 61.147.116.51 port 2860 ssh2
+Dec 11 2018 16:30:06    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:30:06    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:30:06    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:30:06    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:30:04    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:30:04    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:30:04    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:30:04    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:30:04    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:30:04    sshd[51775]: Failed password for root from 61.147.116.51 port 2898 ssh2
+Dec 11 2018 16:29:55    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:55    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:55    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:55    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:54    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:54    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:54    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:54    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:54    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:54    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:54    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:54    sshd[84941]: Failed password for root from 61.147.116.51 port 1735 ssh2
+Dec 11 2018 16:29:53    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:53    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:53    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:53    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:52    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:52    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:52    sshlockout[15383]: Locking out 61.147.116.51 after 15 invalid attempts
+Dec 11 2018 16:29:52    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:52    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:51    sshd[84486]: Failed password for root from 61.147.116.51 port 1658 ssh2
+Dec 11 2018 16:29:50    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:49    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:49    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:49    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:29:49    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:49    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:29:49    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:49    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:29:48    sshd[51405]: Failed password for root from 61.147.116.51 port 2728 ssh2
+Dec 11 2018 16:29:48    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:29:48    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:29:48    sshd[51535]: Failed password for root from 61.147.116.51 port 2826 ssh2
+Dec 11 2018 16:19:33    sshlockout[15383]: Locking out 41.87.156.146 after 15 invalid attempts
+Dec 11 2018 16:19:33    sshd[68965]: Failed password for root from 41.87.156.146 port 26234 ssh2
+Dec 11 2018 16:19:31    sshlockout[15383]: Locking out 41.87.156.146 after 15 invalid attempts
+Dec 11 2018 16:19:31    sshd[68855]: Failed password for root from 41.87.156.146 port 49405 ssh2
+Dec 11 2018 16:19:29    sshlockout[15383]: Locking out 41.87.156.146 after 15 invalid attempts
+Dec 11 2018 16:19:29    sshd[68813]: Failed password for root from 41.87.156.146 port 13197 ssh2
+Dec 11 2018 16:19:29    sshd[68121]: Failed password for root from 41.87.156.146 port 62131 ssh2
+Dec 11 2018 16:19:29    sshd[68216]: Failed password for root from 41.87.156.146 port 26045 ssh2
+Dec 11 2018 16:19:28    sshd[67770]: Failed password for root from 41.87.156.146 port 49216 ssh2
+Dec 11 2018 16:19:26    sshd[67377]: Failed password for root from 41.87.156.146 port 12997 ssh2
+Dec 11 2018 16:19:26    sshd[67263]: Failed password for root from 41.87.156.146 port 25852 ssh2
+Dec 11 2018 16:19:25    sshd[66654]: Failed password for root from 41.87.156.146 port 61945 ssh2
+Dec 11 2018 16:19:25    sshd[66452]: Failed password for root from 41.87.156.146 port 49048 ssh2
+Dec 11 2018 16:19:23    sshd[65961]: Failed password for root from 41.87.156.146 port 12800 ssh2
+Dec 11 2018 16:19:23    sshd[65802]: Failed password for root from 41.87.156.146 port 25461 ssh2
+Dec 11 2018 16:19:23    sshd[65010]: Failed password for root from 41.87.156.146 port 61760 ssh2
+Dec 11 2018 16:19:22    sshd[64909]: Failed password for root from 41.87.156.146 port 48853 ssh2
+Dec 11 2018 16:19:21    sshd[64093]: Failed password for root from 41.87.156.146 port 12576 ssh2
+Dec 11 2018 16:19:20    sshd[64384]: Failed password for root from 41.87.156.146 port 61579 ssh2
+Dec 11 2018 16:19:20    sshd[63824]: Failed password for root from 41.87.156.146 port 48696 ssh2
+Dec 11 2018 15:07:44    sshd[25301]: Did not receive identification string from 151.237.176.113
+Dec 11 2018 15:07:44    sshd[23575]: Did not receive identification string from 151.237.176.113
+Dec 11 2018 15:07:44    sshd[22727]: Did not receive identification string from 151.237.176.113
+Dec 11 2018 15:07:44    sshd[51908]: Did not receive identification string from 151.237.176.113
+Dec 11 2018 14:39:24    sshd[43235]: Failed password for invalid user ubnt from 77.68.62.168 port 56476 ssh2
+Dec 11 2018 14:39:24    sshd[43011]: Failed password for invalid user ubnt from 77.68.62.168 port 43998 ssh2
+Dec 11 2018 14:39:24    sshd[43053]: Failed password for invalid user ubnt from 77.68.62.168 port 60370 ssh2
+Dec 11 2018 14:39:24    sshd[42961]: Failed password for invalid user ubnt from 77.68.62.168 port 59187 ssh2
+Dec 11 2018 14:39:24    sshd[43235]: Invalid user ubnt from 77.68.62.168
+Dec 11 2018 14:39:24    sshd[43011]: Invalid user ubnt from 77.68.62.168
+Dec 11 2018 14:39:24    sshd[43053]: Invalid user ubnt from 77.68.62.168
+Dec 11 2018 14:39:24    sshd[42961]: Invalid user ubnt from 77.68.62.168
+Dec 11 2018 14:38:30    lighttpd[51153]: (connections.c.305) SSL: 1 error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
+Dec 11 2018 10:47:32    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:32    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:32    sshd[81320]: Failed password for invalid user prueba from 220.178.18.67 port 40641 ssh2
+Dec 11 2018 10:47:32    sshd[81413]: Failed password for invalid user prueba from 220.178.18.67 port 54568 ssh2
+Dec 11 2018 10:47:32    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:32    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:32    sshd[81413]: Invalid user prueba from 220.178.18.67
+Dec 11 2018 10:47:32    sshd[81320]: Invalid user prueba from 220.178.18.67
+Dec 11 2018 10:47:22    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:22    sshd[80741]: Failed password for root from 220.178.18.67 port 44960 ssh2
+Dec 11 2018 10:47:21    sshlockout[15383]: Locking out 220.178.18.67 after 15 invalid attempts
+Dec 11 2018 10:47:21    sshd[80715]: Failed password for root from 220.178.18.67 port 21831 ssh2
+Dec 11 2018 10:47:21    sshd[80254]: Failed password for root from 220.178.18.67 port 51033 ssh2
+Dec 11 2018 10:47:20    sshd[79748]: Failed password for root from 220.178.18.67 port 37498 ssh2
+Dec 11 2018 10:47:18    sshd[79312]: Failed password for invalid user db2inst1 from 220.178.18.67 port 40788 ssh2
+Dec 11 2018 10:47:18    sshd[79312]: Invalid user db2inst1 from 220.178.18.67
+Dec 11 2018 10:47:18    sshd[78818]: Failed password for invalid user db2inst1 from 220.178.18.67 port 17609 ssh2
+Dec 11 2018 10:47:18    sshd[78818]: Invalid user db2inst1 from 220.178.18.67
+Dec 11 2018 10:47:17    sshd[79077]: Failed password for invalid user db2inst1 from 220.178.18.67 port 47782 ssh2
+Dec 11 2018 10:47:17    sshd[79077]: Invalid user db2inst1 from 220.178.18.67
+Dec 11 2018 10:47:16    sshd[78614]: Failed password for invalid user db2inst1 from 220.178.18.67 port 34607 ssh2
+Dec 11 2018 10:47:16    sshd[78614]: Invalid user db2inst1 from 220.178.18.67
+Dec 11 2018 10:47:14    sshd[77179]: Failed password for root from 220.178.18.67 port 37143 ssh2
+Dec 11 2018 10:47:14    sshd[76835]: Failed password for root from 220.178.18.67 port 44189 ssh2
+Dec 11 2018 10:47:13    sshd[76632]: Failed password for root from 220.178.18.67 port 14100 ssh2
+Dec 11 2018 10:47:13    sshd[77345]: Failed password for root from 220.178.18.67 port 31346 ssh2
+Dec 11 2018 10:22:20    sshd[28763]: Bad protocol version identification '' from 113.105.144.52
+Dec 11 2018 10:11:20    sshd[90603]: Did not receive identification string from 222.68.192.96
+Dec 11 2018 10:11:00    sshd[89521]: Failed password for root from 222.68.192.96 port 55968 ssh2
+Dec 11 2018 09:53:23    sshd[85153]: Did not receive identification string from 222.68.192.96
+Dec 11 2018 09:53:23    sshd[84815]: Did not receive identification string from 222.68.192.96
+Dec 11 2018 09:53:23    sshd[84598]: Did not receive identification string from 222.68.192.96
+Dec 11 2018 09:53:23    sshd[84385]: Did not receive identification string from 222.68.192.96
+Dec 11 2018 09:46:09    lighttpd[51153]: (connections.c.305) SSL: 1 error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
+Dec 11 2018 05:07:45    sshlockout[15383]: Locking out 61.147.116.62 after 15 invalid attempts
+Dec 11 2018 05:07:45    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:45    sshlockout[15383]: Locking out 61.147.116.62 after 15 invalid attempts
+Dec 11 2018 05:07:45    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:44    sshlockout[15383]: Locking out 61.147.116.62 after 15 invalid attempts
+Dec 11 2018 05:07:44    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:44    sshlockout[15383]: Locking out 61.147.116.62 after 15 invalid attempts
+Dec 11 2018 05:07:44    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:44    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:44    sshd[64667]: Failed password for root from 61.147.116.62 port 4819 ssh2
+Dec 11 2018 05:07:41    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:41    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:41    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:40    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:40    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:40    sshd[64513]: Failed password for root from 61.147.116.62 port 1323 ssh2
+Dec 11 2018 05:07:36    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 11 2018 05:07:36    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 11 2018 05:07:35    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 11 2018 05:07:35    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 11 2018 05:07:35    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 11 2018 05:07:34    sshd[64099]: Failed password for root from 61.147.116.62 port 4386 ssh2
+Dec 10 2018 22:39:39    sshd[75363]: Failed password for invalid user support from 82.221.102.182 port 45619 ssh2
+Dec 10 2018 22:39:39    sshd[75363]: Invalid user support from 82.221.102.182
+Dec 10 2018 22:36:39    sshlockout[15383]: Locking out 114.80.246.132 after 15 invalid attempts
+Dec 10 2018 22:36:39    sshd[80540]: Failed password for root from 114.80.246.132 port 2867 ssh2
+Dec 10 2018 22:36:39    sshlockout[15383]: Locking out 114.80.246.132 after 15 invalid attempts
+Dec 10 2018 22:36:39    sshd[80124]: Failed password for root from 114.80.246.132 port 1093 ssh2
+Dec 10 2018 22:36:37    sshd[79627]: Failed password for root from 114.80.246.132 port 3163 ssh2
+Dec 10 2018 22:36:35    sshd[79027]: Failed password for root from 114.80.246.132 port 1391 ssh2
+Dec 10 2018 22:36:34    sshd[79440]: Failed password for root from 114.80.246.132 port 4314 ssh2
+Dec 10 2018 22:36:32    sshd[78761]: Failed password for root from 114.80.246.132 port 1882 ssh2
+Dec 10 2018 22:36:32    sshd[78246]: Failed password for root from 114.80.246.132 port 2627 ssh2
+Dec 10 2018 22:36:29    sshd[77481]: Failed password for root from 114.80.246.132 port 4060 ssh2
+Dec 10 2018 22:36:29    sshd[77880]: Failed password for root from 114.80.246.132 port 3183 ssh2
+Dec 10 2018 22:36:27    sshd[77050]: Failed password for root from 114.80.246.132 port 1556 ssh2
+Dec 10 2018 22:36:24    sshd[76763]: Failed password for root from 114.80.246.132 port 3879 ssh2
+Dec 10 2018 22:36:24    sshd[76567]: Failed password for root from 114.80.246.132 port 1461 ssh2
+Dec 10 2018 22:36:22    sshd[75601]: Failed password for root from 114.80.246.132 port 1039 ssh2
+Dec 10 2018 22:36:22    sshd[76017]: Failed password for root from 114.80.246.132 port 4509 ssh2
+Dec 10 2018 22:36:19    sshd[75089]: Failed password for root from 114.80.246.132 port 4419 ssh2
+Dec 10 2018 22:36:18    sshd[74963]: Failed password for root from 114.80.246.132 port 3399 ssh2
+Dec 10 2018 21:11:40    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:40    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:39    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:39    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:38    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:38    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:38    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:38    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:38    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:38    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:37    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:37    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:37    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:37    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:37    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:36    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:36    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:35    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:34    sshd[56926]: Failed password for root from 61.147.116.33 port 4318 ssh2
+Dec 10 2018 21:11:34    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:34    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:32    sshd[55712]: Failed password for root from 61.147.116.33 port 3743 ssh2
+Dec 10 2018 21:11:31    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:25    sshd[56536]: Failed password for root from 61.147.116.33 port 4313 ssh2
+Dec 10 2018 21:11:19    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:11:18    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:11:16    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:16    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:11:15    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:15    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:11:15    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:15    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:11:15    sshlockout[15383]: Locking out 61.147.116.33 after 15 invalid attempts
+Dec 10 2018 21:11:15    sshd[55635]: Failed password for root from 61.147.116.33 port 4261 ssh2
+Dec 10 2018 21:08:33    lighttpd[51153]: (connections.c.305) SSL: 1 error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
+Dec 10 2018 19:58:35    sshlockout[15383]: Locking out 183.129.249.98 after 15 invalid attempts
+Dec 10 2018 19:58:35    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:34    sshlockout[15383]: Locking out 183.129.249.98 after 15 invalid attempts
+Dec 10 2018 19:58:34    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:34    sshlockout[15383]: Locking out 183.129.249.98 after 15 invalid attempts
+Dec 10 2018 19:58:34    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:34    sshlockout[15383]: Locking out 183.129.249.98 after 15 invalid attempts
+Dec 10 2018 19:58:34    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:34    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:33    sshd[8087]: Failed password for root from 183.129.249.98 port 1124 ssh2
+Dec 10 2018 19:58:12    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:12    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:12    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:11    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:11    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:11    sshd[28485]: Failed password for root from 183.129.249.98 port 1688 ssh2
+Dec 10 2018 19:58:09    sshd[7136]: Failed password for root from 183.129.249.98 port 4412 ssh2
+Dec 10 2018 19:58:09    sshd[7136]: Failed password for root from 183.129.249.98 port 4412 ssh2
+Dec 10 2018 19:58:08    sshd[7136]: Failed password for root from 183.129.249.98 port 4412 ssh2

--- a/pom.xml
+++ b/pom.xml
@@ -324,13 +324,14 @@
         </executions>
         <configuration>
           <excludes>
-            <!-- Types log1, log2, sqllog and sqllog2 are used to test he logRegex format plugin. -->
+            <!-- Types log1, log2, sqllog and sqllog2, ssdlog are used to test he logRegex format plugin. -->
             <exclude>**/*.log1</exclude>
             <exclude>**/*.log2</exclude>
             <exclude>**/*.sqllog</exclude>
             <exclude>**/*.sqllog2</exclude>
             <exclude>**/*.syslog</exclude>
             <exclude>**/*.syslog1</exclude>
+            <exclude>**/*.ssdlog</exclude>
             <exclude>**/*.ltsv</exclude>
             <exclude>**/*.log</exclude>
             <exclude>**/*.css</exclude>


### PR DESCRIPTION
The previous commit revised the plugin config classes to work
with table functions. That caused Jackson to stop working for
the classess. Fixed those issues and added unit tests.