### PR TITLE
DRILL-7373: Fix problems involving reading from DICT type

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroRecordReader.java
@@ -244,7 +244,7 @@ public class AvroRecordReader extends AbstractRecordReader {
         for (Entry<Object, Object> entry : map.entrySet()) {
           dictWriter.startKeyValuePair();
           processPrimitive(entry.getKey(), keySchema, DictVector.FIELD_KEY_NAME, writer);
-          process(entry.getValue(), valueSchema, DictVector.FIELD_VALUE_NAME, writer, fieldSelection.getChild(entry.getKey().toString()));
+          process(entry.getValue(), valueSchema, DictVector.FIELD_VALUE_NAME, writer, FieldSelection.ALL_VALID);
           dictWriter.endKeyValuePair();
         }
         dictWriter.end();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroFormatTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/avro/AvroFormatTest.java
@@ -637,6 +637,22 @@ public class AvroFormatTest extends BaseTestQuery {
   }
 
   @Test
+  public void testMapSchemaGetByNotExistingKey() throws Exception {
+    String sql = "select map_field['notExists'] as map_field from dfs.`%s`";
+
+    TestBuilder testBuilder = testBuilder()
+        .sqlQuery(sql, mapTableName)
+        .unOrdered()
+        .baselineColumns("map_field");
+
+    Object[] nullValue = new Object[] {null};
+    for (long i = 0; i < RECORD_COUNT; i++) {
+      testBuilder.baselineValues(nullValue);
+    }
+    testBuilder.go();
+  }
+
+  @Test
   public void testMapSchemaGetByKeyUsingDotNotation() throws Exception {
     String sql = "select t.map_field.key1 val1, t.map_field.key2 val2 from dfs.`%s` t";
 

--- a/exec/vector/src/main/codegen/templates/AbstractFieldReader.java
+++ b/exec/vector/src/main/codegen/templates/AbstractFieldReader.java
@@ -141,12 +141,21 @@ public abstract class AbstractFieldReader extends AbstractBaseReader implements 
     return -1;
   }
 
+  public int find(Object key){
+    fail("find(Object key)");
+    return -1;
+  }
+
   public void read(String key, ValueHolder holder) {
     fail("read(String key, ValueHolder holder)");
   }
 
   public void read(int key, ValueHolder holder) {
     fail("read(int key, ValueHolder holder)");
+  }
+
+  public void read(Object key, ValueHolder holder) {
+    fail("read(Object key, ValueHolder holder)");
   }
 
   private void fail(String name) {

--- a/exec/vector/src/main/codegen/templates/BaseReader.java
+++ b/exec/vector/src/main/codegen/templates/BaseReader.java
@@ -84,6 +84,20 @@ public interface BaseReader extends Positionable{
     int find(int key);
 
     /**
+     * Obtain the index for given key in current row used to find a corresponding value with.
+     * Used in generated code when retrieving value from Dict using {@link org.apache.drill.common.expression.PathSegment}
+     * with provided {@link org.apache.drill.common.expression.PathSegment#getOriginalValue()}
+     * in cases when {@link org.apache.drill.exec.vector.complex.DictVector#getValueType()} is complex.
+     *
+     * <p>The {@code key} is assumed to be of actual type, is not converted and used as is.
+     *
+     * @param key key value
+     * @return index for the given key
+     * @see org.apache.drill.exec.vector.complex.DictVector
+     */
+    int find(Object key);
+
+    /**
      * Reads a value corresponding to a {@code key} into the {@code holder}.
      * If there is no entry in the row with the given {@code key}, value is set to null.
      *
@@ -116,6 +130,22 @@ public interface BaseReader extends Positionable{
      * @see org.apache.drill.exec.vector.complex.DictVector
      */
     void read(int key, ValueHolder holder);
+
+    /**
+     * Reads a value corresponding to a {@code key} into the {@code holder}.
+     * If there is no entry in the row with the given {@code key}, value is set to null.
+     *
+     * <p>Used in generated code when retrieving value from Dict using {@link org.apache.drill.common.expression.PathSegment}
+     * with provided {@link org.apache.drill.common.expression.PathSegment#getOriginalValue()}
+     * in cases when {@link org.apache.drill.exec.vector.complex.DictVector#getValueType()} is primitive.
+     *
+     * <p>The {@code key} is assumed to be of actual type, is not converted and used as is.
+     *
+     * @param key key value
+     * @param holder a holder to write value's value into
+     * @see org.apache.drill.exec.vector.complex.DictVector
+     */
+    void read(Object key, ValueHolder holder);
   }
   
   public interface ListReader extends BaseReader{

--- a/exec/vector/src/main/codegen/templates/NullReader.java
+++ b/exec/vector/src/main/codegen/templates/NullReader.java
@@ -155,11 +155,20 @@ public class NullReader extends AbstractBaseReader implements FieldReader {
   }
 
   @Override
+  public int find(Object key) {
+    return -1;
+  }
+
+  @Override
   public void read(String key, ValueHolder holder) {
   }
 
   @Override
   public void read(int key, ValueHolder holder) {
+  }
+
+  @Override
+  public void read(Object key, ValueHolder holder) {
   }
 }
 

--- a/logical/src/main/java/org/apache/drill/common/expression/SchemaPath.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/SchemaPath.java
@@ -25,6 +25,7 @@ import org.apache.drill.common.expression.PathSegment.ArraySegment;
 import org.apache.drill.common.expression.PathSegment.NameSegment;
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.parser.LogicalExpressionParser;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.proto.UserBitShared.NamePart;
@@ -301,8 +302,18 @@ public class SchemaPath extends LogicalExpressionBase {
     return new SchemaPath(newRoot);
   }
 
+  public SchemaPath getChild(String childPath, Object originalValue, TypeProtos.MajorType valueType) {
+    NameSegment newRoot = rootSegment.cloneWithNewChild(new NameSegment(childPath, originalValue, valueType));
+    return new SchemaPath(newRoot);
+  }
+
   public SchemaPath getChild(int index) {
     NameSegment newRoot = rootSegment.cloneWithNewChild(new ArraySegment(index));
+    return new SchemaPath(newRoot);
+  }
+
+  public SchemaPath getChild(int index, Object originalValue, TypeProtos.MajorType valueType) {
+    NameSegment newRoot = rootSegment.cloneWithNewChild(new ArraySegment(index, originalValue, valueType));
     return new SchemaPath(newRoot);
   }
 


### PR DESCRIPTION
- Fixed `FieldIdUtil` to resolve reading from `DICT` for some complex cases;
- optimized reading from `DICT` given a key by passing an appropriate `Object` type to `DictReader#find(...)` and `DictReader#read(...)` methods when schema is known (e.g. when reading from Hive tables) instead of generating it on fly based on int or String path and key type;
- fixed error when accessing value by not existing key value in Avro table.

Jira - [DRILL-7373](https://issues.apache.org/jira/browse/DRILL-7373).