### PR TITLE
DRILL-7347: Upgrade Apache Iceberg to released version

### DIFF
--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -33,7 +33,7 @@
   <name>metastore/Drill Iceberg Metastore</name>
 
   <properties>
-    <iceberg.version>4d8ae52</iceberg.version>
+    <iceberg.version>0.7.0-incubating</iceberg.version>
     <caffeine.version>2.7.0</caffeine.version>
   </properties>
 
@@ -49,27 +49,27 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-parquet</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-data</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-core</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-common</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.apache.incubator-iceberg</groupId>
+      <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
       <version>${iceberg.version}</version>
     </dependency>


### PR DESCRIPTION
Jira - [DRILL-7347](https://issues.apache.org/jira/browse/DRILL-7347).