### PR TITLE
DRILL-7394: JSON in Documentation Contains Typo

### DIFF
--- a/_docs/data-sources-and-file-formats/050-json-data-model.md
+++ b/_docs/data-sources-and-file-formats/050-json-data-model.md
@@ -96,7 +96,7 @@ Drill reads tuples defined in single objects, having no comma between objects. A
 
 To read and [analyze complex JSON]({{ site.baseurl }}/docs/json-data-model/#analyzing-json) files, use the FLATTEN and KVGEN functions. For example, you need to flatten the data to read all the names in this JSON file:
 
-     {"Fruits: [{"name":"Apples", "quantity":115},
+     {"Fruits": [{"name":"Apples", "quantity":115},
                 {"name":"Oranges","quantity":199},
                 {"name":"Peaches", "quantity":116}
                ]


### PR DESCRIPTION
Fixes copy/paste error stemming from bad JSON formatting.