### PR TITLE
DRILL-7374: Support for IPV6 address

### DIFF
--- a/contrib/native/client/src/clientlib/channel.cpp
+++ b/contrib/native/client/src/clientlib/channel.cpp
@@ -308,7 +308,7 @@ connectionStatus_t Channel::connectInternal() {
     const char *port = m_pEndpoint->getPort().c_str();
     try {
         tcp::resolver resolver(m_ioService);
-        tcp::resolver::query query(tcp::v4(), host, port);
+        tcp::resolver::query query(host, port);
         tcp::resolver::iterator iter = resolver.resolve(query);
         tcp::resolver::iterator end;
         while (iter != end) {


### PR DESCRIPTION
This change will now allow the Drill Client to accept IPV6 address to connect to the data source.