### PR TITLE
DRILL-7414: EVF incorrectly sets buffer writer index after rollover

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -17,23 +17,29 @@
  */
 package org.apache.drill.exec.physical.impl.validate;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Method;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
+import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.SimpleVectorWrapper;
 import org.apache.drill.exec.record.VectorAccessible;
+import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.FixedWidthVector;
-import org.apache.drill.exec.vector.NullableVarCharVector;
 import org.apache.drill.exec.vector.NullableVector;
 import org.apache.drill.exec.vector.RepeatedVarCharVector;
+import org.apache.drill.exec.vector.UInt1Vector;
 import org.apache.drill.exec.vector.UInt4Vector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.VarCharVector;
 import org.apache.drill.exec.vector.VariableWidthVector;
 import org.apache.drill.exec.vector.complex.BaseRepeatedValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedFixedWidthVectorLike;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -45,103 +51,334 @@ import org.apache.drill.exec.vector.complex.RepeatedFixedWidthVectorLike;
  */
 
 public class BatchValidator {
-  private static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(BatchValidator.class);
+  private static final Logger logger = LoggerFactory.getLogger(BatchValidator.class);
 
+  public static final boolean LOG_TO_STDOUT = true;
   public static final int MAX_ERRORS = 100;
 
-  private final int rowCount;
-  private final VectorAccessible batch;
-  private final List<String> errorList;
-  private int errorCount;
-
-  public BatchValidator(VectorAccessible batch) {
-    rowCount = batch.getRecordCount();
-    this.batch = batch;
-    errorList = null;
+  public interface ErrorReporter {
+    void error(String name, ValueVector vector, String msg);
+    void warn(String name, ValueVector vector, String msg);
+    void error(String msg);
+    int errorCount();
   }
 
-  public BatchValidator(VectorAccessible batch, boolean captureErrors) {
-    rowCount = batch.getRecordCount();
-    this.batch = batch;
-    if (captureErrors) {
-      errorList = new ArrayList<>();
+  public abstract static class BaseErrorReporter implements ErrorReporter {
+
+    private final String opName;
+    private int errorCount;
+
+    public BaseErrorReporter(String opName) {
+      this.opName = opName;
+    }
+
+    protected boolean startError() {
+      if (errorCount == 0) {
+        logger.error("Found one or more vector errors from {}", opName);
+      }
+      errorCount++;
+      if (errorCount >= MAX_ERRORS) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public void error(String name, ValueVector vector, String msg) {
+      error(String.format("%s - %s: %s",
+            name, vector.getClass().getSimpleName(), msg));
+    }
+
+    @Override
+    public void warn(String name, ValueVector vector, String msg) {
+      warn(String.format("%s - %s: %s",
+            name, vector.getClass().getSimpleName(), msg));
+    }
+
+    public abstract void warn(String msg);
+
+    @Override
+    public int errorCount() { return errorCount; }
+  }
+
+  private static class StdOutReporter extends BaseErrorReporter {
+
+    public StdOutReporter(String opName) {
+      super(opName);
+    }
+
+    @Override
+    public void error(String msg) {
+      if (startError()) {
+        System.out.println(msg);
+      }
+    }
+
+    @Override
+    public void warn(String msg) {
+      System.out.println(msg);
+    }
+  }
+
+  private static class LogReporter extends BaseErrorReporter {
+
+    public LogReporter(String opName) {
+      super(opName);
+    }
+
+    @Override
+    public void error(String msg) {
+      if (startError()) {
+        logger.error(msg);
+      }
+    }
+
+    @Override
+    public void warn(String msg) {
+      logger.error(msg);
+    }
+  }
+
+  private enum CheckMode { COUNTS, ALL };
+
+  private static final Map<Class<? extends RecordBatch>, CheckMode> checkRules = buildRules();
+
+  private final ErrorReporter errorReporter;
+
+  public BatchValidator(ErrorReporter errorReporter) {
+    this.errorReporter = errorReporter;
+  }
+
+  /**
+   * At present, most operators will not pass the checks here. The following
+   * table identifies those that should be checked, and the degree of check.
+   * Over time, this table should include all operators, and thus become
+   * unnecessary.
+   */
+  private static Map<Class<? extends RecordBatch>, CheckMode> buildRules() {
+    final Map<Class<? extends RecordBatch>, CheckMode> rules = new IdentityHashMap<>();
+    rules.put(OperatorRecordBatch.class, CheckMode.ALL);
+    return rules;
+  }
+
+  public static boolean validate(RecordBatch batch) {
+    final CheckMode checkMode = checkRules.get(batch.getClass());
+
+    // If no rule, don't check this batch.
+
+    if (checkMode == null) {
+
+      // As work proceeds, might want to log those batches not checked.
+      // For now, there are too many.
+
+      return true;
+    }
+
+    // All batches that do any checks will at least check counts.
+
+    ErrorReporter reporter = errorReporter(batch);
+    int rowCount = batch.getRecordCount();
+    int valueCount = rowCount;
+    VectorContainer container = batch.getContainer();
+    if (!container.hasRecordCount()) {
+      reporter.error(String.format(
+          "%s: Container record count not set",
+          batch.getClass().getSimpleName()));
     } else {
-      errorList = null;
+      // Row count will = container count for most operators.
+      // Row count <= container count for the filter operator.
+
+      int containerRowCount = container.getRecordCount();
+      valueCount = containerRowCount;
+      switch (batch.getSchema().getSelectionVectorMode()) {
+      case FOUR_BYTE:
+        int sv4Count = batch.getSelectionVector4().getCount();
+        if (sv4Count != rowCount) {
+          reporter.error(String.format(
+              "Mismatch between %s record count = %d, SV4 record count = %d",
+              batch.getClass().getSimpleName(),
+              rowCount, sv4Count));
+        }
+        // TODO: Don't know how to check SV4 batches
+        return true;
+      case TWO_BYTE:
+        int sv2Count = batch.getSelectionVector2().getCount();
+        if (sv2Count != rowCount) {
+          reporter.error(String.format(
+              "Mismatch between %s record count = %d, SV2 record count = %d",
+              batch.getClass().getSimpleName(),
+              rowCount, sv2Count));
+        }
+        if (sv2Count > containerRowCount) {
+          reporter.error(String.format(
+              "Mismatch between %s container count = %d, SV2 record count = %d",
+              batch.getClass().getSimpleName(),
+              containerRowCount, sv2Count));
+        }
+        int svTotalCount = batch.getSelectionVector2().getBatchActualRecordCount();
+        if (svTotalCount != containerRowCount) {
+          reporter.error(String.format(
+              "Mismatch between %s container count = %d, SV2 total count = %d",
+              batch.getClass().getSimpleName(),
+              containerRowCount, svTotalCount));
+        }
+        break;
+      default:
+        if (rowCount != containerRowCount) {
+          reporter.error(String.format(
+              "Mismatch between %s record count = %d, container record count = %d",
+              batch.getClass().getSimpleName(),
+              rowCount, containerRowCount));
+        }
+        break;
+      }
+    }
+    if (checkMode == CheckMode.ALL) {
+      new BatchValidator(reporter).validateBatch(batch, valueCount);
+    }
+    return reporter.errorCount() == 0;
+  }
+
+  public static boolean validate(VectorAccessible batch) {
+    ErrorReporter reporter = errorReporter(batch);
+    new BatchValidator(reporter).validateBatch(batch, batch.getRecordCount());
+    return reporter.errorCount() == 0;
+  }
+
+  private static ErrorReporter errorReporter(VectorAccessible batch) {
+    String opName = batch.getClass().getSimpleName();
+    if (LOG_TO_STDOUT) {
+      return new StdOutReporter(opName);
+    } else {
+      return new LogReporter(opName);
     }
   }
 
-  public void validate() {
-    if (batch.getRecordCount() == 0) {
-      return;
-    }
+  public void validateBatch(VectorAccessible batch, int rowCount) {
     for (VectorWrapper<? extends ValueVector> w : batch) {
-      validateWrapper(w);
+      validateWrapper(rowCount, w);
     }
   }
 
-  private void validateWrapper(VectorWrapper<? extends ValueVector> w) {
+  private void validateWrapper(int rowCount, VectorWrapper<? extends ValueVector> w) {
     if (w instanceof SimpleVectorWrapper) {
-      validateVector(w.getValueVector());
+      ValueVector v = w.getValueVector();
+      int valueCount = v.getAccessor().getValueCount();
+      if (valueCount != rowCount) {
+        error(v.getField().getName(), v, String.format(
+            "Row count = %d, but value count = %d",
+            rowCount, valueCount));
+      }
+      validateVector(v);
     }
   }
 
   private void validateVector(ValueVector vector) {
-    String name = vector.getField().getName();
+    validateVector(vector.getField().getName(), vector);
+  }
+
+  private void validateVector(String name, ValueVector vector) {
     if (vector instanceof NullableVector) {
       validateNullableVector(name, (NullableVector) vector);
     } else if (vector instanceof VariableWidthVector) {
-      validateVariableWidthVector(name, (VariableWidthVector) vector, rowCount);
+      validateVariableWidthVector(name, (VariableWidthVector) vector);
     } else if (vector instanceof FixedWidthVector) {
       validateFixedWidthVector(name, (FixedWidthVector) vector);
     } else if (vector instanceof BaseRepeatedValueVector) {
       validateRepeatedVector(name, (BaseRepeatedValueVector) vector);
     } else {
-      logger.debug("Don't know how to validate vector: " + name + " of class " + vector.getClass().getSimpleName());
+      logger.debug("Don't know how to validate vector: {}  of class {}",
+          name, vector.getClass().getSimpleName());
     }
   }
 
-  private void validateVariableWidthVector(String name, VariableWidthVector vector, int entryCount) {
+  private void validateNullableVector(String name, NullableVector vector) {
+    int outerCount = vector.getAccessor().getValueCount();
+    ValueVector valuesVector = vector.getValuesVector();
+    int valueCount = valuesVector.getAccessor().getValueCount();
+    if (valueCount != outerCount) {
+      error(name, vector, String.format(
+          "Outer value count = %d, but inner value count = %d",
+          outerCount, valueCount));
+    }
+    verifyIsSetVector(vector, (UInt1Vector) vector.getBitsVector());
+    validateVector(name + "-values", valuesVector);
+  }
+
+  private void validateVariableWidthVector(String name, VariableWidthVector vector) {
 
     // Offsets are in the derived classes. Handle only VarChar for now.
 
     if (vector instanceof VarCharVector) {
-      validateVarCharVector(name, (VarCharVector) vector, entryCount);
+      validateVarCharVector(name, (VarCharVector) vector);
     } else {
-      logger.debug("Don't know how to validate vector: " + name + " of class " + vector.getClass().getSimpleName());
+      logger.debug("Don't know how to validate vector: {}  of class {}",
+          name, vector.getClass().getSimpleName());
     }
   }
 
-  private void validateVarCharVector(String name, VarCharVector vector, int entryCount) {
-//    int dataLength = vector.getAllocatedByteCount(); // Includes offsets and data.
-    int dataLength = vector.getBuffer().capacity();
-    validateOffsetVector(name + "-offsets", vector.getOffsetVector(), entryCount, dataLength);
+  private void validateVarCharVector(String name, VarCharVector vector) {
+    int size = vector.getAccessor().getValueCount();
+
+    // Disabled because a large number of operators
+    // set up offset vectors wrongly.
+    if (size == 0) {
+      return;
+    }
+
+    int dataLength = vector.getBuffer().writerIndex();
+    validateOffsetVector(name + "-offsets", vector.getOffsetVector(), false, size, dataLength);
   }
 
   private void validateRepeatedVector(String name, BaseRepeatedValueVector vector) {
-
     int dataLength = Integer.MAX_VALUE;
     if (vector instanceof RepeatedVarCharVector) {
-      dataLength = ((RepeatedVarCharVector) vector).getOffsetVector().getValueCapacity();
+      dataLength = ((RepeatedVarCharVector) vector).getDataVector().getBuffer().writerIndex();
     } else if (vector instanceof RepeatedFixedWidthVectorLike) {
-      dataLength = ((BaseDataValueVector) vector.getDataVector()).getBuffer().capacity();
+      dataLength = ((BaseDataValueVector) vector.getDataVector()).getBuffer().writerIndex();
     }
-    int itemCount = validateOffsetVector(name + "-offsets", vector.getOffsetVector(), rowCount, dataLength);
+    int valueCount = vector.getAccessor().getValueCount();
+    int itemCount = validateOffsetVector(name + "-offsets", vector.getOffsetVector(), true, valueCount, dataLength);
 
     // Special handling of repeated VarChar vectors
     // The nested data vectors are not quite exactly like top-level vectors.
 
     ValueVector dataVector = vector.getDataVector();
+    if (dataVector.getAccessor().getValueCount() != itemCount) {
+      error(name, vector, String.format(
+          "Vector has %d values, but offset vector labels %d values",
+          valueCount, itemCount));
+    }
     if (dataVector instanceof VariableWidthVector) {
-      validateVariableWidthVector(name + "-data", (VariableWidthVector) dataVector, itemCount);
+      validateVariableWidthVector(name + "-data", (VariableWidthVector) dataVector);
     }
   }
 
-  private int validateOffsetVector(String name, UInt4Vector offsetVector, int valueCount, int maxOffset) {
+  private void validateFixedWidthVector(String name, FixedWidthVector vector) {
+    // Not much to do. The only item to check is the vector
+    // count itself, which was already done. There is no inner
+    // structure to check.
+  }
+
+  private int validateOffsetVector(String name, UInt4Vector offsetVector, boolean repeated, int valueCount, int maxOffset) {
+    UInt4Vector.Accessor accessor = offsetVector.getAccessor();
+    int offsetCount = accessor.getValueCount();
+    // TODO: Disabled because a large number of operators
+    // set up offset vectors incorrectly.
+//    if (!repeated && offsetCount == 0) {
+//      System.out.println(String.format(
+//          "Offset vector for %s: [0] has length 0, expected 1+",
+//          name));
+//      return false;
+//    }
+    if (valueCount == 0 && offsetCount > 1 || valueCount > 0 && offsetCount != valueCount + 1) {
+      error(name, offsetVector, String.format(
+          "Outer vector has %d values, but offset vector has %d, expected %d",
+          valueCount, offsetCount, valueCount + 1));
+    }
     if (valueCount == 0) {
       return 0;
     }
-    UInt4Vector.Accessor accessor = offsetVector.getAccessor();
 
     // First value must be zero in current version.
 
@@ -150,12 +387,12 @@ public class BatchValidator {
       error(name, offsetVector, "Offset (0) must be 0 but was " + prevOffset);
     }
 
-    // Note <= comparison: offset vectors have (n+1) entries.
-
-    for (int i = 1; i <= valueCount; i++) {
+    for (int i = 1; i < offsetCount; i++) {
       int offset = accessor.get(i);
       if (offset < prevOffset) {
-        error(name, offsetVector, "Decreasing offsets at (" + (i-1) + ", " + i + ") = (" + prevOffset + ", " + offset + ")");
+        error(name, offsetVector, String.format(
+            "Offset vector [%d] contained %d, expected >= %d",
+            i, offset, prevOffset));
       } else if (offset > maxOffset) {
         error(name, offsetVector, "Invalid offset at index " + i + " = " + offset + " exceeds maximum of " + maxOffset);
       }
@@ -165,42 +402,52 @@ public class BatchValidator {
   }
 
   private void error(String name, ValueVector vector, String msg) {
-    if (errorCount == 0) {
-      logger.error("Found one or more vector errors from " + batch.getClass().getSimpleName());
-    }
-    errorCount++;
-    if (errorCount >= MAX_ERRORS) {
-      return;
-    }
-    String fullMsg = "Column " + name + " of type " + vector.getClass().getSimpleName( ) + ": " + msg;
-    logger.error(fullMsg);
-    if (errorList != null) {
-      errorList.add(fullMsg);
+    if (errorReporter == null) {
+      assert false;
+    } else {
+      // Temporary during debugging
+
+      errorReporter.warn(name, vector, msg);
     }
   }
 
-  private void validateNullableVector(String name, NullableVector vector) {
-    // Can't validate at this time because the bits vector is in each
-    // generated subtype.
-
-    // Validate a VarChar vector because it is common.
-
-    if (vector instanceof NullableVarCharVector) {
-      VarCharVector values = ((NullableVarCharVector) vector).getValuesVector();
-      validateVarCharVector(name + "-values", values, rowCount);
+  private void verifyIsSetVector(ValueVector parent, UInt1Vector bv) {
+    String name = String.format("%s (%s)-bits",
+        parent.getField().getName(),
+        parent.getClass().getSimpleName());
+    int rowCount = parent.getAccessor().getValueCount();
+    int bitCount = bv.getAccessor().getValueCount();
+    if (bitCount != rowCount) {
+      error(name, bv, String.format(
+          "Value count = %d, but bit count = %d",
+          rowCount, bitCount));
     }
-  }
-
-  private void validateFixedWidthVector(String name, FixedWidthVector vector) {
-    // TODO Auto-generated method stub
-
+    UInt1Vector.Accessor ba = bv.getAccessor();
+    for (int i = 0; i < bitCount; i++) {
+      int value = ba.get(i);
+      if (value != 0 && value != 1) {
+        error(name, bv, String.format(
+            "%s %s: bit vector[%d] = %d, expected 0 or 1",
+            i, value));
+      }
+    }
   }
 
   /**
-   * Obtain the list of errors. For use in unit-testing this class.
-   * @return the list of errors found, or null if error capture was
-   * not enabled
+   * Print a record batch. Uses code only available in a test build.
+   * Classes are not visible to the compiler; must load dynamically.
+   * Does nothing if the class is not available.
    */
 
-  public List<String> errors() { return errorList; }
+  public static void print(RecordBatch batch) {
+    try {
+      Class<?> helper = Class.forName("org.apache.drill.test.rowSet.RowSetUtilities");
+      Method print = helper.getMethod("print", VectorContainer.class);
+      System.out.println(batch.getClass().getSimpleName());
+      print.invoke(null, batch.getContainer());
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      // Ignore
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
+import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.SimpleVectorWrapper;
 import org.apache.drill.exec.record.VectorAccessible;
@@ -155,7 +156,7 @@ public class BatchValidator {
    */
   private static Map<Class<? extends RecordBatch>, CheckMode> buildRules() {
     final Map<Class<? extends RecordBatch>, CheckMode> rules = new IdentityHashMap<>();
-    //rules.put(OperatorRecordBatch.class, CheckMode.ALL);
+    rules.put(OperatorRecordBatch.class, CheckMode.ALL);
     return rules;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.validate;
 
-import java.lang.reflect.Method;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
@@ -155,13 +154,13 @@ public class BatchValidator {
    * unnecessary.
    */
   private static Map<Class<? extends RecordBatch>, CheckMode> buildRules() {
-    final Map<Class<? extends RecordBatch>, CheckMode> rules = new IdentityHashMap<>();
+    Map<Class<? extends RecordBatch>, CheckMode> rules = new IdentityHashMap<>();
     rules.put(OperatorRecordBatch.class, CheckMode.ALL);
     return rules;
   }
 
   public static boolean validate(RecordBatch batch) {
-    final CheckMode checkMode = checkRules.get(batch.getClass());
+    CheckMode checkMode = checkRules.get(batch.getClass());
 
     // If no rule, don't check this batch.
 
@@ -175,10 +174,10 @@ public class BatchValidator {
 
     // All batches that do any checks will at least check counts.
 
-    final ErrorReporter reporter = errorReporter(batch);
-    final int rowCount = batch.getRecordCount();
+    ErrorReporter reporter = errorReporter(batch);
+    int rowCount = batch.getRecordCount();
     int valueCount = rowCount;
-    final VectorContainer container = batch.getContainer();
+    VectorContainer container = batch.getContainer();
     if (!container.hasRecordCount()) {
       reporter.error(String.format(
           "%s: Container record count not set",
@@ -187,11 +186,11 @@ public class BatchValidator {
       // Row count will = container count for most operators.
       // Row count <= container count for the filter operator.
 
-      final int containerRowCount = container.getRecordCount();
+      int containerRowCount = container.getRecordCount();
       valueCount = containerRowCount;
       switch (batch.getSchema().getSelectionVectorMode()) {
       case FOUR_BYTE:
-        final int sv4Count = batch.getSelectionVector4().getCount();
+        int sv4Count = batch.getSelectionVector4().getCount();
         if (sv4Count != rowCount) {
           reporter.error(String.format(
               "Mismatch between %s record count = %d, SV4 record count = %d",
@@ -201,7 +200,7 @@ public class BatchValidator {
         // TODO: Don't know how to check SV4 batches
         return true;
       case TWO_BYTE:
-        final int sv2Count = batch.getSelectionVector2().getCount();
+        int sv2Count = batch.getSelectionVector2().getCount();
         if (sv2Count != rowCount) {
           reporter.error(String.format(
               "Mismatch between %s record count = %d, SV2 record count = %d",
@@ -214,7 +213,7 @@ public class BatchValidator {
               batch.getClass().getSimpleName(),
               containerRowCount, sv2Count));
         }
-        final int svTotalCount = batch.getSelectionVector2().getBatchActualRecordCount();
+        int svTotalCount = batch.getSelectionVector2().getBatchActualRecordCount();
         if (svTotalCount != containerRowCount) {
           reporter.error(String.format(
               "Mismatch between %s container count = %d, SV2 total count = %d",
@@ -239,13 +238,13 @@ public class BatchValidator {
   }
 
   public static boolean validate(VectorAccessible batch) {
-    final ErrorReporter reporter = errorReporter(batch);
+    ErrorReporter reporter = errorReporter(batch);
     new BatchValidator(reporter).validateBatch(batch, batch.getRecordCount());
     return reporter.errorCount() == 0;
   }
 
   private static ErrorReporter errorReporter(VectorAccessible batch) {
-    final String opName = batch.getClass().getSimpleName();
+    String opName = batch.getClass().getSimpleName();
     if (LOG_TO_STDOUT) {
       return new StdOutReporter(opName);
     } else {
@@ -254,7 +253,7 @@ public class BatchValidator {
   }
 
   public void validateBatch(VectorAccessible batch, int rowCount) {
-    for (final VectorWrapper<? extends ValueVector> w : batch) {
+    for (VectorWrapper<? extends ValueVector> w : batch) {
       validateWrapper(rowCount, w);
     }
   }
@@ -266,7 +265,7 @@ public class BatchValidator {
   }
 
   private void validateVector(int expectedCount, ValueVector vector) {
-    final int valueCount = vector.getAccessor().getValueCount();
+    int valueCount = vector.getAccessor().getValueCount();
     if (valueCount != expectedCount) {
       error(vector.getField().getName(), vector,
           String.format("Row count = %d, but value count = %d",
@@ -295,9 +294,9 @@ public class BatchValidator {
   }
 
   private void validateNullableVector(String name, NullableVector vector) {
-    final int outerCount = vector.getAccessor().getValueCount();
-    final ValueVector valuesVector = vector.getValuesVector();
-    final int valueCount = valuesVector.getAccessor().getValueCount();
+    int outerCount = vector.getAccessor().getValueCount();
+    ValueVector valuesVector = vector.getValuesVector();
+    int valueCount = valuesVector.getAccessor().getValueCount();
     if (valueCount != outerCount) {
       error(name, vector, String.format(
           "Outer value count = %d, but inner value count = %d",
@@ -320,7 +319,7 @@ public class BatchValidator {
   }
 
   private void validateVarCharVector(String name, VarCharVector vector) {
-    final int valueCount = vector.getAccessor().getValueCount();
+    int valueCount = vector.getAccessor().getValueCount();
 
     // Disabled because a large number of operators
     // set up offset vectors wrongly.
@@ -328,27 +327,15 @@ public class BatchValidator {
       return;
     }
 
-    final int dataLength = vector.getBuffer().writerIndex();
+    int dataLength = vector.getBuffer().writerIndex();
     validateOffsetVector(name + "-offsets", vector.getOffsetVector(), false, valueCount, dataLength);
   }
 
-//  private void validateRepeatedBitVector(String name, BaseRepeatedValueVector vector) {
-//    int dataLength = ((BaseDataValueVector) vector.getDataVector()).getBuffer().writerIndex();
-//    int valueCount = vector.getAccessor().getValueCount();
-//    int itemCount = validateOffsetVector(name + "-offsets", vector.getOffsetVector(), true, valueCount * 8, dataLength);
-//    ValueVector dataVector = vector.getDataVector();
-//    if (dataVector.getAccessor().getValueCount() != itemCount) {
-//      error(name, vector, String.format(
-//          "Bit vector has %d values, but offset vector labels %d values",
-//          valueCount, itemCount));
-//    }
-//  }
-
   private void validateRepeatedVector(String name, BaseRepeatedValueVector vector) {
-    final ValueVector dataVector = vector.getDataVector();
-    final int dataLength = dataVector.getAccessor().getValueCount();
-    final int valueCount = vector.getAccessor().getValueCount();
-    final int itemCount = validateOffsetVector(name + "-offsets", vector.getOffsetVector(),
+    ValueVector dataVector = vector.getDataVector();
+    int dataLength = dataVector.getAccessor().getValueCount();
+    int valueCount = vector.getAccessor().getValueCount();
+    int itemCount = validateOffsetVector(name + "-offsets", vector.getOffsetVector(),
         true, valueCount, dataLength);
 
     if (dataLength != itemCount) {
@@ -366,11 +353,11 @@ public class BatchValidator {
   }
 
   private void validateRepeatedBitVector(String name, RepeatedBitVector vector) {
-    final int valueCount = vector.getAccessor().getValueCount();
-    final int maxBitCount = valueCount * 8;
-    final int elementCount = validateOffsetVector(name + "-offsets",
+    int valueCount = vector.getAccessor().getValueCount();
+    int maxBitCount = valueCount * 8;
+    int elementCount = validateOffsetVector(name + "-offsets",
         vector.getOffsetVector(), true, valueCount, maxBitCount);
-    final BitVector dataVector = vector.getDataVector();
+    BitVector dataVector = vector.getDataVector();
     if (dataVector.getAccessor().getValueCount() != elementCount) {
       error(name, vector, String.format(
           "Bit vector has %d values, but offset vector labels %d values",
@@ -386,10 +373,10 @@ public class BatchValidator {
   }
 
   private void validateBitVector(String name, BitVector vector) {
-    final BitVector.Accessor accessor = vector.getAccessor();
-    final int valueCount = accessor.getValueCount();
-    final int dataLength = vector.getBuffer().writerIndex();
-    final int expectedLength = BitVector.getSizeFromCount(valueCount);
+    BitVector.Accessor accessor = vector.getAccessor();
+    int valueCount = accessor.getValueCount();
+    int dataLength = vector.getBuffer().writerIndex();
+    int expectedLength = BitVector.getSizeFromCount(valueCount);
     if (dataLength != expectedLength) {
       error(name, vector, String.format(
           "Bit vector has %d values, buffer has length %d, expected %d",
@@ -399,8 +386,8 @@ public class BatchValidator {
 
   private int validateOffsetVector(String name, UInt4Vector offsetVector,
       boolean repeated, int valueCount, int maxOffset) {
-    final UInt4Vector.Accessor accessor = offsetVector.getAccessor();
-    final int offsetCount = accessor.getValueCount();
+    UInt4Vector.Accessor accessor = offsetVector.getAccessor();
+    int offsetCount = accessor.getValueCount();
     // TODO: Disabled because a large number of operators
     // set up offset vectors incorrectly.
 //    if (!repeated && offsetCount == 0) {
@@ -426,7 +413,7 @@ public class BatchValidator {
     }
 
     for (int i = 1; i < offsetCount; i++) {
-      final int offset = accessor.get(i);
+      int offset = accessor.get(i);
       if (offset < prevOffset) {
         error(name, offsetVector, String.format(
             "Offset vector [%d] contained %d, expected >= %d",
@@ -446,42 +433,24 @@ public class BatchValidator {
   }
 
   private void verifyIsSetVector(ValueVector parent, UInt1Vector bv) {
-    final String name = String.format("%s (%s)-bits",
+    String name = String.format("%s (%s)-bits",
         parent.getField().getName(),
         parent.getClass().getSimpleName());
-    final int rowCount = parent.getAccessor().getValueCount();
-    final int bitCount = bv.getAccessor().getValueCount();
+    int rowCount = parent.getAccessor().getValueCount();
+    int bitCount = bv.getAccessor().getValueCount();
     if (bitCount != rowCount) {
       error(name, bv, String.format(
           "Value count = %d, but bit count = %d",
           rowCount, bitCount));
     }
-    final UInt1Vector.Accessor ba = bv.getAccessor();
+    UInt1Vector.Accessor ba = bv.getAccessor();
     for (int i = 0; i < bitCount; i++) {
-      final int value = ba.get(i);
+      int value = ba.get(i);
       if (value != 0 && value != 1) {
         error(name, bv, String.format(
             "%s %s: bit vector[%d] = %d, expected 0 or 1",
             i, value));
       }
-    }
-  }
-
-  /**
-   * Print a record batch. Uses code only available in a test build.
-   * Classes are not visible to the compiler; must load dynamically.
-   * Does nothing if the class is not available.
-   */
-
-  public static void print(RecordBatch batch) {
-    try {
-      final Class<?> helper = Class.forName("org.apache.drill.test.rowSet.RowSetUtilities");
-      final Method print = helper.getMethod("print", VectorContainer.class);
-      System.out.println(batch.getClass().getSimpleName());
-      print.invoke(null, batch.getContainer());
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-      // Ignore
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
@@ -36,21 +36,23 @@ import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
 import org.apache.drill.exec.vector.VectorValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
-  private static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(IteratorValidatorBatchIterator.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(IteratorValidatorBatchIterator.class);
 
-  static final boolean VALIDATE_VECTORS = false;
+  static final boolean VALIDATE_VECTORS = true;
 
-  /** For logging/debuggability only. */
+  /** For logging/debugability only. */
   private static volatile int instanceCount;
 
   /** @see org.apache.drill.exec.physical.config.IteratorValidator */
   private final boolean isRepeatable;
 
-  /** For logging/debuggability only. */
+  /** For logging/debugability only. */
   private final int instNum;
   {
     instNum = ++instanceCount;
@@ -62,24 +64,24 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
    */
   private final RecordBatch incoming;
 
-  /** Incoming batch's type (simple class name); for logging/debuggability
+  /** Incoming batch's type (simple class name); for logging/debugability
    *  only. */
   private final String batchTypeName;
 
   /** Exception state of incoming batch; last value thrown by its next()
    *  method. */
-  private Throwable exceptionState = null;
+  private Throwable exceptionState;
 
   /** Main state of incoming batch; last value returned by its next() method. */
-  private IterOutcome batchState = null;
+  private IterOutcome batchState;
 
   /** Last schema retrieved after OK_NEW_SCHEMA or OK from next().  Null if none
-   *  yet. Currently for logging/debuggability only. */
-  private BatchSchema lastSchema = null;
+   *  yet. Currently for logging/debugability only. */
+  private BatchSchema lastSchema;
 
   /** Last schema retrieved after OK_NEW_SCHEMA from next().  Null if none yet.
-   *  Currently for logging/debuggability only. */
-  private BatchSchema lastNewSchema = null;
+   *  Currently for logging/debugability only. */
+  private BatchSchema lastNewSchema;
 
   /**
    * {@link IterOutcome} return value sequence validation state.
@@ -342,8 +344,13 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
   }
 
   private void validateBatch() {
-    if (validateBatches) {
-      new BatchValidator(incoming).validate();
+    if (validateBatches || VALIDATE_VECTORS) {
+      if (! BatchValidator.validate(incoming)) {
+        throw new IllegalStateException(
+            "Batch validation failed. Source operator: " +
+            incoming.getClass().getSimpleName());
+      }
+      //VectorValidator.validate(incoming);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
@@ -350,7 +350,10 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
             "Batch validation failed. Source operator: " +
             incoming.getClass().getSimpleName());
       }
-      //VectorValidator.validate(incoming);
+      // The following validation currently calculates, and discards
+      // a hash code. Since it requires manual checking, it is
+      // disabled by default.
+      // VectorValidator.validate(incoming);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RepeatedVectorState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RepeatedVectorState.java
@@ -47,7 +47,7 @@ public class RepeatedVectorState implements VectorState {
     // vector, and the scalar (value) portion of the array writer.
 
     arrayWriter = (AbstractArrayWriter) writer;
-    AbstractScalarWriterImpl colWriter = (AbstractScalarWriterImpl) writer.entry().events();
+    final AbstractScalarWriterImpl colWriter = (AbstractScalarWriterImpl) writer.entry().events();
     valuesState = SimpleVectorState.vectorState(writer.schema(), colWriter, vector.getDataVector());
 
     // Create the offsets state with the offset vector portion of the repeated
@@ -116,19 +116,19 @@ public class RepeatedVectorState implements VectorState {
    * after the values copied during roll-over.</li>
    * </ul>
    *
-   * @param cardinality the number of outer elements to create in the look-ahead
+   * @param newCardinality the number of outer elements to create in the look-ahead
    * vector
    */
 
   @Override
-  public void rollover(int cardinality) {
+  public void rollover(int newCardinality) {
 
     // Swap out the two vectors. The index presented to the caller
     // is that of the data vector: the next position in the data
     // vector to be set into the data vector writer index.
 
-    valuesState.rollover(childCardinality(cardinality));
-    offsetsState.rollover(cardinality);
+    valuesState.rollover(childCardinality(newCardinality));
+    offsetsState.rollover(newCardinality);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
@@ -94,7 +94,7 @@ public abstract class SingleVectorState implements VectorState {
 
     @Override
     public int allocateVector(ValueVector vector, int cardinality) {
-      final int size = super.allocateVector(vector, cardinality);
+      int size = super.allocateVector(vector, cardinality);
 
       // IsSet ("bit") vectors rely on values being initialized to zero (unset.)
 
@@ -123,7 +123,7 @@ public abstract class SingleVectorState implements VectorState {
 
       // Cap the allocated size to the maximum.
 
-      final int size = (int) Math.min(ValueVector.MAX_BUFFER_SIZE, (long) cardinality * schema.expectedWidth());
+      int size = (int) Math.min(ValueVector.MAX_BUFFER_SIZE, (long) cardinality * schema.expectedWidth());
       ((VariableWidthVector) vector).allocateNew(size, cardinality);
       return vector.getAllocatedSize();
     }
@@ -199,9 +199,9 @@ public abstract class SingleVectorState implements VectorState {
       // for the current row. We must subtract that offset from each copied
       // value to adjust the offset for the destination.
 
-      final UInt4Vector.Accessor sourceAccessor = ((UInt4Vector) backupVector).getAccessor();
-      final UInt4Vector.Mutator destMutator = ((UInt4Vector) mainVector).getMutator();
-      final int offset = childWriter.rowStartIndex();
+      UInt4Vector.Accessor sourceAccessor = ((UInt4Vector) backupVector).getAccessor();
+      UInt4Vector.Mutator destMutator = ((UInt4Vector) mainVector).getMutator();
+      int offset = childWriter.rowStartIndex();
       int newIndex = 1;
       ResultSetLoaderImpl.logger.trace("Offset vector: copy {} values from {} to {} with offset {}",
           Math.max(0, sourceEndIndex - sourceStartIndex + 1),
@@ -261,13 +261,13 @@ public abstract class SingleVectorState implements VectorState {
   @Override
   public void rollover(int cardinality) {
 
-    final int sourceStartIndex = writer.rowStartIndex();
+    int sourceStartIndex = writer.rowStartIndex();
 
     // Remember the last write index for the original vector.
     // This tells us the end of the set of values to move, while the
     // sourceStartIndex above tells us the start.
 
-    final int sourceEndIndex = writer.lastWriteIndex();
+    int sourceEndIndex = writer.lastWriteIndex();
 
     // Switch buffers between the backup vector and the writer's output
     // vector. Done this way because writers are bound to vectors and
@@ -306,7 +306,7 @@ public abstract class SingleVectorState implements VectorState {
    */
 
   protected static MajorType parseVectorType(ValueVector vector) {
-    final MajorType purportedType = vector.getField().getType();
+    MajorType purportedType = vector.getField().getType();
     if (purportedType.getMode() != DataMode.OPTIONAL) {
       return purportedType;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/SingleVectorState.java
@@ -94,7 +94,7 @@ public abstract class SingleVectorState implements VectorState {
 
     @Override
     public int allocateVector(ValueVector vector, int cardinality) {
-      int size = super.allocateVector(vector, cardinality);
+      final int size = super.allocateVector(vector, cardinality);
 
       // IsSet ("bit") vectors rely on values being initialized to zero (unset.)
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/vector/VectorValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/vector/VectorValidator.java
@@ -28,7 +28,7 @@ public class VectorValidator {
     SelectionVectorMode mode = batch.getSchema().getSelectionVectorMode();
     switch(mode) {
       case NONE: {
-        for (VectorWrapper w : batch) {
+        for (VectorWrapper<?> w : batch) {
           ValueVector v = w.getValueVector();
           for (int i = 0; i < count; i++) {
             Object obj = v.getAccessor().getObject(i);
@@ -40,7 +40,7 @@ public class VectorValidator {
         break;
       }
       case TWO_BYTE: {
-        for (VectorWrapper w : batch) {
+        for (VectorWrapper<?> w : batch) {
           ValueVector v = w.getValueVector();
           for (int i = 0; i < count; i++) {
             int index = batch.getSelectionVector2().getIndex(i);
@@ -53,7 +53,7 @@ public class VectorValidator {
         break;
       }
       case FOUR_BYTE: {
-        for (VectorWrapper w : batch) {
+        for (VectorWrapper<?> w : batch) {
           ValueVector[] vv = w.getValueVectors();
           for (int i = 0; i < count; i++) {
             int index = batch.getSelectionVector4().get(i);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -17,11 +17,22 @@
  */
 package org.apache.drill.exec.physical.impl;
 
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.IndirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.TypedFieldId;
@@ -30,20 +41,9 @@ import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
-import org.apache.drill.exec.physical.rowSet.DirectRowSet;
-import org.apache.drill.exec.physical.rowSet.IndirectRowSet;
-import org.apache.drill.exec.physical.rowSet.RowSet;
-
-import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 public class MockRecordBatch implements CloseableRecordBatch {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MockRecordBatch.class);
 
   // These resources are owned by this RecordBatch
   protected VectorContainer container;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -61,12 +61,12 @@ public class MockRecordBatch implements CloseableRecordBatch {
   protected final OperatorContext oContext;
   protected final BufferAllocator allocator;
 
-  private MockRecordBatch(@NotNull final FragmentContext context,
-                          @Nullable final OperatorContext oContext,
-                          @NotNull final List<RowSet> testRowSets,
-                          @NotNull final List<IterOutcome> iterOutcomes,
-                          @NotNull final BatchSchema schema,
-                          final boolean dummy) {
+  private MockRecordBatch(@NotNull FragmentContext context,
+                          @Nullable OperatorContext oContext,
+                          @NotNull List<RowSet> testRowSets,
+                          @NotNull List<IterOutcome> iterOutcomes,
+                          @NotNull BatchSchema schema,
+                          boolean dummy) {
     Preconditions.checkNotNull(testRowSets);
     Preconditions.checkNotNull(iterOutcomes);
     Preconditions.checkNotNull(schema);
@@ -83,11 +83,11 @@ public class MockRecordBatch implements CloseableRecordBatch {
   }
 
   @Deprecated
-  public MockRecordBatch(@Nullable final FragmentContext context,
-                         @Nullable final OperatorContext oContext,
-                         @NotNull final List<VectorContainer> testContainers,
-                         @NotNull final List<IterOutcome> iterOutcomes,
-                         final BatchSchema schema) {
+  public MockRecordBatch(@Nullable FragmentContext context,
+                         @Nullable OperatorContext oContext,
+                         @NotNull List<VectorContainer> testContainers,
+                         @NotNull List<IterOutcome> iterOutcomes,
+                         BatchSchema schema) {
     this(context,
          oContext,
          testContainers.stream().
@@ -99,12 +99,12 @@ public class MockRecordBatch implements CloseableRecordBatch {
   }
 
   @Deprecated
-  public MockRecordBatch(@Nullable final FragmentContext context,
-                         @Nullable final OperatorContext oContext,
-                         @NotNull final List<VectorContainer> testContainers,
-                         @NotNull final List<IterOutcome> iterOutcomes,
-                         @NotNull final List<SelectionVector2> selectionVector2s,
-                         final BatchSchema schema) {
+  public MockRecordBatch(@Nullable FragmentContext context,
+                         @Nullable OperatorContext oContext,
+                         @NotNull List<VectorContainer> testContainers,
+                         @NotNull List<IterOutcome> iterOutcomes,
+                         @NotNull List<SelectionVector2> selectionVector2s,
+                         BatchSchema schema) {
     this(context,
       oContext,
       new Supplier<List<RowSet>>() {
@@ -200,11 +200,11 @@ public class MockRecordBatch implements CloseableRecordBatch {
     IterOutcome currentOutcome;
 
     if (currentContainerIndex < rowSets.size()) {
-      final RowSet rowSet = rowSets.get(currentContainerIndex);
-      final VectorContainer input = rowSet.container();
+      RowSet rowSet = rowSets.get(currentContainerIndex);
+      VectorContainer input = rowSet.container();
       // We need to do this since the downstream operator expects vector reference to be same
       // after first next call in cases when schema is not changed
-      final BatchSchema inputSchema = input.getSchema();
+      BatchSchema inputSchema = input.getSchema();
       if (!container.getSchema().isEquivalent(inputSchema)) {
         container.clear();
         container = new VectorContainer(allocator, inputSchema);
@@ -217,7 +217,7 @@ public class MockRecordBatch implements CloseableRecordBatch {
           if ( input.hasRecordCount() ) { // in case special test of uninitialized input container
             container.setRecordCount(input.getRecordCount());
           }
-          final SelectionVector2 inputSv2 = ((RowSet.SingleRowSet) rowSet).getSv2();
+          SelectionVector2 inputSv2 = ((RowSet.SingleRowSet) rowSet).getSv2();
 
           if (sv2 != null) {
             // Operators assume that new values for an Sv2 are transferred in.
@@ -307,23 +307,23 @@ public class MockRecordBatch implements CloseableRecordBatch {
     public Builder() {
     }
 
-    private Builder sendData(final RowSet rowSet, final IterOutcome outcome) {
+    private Builder sendData(RowSet rowSet, IterOutcome outcome) {
       Preconditions.checkState(batchSchema == null);
       rowSets.add(rowSet);
       iterOutcomes.add(outcome);
       return this;
     }
 
-    public Builder sendData(final RowSet rowSet) {
-      final IterOutcome outcome = rowSets.isEmpty()? IterOutcome.OK_NEW_SCHEMA: IterOutcome.OK;
+    public Builder sendData(RowSet rowSet) {
+      IterOutcome outcome = rowSets.isEmpty()? IterOutcome.OK_NEW_SCHEMA: IterOutcome.OK;
       return sendData(rowSet, outcome);
     }
 
-    public Builder sendDataWithNewSchema(final RowSet rowSet) {
+    public Builder sendDataWithNewSchema(RowSet rowSet) {
       return sendData(rowSet, IterOutcome.OK_NEW_SCHEMA);
     }
 
-    public Builder sendDataAndEmit(final RowSet rowSet) {
+    public Builder sendDataAndEmit(RowSet rowSet) {
       return sendData(rowSet, IterOutcome.EMIT);
     }
 
@@ -335,18 +335,18 @@ public class MockRecordBatch implements CloseableRecordBatch {
       return this;
     }
 
-    public Builder setSchema(final BatchSchema batchSchema) {
+    public Builder setSchema(BatchSchema batchSchema) {
       Preconditions.checkState(!rowSets.isEmpty());
       this.batchSchema = Preconditions.checkNotNull(batchSchema);
       return this;
     }
 
-    public Builder withOperatorContext(final OperatorContext oContext) {
+    public Builder withOperatorContext(OperatorContext oContext) {
       this.oContext = Preconditions.checkNotNull(oContext);
       return this;
     }
 
-    public MockRecordBatch build(final FragmentContext context) {
+    public MockRecordBatch build(FragmentContext context) {
       BatchSchema tempSchema = batchSchema;
 
       if (tempSchema == null && !rowSets.isEmpty()) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOverflow.java
@@ -61,24 +61,24 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testVectorSizeLimit() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
 
     // Number of rows should be driven by vector size.
     // Our row count should include the overflow row
 
-    final int expectedCount = ValueVector.MAX_BUFFER_SIZE / value.length;
+    int expectedCount = ValueVector.MAX_BUFFER_SIZE / value.length;
     {
       int count = 0;
       while (! rootWriter.isFull()) {
@@ -100,9 +100,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
       // Result should exclude the overflow row
 
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(expectedCount, result.rowCount());
       result.clear();
     }
@@ -113,9 +113,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       rsLoader.startBatch();
       assertEquals(1, rootWriter.rowCount());
       assertEquals(expectedCount + 1, rsLoader.totalRowCount());
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(1, result.rowCount());
       result.clear();
     }
@@ -130,26 +130,26 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testBatchSizeLimit() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .setBatchSizeLimit(
             8 * 1024 * 1024 + // Data
             2 * ValueVector.MAX_ROW_COUNT * 4) // Offsets, doubled because of +1
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
 
     // Our row count should include the overflow row
 
-    final int expectedCount = 8 * 1024 * 1024 / value.length;
+    int expectedCount = 8 * 1024 * 1024 / value.length;
 
     // First batch, with overflow
 
@@ -173,9 +173,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
       // Result should exclude the overflow row
 
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(expectedCount, result.rowCount());
       result.clear();
     }
@@ -186,9 +186,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       rsLoader.startBatch();
       assertEquals(1, rootWriter.rowCount());
       assertEquals(expectedCount + 1, rsLoader.totalRowCount());
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(1, result.rowCount());
       result.clear();
     }
@@ -204,18 +204,18 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testCloseWithOverflow() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
     int count = 0;
     while (! rootWriter.isFull()) {
@@ -229,9 +229,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
     // Harvest the full batch
 
-    final VectorContainer container = rsLoader.harvest();
+    VectorContainer container = rsLoader.harvest();
     BatchValidator.validate(container);
-    final RowSet result = fixture.wrap(container);
+    RowSet result = fixture.wrap(container);
     result.clear();
 
     // Close without harvesting the overflow batch.
@@ -247,30 +247,30 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testOversizeArray() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .addArray("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     // Create a single array as the column value in the first row. When
     // this overflows, an exception is thrown since overflow is not possible.
 
     rsLoader.startBatch();
-    final byte[] value = new byte[473];
+    byte[] value = new byte[473];
     Arrays.fill(value, (byte) 'X');
     rootWriter.start();
-    final ScalarWriter array = rootWriter.array(0).scalar();
+    ScalarWriter array = rootWriter.array(0).scalar();
     try {
       for (int i = 0; i < ValueVector.MAX_ROW_COUNT; i++) {
         array.setBytes(value, value.length);
       }
       fail();
-    } catch (final UserException e) {
+    } catch (UserException e) {
       assertTrue(e.getMessage().contains("column value is larger than the maximum"));
     }
     rsLoader.close();
@@ -285,25 +285,25 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testSizeLimitOnArray() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .addArray("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     // Fill batch with rows of with a single array, three values each. Tack on
     // a suffix to each so we can be sure the proper data is written and moved
     // to the overflow batch.
 
     rsLoader.startBatch();
-    final byte[] value = new byte[473];
+    byte[] value = new byte[473];
     Arrays.fill(value, (byte) 'X');
-    final String strValue = new String(value, Charsets.UTF_8);
-    final int valuesPerArray = 13;
+    String strValue = new String(value, Charsets.UTF_8);
+    int valuesPerArray = 13;
     int count = 0;
 
     {
@@ -312,9 +312,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       while (rootWriter.start()) {
         totalSize += rowSize;
         rowSize = 0;
-        final ScalarWriter array = rootWriter.array(0).scalar();
+        ScalarWriter array = rootWriter.array(0).scalar();
         for (int i = 0; i < valuesPerArray; i++) {
-          final String cellValue = strValue + (count + 1) + "." + i;
+          String cellValue = strValue + (count + 1) + "." + i;
           array.setString(cellValue);
           rowSize += cellValue.length();
         }
@@ -324,7 +324,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
       // Row count should include the overflow row.
 
-      final int expectedCount = count - 1;
+      int expectedCount = count - 1;
 
       // Size without overflow row should fit in the vector, size
       // with overflow should not.
@@ -335,18 +335,18 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       // Result should exclude the overflow row. Last row
       // should hold the last full array.
 
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(expectedCount, result.rowCount());
-      final RowSetReader reader = result.reader();
+      RowSetReader reader = result.reader();
       reader.setPosition(expectedCount - 1);
-      final ArrayReader arrayReader = reader.array(0);
-      final ScalarReader strReader = arrayReader.scalar();
+      ArrayReader arrayReader = reader.array(0);
+      ScalarReader strReader = arrayReader.scalar();
       assertEquals(valuesPerArray, arrayReader.size());
       for (int i = 0; i < valuesPerArray; i++) {
         assertTrue(arrayReader.next());
-        final String cellValue = strValue + (count - 1) + "." + i;
+        String cellValue = strValue + (count - 1) + "." + i;
         assertEquals(cellValue, strReader.getString());
       }
       result.clear();
@@ -360,18 +360,18 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       rsLoader.startBatch();
       assertEquals(1, rootWriter.rowCount());
       assertEquals(count, rsLoader.totalRowCount());
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(1, result.rowCount());
-      final RowSetReader reader = result.reader();
+      RowSetReader reader = result.reader();
       reader.next();
-      final ArrayReader arrayReader = reader.array(0);
-      final ScalarReader strReader = arrayReader.scalar();
+      ArrayReader arrayReader = reader.array(0);
+      ScalarReader strReader = arrayReader.scalar();
       assertEquals(valuesPerArray, arrayReader.size());
       for (int i = 0; i < valuesPerArray; i++) {
         assertTrue(arrayReader.next());
-        final String cellValue = strValue + count + "." + i;
+        String cellValue = strValue + count + "." + i;
         assertEquals(cellValue, strReader.getString());
       }
       result.clear();
@@ -396,38 +396,38 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testArrayOverflowWithOtherArrays() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .addArray("a", MinorType.INT)
         .addArray("b", MinorType.VARCHAR)
         .addArray("c", MinorType.INT)
         .addArray("d", MinorType.INT)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     // Fill batch with rows of with a single array, three values each. Tack on
     // a suffix to each so we can be sure the proper data is written and moved
     // to the overflow batch.
 
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
-    final String strValue = new String(value, Charsets.UTF_8);
+    String strValue = new String(value, Charsets.UTF_8);
 
-    final int aCount = 3;
-    final int bCount = 11;
-    final int cCount = 5;
-    final int dCount = 7;
+    int aCount = 3;
+    int bCount = 11;
+    int cCount = 5;
+    int dCount = 7;
 
-    final int cCutoff = ValueVector.MAX_BUFFER_SIZE / value.length / bCount / 2;
+    int cCutoff = ValueVector.MAX_BUFFER_SIZE / value.length / bCount / 2;
 
-    final ScalarWriter aWriter = rootWriter.array("a").scalar();
-    final ScalarWriter bWriter = rootWriter.array("b").scalar();
-    final ScalarWriter cWriter = rootWriter.array("c").scalar();
-    final ScalarWriter dWriter = rootWriter.array("d").scalar();
+    ScalarWriter aWriter = rootWriter.array("a").scalar();
+    ScalarWriter bWriter = rootWriter.array("b").scalar();
+    ScalarWriter cWriter = rootWriter.array("c").scalar();
+    ScalarWriter dWriter = rootWriter.array("d").scalar();
 
     int count = 0;
     rsLoader.startBatch();
@@ -436,7 +436,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
         aWriter.setInt(count * aCount + i);
       }
       for (int i = 0; i < bCount; i++) {
-        final String cellValue = strValue + (count * bCount + i);
+        String cellValue = strValue + (count * bCount + i);
         bWriter.setString(cellValue);
       }
       if (count < cCutoff) {
@@ -460,22 +460,22 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     // Verify
 
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(count - 1, result.rowCount());
-      final RowSetReader reader = result.reader();
-      final ArrayReader aArray = reader.array("a");
-      final ScalarReader aReader = aArray.scalar();
-      final ArrayReader bArray = reader.array("b");
-      final ScalarReader bReader = bArray.scalar();
-      final ArrayReader cArray = reader.array("c");
-      final ScalarReader cReader = cArray.scalar();
-      final ArrayReader dArray = reader.array("d");
-      final ScalarReader dReader = dArray.scalar();
+      RowSetReader reader = result.reader();
+      ArrayReader aArray = reader.array("a");
+      ScalarReader aReader = aArray.scalar();
+      ArrayReader bArray = reader.array("b");
+      ScalarReader bReader = bArray.scalar();
+      ArrayReader cArray = reader.array("c");
+      ScalarReader cReader = cArray.scalar();
+      ArrayReader dArray = reader.array("d");
+      ScalarReader dReader = dArray.scalar();
 
       while (reader.next()) {
-        final int rowId = reader.offset();
+        int rowId = reader.offset();
         assertEquals(aCount, aArray.size());
         for (int i = 0; i < aCount; i++) {
           assertTrue(aArray.next());
@@ -484,7 +484,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
         assertEquals(bCount, bArray.size());
         for (int i = 0; i < bCount; i++) {
           assertTrue(bArray.next());
-          final String cellValue = strValue + (rowId * bCount + i);
+          String cellValue = strValue + (rowId * bCount + i);
           assertEquals(cellValue, bReader.getString());
         }
         if (rowId < cCutoff) {
@@ -505,7 +505,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       }
       result.clear();
     }
-    final int firstCount = count - 1;
+    int firstCount = count - 1;
 
     // One row is in the batch. Write more, skipping over the
     // initial few values for columns c and d. Column d has a
@@ -518,7 +518,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
         aWriter.setInt(count * aCount + i);
       }
       for (int i = 0; i < bCount; i++) {
-        final String cellValue = strValue + (count * bCount + i);
+        String cellValue = strValue + (count * bCount + i);
         bWriter.setString(cellValue);
       }
       if (j > 3) {
@@ -534,23 +534,23 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     }
 
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(6, result.rowCount());
-      final RowSetReader reader = result.reader();
-      final ArrayReader aArray = reader.array("a");
-      final ScalarReader aReader = aArray.scalar();
-      final ArrayReader bArray = reader.array("b");
-      final ScalarReader bReader = bArray.scalar();
-      final ArrayReader cArray = reader.array("c");
-      final ScalarReader cReader = cArray.scalar();
-      final ArrayReader dArray = reader.array("d");
-      final ScalarReader dReader = dArray.scalar();
+      RowSetReader reader = result.reader();
+      ArrayReader aArray = reader.array("a");
+      ScalarReader aReader = aArray.scalar();
+      ArrayReader bArray = reader.array("b");
+      ScalarReader bReader = bArray.scalar();
+      ArrayReader cArray = reader.array("c");
+      ScalarReader cReader = cArray.scalar();
+      ArrayReader dArray = reader.array("d");
+      ScalarReader dReader = dArray.scalar();
 
       int j = 0;
       while (reader.next()) {
-        final int rowId = firstCount + reader.offset();
+        int rowId = firstCount + reader.offset();
         assertEquals(aCount, aArray.size());
         for (int i = 0; i < aCount; i++) {
           assertTrue(aArray.next());
@@ -559,7 +559,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
         assertEquals(bCount, bArray.size());
         for (int i = 0; i < bCount; i++) {
           assertTrue(bArray.next());
-          final String cellValue = strValue + (rowId * bCount + i);
+          String cellValue = strValue + (rowId * bCount + i);
           assertEquals(cellValue, bReader.getString());
         }
         if (j > 4) {
@@ -596,9 +596,9 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testLargeArray() {
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
-    final RowSetLoader rootWriter = rsLoader.writer();
-    final MaterializedField field = SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.REPEATED);
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator());
+    RowSetLoader rootWriter = rsLoader.writer();
+    MaterializedField field = SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.REPEATED);
     rootWriter.addColumn(field);
 
     // Create a single array as the column value in the first row. When
@@ -606,13 +606,13 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
     rsLoader.startBatch();
     rootWriter.start();
-    final ScalarWriter array = rootWriter.array(0).scalar();
+    ScalarWriter array = rootWriter.array(0).scalar();
     try {
       for (int i = 0; i < Integer.MAX_VALUE; i++) {
         array.setInt(i+1);
       }
       fail();
-    } catch (final UserException e) {
+    } catch (UserException e) {
       // Expected
     }
     rsLoader.close();
@@ -624,23 +624,23 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testMissingArrayValues() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("a", MinorType.INT)
         .add("b", MinorType.VARCHAR)
         .addArray("c", MinorType.INT)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
 
-    final int blankAfter = ValueVector.MAX_BUFFER_SIZE / 512 * 2 / 3;
-    final ScalarWriter cWriter = rootWriter.array("c").scalar();
+    int blankAfter = ValueVector.MAX_BUFFER_SIZE / 512 * 2 / 3;
+    ScalarWriter cWriter = rootWriter.array("c").scalar();
 
     rsLoader.startBatch();
     int rowId = 0;
@@ -656,13 +656,13 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
       rowId++;
     }
 
-    final VectorContainer container = rsLoader.harvest();
+    VectorContainer container = rsLoader.harvest();
     BatchValidator.validate(container);
-    final RowSet result = fixture.wrap(container);
+    RowSet result = fixture.wrap(container);
     assertEquals(rowId - 1, result.rowCount());
-    final RowSetReader reader = result.reader();
-    final ArrayReader cArray = reader.array("c");
-    final ScalarReader cReader = cArray.scalar();
+    RowSetReader reader = result.reader();
+    ArrayReader cArray = reader.array("c");
+    ScalarReader cReader = cArray.scalar();
     while (reader.next()) {
       assertEquals(reader.offset(), reader.scalar("a").getInt());
       assertArrayEquals(value, reader.scalar("b").getBytes());
@@ -682,21 +682,21 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testOverflowWithNullables() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("n", MinorType.INT)
         .addNullable("a", MinorType.VARCHAR)
         .addNullable("b", MinorType.VARCHAR)
         .addNullable("c", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
-    final byte[] value = new byte[512];
+    byte[] value = new byte[512];
     Arrays.fill(value, (byte) 'X');
     int count = 0;
     while (! rootWriter.isFull()) {
@@ -712,12 +712,12 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     // Result should exclude the overflow row
 
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(count - 1, result.rowCount());
 
-      final RowSetReader reader = result.reader();
+      RowSetReader reader = result.reader();
       while (reader.next()) {
         assertEquals(reader.offset(), reader.scalar(0).getInt());
         assertTrue(reader.scalar(1).isNull());
@@ -731,10 +731,10 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
     rsLoader.startBatch();
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
-      final RowSetReader reader = result.reader();
+      RowSet result = fixture.wrap(container);
+      RowSetReader reader = result.reader();
       assertEquals(1, result.rowCount());
       assertTrue(reader.next());
       assertEquals(count - 1, reader.scalar(0).getInt());
@@ -749,19 +749,19 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
 
   @Test
   public void testVectorSizeLimitWithAppend() {
-    final TupleMetadata schema = new SchemaBuilder()
+    TupleMetadata schema = new SchemaBuilder()
         .add("s", MinorType.VARCHAR)
         .buildSchema();
-    final ResultSetOptions options = new OptionBuilder()
+    ResultSetOptions options = new OptionBuilder()
         .setRowCountLimit(ValueVector.MAX_ROW_COUNT)
         .setSchema(schema)
         .build();
-    final ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
-    final RowSetLoader rootWriter = rsLoader.writer();
+    ResultSetLoader rsLoader = new ResultSetLoaderImpl(fixture.allocator(), options);
+    RowSetLoader rootWriter = rsLoader.writer();
 
     rsLoader.startBatch();
-    final byte[] head = "abc".getBytes();
-    final byte[] tail = new byte[523];
+    byte[] head = "abc".getBytes();
+    byte[] tail = new byte[523];
     Arrays.fill(tail, (byte) 'X');
 
     String expected = new String(head, Charsets.UTF_8);
@@ -769,7 +769,7 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     expected += new String(tail, Charsets.UTF_8);
 
     int count = 0;
-    final ScalarWriter colWriter = rootWriter.scalar(0);
+    ScalarWriter colWriter = rootWriter.scalar(0);
     while (! rootWriter.isFull()) {
       rootWriter.start();
       colWriter.setBytes(head, head.length);
@@ -782,8 +782,8 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     // Number of rows should be driven by vector size.
     // Our row count should include the overflow row
 
-    final int valueLength = head.length + 2 * tail.length;
-    final int expectedCount = ValueVector.MAX_BUFFER_SIZE / valueLength;
+    int valueLength = head.length + 2 * tail.length;
+    int expectedCount = ValueVector.MAX_BUFFER_SIZE / valueLength;
     assertEquals(expectedCount + 1, count);
 
     // Loader's row count should include only "visible" rows
@@ -797,14 +797,14 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     // Result should exclude the overflow row
 
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(expectedCount, result.rowCount());
 
       // Verify that the values were, in fact, appended.
 
-      final RowSetReader reader = result.reader();
+      RowSetReader reader = result.reader();
       while (reader.next()) {
         assertEquals(expected, reader.scalar(0).getString());
       }
@@ -817,11 +817,11 @@ public class TestResultSetLoaderOverflow extends SubOperatorTest {
     assertEquals(1, rootWriter.rowCount());
     assertEquals(expectedCount + 1, rsLoader.totalRowCount());
     {
-      final VectorContainer container = rsLoader.harvest();
+      VectorContainer container = rsLoader.harvest();
       BatchValidator.validate(container);
-      final RowSet result = fixture.wrap(container);
+      RowSet result = fixture.wrap(container);
       assertEquals(1, result.rowCount());
-      final RowSetReader reader = result.reader();
+      RowSetReader reader = result.reader();
       while (reader.next()) {
         assertEquals(expected, reader.scalar(0).getString());
       }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/BitVector.java
@@ -98,8 +98,8 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
     return getSizeFromCount(valueCount);
   }
 
-  private int getSizeFromCount(int valueCount) {
-    return (int) Math.ceil(valueCount / 8.0);
+  public static int getSizeFromCount(int valueCount) {
+    return (valueCount + 7) / 8;
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
@@ -290,7 +290,7 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
     // rows. But, this being an offset vector, we add one to account
     // for the extra 0 value at the start.
 
-    setValueCount(vectorIndex.rowStartIndex() + 1);
+    setValueCount(vectorIndex.rowStartIndex());
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
@@ -288,7 +288,10 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
     // Rollover is occurring. This means the current row is not complete.
     // We want to keep 0..(row index - 1) which gives us (row index)
     // rows. But, this being an offset vector, we add one to account
-    // for the extra 0 value at the start.
+    // for the extra 0 value at the start. That is, we want to set
+    // the value count to the current row start index, which already
+    // is set to one past the index of the last zero-based index.
+    // (Offset vector indexes are confusing.)
 
     setValueCount(vectorIndex.rowStartIndex());
   }


### PR DESCRIPTION
Enabling the vector validator on the "new" scan operator, in cases in which overflow occurs, identified that the DrillBuf writer index was not properly set for repeated vectors.
    
Enables such checking, adds unit tests, and fixes the writer index issue.
