### PR TITLE
DRILL-1709: Add desc alias for describe command

### DIFF
--- a/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
+++ b/exec/java-exec/src/main/codegen/includes/parserImpls.ftl
@@ -494,8 +494,8 @@ SqlNode SqlRefreshMetadata() :
 
 /**
 * Parses statement
-*   DESCRIBE { SCHEMA | DATABASE } name
-*   DESCRIBE SCHEMA FOR TABLE dfs.my_table [AS (JSON | STATEMENT)]
+*   { DESCRIBE | DESC } { SCHEMA | DATABASE } name
+*   { DESCRIBE | DESC } SCHEMA FOR TABLE dfs.my_table [AS (JSON | STATEMENT)]
 */
 SqlNode SqlDescribeSchema() :
 {
@@ -504,7 +504,7 @@ SqlNode SqlDescribeSchema() :
    String format = "JSON";
 }
 {
-   <DESCRIBE> { pos = getPos(); }
+   (<DESCRIBE> | <DESC>) { pos = getPos(); }
    (
        <SCHEMA>
          (

--- a/exec/java-exec/src/test/java/org/apache/drill/TestSchemaCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestSchemaCommands.java
@@ -661,6 +661,12 @@ public class TestSchemaCommands extends ClusterTest {
         .baselineValues(schema)
         .go();
 
+      testBuilder()
+        .sqlQuery("describe schema for table %s", table)
+        .unOrdered()
+        .sqlBaselineQuery("desc schema for table %s", table)
+        .go();
+
     } finally {
       run("drop table if exists %s", table);
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchema.java
@@ -476,4 +476,11 @@ public class TestInfoSchema extends BaseTestQuery {
   public void describeSchemaInvalid() throws Exception {
     errorMsgTestHelper("describe schema invalid.schema", "Invalid schema name [invalid.schema]");
   }
+
+  @Test
+  public void testDescribeAlias() throws Exception {
+    test("desc schema dfs.tmp");
+    test("desc information_schema.`catalogs`");
+    test("desc table information_schema.`catalogs`");
+  }
 }


### PR DESCRIPTION
`describe [table]` command already supported `desc` alias.
Adding `desc` alias support for `describe schema [for table]` for consistency.

Jira - [DRILL-1709](https://issues.apache.org/jira/browse/DRILL-1709).