### PR TITLE
DRILL-7413: Test and fix scan operator vectors

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -448,6 +448,11 @@ public class VectorContainer implements VectorAccessible {
     return true;
   }
 
+  public void setValueCount(int valueCount) {
+    VectorAccessibleUtilities.setValueCount(this, valueCount);
+    setRecordCount(valueCount);
+  }
+
   /**
    * Merge two batches to create a single, combined, batch. Vectors
    * appear in the order defined by {@link BatchSchema#merge(BatchSchema)}.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -17,15 +17,11 @@
  */
 package org.apache.drill.exec.store.easy.json;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -51,9 +47,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JSONFormatPlugin.class);
+  private static final Logger logger = LoggerFactory.getLogger(JSONFormatPlugin.class);
   public static final String DEFAULT_NAME = "json";
 
   private static final boolean IS_COMPRESSIBLE = true;
@@ -77,11 +81,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
 
   @Override
   public boolean isStatisticsRecordWriter(FragmentContext context, EasyWriter writer) {
-    if (context.getSQLStatementType() == SqlStatementType.ANALYZE) {
-      return true;
-    } else {
-      return false;
-    }
+    return context.getSQLStatementType() == SqlStatementType.ANALYZE;
   }
 
   @Override
@@ -181,7 +181,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
 
     @Override
     public int hashCode() {
-      final int prime = 31;
+      int prime = 31;
       int result = 1;
       result = prime * result + ((extensions == null) ? 0 : extensions.hashCode());
       return result;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
@@ -17,13 +17,16 @@
  */
 package org.apache.drill.exec.store.easy.sequencefile;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
+import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.RecordWriter;
@@ -37,9 +40,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
-
-import java.io.IOException;
-import java.util.List;
 
 public class SequenceFileFormatPlugin extends EasyFormatPlugin<SequenceFileFormatConfig> {
   public SequenceFileFormatPlugin(String name, DrillbitContext context, Configuration fsConf,
@@ -58,7 +58,6 @@ public class SequenceFileFormatPlugin extends EasyFormatPlugin<SequenceFileForma
   public boolean supportsPushDown() {
     return true;
   }
-
 
   @Override
   public AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/vector/TestDateTypes.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.drill.categories.SlowTest;
 import org.apache.drill.categories.VectorTest;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.client.DrillClient;
@@ -33,251 +34,246 @@ import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.drill.categories.SlowTest;
-import org.junit.Test;
-
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-/* This class tests the existing date types. Simply using date types
+/* Tests the existing date types. Simply using date types
  * by casting from VarChar, performing basic functions and converting
  * back to VarChar.
  */
 @Category({SlowTest.class, VectorTest.class})
 public class TestDateTypes extends PopUnitTestBase {
-//    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestDateTypes.class);
 
-    @Test
-    public void testDate() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testDate() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+       Drillbit bit = new Drillbit(CONFIG, serviceSet);
+       DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_date.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(0);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(0);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            for (VectorWrapper<?> v : batchLoader) {
+      for (VectorWrapper<?> v : batchLoader) {
 
-                ValueVector.Accessor accessor = v.getValueVector().getAccessor();
+        ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals((accessor.getObject(0).toString()), ("1970-01-02"));
-                assertEquals((accessor.getObject(1).toString()), ("2008-12-28"));
-                assertEquals((accessor.getObject(2).toString()), ("2000-02-27"));
-            }
+        assertEquals((accessor.getObject(0).toString()), ("1970-01-02"));
+        assertEquals((accessor.getObject(1).toString()), ("2008-12-28"));
+        assertEquals((accessor.getObject(2).toString()), ("2000-02-27"));
+      }
 
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 
-    @Test
-    public void testSortDate() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testSortDate() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+       Drillbit bit = new Drillbit(CONFIG, serviceSet);
+       DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_sort_date.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_date.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_sort_date.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(1);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(1);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            for (VectorWrapper<?> v : batchLoader) {
+      for (VectorWrapper<?> v : batchLoader) {
 
-                ValueVector.Accessor accessor = v.getValueVector().getAccessor();
+        ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals((accessor.getObject(0).toString()), "1970-01-02");
-                assertEquals((accessor.getObject(1).toString()), "2000-02-27");
-                assertEquals((accessor.getObject(2).toString()), "2008-12-28");
-            }
+        assertEquals((accessor.getObject(0).toString()), "1970-01-02");
+        assertEquals((accessor.getObject(1).toString()), "2000-02-27");
+        assertEquals((accessor.getObject(2).toString()), "2008-12-28");
+      }
 
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 
-    @Test
-    public void testTimeStamp() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testTimeStamp() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+       Drillbit bit = new Drillbit(CONFIG, serviceSet);
+       DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_timestamp.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_date.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_timestamp.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(0);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(0);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            for (VectorWrapper<?> v : batchLoader) {
+      for (VectorWrapper<?> v : batchLoader) {
 
-                ValueVector.Accessor accessor = v.getValueVector().getAccessor();
+        ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals(accessor.getObject(0).toString(),"1970-01-02 10:20:33.000");
-                assertEquals(accessor.getObject(1).toString(),"2008-12-28 11:34:00.129");
-                assertEquals(accessor.getObject(2).toString(), "2000-02-27 14:24:00.000");
-            }
+        assertEquals(accessor.getObject(0).toString(),"1970-01-02 10:20:33.000");
+        assertEquals(accessor.getObject(1).toString(),"2008-12-28 11:34:00.129");
+        assertEquals(accessor.getObject(2).toString(), "2000-02-27 14:24:00.000");
+      }
 
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 
-    @Test
-    public void testInterval() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testInterval() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+         Drillbit bit = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_interval.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_interval.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_interval.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(0);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(0);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            Iterator<VectorWrapper<?>> itr = batchLoader.iterator();
+      Iterator<VectorWrapper<?>> itr = batchLoader.iterator();
 
-            ValueVector.Accessor accessor = itr.next().getValueVector().getAccessor();
+      ValueVector.Accessor accessor = itr.next().getValueVector().getAccessor();
 
-            // Check the interval type
-            assertEquals((accessor.getObject(0).toString()), ("2 years 2 months 1 day 1:20:35.0"));
-            assertEquals((accessor.getObject(1).toString()), ("2 years 2 months 0 days 0:0:0.0"));
-            assertEquals((accessor.getObject(2).toString()), ("0 years 0 months 0 days 1:20:35.0"));
-            assertEquals((accessor.getObject(3).toString()),("2 years 2 months 1 day 1:20:35.897"));
-            assertEquals((accessor.getObject(4).toString()), ("0 years 0 months 0 days 0:0:35.4"));
-            assertEquals((accessor.getObject(5).toString()), ("1 year 10 months 1 day 0:-39:-25.0"));
+      // Check the interval type
+      assertEquals((accessor.getObject(0).toString()), ("2 years 2 months 1 day 1:20:35.0"));
+      assertEquals((accessor.getObject(1).toString()), ("2 years 2 months 0 days 0:0:0.0"));
+      assertEquals((accessor.getObject(2).toString()), ("0 years 0 months 0 days 1:20:35.0"));
+      assertEquals((accessor.getObject(3).toString()),("2 years 2 months 1 day 1:20:35.897"));
+      assertEquals((accessor.getObject(4).toString()), ("0 years 0 months 0 days 0:0:35.4"));
+      assertEquals((accessor.getObject(5).toString()), ("1 year 10 months 1 day 0:-39:-25.0"));
 
-            accessor = itr.next().getValueVector().getAccessor();
+      accessor = itr.next().getValueVector().getAccessor();
 
-            // Check the interval year type
-            assertEquals((accessor.getObject(0).toString()), ("2 years 2 months "));
-            assertEquals((accessor.getObject(1).toString()), ("2 years 2 months "));
-            assertEquals((accessor.getObject(2).toString()), ("0 years 0 months "));
-            assertEquals((accessor.getObject(3).toString()), ("2 years 2 months "));
-            assertEquals((accessor.getObject(4).toString()), ("0 years 0 months "));
-            assertEquals((accessor.getObject(5).toString()), ("1 year 10 months "));
+      // Check the interval year type
+      assertEquals((accessor.getObject(0).toString()), ("2 years 2 months "));
+      assertEquals((accessor.getObject(1).toString()), ("2 years 2 months "));
+      assertEquals((accessor.getObject(2).toString()), ("0 years 0 months "));
+      assertEquals((accessor.getObject(3).toString()), ("2 years 2 months "));
+      assertEquals((accessor.getObject(4).toString()), ("0 years 0 months "));
+      assertEquals((accessor.getObject(5).toString()), ("1 year 10 months "));
 
 
-            accessor = itr.next().getValueVector().getAccessor();
+      accessor = itr.next().getValueVector().getAccessor();
 
-            // Check the interval day type
-            assertEquals((accessor.getObject(0).toString()), ("1 day 1:20:35.0"));
-            assertEquals((accessor.getObject(1).toString()), ("0 days 0:0:0.0"));
-            assertEquals((accessor.getObject(2).toString()), ("0 days 1:20:35.0"));
-            assertEquals((accessor.getObject(3).toString()), ("1 day 1:20:35.897"));
-            assertEquals((accessor.getObject(4).toString()), ("0 days 0:0:35.4"));
-            assertEquals((accessor.getObject(5).toString()), ("1 day 0:-39:-25.0"));
+      // Check the interval day type
+      assertEquals((accessor.getObject(0).toString()), ("1 day 1:20:35.0"));
+      assertEquals((accessor.getObject(1).toString()), ("0 days 0:0:0.0"));
+      assertEquals((accessor.getObject(2).toString()), ("0 days 1:20:35.0"));
+      assertEquals((accessor.getObject(3).toString()), ("1 day 1:20:35.897"));
+      assertEquals((accessor.getObject(4).toString()), ("0 days 0:0:35.4"));
+      assertEquals((accessor.getObject(5).toString()), ("1 day 0:-39:-25.0"));
 
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 
-    @Test
-    public void testLiterals() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testLiterals() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+         Drillbit bit = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_all_date_literals.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_date.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_all_date_literals.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(0);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(0);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            String result[] = {"2008-02-27",
-                               "2008-02-27 01:02:03.000",
-                               "10:11:13.999",
-                               "2 years 2 months 3 days 0:1:3.89"};
+      String result[] = {"2008-02-27",
+                         "2008-02-27 01:02:03.000",
+                         "10:11:13.999",
+                         "2 years 2 months 3 days 0:1:3.89"};
 
-            int idx = 0;
+      int idx = 0;
 
-            for (VectorWrapper<?> v : batchLoader) {
+      for (VectorWrapper<?> v : batchLoader) {
 
-                ValueVector.Accessor accessor = v.getValueVector().getAccessor();
+        ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals((accessor.getObject(0).toString()), (result[idx++]));
-            }
+        assertEquals((accessor.getObject(0).toString()), (result[idx++]));
+      }
 
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 
-    @Test
-    public void testDateAdd() throws Exception {
-        try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
-             Drillbit bit = new Drillbit(CONFIG, serviceSet);
-             DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
+  @Test
+  public void testDateAdd() throws Exception {
+    try (RemoteServiceSet serviceSet = RemoteServiceSet.getLocalServiceSet();
+         Drillbit bit = new Drillbit(CONFIG, serviceSet);
+         DrillClient client = new DrillClient(CONFIG, serviceSet.getCoordinator())) {
 
-            // run query.
-            bit.run();
-            client.connect();
-            List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
-                    Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date_add.json"), Charsets.UTF_8).read()
-                            .replace("#{TEST_FILE}", "/test_simple_date.json"));
+      // run query.
+      bit.run();
+      client.connect();
+      List<QueryDataBatch> results = client.runQuery(org.apache.drill.exec.proto.UserBitShared.QueryType.PHYSICAL,
+              Files.asCharSource(DrillFileUtils.getResourceAsFile("/record/vector/test_date_add.json"), Charsets.UTF_8).read()
+                      .replace("#{TEST_FILE}", "/test_simple_date.json"));
 
-            RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
+      RecordBatchLoader batchLoader = new RecordBatchLoader(bit.getContext().getAllocator());
 
-            QueryDataBatch batch = results.get(0);
-            assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
+      QueryDataBatch batch = results.get(0);
+      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
 
-            for (VectorWrapper<?> v : batchLoader) {
+      for (VectorWrapper<?> v : batchLoader) {
 
-                ValueVector.Accessor accessor = v.getValueVector().getAccessor();
+        ValueVector.Accessor accessor = v.getValueVector().getAccessor();
 
-                assertEquals((accessor.getObject(0).toString()), ("2008-03-27 00:00:00.000"));
+        assertEquals((accessor.getObject(0).toString()), ("2008-03-27 00:00:00.000"));
+      }
 
-
-            }
-
-            batchLoader.clear();
-            for(QueryDataBatch b : results){
-              b.release();
-            }
-        }
+      batchLoader.clear();
+      for(QueryDataBatch b : results){
+        b.release();
+      }
     }
+  }
 }

--- a/exec/java-exec/src/test/resources/parquet/alltypes_repeated.json
+++ b/exec/java-exec/src/test/resources/parquet/alltypes_repeated.json
@@ -108,5 +108,5 @@
     "VARBINARY_col" : false,
     "VARCHAR_col" : [ "a string", "asdf", ""],
     "VAR16CHAR_col" : false,
-    "BIT_col" : [ true, true,  true]
+    "BIT_col" : [ true, true, true]
 }


### PR DESCRIPTION
Enables vector validation tests for the ScanBatch and all  EasyFormat plugins. Fixes a bug in scan batch that failed to set the record count in the output container.
    
Fixes a number of formatting and other issues found while adding the tests.
