### PR TITLE
DRILL-7424: Project operator fails to set the container row count

### DIFF
--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoChunkAssignment.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoChunkAssignment.java
@@ -31,14 +31,14 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.store.mongo.common.ChunkInfo;
-import org.junit.Before;
-import org.junit.Test;
-
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
-import com.mongodb.ServerAddress;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import com.mongodb.ServerAddress;
 
 @Category({SlowTest.class, MongoStorageTest.class})
 public class TestMongoChunkAssignment {
@@ -274,5 +274,4 @@ public class TestMongoChunkAssignment {
     assertEquals(6, mongoGroupScan.getSpecificScan(0).getChunkScanSpecList()
         .size());
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AbstractSqlPatternMatcher.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AbstractSqlPatternMatcher.java
@@ -17,13 +17,15 @@
  */
 package org.apache.drill.exec.expr.fn.impl;
 
-import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
-import org.apache.drill.common.exceptions.UserException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetEncoder;
-import static org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.logger;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * To get good performance for most commonly used pattern matches
@@ -42,6 +44,8 @@ import static org.apache.drill.exec.expr.fn.impl.StringFunctionHelpers.logger;
  */
 
 public abstract class AbstractSqlPatternMatcher implements SqlPatternMatcher {
+  private static final Logger logger = LoggerFactory.getLogger(AbstractSqlPatternMatcher.class);
+
   protected final String patternString;
   protected final int patternLength;
   protected final ByteBuffer patternByteBuffer;
@@ -49,8 +53,8 @@ public abstract class AbstractSqlPatternMatcher implements SqlPatternMatcher {
   public AbstractSqlPatternMatcher(String patternString) {
     this.patternString = patternString;
 
-    final CharsetEncoder charsetEncoder = Charsets.UTF_8.newEncoder();
-    final CharBuffer patternCharBuffer = CharBuffer.wrap(patternString);
+    CharsetEncoder charsetEncoder = Charsets.UTF_8.newEncoder();
+    CharBuffer patternCharBuffer = CharBuffer.wrap(patternString);
 
     try {
       patternByteBuffer = charsetEncoder.encode(patternCharBuffer);
@@ -62,5 +66,4 @@ public abstract class AbstractSqlPatternMatcher implements SqlPatternMatcher {
     }
     patternLength = patternByteBuffer.limit();
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -20,16 +20,15 @@ package org.apache.drill.exec.physical.impl.validate;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
-import org.apache.drill.exec.ops.OperatorContext;
-import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.impl.ScanBatch;
+import org.apache.drill.exec.physical.impl.project.ProjectRecordBatch;
+import org.apache.drill.exec.physical.impl.protocol.OperatorRecordBatch;
+import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.SimpleVectorWrapper;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
-import org.apache.drill.exec.store.dfs.FormatPlugin;
-import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.drill.exec.vector.BitVector;
 import org.apache.drill.exec.vector.FixedWidthVector;
 import org.apache.drill.exec.vector.NullableVector;
@@ -142,9 +141,9 @@ public class BatchValidator {
     }
   }
 
-  private enum CheckMode { COUNTS, ALL, NONE, SPECIAL };
+  private enum CheckMode { COUNTS, ALL, NONE };
 
-  private static final Map<Class<?>, CheckMode> checkRules = buildRules();
+  private static final Map<Class<? extends CloseableRecordBatch>, CheckMode> checkRules = buildRules();
 
   private final ErrorReporter errorReporter;
 
@@ -158,40 +157,21 @@ public class BatchValidator {
    * Over time, this table should include all operators, and thus become
    * unnecessary.
    */
-  private static Map<Class<?>, CheckMode> buildRules() {
-    final Map<Class<?>, CheckMode> rules = new IdentityHashMap<>();
-    // Operators
-    rules.put(ScanBatch.class, CheckMode.SPECIAL);
-    // Scan types
-    rules.put(EasySubScan.class, CheckMode.ALL);
+  private static Map<Class<? extends CloseableRecordBatch>, CheckMode> buildRules() {
+    Map<Class<? extends CloseableRecordBatch>, CheckMode> rules = new IdentityHashMap<>();
+    rules.put(OperatorRecordBatch.class, CheckMode.ALL);
+    rules.put(ScanBatch.class, CheckMode.ALL);
+    rules.put(ProjectRecordBatch.class, CheckMode.COUNTS);
     return rules;
   }
 
   private static CheckMode lookup(Object subject) {
-    final CheckMode checkMode = checkRules.get(subject.getClass());
+    CheckMode checkMode = checkRules.get(subject.getClass());
     return checkMode == null ? CheckMode.NONE : checkMode;
   }
 
-  private static CheckMode checkMode(RecordBatch batch) {
-    final CheckMode checkMode = lookup(batch);
-    if (checkMode != CheckMode.SPECIAL) {
-      return checkMode;
-    }
-    // For Scan, enable readers one-by-one.
-    final ScanBatch scan = (ScanBatch) batch;
-    final OperatorContext opContext = scan.getOperatorContext();
-    final PhysicalOperator opDefn = opContext.getOperatorDefn();
-    final CheckMode opCheckMode = lookup(opDefn);
-    if (opCheckMode != CheckMode.SPECIAL) {
-      return opCheckMode;
-    }
-    final EasySubScan easyScan = (EasySubScan) opDefn;
-    final FormatPlugin plugin = easyScan.getFormatPlugin();
-    return lookup(plugin);
-  }
-
   public static boolean validate(RecordBatch batch) {
-    final CheckMode checkMode = checkMode(batch);
+    CheckMode checkMode = lookup(batch);
 
     // If no rule, don't check this batch.
 
@@ -365,7 +345,7 @@ public class BatchValidator {
   }
 
   private void validateVarBinaryVector(String name, VarBinaryVector vector) {
-    final int valueCount = vector.getAccessor().getValueCount();
+    int valueCount = vector.getAccessor().getValueCount();
 
     // Disabled because a large number of operators
     // set up offset vectors wrongly.
@@ -373,7 +353,7 @@ public class BatchValidator {
       return;
     }
 
-    final int dataLength = vector.getBuffer().writerIndex();
+    int dataLength = vector.getBuffer().writerIndex();
     validateOffsetVector(name + "-offsets", vector.getOffsetVector(), false, valueCount, dataLength);
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/TestCTASPartitionFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestCTASPartitionFilter.java
@@ -17,15 +17,14 @@
  */
 package org.apache.drill;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestCTASPartitionFilter extends PlanTestBase {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestCTASPartitionFilter.class);
 
   private static void testExcludeFilter(String query, int expectedNumFiles,
       String excludedFilterPattern, int expectedRowCount) throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestPartitionFilter.java
@@ -19,6 +19,8 @@ package org.apache.drill;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.file.Paths;
+
 import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.categories.SqlTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -26,10 +28,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.nio.file.Paths;
-
 @Category({SqlTest.class, PlannerTest.class})
 public class TestPartitionFilter extends PlanTestBase {
+
   private static void testExcludeFilter(String query, int expectedNumFiles,
       String excludedFilterPattern, int expectedRowCount) throws Exception {
     int actualRowCount = testSql(query);
@@ -394,7 +395,6 @@ public class TestPartitionFilter extends PlanTestBase {
     test("alter session set `planner.in_subquery_threshold` = 10");
     testExcludeFilter(query, 4, "Filter\\(", 40);
   }
-
 
   @Test // DRILL-4825: querying same table with different filter in UNION ALL.
   public void testPruneSameTableInUnionAll() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchSingleMode.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchSingleMode.java
@@ -25,7 +25,6 @@ import org.junit.experimental.categories.Category;
 
 @Category({SlowTest.class})
 public class TestTpchSingleMode extends BaseTestQuery {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchSingleMode.class);
 
   private static final String SINGLE_MODE = "ALTER SESSION SET `planner.disable_exchanges` = true;";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestLateralPlans.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/lateraljoin/TestLateralPlans.java
@@ -23,6 +23,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
@@ -33,10 +37,6 @@ import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.nio.file.Paths;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class TestLateralPlans extends BaseTestQuery {
   private static final String regularTestFile_1 = "cust_order_10_1.json";
@@ -189,7 +189,6 @@ public class TestLateralPlans extends BaseTestQuery {
         .sqlQuery(sql)
         .sqlBaselineQuery(baselineQuery)
         .go();
-
   }
 
   @Test
@@ -289,7 +288,6 @@ public class TestLateralPlans extends BaseTestQuery {
         .sqlQuery(sql)
         .sqlBaselineQuery(baselineQuery)
         .go();
-
   }
 
   @Test
@@ -416,7 +414,6 @@ public class TestLateralPlans extends BaseTestQuery {
     }
   }
 
-
   @Test
   public void testNoExchangeWithLateralsDownStreamJoin() throws Exception {
     String sql = "select d1.totalprice from dfs.`lateraljoin/multipleFiles` t, dfs.`lateraljoin/multipleFiles` t2, " +
@@ -475,7 +472,6 @@ public class TestLateralPlans extends BaseTestQuery {
     String CorrelateUnnest = matcher.group(0);
     return CorrelateUnnest.substring(CorrelateUnnest.lastIndexOf("Scan"));
   }
-
 
   //The following test is for testing the explain plan contains relation between lateral and corresponding unnest.
   @Test


### PR DESCRIPTION
Enabled the "batch validator" for the Project operator. Ran tests.
Exceptions occurred because, in some paths, the Project operator
fails to set the container row count.

Fixes the Project operator. Cleans up formatting issues in files
touched during the investigation. Cleaned up batch-related issues
in Project.