### PR TITLE
DRILL-7341: Vector reAlloc may fails after exchange

### DIFF
--- a/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/exec/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -390,7 +390,14 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements V
   }
 
   public void reAlloc() {
-    final long newAllocationSize = allocationSizeInBytes*2L;
+    long newAllocationSize = allocationSizeInBytes*2L;
+
+    // Some operations, such as Value Vector#exchange, can be change DrillBuf data field without corresponding allocation size changes.
+    // Check that the size of the allocation is sufficient to copy the old buffer.
+    while (newAllocationSize < data.capacity()) {
+      newAllocationSize *= 2L;
+    }
+
     if (newAllocationSize > MAX_ALLOCATION_SIZE)  {
       throw new OversizedAllocationException("Unable to expand the buffer. Max allowed buffer size is reached.");
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -179,7 +179,14 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
    * Allocate new buffer with double capacity, and copy data into the new buffer. Replace vector's buffer with new buffer, and release old one
    */
   public void reAlloc() {
-    final long newAllocationSize = allocationSizeInBytes * 2L;
+    long newAllocationSize = allocationSizeInBytes * 2L;
+
+    // Some operations, such as Value Vector#exchange, can be change DrillBuf data field without corresponding allocation size changes.
+    // Check that the size of the allocation is sufficient to copy the old buffer.
+    while (newAllocationSize < data.capacity()) {
+      newAllocationSize *= 2L;
+    }
+
     if (newAllocationSize > MAX_ALLOCATION_SIZE) {
       throw new OversizedAllocationException("Requested amount of memory is more than max allowed allocation size");
     }

--- a/exec/vector/src/test/java/org/apache/drill/exec/vector/VariableLengthVectorTest.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/vector/VariableLengthVectorTest.java
@@ -89,6 +89,30 @@ public class VariableLengthVectorTest
     }
   }
 
+  @Test
+  public void testDRILL7341() {
+    try (RootAllocator allocator = new RootAllocator(10_000_000)) {
+      final MaterializedField field = MaterializedField.create("stringCol", Types.optional(TypeProtos.MinorType.VARCHAR));
+      final NullableVarCharVector sourceVector = new NullableVarCharVector(field, allocator);
+      final NullableVarCharVector targetVector = new NullableVarCharVector(field, allocator);
+
+      sourceVector.allocateNew();
+      targetVector.allocateNew();
+
+      try {
+        final NullableVarCharVector.Mutator sourceMutator = sourceVector.getMutator();
+        sourceMutator.setValueCount(sourceVector.getValueCapacity() * 4);
+
+        targetVector.exchange(sourceVector);
+        final NullableVarCharVector.Mutator targetMutator = targetVector.getMutator();
+        targetMutator.setValueCount(targetVector.getValueCapacity() * 2);
+      } finally {
+        sourceVector.clear();
+        targetVector.clear();
+      }
+    }
+  }
+
   /**
    * Set 10000 values. Then go back and set new values starting at the 1001 the record.
    */


### PR DESCRIPTION
Fixes a relocate issues after direct  assignment of Vector data field.