### PR TITLE
DRILL-7377: Nested schemas for dynamic EVF columns

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
@@ -78,7 +78,13 @@ import org.apache.drill.exec.vector.complex.UnionVector;
  * projected (not in the list), then creates a dummy writer. Issues an error if
  * the column is projected, but the implied projection type is incompatible with
  * the actual type. (Such as trying to project an INT as x[0].)
+ * <p>
+ * This class builds the internal structure of a vector. If building a "container"
+ * vector (map, list, repeated list or union), this class expects the container
+ * to be added empty, then the members to be added one by one. See
+ * {@link BuildFromSchema} for the class that builds up a compound structure.
  */
+
 public class ColumnBuilder {
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
@@ -310,7 +310,7 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
       // won't be if known up front.
 
       logger.debug("Schema: " + options.schema.toString());
-      new BuildFromSchema().buildTuple(rootWriter, options.schema);
+      BuildFromSchema.instance().buildTuple(rootWriter, options.schema);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/TupleState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/TupleState.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
 import org.apache.drill.exec.physical.resultSet.impl.ColumnState.BaseContainerColumnState;
@@ -490,19 +489,7 @@ public abstract class TupleState extends ContainerState
 
   @Override
   public ObjectWriter addColumn(TupleWriter tupleWriter, ColumnMetadata columnSchema) {
-
-    // Verify name is not a (possibly case insensitive) duplicate.
-
-    final TupleMetadata tupleSchema = schema();
-    final String colName = columnSchema.name();
-    if (tupleSchema.column(colName) != null) {
-      throw UserException
-        .validationError()
-        .message("Duplicate column name: ", colName)
-        .build(ResultSetLoaderImpl.logger);
-    }
-
-    return addColumn(columnSchema).writer();
+    return BuildFromSchema.instance().buildColumn(this, columnSchema);
   }
 
   @Override


### PR DESCRIPTION
The Result Set Loader (part of EVF) allows adding columns up-front
before reading rows (so-called "early schema.") Such schemas allow
nested columns (maps with members, repeated lists with a type, etc.)

The Result Set Loader also allows adding columns dynamically
while loading data (so-called "late schema".) Previously, the code
assumed that columns would be added top-down: first the map, then
the map's contents, etc.

Charles found a need to allow adding a nested column (a repeated
list with a declared list type.)

This patch revises the code to use the same mechanism in both the
early- and late-schema cases, allowing adding nested columns at
any time.

Testing: Added a new unit test case for the repeated list late
schema with content case.