### PR TITLE
DRILL-7358: Fix COUNT(*) for empty text files

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/SchemaTracker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/SchemaTracker.java
@@ -65,7 +65,7 @@ public class SchemaTracker {
   private List<ValueVector> currentVectors = new ArrayList<>();
 
   public void trackSchema(VectorContainer newBatch) {
-    if (! isSameSchema(newBatch)) {
+    if (schemaVersion == 0 || ! isSameSchema(newBatch)) {
       schemaVersion++;
       captureSchema(newBatch);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
@@ -92,7 +92,7 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
   @Override
   public void setTableSchema(TupleMetadata schema, boolean isComplete) {
     tableSchema = schema;
-    this.isSchemaComplete = schema != null && isComplete;
+    isSchemaComplete = schema != null && isComplete;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/EmptyProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/EmptyProjectionSet.java
@@ -37,4 +37,7 @@ public class EmptyProjectionSet implements ProjectionSet {
 
   @Override
   public void setErrorContext(CustomErrorContext errorContext) { }
+
+  @Override
+  public boolean isEmpty() { return true; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
@@ -26,6 +26,8 @@ import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.Requested
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Projection set based on an explicit set of columns provided
@@ -34,7 +36,7 @@ import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
  */
 
 public class ExplicitProjectionSet extends AbstractProjectionSet {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExplicitProjectionSet.class);
+  private static final Logger logger = LoggerFactory.getLogger(ExplicitProjectionSet.class);
 
   private final RequestedTuple requestedProj;
 
@@ -106,4 +108,7 @@ public class ExplicitProjectionSet extends AbstractProjectionSet {
       .addContext(errorContext)
       .build(logger);
   }
+
+  @Override
+  public boolean isEmpty() { return requestedProj.projections().isEmpty(); }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/WildcardProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/WildcardProjectionSet.java
@@ -52,4 +52,11 @@ public class WildcardProjectionSet extends AbstractProjectionSet {
       return new ProjectedReadColumn(col, null, outputSchema, conv);
     }
   }
+
+  // Wildcard means use whatever schema is provided by the reader,
+  // so the projection itself is non-empty even if the reader has no
+  // columns.
+
+  @Override
+  public boolean isEmpty() { return false; }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ProjectionSet.java
@@ -102,4 +102,5 @@ public interface ProjectionSet {
 
   void setErrorContext(CustomErrorContext errorContext);
   ColumnReadProjection readProjection(ColumnMetadata col);
+  boolean isEmpty();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnState.java
@@ -193,8 +193,7 @@ public abstract class ColumnState {
     this.vectorState = vectorState;
     addVersion = writer.isProjected() ?
         loader.bumpVersion() : loader.activeSchemaVersion();
-    state = loader.hasOverflow() ?
-        State.NEW_LOOK_AHEAD : State.NORMAL;
+    state = loader.hasOverflow() ? State.NEW_LOOK_AHEAD : State.NORMAL;
     this.writer = writer;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
@@ -312,6 +312,17 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
       logger.debug("Schema: " + options.schema.toString());
       new BuildFromSchema().buildTuple(rootWriter, options.schema);
     }
+
+    // If we want to project nothing, then we do, in fact, have a
+    // valid schema, it just happens to be an empty schema. Bump the
+    // schema version so we know we have that empty schema.
+    //
+    // This accomplishes a result similar to the "legacy" readers
+    // achieve by adding a dummy column.
+
+    if (projectionSet.isEmpty()) {
+      bumpVersion();
+    }
   }
 
   private void updateCardinality() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/BaseFieldOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/BaseFieldOutput.java
@@ -154,7 +154,7 @@ public abstract class BaseFieldOutput extends TextOutput {
     }
     ScalarWriter colWriter = columnWriter();
     if (fieldWriteCount == 0) {
-       colWriter.setBytes(fieldBytes, currentDataPointer);
+      colWriter.setBytes(fieldBytes, currentDataPointer);
     } else {
       colWriter.appendBytes(fieldBytes, currentDataPointer);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -36,6 +36,9 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.client.LoggingResultsListener;
 import org.apache.drill.exec.client.QuerySubmitter.Format;
 import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.apache.drill.exec.proto.BitControl.PlanFragment;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
@@ -56,9 +59,6 @@ import org.apache.drill.exec.vector.accessor.ScalarReader;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.test.BufferingQueryEventListener.QueryEvent;
 import org.apache.drill.test.ClientFixture.StatementParser;
-import org.apache.drill.exec.physical.rowSet.DirectRowSet;
-import org.apache.drill.exec.physical.rowSet.RowSet;
-import org.apache.drill.exec.physical.rowSet.RowSetReader;
 import org.joda.time.Period;
 
 /**
@@ -478,7 +478,9 @@ public class QueryBuilder {
     }
     try {
       RowSetReader reader = rowSet.reader();
-      reader.next();
+      if (!reader.next()) {
+        throw new IllegalStateException("No rows returned");
+      }
       return scalarReader.read(reader.scalar(0));
     } finally {
       rowSet.clear();


### PR DESCRIPTION
Fixes a subtle error when a text file has a header (and so has a
schema), but is in a COUNT(*) query, so that no columns are
projected. Ensures that, in this case, an empty schema is
treated as a valid result set.

Tests: updated CSV tests to include this case.