### PR TITLE
DRILL-7170: Ignore uninitialized vector containers for OOM error messages

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/common/HashTableTemplate.java
@@ -459,7 +459,11 @@ public abstract class HashTableTemplate implements HashTable {
         size += ledger.getAccountedSize();
       }
 
-      size += new RecordBatchSizer(htContainer).getActualSize();
+      // In some rare cases (e.g., making a detailed debug msg after an OOM) the container
+      // was not initialized; ignore such cases
+      if ( htContainer.hasRecordCount() ) {
+        size += new RecordBatchSizer(htContainer).getActualSize();
+      }
       return size;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/SpillSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/spill/SpillSet.java
@@ -324,8 +324,11 @@ public class SpillSet {
 
     @Override
     public void deleteDir(String fragmentSpillDir) throws IOException {
-      boolean deleted = new File(baseDir, fragmentSpillDir).delete();
-      if ( ! deleted ) { throw new IOException("Failed to delete: " + fragmentSpillDir);}
+      File spillDir = new File(baseDir, fragmentSpillDir);
+      for (File spillFile : spillDir.listFiles()) {
+        spillFile.delete(); // IO exception if file delete fails
+      }
+      spillDir.delete();// IO exception if dir delete fails
     }
 
     @Override


### PR DESCRIPTION
A Hash-Table OOM exception may happen while a vector container was allocated but not yet initialized (with _setRecordCount()_ ). This exception is caught and a detailed error message is generated, which involves calling _getRecordCount()_ on existing vector containers, hence could trigger an **IllegalStateException** on such uninitialized container.

   The fix: Ignore such uninitialized vector container (i.e., like record-count == 0) in the code that is used for generating that error message (currently _getActualSize()_ is only used for this purpose).

   Another code change: While testing on the Mac, the spilling code for regular file systems failed to delete leftover spilled directories (which were not empty). The code was changed to delete all the spill files first in a spill directory, and last the directory itself.
 