### PR TITLE
DRILL-6096: Provide mechanism to configure text writer configuration

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.univocity</groupId>
       <artifactId>univocity-parsers</artifactId>
-      <version>1.3.0</version>
+      <version>2.8.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/exec/java-exec/src/main/codegen/templates/StringOutputRecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/StringOutputRecordWriter.java
@@ -43,7 +43,7 @@ import java.util.Map;
 
 /**
  * Abstract implementation of RecordWriter interface which exposes interface:
- *    {@link #writeHeader(List)}
+ *    {@link #startNewSchema(BatchSchema)}
  *    {@link #addField(int,String)}
  * to output the data in string format instead of implementing addField for each type holder.
  *
@@ -60,13 +60,7 @@ public abstract class StringOutputRecordWriter extends AbstractRecordWriter {
 
   @Override
   public void updateSchema(VectorAccessible batch) throws IOException {
-    BatchSchema schema = batch.getSchema();
-    List<String> columnNames = Lists.newArrayList();
-    for (int i=0; i < schema.getFieldCount(); i++) {
-      columnNames.add(schema.getColumn(i).getName());
-    }
-
-    startNewSchema(columnNames);
+    startNewSchema(batch.getSchema());
   }
 
   @Override
@@ -160,6 +154,6 @@ public abstract class StringOutputRecordWriter extends AbstractRecordWriter {
   public void cleanup() throws IOException {
   }
 
-  public abstract void startNewSchema(List<String> columnNames) throws IOException;
+  public abstract void startNewSchema(BatchSchema schema) throws IOException;
   public abstract void addField(int fieldId, String value) throws IOException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -431,6 +431,13 @@ public final class ExecConstants {
   public static final DoubleValidator TEXT_ESTIMATED_ROW_SIZE = new RangeDoubleValidator("store.text.estimated_row_size_bytes", 1, Long.MAX_VALUE,
       new OptionDescription("Estimate of the row size in a delimited text file, such as csv. The closer to actual, the better the query plan. Used for all csv files in the system/session where the value is set. Impacts the decision to plan a broadcast join or not."));
 
+  public static final String TEXT_WRITER_ADD_HEADER = "store.text.writer.add_header";
+  public static final BooleanValidator TEXT_WRITER_ADD_HEADER_VALIDATOR = new BooleanValidator(TEXT_WRITER_ADD_HEADER,
+    new OptionDescription("Enables the TEXT writer to write header in newly created file. Default is true. (Drill 1.17+)"));
+
+  public static final String TEXT_WRITER_FORCE_QUOTES = "store.text.writer.force_quotes";
+  public static final BooleanValidator TEXT_WRITER_FORCE_QUOTES_VALIDATOR = new BooleanValidator(TEXT_WRITER_FORCE_QUOTES,
+    new OptionDescription("Enables the TEXT writer to enclose in quotes all fields. Default is false. (Drill 1.17+)"));
 
   /**
    * Json writer option for writing `NaN` and `Infinity` tokens as numbers (not enclosed with double quotes)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsArrayParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/columns/ColumnsArrayParser.java
@@ -24,8 +24,10 @@ import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection;
 import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection.ScanProjectionParser;
 import org.apache.drill.exec.physical.resultSet.project.RequestedColumnImpl;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
-import org.apache.drill.exec.store.easy.text.reader.TextReader;
+import org.apache.drill.exec.store.easy.text.TextFormatPlugin;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Parses the `columns` array. Doing so is surprisingly complex.
@@ -68,7 +70,8 @@ import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTes
  */
 
 public class ColumnsArrayParser implements ScanProjectionParser {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ColumnsArrayParser.class);
+
+  private static final Logger logger = LoggerFactory.getLogger(ColumnsArrayParser.class);
 
   // Config
 
@@ -151,13 +154,13 @@ public class ColumnsArrayParser implements ScanProjectionParser {
 
     if (inCol.isArray()) {
       int maxIndex = inCol.maxIndex();
-      if (maxIndex > TextReader.MAXIMUM_NUMBER_COLUMNS) {
+      if (maxIndex > TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS) {
         throw UserException
           .validationError()
           .message("`columns`[%d] index out of bounds, max supported size is %d",
-              maxIndex, TextReader.MAXIMUM_NUMBER_COLUMNS)
+              maxIndex, TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS)
           .addContext("Column:", inCol.name())
-          .addContext("Maximum index:", TextReader.MAXIMUM_NUMBER_COLUMNS)
+          .addContext("Maximum index:", TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS)
           .addContext("Actual index:", maxIndex)
           .addContext(builder.context())
           .build(logger);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -186,6 +186,8 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE_VALIDATOR),
       new OptionDefinition(ExecConstants.ENABLE_UNION_TYPE),
       new OptionDefinition(ExecConstants.TEXT_ESTIMATED_ROW_SIZE),
+      new OptionDefinition(ExecConstants.TEXT_WRITER_ADD_HEADER_VALIDATOR),
+      new OptionDefinition(ExecConstants.TEXT_WRITER_FORCE_QUOTES_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_EXTENDED_TYPES),
       new OptionDefinition(ExecConstants.JSON_WRITER_UGLIFY),
       new OptionDefinition(ExecConstants.JSON_WRITER_SKIPNULLFIELDS),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/BaseFieldOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/BaseFieldOutput.java
@@ -20,7 +20,7 @@ package org.apache.drill.exec.store.easy.text.reader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
-public abstract class BaseFieldOutput extends TextOutput {
+public abstract class BaseFieldOutput implements TextOutput {
 
   /**
    * Width of the per-field data buffer. Fields can be larger.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/FieldVarCharOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/FieldVarCharOutput.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.easy.text.reader;
 
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.text.TextFormatPlugin;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 
 /**
@@ -31,20 +32,18 @@ class FieldVarCharOutput extends BaseFieldOutput {
   /**
    * We initialize and add the varchar vector for each incoming field in this
    * constructor.
-   * @param outputMutator  Used to create/modify schema
-   * @param fieldNames Incoming field names
-   * @param columns  List of columns selected in the query
-   * @param isStarQuery  boolean to indicate if all fields are selected or not
+   *
+   * @param writer row set writer
    */
-  public FieldVarCharOutput(RowSetLoader writer) {
+  FieldVarCharOutput(RowSetLoader writer) {
     super(writer,
-        TextReader.MAXIMUM_NUMBER_COLUMNS,
+        TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS,
         makeMask(writer));
   }
 
   private static boolean[] makeMask(RowSetLoader writer) {
     final TupleMetadata schema = writer.tupleSchema();
-    final boolean projectionMask[] = new boolean[schema.size()];
+    final boolean[] projectionMask = new boolean[schema.size()];
     for (int i = 0; i < schema.size(); i++) {
       projectionMask[i] = writer.column(i).isProjected();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/HeaderBuilder.java
@@ -17,17 +17,18 @@
  */
 package org.apache.drill.exec.store.easy.text.reader;
 
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.hadoop.fs.Path;
-
-import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 
 /**
  * Text output that implements a header reader/parser.
@@ -45,8 +46,9 @@ import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 // and read a single row, there is no good reason to try to use
 // value vectors and direct memory for this task.
 
-public class HeaderBuilder extends TextOutput {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HeaderBuilder.class);
+public class HeaderBuilder implements TextOutput {
+
+  private static final Logger logger = LoggerFactory.getLogger(HeaderBuilder.class);
 
   /**
    * Maximum Drill symbol length, as enforced for headers.
@@ -71,9 +73,9 @@ public class HeaderBuilder extends TextOutput {
 
   public static final String ANONYMOUS_COLUMN_PREFIX = "column_";
 
-  public final Path filePath;
-  public final List<String> headers = new ArrayList<>();
-  public final ByteBuffer currentField = ByteBuffer.allocate(MAX_HEADER_LEN);
+  private final Path filePath;
+  private final List<String> headers = new ArrayList<>();
+  private final ByteBuffer currentField = ByteBuffer.allocate(MAX_HEADER_LEN);
 
   public HeaderBuilder(Path filePath) {
     this.filePath = filePath;
@@ -214,7 +216,7 @@ public class HeaderBuilder extends TextOutput {
 
     // Force headers to be unique.
 
-    final Set<String> idents = new HashSet<String>();
+    final Set<String> idents = new HashSet<>();
     for (int i = 0; i < headers.size(); i++) {
       String header = headers.get(i);
       String key = header.toLowerCase();
@@ -254,7 +256,7 @@ public class HeaderBuilder extends TextOutput {
     // Just return the headers: any needed checks were done in
     // finishRecord()
 
-    final String array[] = new String[headers.size()];
+    final String[] array = new String[headers.size()];
     return headers.toArray(array);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/RepeatedVarCharOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/RepeatedVarCharOutput.java
@@ -19,8 +19,11 @@ package org.apache.drill.exec.store.easy.text.reader;
 
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.store.easy.text.TextFormatPlugin;
 import org.apache.drill.exec.vector.accessor.ArrayWriter;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class is responsible for generating record batches for text file inputs. We generate
@@ -28,23 +31,23 @@ import org.apache.drill.exec.vector.accessor.ScalarWriter;
  * value within the vector containing all the fields in the record as individual array elements.
  */
 public class RepeatedVarCharOutput extends BaseFieldOutput {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseFieldOutput.class);
+
+  private static final Logger logger = LoggerFactory.getLogger(BaseFieldOutput.class);
 
   private final ScalarWriter columnWriter;
-  private final ArrayWriter arrayWriter;
 
   /**
    * Provide the row set loader (which must have just one repeated Varchar
    * column) and an optional array projection mask.
-   * @param projectionMask
-   * @param tupleLoader
+   *
+   * @param loader row set loader
+   * @param projectionMask array projection mask
    */
-
   public RepeatedVarCharOutput(RowSetLoader loader, boolean[] projectionMask) {
     super(loader,
         maxField(loader, projectionMask),
         projectionMask);
-    arrayWriter = writer.array(0);
+    ArrayWriter arrayWriter = writer.array(0);
     columnWriter = arrayWriter.scalar();
   }
 
@@ -61,7 +64,7 @@ public class RepeatedVarCharOutput extends BaseFieldOutput {
     // possible fields.
 
     if (projectionMask == null) {
-      return TextReader.MAXIMUM_NUMBER_COLUMNS;
+      return TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS;
     }
 
     // Else, this is a SELECT columns[x], columns[y], ... query.
@@ -110,11 +113,11 @@ public class RepeatedVarCharOutput extends BaseFieldOutput {
       // this only if all fields are selected; the same query will succeed if
       // the user does a COUNT(*) or SELECT columns[x], columns[y], ...
 
-      if (currentFieldIndex > TextReader.MAXIMUM_NUMBER_COLUMNS) {
+      if (currentFieldIndex > TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS) {
         throw UserException
           .unsupportedError()
           .message("Text file contains too many fields")
-          .addContext("Limit", TextReader.MAXIMUM_NUMBER_COLUMNS)
+          .addContext("Limit", TextFormatPlugin.MAXIMUM_NUMBER_COLUMNS)
           .build(logger);
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextInput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextInput.java
@@ -74,12 +74,12 @@ final class TextInput {
   /**
    * The current position in the buffer.
    */
-  public int bufferPtr;
+  private int bufferPtr;
 
   /**
    * The quantity of valid data in the buffer.
    */
-  public int length = -1;
+  private int length = -1;
 
   private boolean endFound = false;
 
@@ -91,7 +91,7 @@ final class TextInput {
    * {@link TextParsingSettings#getNormalizedNewLine()}) that is used to replace any
    * lineSeparator sequence found in the input.
    */
-  public TextInput(TextParsingSettings settings, InputStream input, DrillBuf readBuffer, long startPos, long endPos) {
+  TextInput(TextParsingSettings settings, InputStream input, DrillBuf readBuffer, long startPos, long endPos) {
     this.lineSeparator = settings.getNewLineDelimiter();
     byte normalizedLineSeparator = settings.getNormalizedNewLine();
     Preconditions.checkArgument(input instanceof Seekable, "Text input only supports an InputStream that supports Seekable.");
@@ -156,9 +156,8 @@ final class TextInput {
    * May get an incomplete string since we don't support stream rewind.  Returns empty string for now.
    *
    * @return String of last few bytes.
-   * @throws IOException for input file read errors
    */
-  public String getStringSinceMarkForError() throws IOException {
+  public String getStringSinceMarkForError() {
     return " ";
   }
 
@@ -357,10 +356,6 @@ final class TextInput {
 
   public final long charCount() {
     return charCount + bufferPtr;
-  }
-
-  public long getLineCount() {
-    return lineCount;
   }
 
   public void close() throws IOException{

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextOutput.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextOutput.java
@@ -17,63 +17,58 @@
  */
 package org.apache.drill.exec.store.easy.text.reader;
 
-
 /**
- * Base class for producing output record batches while dealing with
+ * Interface for producing output record batches while dealing with
  * text files. Defines the interface called from text parsers to create
  * the corresponding value vectors (record batch).
  */
+interface TextOutput {
 
-abstract class TextOutput {
-
-  public abstract void startRecord();
+  /**
+   * Start processing a new record.
+   */
+  void startRecord();
 
   /**
    * Start processing a new field within a record.
-   * @param index  index within the record
+   *
+   * @param index index within the record
    */
-  public abstract void startField(int index);
+  void startField(int index);
 
   /**
    * End processing a field within a record.
-   * @return  true if engine should continue processing record.  false if rest of record can be skipped.
+   *
+   * @return true if engine should continue processing record.  false if rest of record can be skipped.
    */
-  public abstract boolean endField();
+  boolean endField();
 
   /**
    * Shortcut that lets the output know that we are closing ending a field with no data.
+   *
    * @return true if engine should continue processing record.  false if rest of record can be skipped.
    */
-  public abstract boolean endEmptyField();
+  boolean endEmptyField();
 
   /**
-   * Add the provided data but drop any whitespace.
-   * @param data character to append
+   * Appends a byte to the output character data buffer.
+   *
+   * @param data current byte read
    */
-  public void appendIgnoringWhitespace(byte data) {
-    if (TextReader.isWhite(data)) {
-      // noop
-    } else {
-      append(data);
-    }
-  }
-
-  /**
-   * Appends a byte to the output character data buffer
-   * @param data  current byte read
-   */
-  public abstract void append(byte data);
+  void append(byte data);
 
   /**
    * Completes the processing of a given record. Also completes the processing of the
    * last field being read.
    */
-  public abstract void finishRecord();
+  void finishRecord();
 
   /**
-   *  Return the total number of records (across batches) processed
+   * Return the total number of records (across batches) processed
+   *
+   * @return record count
    */
-  public abstract long getRecordCount();
+  long getRecordCount();
 
   /**
    * Indicates if the current batch is full and reading for this batch
@@ -83,6 +78,5 @@ abstract class TextOutput {
    * the batch to be sent downstream, false if the reader may continue to
    * add rows to the current batch
    */
-
-  public abstract boolean isFull();
+  boolean isFull();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingContext.java
@@ -17,101 +17,130 @@
  */
 package org.apache.drill.exec.store.easy.text.reader;
 
-import java.io.IOException;
-
 import com.univocity.parsers.common.ParsingContext;
+import com.univocity.parsers.common.record.Record;
+import com.univocity.parsers.common.record.RecordMetaData;
+
+import java.util.Collections;
+import java.util.Map;
 
 class TextParsingContext implements ParsingContext {
 
   private final TextInput input;
   private final TextOutput output;
-  protected boolean stopped;
 
-  private int[] extractedIndexes;
+  private boolean stopped;
 
-  public TextParsingContext(TextInput input, TextOutput output) {
+  TextParsingContext(TextInput input, TextOutput output) {
     this.input = input;
     this.output = output;
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  public boolean isFull() {
+    return output.isFull();
+  }
+
+  public void stop(boolean stopped) {
+    this.stopped = stopped;
+  }
+
   @Override
   public void stop() {
     stopped = true;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public boolean isStopped() {
     return stopped;
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
+  public int errorContentLength() {
+    return -1;
+  }
+
+  @Override
+  public Record toRecord(String[] row) {
+    return null;
+  }
+
+  @Override
+  public RecordMetaData recordMetaData() {
+    return null;
+  }
+
   @Override
   public long currentLine() {
     return input.lineCount();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public long currentChar() {
     return input.charCount();
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
+  public void skipLines(long lines) {
+  }
+
+  @Override
+  public String[] parsedHeaders() {
+    return new String[0];
+  }
+
   @Override
   public int currentColumn() {
     return -1;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public String[] headers() {
-    return new String[]{};
+    return new String[0];
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
+  public String[] selectedHeaders() {
+    return new String[0];
+  }
+
   @Override
   public int[] extractedFieldIndexes() {
-    return extractedIndexes;
+    return new int[0];
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public long currentRecord() {
     return output.getRecordCount();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public String currentParsedContent() {
-    try {
-      return input.getStringSinceMarkForError();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return input.getStringSinceMarkForError();
   }
 
   @Override
-  public void skipLines(int lines) {
+  public int currentParsedContentLength() {
+    return input.getStringSinceMarkForError().toCharArray().length;
+  }
+
+  @Override
+  public String fieldContentOnError() {
+    return null;
+  }
+
+  @Override
+  public Map<Long, String> comments() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public String lastComment() {
+    return null;
+  }
+
+  @Override
+  public char[] lineSeparator() {
+    return new char[0];
   }
 
   @Override
@@ -119,8 +148,14 @@ class TextParsingContext implements ParsingContext {
     return false;
   }
 
-  public boolean isFull() {
-    return output.isFull();
+  @Override
+  public int indexOf(String header) {
+    return -1;
+  }
+
+  @Override
+  public int indexOf(Enum<?> header) {
+    return -1;
   }
 }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingSettings.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/reader/TextParsingSettings.java
@@ -33,7 +33,7 @@ public class TextParsingSettings {
   private final byte delimiter;
   private final byte comment;
 
-  private final long maxCharsPerColumn = Character.MAX_VALUE;
+  private final long maxCharsPerColumn = TextFormatPlugin.MAX_CHARS_PER_COLUMN;
   private final byte normalizedNewLine = b('\n');
   private final byte[] newLineDelimiter;
   private final boolean ignoreLeadingWhitespaces = false;

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -656,6 +656,8 @@ drill.exec.options: {
     store.table.use_schema_file: false,
     store.partition.hash_distribute: false,
     store.text.estimated_row_size_bytes: 100.0,
+    store.text.writer.add_header: true,
+    store.text.writer.force_quotes: false,
     store.kafka.all_text_mode: false,
     store.kafka.read_numbers_as_double: false,
     store.kafka.record.reader: "org.apache.drill.exec.store.kafka.decoders.JsonMessageReader",

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestTextWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/writer/TestTextWriter.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.writer;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
+import static org.junit.Assert.assertEquals;
+
+public class TestTextWriter extends ClusterTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private static final List<String> tablesToDrop = new ArrayList<>();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+
+    Map<String, FormatPluginConfig> formats = new HashMap<>();
+
+    TextFormatConfig csv = new TextFormatConfig();
+    csv.extensions = Collections.singletonList("csv");
+    csv.lineDelimiter = "\n";
+    csv.fieldDelimiter = ',';
+    csv.quote = '"';
+    csv.escape = '"';
+    csv.extractHeader = true;
+    formats.put("csv", csv);
+
+    TextFormatConfig tsv = new TextFormatConfig();
+    tsv.extensions = Collections.singletonList("tsv");
+    tsv.lineDelimiter = "\n";
+    tsv.fieldDelimiter = '\t';
+    tsv.quote = '"';
+    tsv.escape = '"';
+    tsv.extractHeader = true;
+    formats.put("tsv", tsv);
+
+    TextFormatConfig custom = new TextFormatConfig();
+    custom.extensions = Collections.singletonList("custom");
+    custom.lineDelimiter = "!";
+    custom.fieldDelimiter = '_';
+    custom.quote = '$';
+    custom.escape = '^';
+    custom.extractHeader = true;
+    formats.put("custom", custom);
+
+    cluster.defineFormats("dfs", formats);
+  }
+
+  @After
+  public void cleanUp() {
+    client.resetSession(ExecConstants.OUTPUT_FORMAT_OPTION);
+    client.resetSession(ExecConstants.TEXT_WRITER_ADD_HEADER);
+    client.resetSession(ExecConstants.TEXT_WRITER_FORCE_QUOTES);
+
+    tablesToDrop.forEach(
+      table -> client.runSqlSilently(String.format("drop table if exists %s", table)));
+  }
+
+  @Test
+  public void testWithHeaders() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+
+    String tableName = "csv_with_headers_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as select 'a' as col1, 'b' as col2 from (values(1))", fullTableName).run();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.csv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Arrays.asList("col1,col2", "a,b"), lines);
+  }
+
+  @Test
+  public void testWithoutHeaders() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+    client.alterSession(ExecConstants.TEXT_WRITER_ADD_HEADER, false);
+
+    String tableName = "csv_without_headers_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as select 'a' as col1, 'b' as col2 from (values(1))", fullTableName).run();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.csv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Collections.singletonList("a,b"), lines);
+  }
+
+  @Test
+  public void testNoQuotes() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+
+    String tableName = "csv_no_quotes_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as " +
+      "select 1 as id, 'Bob' as name, 'A B C' as desc from (values(1))", fullTableName).run();
+
+    testBuilder()
+      .sqlQuery("select * from %s", fullTableName)
+      .unOrdered()
+      .baselineColumns("id", "name", "desc")
+      .baselineValues("1", "Bob", "A B C")
+      .go();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.csv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Arrays.asList("id,name,desc", "1,Bob,A B C"), lines);
+  }
+
+  @Test
+  public void testQuotesOnDemand() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+
+    String tableName = "csv_quotes_on_demand_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as " +
+      "select 1 as id, 'Bob\nSmith' as name, 'A,B,C' as desc from (values(1))", fullTableName).run();
+
+    testBuilder()
+      .sqlQuery("select * from %s", fullTableName)
+      .unOrdered()
+      .baselineColumns("id", "name", "desc")
+      .baselineValues("1", "Bob\nSmith", "A,B,C")
+      .go();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.csv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Arrays.asList("id,name,desc", "1,\"Bob", "Smith\",\"A,B,C\""), lines);
+  }
+
+  @Test
+  public void testForceQuotes() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "csv");
+    client.alterSession(ExecConstants.TEXT_WRITER_FORCE_QUOTES, true);
+
+    String tableName = "csv_force_quotes_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as " +
+      "select 1 as id, 'Bob' as name, 'A,B,C' as desc from (values(1))", fullTableName).run();
+
+    testBuilder()
+      .sqlQuery("select * from %s", fullTableName)
+      .unOrdered()
+      .baselineColumns("id", "name", "desc")
+      .baselineValues("1", "Bob", "A,B,C")
+      .go();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.csv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Arrays.asList("\"id\",\"name\",\"desc\"", "\"1\",\"Bob\",\"A,B,C\""), lines);
+  }
+
+  @Test
+  public void testTsv() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "tsv");
+
+    String tableName = "tsv_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as " +
+      "select 1 as id, 'Bob\tSmith' as name, 'A\"B\"C' as desc from (values(1))", fullTableName).run();
+
+    testBuilder()
+      .sqlQuery("select * from %s", fullTableName)
+      .unOrdered()
+      .baselineColumns("id", "name", "desc")
+      .baselineValues("1", "Bob\tSmith", "A\"B\"C")
+      .go();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.tsv");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Arrays.asList("id\tname\tdesc", "1\t\"Bob\tSmith\"\tA\"B\"C"), lines);
+  }
+
+  @Test
+  public void testCustomFormat() throws Exception {
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "custom");
+
+    String tableName = "custom_format_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    queryBuilder().sql("create table %s as " +
+      "select 1 as `id_`, 'Bob$Smith' as name, 'A^B!C' as desc from (values(1))", fullTableName).run();
+
+    testBuilder()
+      .sqlQuery("select * from %s", fullTableName)
+      .unOrdered()
+      .baselineColumns("id_", "name", "desc")
+      .baselineValues("1", "Bob$Smith", "A^B!C")
+      .go();
+
+    Path path = Paths.get(dirTestWatcher.getDfsTestTmpDir().getAbsolutePath(), tableName, "0_0_0.custom");
+    List<String> lines = Files.readAllLines(path);
+    assertEquals(Collections.singletonList("$id_$_name_desc!1_Bob$Smith_$A^B!C$!"), lines);
+  }
+
+  @Test
+  public void testLineDelimiterLengthLimit() throws Exception {
+    TextFormatConfig incorrect = new TextFormatConfig();
+    incorrect.lineDelimiter = "end";
+    cluster.defineFormat("dfs", "incorrect", incorrect);
+
+    client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "incorrect");
+
+    String tableName = "incorrect_line_delimiter_table";
+    String fullTableName = String.format("dfs.tmp.`%s`", tableName);
+    tablesToDrop.add(fullTableName);
+
+    // univocity-parsers allow only 1 - 2 characters line separators
+    thrown.expect(UserException.class);
+    thrown.expectMessage("Invalid line separator");
+
+    queryBuilder().sql("create table %s as select 1 as id from (values(1))", fullTableName).run();
+  }
+}


### PR DESCRIPTION
1. Usage of format plugin configuration allows to specify line and field delimiters, quotes and escape characters.
2. Usage of system / session options allows to specify if writer should add headers, force quotes.

Jira - [DRILL-6096](https://issues.apache.org/jira/browse/DRILL-6096).