### PR TITLE
DRILL-5674: Support ZIP compression

### DIFF
--- a/contrib/format-ltsv/src/main/java/org/apache/drill/exec/store/ltsv/LTSVFormatPlugin.java
+++ b/contrib/format-ltsv/src/main/java/org/apache/drill/exec/store/ltsv/LTSVFormatPlugin.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.store.ltsv;
 
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.FragmentContext;
@@ -34,16 +33,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import java.io.IOException;
 import java.util.List;
 
 public class LTSVFormatPlugin extends EasyFormatPlugin<LTSVFormatPluginConfig> {
 
-  private static final boolean IS_COMPRESSIBLE = false;
+  private static final boolean IS_COMPRESSIBLE = true;
 
   private static final String DEFAULT_NAME = "ltsv";
-
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LTSVFormatPlugin.class);
 
   public LTSVFormatPlugin(String name, DrillbitContext context, Configuration fsConf, StoragePluginConfig storageConfig) {
     this(name, context, fsConf, storageConfig, new LTSVFormatPluginConfig());
@@ -54,7 +50,7 @@ public class LTSVFormatPlugin extends EasyFormatPlugin<LTSVFormatPluginConfig> {
   }
 
   @Override
-  public RecordReader getRecordReader(FragmentContext context, DrillFileSystem dfs, FileWork fileWork, List<SchemaPath> columns, String userName) throws ExecutionSetupException {
+  public RecordReader getRecordReader(FragmentContext context, DrillFileSystem dfs, FileWork fileWork, List<SchemaPath> columns, String userName) {
     return new LTSVRecordReader(context, fileWork.getPath(), dfs, columns);
   }
 
@@ -75,7 +71,7 @@ public class LTSVFormatPlugin extends EasyFormatPlugin<LTSVFormatPluginConfig> {
   }
 
   @Override
-  public RecordWriter getRecordWriter(FragmentContext context, EasyWriter writer) throws IOException {
+  public RecordWriter getRecordWriter(FragmentContext context, EasyWriter writer) {
     throw new UnsupportedOperationException("Drill doesn't currently support writing to LTSV files.");
   }
 
@@ -85,13 +81,12 @@ public class LTSVFormatPlugin extends EasyFormatPlugin<LTSVFormatPluginConfig> {
   }
 
   @Override
-  public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException {
+  public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) {
     throw new UnsupportedOperationException("unimplemented");
   }
 
   @Override
-  public void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) throws IOException {
+  public void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) {
     throw new UnsupportedOperationException("unimplemented");
   }
-
 }

--- a/contrib/format-syslog/src/main/java/org/apache/drill/exec/store/syslog/SyslogFormatPlugin.java
+++ b/contrib/format-syslog/src/main/java/org/apache/drill/exec/store/syslog/SyslogFormatPlugin.java
@@ -17,13 +17,12 @@
  */
 
 package org.apache.drill.exec.store.syslog;
-import java.io.IOException;
-import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.common.exceptions.ExecutionSetupException;
+
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
+import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.RecordWriter;
@@ -31,13 +30,12 @@ import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
 import org.apache.drill.exec.store.dfs.easy.EasyWriter;
 import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
-
-
-import java.util.List;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import java.util.List;
 
 public class SyslogFormatPlugin extends EasyFormatPlugin<SyslogFormatConfig> {
 
@@ -59,7 +57,7 @@ public class SyslogFormatPlugin extends EasyFormatPlugin<SyslogFormatConfig> {
 
   @Override
   public RecordReader getRecordReader(FragmentContext context, DrillFileSystem dfs, FileWork fileWork,
-                                      List<SchemaPath> columns, String userName) throws ExecutionSetupException {
+                                      List<SchemaPath> columns, String userName) {
     return new SyslogRecordReader(context, dfs, fileWork, columns, userName, formatConfig);
   }
 
@@ -90,12 +88,12 @@ public class SyslogFormatPlugin extends EasyFormatPlugin<SyslogFormatConfig> {
   }
 
   @Override
-  public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException {
+  public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) {
     throw new UnsupportedOperationException("unimplemented");
   }
 
   @Override
-  public void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) throws IOException {
+  public void writeStatistics(TableStatistics statistics, FileSystem fs, Path statsTablePath) {
     throw new UnsupportedOperationException("unimplemented");
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/partition/PruneScanRule.java
@@ -544,7 +544,7 @@ public abstract class PruneScanRule extends StoragePluginOptimizerRule {
     if (scan instanceof EnumerableTableScan) {
       final Object selection = DrillRelOptUtil.getDrillTable(scan).getSelection();
       if (selection instanceof FormatSelection
-          && ((FormatSelection)selection).supportDirPruning()) {
+          && ((FormatSelection)selection).supportsDirPruning()) {
         return true;  // Do directory-based pruning in Calcite logical
       } else {
         return false; // Do not do directory-based pruning in Calcite logical

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatSelection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatSelection.java
@@ -17,18 +17,15 @@
  */
 package org.apache.drill.exec.store.dfs;
 
-import java.util.List;
-
-import org.apache.drill.common.logical.FormatPluginConfig;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.hadoop.fs.Path;
 
+import java.util.List;
 
 public class FormatSelection {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FormatSelection.class);
 
   private FormatPluginConfig format;
   private FileSelection selection;
@@ -62,7 +59,7 @@ public class FormatSelection {
   }
 
   @JsonIgnore
-  public boolean supportDirPruning() {
-    return selection.supportDirPrunig();
+  public boolean supportsDirPruning() {
+    return selection.supportsDirPruning();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/ZipCodec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/ZipCodec.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.dfs;
+
+import org.apache.hadoop.io.compress.CompressionInputStream;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.DefaultCodec;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * ZIP codec implementation which cna read or create single entry.
+ * <p/>
+ * Note: Do not rename this class. Class naming must be 'ZipCodec' so it can be mapped by
+ * {@link org.apache.hadoop.io.compress.CompressionCodecFactory} to the 'zip' extension.
+ */
+public class ZipCodec extends DefaultCodec {
+
+  private static final String EXTENSION = ".zip";
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream out) throws IOException {
+    return new ZipCompressionOutputStream(new ResetableZipOutputStream(out));
+  }
+
+  @Override
+  public CompressionInputStream createInputStream(InputStream in) throws IOException {
+    return new ZipCompressionInputStream(new ZipInputStream(in));
+  }
+
+  @Override
+  public String getDefaultExtension() {
+    return EXTENSION;
+  }
+
+  /**
+   * Reads only first entry from {@link ZipInputStream},
+   * other entries if present will be ignored.
+   */
+  private static class ZipCompressionInputStream extends CompressionInputStream {
+
+    ZipCompressionInputStream(ZipInputStream in) throws IOException {
+      super(in);
+      // positions stream at the beginning of the first entry data
+      in.getNextEntry();
+    }
+
+    @Override
+    public int read() throws IOException {
+      return in.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return in.read(b, off, len);
+    }
+
+    @Override
+    public void resetState() throws IOException {
+      in.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        ((ZipInputStream) in).closeEntry();
+      } finally {
+        super.close();
+      }
+    }
+  }
+
+  /**
+   * Extends {@link ZipOutputStream} to allow resetting compressor stream,
+   * required by {@link CompressionOutputStream} implementation.
+   */
+  private static class ResetableZipOutputStream extends ZipOutputStream {
+
+    ResetableZipOutputStream(OutputStream out) {
+      super(out);
+    }
+
+    void resetState() {
+      def.reset();
+    }
+  }
+
+  /**
+   * Writes given data into ZIP archive by placing all data in one entry with default naming.
+   */
+  private static class ZipCompressionOutputStream extends CompressionOutputStream {
+
+    private static final String DEFAULT_ENTRY_NAME = "entry.out";
+
+    ZipCompressionOutputStream(ResetableZipOutputStream out) throws IOException {
+      super(out);
+      ZipEntry zipEntry = new ZipEntry(DEFAULT_ENTRY_NAME);
+      out.putNextEntry(zipEntry);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      out.write(b, off, len);
+    }
+
+    @Override
+    public void finish() throws IOException {
+      ((ResetableZipOutputStream) out).closeEntry();
+    }
+
+    @Override
+    public void resetState() {
+      ((ResetableZipOutputStream) out).resetState();
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogBatchReader.java
@@ -178,7 +178,7 @@ public class LogBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private void openFile(FileSchemaNegotiator negotiator) {
     InputStream in;
     try {
-      in = negotiator.fileSystem().open(split.getPath());
+      in = negotiator.fileSystem().openPossiblyCompressedStream(split.getPath());
     } catch (Exception e) {
       throw UserException
           .dataReadError(e)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFormatPlugin.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,13 +61,11 @@ import org.apache.drill.exec.store.dfs.FormatPlugin;
 import org.apache.drill.exec.store.dfs.FormatSelection;
 import org.apache.drill.exec.store.dfs.MagicString;
 import org.apache.drill.exec.store.dfs.MetadataContext;
-import org.apache.drill.exec.store.mock.MockStorageEngine;
 import org.apache.drill.exec.store.parquet.metadata.Metadata;
 import org.apache.drill.exec.store.parquet.metadata.ParquetTableMetadataDirs;
 import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -73,19 +73,21 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ParquetFormatPlugin implements FormatPlugin {
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MockStorageEngine.class);
+  private static final Logger logger = LoggerFactory.getLogger(ParquetFormatPlugin.class);
 
   public static final ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
 
   private static final String DEFAULT_NAME = "parquet";
 
-  private static final List<Pattern> PATTERNS = Lists.newArrayList(
+  private static final List<Pattern> PATTERNS = Arrays.asList(
       Pattern.compile(".*\\.parquet$"),
       Pattern.compile(".*/" + ParquetFileWriter.PARQUET_METADATA_FILE));
-  private static final List<MagicString> MAGIC_STRINGS = Lists.newArrayList(new MagicString(0, ParquetFileWriter.MAGIC));
+  private static final List<MagicString> MAGIC_STRINGS = Collections.singletonList(new MagicString(0, ParquetFileWriter.MAGIC));
 
   private final DrillbitContext context;
   private final Configuration fsConf;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapFormatPlugin.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanB
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
@@ -34,9 +33,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.drill.exec.store.pcap.PcapBatchReader.PcapReaderConfig;
 
 public class PcapFormatPlugin extends EasyFormatPlugin<PcapFormatConfig> {
+
   public static final String PLUGIN_NAME = "pcap";
 
   private static class PcapReaderFactory extends FileReaderFactory {
+
     private final PcapReaderConfig readerConfig;
 
     public PcapReaderFactory(PcapReaderConfig config) {
@@ -48,6 +49,7 @@ public class PcapFormatPlugin extends EasyFormatPlugin<PcapFormatConfig> {
       return new PcapBatchReader(readerConfig);
     }
   }
+
   public PcapFormatPlugin(String name, DrillbitContext context,
                            Configuration fsConf, StoragePluginConfig storageConfig,
                            PcapFormatConfig formatConfig) {
@@ -58,7 +60,7 @@ public class PcapFormatPlugin extends EasyFormatPlugin<PcapFormatConfig> {
     EasyFormatConfig config = new EasyFormatConfig();
     config.readable = true;
     config.writable = false;
-    config.blockSplittable = true;
+    config.blockSplittable = false;
     config.compressible = true;
     config.supportsProjectPushdown = true;
     config.extensions = pluginConfig.getExtensions();
@@ -70,13 +72,12 @@ public class PcapFormatPlugin extends EasyFormatPlugin<PcapFormatConfig> {
   }
 
   @Override
-  public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(
-    EasySubScan scan, OptionManager options) throws ExecutionSetupException {
+  public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(EasySubScan scan, OptionManager options) {
     return new PcapBatchReader(new PcapReaderConfig(this));
   }
 
   @Override
-  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) throws ExecutionSetupException {
+  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanBuilder builder = new FileScanBuilder();
     builder.setReaderFactory(new PcapReaderFactory(new PcapReaderConfig(this)));
     initScanBuilder(builder, scan);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngFormatPlugin.java
@@ -47,7 +47,7 @@ public class PcapngFormatPlugin extends EasyFormatPlugin<PcapngFormatConfig> {
 
   public PcapngFormatPlugin(String name, DrillbitContext context, Configuration fsConf, StoragePluginConfig config, PcapngFormatConfig formatPluginConfig) {
     super(name, context, fsConf, config, formatPluginConfig, true,
-        false, true, false,
+        false, false, true,
         formatPluginConfig.getExtensions(), DEFAULT_NAME);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngRecordReader.java
@@ -31,18 +31,18 @@ import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.impl.OutputMutator;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.store.AbstractRecordReader;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.pcapng.schema.Column;
 import org.apache.drill.exec.store.pcapng.schema.DummyArrayImpl;
 import org.apache.drill.exec.store.pcapng.schema.DummyImpl;
 import org.apache.drill.exec.store.pcapng.schema.Schema;
 import org.apache.drill.exec.vector.ValueVector;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -59,14 +59,14 @@ public class PcapngRecordReader extends AbstractRecordReader {
   private final Path pathToFile;
   private OutputMutator output;
   private List<ProjectedColumnInfo> projectedCols;
-  private FileSystem fs;
-  private FSDataInputStream in;
+  private DrillFileSystem fs;
+  private InputStream in;
   private List<SchemaPath> columns;
 
   private Iterator<IPcapngType> it;
 
   public PcapngRecordReader(final Path pathToFile,
-                            final FileSystem fileSystem,
+                            final DrillFileSystem fileSystem,
                             final List<SchemaPath> columns) {
     this.fs = fileSystem;
     this.pathToFile = fs.makeQualified(pathToFile);
@@ -79,7 +79,7 @@ public class PcapngRecordReader extends AbstractRecordReader {
     try {
 
       this.output = output;
-      this.in = fs.open(pathToFile);
+      this.in = fs.openPossiblyCompressedStream(pathToFile);
       PcapDecoder decoder = new PcapDecoder(IOUtils.toByteArray(in));
       decoder.decode();
       this.it = decoder.getSectionList().iterator();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/package-info.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 /**
- * For comments on realization of this format plugin look at :
+ * For comments on implementation of this format plugin see:
  *
  * @see <a href="https://issues.apache.org/jira/browse/DRILL-6179"> Jira</a>
  */

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestCompressedFiles.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestCompressedFiles.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.dfs;
+
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.exec.ExecTest;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+@Category(UnlikelyTest.class)
+public class TestCompressedFiles extends ClusterTest {
+
+  private static FileSystem fs;
+  private static CompressionCodecFactory factory;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+
+    fs = ExecTest.getLocalFileSystem();
+    Configuration conf = fs.getConf();
+    conf.set(CommonConfigurationKeys.IO_COMPRESSION_CODECS_KEY, ZipCodec.class.getCanonicalName());
+    factory = new CompressionCodecFactory(conf);
+  }
+
+  @Test
+  public void testGzip() throws Exception {
+    String fileName = "gz_data.csvh.gz";
+    writeData(fileName, "gzip", "id,name\n1,Fred\n2,Wilma");
+
+    testBuilder()
+      .sqlQuery("select * from dfs.`root`.`%s`", fileName)
+      .unOrdered()
+      .baselineColumns("id", "name")
+      .baselineValues("1", "Fred")
+      .baselineValues("2", "Wilma")
+      .go();
+  }
+
+  @Test
+  public void testBzip2() throws Exception {
+    String fileName = "bzip2_data.csvh.bz2";
+    writeData(fileName, "bzip2", "id,name\n3,Bamm-Bamm\n4,Barney");
+
+    testBuilder()
+      .sqlQuery("select * from dfs.`root`.`%s`", fileName)
+      .unOrdered()
+      .baselineColumns("id", "name")
+      .baselineValues("3", "Bamm-Bamm")
+      .baselineValues("4", "Barney")
+      .go();
+  }
+
+  @Test
+  public void testZip() throws Exception {
+    String fileName = "zip_data.csvh.zip";
+    writeData(fileName, "zip", "id,name\n5,Dino\n6,Pebbles");
+
+    testBuilder()
+      .sqlQuery("select * from dfs.`root`.`%s`", fileName)
+      .unOrdered()
+      .baselineColumns("id", "name")
+      .baselineValues("5", "Dino")
+      .baselineValues("6", "Pebbles")
+      .go();
+  }
+
+  private void writeData(String fileName, String codecName, String data) throws IOException {
+    CompressionCodec codec = factory.getCodecByName(codecName);
+    assertNotNull(codecName + " is not found", codec);
+    Path outFile = new Path(dirTestWatcher.getRootDir().getAbsolutePath(), fileName);
+    try (InputStream inputStream = new ByteArrayInputStream(data.getBytes());
+         OutputStream outputStream = codec.createOutputStream(fs.create(outFile))) {
+      IOUtils.copyBytes(inputStream, outputStream, fs.getConf(), false);
+    }
+  }
+}


### PR DESCRIPTION
1. Added ZipCodec implementation which can read / write single file.
2. Revisited Drill plugin formats to ensure 'openPossiblyCompressedStream' method is used in those which support compression.
3. Added unit tests.
4. General refactoring.

Jira - [DRILL-5674](https://issues.apache.org/jira/browse/DRILL-5674).