### PR TITLE
DRILL-7273: Introduce operators for handling metadata

### DIFF
--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -609,7 +609,7 @@ public class Types {
   }
 
   public static MajorType overrideMode(final MajorType originalMajorType, final DataMode overrideMode) {
-    return withPrecisionAndScale(originalMajorType.getMinorType(), overrideMode, originalMajorType.getPrecision(), originalMajorType.getScale());
+    return originalMajorType.toBuilder().setMode(overrideMode).build();
   }
 
   public static MajorType getMajorTypeFromName(final String typeName) {

--- a/common/src/main/java/org/apache/drill/common/util/function/CheckedSupplier.java
+++ b/common/src/main/java/org/apache/drill/common/util/function/CheckedSupplier.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.common.util.function;
 
+import java.util.function.Supplier;
+
+import static org.apache.drill.common.exceptions.ErrorHelper.sneakyThrow;
+
 /**
  * The java standard library does not provide a lambda function interface for functions that take no arguments,
  * but that throw an exception. So, we have to define our own here.
@@ -24,6 +28,24 @@ package org.apache.drill.common.util.function;
  * @param <E> The type of exception thrown by the lambda function.
  */
 @FunctionalInterface
-public interface CheckedSupplier<T, E extends Exception> {
-  T get() throws E;
+public interface CheckedSupplier<T, E extends Exception> extends Supplier<T> {
+
+  @Override
+  default T get() {
+    try {
+      return getAndThrow();
+    } catch (Throwable e) {
+      sneakyThrow(e);
+    }
+    // should never happen
+    throw new RuntimeException();
+  }
+
+  /**
+   * Gets a result.
+   *
+   * @return a result
+   * @throws E exception in case of errors
+   */
+  T getAndThrow() throws E;
 }

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -1034,7 +1034,7 @@ void AddDescriptorsImpl() {
       "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000"
       "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014"
       "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022"
-      "\032\n\026CANCELLATION_REQUESTED\020\006*\242\n\n\020CoreOper"
+      "\032\n\026CANCELLATION_REQUESTED\020\006*\321\n\n\020CoreOper"
       "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST"
       "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020"
       "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH"
@@ -1067,14 +1067,15 @@ void AddDescriptorsImpl() {
       "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR"
       "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_"
       "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>\022\022\n\016EXCEL_SUB_"
-      "SCAN\020@\022\020\n\014SHP_SUB_SCAN\020A*g\n\nSaslStatus\022\020"
-      "\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL"
-      "_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL"
-      "_FAILED\020\004B.\n\033org.apache.drill.exec.proto"
-      "B\rUserBitSharedH\001"
+      "SCAN\020@\022\020\n\014SHP_SUB_SCAN\020A\022\024\n\020METADATA_HAN"
+      "DLER\020B\022\027\n\023METADATA_CONTROLLER\020C*g\n\nSaslS"
+      "tatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022"
+      "\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022"
+      "\017\n\013SASL_FAILED\020\004B.\n\033org.apache.drill.exe"
+      "c.protoB\rUserBitSharedH\001"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 5697);
+      descriptor, 5744);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "UserBitShared.proto", &protobuf_RegisterTypes);
   ::protobuf_Types_2eproto::AddDescriptors();
@@ -1318,6 +1319,8 @@ bool CoreOperatorType_IsValid(int value) {
     case 62:
     case 64:
     case 65:
+    case 66:
+    case 67:
       return true;
     default:
       return false;

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -355,11 +355,13 @@ enum CoreOperatorType {
   STATISTICS_MERGE = 61,
   LTSV_SUB_SCAN = 62,
   EXCEL_SUB_SCAN = 64,
-  SHP_SUB_SCAN = 65
+  SHP_SUB_SCAN = 65,
+  METADATA_HANDLER = 66,
+  METADATA_CONTROLLER = 67
 };
 bool CoreOperatorType_IsValid(int value);
 const CoreOperatorType CoreOperatorType_MIN = SINGLE_SENDER;
-const CoreOperatorType CoreOperatorType_MAX = SHP_SUB_SCAN;
+const CoreOperatorType CoreOperatorType_MAX = METADATA_CONTROLLER;
 const int CoreOperatorType_ARRAYSIZE = CoreOperatorType_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* CoreOperatorType_descriptor();

--- a/docs/dev/MetastoreAnalyze.md
+++ b/docs/dev/MetastoreAnalyze.md
@@ -1,0 +1,119 @@
+# Metastore ANALYZE commands
+
+Drill provides the functionality to collect, use and store table metadata into Drill Metastore.
+
+Set `metastore.enabled` option to true to enable Metastore usage.
+
+To collect table metadata, the following command should be used:
+
+```
+ANALYZE TABLE [table_name] [COLUMNS (col1, col2, ...)]
+REFRESH METADATA [partition LEVEL]
+{COMPUTE | ESTIMATE} | STATISTICS [(column1, column2, ...)]
+[ SAMPLE numeric PERCENT ]
+```
+
+For the case when this command is executed for the first time, whole table metadata will be collected and stored into
+ Metastore.
+If analyze was already executed for the table, and table data wasn't changed, all further analyze commands wouldn't
+ trigger table analyzing and message that table metadata is up to date will be returned.
+
+# Incremental analyze
+
+For the case when some table data was updated, Drill will try to execute incremental analyze - calculate metadata only
+ for updated data and reuse required metadata from the Metastore.
+
+Incremental analyze wouldn't be produced for the following cases:
+ - list of interesting columns specified in analyze is not a subset of interesting columns from the previous analyze;
+ - specified metadata level differs from the metadata level in previous analyze.
+
+# Metadata usage
+
+Drill provides the ability to use metadata obtained from the Metastore at the planning stage to prune segments, files
+ and row groups.
+
+Tables metadata from the Metastore is exposed to `INFORMATION_SCHEMA` tables (if Metastore usage is enabled).
+
+The following tables are populated with table metadata from the Metastore:
+
+`TABLES` table has the following additional columns populated from the Metastore:
+ - `TABLE_SOURCE` - table data type: `PARQUET`, `CSV`, `JSON`
+ - `LOCATION` - table location: `/tmp/nation`
+ - `NUM_ROWS` - number of rows in a table if known, `null` if not known
+ - `LAST_MODIFIED_TIME` - table's last modification time
+
+`COLUMNS` table has the following additional columns populated from the Metastore:
+ - `COLUMN_DEFAULT` - column default value
+ - `COLUMN_FORMAT` - usually applicable for date time columns: `yyyy-MM-dd`
+ - `NUM_NULLS` - number of nulls in column values
+ - `MIN_VAL` - column min value in String representation: `aaa`
+ - `MAX_VAL` - column max value in String representation: `zzz`
+ - `NDV` - number of distinct values in column, expressed in Double
+ - `EST_NUM_NON_NULLS` - estimated number of non null values, expressed in Double
+ - `IS_NESTED` - if column is nested. Nested columns are extracted from columns with struct type.
+
+`PARTITIONS` table has the following additional columns populated from the Metastore:
+ - `TABLE_CATALOG` - table catalog (currently we have only one catalog): `DRILL`
+ - `TABLE_SCHEMA` - table schema: `dfs.tmp`
+ - `TABLE_NAME` - table name: `nation`
+ - `METADATA_KEY` - top level segment key, the same for all nested segments and partitions: `part_int=3`
+ - `METADATA_TYPE` - `SEGMENT` or `PARTITION`
+ - `METADATA_IDENTIFIER` - current metadata identifier: `part_int=3/part_varchar=g`
+ - `PARTITION_COLUMN` - partition column name: `part_varchar`
+ - `PARTITION_VALUE` - partition column value: `g`
+ - `LOCATION` - segment location, `null` for partitions: `/tmp/nation/part_int=3`
+ - `LAST_MODIFIED_TIME` - last modification time
+
+# Metastore related options
+
+ - `metastore.enabled` - enables Drill Metastore usage to be able to store table metadata during `ANALYZE TABLE` commands 
+execution and to be able to read table metadata during regular queries execution or when querying some `INFORMATION_SCHEMA` tables.
+ - `metastore.metadata.store.depth_level` - specifies maximum level depth for collecting metadata.
+ Possible values : `TABLE`, `SEGMENT`, `PARTITION`, `FILE`, `ROW_GROUP`, `ALL`.
+ - `metastore.metadata.use_schema` - enables schema usage, stored to the Metastore.
+ - `metastore.metadata.use_statistics` - enables statistics usage, stored in the Metastore, at the planning stage.
+ - `metastore.metadata.fallback_to_file_metadata` - allows using file metadata cache for the case when required metadata is absent in the Metastore.
+ - `metastore.retrieval.retry_attempts` - specifies the number of attempts for retrying query planning after detecting that query metadata is changed. 
+ If the number of retries was exceeded, query will be planned without metadata information from the Metastore.
+ 
+# Analyze operators description
+
+Entry point for `ANALYZE` command is `MetastoreAnalyzeTableHandler` class. It creates plan which includes some
+Metastore specific operators for collecting metadata.
+
+`MetastoreAnalyzeTableHandler` uses `AnalyzeInfoProvider` for providing the information
+required for building a suitable plan for collecting metadata.
+Each group scan should provide corresponding `AnalyzeInfoProvider` implementation class.
+
+Analyze command specific operators:
+ - `MetadataAggBatch` - operator which adds aggregate calls for all incoming table columns to calculate required
+  metadata and produces aggregations. If aggregation is performed on top of another aggregation,
+  required aggregate calls for merging metadata will be added.
+ - `MetadataHandlerBatch` - operator responsible for handling metadata returned by incoming aggregate operators and
+  fetching required metadata form the Metastore to produce further aggregations.
+ - `MetadataControllerBatch` - responsible for converting obtained metadata, fetching absent metadata from the Metastore
+  and storing resulting metadata into the Metastore.
+
+`MetastoreAnalyzeTableHandler` forms plan  depending on segments count in the following form:
+
+```
+MetadataControllerBatch
+  ...
+    MetadataHandlerBatch
+      MetadataAggBatch(dir0, ...)
+        MetadataHandlerBatch
+          MetadataAggBatch(dir0, dir1, ...)
+            MetadataHandlerBatch
+              MetadataAggBatch(dir0, dir1, fqn, ...)
+                Scan(DYNAMIC_STAR **, ANY fqn, ...)
+```
+
+The lowest `MetadataAggBatch` creates required aggregate calls for every (or interesting only) table columns
+and produces aggregations with grouping by segment columns that correspond to specific table level.
+`MetadataHandlerBatch` above it populates batch with additional information about metadata type and other info.
+`MetadataAggBatch` above merges metadata calculated before to obtain metadata for parent metadata levels and also stores incoming data to populate it to the Metastore later.
+
+`MetadataControllerBatch` obtains all calculated metadata, converts it to the suitable form and sends it to the Metastore.
+
+For the case of incremental analyze, `MetastoreAnalyzeTableHandler` creates Scan with updated files only
+and provides `MetadataHandlerBatch` with information about metadata which should be fetched from the Metastore, so existing actual metadata wouldn't be recalculated.

--- a/exec/java-exec/src/main/codegen/data/AggrTypes1.tdd
+++ b/exec/java-exec/src/main/codegen/data/AggrTypes1.tdd
@@ -46,8 +46,10 @@
      ]
     },
     {className: "Max", funcName: "max", types: [
+      {inputType: "Bit", outputType: "NullableBit", runningType: "Bit", major: "Numeric"},
       {inputType: "Int", outputType: "NullableInt", runningType: "Int", major: "Numeric"},
       {inputType: "BigInt", outputType: "NullableBigInt", runningType: "BigInt", major: "Numeric"},
+      {inputType: "NullableBit", outputType: "NullableBit", runningType: "Bit", major: "Numeric"},
       {inputType: "NullableInt", outputType: "NullableInt", runningType: "Int", major: "Numeric"},
       {inputType: "NullableBigInt", outputType: "NullableBigInt", runningType: "BigInt", major: "Numeric"},
       {inputType: "Float4", outputType: "NullableFloat4", runningType: "Float4", major: "Numeric"},

--- a/exec/java-exec/src/main/codegen/templates/AggrTypeFunctions1.java
+++ b/exec/java-exec/src/main/codegen/templates/AggrTypeFunctions1.java
@@ -161,6 +161,8 @@ public class ${aggrtype.className}Functions {
       value.value = Float.NaN;
       <#elseif type.runningType?starts_with("Float8")>
       value.value = Double.NaN;
+      <#elseif type.runningType?starts_with("Bit")>
+      value.value = 1;
       </#if>
     <#elseif aggrtype.funcName == "max">
       <#if type.runningType?starts_with("Int")>
@@ -171,6 +173,8 @@ public class ${aggrtype.className}Functions {
       value.value = -Float.MAX_VALUE;
       <#elseif type.runningType?starts_with("Float8")>
       value.value = -Double.MAX_VALUE;
+      <#elseif type.runningType?starts_with("Bit")>
+      value.value = 0;
       </#if>
     </#if>
     }

--- a/exec/java-exec/src/main/codegen/templates/JsonBaseStatisticsRecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/JsonBaseStatisticsRecordWriter.java
@@ -40,7 +40,7 @@ import java.util.List;
  *
  * NB: Source code generated using FreeMarker template ${.template_name}
  */
-public abstract class JSONBaseStatisticsRecordWriter implements StatisticsRecordWriter {
+public abstract class JSONBaseStatisticsRecordWriter implements StatisticsRecordCollector {
 
   protected JsonOutput gen;
   protected boolean skipNullFields = true;

--- a/exec/java-exec/src/main/codegen/templates/StatisticsRecordCollector.java
+++ b/exec/java-exec/src/main/codegen/templates/StatisticsRecordCollector.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+<@pp.dropOutputFile />
+<@pp.changeOutputFile name="org/apache/drill/exec/store/StatisticsRecordCollector.java" />
+<#include "/@includes/license.ftl" />
+
+package org.apache.drill.exec.store;
+
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.VectorAccessible;
+import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+
+import java.io.IOException;
+import java.util.Map;
+
+/*
+ * This class is generated using freemarker and the ${.template_name} template.
+ */
+
+/**
+ * Interface for collecting and obtaining statistics.
+ */
+public interface StatisticsRecordCollector {
+
+  /**
+   * Called before starting writing fields in a record.
+   * @throws IOException
+   */
+  void startStatisticsRecord() throws IOException;
+
+  /**
+   * Called after adding all fields in a particular statistics record are added using
+   * add{TypeHolder}(fieldId, TypeHolder) methods.
+   * @throws IOException
+   */
+  void endStatisticsRecord() throws IOException;
+
+  /**
+   * Returns true if this {@link StatisticsRecordCollector} has non-empty statistics.
+   *
+   * @return {@ode true} if this {@link StatisticsRecordCollector} has non-empty statistics
+   */
+  boolean hasStatistics();
+
+  /**
+   * Returns {@link DrillStatsTable.TableStatistics} instance with statistics collected using this {@link StatisticsRecordCollector}.
+   *
+   * @return {@link DrillStatsTable.TableStatistics} instance
+   */
+  DrillStatsTable.TableStatistics getStatistics();
+
+  <#list vv.types as type>
+  <#list type.minor as minor>
+  <#list vv.modes as mode>
+
+  /**
+   * Add the field value given in <code>valueHolder</code> at the given column number <code>fieldId</code>.
+   */
+  public FieldConverter getNew${mode.prefix}${minor.class}Converter(int fieldId, String fieldName, FieldReader reader);
+  </#list>
+  </#list>
+  </#list>
+}

--- a/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriter.java
+++ b/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriter.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 
 /** StatisticsRecordWriter interface. */
-public interface StatisticsRecordWriter {
+public interface StatisticsRecordWriter extends StatisticsRecordCollector {
 
   /**
    * Initialize the writer.
@@ -61,28 +61,6 @@ public interface StatisticsRecordWriter {
    */
   boolean isBlockingWriter();
 
-  /**
-   * Called before starting writing fields in a record.
-   * @throws IOException
-   */
-  void startStatisticsRecord() throws IOException;
-
-  <#list vv.types as type>
-  <#list type.minor as minor>
-  <#list vv.modes as mode>
-  /** Add the field value given in <code>valueHolder</code> at the given column number <code>fieldId</code>. */
-  public FieldConverter getNew${mode.prefix}${minor.class}Converter(int fieldId, String fieldName, FieldReader reader);
-
-  </#list>
-  </#list>
-  </#list>
-
-  /**
-   * Called after adding all fields in a particular statistics record are added using
-   * add{TypeHolder}(fieldId, TypeHolder) methods.
-   * @throws IOException
-   */
-  void endStatisticsRecord() throws IOException;
   /**
    * For a blocking writer, called after processing all the records to flush out the writes
    * @throws IOException

--- a/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriterImpl.java
+++ b/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriterImpl.java
@@ -31,6 +31,8 @@ import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -39,9 +41,11 @@ import java.util.List;
  * This class is generated using freemarker and the ${.template_name} template.
  */
 
-/** Reads records from the RecordValueAccessor and writes into StatisticsRecordWriter. */
+/**
+ * Reads records from the RecordValueAccessor and writes into StatisticsRecordCollector.
+ */
 public class StatisticsRecordWriterImpl {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StatisticsRecordWriterImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(StatisticsRecordWriterImpl.class);
 
   private VectorAccessible batch;
   private StatisticsRecordWriter recordWriter;
@@ -97,7 +101,7 @@ public class StatisticsRecordWriterImpl {
     }
   }
 
-  public static FieldConverter getConverter(StatisticsRecordWriter recordWriter, int fieldId, String fieldName,
+  public static FieldConverter getConverter(StatisticsRecordCollector recordWriter, int fieldId, String fieldName,
       FieldReader reader) {
     switch (reader.getType().getMinorType()) {
       <#list vv.types as type>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -489,6 +489,25 @@ public final class ExecConstants {
   public static final String IMPLICIT_FILEPATH_COLUMN_LABEL = "drill.exec.storage.implicit.filepath.column.label";
   public static final OptionValidator IMPLICIT_FILEPATH_COLUMN_LABEL_VALIDATOR = new StringValidator(IMPLICIT_FILEPATH_COLUMN_LABEL,
       new OptionDescription("Available as of Drill 1.10. Sets the implicit column name for the filepath column."));
+  public static final String IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL = "drill.exec.storage.implicit.row_group_index.column.label";
+  public static final OptionValidator IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL_VALIDATOR = new StringValidator(IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL,
+      new OptionDescription("Available as of Drill 1.17. Sets the implicit column name for the row group index (rgi) column. " +
+          "For internal usage when producing Metastore analyze."));
+
+  public static final String IMPLICIT_ROW_GROUP_START_COLUMN_LABEL = "drill.exec.storage.implicit.row_group_start.column.label";
+  public static final OptionValidator IMPLICIT_ROW_GROUP_START_COLUMN_LABEL_VALIDATOR = new StringValidator(IMPLICIT_ROW_GROUP_START_COLUMN_LABEL,
+      new OptionDescription("Available as of Drill 1.17. Sets the implicit column name for the row group start (rgs) column. " +
+          "For internal usage when producing Metastore analyze."));
+
+  public static final String IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL = "drill.exec.storage.implicit.row_group_length.column.label";
+  public static final OptionValidator IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL_VALIDATOR = new StringValidator(IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL,
+      new OptionDescription("Available as of Drill 1.17. Sets the implicit column name for the row group length (rgl) column. " +
+          "For internal usage when producing Metastore analyze."));
+
+  public static final String IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL = "drill.exec.storage.implicit.last_modified_time.column.label";
+  public static final OptionValidator IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL_VALIDATOR = new StringValidator(IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL,
+      new OptionDescription("Available as of Drill 1.17. Sets the implicit column name for the lastModifiedTime column. " +
+          "For internal usage when producing Metastore analyze."));
 
   public static final String JSON_READ_NUMBERS_AS_DOUBLE = "store.json.read_numbers_as_double";
   public static final BooleanValidator JSON_READ_NUMBERS_AS_DOUBLE_VALIDATOR = new BooleanValidator(JSON_READ_NUMBERS_AS_DOUBLE,
@@ -1060,8 +1079,7 @@ public final class ExecConstants {
   public static final BooleanValidator METASTORE_ENABLED_VALIDATOR = new BooleanValidator(METASTORE_ENABLED,
       new OptionDescription("Enables Drill Metastore usage to be able to store table metadata " +
           "during ANALYZE TABLE commands execution and to be able to read table metadata during regular " +
-          "queries execution or when querying some INFORMATION_SCHEMA tables. " +
-          "This option is not active for now. Default is false. (Drill 1.17+)"));
+          "queries execution or when querying some INFORMATION_SCHEMA tables. Default is false. (Drill 1.17+)"));
 
   /**
    * Option for specifying maximum level depth for collecting metadata
@@ -1070,25 +1088,22 @@ public final class ExecConstants {
    */
   public static final String METASTORE_METADATA_STORE_DEPTH_LEVEL = "metastore.metadata.store.depth_level";
   public static final EnumeratedStringValidator METASTORE_METADATA_STORE_DEPTH_LEVEL_VALIDATOR = new EnumeratedStringValidator(METASTORE_METADATA_STORE_DEPTH_LEVEL,
-      new OptionDescription("Specifies maximum level depth for collecting metadata. " +
-          "This option is not active for now. Default is 'ROW_GROUP'. (Drill 1.17+)"),
-      "TABLE", "SEGMENT", "PARTITION", "FILE", "ROW_GROUP");
+      new OptionDescription("Specifies maximum level depth for collecting metadata. Default is 'ALL'. (Drill 1.17+)"),
+      "TABLE", "SEGMENT", "PARTITION", "FILE", "ROW_GROUP", "ALL");
 
   /**
    * Option for enabling schema usage, stored to the Metastore.
    */
   public static final String METASTORE_USE_SCHEMA_METADATA = "metastore.metadata.use_schema";
   public static final BooleanValidator METASTORE_USE_SCHEMA_METADATA_VALIDATOR = new BooleanValidator(METASTORE_USE_SCHEMA_METADATA,
-      new OptionDescription("Enables schema usage, stored to the Metastore. " +
-          "This option is not active for now. Default is false. (Drill 1.17+)"));
+      new OptionDescription("Enables schema usage, stored to the Metastore. Default is false. (Drill 1.17+)"));
 
   /**
    * Option for enabling statistics usage, stored in the Metastore, at the planning stage.
    */
   public static final String METASTORE_USE_STATISTICS_METADATA = "metastore.metadata.use_statistics";
   public static final BooleanValidator METASTORE_USE_STATISTICS_METADATA_VALIDATOR = new BooleanValidator(METASTORE_USE_STATISTICS_METADATA,
-      new OptionDescription("Enables statistics usage, stored in the Metastore, at the planning stage. " +
-          "This option is not active for now. Default is false. (Drill 1.17+)"));
+      new OptionDescription("Enables statistics usage, stored in the Metastore, at the planning stage. Default is false. (Drill 1.17+)"));
 
   /**
    * Option for collecting schema and / or column statistics for every table after CTAS and CTTAS execution.
@@ -1106,16 +1121,16 @@ public final class ExecConstants {
   public static final String METASTORE_FALLBACK_TO_FILE_METADATA = "metastore.metadata.fallback_to_file_metadata";
   public static final BooleanValidator METASTORE_FALLBACK_TO_FILE_METADATA_VALIDATOR = new BooleanValidator(METASTORE_FALLBACK_TO_FILE_METADATA,
       new OptionDescription("Allows using file metadata cache for the case when required metadata is absent in the Metastore. " +
-          "This option is not active for now. Default is true. (Drill 1.17+)"));
+          "Default is true. (Drill 1.17+)"));
 
   /**
    * Option for specifying the number of attempts for retrying query planning after detecting that query metadata is changed.
    */
-  public static final String METASTORE_RETRIVAL_RETRY_ATTEMPTS = "metastore.retrival.retry_attempts";
-  public static final IntegerValidator METASTORE_RETRIVAL_RETRY_ATTEMPTS_VALIDATOR = new IntegerValidator(METASTORE_RETRIVAL_RETRY_ATTEMPTS,
+  public static final String METASTORE_RETRIEVAL_RETRY_ATTEMPTS = "metastore.retrieval.retry_attempts";
+  public static final IntegerValidator METASTORE_RETRIEVAL_RETRY_ATTEMPTS_VALIDATOR = new IntegerValidator(METASTORE_RETRIEVAL_RETRY_ATTEMPTS,
       new OptionDescription("Specifies the number of attempts for retrying query planning after detecting that query metadata is changed. " +
           "If the number of retries was exceeded, query will be planned without metadata information from the Metastore. " +
-          "This option is not active for now. Default is 5. (Drill 1.17+)"));
+          "Default is 5. (Drill 1.17+)"));
 
   public static final String PARQUET_READER_ENABLE_MAP_SUPPORT = "store.parquet.reader.enable_map_support";
   public static final BooleanValidator PARQUET_READER_ENABLE_MAP_SUPPORT_VALIDATOR = new BooleanValidator(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/exception/MetadataException.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/exception/MetadataException.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.exception;
+
+import org.apache.drill.common.exceptions.DrillRuntimeException;
+
+/**
+ * Metadata runtime exception to indicate issues connected with table metadata.
+ */
+public class MetadataException extends DrillRuntimeException {
+  private final MetadataExceptionType exceptionType;
+
+  private MetadataException(MetadataExceptionType exceptionType) {
+    super(exceptionType.message);
+    this.exceptionType = exceptionType;
+  }
+
+  private MetadataException(MetadataExceptionType exceptionType, Throwable cause) {
+    super(exceptionType.message, cause);
+    this.exceptionType = exceptionType;
+  }
+
+  public MetadataExceptionType getExceptionType() {
+    return exceptionType;
+  }
+
+  public static MetadataException of(MetadataExceptionType exceptionType) {
+    return new MetadataException(exceptionType);
+  }
+
+  public static MetadataException of(MetadataExceptionType exceptionType, Throwable cause) {
+    return new MetadataException(exceptionType, cause);
+  }
+
+  public enum MetadataExceptionType {
+    OUTDATED_METADATA("Metastore metadata is outdated."),
+
+    INCONSISTENT_METADATA("Inconsistent Metastore metadata. " +
+        "Metadata was refreshed after it was fetched from the Metastore."),
+
+    INCOMPLETE_METADATA("Metastore does not have metadata for row groups " +
+        "and `metastore.metadata.fallback_to_file_metadata` is disabled. " +
+        "Please either execute ANALYZE with 'ROW_GROUP' level " +
+        "for the querying table or enable `metastore.metadata.fallback_to_file_metadata` to allow " +
+        "using metadata taken from the file metadata cache or table files."),
+
+    ABSENT_SCHEMA("Table schema wasn't provided " +
+        "and `metastore.metadata.use_schema` is disabled. " +
+        "Please either provide table schema for [%s] table " +
+        "(using table function or creating schema file) or enable " +
+        "`metastore.metadata.use_schema`."),
+
+    FALLBACK_EXCEPTION("Exception happened when was attempting to use fallback metadata.");
+
+    private final String message;
+
+    MetadataExceptionType(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillComplexWriterAggFuncHolder.java
@@ -90,7 +90,7 @@ public class DrillComplexWriterAggFuncHolder extends DrillAggFuncHolder {
     if (classGenerator.getCodeGenerator().getDefinition() == StreamingAggTemplate.TEMPLATE_DEFINITION) {
       aggBatchClass = classGenerator.getModel().ref(StreamingAggBatch.class);
     }
-    assert aggBatchClass != null : "ComplexWriterAggFuncHolder should only be used with an Aggregate Operator";
+    assert aggBatchClass != null : "ComplexWriterAggFuncHolder should only be used with Streaming Aggregate Operator";
 
     JExpression aggBatch = JExpr.cast(aggBatchClass, classGenerator.getMappingSet().getOutgoing());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionConverter.java
@@ -118,7 +118,8 @@ public class FunctionConverter {
         // Special processing for @Output ComplexWriter
         if (output != null && ComplexWriter.class.isAssignableFrom(fieldClass)) {
           if (outputField != null) {
-            return failure("You've declared more than one @Output field.  You must declare one and only @Output field per Function class.", func, field);
+            return failure("You've declared more than one @Output field.\n" +
+                "You must declare one and only @Output field per Function class.", func, field);
           } else {
             outputField = ValueReference.createComplexWriterRef(field.getName());
           }
@@ -127,7 +128,8 @@ public class FunctionConverter {
 
         // check that param and output are value holders.
         if (!ValueHolder.class.isAssignableFrom(fieldClass)) {
-          return failure(String.format("The field doesn't holds value of type %s which does not implement the ValueHolder interface.  All fields of type @Param or @Output must extend this interface..", fieldClass), func, field);
+          return failure(String.format("The field doesn't holds value of type %s which does not implement the ValueHolder or ComplexWriter interfaces.\n" +
+              "All fields of type @Param or @Output must extend this interface.", fieldClass), func, field);
         }
 
         // get the type field from the value holder.
@@ -171,7 +173,7 @@ public class FunctionConverter {
 
         //If the workspace var is of Holder type, get its MajorType and assign to WorkspaceReference.
         if (ValueHolder.class.isAssignableFrom(fieldClass)) {
-          MajorType majorType = null;
+          MajorType majorType;
           try {
             majorType = getStaticFieldValue("TYPE", fieldClass, MajorType.class);
           } catch (Exception e) {
@@ -190,8 +192,8 @@ public class FunctionConverter {
     FunctionInitializer initializer = new FunctionInitializer(func.getClassName(), classLoader);
     try {
       // return holder
-      ValueReference[] ps = params.toArray(new ValueReference[params.size()]);
-      WorkspaceReference[] works = workspaceFields.toArray(new WorkspaceReference[workspaceFields.size()]);
+      ValueReference[] ps = params.toArray(new ValueReference[0]);
+      WorkspaceReference[] works = workspaceFields.toArray(new WorkspaceReference[0]);
 
       FunctionAttributes functionAttributes = new FunctionAttributes(template, ps, outputField, works);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AggregateErrorFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/AggregateErrorFunctions.java
@@ -35,7 +35,7 @@ import org.apache.drill.exec.expr.holders.VarCharHolder;
  */
 public class AggregateErrorFunctions {
 
-  @FunctionTemplate(names = {"sum", "max", "avg", "stddev_pop", "stddev_samp", "stddev", "var_pop",
+  @FunctionTemplate(names = {"sum", "avg", "stddev_pop", "stddev_samp", "stddev", "var_pop",
       "var_samp", "variance"}, scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
   public static class BitAggregateErrorFunctions implements DrillAggFunc {
 
@@ -65,7 +65,7 @@ public class AggregateErrorFunctions {
 
   }
 
-  @FunctionTemplate(names = {"sum", "max", "avg", "stddev_pop", "stddev_samp", "stddev", "var_pop",
+  @FunctionTemplate(names = {"sum", "avg", "stddev_pop", "stddev_samp", "stddev", "var_pop",
       "var_samp", "variance"}, scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
   public static class NullableBitAggregateErrorFunctions implements DrillAggFunc {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CollectListMapsAggFunction.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CollectListMapsAggFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.exec.expr.DrillAggFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.ObjectHolder;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter;
+
+/**
+ * Aggregate function which stores incoming fields into the map.
+ * This function accepts a variable number of arguments, where one argument is a field name
+ * within the resulting map and another argument is actual field to store into the map.
+ */
+@FunctionTemplate(name = "collect_list",
+                  isVarArg = true,
+                  isInternal = true,
+                  scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE)
+public class CollectListMapsAggFunction implements DrillAggFunc {
+
+  @Param FieldReader[] inputs;
+  @Output BaseWriter.ComplexWriter writer;
+  @Workspace ObjectHolder writerHolder;
+
+  @Override
+  public void setup() {
+    writerHolder = new ObjectHolder();
+  }
+
+  @Override
+  public void add() {
+    org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter;
+    if (writerHolder.obj == null) {
+      writerHolder.obj = writer.rootAsList();
+    }
+
+    listWriter = (org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter) writerHolder.obj;
+    org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter mapWriter = listWriter.map();
+
+    mapWriter.start();
+
+    for (int i = 0; i < inputs.length; i += 2) {
+      org.apache.drill.exec.vector.complex.MapUtility.writeToMapFromReader(
+          inputs[i + 1], mapWriter, inputs[i].readText().toString(), "CollectListMapsAggFunction");
+    }
+    mapWriter.end();
+  }
+
+  @Override
+  public void output() {
+    ((org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter) writerHolder.obj).endList();
+  }
+
+  @Override
+  public void reset() {
+    writerHolder.obj = null;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CollectToListVarcharAggFunction.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/CollectToListVarcharAggFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import org.apache.drill.exec.expr.DrillAggFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.ObjectHolder;
+import org.apache.drill.exec.vector.complex.writer.BaseWriter;
+
+/**
+ * Aggregate function which collects incoming VarChar column values into the list.
+ */
+@FunctionTemplate(name = "collect_to_list_varchar",
+                  scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE,
+                  isInternal = true)
+public class CollectToListVarcharAggFunction implements DrillAggFunc {
+
+  @Param NullableVarCharHolder input;
+  @Output BaseWriter.ComplexWriter writer;
+  @Workspace ObjectHolder writerHolder;
+
+  @Override
+  public void setup() {
+    writerHolder = new ObjectHolder();
+  }
+
+  @Override
+  public void add() {
+    org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter listWriter;
+    if (writerHolder.obj == null) {
+      writerHolder.obj = writer.rootAsList();
+    }
+
+    listWriter = (org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter) writerHolder.obj;
+
+    if (input.isSet > 0) {
+      listWriter.varChar().writeVarChar(input.start, input.end, input.buffer);
+    }
+  }
+
+  @Override
+  public void output() {
+  }
+
+  @Override
+  public void reset() {
+    writerHolder.obj = null;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParentPathFunction.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/ParentPathFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.holders.VarCharHolder;
+
+import javax.inject.Inject;
+
+@FunctionTemplate(name = "parentPath",
+                  scope = FunctionTemplate.FunctionScope.SIMPLE,
+                  nulls = FunctionTemplate.NullHandling.NULL_IF_NULL,
+                  isInternal = true)
+public class ParentPathFunction implements DrillSimpleFunc {
+
+  @Param VarCharHolder input;
+  @Output VarCharHolder out;
+  @Inject DrillBuf buf;
+
+  @Override
+  public void setup() {
+  }
+
+  @Override
+  public void eval() {
+    org.apache.hadoop.fs.Path path =
+        new org.apache.hadoop.fs.Path(org.apache.drill.common.util.DrillStringUtils.toBinaryString(input.buffer, input.start, input.end));
+    byte[] bytes = path.getParent().toUri().getPath().getBytes();
+
+    buf = buf.reallocIfNeeded(bytes.length);
+    buf.setBytes(0, bytes);
+    out.buffer = buf;
+    out.start = 0;
+    out.end = bytes.length;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SchemaFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/SchemaFunctions.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.expr.fn.impl;
+
+import io.netty.buffer.DrillBuf;
+import org.apache.drill.exec.expr.DrillAggFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.annotations.Workspace;
+import org.apache.drill.exec.expr.holders.NullableVarCharHolder;
+import org.apache.drill.exec.expr.holders.ObjectHolder;
+import org.apache.drill.exec.expr.holders.VarCharHolder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+
+import javax.inject.Inject;
+
+public class SchemaFunctions {
+
+  /**
+   * Aggregate function which infers schema from incoming data and returns string representation of {@link TupleMetadata}
+   * with incoming schema.
+   */
+  @FunctionTemplate(name = "schema",
+                    scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE,
+                    isInternal = true,
+                    isVarArg = true)
+  public static class SchemaFunction implements DrillAggFunc {
+
+    @Param FieldReader[] inputs;
+    @Output NullableVarCharHolder out;
+    @Inject DrillBuf buf;
+    @Workspace ObjectHolder columnsHolder;
+
+    @Override
+    public void setup() {
+      columnsHolder = new ObjectHolder();
+    }
+
+    @Override
+    public void add() {
+      java.util.Map<String, org.apache.drill.exec.record.MaterializedField> columns;
+      if (columnsHolder.obj == null) {
+        // Janino does not support diamond operator for this case :(
+        columnsHolder.obj = new java.util.LinkedHashMap<String, org.apache.drill.exec.record.MaterializedField>();
+      }
+
+      columns = (java.util.Map<String, org.apache.drill.exec.record.MaterializedField>) columnsHolder.obj;
+
+      for (int i = 0; i < inputs.length; i += 2) {
+        String columnName = inputs[i].readObject().toString();
+        // Janino cannot infer type
+        org.apache.drill.exec.record.MaterializedField materializedField =
+            (org.apache.drill.exec.record.MaterializedField) columns.get(columnName);
+        org.apache.drill.common.types.TypeProtos.MajorType type = inputs[i + 1].getType();
+        if (materializedField != null && !materializedField.getType().equals(type)) {
+          org.apache.drill.common.types.TypeProtos.MinorType leastRestrictiveType =
+              org.apache.drill.exec.resolver.TypeCastRules.getLeastRestrictiveType(
+                  java.util.Arrays.asList(materializedField.getType().getMinorType(), type.getMinorType()));
+          org.apache.drill.common.types.TypeProtos.DataMode leastRestrictiveMode =
+              org.apache.drill.exec.resolver.TypeCastRules.getLeastRestrictiveDataMode(
+                  java.util.Arrays.asList(materializedField.getType().getMode(), type.getMode()));
+
+          org.apache.drill.exec.record.MaterializedField clone = materializedField.clone();
+          clone.replaceType(materializedField.getType().toBuilder()
+              .setMinorType(leastRestrictiveType)
+              .setMode(leastRestrictiveMode)
+              .build());
+          columns.put(columnName, clone);
+        } else {
+          if (type.getMinorType() == org.apache.drill.common.types.TypeProtos.MinorType.MAP) {
+            columns.put(columnName, inputs[i + 1].getField());
+          } else {
+            columns.put(columnName, org.apache.drill.exec.record.MaterializedField.create(columnName, type));
+          }
+        }
+      }
+    }
+
+    @Override
+    public void output() {
+      org.apache.drill.exec.record.metadata.SchemaBuilder schemaBuilder =
+          new org.apache.drill.exec.record.metadata.SchemaBuilder();
+
+      java.util.Map<String, org.apache.drill.exec.record.MaterializedField> columns =
+          (java.util.Map<String, org.apache.drill.exec.record.MaterializedField>) columnsHolder.obj;
+
+      if (columns == null) {
+        return;
+      }
+
+      for (org.apache.drill.exec.record.MaterializedField materializedField : columns.values()) {
+        // Janino compiler cannot infer types from generics :(
+        schemaBuilder.add((org.apache.drill.exec.record.MaterializedField) materializedField);
+      }
+
+      byte[] type = schemaBuilder.build().jsonString().getBytes();
+      buf = buf.reallocIfNeeded(type.length);
+      buf.setBytes(0, type);
+      out.buffer = buf;
+      out.start = 0;
+      out.end = type.length;
+      out.isSet = 1;
+    }
+
+    @Override
+    public void reset() {
+      columnsHolder.obj = null;
+    }
+  }
+
+  /**
+   * Aggregate function which accepts VarChar column with string representations of {@link TupleMetadata}
+   * and returns string representation of {@link TupleMetadata} with merged schema.
+   */
+  @FunctionTemplate(name = "merge_schema",
+                    scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE,
+                    isInternal = true)
+  public static class MergeNullableSchemaFunction implements DrillAggFunc {
+
+    @Param NullableVarCharHolder input;
+    @Output NullableVarCharHolder out;
+    @Inject DrillBuf buf;
+    @Workspace ObjectHolder schemaHolder;
+
+    @Override
+    public void setup() {
+      schemaHolder = new ObjectHolder();
+    }
+
+    @Override
+    public void add() {
+      if (input.isSet == 0) {
+        return;
+      }
+
+      org.apache.drill.exec.record.metadata.TupleMetadata currentSchema =
+          org.apache.drill.exec.expr.fn.impl.SchemaFunctions.getTupleMetadata(
+              org.apache.drill.common.util.DrillStringUtils.toBinaryString(input.buffer, input.start, input.end));
+      if (schemaHolder.obj == null) {
+        schemaHolder.obj = currentSchema;
+        return;
+      }
+
+      org.apache.drill.exec.record.metadata.TupleMetadata resolvedSchema =
+          (org.apache.drill.exec.record.metadata.TupleMetadata) schemaHolder.obj;
+
+      if (!resolvedSchema.isEquivalent(currentSchema)) {
+        throw new UnsupportedOperationException("merge_schema function does not support schema changes.");
+      }
+    }
+
+    @Override
+    public void output() {
+      org.apache.drill.exec.record.metadata.TupleMetadata resolvedSchema =
+          (org.apache.drill.exec.record.metadata.TupleMetadata) schemaHolder.obj;
+
+      byte[] type = resolvedSchema.jsonString().getBytes();
+      buf = buf.reallocIfNeeded(type.length);
+      buf.setBytes(0, type);
+      out.buffer = buf;
+      out.start = 0;
+      out.end = type.length;
+      out.isSet = 1;
+    }
+
+    @Override
+    public void reset() {
+      schemaHolder.obj = null;
+    }
+
+  }
+
+  @FunctionTemplate(name = "merge_schema",
+                    scope = FunctionTemplate.FunctionScope.POINT_AGGREGATE,
+                    isInternal = true)
+  public static class MergeSchemaFunction implements DrillAggFunc {
+
+    @Param VarCharHolder input;
+    @Output VarCharHolder out;
+    @Inject DrillBuf buf;
+    @Workspace ObjectHolder schemaHolder;
+
+    @Override
+    public void setup() {
+      schemaHolder = new ObjectHolder();
+    }
+
+    @Override
+    public void add() {
+      org.apache.drill.exec.record.metadata.TupleMetadata currentSchema = org.apache.drill.exec.expr.fn.impl.SchemaFunctions.getTupleMetadata(
+          org.apache.drill.common.util.DrillStringUtils.toBinaryString(input.buffer, input.start, input.end));
+      if (schemaHolder.obj == null) {
+        schemaHolder.obj = currentSchema;
+        return;
+      }
+
+      org.apache.drill.exec.record.metadata.TupleMetadata resolvedSchema =
+          (org.apache.drill.exec.record.metadata.TupleMetadata) schemaHolder.obj;
+
+      if (!resolvedSchema.isEquivalent(currentSchema)) {
+        throw new UnsupportedOperationException("merge_schema function does not support schema changes.");
+      }
+    }
+
+    @Override
+    public void output() {
+      org.apache.drill.exec.record.metadata.TupleMetadata resolvedSchema =
+          (org.apache.drill.exec.record.metadata.TupleMetadata) schemaHolder.obj;
+
+      byte[] type = resolvedSchema.jsonString().getBytes();
+      buf = buf.reallocIfNeeded(type.length);
+      buf.setBytes(0, type);
+      out.buffer = buf;
+      out.start = 0;
+      out.end = type.length;
+    }
+
+    @Override
+    public void reset() {
+      schemaHolder.obj = null;
+    }
+  }
+
+  /**
+   * Wraps static method from TupleMetadata to avoid {@link IncompatibleClassChangeError} for JDK 9+.
+   * {@see JDK-8147755}.
+   *
+   * @param serialized tuple metadata in JSON string representation
+   * @return {@link TupleMetadata} instance
+   */
+  public static TupleMetadata getTupleMetadata(String serialized) {
+    return TupleMetadata.of(serialized);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/MetastoreMetadataProviderManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/MetastoreMetadataProviderManager.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore;
+
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+import org.apache.drill.metastore.MetastoreRegistry;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.metadata.TableMetadataProvider;
+import org.apache.drill.metastore.metadata.TableMetadataProviderBuilder;
+
+/**
+ * Implementation of {@link MetadataProviderManager} which uses Drill Metastore providers and returns
+ * builders for metastore-based {@link TableMetadataProvider} instances.
+ */
+public class MetastoreMetadataProviderManager implements MetadataProviderManager {
+
+  private final MetastoreRegistry metastoreRegistry;
+  private final TableInfo tableInfo;
+  private final MetastoreMetadataProviderConfig config;
+
+  private TableMetadataProvider tableMetadataProvider;
+
+  private SchemaProvider schemaProvider;
+  private DrillStatsTable statsProvider;
+
+  public MetastoreMetadataProviderManager(MetastoreRegistry metastoreRegistry,
+      TableInfo tableInfo, MetastoreMetadataProviderConfig config) {
+    this.metastoreRegistry = metastoreRegistry;
+    this.tableInfo = tableInfo;
+    this.config = config;
+  }
+
+  @Override
+  public void setSchemaProvider(SchemaProvider schemaProvider) {
+    this.schemaProvider = schemaProvider;
+  }
+
+  @Override
+  public SchemaProvider getSchemaProvider() {
+    return schemaProvider;
+  }
+
+  @Override
+  public void setStatsProvider(DrillStatsTable statsProvider) {
+    this.statsProvider = statsProvider;
+  }
+
+  @Override
+  public DrillStatsTable getStatsProvider() {
+    return statsProvider;
+  }
+
+  @Override
+  public void setTableMetadataProvider(TableMetadataProvider tableMetadataProvider) {
+    this.tableMetadataProvider = tableMetadataProvider;
+  }
+
+  @Override
+  public TableMetadataProvider getTableMetadataProvider() {
+    return tableMetadataProvider;
+  }
+
+  public MetastoreRegistry getMetastoreRegistry() {
+    return metastoreRegistry;
+  }
+
+  public TableInfo getTableInfo() {
+    return tableInfo;
+  }
+
+  public MetastoreMetadataProviderConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  public TableMetadataProviderBuilder builder(MetadataProviderKind kind) {
+    switch (kind) {
+      case PARQUET_TABLE:
+        return new MetastoreParquetTableMetadataProvider.Builder(this);
+    }
+    return null;
+  }
+
+  public static class MetastoreMetadataProviderConfig {
+    private final boolean useSchema;
+    private final boolean useStatistics;
+    private final boolean fallbackToFileMetadata;
+
+    public MetastoreMetadataProviderConfig(boolean useSchema, boolean useStatistics, boolean fallbackToFileMetadata) {
+      this.useSchema = useSchema;
+      this.useStatistics = useStatistics;
+      this.fallbackToFileMetadata = fallbackToFileMetadata;
+    }
+
+    public boolean useSchema() {
+      return useSchema;
+    }
+
+    public boolean useStatistics() {
+      return useStatistics;
+    }
+
+    public boolean fallbackToFileMetadata() {
+      return fallbackToFileMetadata;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/MetastoreParquetTableMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/MetastoreParquetTableMetadataProvider.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.exception.MetadataException;
+import org.apache.drill.exec.metastore.MetastoreMetadataProviderManager.MetastoreMetadataProviderConfig;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.SchemaUtil;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.schema.SchemaProvider;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.ReadEntryWithPath;
+import org.apache.drill.exec.store.parquet.ParquetFileTableMetadataProviderBuilder;
+import org.apache.drill.exec.store.parquet.ParquetReaderConfig;
+import org.apache.drill.exec.store.parquet.ParquetTableMetadataProviderImpl;
+import org.apache.drill.exec.store.parquet.ParquetTableMetadataUtils;
+import org.apache.drill.exec.util.DrillFileSystemUtil;
+import org.apache.drill.metastore.MetastoreRegistry;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.metadata.BaseTableMetadata;
+import org.apache.drill.metastore.metadata.FileMetadata;
+import org.apache.drill.metastore.metadata.NonInterestingColumnsMetadata;
+import org.apache.drill.metastore.metadata.PartitionMetadata;
+import org.apache.drill.metastore.metadata.RowGroupMetadata;
+import org.apache.drill.metastore.metadata.SegmentMetadata;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.metadata.TableMetadata;
+import org.apache.drill.metastore.statistics.ColumnStatistics;
+import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
+import org.apache.drill.metastore.statistics.Statistic;
+import org.apache.drill.metastore.statistics.StatisticsHolder;
+import org.apache.drill.metastore.util.SchemaPathUtils;
+import org.apache.drill.shaded.guava.com.google.common.collect.LinkedListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class MetastoreParquetTableMetadataProvider implements ParquetTableMetadataProvider {
+  private static final Logger logger = LoggerFactory.getLogger(MetastoreParquetTableMetadataProvider.class);
+
+  private final BasicTablesRequests basicTablesRequests;
+  private final TableInfo tableInfo;
+  private final MetastoreTableInfo metastoreTableInfo;
+  private final TupleMetadata schema;
+  private final List<ReadEntryWithPath> entries;
+  private final List<String> paths;
+  private final DrillStatsTable statsProvider;
+
+  private final boolean useSchema;
+  private final boolean useStatistics;
+  private final boolean fallbackToFileMetadata;
+
+  private BaseTableMetadata tableMetadata;
+  private Map<Path, SegmentMetadata> segmentsMetadata;
+  private List<PartitionMetadata> partitions;
+  private Map<Path, FileMetadata> files;
+  private Multimap<Path, RowGroupMetadata> rowGroups;
+  private NonInterestingColumnsMetadata nonInterestingColumnsMetadata;
+  // stores builder to provide lazy init for fallback ParquetTableMetadataProvider
+  private ParquetFileTableMetadataProviderBuilder fallbackBuilder;
+  private ParquetTableMetadataProvider fallback;
+
+  private MetastoreParquetTableMetadataProvider(List<ReadEntryWithPath> entries,
+      MetastoreRegistry metastoreRegistry, TableInfo tableInfo, TupleMetadata schema,
+      ParquetFileTableMetadataProviderBuilder fallbackBuilder, MetastoreMetadataProviderConfig config, DrillStatsTable statsProvider) {
+    this.basicTablesRequests = metastoreRegistry.get().tables().basicRequests();
+    this.tableInfo = tableInfo;
+    this.metastoreTableInfo = basicTablesRequests.metastoreTableInfo(tableInfo);
+    this.useSchema = config.useSchema();
+    this.useStatistics = config.useStatistics();
+    this.fallbackToFileMetadata = config.fallbackToFileMetadata();
+    this.schema = schema;
+    this.entries = entries == null ? new ArrayList<>() : entries;
+    this.fallbackBuilder = fallbackBuilder;
+    this.statsProvider = statsProvider;
+    this.paths = this.entries.stream()
+        .map(readEntryWithPath -> readEntryWithPath.getPath().toUri().getPath())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean isUsedMetadataCache() {
+    return false;
+  }
+
+  @Override
+  public Path getSelectionRoot() {
+    return getTableMetadata().getLocation();
+  }
+
+  @Override
+  public List<ReadEntryWithPath> getEntries() {
+    return entries;
+  }
+
+  @Override
+  public List<RowGroupMetadata> getRowGroupsMeta() {
+    return new ArrayList<>(getRowGroupsMetadataMap().values());
+  }
+
+  @Override
+  public List<Path> getLocations() {
+    return new ArrayList<>(getFilesMetadataMap().keySet());
+  }
+
+  @Override
+  public Multimap<Path, RowGroupMetadata> getRowGroupsMetadataMap() {
+    throwIfChanged();
+    if (rowGroups == null) {
+      rowGroups = LinkedListMultimap.create();
+      basicTablesRequests.rowGroupsMetadata(tableInfo, null, paths).stream()
+          .collect(Collectors.groupingBy(RowGroupMetadata::getPath, Collectors.toList()))
+          .forEach((path, rowGroupMetadata) -> rowGroups.putAll(path, rowGroupMetadata));
+      if (rowGroups.isEmpty()) {
+        if (fallbackToFileMetadata) {
+          try {
+            rowGroups = getFallbackTableMetadataProvider().getRowGroupsMetadataMap();
+          } catch (IOException e) {
+            throw MetadataException.of(MetadataException.MetadataExceptionType.FALLBACK_EXCEPTION, e);
+          }
+        } else {
+          throw MetadataException.of(MetadataException.MetadataExceptionType.INCOMPLETE_METADATA);
+        }
+      }
+    }
+    return rowGroups;
+  }
+
+  @Override
+  public Set<Path> getFileSet() {
+    throwIfChanged();
+    return getFilesMetadataMap().keySet();
+  }
+
+  @Override
+  public TableMetadata getTableMetadata() {
+    throwIfChanged();
+    if (tableMetadata == null) {
+      if (schema == null) {
+        if (useSchema) {
+          tableMetadata = basicTablesRequests.tableMetadata(tableInfo);
+        } else {
+          throw MetadataException.of(MetadataException.MetadataExceptionType.ABSENT_SCHEMA);
+        }
+      } else {
+        tableMetadata = basicTablesRequests.tableMetadata(tableInfo).toBuilder()
+            .schema(schema)
+            .build();
+      }
+
+      if (!useStatistics) {
+        // removes statistics to prevent its usage later
+        tableMetadata = tableMetadata.toBuilder()
+            .columnsStatistics(Collections.emptyMap())
+            .build();
+      }
+
+      if (statsProvider != null) {
+        if (!statsProvider.isMaterialized()) {
+          statsProvider.materialize();
+        }
+        tableMetadata = tableMetadata.cloneWithStats(
+            ParquetTableMetadataUtils.getColumnStatistics(tableMetadata.getSchema(), statsProvider),
+            DrillStatsTable.getEstimatedTableStats(statsProvider));
+      }
+    }
+    return tableMetadata;
+  }
+
+  @Override
+  public List<SchemaPath> getPartitionColumns() {
+    throwIfChanged();
+    return basicTablesRequests.interestingColumnsAndPartitionKeys(tableInfo).partitionKeys().values().stream()
+        .map(SchemaPath::getSimplePath)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<PartitionMetadata> getPartitionsMetadata() {
+    throwIfChanged();
+    if (partitions == null) {
+      partitions = basicTablesRequests.partitionsMetadata(tableInfo, null, null);
+    }
+    return partitions;
+  }
+
+  @Override
+  public List<PartitionMetadata> getPartitionMetadata(SchemaPath columnName) {
+    throwIfChanged();
+    return basicTablesRequests.partitionsMetadata(tableInfo, null, columnName.getRootSegmentPath());
+  }
+
+  @Override
+  public Map<Path, FileMetadata> getFilesMetadataMap() {
+    throwIfChanged();
+    if (files == null) {
+      files = basicTablesRequests.filesMetadata(tableInfo, null, paths).stream()
+          .collect(Collectors.toMap(FileMetadata::getPath, Function.identity()));
+    }
+    return files;
+  }
+
+  @Override
+  public Map<Path, SegmentMetadata> getSegmentsMetadataMap() {
+    throwIfChanged();
+    if (segmentsMetadata == null) {
+      segmentsMetadata = basicTablesRequests.segmentsMetadataByColumn(tableInfo, null, null).stream()
+          .collect(Collectors.toMap(SegmentMetadata::getPath, Function.identity()));
+    }
+    return segmentsMetadata;
+  }
+
+  @Override
+  public FileMetadata getFileMetadata(Path location) {
+    throwIfChanged();
+    return basicTablesRequests.fileMetadata(tableInfo, null, location.toUri().getPath());
+  }
+
+  @Override
+  public List<FileMetadata> getFilesForPartition(PartitionMetadata partition) {
+    throwIfChanged();
+    List<String> paths = partition.getLocations().stream()
+        .map(path -> path.toUri().getPath())
+        .collect(Collectors.toList());
+    return basicTablesRequests.filesMetadata(tableInfo, null, paths);
+  }
+
+  @Override
+  public NonInterestingColumnsMetadata getNonInterestingColumnsMetadata() {
+    throwIfChanged();
+    if (nonInterestingColumnsMetadata == null) {
+      TupleMetadata schema = getTableMetadata().getSchema();
+
+      List<StatisticsHolder> statistics = Collections.singletonList(new StatisticsHolder<>(Statistic.NO_COLUMN_STATS, ColumnStatisticsKind.NULLS_COUNT));
+
+      List<SchemaPath> columnPaths = SchemaUtil.getSchemaPaths(schema);
+      List<SchemaPath> interestingColumns = getInterestingColumns(columnPaths);
+      // populates statistics for non-interesting columns and columns for which statistics wasn't collected
+      Map<SchemaPath, ColumnStatistics> columnsStatistics = columnPaths.stream()
+          .filter(schemaPath -> !interestingColumns.contains(schemaPath)
+              || SchemaPathUtils.getColumnMetadata(schemaPath, schema).isArray())
+          .collect(Collectors.toMap(
+              Function.identity(),
+              schemaPath -> new ColumnStatistics<>(statistics, SchemaPathUtils.getColumnMetadata(schemaPath, schema).type())));
+      nonInterestingColumnsMetadata = new NonInterestingColumnsMetadata(columnsStatistics);
+    }
+    return nonInterestingColumnsMetadata;
+  }
+
+  @Override
+  public boolean checkMetadataVersion() {
+    return true;
+  }
+
+  private List<SchemaPath> getInterestingColumns(List<SchemaPath> columnPaths) {
+    if (useStatistics) {
+      return getTableMetadata().getInterestingColumns() == null
+          ? columnPaths
+          : getTableMetadata().getInterestingColumns();
+    } else {
+      // if `metastore.metadata.use_statistics` is false, all columns are treated as non-interesting
+      return Collections.emptyList();
+    }
+  }
+
+  private ParquetTableMetadataProvider getFallbackTableMetadataProvider() throws IOException {
+    if (fallback == null) {
+      fallback = fallbackBuilder == null ? null : fallbackBuilder.build();
+    }
+    return fallback;
+  }
+
+  private void throwIfChanged() {
+    if (basicTablesRequests.hasMetastoreTableInfoChanged(metastoreTableInfo)) {
+      throw MetadataException.of(MetadataException.MetadataExceptionType.INCONSISTENT_METADATA);
+    }
+  }
+
+  public static class Builder implements ParquetFileTableMetadataProviderBuilder {
+    private final MetastoreMetadataProviderManager metadataProviderManager;
+
+    private List<ReadEntryWithPath> entries;
+    private DrillFileSystem fs;
+    private TupleMetadata schema;
+
+    private FileSelection selection;
+
+    // builder for fallback ParquetFileTableMetadataProvider
+    // for the case when required metadata is absent in Metastore
+    private ParquetFileTableMetadataProviderBuilder fallback;
+
+    public Builder(MetastoreMetadataProviderManager source) {
+      this.metadataProviderManager = source;
+      this.fallback = new ParquetTableMetadataProviderImpl.Builder(FileSystemMetadataProviderManager.init());
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withEntries(List<ReadEntryWithPath> entries) {
+      this.entries = entries;
+      fallback.withEntries(entries);
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withSelectionRoot(Path selectionRoot) {
+      fallback.withSelectionRoot(selectionRoot);
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withCacheFileRoot(Path cacheFileRoot) {
+      fallback.withCacheFileRoot(cacheFileRoot);
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withReaderConfig(ParquetReaderConfig readerConfig) {
+      fallback.withReaderConfig(readerConfig);
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withFileSystem(DrillFileSystem fs) {
+      fallback.withFileSystem(fs);
+      this.fs = fs;
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withCorrectCorruptedDates(boolean autoCorrectCorruptedDates) {
+      fallback.withCorrectCorruptedDates(autoCorrectCorruptedDates);
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withSelection(FileSelection selection) {
+      fallback.withSelection(selection);
+      this.selection = selection;
+      return this;
+    }
+
+    @Override
+    public ParquetFileTableMetadataProviderBuilder withSchema(TupleMetadata schema) {
+      fallback.withSchema(schema);
+      this.schema = schema;
+      return this;
+    }
+
+    @Override
+    public ParquetTableMetadataProvider build() throws IOException {
+      MetastoreParquetTableMetadataProvider provider;
+      SchemaProvider schemaProvider = metadataProviderManager.getSchemaProvider();
+      ParquetMetadataProvider source = (ParquetTableMetadataProvider) metadataProviderManager.getTableMetadataProvider();
+
+      DrillStatsTable statsProvider = metadataProviderManager.getStatsProvider();
+      // schema passed into the builder has greater priority
+      try {
+        if (this.schema == null) {
+          schema = schemaProvider != null ? schemaProvider.read().getSchema() : null;
+        }
+      } catch (IOException e) {
+        logger.debug("Unable to deserialize schema from schema file for table: {}", metadataProviderManager.getTableInfo().name(), e);
+      }
+      if (entries == null) {
+        if (!selection.isExpandedFully()) {
+          entries = DrillFileSystemUtil.listFiles(fs, selection.getSelectionRoot(), true).stream()
+              .map(fileStatus -> new ReadEntryWithPath(Path.getPathWithoutSchemeAndAuthority(fileStatus.getPath())))
+              .collect(Collectors.toList());
+        } else {
+          entries = selection.getFiles().stream()
+              .map(Path::getPathWithoutSchemeAndAuthority)
+              .map(ReadEntryWithPath::new)
+              .collect(Collectors.toList());
+        }
+      }
+      provider = new MetastoreParquetTableMetadataProvider(entries, metadataProviderManager.getMetastoreRegistry(),
+          metadataProviderManager.getTableInfo(), schema, fallback, metadataProviderManager.getConfig(), statsProvider);
+      // store results into metadataProviderManager to be able to use them when creating new instances
+      // for the case when source wasn't provided or it contains less row group metadata than the provider
+      if (source == null || source.getRowGroupsMeta().size() < provider.getRowGroupsMeta().size()) {
+        metadataProviderManager.setTableMetadataProvider(provider);
+      }
+      return provider;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/SimpleFileTableMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/SimpleFileTableMetadataProvider.java
@@ -100,6 +100,11 @@ public class SimpleFileTableMetadataProvider implements TableMetadataProvider {
     return null;
   }
 
+  @Override
+  public boolean checkMetadataVersion() {
+    return false;
+  }
+
   public static class Builder implements SimpleFileTableMetadataProviderBuilder {
     private String tableName;
     private Path location;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeColumnUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeColumnUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.sql.SqlKind;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.metastore.statistics.BaseStatisticsKind;
+import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
+import org.apache.drill.metastore.statistics.StatisticsKind;
+import org.apache.drill.metastore.statistics.TableStatisticsKind;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class AnalyzeColumnUtils {
+  private static final String COLUMN_SEPARATOR = "$";
+
+  public static final Map<StatisticsKind, SqlKind> COLUMN_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind, SqlKind>builder()
+      .put(ColumnStatisticsKind.MAX_VALUE, SqlKind.MAX)
+      .put(ColumnStatisticsKind.MIN_VALUE, SqlKind.MIN)
+      .put(ColumnStatisticsKind.NON_NULL_COUNT, SqlKind.COUNT)
+      .put(TableStatisticsKind.ROW_COUNT, SqlKind.COUNT)
+      .build();
+
+  public static final Map<StatisticsKind, TypeProtos.MinorType> COLUMN_STATISTICS_TYPES = ImmutableMap.<StatisticsKind, TypeProtos.MinorType>builder()
+      .put(ColumnStatisticsKind.NON_NULL_COUNT, TypeProtos.MinorType.BIGINT)
+      .put(TableStatisticsKind.ROW_COUNT, TypeProtos.MinorType.BIGINT)
+      .build();
+
+  public static final Map<StatisticsKind, SqlKind> META_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind, SqlKind>builder()
+      .put(TableStatisticsKind.ROW_COUNT, SqlKind.COUNT)
+      .build();
+
+  /**
+   * Returns actual column name obtained form intermediate name which includes statistics kind and other analyze-specific info.
+   * <p>
+   * Example: column which corresponds to max statistics value for {@code `o_shippriority`} column is {@code column$maxValue$`o_shippriority`}.
+   * This method will return actual column name: {@code `o_shippriority`}.
+   *
+   * @param fullName the source of actual column name
+   * @return actual column name
+   */
+  public static String getColumnName(String fullName) {
+    return fullName.substring(fullName.indexOf(COLUMN_SEPARATOR, fullName.indexOf(COLUMN_SEPARATOR) + 1) + 1);
+  }
+
+  /**
+   * Returns {@link StatisticsKind} instance obtained form intermediate field name.
+   *
+   * @param fullName the source of {@link StatisticsKind} to obtain
+   * @return {@link StatisticsKind} instance
+   */
+  public static StatisticsKind getStatisticsKind(String fullName) {
+    String statisticsIdentifier = fullName.split("\\" + COLUMN_SEPARATOR)[1];
+    switch (statisticsIdentifier) {
+      case "minValue":
+        return ColumnStatisticsKind.MIN_VALUE;
+      case "maxValue":
+        return ColumnStatisticsKind.MAX_VALUE;
+      case "nullsCount":
+        return ColumnStatisticsKind.NULLS_COUNT;
+      case "nonnullrowcount":
+        return ColumnStatisticsKind.NON_NULL_COUNT;
+      case "rowCount":
+        return TableStatisticsKind.ROW_COUNT;
+    }
+    return new BaseStatisticsKind(statisticsIdentifier, false);
+  }
+
+  /**
+   * Returns analyze-specific field name for column statistics which includes
+   * actual column name and statistics kind information.
+   * <p>
+   * Example: analyze-specific field name for column {@code `o_shippriority`}
+   * and statistics {@code MAX_VALUE} is the following: {@code column$maxValue$`o_shippriority`}.
+   *
+   * @param columnName     name of the column
+   * @param statisticsKind statistics kind
+   * @return analyze-specific field name which includes actual column name and statistics kind information
+   */
+  public static String getColumnStatisticsFieldName(String columnName, StatisticsKind statisticsKind) {
+    return String.format("column%1$s%2$s%1$s%3$s", COLUMN_SEPARATOR, statisticsKind.getName(), columnName);
+  }
+
+  /**
+   * Returns analyze-specific field name for metadata statistics which includes statistics kind information.
+   * <p>
+   * Example: analyze-specific field name for statistics {@code ROW_COUNT} is the following: {@code metadata$rowCount}.
+   *
+   * @param statisticsKind statistics kind
+   * @return analyze-specific field name for metadata statistics
+   */
+  public static String getMetadataStatisticsFieldName(StatisticsKind statisticsKind) {
+    return String.format("metadata%s%s", COLUMN_SEPARATOR, statisticsKind.getName());
+  }
+
+  /**
+   * Checks whether specified field name is analyze-specific field for column statistics.
+   *
+   * @param fieldName name of the field to check
+   * @return {@code true} if specified field name is analyze-specific field for column statistics
+   */
+  public static boolean isColumnStatisticsField(String fieldName) {
+    return fieldName.startsWith("column" + COLUMN_SEPARATOR);
+  }
+
+  /**
+   * Checks whether specified field name is analyze-specific field for metadata statistics.
+   * @param fieldName name of the field to check
+   * @return {@code true} if specified field name is analyze-specific field for metadata statistics
+   */
+  public static boolean isMetadataStatisticsField(String fieldName) {
+    return fieldName.startsWith("metadata" + COLUMN_SEPARATOR);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeFileInfoProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeFileInfoProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.store.ColumnExplorer;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link AnalyzeInfoProvider} for file-based tables.
+ */
+public abstract class AnalyzeFileInfoProvider implements AnalyzeInfoProvider {
+
+  @Override
+  public List<SchemaPath> getSegmentColumns(DrillTable table, OptionManager options) throws IOException {
+    FormatSelection selection = (FormatSelection) table.getSelection();
+
+    FileSelection fileSelection = selection.getSelection();
+    if (!fileSelection.isExpandedFully()) {
+      fileSelection = FileMetadataInfoCollector.getExpandedFileSelection(fileSelection);
+    }
+
+    return ColumnExplorer.getPartitionColumnNames(fileSelection, options).stream()
+        .map(SchemaPath::getSimplePath)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SqlIdentifier> getProjectionFields(MetadataType metadataLevel, OptionManager options) {
+    return Arrays.asList(
+        new SqlIdentifier(options.getString(ExecConstants.IMPLICIT_FQN_COLUMN_LABEL), SqlParserPos.ZERO),
+        new SqlIdentifier(options.getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL), SqlParserPos.ZERO));
+  }
+
+  @Override
+  public MetadataInfoCollector getMetadataInfoCollector(BasicTablesRequests basicRequests, TableInfo tableInfo,
+      FormatSelection selection, PlannerSettings settings, Supplier<TableScan> tableScanSupplier,
+      List<SchemaPath> interestingColumns, MetadataType metadataLevel, int segmentColumnsCount) throws IOException {
+    return new FileMetadataInfoCollector(basicRequests, tableInfo, selection,
+        settings, tableScanSupplier, interestingColumns, metadataLevel, segmentColumnsCount);
+  }
+
+  @Override
+  public SchemaPath getLocationField(OptionManager optionManager) {
+    return SchemaPath.getSimplePath(optionManager.getString(ExecConstants.IMPLICIT_FQN_COLUMN_LABEL));
+  }
+
+  @Override
+  public NamedExpression getParentLocationExpression(SchemaPath locationField) {
+    return new NamedExpression(new FunctionCall("parentPath",
+        Collections.singletonList(locationField), ExpressionPosition.UNKNOWN),
+        FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.LOCATION_FIELD));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeInfoProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeInfoProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Interface for obtaining information required for analyzing tables such as table segment columns, etc.
+ */
+public interface AnalyzeInfoProvider {
+
+  /**
+   * Returns list of segment column names for specified {@link DrillTable} table.
+   *
+   * @param table   table for which should be returned segment column names
+   * @param options option manager
+   * @return list of segment column names
+   */
+  List<SchemaPath> getSegmentColumns(DrillTable table, OptionManager options) throws IOException;
+
+  /**
+   * Returns list of fields required for ANALYZE.
+   *
+   * @param metadataLevel metadata level for analyze
+   * @param options       option manager
+   * @return list of fields required for ANALYZE
+   */
+  List<SqlIdentifier> getProjectionFields(MetadataType metadataLevel, OptionManager options);
+
+  /**
+   * Returns {@link MetadataInfoCollector} instance for obtaining information about segments, files, etc.
+   * which should be handled in metastore.
+   *
+   * @param basicRequests       Metastore tables data provider helper
+   * @param tableInfo           table info
+   * @param selection           format selection
+   * @param settings            planner settings
+   * @param tableScanSupplier   supplier for table scan
+   * @param interestingColumns  list of interesting columns
+   * @param metadataLevel       metadata level
+   * @param segmentColumnsCount number of segment columns
+   * @return {@link MetadataInfoCollector} instance
+   */
+  MetadataInfoCollector getMetadataInfoCollector(BasicTablesRequests basicRequests, TableInfo tableInfo,
+      FormatSelection selection, PlannerSettings settings, Supplier<TableScan> tableScanSupplier,
+      List<SchemaPath> interestingColumns, MetadataType metadataLevel, int segmentColumnsCount) throws IOException;
+
+  /**
+   * Provides schema path to field which will be used as a location for specific table data,
+   * for example, for file-based tables, it may be `fqn`.
+   *
+   * @param optionManager option manager
+   * @return location field
+   */
+  SchemaPath getLocationField(OptionManager optionManager);
+
+  /**
+   * Returns expression which may be used to determine parent location for specific table data,
+   * i.e. segment location. For example, for file-based tables, such expression will be `parentPath` function call.
+   *
+   * @param locationField location field
+   * @return expression to determine parent location
+   */
+  NamedExpression getParentLocationExpression(SchemaPath locationField);
+
+  /**
+   * Checks whether this {@link AnalyzeInfoProvider} supports specified {@link GroupScan} type.
+   *
+   * @param groupScan group scan
+   * @return {@code true} if this {@link AnalyzeInfoProvider} supports specified {@link GroupScan} type
+   */
+  boolean supportsGroupScan(GroupScan groupScan);
+
+  /**
+   * Returns table type name supported by this {@link AnalyzeInfoProvider}.
+   *
+   * @return table type name
+   */
+  String getTableTypeName();
+
+  /**
+   * Checks whether this {@link AnalyzeInfoProvider} supports specified {@link MetadataType}.
+   *
+   * @param metadataType metadata type
+   * @return {@code true} if this {@link AnalyzeInfoProvider} supports specified {@link MetadataType}
+   */
+  boolean supportsMetadataType(MetadataType metadataType);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeParquetInfoProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeParquetInfoProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.store.parquet.ParquetGroupScan;
+import org.apache.drill.metastore.metadata.MetadataType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Implementation of {@link AnalyzeInfoProvider} for parquet tables.
+ */
+public class AnalyzeParquetInfoProvider extends AnalyzeFileInfoProvider {
+  public static final AnalyzeParquetInfoProvider INSTANCE = new AnalyzeParquetInfoProvider();
+
+  public static final String TABLE_TYPE_NAME = "PARQUET";
+
+  @Override
+  public List<SqlIdentifier> getProjectionFields(MetadataType metadataLevel, OptionManager options) {
+    List<SqlIdentifier> columnList = new ArrayList<>(super.getProjectionFields(metadataLevel, options));
+    if (metadataLevel.includes(MetadataType.ROW_GROUP)) {
+      columnList.add(new SqlIdentifier(options.getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL), SqlParserPos.ZERO));
+      columnList.add(new SqlIdentifier(options.getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL), SqlParserPos.ZERO));
+      columnList.add(new SqlIdentifier(options.getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL), SqlParserPos.ZERO));
+    }
+    return Collections.unmodifiableList(columnList);
+  }
+
+  @Override
+  public boolean supportsGroupScan(GroupScan groupScan) {
+    return groupScan instanceof ParquetGroupScan;
+  }
+
+  @Override
+  public String getTableTypeName() {
+    return TABLE_TYPE_NAME;
+  }
+
+  @Override
+  public boolean supportsMetadataType(MetadataType metadataType) {
+    switch (metadataType) {
+      case ROW_GROUP:
+      case FILE:
+      case SEGMENT:
+      case TABLE:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.base.SchemalessScan;
+import org.apache.drill.exec.planner.FileSystemPartitionDescriptor;
+import org.apache.drill.exec.planner.PartitionLocation;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.DrillScanRel;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.store.ColumnExplorer;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.FileSelection;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.exec.util.DrillFileSystemUtil;
+import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.statistics.TableStatisticsKind;
+import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Streams;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link MetadataInfoCollector} for file-based tables.
+ */
+public class FileMetadataInfoCollector implements MetadataInfoCollector {
+  private final List<MetadataInfo> allMetaToHandle;
+  private final List<MetadataInfo> metadataToRemove;
+
+  private final BasicTablesRequests basicRequests;
+  private final TableInfo tableInfo;
+  private final MetadataType metadataLevel;
+
+  private List<MetadataInfo> rowGroupsInfo = Collections.emptyList();
+  private List<MetadataInfo> filesInfo = Collections.emptyList();
+  private Multimap<Integer, MetadataInfo> segmentsInfo = ArrayListMultimap.create();
+
+  private TableScan tableScan;
+
+  private boolean outdated = true;
+
+  public FileMetadataInfoCollector(BasicTablesRequests basicRequests, TableInfo tableInfo, FormatSelection selection,
+      PlannerSettings settings, Supplier<TableScan> tableScanSupplier, List<SchemaPath> interestingColumns,
+      MetadataType metadataLevel, int segmentColumnsCount) throws IOException {
+    this.basicRequests = basicRequests;
+    this.tableInfo = tableInfo;
+    this.metadataLevel = metadataLevel;
+    this.allMetaToHandle = new ArrayList<>();
+    this.metadataToRemove = new ArrayList<>();
+    init(selection, settings, tableScanSupplier, interestingColumns, segmentColumnsCount);
+  }
+
+  @Override
+  public List<MetadataInfo> getRowGroupsInfo() {
+    return rowGroupsInfo;
+  }
+
+  @Override
+  public List<MetadataInfo> getFilesInfo() {
+    return filesInfo;
+  }
+
+  @Override
+  public Multimap<Integer, MetadataInfo> getSegmentsInfo() {
+    return segmentsInfo;
+  }
+
+  @Override
+  public List<MetadataInfo> getAllMetaToHandle() {
+    return allMetaToHandle;
+  }
+
+  @Override
+  public List<MetadataInfo> getMetadataToRemove() {
+    return metadataToRemove;
+  }
+
+  @Override
+  public TableScan getPrunedScan() {
+    return tableScan;
+  }
+
+  @Override
+  public boolean isOutdated() {
+    return outdated;
+  }
+
+  private void init(FormatSelection selection, PlannerSettings settings, Supplier<TableScan> tableScanSupplier,
+      List<SchemaPath> interestingColumns, int segmentColumnsCount) throws IOException {
+    List<SchemaPath> metastoreInterestingColumns =
+        Optional.ofNullable(basicRequests.interestingColumnsAndPartitionKeys(tableInfo).interestingColumns())
+            .map(metastoreInterestingColumnNames -> metastoreInterestingColumnNames.stream()
+                .map(SchemaPath::parseFromString)
+                .collect(Collectors.toList()))
+        .orElse(null);
+
+    Map<String, Long> filesNamesLastModifiedTime = basicRequests.filesLastModifiedTime(tableInfo, null, null);
+
+    List<String> newFiles = new ArrayList<>();
+    List<String> updatedFiles = new ArrayList<>();
+    List<String> removedFiles = new ArrayList<>(filesNamesLastModifiedTime.keySet());
+    List<String> allFiles = new ArrayList<>();
+
+    for (FileStatus fileStatus : getFileStatuses(selection)) {
+      String path = Path.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toUri().getPath();
+      Long lastModificationTime = filesNamesLastModifiedTime.get(path);
+      if (lastModificationTime == null) {
+        newFiles.add(path);
+      } else if (lastModificationTime < fileStatus.getModificationTime()) {
+        updatedFiles.add(path);
+      }
+      removedFiles.remove(path);
+      allFiles.add(path);
+    }
+
+    String selectionRoot = selection.getSelection().getSelectionRoot().toUri().getPath();
+
+    if (!Objects.equals(metastoreInterestingColumns, interestingColumns)
+        && (metastoreInterestingColumns == null || !metastoreInterestingColumns.containsAll(interestingColumns))
+        || TableStatisticsKind.ANALYZE_METADATA_LEVEL.getValue(basicRequests.tableMetadata(tableInfo)).compareTo(metadataLevel) != 0) {
+      // do not update table scan and lists of segments / files / row groups,
+      // metadata should be recalculated
+      tableScan = tableScanSupplier.get();
+      metadataToRemove.addAll(getMetadataInfoList(selectionRoot, removedFiles, MetadataType.SEGMENT, 0));
+      return;
+    }
+
+    // checks whether there are no new, updated and removed files
+    if (!newFiles.isEmpty() || !updatedFiles.isEmpty() || !removedFiles.isEmpty()) {
+      List<String> scanFiles = new ArrayList<>(newFiles);
+      scanFiles.addAll(updatedFiles);
+
+      // updates scan to read updated / new files
+      tableScan = getTableScan(settings, tableScanSupplier.get(), scanFiles);
+
+      // iterates from the end;
+      // takes deepest updated segments;
+      // finds their parents:
+      //  - fetches all segments for parent level;
+      //  - filters segments to leave parents only;
+      // obtains all child segments;
+      // filters child segments for filtered parent segments
+
+      int lastSegmentIndex = segmentColumnsCount - 1;
+
+      List<String> scanAndRemovedFiles = new ArrayList<>(scanFiles);
+      scanAndRemovedFiles.addAll(removedFiles);
+
+      // 1. Obtain files info for files from the same folder without removed files
+      // 2. Get segments for obtained files + segments for removed files
+      // 3. Get parent segments
+      // 4. Get other segments for the same parent segment
+      // 5. Remove segments which have only removed files (matched for removedFileInfo and don't match to filesInfo)
+      // 6. Do the same for parent segments
+
+      List<MetadataInfo> allFilesInfo = getMetadataInfoList(selectionRoot, allFiles, MetadataType.FILE, 0);
+
+      // first pass: collect updated segments even without files, they will be removed later
+      List<MetadataInfo> leafSegments = getMetadataInfoList(selectionRoot, scanAndRemovedFiles, MetadataType.SEGMENT, lastSegmentIndex);
+      List<MetadataInfo> removedFilesMetadata = getMetadataInfoList(selectionRoot, removedFiles, MetadataType.FILE, 0);
+
+      List<MetadataInfo> scanFilesInfo = getMetadataInfoList(selectionRoot, scanAndRemovedFiles, MetadataType.FILE, 0);
+      // files from scan + files from the same folder without removed files
+      filesInfo = leafSegments.stream()
+          .filter(parent -> scanFilesInfo.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .flatMap(parent ->
+              allFilesInfo.stream()
+                  .filter(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .collect(Collectors.toList());
+
+      Multimap<Integer, MetadataInfo> allSegments = populateSegments(removedFiles, allFiles, selectionRoot, lastSegmentIndex, leafSegments, removedFilesMetadata);
+
+      List<MetadataInfo> allRowGroupsInfo = getAllRowGroupsMetadataInfos(allFiles);
+
+      rowGroupsInfo = allRowGroupsInfo.stream()
+          .filter(child -> filesInfo.stream()
+              .map(MetadataInfo::identifier)
+              .anyMatch(parent -> MetadataIdentifierUtils.isMetadataKeyParent(parent, child.identifier())))
+          .collect(Collectors.toList());
+
+      List<MetadataInfo> segmentsToUpdate = getMetadataInfoList(selectionRoot, scanAndRemovedFiles, MetadataType.SEGMENT, 0);
+      Streams.concat(allSegments.values().stream(), allFilesInfo.stream(), allRowGroupsInfo.stream())
+          .filter(child -> segmentsToUpdate.stream().anyMatch(parent -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .filter(parent ->
+              removedFilesMetadata.stream().noneMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier()))
+                  || filesInfo.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .forEach(allMetaToHandle::add);
+
+      allMetaToHandle.addAll(segmentsToUpdate);
+
+      // removed top-level segments are handled separately since their metadata is not overridden when producing writing to the Metastore
+      List<MetadataInfo> removedTopSegments = getMetadataInfoList(selectionRoot, removedFiles, MetadataType.SEGMENT, 0).stream()
+          .filter(parent ->
+              removedFilesMetadata.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier()))
+                  && allFilesInfo.stream().noneMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .collect(Collectors.toList());
+      metadataToRemove.addAll(removedTopSegments);
+    } else {
+      // table metadata may still be actual
+      outdated = false;
+    }
+  }
+
+  private Multimap<Integer, MetadataInfo> populateSegments(List<String> removedFiles, List<String> allFiles,
+      String selectionRoot, int lastSegmentIndex, List<MetadataInfo> leafSegments, List<MetadataInfo> removedFilesMetadata) {
+    List<String> presentAndRemovedFiles = new ArrayList<>(allFiles);
+    presentAndRemovedFiles.addAll(removedFiles);
+    Multimap<Integer, MetadataInfo> allSegments = ArrayListMultimap.create();
+    if (lastSegmentIndex > 0) {
+      allSegments.putAll(lastSegmentIndex, getMetadataInfoList(selectionRoot, presentAndRemovedFiles, MetadataType.SEGMENT, lastSegmentIndex));
+    }
+
+    for (int i = lastSegmentIndex - 1; i >= 0; i--) {
+      List<MetadataInfo> currentChildSegments = leafSegments;
+      List<MetadataInfo> allParentSegments = getMetadataInfoList(selectionRoot, presentAndRemovedFiles, MetadataType.SEGMENT, i);
+      allSegments.putAll(i, allParentSegments);
+
+      // segments, parent for segments from currentChildSegments
+      List<MetadataInfo> parentSegments = allParentSegments.stream()
+          .filter(parent -> currentChildSegments.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .collect(Collectors.toList());
+
+      // all segments children for parentSegments segments except empty segments
+      List<MetadataInfo> childSegments = allSegments.get(i + 1).stream()
+          .filter(child -> parentSegments.stream().anyMatch(parent -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .filter(parent ->
+              removedFilesMetadata.stream().noneMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier()))
+                  || filesInfo.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+          .collect(Collectors.toList());
+
+      segmentsInfo.putAll(i + 1, childSegments);
+      leafSegments = childSegments;
+    }
+    segmentsInfo.putAll(0, getMetadataInfoList(selectionRoot, presentAndRemovedFiles, MetadataType.SEGMENT, 0).stream()
+        .filter(parent ->
+            removedFilesMetadata.stream().noneMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier()))
+                || filesInfo.stream().anyMatch(child -> MetadataIdentifierUtils.isMetadataKeyParent(parent.identifier(), child.identifier())))
+        .collect(Collectors.toList()));
+    return allSegments;
+  }
+
+  private List<MetadataInfo> getAllRowGroupsMetadataInfos(List<String> allFiles) {
+    List<String> metadataKeys = filesInfo.stream()
+        .map(MetadataInfo::key)
+        .distinct()
+        .collect(Collectors.toList());
+
+    BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataKeys(metadataKeys)
+        .paths(allFiles)
+        .metadataType(MetadataType.ROW_GROUP.name())
+        .requestColumns(Arrays.asList(MetadataInfo.METADATA_KEY, MetadataInfo.METADATA_IDENTIFIER, MetadataInfo.METADATA_TYPE))
+        .build();
+
+    return basicRequests.request(requestMetadata).stream()
+        .map(unit -> MetadataInfo.builder().metadataUnit(unit).build())
+        .collect(Collectors.toList());
+  }
+
+  private List<FileStatus> getFileStatuses(FormatSelection selection) throws IOException {
+    FileSelection fileSelection = selection.getSelection();
+
+    FileSystem rawFs = fileSelection.getSelectionRoot().getFileSystem(new Configuration());
+    DrillFileSystem fs = ImpersonationUtil.createFileSystem(ImpersonationUtil.getProcessUserName(), rawFs.getConf());
+
+    return getFileStatuses(fileSelection, fs);
+  }
+
+  private TableScan getTableScan(PlannerSettings settings, TableScan scanRel, List<String> scanFiles) {
+    FileSystemPartitionDescriptor descriptor =
+        new FileSystemPartitionDescriptor(settings, scanRel);
+
+    List<PartitionLocation> newPartitions = Lists.newArrayList(descriptor.iterator()).stream()
+        .flatMap(Collection::stream)
+        .flatMap(p -> p.getPartitionLocationRecursive().stream())
+        .filter(p -> scanFiles.contains(p.getEntirePartitionLocation().toUri().getPath()))
+        .collect(Collectors.toList());
+
+    try {
+      if (!newPartitions.isEmpty()) {
+        return descriptor.createTableScan(newPartitions, false);
+      } else {
+        DrillTable drillTable = descriptor.getTable();
+        SchemalessScan scan = new SchemalessScan(drillTable.getUserName(), ((FormatSelection) descriptor.getTable().getSelection()).getSelection().getSelectionRoot());
+
+        return new DrillScanRel(scanRel.getCluster(),
+            scanRel.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
+            scanRel.getTable(),
+            scan,
+            scanRel.getRowType(),
+            DrillScanRel.getProjectedColumns(scanRel.getTable(), true),
+            true /*filter pushdown*/);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error happened during recreation of pruned scan", e);
+    }
+  }
+
+  private List<MetadataInfo> getMetadataInfoList(String parent, List<String> locations, MetadataType metadataType, int level) {
+    return locations.stream()
+        .map(location -> getMetadataInfo(parent, location, metadataType, level))
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  private MetadataInfo getMetadataInfo(String parent, String location, MetadataType metadataType, int level) {
+    List<String> values = ColumnExplorer.listPartitionValues(new Path(location), new Path(parent), true);
+
+    switch (metadataType) {
+      case ROW_GROUP: {
+        throw new UnsupportedOperationException("MetadataInfo cannot be obtained for row group using file location only");
+      }
+      case FILE: {
+        String key = values.size() > 1 ? values.iterator().next() : MetadataInfo.DEFAULT_SEGMENT_KEY;
+        return MetadataInfo.builder()
+            .type(metadataType)
+            .key(key)
+            .identifier(MetadataIdentifierUtils.getMetadataIdentifierKey(values))
+            .build();
+      }
+      case SEGMENT: {
+        String key = values.size() > 1 ? values.iterator().next() : MetadataInfo.DEFAULT_SEGMENT_KEY;
+        return MetadataInfo.builder()
+            .type(metadataType)
+            .key(key)
+            .identifier(values.size() > 1 ? MetadataIdentifierUtils.getMetadataIdentifierKey(values.subList(0, level + 1)) :  MetadataInfo.DEFAULT_SEGMENT_KEY)
+            .build();
+      }
+      case TABLE: {
+        return MetadataInfo.builder()
+            .type(metadataType)
+            .key(MetadataInfo.GENERAL_INFO_KEY)
+            .build();
+      }
+      default:
+        throw new UnsupportedOperationException(metadataType.name());
+    }
+  }
+
+  /**
+   * Returns list of {@link FileStatus} file statuses obtained from specified {@link FileSelection} file selection.
+   * Specified file selection may be expanded fully if it wasn't expanded before.
+   *
+   * @param fileSelection file selection
+   * @param fs            file system
+   * @return list of {@link FileStatus} file statuses
+   */
+  public static List<FileStatus> getFileStatuses(FileSelection fileSelection, DrillFileSystem fs) throws IOException {
+    if (!fileSelection.isExpandedFully()) {
+      fileSelection = getExpandedFileSelection(fileSelection, fs);
+    }
+    return fileSelection.getStatuses(fs);
+  }
+
+  /**
+   * Returns {@link FileSelection} file selection based on specified file selection with expanded file statuses.
+   *
+   * @param fileSelection file selection
+   * @return expanded file selection
+   */
+  public static FileSelection getExpandedFileSelection(FileSelection fileSelection) throws IOException {
+    FileSystem rawFs = fileSelection.getSelectionRoot().getFileSystem(new Configuration());
+    FileSystem fs = ImpersonationUtil.createFileSystem(ImpersonationUtil.getProcessUserName(), rawFs.getConf());
+    return getExpandedFileSelection(fileSelection, fs);
+  }
+
+  private static FileSelection getExpandedFileSelection(FileSelection fileSelection, FileSystem fs) throws IOException {
+    List<FileStatus> fileStatuses = DrillFileSystemUtil.listFiles(fs, fileSelection.getSelectionRoot(), true);
+    fileSelection = FileSelection.create(fileStatuses, null, fileSelection.getSelectionRoot());
+    return fileSelection;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataAggregateContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataAggregateContext.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.NamedExpression;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Class which provides information required for producing metadata aggregation when performing analyze.
+ */
+@JsonDeserialize(builder = MetadataAggregateContext.MetadataAggregateContextBuilder.class)
+public class MetadataAggregateContext {
+  private final List<NamedExpression> groupByExpressions;
+  private final List<SchemaPath> interestingColumns;
+  private final List<SchemaPath> excludedColumns;
+  private final boolean createNewAggregations;
+
+  public MetadataAggregateContext(MetadataAggregateContextBuilder builder) {
+    this.groupByExpressions = builder.groupByExpressions;
+    this.interestingColumns = builder.interestingColumns;
+    this.createNewAggregations = builder.createNewAggregations;
+    this.excludedColumns = builder.excludedColumns;
+  }
+
+  @JsonProperty
+  public List<NamedExpression> groupByExpressions() {
+    return groupByExpressions;
+  }
+
+  @JsonProperty
+  public List<SchemaPath> interestingColumns() {
+    return interestingColumns;
+  }
+
+  @JsonProperty
+  public boolean createNewAggregations() {
+    return createNewAggregations;
+  }
+
+  @JsonProperty
+  public List<SchemaPath> excludedColumns() {
+    return excludedColumns;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", MetadataAggregateContext.class.getSimpleName() + "[", "]")
+        .add("groupByExpressions=" + groupByExpressions)
+        .add("interestingColumns=" + interestingColumns)
+        .add("createNewAggregations=" + createNewAggregations)
+        .add("excludedColumns=" + excludedColumns)
+        .toString();
+  }
+
+  public static MetadataAggregateContextBuilder builder() {
+    return new MetadataAggregateContextBuilder();
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class MetadataAggregateContextBuilder {
+    private List<NamedExpression> groupByExpressions;
+    private List<SchemaPath> interestingColumns;
+    private Boolean createNewAggregations;
+    private List<SchemaPath> excludedColumns;
+
+    public MetadataAggregateContextBuilder groupByExpressions(List<NamedExpression> groupByExpressions) {
+      this.groupByExpressions = groupByExpressions;
+      return this;
+    }
+
+    public MetadataAggregateContextBuilder interestingColumns(List<SchemaPath> interestingColumns) {
+      this.interestingColumns = interestingColumns;
+      return this;
+    }
+
+    public MetadataAggregateContextBuilder createNewAggregations(boolean createNewAggregations) {
+      this.createNewAggregations = createNewAggregations;
+      return this;
+    }
+
+    public MetadataAggregateContextBuilder excludedColumns(List<SchemaPath> excludedColumns) {
+      this.excludedColumns = excludedColumns;
+      return this;
+    }
+
+    public MetadataAggregateContext build() {
+      Objects.requireNonNull(groupByExpressions, "groupByExpressions were not set");
+      Objects.requireNonNull(createNewAggregations, "createNewAggregations was not set");
+      Objects.requireNonNull(excludedColumns, "excludedColumns were not set");
+      return new MetadataAggregateContext(this);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataControllerContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataControllerContext.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Class which provides information required for storing metadata to the Metastore when performing analyze.
+ */
+@JsonDeserialize(builder = MetadataControllerContext.MetadataControllerContextBuilder.class)
+public class MetadataControllerContext {
+  private final TableInfo tableInfo;
+  private final MetastoreTableInfo metastoreTableInfo;
+  private final Path location;
+  private final List<SchemaPath> interestingColumns;
+  private final List<String> segmentColumns;
+  private final List<MetadataInfo> metadataToHandle;
+  private final List<MetadataInfo> metadataToRemove;
+  private final MetadataType analyzeMetadataLevel;
+
+  private MetadataControllerContext(MetadataControllerContextBuilder builder) {
+    this.tableInfo = builder.tableInfo;
+    this.metastoreTableInfo = builder.metastoreTableInfo;
+    this.location = builder.location;
+    this.interestingColumns = builder.interestingColumns;
+    this.segmentColumns = builder.segmentColumns;
+    this.metadataToHandle = builder.metadataToHandle;
+    this.metadataToRemove = builder.metadataToRemove;
+    this.analyzeMetadataLevel = builder.analyzeMetadataLevel;
+  }
+
+  @JsonProperty
+  public TableInfo tableInfo() {
+    return tableInfo;
+  }
+
+  @JsonProperty
+  public MetastoreTableInfo metastoreTableInfo() {
+    return metastoreTableInfo;
+  }
+
+  @JsonProperty
+  public Path location() {
+    return location;
+  }
+
+  @JsonProperty
+  public List<SchemaPath> interestingColumns() {
+    return interestingColumns;
+  }
+
+  @JsonProperty
+  public List<String> segmentColumns() {
+    return segmentColumns;
+  }
+
+  @JsonProperty
+  public List<MetadataInfo> metadataToHandle() {
+    return metadataToHandle;
+  }
+
+  @JsonProperty
+  public List<MetadataInfo> metadataToRemove() {
+    return metadataToRemove;
+  }
+
+  @JsonProperty
+  public MetadataType analyzeMetadataLevel() {
+    return analyzeMetadataLevel;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", MetadataControllerContext.class.getSimpleName() + "[", "]")
+        .add("tableInfo=" + tableInfo)
+        .add("location=" + location)
+        .add("interestingColumns=" + interestingColumns)
+        .add("segmentColumns=" + segmentColumns)
+        .add("metadataToHandle=" + metadataToHandle)
+        .add("metadataToRemove=" + metadataToRemove)
+        .add("analyzeMetadataLevel=" + analyzeMetadataLevel)
+        .toString();
+  }
+
+  public static MetadataControllerContextBuilder builder() {
+    return new MetadataControllerContextBuilder();
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class MetadataControllerContextBuilder {
+    private TableInfo tableInfo;
+    private MetastoreTableInfo metastoreTableInfo;
+    private Path location;
+    private List<SchemaPath> interestingColumns;
+    private List<String> segmentColumns;
+    private List<MetadataInfo> metadataToHandle;
+    private List<MetadataInfo> metadataToRemove;
+    private MetadataType analyzeMetadataLevel;
+
+    public MetadataControllerContextBuilder tableInfo(TableInfo tableInfo) {
+      this.tableInfo = tableInfo;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder metastoreTableInfo(MetastoreTableInfo metastoreTableInfo) {
+      this.metastoreTableInfo = metastoreTableInfo;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder location(Path location) {
+      this.location = location;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder interestingColumns(List<SchemaPath> interestingColumns) {
+      this.interestingColumns = interestingColumns;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder segmentColumns(List<String> segmentColumns) {
+      this.segmentColumns = segmentColumns;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder metadataToHandle(List<MetadataInfo> metadataToHandle) {
+      this.metadataToHandle = metadataToHandle;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder metadataToRemove(List<MetadataInfo> metadataToRemove) {
+      this.metadataToRemove = metadataToRemove;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder analyzeMetadataLevel(MetadataType metadataType) {
+      this.analyzeMetadataLevel = metadataType;
+      return this;
+    }
+
+    public MetadataControllerContext build() {
+      Objects.requireNonNull(tableInfo, "tableInfo was not set");
+      Objects.requireNonNull(location, "location was not set");
+      Objects.requireNonNull(segmentColumns, "segmentColumns were not set");
+      Objects.requireNonNull(metadataToHandle, "metadataToHandle was not set");
+      Objects.requireNonNull(metadataToRemove, "metadataToRemove was not set");
+      return new MetadataControllerContext(this);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataHandlerContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataHandlerContext.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Class which provides information required for handling results of metadata aggregation when performing analyze.
+ */
+@JsonDeserialize(builder = MetadataHandlerContext.MetadataHandlerContextBuilder.class)
+public class MetadataHandlerContext {
+  private final TableInfo tableInfo;
+  private final List<MetadataInfo> metadataToHandle;
+  private final MetadataType metadataType;
+  private final int depthLevel;
+  private final List<String> segmentColumns;
+
+  private MetadataHandlerContext(MetadataHandlerContextBuilder builder) {
+    this.tableInfo = builder.tableInfo;
+    this.metadataToHandle = builder.metadataToHandle;
+    this.metadataType = builder.metadataType;
+    this.depthLevel = builder.depthLevel;
+    this.segmentColumns = builder.segmentColumns;
+  }
+
+  @JsonProperty
+  public TableInfo tableInfo() {
+    return tableInfo;
+  }
+
+  @JsonProperty
+  public List<MetadataInfo> metadataToHandle() {
+    return metadataToHandle;
+  }
+
+  @JsonProperty
+  public MetadataType metadataType() {
+    return metadataType;
+  }
+
+  @JsonProperty
+  public int depthLevel() {
+    return depthLevel;
+  }
+
+  @JsonProperty
+  public List<String> segmentColumns() {
+    return segmentColumns;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", MetadataHandlerContext.class.getSimpleName() + "[", "]")
+        .add("tableInfo=" + tableInfo)
+        .add("metadataToHandle=" + metadataToHandle)
+        .add("metadataType=" + metadataType)
+        .add("depthLevel=" + depthLevel)
+        .add("segmentColumns=" + segmentColumns)
+        .toString();
+  }
+
+  public static MetadataHandlerContextBuilder builder() {
+    return new MetadataHandlerContextBuilder();
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class MetadataHandlerContextBuilder {
+    private TableInfo tableInfo;
+    private List<MetadataInfo> metadataToHandle;
+    private MetadataType metadataType;
+    private Integer depthLevel;
+    private List<String> segmentColumns;
+
+    public MetadataHandlerContextBuilder tableInfo(TableInfo tableInfo) {
+      this.tableInfo = tableInfo;
+      return this;
+    }
+
+    public MetadataHandlerContextBuilder metadataToHandle(List<MetadataInfo> metadataToHandle) {
+      this.metadataToHandle = metadataToHandle;
+      return this;
+    }
+
+    public MetadataHandlerContextBuilder metadataType(MetadataType metadataType) {
+      this.metadataType = metadataType;
+      return this;
+    }
+
+    public MetadataHandlerContextBuilder depthLevel(int depthLevel) {
+      this.depthLevel = depthLevel;
+      return this;
+    }
+
+    public MetadataHandlerContextBuilder segmentColumns(List<String> segmentColumns) {
+      this.segmentColumns = segmentColumns;
+      return this;
+    }
+
+    public MetadataHandlerContext build() {
+      Objects.requireNonNull(tableInfo, "tableInfo was not set");
+      Objects.requireNonNull(metadataToHandle, "metadataToHandle was not set");
+      Objects.requireNonNull(metadataType, "metadataType was not set");
+      Objects.requireNonNull(depthLevel, "depthLevel was not set");
+      Objects.requireNonNull(segmentColumns, "segmentColumns were not set");
+      return new MetadataHandlerContext(this);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataIdentifierUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataIdentifierUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.drill.exec.store.ColumnExplorer;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.hadoop.fs.Path;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetadataIdentifierUtils {
+  private static final String METADATA_IDENTIFIER_SEPARATOR = "/";
+
+  /**
+   * Returns string representation of metadata identifier using specified metadata identifier values.
+   *
+   * @param values metadata identifier values
+   * @return string representation of metadata identifier
+   */
+  public static String getMetadataIdentifierKey(List<String> values) {
+    return String.join(METADATA_IDENTIFIER_SEPARATOR, values);
+  }
+
+  /**
+   * Checks whether the specified metadata identifier is a parent for another specified metadata identifier.
+   *
+   * @param parent parent metadata identifier
+   * @param child  child metadata identifier
+   * @return {@code true} if specified metadata identifier is a parent for another specified metadata identifier
+   */
+  public static boolean isMetadataKeyParent(String parent, String child) {
+    return child.startsWith(parent + METADATA_IDENTIFIER_SEPARATOR) || parent.equals(MetadataInfo.DEFAULT_SEGMENT_KEY);
+  }
+
+  /**
+   * Returns file metadata identifier.
+   *
+   * @param partitionValues partition values
+   * @param path            file path
+   * @return file metadata identifier
+   */
+  public static String getFileMetadataIdentifier(List<String> partitionValues, Path path) {
+    List<String> identifierValues = new ArrayList<>(partitionValues);
+    identifierValues.add(ColumnExplorer.ImplicitFileColumns.FILENAME.getValue(path));
+    return getMetadataIdentifierKey(identifierValues);
+  }
+
+  /**
+   * Returns row group metadata identifier.
+   *
+   * @param partitionValues partition values
+   * @param path            file path
+   * @param index           row group index
+   * @return row group metadata identifier
+   */
+  public static String getRowGroupMetadataIdentifier(List<String> partitionValues, Path path, int index) {
+    List<String> identifierValues = new ArrayList<>(partitionValues);
+    identifierValues.add(ColumnExplorer.ImplicitFileColumns.FILENAME.getValue(path));
+    identifierValues.add(Integer.toString(index));
+    return getMetadataIdentifierKey(identifierValues);
+  }
+
+  /**
+   * Returns array with metadata identifier values obtained from specified metadata identifier string.
+   *
+   * @param metadataIdentifier metadata identifier
+   * @return array with metadata identifier values
+   */
+  public static String[] getValuesFromMetadataIdentifier(String metadataIdentifier) {
+    return metadataIdentifier.split(METADATA_IDENTIFIER_SEPARATOR);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataInfoCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataInfoCollector.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
+
+import java.util.List;
+
+/**
+ * Interface for obtaining information about segments, files etc which should be handled in Metastore
+ * when producing incremental analyze.
+ */
+public interface MetadataInfoCollector {
+
+  /**
+   * Returns list of row groups metadata info which should be fetched from the Metastore.
+   *
+   * @return list of row groups metadata info
+   */
+  List<MetadataInfo> getRowGroupsInfo();
+
+  /**
+   * Returns list of files metadata info which should be fetched from the Metastore.
+   *
+   * @return list of files metadata info
+   */
+  List<MetadataInfo> getFilesInfo();
+
+  /**
+   * Returns list of segments metadata info which should be fetched from the Metastore.
+   *
+   * @return list of segments metadata info
+   */
+  Multimap<Integer, MetadataInfo> getSegmentsInfo();
+
+  /**
+   * Returns list of all metadata info instances which should be handled
+   * either producing analyze or when fetching from the Metastore.
+   *
+   * @return list of all metadata info
+   */
+  List<MetadataInfo> getAllMetaToHandle();
+
+  /**
+   * Returns list of all metadata info which corresponds to top-level segments and should be removed from the Metastore.
+   *
+   * @return list of all metadata info which should be removed
+   */
+  List<MetadataInfo> getMetadataToRemove();
+
+  /**
+   * Returns {@link TableScan} instance which will be used when produced incremental analyze.
+   * Table scan will contain minimal selection required for obtaining correct metadata.
+   *
+   * @return {@link TableScan} instance
+   */
+  TableScan getPrunedScan();
+
+  /**
+   * Returns true if table metadata is outdated.
+   *
+   * @return true if table metadata is outdated
+   */
+  boolean isOutdated();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetastoreAnalyzeConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetastoreAnalyzeConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metastore.analyze;
+
+public interface MetastoreAnalyzeConstants {
+  String OK_FIELD_NAME = "ok";
+  String SUMMARY_FIELD_NAME = "summary";
+
+  String COLLECTED_MAP_FIELD = "collectedMap";
+  String LOCATIONS_FIELD = "locations";
+  String SCHEMA_FIELD = "schema";
+  String METADATA_TYPE = "metadataType";
+  String LOCATION_FIELD = "location";
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryContext.java
@@ -52,6 +52,7 @@ import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.util.Utilities;
 
+import org.apache.drill.metastore.MetastoreRegistry;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
@@ -360,11 +361,10 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
     }
   }
 
-  /*
-   * Clears the type {@link SqlStatementType} of the statement. Ideally we should not clear the statement type
-   * so this should never be exposed outside the QueryContext
+  /**
+   * Clears the type {@link SqlStatementType} of the statement.
    */
-  private void clearSQLStatementType() {
+  public void clearSQLStatementType() {
     this.stmtType = null;
   }
 
@@ -388,5 +388,9 @@ public class QueryContext implements AutoCloseable, OptimizerRulesContext, Schem
    */
   public boolean isSkipProfileWrite() {
     return skipProfileWrite;
+  }
+
+  public MetastoreRegistry getMetastoreRegistry() {
+    return drillbitContext.getMetastoreRegistry();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/opt/BasicOptimizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/opt/BasicOptimizer.java
@@ -141,7 +141,7 @@ public class BasicOptimizer extends Optimizer {
         input = new Sort(input, orderDefs, false);
       }
 
-      return new StreamingAggregate(input, groupBy.getKeys(), groupBy.getExprs(), 1.0f);
+      return new StreamingAggregate(input, groupBy.getKeys(), groupBy.getExprs());
     }
 
     @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.drill.exec.metastore.analyze.AnalyzeInfoProvider;
 import org.apache.drill.metastore.metadata.TableMetadata;
 import org.apache.drill.metastore.metadata.TableMetadataProvider;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -205,6 +206,16 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
 
   @Override
   public TableMetadata getTableMetadata() {
+    return null;
+  }
+
+  @Override
+  public boolean usedMetastore() {
+    return false;
+  }
+
+  @Override
+  public AnalyzeInfoProvider getAnalyzeInfoProvider() {
     return null;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/GroupScan.java
@@ -24,6 +24,7 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
+import org.apache.drill.exec.metastore.analyze.AnalyzeInfoProvider;
 import org.apache.drill.exec.ops.UdfUtilities;
 import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
@@ -171,4 +172,20 @@ public interface GroupScan extends Scan, HasAffinity {
 
   @JsonIgnore
   TableMetadata getTableMetadata();
+
+  /**
+   * Returns {@code true} if current group scan uses metadata obtained from the Metastore.
+   *
+   * @return {@code true} if current group scan uses metadata obtained from the Metastore, {@code false} otherwise.
+   */
+  @JsonIgnore
+  boolean usedMetastore();
+
+  /**
+   * Returns {@link AnalyzeInfoProvider} instance which will be used when running ANALYZE statement.
+   *
+   * @return {@link AnalyzeInfoProvider} instance
+   */
+  @JsonIgnore
+  AnalyzeInfoProvider getAnalyzeInfoProvider();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataAggPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataAggPOP.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.metastore.analyze.MetadataAggregateContext;
+
+import java.util.Collections;
+
+@JsonTypeName("metadataAggregate")
+public class MetadataAggPOP extends StreamingAggregate {
+  private final MetadataAggregateContext context;
+
+  @JsonCreator
+  public MetadataAggPOP(@JsonProperty("child") PhysicalOperator child,
+      @JsonProperty("context") MetadataAggregateContext context) {
+    super(child, context.groupByExpressions(), Collections.emptyList());
+    this.context = context;
+  }
+
+  @Override
+  protected PhysicalOperator getNewWithChild(PhysicalOperator child) {
+    return new MetadataAggPOP(child, context);
+  }
+
+  @JsonProperty
+  public MetadataAggregateContext getContext() {
+    return context;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataControllerPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataControllerPOP.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.exec.physical.base.AbstractBase;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.PhysicalVisitor;
+import org.apache.drill.exec.metastore.analyze.MetadataControllerContext;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+@JsonTypeName("metadataController")
+public class MetadataControllerPOP extends AbstractBase {
+  private final MetadataControllerContext context;
+  private final PhysicalOperator left;
+  private final PhysicalOperator right;
+
+  @JsonCreator
+  public MetadataControllerPOP(@JsonProperty("left") PhysicalOperator left,
+      @JsonProperty("right") PhysicalOperator right, @JsonProperty("context") MetadataControllerContext context) {
+    this.context = context;
+    this.left = left;
+    this.right = right;
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
+    return physicalVisitor.visitOp(this, value);
+  }
+
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
+    Preconditions.checkArgument(children.size() == 2);
+    return new MetadataControllerPOP(children.get(0), children.get(1), context);
+  }
+
+  @Override
+  public int getOperatorType() {
+    return UserBitShared.CoreOperatorType.METADATA_CONTROLLER_VALUE;
+  }
+
+  @Override
+  public Iterator<PhysicalOperator> iterator() {
+    return Arrays.asList(left, right).iterator();
+  }
+
+  @JsonProperty
+  public MetadataControllerContext getContext() {
+    return context;
+  }
+
+  @JsonProperty
+  public PhysicalOperator getLeft() {
+    return left;
+  }
+
+  @JsonProperty
+  public PhysicalOperator getRight() {
+    return right;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataHandlerPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataHandlerPOP.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.exec.physical.base.AbstractSingle;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.PhysicalVisitor;
+import org.apache.drill.exec.metastore.analyze.MetadataHandlerContext;
+import org.apache.drill.exec.proto.UserBitShared;
+
+@JsonTypeName("metadataHandler")
+public class MetadataHandlerPOP extends AbstractSingle {
+  private final MetadataHandlerContext context;
+
+  @JsonCreator
+  public MetadataHandlerPOP(@JsonProperty("child") PhysicalOperator child,
+      @JsonProperty("context") MetadataHandlerContext context) {
+    super(child);
+    this.context = context;
+  }
+
+  @Override
+  protected PhysicalOperator getNewWithChild(PhysicalOperator child) {
+    return new MetadataHandlerPOP(child, context);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
+    return physicalVisitor.visitOp(this, value);
+  }
+
+  @Override
+  public int getOperatorType() {
+    return UserBitShared.CoreOperatorType.METADATA_HANDLER_VALUE;
+  }
+
+  public MetadataHandlerContext getContext() {
+    return context;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsAggregate.java
@@ -37,7 +37,7 @@ public class StatisticsAggregate extends StreamingAggregate {
   public StatisticsAggregate(
       @JsonProperty("child") PhysicalOperator child,
       @JsonProperty("functions") List<String> functions) {
-    super(child, null, null, 0.f);
+    super(child, null, null);
     this.functions = ImmutableList.copyOf(functions);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StreamingAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StreamingAggregate.java
@@ -37,14 +37,13 @@ public class StreamingAggregate extends AbstractSingle {
   private final List<NamedExpression> keys;
   private final List<NamedExpression> exprs;
 
-  private final float cardinality;
-
   @JsonCreator
-  public StreamingAggregate(@JsonProperty("child") PhysicalOperator child, @JsonProperty("keys") List<NamedExpression> keys, @JsonProperty("exprs") List<NamedExpression> exprs, @JsonProperty("cardinality") float cardinality) {
+  public StreamingAggregate(@JsonProperty("child") PhysicalOperator child,
+      @JsonProperty("keys") List<NamedExpression> keys,
+      @JsonProperty("exprs") List<NamedExpression> exprs) {
     super(child);
     this.keys = keys;
     this.exprs = exprs;
-    this.cardinality = cardinality;
   }
 
   public List<NamedExpression> getKeys() {
@@ -62,7 +61,7 @@ public class StreamingAggregate extends AbstractSingle {
 
   @Override
   protected PhysicalOperator getNewWithChild(PhysicalOperator child) {
-    return new StreamingAggregate(child, keys, exprs, cardinality);
+    return new StreamingAggregate(child, keys, exprs);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnpivotMaps.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnpivotMaps.java
@@ -30,16 +30,17 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("unpivot-maps")
 public class UnpivotMaps extends AbstractSingle {
-  private final List<String> mapFieldsNames;
+  private final List<String> mapFieldNames;
 
   @JsonCreator
-  public UnpivotMaps(@JsonProperty("child") PhysicalOperator child, List<String> mapFieldsNames) {
+  public UnpivotMaps(@JsonProperty("child") PhysicalOperator child, @JsonProperty("mapFieldNames") List<String> mapFieldNames) {
     super(child);
-    this.mapFieldsNames = mapFieldsNames;
+    this.mapFieldNames = mapFieldNames;
   }
 
+  @JsonProperty
   public List<String> getMapFieldNames() {
-    return mapFieldsNames;
+    return mapFieldNames;
   }
 
   @Override
@@ -49,7 +50,7 @@ public class UnpivotMaps extends AbstractSingle {
 
   @Override
   protected PhysicalOperator getNewWithChild(PhysicalOperator child) {
-    return new UnpivotMaps(child, mapFieldsNames);
+    return new UnpivotMaps(child, mapFieldNames);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 
 import com.carrotsearch.hppc.IntArrayList;
 import org.apache.drill.exec.exception.SchemaChangeException;
-import org.apache.drill.exec.physical.config.HashJoinPOP;
 import org.apache.drill.exec.physical.impl.common.HashPartition;
 import org.apache.drill.exec.planner.common.JoinControl;
 import org.apache.drill.exec.record.BatchSchema;
@@ -137,7 +136,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
 
     partitionMask = numPartitions - 1; // e.g. 32 --> 0x1F
     bitsInMask = Integer.bitCount(partitionMask); // e.g. 0x1F -> 5
-    joinControl = new JoinControl(((HashJoinPOP)outgoingJoinBatch.getPopConfig()).getJoinControl());
+    joinControl = new JoinControl(outgoingJoinBatch.getPopConfig().getJoinControl());
 
     probeState = ProbeState.PROBE_PROJECT;
     this.recordsToProcess = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinTemplate.java
@@ -21,7 +21,6 @@ import javax.inject.Named;
 
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.physical.config.MergeJoinPOP;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.calcite.rel.core.JoinRelType;
 
@@ -41,7 +40,7 @@ public abstract class JoinTemplate implements JoinWorker {
    * @return  true of join succeeded; false if the worker needs to be regenerated
    */
   public final boolean doJoin(final JoinStatus status) {
-    final boolean isLeftJoin = (((MergeJoinPOP)status.outputBatch.getPopConfig()).getJoinType() == JoinRelType.LEFT);
+    final boolean isLeftJoin = status.outputBatch.getPopConfig().getJoinType() == JoinRelType.LEFT;
     status.setHasMoreData(false);
     while (!status.isOutgoingBatchFull()) {
       if (status.right.finished()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggBatch.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.expression.ExpressionPosition;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.ValueExpressions;
+import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.physical.config.MetadataAggPOP;
+import org.apache.drill.exec.physical.impl.aggregate.StreamingAggBatch;
+import org.apache.drill.exec.physical.impl.aggregate.StreamingAggregator;
+import org.apache.drill.exec.metastore.analyze.AnalyzeColumnUtils;
+import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+/**
+ * Operator which adds aggregate calls for all incoming columns to calculate required metadata and produces aggregations.
+ * If aggregation is performed on top of another aggregation, required aggregate calls for merging metadata will be added.
+ */
+public class MetadataAggBatch extends StreamingAggBatch {
+
+  private List<NamedExpression> valueExpressions;
+
+  public MetadataAggBatch(MetadataAggPOP popConfig, RecordBatch incoming, FragmentContext context) throws OutOfMemoryException {
+    super(popConfig, incoming, context);
+  }
+
+  @Override
+  protected StreamingAggregator createAggregatorInternal()
+      throws SchemaChangeException, ClassTransformationException, IOException {
+    valueExpressions = new ArrayList<>();
+    MetadataAggPOP popConfig = (MetadataAggPOP) this.popConfig;
+
+    List<SchemaPath> excludedColumns = popConfig.getContext().excludedColumns();
+
+    BatchSchema schema = incoming.getSchema();
+    // Iterates through input expressions and adds aggregate calls for table fields
+    // to collect required statistics (MIN, MAX, COUNT, etc.) or aggregate calls to merge incoming metadata
+    getUnflattenedFileds(Lists.newArrayList(schema), null)
+        .forEach((fieldName, fieldRef) -> addColumnAggregateCalls(fieldRef, fieldName));
+
+    List<LogicalExpression> fieldsList = new ArrayList<>();
+    StreamSupport.stream(schema.spliterator(), false)
+        .map(MaterializedField::getName)
+        .filter(field -> !excludedColumns.contains(FieldReference.getWithQuotedRef(field)))
+        .forEach(filedName -> {
+          // adds string literal with field name to the list
+          fieldsList.add(ValueExpressions.getChar(filedName,
+              DrillRelDataTypeSystem.DRILL_REL_DATATYPE_SYSTEM.getDefaultPrecision(SqlTypeName.VARCHAR)));
+          // adds field reference to the list
+          fieldsList.add(FieldReference.getWithQuotedRef(filedName));
+        });
+
+    if (popConfig.getContext().createNewAggregations()) {
+      addMetadataAggregateCalls();
+      // infer schema from incoming data
+      addSchemaCall(fieldsList);
+      addNewMetadataAggregations();
+    } else {
+      addCollectListCall(fieldsList);
+      addMergeSchemaCall();
+    }
+
+    for (SchemaPath excludedColumn : excludedColumns) {
+      if (excludedColumn.equals(SchemaPath.getSimplePath(context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL)))
+          || excludedColumn.equals(SchemaPath.getSimplePath(context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL)))) {
+        LogicalExpression lastModifiedTime = new FunctionCall("any_value",
+            Collections.singletonList(
+                FieldReference.getWithQuotedRef(excludedColumn.getRootSegmentPath())),
+            ExpressionPosition.UNKNOWN);
+
+        valueExpressions.add(new NamedExpression(lastModifiedTime,
+            FieldReference.getWithQuotedRef(excludedColumn.getRootSegmentPath())));
+      }
+    }
+
+    addMaxLastModifiedCall();
+
+    return super.createAggregatorInternal();
+  }
+
+  /**
+   * Adds {@code max(`lastModifiedTime`)} function call to the value expressions list.
+   */
+  private void addMaxLastModifiedCall() {
+    String lastModifiedColumn = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+    LogicalExpression lastModifiedTime = new FunctionCall("max",
+        Collections.singletonList(
+            FieldReference.getWithQuotedRef(lastModifiedColumn)),
+        ExpressionPosition.UNKNOWN);
+
+    valueExpressions.add(new NamedExpression(lastModifiedTime,
+        FieldReference.getWithQuotedRef(lastModifiedColumn)));
+  }
+
+  /**
+   * Adds {@code collect_list()}} function call with specified fields list
+   * and excluded columns as arguments of this function to collect all these fields into repeated map list.
+   *
+   * @param fieldList list of the function arguments
+   */
+  private void addCollectListCall(List<LogicalExpression> fieldList) {
+    ArrayList<LogicalExpression> collectListArguments = new ArrayList<>(fieldList);
+    MetadataAggPOP popConfig = (MetadataAggPOP) this.popConfig;
+    List<SchemaPath> excludedColumns = popConfig.getContext().excludedColumns();
+    // populate columns which weren't included in the schema, but should be collected to the COLLECTED_MAP_FIELD
+    for (SchemaPath logicalExpressions : excludedColumns) {
+      // adds string literal with field name to the list
+      collectListArguments.add(ValueExpressions.getChar(logicalExpressions.getRootSegmentPath(),
+          DrillRelDataTypeSystem.DRILL_REL_DATATYPE_SYSTEM.getDefaultPrecision(SqlTypeName.VARCHAR)));
+      // adds field reference to the list
+      collectListArguments.add(FieldReference.getWithQuotedRef(logicalExpressions.getRootSegmentPath()));
+    }
+
+    LogicalExpression collectList = new FunctionCall("collect_list",
+        collectListArguments, ExpressionPosition.UNKNOWN);
+
+    valueExpressions.add(
+        new NamedExpression(collectList, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD)));
+  }
+
+  /**
+   * Adds {@code merge_schema(`schema`)}} function call to obtain schema common for underlying metadata parts.
+   */
+  private void addMergeSchemaCall() {
+    LogicalExpression schemaExpr = new FunctionCall("merge_schema",
+        Collections.singletonList(FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.SCHEMA_FIELD)),
+        ExpressionPosition.UNKNOWN);
+
+    valueExpressions.add(new NamedExpression(schemaExpr, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.SCHEMA_FIELD)));
+  }
+
+  /**
+   * Adds {@code collect_to_list_varchar(`fqn`)} call to collect file paths into the list.
+   */
+  private void addNewMetadataAggregations() {
+    LogicalExpression locationsExpr = new FunctionCall("collect_to_list_varchar",
+        Collections.singletonList(SchemaPath.getSimplePath(context.getOptions().getString(ExecConstants.IMPLICIT_FQN_COLUMN_LABEL))),
+        ExpressionPosition.UNKNOWN);
+
+    valueExpressions.add(new NamedExpression(locationsExpr, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.LOCATIONS_FIELD)));
+  }
+
+  /**
+   * Adds a call to {@code schema()}} function with specified fields list
+   * as arguments of this function to obtain their schema.
+   *
+   * @param fieldsList list of the function arguments
+   */
+  private void addSchemaCall(List<LogicalExpression> fieldsList) {
+    LogicalExpression schemaExpr = new FunctionCall("schema",
+        fieldsList, ExpressionPosition.UNKNOWN);
+
+    valueExpressions.add(new NamedExpression(schemaExpr, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.SCHEMA_FIELD)));
+  }
+
+  /**
+   * Adds aggregate calls to calculate non-column metadata.
+   */
+  private void addMetadataAggregateCalls() {
+    AnalyzeColumnUtils.META_STATISTICS_FUNCTIONS.forEach((statisticsKind, sqlKind) -> {
+      LogicalExpression call = new FunctionCall(sqlKind.name(),
+          Collections.singletonList(ValueExpressions.getBigInt(1)), ExpressionPosition.UNKNOWN);
+      valueExpressions.add(
+          new NamedExpression(call,
+              FieldReference.getWithQuotedRef(AnalyzeColumnUtils.getMetadataStatisticsFieldName(statisticsKind))));
+    });
+  }
+
+  /**
+   * Returns map with field names as keys and field references as values. For the case when field is map,
+   * fully qualified child names will be present in this map.
+   * For example, for (a{b, c}, d) fields list will be returned map with a.b, a.c and d keys.
+   *
+   * @param fields       list of top-level fields to unflatten if required
+   * @param parentFields list of parent name segments
+   * @return map with field names as keys and field references as values
+   */
+  private Map<String, FieldReference> getUnflattenedFileds(Collection<MaterializedField> fields, List<String> parentFields) {
+    Map<String, FieldReference> fieldNameRefMap = new HashMap<>();
+    for (MaterializedField field : fields) {
+      // statistics collecting is not supported for array types
+      if (field.getType().getMode() != TypeProtos.DataMode.REPEATED) {
+        MetadataAggPOP popConfig = (MetadataAggPOP) this.popConfig;
+        List<SchemaPath> excludedColumns = popConfig.getContext().excludedColumns();
+        // excludedColumns are applied for root fields only
+        if (parentFields != null || !excludedColumns.contains(SchemaPath.getSimplePath(field.getName()))) {
+          List<String> currentPath;
+          if (parentFields == null) {
+            currentPath = Collections.singletonList(field.getName());
+          } else {
+            currentPath = new ArrayList<>(parentFields);
+            currentPath.add(field.getName());
+          }
+          if (field.getType().getMinorType() == TypeProtos.MinorType.MAP && popConfig.getContext().createNewAggregations()) {
+            fieldNameRefMap.putAll(getUnflattenedFileds(field.getChildren(), currentPath));
+          } else {
+            SchemaPath schemaPath = SchemaPath.getCompoundPath(currentPath.toArray(new String[0]));
+            // adds backticks for popConfig.createNewAggregations() to ensure that field will be parsed correctly
+            String name = popConfig.getContext().createNewAggregations() ? schemaPath.toExpr() : schemaPath.getRootSegmentPath();
+            fieldNameRefMap.put(name, new FieldReference(schemaPath));
+          }
+        }
+      }
+    }
+
+    return fieldNameRefMap;
+  }
+
+  /**
+   * Adds aggregate calls to calculate column metadata either from column data itself
+   * or from previously calculated metadata.
+   *
+   * @param fieldRef  field reference
+   * @param fieldName field name
+   */
+  private void addColumnAggregateCalls(FieldReference fieldRef, String fieldName) {
+    MetadataAggPOP popConfig = (MetadataAggPOP) this.popConfig;
+    List<SchemaPath> interestingColumns = popConfig.getContext().interestingColumns();
+    if (popConfig.getContext().createNewAggregations()) {
+      if (interestingColumns == null || interestingColumns.contains(fieldRef)) {
+        // collect statistics for all or only interesting columns if they are specified
+        AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.forEach((statisticsKind, sqlKind) -> {
+          LogicalExpression call = new FunctionCall(sqlKind.name(),
+              Collections.singletonList(fieldRef), ExpressionPosition.UNKNOWN);
+          valueExpressions.add(
+              new NamedExpression(call,
+                  FieldReference.getWithQuotedRef(AnalyzeColumnUtils.getColumnStatisticsFieldName(fieldName, statisticsKind))));
+        });
+      }
+    } else if (AnalyzeColumnUtils.isColumnStatisticsField(fieldName)
+        || AnalyzeColumnUtils.isMetadataStatisticsField(fieldName)) {
+      SqlKind function = AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.get(
+          AnalyzeColumnUtils.getStatisticsKind(fieldName));
+      if (function == SqlKind.COUNT) {
+        // for the case when aggregation was done, call SUM function for the results of COUNT aggregate call
+        function = SqlKind.SUM;
+      }
+      LogicalExpression functionCall = new FunctionCall(function.name(),
+          Collections.singletonList(fieldRef), ExpressionPosition.UNKNOWN);
+      valueExpressions.add(new NamedExpression(functionCall, fieldRef));
+    }
+  }
+
+  @Override
+  protected List<NamedExpression> getValueExpressions() {
+    return valueExpressions;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggBatchCreator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.config.MetadataAggPOP;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class MetadataAggBatchCreator implements BatchCreator<MetadataAggPOP> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+      MetadataAggPOP config, List<RecordBatch> children) throws ExecutionSetupException {
+    Preconditions.checkArgument(children.size() == 1);
+    return new MetadataAggBatch(config, children.iterator().next(), context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
@@ -1,0 +1,760 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.metastore.analyze.AnalyzeColumnUtils;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.physical.config.MetadataControllerPOP;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.planner.physical.WriterPrel;
+import org.apache.drill.exec.metastore.analyze.MetadataIdentifierUtils;
+import org.apache.drill.exec.record.AbstractBinaryRecordBatch;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
+import org.apache.drill.exec.store.StatisticsRecordCollector;
+import org.apache.drill.exec.store.StatisticsRecordWriterImpl;
+import org.apache.drill.exec.store.easy.json.StatisticsCollectorImpl;
+import org.apache.drill.exec.store.parquet.ParquetTableMetadataUtils;
+import org.apache.drill.exec.vector.BitVector;
+import org.apache.drill.exec.vector.VarCharVector;
+import org.apache.drill.exec.vector.accessor.ArrayReader;
+import org.apache.drill.exec.vector.accessor.ObjectReader;
+import org.apache.drill.exec.vector.accessor.ObjectType;
+import org.apache.drill.exec.vector.accessor.TupleReader;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.components.tables.TableMetadataUnit;
+import org.apache.drill.metastore.components.tables.Tables;
+import org.apache.drill.metastore.expressions.FilterExpression;
+import org.apache.drill.metastore.metadata.BaseMetadata;
+import org.apache.drill.metastore.metadata.BaseTableMetadata;
+import org.apache.drill.metastore.metadata.FileMetadata;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.PartitionMetadata;
+import org.apache.drill.metastore.metadata.RowGroupMetadata;
+import org.apache.drill.metastore.metadata.SegmentMetadata;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.operate.Modify;
+import org.apache.drill.metastore.statistics.BaseStatisticsKind;
+import org.apache.drill.metastore.statistics.ColumnStatistics;
+import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
+import org.apache.drill.metastore.statistics.ExactStatisticsConstants;
+import org.apache.drill.metastore.statistics.StatisticsHolder;
+import org.apache.drill.metastore.statistics.StatisticsKind;
+import org.apache.drill.metastore.statistics.TableStatisticsKind;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Terminal operator for producing ANALYZE statement. This operator is responsible for converting
+ * obtained metadata, fetching absent metadata from the Metastore and storing resulting metadata into the Metastore.
+ * <p>
+ * This operator has two inputs: left input contains metadata and right input contains statistics metadata.
+ */
+public class MetadataControllerBatch extends AbstractBinaryRecordBatch<MetadataControllerPOP> {
+  private static final Logger logger = LoggerFactory.getLogger(MetadataControllerBatch.class);
+
+  private final Tables tables;
+  private final TableInfo tableInfo;
+  private final Map<String, MetadataInfo> metadataToHandle;
+  private final StatisticsRecordCollector statisticsCollector;
+  private final List<TableMetadataUnit> metadataUnits;
+
+  private boolean firstLeft = true;
+  private boolean firstRight = true;
+  private boolean finished = false;
+  private boolean finishedRight = false;
+  private int recordCount = 0;
+
+  protected MetadataControllerBatch(MetadataControllerPOP popConfig,
+      FragmentContext context, RecordBatch left, RecordBatch right) throws OutOfMemoryException {
+    super(popConfig, context, false, left, right);
+    this.tables = context.getMetastoreRegistry().get().tables();
+    this.tableInfo = popConfig.getContext().tableInfo();
+    this.metadataToHandle = popConfig.getContext().metadataToHandle() == null
+        ? null
+        : popConfig.getContext().metadataToHandle().stream()
+            .collect(Collectors.toMap(MetadataInfo::identifier, Function.identity()));
+    this.metadataUnits = new ArrayList<>();
+    this.statisticsCollector = new StatisticsCollectorImpl();
+  }
+
+  protected boolean setupNewSchema() {
+    container.clear();
+
+    container.addOrGet(MetastoreAnalyzeConstants.OK_FIELD_NAME, Types.required(TypeProtos.MinorType.BIT), null);
+    container.addOrGet(MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME, Types.required(TypeProtos.MinorType.VARCHAR), null);
+
+    container.buildSchema(BatchSchema.SelectionVectorMode.NONE);
+
+    return true;
+  }
+
+  @Override
+  public IterOutcome innerNext() {
+    IterOutcome outcome;
+    boolean finishedLeft;
+    if (finished) {
+      return IterOutcome.NONE;
+    }
+
+    if (!finishedRight) {
+      outcome = handleRightIncoming();
+      if (outcome != null) {
+        return outcome;
+      }
+    }
+
+    outer:
+    while (true) {
+      outcome = next(0, left);
+      switch (outcome) {
+        case NONE:
+          // all incoming data was processed when returned OK_NEW_SCHEMA
+          finishedLeft = !firstLeft;
+          break outer;
+        case OUT_OF_MEMORY:
+        case NOT_YET:
+        case STOP:
+          return outcome;
+        case OK_NEW_SCHEMA:
+          if (firstLeft) {
+            firstLeft = false;
+            if (!setupNewSchema()) {
+              outcome = IterOutcome.OK;
+            }
+            IterOutcome out = handleLeftIncoming();
+            if (out != IterOutcome.OK) {
+              return out;
+            }
+            return outcome;
+          }
+          //fall through
+        case OK:
+          assert !firstLeft : "First batch should be OK_NEW_SCHEMA";
+          IterOutcome out = handleLeftIncoming();
+          if (out != IterOutcome.OK) {
+            return out;
+          }
+          break;
+        default:
+          context.getExecutorState()
+              .fail(new UnsupportedOperationException("Unsupported upstream state " + outcome));
+          close();
+          killIncoming(false);
+          return IterOutcome.STOP;
+      }
+    }
+
+    if (finishedLeft) {
+      IterOutcome out = writeToMetastore();
+      finished = true;
+      return out;
+    }
+    return outcome;
+  }
+
+  private IterOutcome handleRightIncoming() {
+    IterOutcome outcome;
+    outer:
+    while (true) {
+      outcome = next(0, right);
+      switch (outcome) {
+        case NONE:
+          // all incoming data was processed
+          finishedRight = true;
+          break outer;
+        case OUT_OF_MEMORY:
+        case NOT_YET:
+        case STOP:
+          return outcome;
+        case OK_NEW_SCHEMA:
+          firstRight = false;
+          //fall through
+        case OK:
+          assert !firstRight : "First batch should be OK_NEW_SCHEMA";
+          try {
+            appendStatistics(statisticsCollector);
+          } catch (IOException e) {
+            context.getExecutorState().fail(e);
+            close();
+            killIncoming(false);
+            return IterOutcome.STOP;
+          }
+          break;
+        default:
+          context.getExecutorState()
+              .fail(new UnsupportedOperationException("Unsupported upstream state " + outcome));
+          close();
+          killIncoming(false);
+          return IterOutcome.STOP;
+      }
+    }
+    return null;
+  }
+
+  private IterOutcome handleLeftIncoming() {
+    try {
+      metadataUnits.addAll(getMetadataUnits(left.getContainer()));
+    } catch (Exception e) {
+      context.getExecutorState().fail(e);
+      close();
+      killIncoming(false);
+      return IterOutcome.STOP;
+    }
+    return IterOutcome.OK;
+  }
+
+  private IterOutcome writeToMetastore() {
+    FilterExpression deleteFilter = popConfig.getContext().tableInfo().toFilter();
+
+    for (MetadataInfo metadataInfo : popConfig.getContext().metadataToRemove()) {
+      deleteFilter = FilterExpression.and(deleteFilter,
+          FilterExpression.equal(MetadataInfo.METADATA_KEY, metadataInfo.key()));
+    }
+
+    Modify<TableMetadataUnit> modify = tables.modify();
+    if (!popConfig.getContext().metadataToRemove().isEmpty()) {
+      modify.delete(deleteFilter);
+    }
+
+    MetastoreTableInfo metastoreTableInfo = popConfig.getContext().metastoreTableInfo();
+
+    if (tables.basicRequests().hasMetastoreTableInfoChanged(metastoreTableInfo)) {
+      context.getExecutorState()
+          .fail(new IllegalStateException(String.format("Metadata for table [%s] was changed before analyze is finished", tableInfo.name())));
+      close();
+      killIncoming(false);
+      return IterOutcome.STOP;
+    }
+
+    modify.overwrite(metadataUnits)
+        .execute();
+
+    BitVector bitVector =
+        container.addOrGet(MetastoreAnalyzeConstants.OK_FIELD_NAME, Types.required(TypeProtos.MinorType.BIT), null);
+    VarCharVector varCharVector =
+        container.addOrGet(MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME, Types.required(TypeProtos.MinorType.VARCHAR), null);
+
+    bitVector.allocateNew();
+    varCharVector.allocateNew();
+
+    bitVector.getMutator().set(0, 1);
+    varCharVector.getMutator().setSafe(0,
+        String.format("Collected / refreshed metadata for table [%s.%s.%s]",
+            popConfig.getContext().tableInfo().storagePlugin(),
+            popConfig.getContext().tableInfo().workspace(),
+            popConfig.getContext().tableInfo().name()).getBytes());
+
+    bitVector.getMutator().setValueCount(1);
+    varCharVector.getMutator().setValueCount(1);
+    container.setRecordCount(++recordCount);
+
+    return IterOutcome.OK;
+  }
+
+  private List<TableMetadataUnit> getMetadataUnits(VectorContainer container) {
+    List<TableMetadataUnit> metadataUnits = new ArrayList<>();
+    RowSetReader reader = DirectRowSet.fromContainer(container).reader();
+    while (reader.next()) {
+      metadataUnits.addAll(getMetadataUnits(reader, 0));
+    }
+
+    if (!metadataToHandle.isEmpty()) {
+      // leaves only table metadata and metadata which belongs to segments to be overridden
+      metadataUnits = metadataUnits.stream()
+          .filter(tableMetadataUnit ->
+              metadataToHandle.values().stream()
+                  .map(MetadataInfo::key)
+                  .anyMatch(s -> s.equals(tableMetadataUnit.metadataKey()))
+              || MetadataType.TABLE.name().equals(tableMetadataUnit.metadataType()))
+          .collect(Collectors.toList());
+
+      // leaves only metadata which should be fetched from the Metastore
+      metadataUnits.stream()
+          .map(TableMetadataUnit::metadataIdentifier)
+          .forEach(metadataToHandle::remove);
+
+      List<TableMetadataUnit> metadata = metadataToHandle.isEmpty()
+          ? Collections.emptyList()
+          : tables.basicRequests().metadata(popConfig.getContext().tableInfo(), metadataToHandle.values());
+
+      metadataUnits.addAll(metadata);
+    }
+
+    boolean insertDefaultSegment = metadataUnits.stream()
+        .noneMatch(metadataUnit -> metadataUnit.metadataType().equals(MetadataType.SEGMENT.name()));
+
+    if (insertDefaultSegment) {
+      TableMetadataUnit defaultSegmentMetadata = getDefaultSegment(metadataUnits);
+      metadataUnits.add(defaultSegmentMetadata);
+    }
+
+    return metadataUnits;
+  }
+
+  private TableMetadataUnit getDefaultSegment(List<TableMetadataUnit> metadataUnits) {
+    TableMetadataUnit tableMetadataUnit = metadataUnits.stream()
+        .filter(metadataUnit -> metadataUnit.metadataType().equals(MetadataType.TABLE.name()))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Table metadata wasn't found among collected metadata."));
+
+    List<String> paths = metadataUnits.stream()
+        .filter(metadataUnit -> metadataUnit.metadataType().equals(MetadataType.FILE.name()))
+        .map(TableMetadataUnit::path)
+        .collect(Collectors.toList());
+
+    return tableMetadataUnit.toBuilder()
+        .metadataType(MetadataType.SEGMENT.name())
+        .metadataKey(MetadataInfo.DEFAULT_SEGMENT_KEY)
+        .owner(null)
+        .tableType(null)
+        .metadataStatistics(Collections.emptyList())
+        .columnsStatistics(Collections.emptyMap())
+        .path(tableMetadataUnit.location())
+        .schema(null)
+        .locations(paths)
+        .build();
+  }
+
+  private List<TableMetadataUnit> getMetadataUnits(TupleReader reader, int nestingLevel) {
+    List<TableMetadataUnit> metadataUnits = new ArrayList<>();
+
+    TupleMetadata columnMetadata = reader.tupleSchema();
+    ObjectReader metadataColumnReader = reader.column(MetastoreAnalyzeConstants.METADATA_TYPE);
+    Preconditions.checkNotNull(metadataColumnReader, "metadataType column wasn't found");
+
+    ObjectReader underlyingMetadataReader = reader.column(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD);
+    if (underlyingMetadataReader != null) {
+      if (!underlyingMetadataReader.schema().isArray()) {
+        throw new IllegalStateException("Incoming vector with name `collected_map` should be repeated map");
+      }
+      // current row contains information about underlying metadata
+      ArrayReader array = underlyingMetadataReader.array();
+      while (array.next()) {
+        metadataUnits.addAll(getMetadataUnits(array.tuple(), nestingLevel + 1));
+      }
+    }
+
+    List<StatisticsHolder> metadataStatistics = getMetadataStatistics(reader, columnMetadata);
+
+    Long rowCount = (Long) metadataStatistics.stream()
+        .filter(statisticsHolder -> statisticsHolder.getStatisticsKind() == TableStatisticsKind.ROW_COUNT)
+        .findAny()
+        .map(StatisticsHolder::getStatisticsValue)
+        .orElse(null);
+
+    Map<SchemaPath, ColumnStatistics> columnStatistics = getColumnStatistics(reader, columnMetadata, rowCount);
+
+    MetadataType metadataType = MetadataType.valueOf(metadataColumnReader.scalar().getString());
+
+    BaseMetadata metadata;
+
+    switch (metadataType) {
+      case TABLE: {
+        metadata = getTableMetadata(reader, metadataStatistics, columnStatistics);
+        break;
+      }
+      case SEGMENT: {
+        metadata = getSegmentMetadata(reader, metadataStatistics, columnStatistics, nestingLevel);
+        break;
+      }
+      case PARTITION: {
+        metadata = getPartitionMetadata(reader, metadataStatistics, columnStatistics, nestingLevel);
+        break;
+      }
+      case FILE: {
+        metadata = getFileMetadata(reader, metadataStatistics, columnStatistics, nestingLevel);
+        break;
+      }
+      case ROW_GROUP: {
+        metadata = getRowGroupMetadata(reader, metadataStatistics, columnStatistics, nestingLevel);
+        break;
+      }
+      default:
+        throw new UnsupportedOperationException("Unsupported metadata type: " + metadataType);
+    }
+    metadataUnits.add(metadata.toMetadataUnit());
+
+    return metadataUnits;
+  }
+
+  private PartitionMetadata getPartitionMetadata(TupleReader reader, List<StatisticsHolder> metadataStatistics,
+      Map<SchemaPath, ColumnStatistics> columnStatistics, int nestingLevel) {
+    List<String> segmentColumns = popConfig.getContext().segmentColumns();
+    String lastModifiedTimeCol = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+
+    String segmentKey = segmentColumns.size() > 0
+        ? reader.column(segmentColumns.iterator().next()).scalar().getString()
+        : MetadataInfo.DEFAULT_SEGMENT_KEY;
+
+    List<String> partitionValues = segmentColumns.stream()
+        .limit(nestingLevel)
+        .map(columnName -> reader.column(columnName).scalar().getString())
+        .collect(Collectors.toList());
+    String metadataIdentifier = MetadataIdentifierUtils.getMetadataIdentifierKey(partitionValues);
+    MetadataInfo metadataInfo = MetadataInfo.builder()
+        .type(MetadataType.PARTITION)
+        .key(segmentKey)
+        .identifier(StringUtils.defaultIfEmpty(metadataIdentifier, null))
+        .build();
+    return PartitionMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(metadataStatistics)
+        .locations(getIncomingLocations(reader))
+        .lastModifiedTime(Long.parseLong(reader.column(lastModifiedTimeCol).scalar().getString()))
+//            .column(SchemaPath.getSimplePath("dir1"))
+//            .partitionValues()
+        .schema(TupleMetadata.of(reader.column(MetastoreAnalyzeConstants.SCHEMA_FIELD).scalar().getString()))
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private BaseTableMetadata getTableMetadata(TupleReader reader, List<StatisticsHolder> metadataStatistics,
+      Map<SchemaPath, ColumnStatistics> columnStatistics) {
+    String lastModifiedTimeCol = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+    List<StatisticsHolder> updatedMetaStats = new ArrayList<>(metadataStatistics);
+    updatedMetaStats.add(new StatisticsHolder(popConfig.getContext().analyzeMetadataLevel(), TableStatisticsKind.ANALYZE_METADATA_LEVEL));
+
+    MetadataInfo metadataInfo = MetadataInfo.builder()
+        .type(MetadataType.TABLE)
+        .key(MetadataInfo.GENERAL_INFO_KEY)
+        .build();
+
+    BaseTableMetadata tableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(updatedMetaStats)
+        .partitionKeys(Collections.emptyMap())
+        .interestingColumns(popConfig.getContext().interestingColumns())
+        .location(popConfig.getContext().location())
+        .lastModifiedTime(Long.parseLong(reader.column(lastModifiedTimeCol).scalar().getString()))
+        .schema(TupleMetadata.of(reader.column(MetastoreAnalyzeConstants.SCHEMA_FIELD).scalar().getString()))
+        .build();
+
+    if (context.getOptions().getOption(PlannerSettings.STATISTICS_USE)) {
+      DrillStatsTable statistics = new DrillStatsTable(statisticsCollector.getStatistics());
+      Map<SchemaPath, ColumnStatistics> tableColumnStatistics =
+          ParquetTableMetadataUtils.getColumnStatistics(tableMetadata.getSchema(), statistics);
+      tableMetadata = tableMetadata.cloneWithStats(tableColumnStatistics, DrillStatsTable.getEstimatedTableStats(statistics));
+    }
+
+    return tableMetadata;
+  }
+
+  private SegmentMetadata getSegmentMetadata(TupleReader reader, List<StatisticsHolder> metadataStatistics,
+      Map<SchemaPath, ColumnStatistics> columnStatistics, int nestingLevel) {
+    List<String> segmentColumns = popConfig.getContext().segmentColumns();
+    String lastModifiedTimeCol = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+
+    String segmentKey = segmentColumns.size() > 0
+        ? reader.column(segmentColumns.iterator().next()).scalar().getString()
+        : MetadataInfo.DEFAULT_SEGMENT_KEY;
+
+    List<String> partitionValues = segmentColumns.stream()
+        .limit(nestingLevel)
+        .map(columnName -> reader.column(columnName).scalar().getString())
+        .collect(Collectors.toList());
+    String metadataIdentifier = MetadataIdentifierUtils.getMetadataIdentifierKey(partitionValues);
+
+    MetadataInfo metadataInfo = MetadataInfo.builder()
+        .type(MetadataType.SEGMENT)
+        .key(segmentKey)
+        .identifier(StringUtils.defaultIfEmpty(metadataIdentifier, null))
+        .build();
+
+    return SegmentMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(metadataStatistics)
+        .path(new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString()))
+        .locations(getIncomingLocations(reader))
+        .column(segmentColumns.size() > 0 ? SchemaPath.getSimplePath(segmentColumns.get(nestingLevel - 1)) : null)
+        .partitionValues(partitionValues)
+        .lastModifiedTime(Long.parseLong(reader.column(lastModifiedTimeCol).scalar().getString()))
+        .schema(TupleMetadata.of(reader.column(MetastoreAnalyzeConstants.SCHEMA_FIELD).scalar().getString()))
+        .build();
+  }
+
+  private FileMetadata getFileMetadata(TupleReader reader, List<StatisticsHolder> metadataStatistics,
+      Map<SchemaPath, ColumnStatistics> columnStatistics, int nestingLevel) {
+    List<String> segmentColumns = popConfig.getContext().segmentColumns();
+    String lastModifiedTimeCol = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+
+    String segmentKey = segmentColumns.size() > 0
+        ? reader.column(segmentColumns.iterator().next()).scalar().getString()
+        : MetadataInfo.DEFAULT_SEGMENT_KEY;
+
+    List<String> partitionValues = segmentColumns.stream()
+        .limit(nestingLevel - 1)
+        .map(columnName -> reader.column(columnName).scalar().getString())
+        .collect(Collectors.toList());
+
+    Path path = new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString());
+    String metadataIdentifier = MetadataIdentifierUtils.getFileMetadataIdentifier(partitionValues, path);
+
+    MetadataInfo metadataInfo = MetadataInfo.builder()
+        .type(MetadataType.FILE)
+        .key(segmentKey)
+        .identifier(StringUtils.defaultIfEmpty(metadataIdentifier, null))
+        .build();
+
+    return FileMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(metadataStatistics)
+        .path(path)
+        .lastModifiedTime(Long.parseLong(reader.column(lastModifiedTimeCol).scalar().getString()))
+        .schema(TupleMetadata.of(reader.column(MetastoreAnalyzeConstants.SCHEMA_FIELD).scalar().getString()))
+        .build();
+  }
+
+  private RowGroupMetadata getRowGroupMetadata(TupleReader reader,List<StatisticsHolder> metadataStatistics,
+      Map<SchemaPath, ColumnStatistics> columnStatistics, int nestingLevel) {
+    String lastModifiedTimeCol = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+    String rgi = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL);
+
+    List<String> segmentColumns = popConfig.getContext().segmentColumns();
+    String segmentKey = segmentColumns.size() > 0
+        ? reader.column(segmentColumns.iterator().next()).scalar().getString()
+        : MetadataInfo.DEFAULT_SEGMENT_KEY;
+
+    List<String> partitionValues = segmentColumns.stream()
+        .limit(nestingLevel - 2)
+        .map(columnName -> reader.column(columnName).scalar().getString())
+        .collect(Collectors.toList());
+
+    Path path = new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString());
+
+    int rowGroupIndex = Integer.parseInt(reader.column(rgi).scalar().getString());
+
+    String metadataIdentifier = MetadataIdentifierUtils.getRowGroupMetadataIdentifier(partitionValues, path, rowGroupIndex);
+
+    MetadataInfo metadataInfo = MetadataInfo.builder()
+        .type(MetadataType.ROW_GROUP)
+        .key(segmentKey)
+        .identifier(StringUtils.defaultIfEmpty(metadataIdentifier, null))
+        .build();
+
+    return RowGroupMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(metadataStatistics)
+        .hostAffinity(Collections.emptyMap())
+        .rowGroupIndex(rowGroupIndex)
+        .path(path)
+        .lastModifiedTime(Long.parseLong(reader.column(lastModifiedTimeCol).scalar().getString()))
+        .schema(TupleMetadata.of(reader.column(MetastoreAnalyzeConstants.SCHEMA_FIELD).scalar().getString()))
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<SchemaPath, ColumnStatistics> getColumnStatistics(TupleReader reader, TupleMetadata columnMetadata, Long rowCount) {
+    Multimap<String, StatisticsHolder> columnStatistics = ArrayListMultimap.create();
+    Map<String, TypeProtos.MinorType> columnTypes = new HashMap<>();
+    for (ColumnMetadata column : columnMetadata) {
+      String fieldName = AnalyzeColumnUtils.getColumnName(column.name());
+
+      if (AnalyzeColumnUtils.isColumnStatisticsField(column.name())) {
+        StatisticsKind statisticsKind = AnalyzeColumnUtils.getStatisticsKind(column.name());
+        columnStatistics.put(fieldName,
+            new StatisticsHolder(getConvertedColumnValue(reader.column(column.name())), statisticsKind));
+        if (statisticsKind.getName().equalsIgnoreCase(ColumnStatisticsKind.MIN_VALUE.getName())
+            || statisticsKind.getName().equalsIgnoreCase(ColumnStatisticsKind.MAX_VALUE.getName())) {
+          columnTypes.putIfAbsent(fieldName, column.type());
+        }
+      }
+    }
+
+    // adds NON_NULL_COUNT to use it during filter pushdown
+    if (rowCount != null) {
+      Map<String, StatisticsHolder> nullsCountColumnStatistics = new HashMap<>();
+      columnStatistics.asMap().forEach((key, value) ->
+          value.stream()
+              .filter(statisticsHolder -> statisticsHolder.getStatisticsKind() == ColumnStatisticsKind.NON_NULL_COUNT)
+              .findAny()
+              .map(statisticsHolder -> (Long) statisticsHolder.getStatisticsValue())
+              .ifPresent(nonNullCount ->
+                  nullsCountColumnStatistics.put(
+                      key,
+                      new StatisticsHolder(rowCount - nonNullCount, ColumnStatisticsKind.NULLS_COUNT))));
+
+      nullsCountColumnStatistics.forEach(columnStatistics::put);
+    }
+
+    Map<SchemaPath, ColumnStatistics> resultingStats = new HashMap<>();
+
+    columnStatistics.asMap().forEach((fieldName, statisticsHolders) ->
+        resultingStats.put(SchemaPath.parseFromString(fieldName), new ColumnStatistics(statisticsHolders, columnTypes.get(fieldName))));
+    return resultingStats;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<StatisticsHolder> getMetadataStatistics(TupleReader reader, TupleMetadata columnMetadata) {
+    List<StatisticsHolder> metadataStatistics = new ArrayList<>();
+    String rgs = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL);
+    String rgl = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL);
+    for (ColumnMetadata column : columnMetadata) {
+      String columnName = column.name();
+      if (AnalyzeColumnUtils.isMetadataStatisticsField(columnName)) {
+        metadataStatistics.add(new StatisticsHolder(reader.column(columnName).getObject(),
+            AnalyzeColumnUtils.getStatisticsKind(columnName)));
+      } else if (columnName.equals(rgs)) {
+        metadataStatistics.add(new StatisticsHolder(Long.parseLong(reader.column(columnName).scalar().getString()),
+            new BaseStatisticsKind(ExactStatisticsConstants.START, true)));
+      } else if (columnName.equals(rgl)) {
+        metadataStatistics.add(new StatisticsHolder(Long.parseLong(reader.column(columnName).scalar().getString()),
+            new BaseStatisticsKind(ExactStatisticsConstants.LENGTH, true)));
+      }
+    }
+    return metadataStatistics;
+  }
+
+  private void appendStatistics(StatisticsRecordCollector statisticsCollector) throws IOException {
+    if (context.getOptions().getOption(PlannerSettings.STATISTICS_USE)) {
+      List<FieldConverter> fieldConverters = new ArrayList<>();
+      int fieldId = 0;
+
+      for (VectorWrapper wrapper : right) {
+        if (wrapper.getField().getName().equalsIgnoreCase(WriterPrel.PARTITION_COMPARATOR_FIELD)) {
+          continue;
+        }
+        FieldReader reader = wrapper.getValueVector().getReader();
+        FieldConverter converter =
+            StatisticsRecordWriterImpl.getConverter(statisticsCollector, fieldId++, wrapper.getField().getName(), reader);
+        fieldConverters.add(converter);
+      }
+
+      for (int counter = 0; counter < right.getRecordCount(); counter++) {
+        statisticsCollector.startStatisticsRecord();
+        // write the current record
+        for (FieldConverter converter : fieldConverters) {
+          converter.setPosition(counter);
+          converter.startField();
+          converter.writeField();
+          converter.endField();
+        }
+        statisticsCollector.endStatisticsRecord();
+      }
+    }
+  }
+
+  private Object getConvertedColumnValue(ObjectReader objectReader) {
+    switch (objectReader.schema().type()) {
+      case VARBINARY:
+      case FIXEDBINARY:
+        return new String(objectReader.scalar().getBytes());
+      default:
+        return objectReader.getObject();
+    }
+
+  }
+
+  private Set<Path> getIncomingLocations(TupleReader reader) {
+    Set<Path> childLocations = new HashSet<>();
+
+    ObjectReader metadataColumnReader = reader.column(MetastoreAnalyzeConstants.METADATA_TYPE);
+    Preconditions.checkNotNull(metadataColumnReader, "metadataType column wasn't found");
+
+    MetadataType metadataType = MetadataType.valueOf(metadataColumnReader.scalar().getString());
+
+    switch (metadataType) {
+      case SEGMENT:
+      case PARTITION: {
+        ObjectReader locationsReader = reader.column(MetastoreAnalyzeConstants.LOCATIONS_FIELD);
+        // populate list of file locations from "locations" field if it is present in the schema
+        if (locationsReader != null && locationsReader.type() == ObjectType.ARRAY) {
+          ArrayReader array = locationsReader.array();
+          while (array.next()) {
+            childLocations.add(new Path(array.scalar().getString()));
+          }
+          break;
+        }
+        // in the opposite case, populate list of file locations using underlying metadata
+        ObjectReader underlyingMetadataReader = reader.column(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD);
+        if (underlyingMetadataReader != null) {
+          // current row contains information about underlying metadata
+          ArrayReader array = underlyingMetadataReader.array();
+          array.rewind();
+          while (array.next()) {
+            childLocations.addAll(getIncomingLocations(array.tuple()));
+          }
+        }
+        break;
+      }
+      case FILE: {
+        childLocations.add(new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString()));
+      }
+    }
+
+    return childLocations;
+  }
+
+  @Override
+  protected void killIncoming(boolean sendUpstream) {
+    left.kill(sendUpstream);
+    right.kill(sendUpstream);
+  }
+
+  @Override
+  public void dump() {
+    logger.error("MetadataHandlerBatch[container={}, popConfig={}]", container, popConfig);
+  }
+
+  @Override
+  public int getRecordCount() {
+    return recordCount;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatchCreator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.config.MetadataControllerPOP;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public class MetadataControllerBatchCreator implements BatchCreator<MetadataControllerPOP> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+      MetadataControllerPOP config, List<RecordBatch> children) throws ExecutionSetupException {
+    Preconditions.checkArgument(children.size() == 2);
+    return new MetadataControllerBatch(config, context, children.get(0), children.get(1));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.physical.config.MetadataHandlerPOP;
+import org.apache.drill.exec.metastore.analyze.AnalyzeColumnUtils;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.OptionBuilder;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.exec.metastore.analyze.MetadataIdentifierUtils;
+import org.apache.drill.exec.record.AbstractSingleRecordBatch;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.vector.VarCharVector;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.components.tables.Tables;
+import org.apache.drill.metastore.metadata.BaseMetadata;
+import org.apache.drill.metastore.metadata.FileMetadata;
+import org.apache.drill.metastore.metadata.LocationProvider;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.RowGroupMetadata;
+import org.apache.drill.metastore.metadata.SegmentMetadata;
+import org.apache.drill.metastore.statistics.ExactStatisticsConstants;
+import org.apache.drill.metastore.statistics.StatisticsKind;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
+import static org.apache.drill.exec.record.RecordBatch.IterOutcome.STOP;
+
+/**
+ * Operator responsible for handling metadata returned by incoming aggregate operators and fetching
+ * required metadata form the Metastore.
+ */
+public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHandlerPOP> {
+  private static final Logger logger = LoggerFactory.getLogger(MetadataHandlerBatch.class);
+
+  private final Tables tables;
+  private final MetadataType metadataType;
+  private final Map<String, MetadataInfo> metadataToHandle;
+
+  private boolean firstBatch = true;
+
+  protected MetadataHandlerBatch(MetadataHandlerPOP popConfig,
+      FragmentContext context, RecordBatch incoming) throws OutOfMemoryException {
+    super(popConfig, context, incoming);
+    this.tables = context.getMetastoreRegistry().get().tables();
+    this.metadataType = popConfig.getContext().metadataType();
+    this.metadataToHandle = popConfig.getContext().metadataToHandle() != null
+        ? popConfig.getContext().metadataToHandle().stream()
+            .collect(Collectors.toMap(MetadataInfo::identifier, Function.identity()))
+        : null;
+  }
+
+  @Override
+  public IterOutcome doWork() {
+    // 1. Consume data from incoming operators and update metadataToHandle to remove incoming metadata
+    // 2. For the case when incoming operator returned nothing - no updated underlying metadata was found.
+    // 3. Fetches metadata which should be handled but wasn't returned by incoming batch from the Metastore
+
+    IterOutcome outcome = next(incoming);
+
+    switch (outcome) {
+      case NONE:
+        if (firstBatch) {
+          Preconditions.checkState(metadataToHandle.isEmpty(),
+              "Incoming batch didn't return the result for modified segments");
+        }
+        return outcome;
+      case OK_NEW_SCHEMA:
+        if (firstBatch) {
+          firstBatch = false;
+          if (!setupNewSchema()) {
+            outcome = IterOutcome.OK;
+          }
+        }
+        doWorkInternal();
+        return outcome;
+      case OK:
+        assert !firstBatch : "First batch should be OK_NEW_SCHEMA";
+        doWorkInternal();
+        // fall thru
+      case OUT_OF_MEMORY:
+      case NOT_YET:
+      case STOP:
+        return outcome;
+      default:
+        context.getExecutorState()
+            .fail(new UnsupportedOperationException("Unsupported upstream state " + outcome));
+        close();
+        killIncoming(false);
+        return IterOutcome.STOP;
+    }
+  }
+
+  @Override
+  public IterOutcome innerNext() {
+    IterOutcome outcome = getLastKnownOutcome();
+    if (outcome != NONE && outcome != STOP) {
+      outcome = super.innerNext();
+    }
+    // if incoming is exhausted, reads metadata which should be obtained from the Metastore
+    // and returns OK or NONE if there is no metadata to read
+    if (outcome == IterOutcome.NONE && !metadataToHandle.isEmpty()) {
+      BasicTablesRequests basicTablesRequests = tables.basicRequests();
+
+      switch (metadataType) {
+        case ROW_GROUP: {
+          List<RowGroupMetadata> rowGroups =
+              basicTablesRequests.rowGroupsMetadata(
+                  popConfig.getContext().tableInfo(),
+                  new ArrayList<>(metadataToHandle.values()));
+          return populateContainer(rowGroups);
+        }
+        case FILE: {
+          List<FileMetadata> files =
+              basicTablesRequests.filesMetadata(
+                  popConfig.getContext().tableInfo(),
+                  new ArrayList<>(metadataToHandle.values()));
+          return populateContainer(files);
+        }
+        case SEGMENT: {
+          List<SegmentMetadata> segments =
+              basicTablesRequests.segmentsMetadata(
+                  popConfig.getContext().tableInfo(),
+                  new ArrayList<>(metadataToHandle.values()));
+          return populateContainer(segments);
+        }
+      }
+    }
+    return outcome;
+  }
+
+  private <T extends BaseMetadata & LocationProvider> IterOutcome populateContainer(List<T> metadata) {
+    VectorContainer populatedContainer;
+    if (firstBatch) {
+      populatedContainer = writeMetadata(metadata);
+      setupSchemaFromContainer(populatedContainer);
+    } else {
+      populatedContainer = writeMetadataUsingBatchSchema(metadata);
+    }
+    container.transferIn(populatedContainer);
+    container.setRecordCount(populatedContainer.getRecordCount());
+
+    if (firstBatch) {
+      firstBatch = false;
+      return IterOutcome.OK_NEW_SCHEMA;
+    } else {
+      return IterOutcome.OK;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends BaseMetadata & LocationProvider> VectorContainer writeMetadata(List<T> metadataList) {
+    BaseMetadata firstElement = metadataList.iterator().next();
+
+    ResultSetLoader resultSetLoader = getResultSetLoaderForMetadata(firstElement);
+    resultSetLoader.startBatch();
+    RowSetLoader rowWriter = resultSetLoader.writer();
+    Iterator<T> segmentsIterator = metadataList.iterator();
+    while (!rowWriter.isFull() && segmentsIterator.hasNext()) {
+      T metadata = segmentsIterator.next();
+      metadataToHandle.remove(metadata.getMetadataInfo().identifier());
+
+      List<Object> arguments = new ArrayList<>();
+      // adds required segment names to the arguments
+      arguments.add(metadata.getPath().toUri().getPath());
+      Collections.addAll(
+          arguments,
+          Arrays.copyOf(
+              MetadataIdentifierUtils.getValuesFromMetadataIdentifier(metadata.getMetadataInfo().identifier()),
+              popConfig.getContext().segmentColumns().size()));
+
+      // adds column statistics values assuming that they are sorted in alphabetic order
+      // (see getResultSetLoaderForMetadata() method)
+      metadata.getColumnsStatistics().entrySet().stream()
+          .sorted(Comparator.comparing(e -> e.getKey().toExpr()))
+          .map(Map.Entry::getValue)
+          .flatMap(columnStatistics ->
+              AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet().stream()
+                  .map(columnStatistics::get))
+          .forEach(arguments::add);
+
+      AnalyzeColumnUtils.META_STATISTICS_FUNCTIONS.keySet().stream()
+          .map(metadata::getStatistic)
+          .forEach(arguments::add);
+
+      // collectedMap field value
+      arguments.add(new Object[]{});
+
+      if (metadataType == MetadataType.SEGMENT) {
+        arguments.add(((SegmentMetadata) metadata).getLocations().stream()
+            .map(path -> path.toUri().getPath())
+            .toArray(String[]::new));
+      }
+
+      if (metadataType == MetadataType.ROW_GROUP) {
+        arguments.add(String.valueOf(((RowGroupMetadata) metadata).getRowGroupIndex()));
+        arguments.add(Long.toString(metadata.getStatistic(() -> ExactStatisticsConstants.START)));
+        arguments.add(Long.toString(metadata.getStatistic(() -> ExactStatisticsConstants.LENGTH)));
+      }
+
+      arguments.add(metadata.getSchema().jsonString());
+      arguments.add(String.valueOf(metadata.getLastModifiedTime()));
+      arguments.add(metadataType.name());
+      rowWriter.addRow(arguments.toArray());
+    }
+
+    return resultSetLoader.harvest();
+  }
+
+  private ResultSetLoader getResultSetLoaderForMetadata(BaseMetadata baseMetadata) {
+    SchemaBuilder schemaBuilder = new SchemaBuilder()
+        .addNullable(MetastoreAnalyzeConstants.LOCATION_FIELD, MinorType.VARCHAR);
+    for (String segmentColumn : popConfig.getContext().segmentColumns()) {
+      schemaBuilder.addNullable(segmentColumn, MinorType.VARCHAR);
+    }
+
+    baseMetadata.getColumnsStatistics().entrySet().stream()
+        .sorted(Comparator.comparing(e -> e.getKey().getRootSegmentPath()))
+        .forEach(entry -> {
+          for (StatisticsKind statisticsKind : AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet()) {
+            MinorType type = AnalyzeColumnUtils.COLUMN_STATISTICS_TYPES.get(statisticsKind);
+            type = type != null ? type : entry.getValue().getComparatorType();
+            schemaBuilder.addNullable(
+                AnalyzeColumnUtils.getColumnStatisticsFieldName(entry.getKey().getRootSegmentPath(), statisticsKind),
+                type);
+          }
+        });
+
+    for (StatisticsKind statisticsKind : AnalyzeColumnUtils.META_STATISTICS_FUNCTIONS.keySet()) {
+      schemaBuilder.addNullable(
+          AnalyzeColumnUtils.getMetadataStatisticsFieldName(statisticsKind),
+          AnalyzeColumnUtils.COLUMN_STATISTICS_TYPES.get(statisticsKind));
+    }
+
+    schemaBuilder
+        .addMapArray(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD)
+        .resumeSchema();
+
+    if (metadataType == MetadataType.SEGMENT) {
+      schemaBuilder.addArray(MetastoreAnalyzeConstants.LOCATIONS_FIELD, MinorType.VARCHAR);
+    }
+
+    if (metadataType == MetadataType.ROW_GROUP) {
+      schemaBuilder.addNullable(context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL), MinorType.VARCHAR);
+      schemaBuilder.addNullable(context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL), MinorType.VARCHAR);
+      schemaBuilder.addNullable(context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL), MinorType.VARCHAR);
+    }
+
+    schemaBuilder
+        .addNullable(MetastoreAnalyzeConstants.SCHEMA_FIELD, MinorType.VARCHAR)
+        .addNullable(context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL), MinorType.VARCHAR)
+        .add(MetastoreAnalyzeConstants.METADATA_TYPE, MinorType.VARCHAR);
+
+    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schemaBuilder.buildSchema())
+        .build();
+
+    return new ResultSetLoaderImpl(container.getAllocator(), options);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends BaseMetadata & LocationProvider> VectorContainer writeMetadataUsingBatchSchema(List<T> metadataList) {
+    Preconditions.checkArgument(!metadataList.isEmpty(), "Metadata list shouldn't be empty.");
+
+    String lastModifiedTimeField = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+    String rgiField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL);
+    String rgsField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL);
+    String rglField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL);
+
+    ResultSetLoader resultSetLoader = getResultSetLoaderWithBatchSchema();
+    resultSetLoader.startBatch();
+    RowSetLoader rowWriter = resultSetLoader.writer();
+    Iterator<T> segmentsIterator = metadataList.iterator();
+    while (!rowWriter.isFull() && segmentsIterator.hasNext()) {
+      T metadata = segmentsIterator.next();
+      metadataToHandle.remove(metadata.getMetadataInfo().identifier());
+
+      List<Object> arguments = new ArrayList<>();
+      for (VectorWrapper<?> vectorWrapper : container) {
+
+        String[] identifierValues = Arrays.copyOf(
+            MetadataIdentifierUtils.getValuesFromMetadataIdentifier(metadata.getMetadataInfo().identifier()),
+            popConfig.getContext().segmentColumns().size());
+
+        MaterializedField field = vectorWrapper.getField();
+        String fieldName = field.getName();
+        if (fieldName.equals(MetastoreAnalyzeConstants.LOCATION_FIELD)) {
+          arguments.add(metadata.getPath().toUri().getPath());
+        } else if (fieldName.equals(MetastoreAnalyzeConstants.LOCATIONS_FIELD)) {
+          if (metadataType == MetadataType.SEGMENT) {
+            arguments.add(((SegmentMetadata) metadata).getLocations().stream()
+                .map(path -> path.toUri().getPath())
+                .toArray(String[]::new));
+          } else {
+            arguments.add(null);
+          }
+        } else if (popConfig.getContext().segmentColumns().contains(fieldName)) {
+          arguments.add(identifierValues[popConfig.getContext().segmentColumns().indexOf(fieldName)]);
+        } else if (AnalyzeColumnUtils.isColumnStatisticsField(fieldName)) {
+          arguments.add(
+              metadata.getColumnStatistics(SchemaPath.parseFromString(AnalyzeColumnUtils.getColumnName(fieldName)))
+                  .get(AnalyzeColumnUtils.getStatisticsKind(fieldName)));
+        } else if (AnalyzeColumnUtils.isMetadataStatisticsField(fieldName)) {
+          arguments.add(metadata.getStatistic(AnalyzeColumnUtils.getStatisticsKind(fieldName)));
+        } else if (fieldName.equals(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD)) {
+          // collectedMap field value
+          arguments.add(new Object[]{});
+        } else if (fieldName.equals(MetastoreAnalyzeConstants.SCHEMA_FIELD)) {
+          arguments.add(metadata.getSchema().jsonString());
+        } else if (fieldName.equals(lastModifiedTimeField)) {
+          arguments.add(String.valueOf(metadata.getLastModifiedTime()));
+        } else if (fieldName.equals(rgiField)) {
+          arguments.add(String.valueOf(((RowGroupMetadata) metadata).getRowGroupIndex()));
+        } else if (fieldName.equals(rgsField)) {
+          arguments.add(Long.toString(metadata.getStatistic(() -> ExactStatisticsConstants.START)));
+        } else if (fieldName.equals(rglField)) {
+          arguments.add(Long.toString(metadata.getStatistic(() -> ExactStatisticsConstants.LENGTH)));
+        } else if (fieldName.equals(MetastoreAnalyzeConstants.METADATA_TYPE)) {
+          arguments.add(metadataType.name());
+        } else {
+          throw new UnsupportedOperationException(String.format("Found unexpected field [%s] in incoming batch.",  field));
+        }
+      }
+
+      rowWriter.addRow(arguments.toArray());
+    }
+
+    return resultSetLoader.harvest();
+  }
+
+  private ResultSetLoader getResultSetLoaderWithBatchSchema() {
+    String lastModifiedTimeField = context.getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL);
+    String rgiField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL);
+    String rgsField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL);
+    String rglField = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL);
+    SchemaBuilder schemaBuilder = new SchemaBuilder();
+    // adds fields to the schema preserving their order to avoid issues in outcoming batches
+    for (VectorWrapper<?> vectorWrapper : container) {
+      MaterializedField field = vectorWrapper.getField();
+      String fieldName = field.getName();
+      if (fieldName.equals(MetastoreAnalyzeConstants.LOCATION_FIELD)
+          || fieldName.equals(MetastoreAnalyzeConstants.SCHEMA_FIELD)
+          || fieldName.equals(lastModifiedTimeField)
+          || fieldName.equals(rgiField)
+          || fieldName.equals(rgsField)
+          || fieldName.equals(rglField)
+          || fieldName.equals(MetastoreAnalyzeConstants.METADATA_TYPE)
+          || popConfig.getContext().segmentColumns().contains(fieldName)) {
+        schemaBuilder.add(fieldName, field.getType().getMinorType(), field.getDataMode());
+      } else if (AnalyzeColumnUtils.isColumnStatisticsField(fieldName)
+          || AnalyzeColumnUtils.isMetadataStatisticsField(fieldName)) {
+        schemaBuilder.add(fieldName, field.getType().getMinorType(), field.getType().getMode());
+      } else if (fieldName.equals(MetastoreAnalyzeConstants.COLLECTED_MAP_FIELD)) {
+        schemaBuilder.addMapArray(fieldName)
+            .resumeSchema();
+      } else if (fieldName.equals(MetastoreAnalyzeConstants.LOCATIONS_FIELD)) {
+        schemaBuilder.addArray(fieldName, MinorType.VARCHAR);
+      } else {
+        throw new UnsupportedOperationException(String.format("Found unexpected field [%s] in incoming batch.",  field));
+      }
+    }
+
+    ResultSetLoaderImpl.ResultSetOptions options = new OptionBuilder()
+        .setSchema(schemaBuilder.buildSchema())
+        .build();
+
+    return new ResultSetLoaderImpl(container.getAllocator(), options);
+  }
+
+  private void setupSchemaFromContainer(VectorContainer populatedContainer) {
+    container.clear();
+    StreamSupport.stream(populatedContainer.spliterator(), false)
+        .map(VectorWrapper::getField)
+        .filter(field -> field.getType().getMinorType() != MinorType.NULL)
+        .forEach(container::addOrGet);
+    container.buildSchema(BatchSchema.SelectionVectorMode.NONE);
+  }
+
+  protected boolean setupNewSchema() {
+    setupSchemaFromContainer(incoming.getContainer());
+    return true;
+  }
+
+  private IterOutcome doWorkInternal() {
+    container.transferIn(incoming.getContainer());
+    VarCharVector metadataTypeVector = container.addOrGet(
+        MaterializedField.create(MetastoreAnalyzeConstants.METADATA_TYPE, Types.required(MinorType.VARCHAR)));
+    metadataTypeVector.allocateNew();
+    for (int i = 0; i < incoming.getRecordCount(); i++) {
+      metadataTypeVector.getMutator().setSafe(i, metadataType.name().getBytes());
+    }
+
+    metadataTypeVector.getMutator().setValueCount(incoming.getRecordCount());
+    container.setRecordCount(incoming.getRecordCount());
+
+    container.buildSchema(BatchSchema.SelectionVectorMode.NONE);
+    updateMetadataToHandle();
+
+    return IterOutcome.OK;
+  }
+
+  private void updateMetadataToHandle() {
+    RowSetReader reader = DirectRowSet.fromContainer(container).reader();
+    // updates metadataToHandle to be able to fetch required data which wasn't returned by incoming batch
+    if (metadataToHandle != null && !metadataToHandle.isEmpty()) {
+      switch (metadataType) {
+        case ROW_GROUP: {
+          String rgiColumnName = context.getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL);
+          while (reader.next() && !metadataToHandle.isEmpty()) {
+            List<String> partitionValues = popConfig.getContext().segmentColumns().stream()
+                .map(columnName -> reader.column(columnName).scalar().getString())
+                .collect(Collectors.toList());
+            Path location = new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString());
+            int rgi = Integer.parseInt(reader.column(rgiColumnName).scalar().getString());
+            metadataToHandle.remove(MetadataIdentifierUtils.getRowGroupMetadataIdentifier(partitionValues, location, rgi));
+          }
+          break;
+        }
+        case FILE: {
+          while (reader.next() && !metadataToHandle.isEmpty()) {
+            List<String> partitionValues = popConfig.getContext().segmentColumns().stream()
+                .map(columnName -> reader.column(columnName).scalar().getString())
+                .collect(Collectors.toList());
+            Path location = new Path(reader.column(MetastoreAnalyzeConstants.LOCATION_FIELD).scalar().getString());
+            // use metadata identifier for files since row group indexes are not required when file is updated
+            metadataToHandle.remove(MetadataIdentifierUtils.getFileMetadataIdentifier(partitionValues, location));
+          }
+          break;
+        }
+        case SEGMENT: {
+          while (reader.next() && !metadataToHandle.isEmpty()) {
+            List<String> partitionValues = popConfig.getContext().segmentColumns().stream()
+                .limit(popConfig.getContext().depthLevel())
+                .map(columnName -> reader.column(columnName).scalar().getString())
+                .collect(Collectors.toList());
+            metadataToHandle.remove(MetadataIdentifierUtils.getMetadataIdentifierKey(partitionValues));
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void dump() {
+    logger.error("MetadataHandlerBatch[container={}, popConfig={}]", container, popConfig);
+  }
+
+  @Override
+  public int getRecordCount() {
+    return container.getRecordCount();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatchCreator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.metadata;
+
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.config.MetadataHandlerPOP;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class MetadataHandlerBatchCreator implements BatchCreator<MetadataHandlerPOP> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+      MetadataHandlerPOP config, List<RecordBatch> children) throws ExecutionSetupException {
+    Preconditions.checkArgument(children.size() == 1);
+    return new MetadataHandlerBatch(config, context, children.iterator().next());
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSDirPartitionLocation.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSDirPartitionLocation.java
@@ -81,5 +81,4 @@ public class DFSDirPartitionLocation implements PartitionLocation {
 
     return DrillFileSystemUtil.createPathSafe(path.toString());
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.planner;
 
+import org.apache.drill.exec.planner.physical.MetadataAggPrule;
+import org.apache.drill.exec.planner.physical.MetadataControllerPrule;
+import org.apache.drill.exec.planner.physical.MetadataHandlerPrule;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet.Builder;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -518,6 +521,10 @@ public enum PlannerPhase {
     ruleList.add(DirectScanPrule.INSTANCE);
     ruleList.add(RowKeyJoinPrule.INSTANCE);
     ruleList.add(AnalyzePrule.INSTANCE);
+
+    ruleList.add(MetadataControllerPrule.INSTANCE);
+    ruleList.add(MetadataHandlerPrule.INSTANCE);
+    ruleList.add(MetadataAggPrule.INSTANCE);
 
     ruleList.add(UnnestPrule.INSTANCE);
     ruleList.add(LateralJoinPrule.INSTANCE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertCountToDirectScanRule.java
@@ -170,7 +170,7 @@ public class ConvertCountToDirectScanRule extends RelOptRule {
         Collections.singletonList(new ArrayList<>(result.values())));
 
     final ScanStats scanStats = new ScanStats(ScanStats.GroupScanProperty.EXACT_ROW_COUNT, 1, 1, scanRowType.getFieldCount());
-    final MetadataDirectGroupScan directScan = new MetadataDirectGroupScan(reader, summaryFileName, 1, scanStats, true);
+    final MetadataDirectGroupScan directScan = new MetadataDirectGroupScan(reader, summaryFileName, 1, scanStats, true, false);
 
     final DrillDirectScanRel newScan = new DrillDirectScanRel(scan.getCluster(), scan.getTraitSet().plus(DrillRel.DRILL_LOGICAL),
       directScan, scanRowType);
@@ -214,7 +214,8 @@ public class ConvertCountToDirectScanRule extends RelOptRule {
 
     Metadata_V4.MetadataSummary metadataSummary = Metadata.getSummary(fs, selectionRoot, false, parquetReaderConfig);
 
-    return metadataSummary != null ? new ImmutablePair<>(true, metadataSummary) : new ImmutablePair<>(false, null);
+    return metadataSummary != null ? new ImmutablePair<>(true, metadataSummary) :
+        new ImmutablePair<>(false, null);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRel.java
@@ -176,9 +176,9 @@ public class DrillScanRel extends DrillScanRelBase implements DrillRel {
     return this.partitionFilterPushdown;
   }
 
-  private static List<SchemaPath> getProjectedColumns(final RelOptTable table, boolean isSelectStar) {
+  public static List<SchemaPath> getProjectedColumns(final RelOptTable table, boolean isSelectStar) {
     List<String> columnNames = table.getRowType().getFieldNames();
-    List<SchemaPath> projectedColumns = new ArrayList<SchemaPath>(columnNames.size());
+    List<SchemaPath> projectedColumns = new ArrayList<>(columnNames.size());
 
     for (String columnName : columnNames) {
        projectedColumns.add(SchemaPath.getSimplePath(columnName));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataAggRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataAggRel.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.drill.common.logical.data.LogicalOperator;
+import org.apache.drill.common.logical.data.MetadataAggregate;
+import org.apache.drill.exec.planner.cost.DrillCostBase;
+import org.apache.drill.exec.metastore.analyze.MetadataAggregateContext;
+
+import java.util.List;
+
+public class MetadataAggRel extends SingleRel implements DrillRel {
+
+  private final MetadataAggregateContext context;
+
+  public MetadataAggRel(RelOptCluster cluster, RelTraitSet traits, RelNode input,
+      MetadataAggregateContext context) {
+    super(cluster, traits, input);
+    this.context = context;
+  }
+
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    double dRows = mq.getRowCount(getInput());
+    double dCpu = dRows * DrillCostBase.COMPARE_CPU_COST;
+    double dIo = 0;
+    return planner.getCostFactory().makeCost(dRows, dCpu, dIo);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new MetadataAggRel(getCluster(), traitSet, sole(inputs), context);
+  }
+
+  @Override
+  public LogicalOperator implement(DrillImplementor implementor) {
+    LogicalOperator inputOp = implementor.visitChild(this, 0, getInput());
+    MetadataAggregate rel = new MetadataAggregate();
+    rel.setInput(inputOp);
+    return rel;
+  }
+
+  public MetadataAggregateContext getContext() {
+    return context;
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw).item("context: ", context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataControllerRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataControllerRel.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.BiRel;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.logical.data.LogicalOperator;
+import org.apache.drill.common.logical.data.MetadataController;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.planner.cost.DrillCostBase;
+import org.apache.drill.exec.metastore.analyze.MetadataControllerContext;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class MetadataControllerRel extends BiRel implements DrillRel {
+  private final MetadataControllerContext context;
+
+  public MetadataControllerRel(RelOptCluster cluster, RelTraitSet traits, RelNode left, RelNode right,
+      MetadataControllerContext context) {
+    super(cluster, traits, left, right);
+    this.context = context;
+  }
+
+  public MetadataControllerContext getContext() {
+    return context;
+  }
+
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    double dRows = Math.max(mq.getRowCount(getLeft()), mq.getRowCount(getRight()));
+    double dCpu = dRows * DrillCostBase.COMPARE_CPU_COST;
+    double dIo = 0;
+    return planner.getCostFactory().makeCost(dRows, dCpu, dIo);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    Preconditions.checkArgument(inputs.size() == 2);
+    return new MetadataControllerRel(getCluster(), traitSet, inputs.get(0), inputs.get(1), context);
+  }
+
+  @Override
+  public LogicalOperator implement(DrillImplementor implementor) {
+    LogicalOperator left = implementor.visitChild(this, 0, getLeft());
+    LogicalOperator right = implementor.visitChild(this, 1, getRight());
+    return new MetadataController(left, right);
+  }
+
+  @Override
+  protected RelDataType deriveRowType() {
+    return getCluster().getTypeFactory().builder()
+        .add(MetastoreAnalyzeConstants.OK_FIELD_NAME, SqlTypeName.BOOLEAN)
+        .add(MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME, SqlTypeName.VARCHAR)
+        .build();
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw).item("context: ", context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataHandlerRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/MetadataHandlerRel.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.drill.common.logical.data.LogicalOperator;
+import org.apache.drill.common.logical.data.MetadataHandler;
+import org.apache.drill.exec.planner.cost.DrillCostBase;
+import org.apache.drill.exec.metastore.analyze.MetadataHandlerContext;
+
+import java.util.List;
+
+public class MetadataHandlerRel extends SingleRel implements DrillRel {
+  private final MetadataHandlerContext context;
+
+  public MetadataHandlerRel(RelOptCluster cluster, RelTraitSet traits, RelNode input,
+      MetadataHandlerContext context) {
+    super(cluster, traits, input);
+    this.context = context;
+  }
+
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    double dRows = mq.getRowCount(getInput());
+    double dCpu = dRows * DrillCostBase.COMPARE_CPU_COST;
+    double dIo = 0;
+    return planner.getCostFactory().makeCost(dRows, dCpu, dIo);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new MetadataHandlerRel(getCluster(), traitSet, sole(inputs), context);
+  }
+
+  @Override
+  public LogicalOperator implement(DrillImplementor implementor) {
+    LogicalOperator inputOp = implementor.visitChild(this, 0, getInput());
+    MetadataHandler rel = new MetadataHandler();
+    rel.setInput(inputOp);
+    return rel;
+  }
+
+  public MetadataHandlerContext getContext() {
+    return context;
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw).item("context: ", context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ConvertCountToDirectScanPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ConvertCountToDirectScanPrule.java
@@ -100,7 +100,7 @@ public class ConvertCountToDirectScanPrule extends Prule {
   public void onMatch(RelOptRuleCall call) {
     final DrillAggregateRel agg = call.rel(0);
     final DrillScanRel scan = call.rel(call.rels.length - 1);
-    final DrillProjectRel project = call.rels.length == 3 ? (DrillProjectRel) call.rel(1) : null;
+    final DrillProjectRel project = call.rels.length == 3 ? call.rel(1) : null;
 
     final GroupScan oldGrpScan = scan.getGroupScan();
     final PlannerSettings settings = PrelUtil.getPlannerSettings(call.getPlanner());
@@ -130,7 +130,7 @@ public class ConvertCountToDirectScanPrule extends Prule {
 
     final ScanStats scanStats = new ScanStats(ScanStats.GroupScanProperty.EXACT_ROW_COUNT, 1, 1, scanRowType.getFieldCount());
     final int numFiles = oldGrpScan.hasFiles() ? oldGrpScan.getFiles().size() : -1;
-    final GroupScan directScan = new MetadataDirectGroupScan(reader, oldGrpScan.getSelectionRoot(), numFiles, scanStats, false);
+    final GroupScan directScan = new MetadataDirectGroupScan(reader, oldGrpScan.getSelectionRoot(), numFiles, scanStats, false, oldGrpScan.usedMetastore());
 
     final DirectScanPrel newScan = DirectScanPrel.create(scan, scan.getTraitSet().plus(Prel.DRILL_PHYSICAL)
         .plus(DrillDistributionTrait.SINGLETON), directScan, scanRowType);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataAggPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataAggPrel.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.config.MetadataAggPOP;
+import org.apache.drill.exec.planner.common.DrillRelNode;
+import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
+import org.apache.drill.exec.metastore.analyze.MetadataAggregateContext;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class MetadataAggPrel extends SingleRel implements DrillRelNode, Prel {
+  private final MetadataAggregateContext context;
+
+  public MetadataAggPrel(RelOptCluster cluster, RelTraitSet traits, RelNode input,
+      MetadataAggregateContext context) {
+    super(cluster, traits, input);
+    this.context = context;
+  }
+
+  @Override
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
+    Prel child = (Prel) this.getInput();
+    MetadataAggPOP physicalOperator = new MetadataAggPOP(child.getPhysicalOperator(creator), context);
+    return creator.addMetadata(this, physicalOperator);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PrelVisitor<T, X, E> logicalVisitor, X value) throws E {
+    return logicalVisitor.visitPrel(this, value);
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode[] getSupportedEncodings() {
+    return BatchSchema.SelectionVectorMode.DEFAULT;
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode getEncoding() {
+    return BatchSchema.SelectionVectorMode.NONE;
+  }
+
+  @Override
+  public boolean needsFinalColumnReordering() {
+    return true;
+  }
+
+  @Override
+  public Iterator<Prel> iterator() {
+    return PrelUtil.iter(getInput());
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    Preconditions.checkState(inputs.size() == 1);
+    return new MetadataAggPrel(getCluster(), traitSet, inputs.iterator().next(), context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataAggPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataAggPrule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.MetadataAggRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class MetadataAggPrule extends Prule {
+  public static final MetadataAggPrule INSTANCE = new MetadataAggPrule();
+
+  public MetadataAggPrule() {
+    super(RelOptHelper.any(MetadataAggRel.class, DrillRel.DRILL_LOGICAL),
+        "MetadataAggPrule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    MetadataAggRel relNode = call.rel(0);
+    RelNode input = relNode.getInput();
+
+    int groupByExprsSize = relNode.getContext().groupByExpressions().size();
+
+    // group by expressions will be returned first
+    RelCollation collation = RelCollations.of(IntStream.range(1, groupByExprsSize)
+        .mapToObj(RelFieldCollation::new)
+        .collect(Collectors.toList()));
+
+    // TODO: update DrillDistributionTrait when implemented parallelization for metadata collecting (see DRILL-7433)
+    RelTraitSet traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON);
+    traits = groupByExprsSize > 0 ? traits.plus(collation) : traits;
+    RelNode convertedInput = convert(input, traits);
+    call.transformTo(
+        new MetadataAggPrel(relNode.getCluster(), traits, convertedInput, relNode.getContext()));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.BiRel;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.config.MetadataControllerPOP;
+import org.apache.drill.exec.planner.common.DrillRelNode;
+import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
+import org.apache.drill.exec.metastore.analyze.MetadataControllerContext;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class MetadataControllerPrel extends BiRel implements DrillRelNode, Prel {
+  private final MetadataControllerContext context;
+
+  protected MetadataControllerPrel(RelOptCluster cluster, RelTraitSet traits, RelNode left,
+      RelNode right, MetadataControllerContext context) {
+    super(cluster, traits, left, right);
+    this.context = context;
+  }
+
+  @Override
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
+    Prel left = (Prel) this.getLeft();
+    Prel right = (Prel) this.getRight();
+    MetadataControllerPOP physicalOperator =
+        new MetadataControllerPOP(left.getPhysicalOperator(creator), right.getPhysicalOperator(creator), context);
+    return creator.addMetadata(this, physicalOperator);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PrelVisitor<T, X, E> logicalVisitor, X value) throws E {
+    return logicalVisitor.visitPrel(this, value);
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode[] getSupportedEncodings() {
+    return BatchSchema.SelectionVectorMode.ALL;
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode getEncoding() {
+    return BatchSchema.SelectionVectorMode.NONE;
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    Preconditions.checkArgument(inputs.size() == 2);
+    return new MetadataControllerPrel(getCluster(), traitSet, inputs.get(0), inputs.get(1), context);
+  }
+
+  @Override
+  public boolean needsFinalColumnReordering() {
+    return true;
+  }
+
+  @Override
+  public Iterator<Prel> iterator() {
+    return PrelUtil.iter(getLeft(), getRight());
+  }
+
+  @Override
+  protected RelDataType deriveRowType() {
+    return getCluster().getTypeFactory().builder()
+        .add(MetastoreAnalyzeConstants.OK_FIELD_NAME, SqlTypeName.BOOLEAN)
+        .add(MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME, SqlTypeName.VARCHAR)
+        .build();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.MetadataControllerRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+
+public class MetadataControllerPrule extends Prule {
+  public static final MetadataControllerPrule INSTANCE = new MetadataControllerPrule();
+
+  public MetadataControllerPrule() {
+    super(RelOptHelper.some(MetadataControllerRel.class, DrillRel.DRILL_LOGICAL,
+        RelOptHelper.any(RelNode.class)), "MetadataControllerPrule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    MetadataControllerRel relNode = call.rel(0);
+    RelNode left = relNode.getLeft();
+    RelNode right = relNode.getRight();
+    RelTraitSet traits = call.getPlanner().emptyTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON);
+    RelNode convertedLeft = convert(left, traits);
+    RelNode convertedRight = convert(right, traits);
+    call.transformTo(new MetadataControllerPrel(relNode.getCluster(),
+        relNode.getTraitSet().plus(Prel.DRILL_PHYSICAL), convertedLeft, convertedRight, relNode.getContext()));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataHandlerPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataHandlerPrel.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.config.MetadataHandlerPOP;
+import org.apache.drill.exec.planner.common.DrillRelNode;
+import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
+import org.apache.drill.exec.metastore.analyze.MetadataHandlerContext;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class MetadataHandlerPrel extends SingleRel implements DrillRelNode, Prel {
+  private final MetadataHandlerContext context;
+
+  protected MetadataHandlerPrel(RelOptCluster cluster, RelTraitSet traits, RelNode input, MetadataHandlerContext context) {
+    super(cluster, traits, input);
+    this.context = context;
+  }
+
+  @Override
+  public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
+    Prel child = (Prel) this.getInput();
+    MetadataHandlerPOP physicalOperator = new MetadataHandlerPOP(child.getPhysicalOperator(creator), context);
+
+    return creator.addMetadata(this, physicalOperator);
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PrelVisitor<T, X, E> logicalVisitor, X value) throws E {
+    return logicalVisitor.visitPrel(this, value);
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode[] getSupportedEncodings() {
+    return BatchSchema.SelectionVectorMode.ALL;
+  }
+
+  @Override
+  public BatchSchema.SelectionVectorMode getEncoding() {
+    return BatchSchema.SelectionVectorMode.NONE;
+  }
+
+  @Override
+  public boolean needsFinalColumnReordering() {
+    return true;
+  }
+
+  @Override
+  public Iterator<Prel> iterator() {
+    return PrelUtil.iter(getInput());
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    Preconditions.checkState(inputs.size() == 1);
+    return new MetadataHandlerPrel(getCluster(), traitSet, inputs.iterator().next(), context);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataHandlerPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataHandlerPrule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.physical;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.MetadataHandlerRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+
+public class MetadataHandlerPrule extends Prule {
+  public static final MetadataHandlerPrule INSTANCE = new MetadataHandlerPrule();
+
+  public MetadataHandlerPrule() {
+    super(RelOptHelper.any(MetadataHandlerRel.class, DrillRel.DRILL_LOGICAL),
+        "MetadataHandlerPrule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    MetadataHandlerRel relNode = call.rel(0);
+    RelNode input = relNode.getInput();
+    RelTraitSet traits = input.getTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.DEFAULT);
+    RelNode convertedInput = convert(input, traits);
+    call.transformTo(new MetadataHandlerPrel(relNode.getCluster(), traits,
+        convertedInput,
+        relNode.getContext()));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PrelUtil.java
@@ -49,7 +49,7 @@ public class PrelUtil {
     final List<String> childFields = rowType.getFieldNames();
 
     for (RelFieldCollation fc : collation.getFieldCollations()) {
-      FieldReference fr = new FieldReference(childFields.get(fc.getFieldIndex()), ExpressionPosition.UNKNOWN, false);
+      FieldReference fr = new FieldReference(childFields.get(fc.getFieldIndex()), ExpressionPosition.UNKNOWN);
       orderExpr.add(new Ordering(fc.getDirection(), fr, fc.nullDirection));
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/StreamAggPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/StreamAggPrel.java
@@ -82,7 +82,7 @@ public class StreamAggPrel extends AggPrelBase implements Prel{
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
 
     Prel child = (Prel) this.getInput();
-    StreamingAggregate g = new StreamingAggregate(child.getPhysicalOperator(creator), keys, aggExprs, 1.0f);
+    StreamingAggregate g = new StreamingAggregate(child.getPhysicalOperator(creator), keys, aggExprs);
 
     return creator.addMetadata(this, g);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreAnalyzeTableHandler.java
@@ -1,0 +1,536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelConversionException;
+import org.apache.calcite.tools.ValidationException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.FieldReference;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.data.NamedExpression;
+import org.apache.drill.common.util.function.CheckedSupplier;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.metastore.analyze.AnalyzeInfoProvider;
+import org.apache.drill.exec.metastore.analyze.MetadataAggregateContext;
+import org.apache.drill.exec.metastore.analyze.MetadataControllerContext;
+import org.apache.drill.exec.metastore.analyze.MetadataHandlerContext;
+import org.apache.drill.exec.metastore.analyze.MetadataInfoCollector;
+import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
+import org.apache.drill.exec.physical.PhysicalPlan;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.planner.logical.DrillAnalyzeRel;
+import org.apache.drill.exec.planner.logical.DrillRel;
+import org.apache.drill.exec.planner.logical.DrillScreenRel;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.logical.MetadataAggRel;
+import org.apache.drill.exec.planner.logical.MetadataControllerRel;
+import org.apache.drill.exec.planner.logical.MetadataHandlerRel;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.planner.physical.Prel;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.parser.SqlMetastoreAnalyzeTable;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.exec.store.dfs.FormatSelection;
+import org.apache.drill.exec.util.Pointer;
+import org.apache.drill.exec.work.foreman.ForemanSetupException;
+import org.apache.drill.exec.work.foreman.SqlUnsupportedException;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
+import org.apache.parquet.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.drill.exec.planner.logical.DrillRelFactories.LOGICAL_BUILDER;
+
+/**
+ * Constructs plan to be executed for collecting metadata and storing it to the Metastore.
+ */
+public class MetastoreAnalyzeTableHandler extends DefaultSqlHandler {
+  private static final Logger logger = LoggerFactory.getLogger(MetastoreAnalyzeTableHandler.class);
+
+  public MetastoreAnalyzeTableHandler(SqlHandlerConfig config, Pointer<String> textPlan) {
+    super(config, textPlan);
+  }
+
+  @Override
+  public PhysicalPlan getPlan(SqlNode sqlNode)
+      throws ValidationException, RelConversionException, IOException, ForemanSetupException {
+    if (!context.getOptions().getOption(ExecConstants.METASTORE_ENABLED_VALIDATOR)) {
+      throw UserException.validationError()
+          .message("Running ANALYZE TABLE REFRESH METADATA command when Metastore is disabled (`metastore.enabled` is set to false)")
+          .build(logger);
+    }
+    // disables during analyze to prevent using data about locations from the Metastore
+    context.getOptions().setLocalOption(ExecConstants.METASTORE_ENABLED, false);
+    SqlMetastoreAnalyzeTable sqlAnalyzeTable = unwrap(sqlNode, SqlMetastoreAnalyzeTable.class);
+
+    AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+        config.getConverter().getDefaultSchema(), sqlAnalyzeTable.getSchemaPath());
+    DrillTable table = getDrillTable(drillSchema, sqlAnalyzeTable.getName());
+
+    AnalyzeInfoProvider analyzeInfoProvider = table.getGroupScan().getAnalyzeInfoProvider();
+
+    if (analyzeInfoProvider == null) {
+      throw UserException.validationError()
+          .message("ANALYZE is not supported for group scan [%s]", table.getGroupScan())
+          .build(logger);
+    }
+
+    SqlIdentifier tableIdentifier = sqlAnalyzeTable.getTableIdentifier();
+    // creates select with DYNAMIC_STAR column and analyze specific columns to obtain corresponding table scan
+    SqlSelect scanSql = new SqlSelect(
+        SqlParserPos.ZERO,
+        SqlNodeList.EMPTY,
+        getColumnList(sqlAnalyzeTable, analyzeInfoProvider),
+        tableIdentifier,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
+
+    ConvertedRelNode convertedRelNode = validateAndConvert(rewrite(scanSql));
+    RelDataType validatedRowType = convertedRelNode.getValidatedRowType();
+
+    RelNode relScan = convertedRelNode.getConvertedNode();
+
+    DrillRel drel = convertToDrel(relScan, drillSchema, table, sqlAnalyzeTable);
+
+    Prel prel = convertToPrel(drel, validatedRowType);
+    logAndSetTextPlan("Drill Physical", prel, logger);
+    PhysicalOperator pop = convertToPop(prel);
+    PhysicalPlan plan = convertToPlan(pop);
+    log("Drill Plan", plan, logger);
+    return plan;
+  }
+
+  private DrillTable getDrillTable(AbstractSchema drillSchema, String tableName) {
+    Table tableFromSchema = SqlHandlerUtil.getTableFromSchema(drillSchema, tableName);
+
+    if (tableFromSchema == null) {
+      throw UserException.validationError()
+          .message("No table with given name [%s] exists in schema [%s]", tableName, drillSchema.getFullSchemaName())
+          .build(logger);
+    }
+
+    switch (tableFromSchema.getJdbcTableType()) {
+      case TABLE:
+        if (tableFromSchema instanceof DrillTable) {
+          return  (DrillTable) tableFromSchema;
+        } else {
+          throw UserException.validationError()
+              .message("ANALYZE does not support [%s] table kind", tableFromSchema.getClass().getSimpleName())
+              .build(logger);
+        }
+      default:
+        throw UserException.validationError()
+            .message("ANALYZE does not support [%s] object type", tableFromSchema.getJdbcTableType())
+            .build(logger);
+    }
+  }
+
+  /**
+   * Generates the column list with {@link SchemaPath#DYNAMIC_STAR} and columns required for analyze.
+   */
+  private SqlNodeList getColumnList(SqlMetastoreAnalyzeTable sqlAnalyzeTable, AnalyzeInfoProvider analyzeInfoProvider) {
+    SqlNodeList columnList = new SqlNodeList(SqlParserPos.ZERO);
+    columnList.add(new SqlIdentifier(SchemaPath.DYNAMIC_STAR, SqlParserPos.ZERO));
+    MetadataType metadataLevel = getMetadataType(sqlAnalyzeTable);
+    for (SqlIdentifier field : analyzeInfoProvider.getProjectionFields(metadataLevel, context.getPlannerSettings().getOptions())) {
+      columnList.add(field);
+    }
+    return columnList;
+  }
+
+  private MetadataType getMetadataType(SqlMetastoreAnalyzeTable sqlAnalyzeTable) {
+    SqlLiteral stringLiteral = sqlAnalyzeTable.getLevel();
+    // for the case when metadata level is not specified in ANALYZE statement,
+    // value from the `metastore.metadata.store.depth_level` option is used
+    String metadataLevel;
+    if (stringLiteral == null) {
+      metadataLevel = context.getOption(ExecConstants.METASTORE_METADATA_STORE_DEPTH_LEVEL).string_val;
+    } else {
+      metadataLevel = stringLiteral.toValue();
+    }
+    return metadataLevel != null ? MetadataType.valueOf(metadataLevel.toUpperCase()) : MetadataType.ALL;
+  }
+
+  /**
+   * Converts to Drill logical plan
+   */
+  private DrillRel convertToDrel(RelNode relNode, AbstractSchema schema,
+      DrillTable table, SqlMetastoreAnalyzeTable sqlAnalyzeTable) throws ForemanSetupException, IOException {
+    RelBuilder relBuilder = LOGICAL_BUILDER.create(relNode.getCluster(), null);
+
+    AnalyzeInfoProvider analyzeInfoProvider = table.getGroupScan().getAnalyzeInfoProvider();
+
+    List<String> schemaPath = schema.getSchemaPath();
+    String pluginName = schemaPath.get(0);
+    String workspaceName = Strings.join(schemaPath.subList(1, schemaPath.size()), AbstractSchema.SCHEMA_SEPARATOR);
+
+    TableInfo tableInfo = TableInfo.builder()
+        .name(sqlAnalyzeTable.getName())
+        .owner(table.getUserName())
+        .type(analyzeInfoProvider.getTableTypeName())
+        .storagePlugin(pluginName)
+        .workspace(workspaceName)
+        .build();
+
+    List<String> segmentColumns = analyzeInfoProvider.getSegmentColumns(table, context.getPlannerSettings().getOptions()).stream()
+        .map(SchemaPath::getRootSegmentPath)
+        .collect(Collectors.toList());
+    List<NamedExpression> segmentExpressions = segmentColumns.stream()
+        .map(partitionName ->
+            new NamedExpression(SchemaPath.getSimplePath(partitionName), FieldReference.getWithQuotedRef(partitionName)))
+        .collect(Collectors.toList());
+
+    List<MetadataInfo> rowGroupsInfo = Collections.emptyList();
+    List<MetadataInfo> filesInfo = Collections.emptyList();
+    Multimap<Integer, MetadataInfo> segments = ArrayListMultimap.create();
+
+    BasicTablesRequests basicRequests;
+    try {
+      basicRequests = context.getMetastoreRegistry().get()
+          .tables()
+          .basicRequests();
+    } catch (MetastoreException e) {
+      logger.error("Error when obtaining Metastore instance for table {}", sqlAnalyzeTable.getName(), e);
+      DrillRel convertedRelNode = convertToRawDrel(
+          relBuilder.values(
+                new String[]{MetastoreAnalyzeConstants.OK_FIELD_NAME, MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME},
+                false, e.getMessage())
+              .build());
+      return new DrillScreenRel(convertedRelNode.getCluster(), convertedRelNode.getTraitSet(), convertedRelNode);
+    }
+
+    MetadataType metadataLevel = getMetadataType(sqlAnalyzeTable);
+
+    List<SchemaPath> interestingColumns = sqlAnalyzeTable.getFieldNames();
+
+    MetastoreTableInfo metastoreTableInfo = basicRequests.metastoreTableInfo(tableInfo);
+
+    List<MetadataInfo> allMetaToHandle = new ArrayList<>();
+    List<MetadataInfo> metadataToRemove = new ArrayList<>();
+
+    // Step 1: checks whether table metadata is present in the Metastore to determine
+    // whether incremental analyze may be produced
+    if (metastoreTableInfo.isExists()) {
+      RelNode finalRelNode = relNode;
+      CheckedSupplier<TableScan, SqlUnsupportedException> tableScanSupplier =
+          () -> AnalyzeTableHandler.findScan(convertToDrel(finalRelNode.getInput(0)));
+
+      MetadataInfoCollector metadataInfoCollector = analyzeInfoProvider.getMetadataInfoCollector(basicRequests,
+          tableInfo, (FormatSelection) table.getSelection(), context.getPlannerSettings(),
+          tableScanSupplier, interestingColumns, metadataLevel, segmentColumns.size());
+
+      if (!metadataInfoCollector.isOutdated()) {
+        DrillRel convertedRelNode = convertToRawDrel(
+            relBuilder.values(new String[]{MetastoreAnalyzeConstants.OK_FIELD_NAME, MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME},
+                false, "Table metadata is up to date, analyze wasn't performed.")
+                .build());
+        return new DrillScreenRel(convertedRelNode.getCluster(), convertedRelNode.getTraitSet(), convertedRelNode);
+      }
+
+      // updates scan to read updated / new files, pass removed files into metadata handler
+      relNode = relNode.copy(relNode.getTraitSet(), Collections.singletonList(metadataInfoCollector.getPrunedScan()));
+
+      filesInfo = metadataInfoCollector.getFilesInfo();
+      segments = metadataInfoCollector.getSegmentsInfo();
+      rowGroupsInfo = metadataInfoCollector.getRowGroupsInfo();
+
+      allMetaToHandle = metadataInfoCollector.getAllMetaToHandle();
+      metadataToRemove = metadataInfoCollector.getMetadataToRemove();
+    }
+
+    // Step 2: constructs plan for producing analyze
+    DrillRel convertedRelNode = convertToRawDrel(relNode);
+
+    boolean createNewAggregations = true;
+
+    // List of columns for which statistics should be collected: interesting columns + segment columns
+    List<SchemaPath> statisticsColumns = interestingColumns == null ? null : new ArrayList<>(interestingColumns);
+    if (statisticsColumns != null) {
+      segmentColumns.stream()
+          .map(SchemaPath::getSimplePath)
+          .forEach(statisticsColumns::add);
+    }
+
+    SchemaPath locationField = analyzeInfoProvider.getLocationField(config.getContext().getOptions());
+
+    if (analyzeInfoProvider.supportsMetadataType(MetadataType.ROW_GROUP) && metadataLevel.includes(MetadataType.ROW_GROUP)) {
+      MetadataHandlerContext handlerContext = MetadataHandlerContext.builder()
+          .tableInfo(tableInfo)
+          .metadataToHandle(rowGroupsInfo)
+          .metadataType(MetadataType.ROW_GROUP)
+          .depthLevel(segmentExpressions.size())
+          .segmentColumns(segmentColumns)
+          .build();
+
+      convertedRelNode = getRowGroupAggRelNode(segmentExpressions, convertedRelNode, createNewAggregations,
+          statisticsColumns, handlerContext);
+
+      createNewAggregations = false;
+      locationField = SchemaPath.getSimplePath(MetastoreAnalyzeConstants.LOCATION_FIELD);
+    }
+
+    if (analyzeInfoProvider.supportsMetadataType(MetadataType.FILE) && metadataLevel.includes(MetadataType.FILE)) {
+      MetadataHandlerContext handlerContext = MetadataHandlerContext.builder()
+          .tableInfo(tableInfo)
+          .metadataToHandle(filesInfo)
+          .metadataType(MetadataType.FILE)
+          .depthLevel(segmentExpressions.size())
+          .segmentColumns(segmentColumns)
+          .build();
+
+      convertedRelNode = getFileAggRelNode(segmentExpressions, convertedRelNode,
+          createNewAggregations, statisticsColumns, locationField, handlerContext);
+
+      locationField = SchemaPath.getSimplePath(MetastoreAnalyzeConstants.LOCATION_FIELD);
+
+      createNewAggregations = false;
+    }
+
+    if (analyzeInfoProvider.supportsMetadataType(MetadataType.SEGMENT) && metadataLevel.includes(MetadataType.SEGMENT)) {
+      for (int i = segmentExpressions.size(); i > 0; i--) {
+        MetadataHandlerContext handlerContext = MetadataHandlerContext.builder()
+            .tableInfo(tableInfo)
+            .metadataToHandle(new ArrayList<>(segments.get(i - 1)))
+            .metadataType(MetadataType.SEGMENT)
+            .depthLevel(i)
+            .segmentColumns(segmentColumns.subList(0, i))
+            .build();
+
+        convertedRelNode = getSegmentAggRelNode(segmentExpressions, convertedRelNode,
+            createNewAggregations, statisticsColumns, locationField, analyzeInfoProvider, i, handlerContext);
+
+        locationField = SchemaPath.getSimplePath(MetastoreAnalyzeConstants.LOCATION_FIELD);
+
+        createNewAggregations = false;
+      }
+    }
+
+    if (analyzeInfoProvider.supportsMetadataType(MetadataType.TABLE) && metadataLevel.includes(MetadataType.TABLE)) {
+      MetadataHandlerContext handlerContext = MetadataHandlerContext.builder()
+          .tableInfo(tableInfo)
+          .metadataToHandle(Collections.emptyList())
+          .metadataType(MetadataType.TABLE)
+          .depthLevel(segmentExpressions.size())
+          .segmentColumns(segmentColumns)
+          .build();
+
+      convertedRelNode = getTableAggRelNode(convertedRelNode, createNewAggregations,
+          statisticsColumns, locationField, handlerContext);
+    } else {
+      throw new IllegalStateException("Analyze table with NONE level");
+    }
+
+    boolean useStatistics = context.getOptions().getOption(PlannerSettings.STATISTICS_USE);
+    SqlNumericLiteral samplePercentLiteral = sqlAnalyzeTable.getSamplePercent();
+    double samplePercent = samplePercentLiteral == null ? 100.0 : samplePercentLiteral.intValue(true);
+
+    // Step 3: adds rel nodes for producing statistics analyze if required
+    RelNode analyzeRel = useStatistics
+        ? new DrillAnalyzeRel(
+              convertedRelNode.getCluster(), convertedRelNode.getTraitSet(), convertToRawDrel(relNode), samplePercent)
+        : convertToRawDrel(relBuilder.values(new String[]{""}, "").build());
+
+    MetadataControllerContext metadataControllerContext = MetadataControllerContext.builder()
+        .tableInfo(tableInfo)
+        .metastoreTableInfo(metastoreTableInfo)
+        .location(((FormatSelection) table.getSelection()).getSelection().getSelectionRoot())
+        .interestingColumns(interestingColumns)
+        .segmentColumns(segmentColumns)
+        .metadataToHandle(allMetaToHandle)
+        .metadataToRemove(metadataToRemove)
+        .analyzeMetadataLevel(metadataLevel)
+        .build();
+
+    convertedRelNode = new MetadataControllerRel(convertedRelNode.getCluster(),
+        convertedRelNode.getTraitSet(),
+        convertedRelNode,
+        analyzeRel,
+        metadataControllerContext);
+
+    return new DrillScreenRel(convertedRelNode.getCluster(), convertedRelNode.getTraitSet(), convertedRelNode);
+  }
+
+  private DrillRel getTableAggRelNode(DrillRel convertedRelNode, boolean createNewAggregations,
+      List<SchemaPath> statisticsColumns, SchemaPath locationField, MetadataHandlerContext handlerContext) {
+    SchemaPath lastModifiedTimeField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL));
+
+    List<SchemaPath> excludedColumns = Arrays.asList(locationField, lastModifiedTimeField);
+
+    MetadataAggregateContext aggregateContext = MetadataAggregateContext.builder()
+        .groupByExpressions(Collections.emptyList())
+        .interestingColumns(statisticsColumns)
+        .createNewAggregations(createNewAggregations)
+        .excludedColumns(excludedColumns)
+        .build();
+
+    convertedRelNode = new MetadataAggRel(convertedRelNode.getCluster(),
+        convertedRelNode.getTraitSet(), convertedRelNode, aggregateContext);
+
+    convertedRelNode =
+        new MetadataHandlerRel(convertedRelNode.getCluster(),
+            convertedRelNode.getTraitSet(),
+            convertedRelNode,
+            handlerContext);
+    return convertedRelNode;
+  }
+
+  private DrillRel getSegmentAggRelNode(List<NamedExpression> segmentExpressions, DrillRel convertedRelNode,
+      boolean createNewAggregations, List<SchemaPath> statisticsColumns, SchemaPath locationField,
+      AnalyzeInfoProvider analyzeInfoProvider, int segmentLevel, MetadataHandlerContext handlerContext) {
+      SchemaPath lastModifiedTimeField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL));
+
+    List<SchemaPath> excludedColumns = Arrays.asList(lastModifiedTimeField, locationField);
+
+    List<NamedExpression> groupByExpressions = new ArrayList<>();
+    groupByExpressions.add(analyzeInfoProvider.getParentLocationExpression(locationField));
+
+    groupByExpressions.addAll(segmentExpressions);
+
+    MetadataAggregateContext aggregateContext = MetadataAggregateContext.builder()
+        .groupByExpressions(groupByExpressions.subList(0, segmentLevel + 1))
+        .interestingColumns(statisticsColumns)
+        .createNewAggregations(createNewAggregations)
+        .excludedColumns(excludedColumns)
+        .build();
+
+    convertedRelNode = new MetadataAggRel(convertedRelNode.getCluster(),
+        convertedRelNode.getTraitSet(), convertedRelNode, aggregateContext);
+
+    convertedRelNode =
+        new MetadataHandlerRel(convertedRelNode.getCluster(),
+            convertedRelNode.getTraitSet(),
+            convertedRelNode,
+            handlerContext);
+    return convertedRelNode;
+  }
+
+  private DrillRel getFileAggRelNode(List<NamedExpression> segmentExpressions, DrillRel convertedRelNode,
+      boolean createNewAggregations, List<SchemaPath> statisticsColumns, SchemaPath locationField, MetadataHandlerContext handlerContext) {
+    SchemaPath lastModifiedTimeField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL));
+
+    List<SchemaPath> excludedColumns = Arrays.asList(lastModifiedTimeField, locationField);
+
+    NamedExpression locationExpression =
+        new NamedExpression(locationField, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.LOCATION_FIELD));
+    List<NamedExpression> fileGroupByExpressions = new ArrayList<>(segmentExpressions);
+    fileGroupByExpressions.add(locationExpression);
+
+    MetadataAggregateContext aggregateContext = MetadataAggregateContext.builder()
+        .groupByExpressions(fileGroupByExpressions)
+        .interestingColumns(statisticsColumns)
+        .createNewAggregations(createNewAggregations)
+        .excludedColumns(excludedColumns)
+        .build();
+
+    convertedRelNode = new MetadataAggRel(convertedRelNode.getCluster(),
+        convertedRelNode.getTraitSet(), convertedRelNode, aggregateContext);
+
+    convertedRelNode =
+        new MetadataHandlerRel(convertedRelNode.getCluster(),
+            convertedRelNode.getTraitSet(),
+            convertedRelNode,
+            handlerContext);
+    return convertedRelNode;
+  }
+
+  private DrillRel getRowGroupAggRelNode(List<NamedExpression> segmentExpressions, DrillRel convertedRelNode,
+      boolean createNewAggregations, List<SchemaPath> statisticsColumns, MetadataHandlerContext handlerContext) {
+    SchemaPath locationField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_FQN_COLUMN_LABEL));
+    SchemaPath lastModifiedTimeField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL));
+
+    String rowGroupIndexColumn = config.getContext().getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL);
+    SchemaPath rgiField = SchemaPath.getSimplePath(rowGroupIndexColumn);
+
+    List<NamedExpression> rowGroupGroupByExpressions =
+        getRowGroupExpressions(segmentExpressions, locationField, rowGroupIndexColumn, rgiField);
+
+    SchemaPath rowGroupStartField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL));
+    SchemaPath rowGroupLengthField =
+        SchemaPath.getSimplePath(config.getContext().getOptions().getString(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL));
+
+    List<SchemaPath> excludedColumns = Arrays.asList(lastModifiedTimeField, locationField, rgiField, rowGroupStartField, rowGroupLengthField);
+
+    MetadataAggregateContext aggregateContext = MetadataAggregateContext.builder()
+        .groupByExpressions(rowGroupGroupByExpressions)
+        .interestingColumns(statisticsColumns)
+        .createNewAggregations(createNewAggregations)
+        .excludedColumns(excludedColumns)
+        .build();
+
+    convertedRelNode = new MetadataAggRel(convertedRelNode.getCluster(),
+        convertedRelNode.getTraitSet(), convertedRelNode, aggregateContext);
+
+    convertedRelNode =
+        new MetadataHandlerRel(convertedRelNode.getCluster(),
+            convertedRelNode.getTraitSet(),
+            convertedRelNode,
+            handlerContext);
+    return convertedRelNode;
+  }
+
+  private List<NamedExpression> getRowGroupExpressions(List<NamedExpression> segmentExpressions,
+      SchemaPath locationField, String rowGroupIndexColumn, SchemaPath rgiField) {
+    List<NamedExpression> rowGroupGroupByExpressions = new ArrayList<>(segmentExpressions);
+    rowGroupGroupByExpressions.add(
+        new NamedExpression(rgiField,
+            FieldReference.getWithQuotedRef(rowGroupIndexColumn)));
+
+    rowGroupGroupByExpressions.add(
+        new NamedExpression(locationField, FieldReference.getWithQuotedRef(MetastoreAnalyzeConstants.LOCATION_FIELD)));
+    return rowGroupGroupByExpressions;
+  }
+
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.PhysicalPlan;
+import org.apache.drill.exec.planner.sql.DirectPlan;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.planner.sql.parser.SqlDropTableMetadata;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.exec.util.Pointer;
+import org.apache.drill.exec.work.foreman.ForemanSetupException;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.components.tables.Tables;
+import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.parquet.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class MetastoreDropTableMetadataHandler extends DefaultSqlHandler {
+  private static final Logger logger = LoggerFactory.getLogger(MetastoreDropTableMetadataHandler.class);
+
+  public MetastoreDropTableMetadataHandler(SqlHandlerConfig config, Pointer<String> textPlan) {
+    super(config, textPlan);
+  }
+
+  @Override
+  public PhysicalPlan getPlan(SqlNode sqlNode) throws ForemanSetupException {
+    if (!context.getOptions().getOption(ExecConstants.METASTORE_ENABLED_VALIDATOR)) {
+      throw UserException.validationError()
+          .message("Running ANALYZE TABLE DROP command when Metastore is disabled (`metastore.enabled` is set to false)")
+          .build(logger);
+    }
+
+    SqlDropTableMetadata dropTableMetadata = unwrap(sqlNode, SqlDropTableMetadata.class);
+
+    AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+        config.getConverter().getDefaultSchema(), dropTableMetadata.getSchemaPath());
+
+    List<String> schemaPath = drillSchema.getSchemaPath();
+    String pluginName = schemaPath.get(0);
+    String workspaceName = Strings.join(schemaPath.subList(1, schemaPath.size()), AbstractSchema.SCHEMA_SEPARATOR);
+
+    TableInfo tableInfo = TableInfo.builder()
+        .name(dropTableMetadata.getName())
+        .storagePlugin(pluginName)
+        .workspace(workspaceName)
+        .build();
+
+    try {
+      Tables tables = context.getMetastoreRegistry().get().tables();
+
+      MetastoreTableInfo metastoreTableInfo = tables.basicRequests()
+          .metastoreTableInfo(tableInfo);
+
+      if (!metastoreTableInfo.isExists()) {
+        if (dropTableMetadata.checkMetadataExistence()) {
+          throw UserException.validationError()
+              .message("Metadata for table [%s] not found.", dropTableMetadata.getName())
+              .build(logger);
+        }
+        return DirectPlan.createDirectPlan(context, false,
+            String.format("Metadata for table [%s] does not exist.", dropTableMetadata.getName()));
+      }
+
+      tables.modify()
+          .delete(tableInfo.toFilter())
+          .execute();
+    } catch (MetastoreException e) {
+      logger.error("Error when dropping metadata for table {}", dropTableMetadata.getName(), e);
+      return DirectPlan.createDirectPlan(context, false, e.getMessage());
+    }
+
+    return DirectPlan.createDirectPlan(context, true,
+        String.format("Metadata for table [%s] dropped.", dropTableMetadata.getName()));
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/RefreshMetadataHandler.java
@@ -78,7 +78,7 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
 
       final String tableName = refreshTable.getName();
       final SqlNodeList columnList = getColumnList(refreshTable);
-      final Set<String> columnSet = getColumnRootSegments(columnList);
+      final Set<SchemaPath> columnSet = getColumnRootSegments(columnList);
       final SqlLiteral allColumns = refreshTable.getAllColumns();
 
       if (tableName.contains("*") || tableName.contains("?")) {
@@ -143,12 +143,12 @@ public class RefreshMetadataHandler extends DefaultSqlHandler {
     }
   }
 
-  private Set<String> getColumnRootSegments(SqlNodeList columnList) {
-    Set<String> columnSet = new HashSet<>();
+  private Set<SchemaPath> getColumnRootSegments(SqlNodeList columnList) {
+    Set<SchemaPath> columnSet = new HashSet<>();
     if (columnList != null) {
       for (SqlNode column : columnList.getList()) {
         // Add only the root segment. Collect metadata for all the columns under that root segment
-        columnSet.add(SchemaPath.parseFromString(column.toString()).getRootSegmentPath());
+        columnSet.add(SchemaPath.getSimplePath(SchemaPath.parseFromString(column.toString()).getRootSegmentPath()));
       }
     }
     return columnSet;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/CompoundIdentifierConverter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/CompoundIdentifierConverter.java
@@ -64,6 +64,8 @@ public class CompoundIdentifierConverter extends SqlShuttle {
     // returned by getOperandList() method for concrete SqlCall implementation.
     REWRITE_RULES = ImmutableMap.<Class<? extends SqlCall>, RewriteType[]>builder()
         .put(SqlAnalyzeTable.class, arrayOf(D, D, E, D))
+        .put(SqlMetastoreAnalyzeTable.class, arrayOf(D, E, D, D, D))
+        .put(SqlDropTableMetadata.class, arrayOf(D, D, D))
         .put(SqlSelect.class, arrayOf(D, E, D, E, E, E, E, E, D, D))
         .put(SqlCreateTable.class, arrayOf(D, D, D, E, D, D))
         .put(SqlCreateView.class, arrayOf(D, E, E, D))

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlAnalyzeTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlAnalyzeTable.java
@@ -44,7 +44,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
  * SQL tree for ANALYZE statement.
  */
 public class SqlAnalyzeTable extends DrillSqlCall {
-  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ANALYZE_TABLE", SqlKind.OTHER) {
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("ANALYZE_TABLE", SqlKind.OTHER_DDL) {
     public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
       Preconditions.checkArgument(operands.length == 4, "SqlAnalyzeTable.createCall() has to get 4 operands!");
       return new SqlAnalyzeTable(pos, (SqlIdentifier) operands[0], (SqlLiteral) operands[1],

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
@@ -42,8 +42,8 @@ public class SqlDropTable extends DrillSqlCall {
     }
   };
 
-  private SqlIdentifier tableName;
-  private boolean tableExistenceCheck;
+  private final SqlIdentifier tableName;
+  private final boolean tableExistenceCheck;
 
   public SqlDropTable(SqlParserPos pos, SqlIdentifier tableName, SqlLiteral tableExistenceCheck) {
     this(pos, tableName, tableExistenceCheck.booleanValue());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.Util;
+import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
+import org.apache.drill.exec.planner.sql.handlers.MetastoreDropTableMetadataHandler;
+import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
+import org.apache.drill.exec.util.Pointer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class SqlDropTableMetadata extends DrillSqlCall {
+
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP_TABLE_METADATA", SqlKind.OTHER) {
+    @Override
+    public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+      return new SqlDropTableMetadata(pos, (SqlIdentifier) operands[0], (SqlLiteral) operands[1], (SqlLiteral) operands[2]);
+    }
+  };
+
+  private final SqlIdentifier tableName;
+  private final boolean checkMetadataExistence;
+  private final DropMetadataType dropType;
+
+  public SqlDropTableMetadata(SqlParserPos pos, SqlIdentifier tableName, SqlLiteral dropType, SqlLiteral checkMetadataExistence) {
+    super(pos);
+    this.tableName = tableName;
+    this.dropType = DropMetadataType.valueOf(dropType.getStringValue().toUpperCase());
+    this.checkMetadataExistence = checkMetadataExistence.booleanValue();
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Arrays.asList(
+        tableName,
+        SqlLiteral.createCharString(dropType.name(), SqlParserPos.ZERO),
+        SqlLiteral.createBoolean(checkMetadataExistence, SqlParserPos.ZERO)
+    );
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("ANALYZE");
+    writer.keyword("TABLE");
+    tableName.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("DROP");
+    writer.keyword(dropType.name());
+    if (checkMetadataExistence) {
+      writer.keyword("IF");
+      writer.keyword("EXISTS");
+    }
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config, Pointer<String> textPlan) {
+    return new MetastoreDropTableMetadataHandler(config, textPlan);
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config) {
+    return getSqlHandler(config, null);
+  }
+
+  public List<String> getSchemaPath() {
+    if (tableName.isSimple()) {
+      return Collections.emptyList();
+    }
+
+    return tableName.names.subList(0, tableName.names.size() - 1);
+  }
+
+  public String getName() {
+    return Util.last(tableName.names);
+  }
+
+  public boolean checkMetadataExistence() {
+    return checkMetadataExistence;
+  }
+
+  public DropMetadataType getDropType() {
+    return dropType;
+  }
+
+  /**
+   * Enum for metadata types to drop.
+   */
+  public enum DropMetadataType {
+    METADATA,
+    STATISTICS
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlMetastoreAnalyzeTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlMetastoreAnalyzeTable.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.Util;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
+import org.apache.drill.exec.planner.sql.handlers.MetastoreAnalyzeTableHandler;
+import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
+import org.apache.drill.exec.util.Pointer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SqlMetastoreAnalyzeTable extends DrillSqlCall {
+
+  public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("METASTORE_ANALYZE_TABLE", SqlKind.OTHER_DDL) {
+    public SqlCall createCall(SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+      return new SqlMetastoreAnalyzeTable(pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1], operands[2],
+          (SqlLiteral) operands[3], (SqlNumericLiteral) operands[4]);
+    }
+  };
+
+  private final SqlIdentifier tableName;
+  private final SqlNodeList fieldList;
+  private final SqlLiteral level;
+  private final SqlLiteral estimate;
+  private final SqlNumericLiteral samplePercent;
+
+  public SqlMetastoreAnalyzeTable(SqlParserPos pos, SqlIdentifier tableName, SqlNodeList fieldList,
+      SqlNode level, SqlLiteral estimate, SqlNumericLiteral samplePercent) {
+    super(pos);
+    this.tableName = tableName;
+    this.fieldList = fieldList;
+    this.level = level != null ? SqlLiteral.unchain(level) : null;
+    this.estimate = estimate;
+    this.samplePercent = samplePercent;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Arrays.asList(tableName, fieldList, level, estimate, samplePercent);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("ANALYZE");
+    writer.keyword("TABLE");
+    tableName.unparse(writer, leftPrec, rightPrec);
+    if (fieldList != null) {
+      writer.keyword("COLUMNS");
+      if (fieldList.size() > 0) {
+        writer.keyword("(");
+        fieldList.get(0).unparse(writer, leftPrec, rightPrec);
+        for (int i = 1; i < fieldList.size(); i++) {
+          writer.keyword(",");
+          fieldList.get(i).unparse(writer, leftPrec, rightPrec);
+        }
+        writer.keyword(")");
+      } else {
+        writer.keyword("NONE");
+      }
+    }
+    writer.keyword("REFRESH");
+    writer.keyword("METADATA");
+    if (level != null) {
+      level.unparse(writer, leftPrec, rightPrec);
+    }
+    if (estimate != null) {
+      writer.keyword(estimate.booleanValue() ? "ESTIMATE" : "COMPUTE");
+      writer.keyword("STATISTICS");
+    }
+    if (samplePercent != null) {
+      writer.keyword("SAMPLE");
+      samplePercent.unparse(writer, leftPrec, rightPrec);
+      writer.keyword("PERCENT");
+    }
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config, Pointer<String> textPlan) {
+    return new MetastoreAnalyzeTableHandler(config, textPlan);
+  }
+
+  @Override
+  public AbstractSqlHandler getSqlHandler(SqlHandlerConfig config) {
+    return getSqlHandler(config, null);
+  }
+
+  public List<String> getSchemaPath() {
+    if (tableName.isSimple()) {
+      return Collections.emptyList();
+    }
+
+    return tableName.names.subList(0, tableName.names.size() - 1);
+  }
+
+  public SqlIdentifier getTableIdentifier() {
+    return tableName;
+  }
+
+  public String getName() {
+    return Util.last(tableName.names);
+  }
+
+  public List<SchemaPath> getFieldNames() {
+    if (fieldList == null) {
+      return null;
+    }
+
+    return fieldList.getList().stream()
+        .map(SqlNode::toString)
+        .map(SchemaPath::parseFromString)
+        .collect(Collectors.toList());
+  }
+
+  public SqlNodeList getFieldList() {
+    return fieldList;
+  }
+
+  public SqlLiteral getLevel() {
+    return level;
+  }
+
+  public SqlLiteral getEstimate() {
+    return estimate;
+  }
+
+  public SqlNumericLiteral getSamplePercent() {
+    return samplePercent;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/DrillRelDataTypeSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/types/DrillRelDataTypeSystem.java
@@ -19,10 +19,25 @@ package org.apache.drill.exec.planner.types;
 
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.common.types.Types;
 
 public class DrillRelDataTypeSystem extends RelDataTypeSystemImpl {
 
   public static final RelDataTypeSystem DRILL_REL_DATATYPE_SYSTEM = new DrillRelDataTypeSystem();
+
+  @Override
+  public int getDefaultPrecision(SqlTypeName typeName) {
+    switch (typeName) {
+      case CHAR:
+      case BINARY:
+      case VARCHAR:
+      case VARBINARY:
+        return Types.MAX_VARCHAR_LENGTH;
+      default:
+        return super.getDefaultPrecision(typeName);
+    }
+  }
 
   @Override
   public int getMaxNumericScale() {
@@ -32,6 +47,12 @@ public class DrillRelDataTypeSystem extends RelDataTypeSystemImpl {
   @Override
   public int getMaxNumericPrecision() {
     return 38;
+  }
+
+  @Override
+  public boolean isSchemaCaseSensitive() {
+    // Drill uses case-insensitive policy
+    return false;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractBinaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractBinaryRecordBatch.java
@@ -23,8 +23,6 @@ import org.apache.drill.exec.ops.MetricDef;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 
 public abstract class AbstractBinaryRecordBatch<T extends PhysicalOperator> extends  AbstractRecordBatch<T> {
-  private static final org.slf4j.Logger logger =
-    org.slf4j.LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
   protected final RecordBatch left;
   protected final RecordBatch right;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -82,7 +82,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     }
   }
 
-  public static enum BatchState {
+  public enum BatchState {
     /** Need to build schema and return. */
     BUILD_SCHEMA,
     /** This is still the first data batch. */
@@ -107,7 +107,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     return context;
   }
 
-  public PhysicalOperator getPopConfig() {
+  public T getPopConfig() {
     return popConfig;
   }
 
@@ -118,10 +118,10 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     return next(0, b);
   }
 
-  public final IterOutcome next(int inputIndex, RecordBatch b){
+  public final IterOutcome next(int inputIndex, RecordBatch b) {
     IterOutcome next;
     stats.stopProcessing();
-    try{
+    try {
       if (!context.getExecutorState().shouldContinue()) {
         return IterOutcome.STOP;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
@@ -21,13 +21,11 @@ import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 
-
 /**
- * Implements an AbstractUnaryRecordBatch where the inoming record batch is known at the time of creation
+ * Implements an AbstractUnaryRecordBatch where the incoming record batch is known at the time of creation
  * @param <T>
  */
 public abstract class AbstractSingleRecordBatch<T extends PhysicalOperator> extends AbstractUnaryRecordBatch<T> {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
   protected final RecordBatch incoming;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
@@ -136,15 +136,6 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
     }
   }
 
-  @Override
-  public BatchSchema getSchema() {
-    if (container.hasSchema()) {
-      return container.getSchema();
-    }
-
-    return null;
-  }
-
   protected abstract boolean setupNewSchema() throws SchemaChangeException;
   protected abstract IterOutcome doWork();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
@@ -152,6 +152,7 @@ public class RecordBatchLoader implements VectorAccessible, Iterable<VectorWrapp
       schema = builder.build();
       newVectors.buildSchema(BatchSchema.SelectionVectorMode.NONE);
       container = newVectors;
+      container.setRecordCount(valueCount);
     } catch (final Throwable cause) {
       // We have to clean up new vectors created here and pass over the actual cause. It is upper layer who should
       // adjudicate to call upper layer specific clean up logic.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SchemaUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SchemaUtil.java
@@ -17,9 +17,12 @@
  */
 package org.apache.drill.exec.record;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.DataMode;
@@ -29,6 +32,7 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
@@ -186,5 +190,33 @@ public class SchemaUtil {
       tuple.add(MetadataUtils.fromView(field));
     }
     return tuple;
+  }
+
+  /**
+   * Returns list of {@link SchemaPath} for fields taken from specified schema.
+   *
+   * @param schema the source of fields to return
+   * @return list of {@link SchemaPath}
+   */
+  public static List<SchemaPath> getSchemaPaths(TupleMetadata schema) {
+    return SchemaUtil.getColumnPaths(schema, null).stream()
+        .map(stringList -> SchemaPath.getCompoundPath(stringList.toArray(new String[0])))
+        .collect(Collectors.toList());
+  }
+
+  private static List<List<String>> getColumnPaths(TupleMetadata schema, List<String> parentNames) {
+    List<List<String>> result = new ArrayList<>();
+    for (ColumnMetadata columnMetadata : schema) {
+      if (columnMetadata.isMap()) {
+        List<String> currentNames = parentNames == null
+            ? new ArrayList<>()
+            : new ArrayList<>(parentNames);
+        currentNames.add(columnMetadata.name());
+        result.addAll(getColumnPaths(columnMetadata.mapSchema(), currentNames));
+      } else {
+        result.add(Collections.singletonList(columnMetadata.name()));
+      }
+    }
+    return result;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -260,6 +260,10 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.IMPLICIT_SUFFIX_COLUMN_LABEL_VALIDATOR),
       new OptionDefinition(ExecConstants.IMPLICIT_FQN_COLUMN_LABEL_VALIDATOR),
       new OptionDefinition(ExecConstants.IMPLICIT_FILEPATH_COLUMN_LABEL_VALIDATOR),
+      new OptionDefinition(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL_VALIDATOR),
+      new OptionDefinition(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL_VALIDATOR),
+      new OptionDefinition(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL_VALIDATOR),
+      new OptionDefinition(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL_VALIDATOR),
       new OptionDefinition(ExecConstants.CODE_GEN_EXP_IN_METHOD_SIZE_VALIDATOR),
       new OptionDefinition(ExecConstants.CREATE_PREPARE_STATEMENT_TIMEOUT_MILLIS_VALIDATOR),
       new OptionDefinition(ExecConstants.DYNAMIC_UDF_SUPPORT_ENABLED_VALIDATOR,  new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM, true, false)),
@@ -296,7 +300,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.METASTORE_USE_STATISTICS_METADATA_VALIDATOR),
       new OptionDefinition(ExecConstants.METASTORE_CTAS_AUTO_COLLECT_METADATA_VALIDATOR),
       new OptionDefinition(ExecConstants.METASTORE_FALLBACK_TO_FILE_METADATA_VALIDATOR),
-      new OptionDefinition(ExecConstants.METASTORE_RETRIVAL_RETRY_ATTEMPTS_VALIDATOR),
+      new OptionDefinition(ExecConstants.METASTORE_RETRIEVAL_RETRY_ATTEMPTS_VALIDATOR),
       new OptionDefinition(ExecConstants.PARQUET_READER_ENABLE_MAP_SUPPORT_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, false, false))
     };
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
@@ -82,6 +82,8 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
       drillTable.getMetadataProviderManager().setSchemaProvider(schemaProvider);
     });
 
+  public static final String SCHEMA_SEPARATOR = ".";
+
   protected final List<String> schemaPath;
   protected final String name;
 
@@ -113,7 +115,7 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
   }
 
   public String getFullSchemaName() {
-    return Joiner.on(".").join(schemaPath);
+    return Joiner.on(SCHEMA_SEPARATOR).join(schemaPath);
   }
 
   public abstract String getTypeName();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ColumnExplorer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ColumnExplorer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.exec.ExecConstants;
@@ -33,6 +35,7 @@ import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.store.dfs.FileSelection;
 import org.apache.drill.exec.util.Utilities;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -46,7 +49,9 @@ public class ColumnExplorer {
   private final List<Integer> selectedPartitionColumns;
   private final List<SchemaPath> tableColumns;
   private final Map<String, ImplicitFileColumns> allImplicitColumns;
+  private final Map<String, ImplicitInternalFileColumns> allInternalColumns;
   private final Map<String, ImplicitFileColumns> selectedImplicitColumns;
+  private final Map<String, ImplicitInternalFileColumns> selectedInternalColumns;
 
   /**
    * Helper class that encapsulates logic for sorting out columns
@@ -58,7 +63,9 @@ public class ColumnExplorer {
     this.selectedPartitionColumns = Lists.newArrayList();
     this.tableColumns = Lists.newArrayList();
     this.allImplicitColumns = initImplicitFileColumns(optionManager);
+    this.allInternalColumns = initImplicitInternalFileColumns(optionManager);
     this.selectedImplicitColumns = CaseInsensitiveMap.newHashMap();
+    this.selectedInternalColumns = CaseInsensitiveMap.newHashMap();
     if (columns == null) {
       isStarQuery = false;
       this.columns = null;
@@ -93,6 +100,22 @@ public class ColumnExplorer {
         map.put(optionValue.string_val, e);
       }
     }
+    return map;
+  }
+
+  /**
+   * Creates case insensitive map with implicit internal file columns as keys and
+   * appropriate ImplicitFileColumns enum as values
+   */
+  public static Map<String, ImplicitInternalFileColumns> initImplicitInternalFileColumns(OptionManager optionManager) {
+    Map<String, ImplicitInternalFileColumns> map = CaseInsensitiveMap.newHashMap();
+    for (ImplicitInternalFileColumns e : ImplicitInternalFileColumns.values()) {
+      OptionValue optionValue;
+      if ((optionValue = optionManager.getOption(e.name)) != null) {
+        map.put(optionValue.string_val, e);
+      }
+    }
+
     return map;
   }
 
@@ -157,10 +180,40 @@ public class ColumnExplorer {
    * @return list with partition column names.
    */
   public static List<String> getPartitionColumnNames(FileSelection selection, SchemaConfig schemaConfig) {
-    int partitionsCount = getPartitionDepth(selection);
 
     String partitionColumnLabel = schemaConfig.getOption(
         ExecConstants.FILESYSTEM_PARTITION_COLUMN_LABEL).string_val;
+
+    return getPartitionColumnNames(selection, partitionColumnLabel);
+  }
+
+  /**
+   * Returns list with partition column names.
+   * For the case when table has several levels of nesting, max level is chosen.
+   *
+   * @param selection     the source of file paths
+   * @param optionManager the source of session option value for partition column label
+   * @return list with partition column names.
+   */
+  public static List<String> getPartitionColumnNames(FileSelection selection, OptionManager optionManager) {
+
+    String partitionColumnLabel = optionManager.getString(
+        ExecConstants.FILESYSTEM_PARTITION_COLUMN_LABEL);
+
+    return getPartitionColumnNames(selection, partitionColumnLabel);
+  }
+
+  /**
+   * Returns list with partition column names.
+   * For the case when table has several levels of nesting, max level is chosen.
+   *
+   * @param selection            the source of file paths
+   * @param partitionColumnLabel partition column label
+   * @return list with partition column names.
+   */
+  private static List<String> getPartitionColumnNames(FileSelection selection, String partitionColumnLabel) {
+    int partitionsCount = getPartitionDepth(selection);
+
     List<String> partitions = new ArrayList<>();
 
     // generates partition column names: dir0, dir1 etc.
@@ -214,6 +267,48 @@ public class ColumnExplorer {
         implicitValues.put(entry.getKey(), entry.getValue().getValue(path));
       }
     }
+
+    return implicitValues;
+  }
+
+  /**
+   * Creates map with implicit and internal columns where key is column name, value is columns actual value.
+   * This map contains partition, implicit and internal file columns (if requested).
+   * Partition columns names are formed based in partition designator and value index.
+   *
+   * @param filePath                   file path, used to populate file implicit columns
+   * @param partitionValues            list of partition values
+   * @param includeFileImplicitColumns if file implicit columns should be included into the result
+   * @param fs                         file system
+   * @param index                      index of row group to populate
+   * @return implicit columns map
+   */
+  public Map<String, String> populateImplicitAndInternalColumns(Path filePath,
+      List<String> partitionValues, boolean includeFileImplicitColumns, FileSystem fs, int index, long start, long length) {
+
+    Map<String, String> implicitValues =
+        new LinkedHashMap<>(populateImplicitColumns(filePath, partitionValues, includeFileImplicitColumns));
+
+    selectedInternalColumns.forEach((key, value) -> {
+      switch (value) {
+        case ROW_GROUP_INDEX:
+          implicitValues.put(key, String.valueOf(index));
+          break;
+        case ROW_GROUP_START:
+          implicitValues.put(key, String.valueOf(start));
+          break;
+        case ROW_GROUP_LENGTH:
+          implicitValues.put(key, String.valueOf(length));
+          break;
+        case LAST_MODIFIED_TIME:
+          try {
+            implicitValues.put(key, String.valueOf(fs.getFileStatus(filePath).getModificationTime()));
+          } catch (IOException e) {
+            throw new DrillRuntimeException(e);
+          }
+          break;
+      }
+    });
 
     return implicitValues;
   }
@@ -314,12 +409,16 @@ public class ColumnExplorer {
       if (isStarQuery) {
         if (allImplicitColumns.get(path) != null) {
           selectedImplicitColumns.put(path, allImplicitColumns.get(path));
+        } else if (allInternalColumns.get(path) != null) {
+          selectedInternalColumns.put(path, allInternalColumns.get(path));
         }
       } else {
         if (isPartitionColumn(partitionDesignator, path)) {
           selectedPartitionColumns.add(Integer.parseInt(path.substring(partitionDesignator.length())));
         } else if (allImplicitColumns.get(path) != null) {
           selectedImplicitColumns.put(path, allImplicitColumns.get(path));
+        } else if (allInternalColumns.get(path) != null) {
+          selectedInternalColumns.put(path, allInternalColumns.get(path));
         } else {
           tableColumns.add(column);
         }
@@ -385,5 +484,26 @@ public class ColumnExplorer {
      * Using file path calculates value for each implicit file column
      */
     public abstract String getValue(Path path);
+  }
+
+  /**
+   * Columns that give internal information about file or its parts.
+   * Columns are implicit, so should be called explicitly in query.
+   */
+  public enum ImplicitInternalFileColumns {
+
+    LAST_MODIFIED_TIME(ExecConstants.IMPLICIT_LAST_MODIFIED_TIME_COLUMN_LABEL),
+
+    ROW_GROUP_INDEX(ExecConstants.IMPLICIT_ROW_GROUP_INDEX_COLUMN_LABEL),
+
+    ROW_GROUP_START(ExecConstants.IMPLICIT_ROW_GROUP_START_COLUMN_LABEL),
+
+    ROW_GROUP_LENGTH(ExecConstants.IMPLICIT_ROW_GROUP_LENGTH_COLUMN_LABEL);
+
+    private final String name;
+
+    ImplicitInternalFileColumns(String name) {
+      this.name = name;
+    }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
@@ -53,6 +53,8 @@ import org.apache.drill.exec.dotdrill.DotDrillUtil;
 import org.apache.drill.exec.dotdrill.View;
 import org.apache.drill.exec.metastore.FileSystemMetadataProviderManager;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.metastore.MetastoreMetadataProviderManager;
+import org.apache.drill.exec.metastore.MetastoreMetadataProviderManager.MetastoreMetadataProviderConfig;
 import org.apache.drill.exec.planner.common.DrillStatsTable;
 import org.apache.drill.exec.planner.logical.CreateTableEntry;
 import org.apache.drill.exec.planner.logical.DrillTable;
@@ -71,6 +73,10 @@ import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.exec.store.StorageStrategy;
 import org.apache.drill.exec.store.easy.json.JSONFormatPlugin;
 import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.metastore.MetastoreRegistry;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -438,8 +444,34 @@ public class WorkspaceSchemaFactory {
       }
       final DrillTable table = tables.get(tableKey);
       if (table != null) {
-        MetadataProviderManager providerManager = FileSystemMetadataProviderManager.init();
+        MetadataProviderManager providerManager = null;
 
+        if (schemaConfig.getOption(ExecConstants.METASTORE_ENABLED).bool_val) {
+          try {
+            MetastoreRegistry metastoreRegistry = plugin.getContext().getMetastoreRegistry();
+            TableInfo tableInfo = TableInfo.builder()
+                .storagePlugin(plugin.getName())
+                .workspace(schemaName)
+                .name(tableName)
+                .build();
+
+            MetastoreTableInfo metastoreTableInfo = metastoreRegistry.get()
+                .tables()
+                .basicRequests()
+                .metastoreTableInfo(tableInfo);
+            if (metastoreTableInfo.isExists()) {
+              providerManager = new MetastoreMetadataProviderManager(metastoreRegistry, tableInfo,
+                  new MetastoreMetadataProviderConfig(schemaConfig.getOption(ExecConstants.METASTORE_USE_SCHEMA_METADATA).bool_val,
+                      schemaConfig.getOption(ExecConstants.METASTORE_USE_STATISTICS_METADATA).bool_val,
+                      schemaConfig.getOption(ExecConstants.METASTORE_FALLBACK_TO_FILE_METADATA).bool_val));
+            }
+          } catch (MetastoreException e) {
+            logger.warn("Exception happened during obtaining Metastore instance.", e);
+          }
+        }
+        if (providerManager == null) {
+          providerManager = FileSystemMetadataProviderManager.init();
+        }
         setMetadataTable(providerManager, table, tableName);
         setSchema(providerManager, tableName);
         table.setTableMetadataProviderManager(providerManager);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/MetadataDirectGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/MetadataDirectGroupScan.java
@@ -43,18 +43,22 @@ public class MetadataDirectGroupScan extends DirectGroupScan {
   @JsonProperty
   private final int numFiles;
   @JsonProperty
-  private boolean usedMetadataSummaryFile;
+  private final boolean usedMetadataSummaryFile;
+  @JsonProperty
+  private final boolean usedMetastore;
 
   @JsonCreator
   public MetadataDirectGroupScan(@JsonProperty("reader") RecordReader reader,
-                                 @JsonProperty("selectionRoot") Path selectionRoot,
-                                 @JsonProperty("numFiles") int numFiles,
-                                 @JsonProperty("stats") ScanStats stats,
-                                 @JsonProperty("usedMetadataSummaryFile") boolean usedMetadataSummaryFile) {
+      @JsonProperty("selectionRoot") Path selectionRoot,
+      @JsonProperty("numFiles") int numFiles,
+      @JsonProperty("stats") ScanStats stats,
+      @JsonProperty("usedMetadataSummaryFile") boolean usedMetadataSummaryFile,
+      @JsonProperty("usedMetastore") boolean usedMetastore) {
     super(reader, stats);
     this.selectionRoot = selectionRoot;
     this.numFiles = numFiles;
     this.usedMetadataSummaryFile = usedMetadataSummaryFile;
+    this.usedMetastore = usedMetastore;
   }
 
   @Override
@@ -65,7 +69,7 @@ public class MetadataDirectGroupScan extends DirectGroupScan {
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
     assert children == null || children.isEmpty();
-    return new MetadataDirectGroupScan(reader, selectionRoot, numFiles, stats, usedMetadataSummaryFile);
+    return new MetadataDirectGroupScan(reader, selectionRoot, numFiles, stats, usedMetadataSummaryFile, usedMetastore);
   }
 
   @Override
@@ -81,7 +85,7 @@ public class MetadataDirectGroupScan extends DirectGroupScan {
    * </p>
    *
    * <p>
-   * Example: [selectionRoot = [/tmp/users], numFiles = 1, usedMetadataSummaryFile = false]
+   * Example: [selectionRoot = [/tmp/users], numFiles = 1, usedMetadataSummaryFile = false, usedMetastore = true]
    * </p>
    *
    * @return string representation of group scan data
@@ -94,6 +98,7 @@ public class MetadataDirectGroupScan extends DirectGroupScan {
     }
     builder.append("numFiles = ").append(numFiles).append(", ");
     builder.append("usedMetadataSummaryFile = ").append(usedMetadataSummaryFile).append(", ");
+    builder.append("usedMetastore = ").append(usedMetastore).append(", ");
     builder.append(super.getDigest());
     return builder.toString();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/StatisticsCollectorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/StatisticsCollectorImpl.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
+import org.apache.drill.exec.store.JSONBaseStatisticsRecordWriter;
+import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.metastore.statistics.Statistic;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StatisticsCollectorImpl extends JSONBaseStatisticsRecordWriter {
+
+  private final List<DrillStatsTable.ColumnStatistics> columnStatisticsList = new ArrayList<>();
+
+  private String nextField = null;
+  private DrillStatsTable.ColumnStatistics columnStatistics;
+  private LocalDate dirComputedTime = null;
+  private boolean errStatus = false;
+
+  @Override
+  public void startStatisticsRecord() {
+    columnStatistics = new DrillStatsTable.ColumnStatistics_v1();
+  }
+
+  @Override
+  public void endStatisticsRecord() {
+    columnStatisticsList.add(columnStatistics);
+  }
+
+  @Override
+  public boolean hasStatistics() {
+    return !columnStatisticsList.isEmpty();
+  }
+
+  public DrillStatsTable.TableStatistics getStatistics() {
+    return DrillStatsTable.generateDirectoryStructure(dirComputedTime.toString(),
+        columnStatisticsList);
+  }
+
+  public boolean hasErrors() {
+    return errStatus;
+  }
+
+  @Override
+  public FieldConverter getNewBigIntConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new BigIntJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewIntConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new IntJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewDateConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new DateJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewVarCharConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new VarCharJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewNullableBigIntConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new NullableBigIntJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewNullableVarBinaryConverter(int fieldId, String fieldName, FieldReader reader) {
+    return new NullableVarBinaryJsonConverter(fieldId, fieldName, reader);
+  }
+
+  @Override
+  public FieldConverter getNewNullableFloat8Converter(int fieldId, String fieldName, FieldReader reader) {
+    return new NullableFloat8JsonConverter(fieldId, fieldName, reader);
+  }
+
+  public class BigIntJsonConverter extends FieldConverter {
+
+    public BigIntJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      switch (fieldName) {
+        case Statistic.SCHEMA:
+        case Statistic.ROWCOUNT:
+        case Statistic.NNROWCOUNT:
+        case Statistic.NDV:
+        case Statistic.AVG_WIDTH:
+        case Statistic.SUM_DUPS:
+          nextField = fieldName;
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (nextField == null) {
+        errStatus = true;
+        throw new IOException("Statistics writer encountered unexpected field");
+      }
+      DrillStatsTable.ColumnStatistics_v1 columnStatistics =
+          (DrillStatsTable.ColumnStatistics_v1) StatisticsCollectorImpl.this.columnStatistics;
+      switch (nextField) {
+        case Statistic.SCHEMA:
+          columnStatistics.setSchema(reader.readLong());
+          break;
+        case Statistic.ROWCOUNT:
+          columnStatistics.setCount(reader.readLong());
+          break;
+        case Statistic.NNROWCOUNT:
+          columnStatistics.setNonNullCount(reader.readLong());
+          break;
+        case Statistic.NDV:
+          columnStatistics.setNdv(reader.readLong());
+          break;
+        case Statistic.AVG_WIDTH:
+          columnStatistics.setAvgWidth(reader.readLong());
+          break;
+        case Statistic.SUM_DUPS:
+          // Ignore Count_Approx_Dups statistic
+          break;
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class IntJsonConverter extends FieldConverter {
+
+    public IntJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      if (fieldName.equals(Statistic.COLTYPE)) {
+        nextField = fieldName;
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (nextField == null) {
+        errStatus = true;
+        throw new IOException("Statistics writer encountered unexpected field");
+      }
+      if (nextField.equals(Statistic.COLTYPE)) {
+        // Do not write out the type
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class DateJsonConverter extends FieldConverter {
+
+    public DateJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      if (fieldName.equals(Statistic.COMPUTED)) {
+        nextField = fieldName;
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (nextField == null) {
+        errStatus = true;
+        throw new IOException("Statistics writer encountered unexpected field");
+      }
+      if (nextField.equals((Statistic.COMPUTED))) {
+        LocalDate computedTime = reader.readLocalDate();
+        if (dirComputedTime == null
+            || computedTime.compareTo(dirComputedTime) > 0) {
+          dirComputedTime = computedTime;
+        }
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class VarCharJsonConverter extends FieldConverter {
+
+    public VarCharJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      switch (fieldName) {
+        case Statistic.COLNAME:
+        case Statistic.COLTYPE:
+          nextField = fieldName;
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (nextField == null) {
+        errStatus = true;
+        throw new IOException("Statistics writer encountered unexpected field");
+      }
+      switch (nextField) {
+        case Statistic.COLNAME:
+          ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setName(SchemaPath.parseFromString(reader.readText().toString()));
+          break;
+        case Statistic.COLTYPE:
+          TypeProtos.MajorType fieldType = DrillStatsTable.getMapper().readValue(reader.readText().toString(), TypeProtos.MajorType.class);
+          ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setType(fieldType);
+          break;
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class NullableBigIntJsonConverter extends FieldConverter {
+
+    public NullableBigIntJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        switch (fieldName) {
+          case Statistic.ROWCOUNT:
+          case Statistic.NNROWCOUNT:
+          case Statistic.NDV:
+          case Statistic.SUM_DUPS:
+            nextField = fieldName;
+            break;
+        }
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        if (nextField == null) {
+          errStatus = true;
+          throw new IOException("Statistics writer encountered unexpected field");
+        }
+        switch (nextField) {
+          case Statistic.ROWCOUNT:
+            ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setCount(reader.readLong());
+            break;
+          case Statistic.NNROWCOUNT:
+            ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setNonNullCount(reader.readLong());
+            break;
+          case Statistic.NDV:
+            ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setNdv(reader.readLong());
+            break;
+          case Statistic.SUM_DUPS:
+            // Ignore Count_Approx_Dups statistic
+            break;
+        }
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class NullableVarBinaryJsonConverter extends FieldConverter {
+
+    public NullableVarBinaryJsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        switch (fieldName) {
+          case Statistic.HLL:
+          case Statistic.HLL_MERGE:
+          case Statistic.TDIGEST_MERGE:
+            nextField = fieldName;
+            break;
+        }
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        if (nextField == null) {
+          errStatus = true;
+          throw new IOException("Statistics writer encountered unexpected field");
+        }
+        switch (nextField) {
+          case Statistic.HLL:
+          case Statistic.HLL_MERGE:
+            // Do NOT write out the HLL output, since it is not used yet for computing statistics for a
+            // subset of partitions in the query OR for computing NDV with incremental statistics.
+            break;
+          case Statistic.TDIGEST_MERGE:
+            byte[] tdigest_bytearray = reader.readByteArray();
+            ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).buildHistogram(tdigest_bytearray);
+            break;
+        }
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+
+  public class NullableFloat8JsonConverter extends FieldConverter {
+
+    public NullableFloat8JsonConverter(int fieldId, String fieldName, FieldReader reader) {
+      super(fieldId, fieldName, reader);
+    }
+
+    @Override
+    public void startField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        if (fieldName.equals(Statistic.AVG_WIDTH)) {
+          nextField = fieldName;
+        }
+      }
+    }
+
+    @Override
+    public void writeField() throws IOException {
+      if (!skipNullFields || this.reader.isSet()) {
+        if (nextField == null) {
+          errStatus = true;
+          throw new IOException("Statistics writer encountered unexpected field");
+        }
+        if (nextField.equals(Statistic.AVG_WIDTH)) {
+          ((DrillStatsTable.ColumnStatistics_v1) columnStatistics).setAvgWidth(reader.readDouble());
+        }
+      }
+    }
+
+    @Override
+    public void endField() {
+      nextField = null;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/BaseParquetMetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/BaseParquetMetadataProvider.java
@@ -539,6 +539,10 @@ public abstract class BaseParquetMetadataProvider implements ParquetMetadataProv
     return rowGroups;
   }
 
-  protected abstract void initInternal() throws IOException;
+  @Override
+  public boolean checkMetadataVersion() {
+    return false;
+  }
 
+  protected abstract void initInternal() throws IOException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
@@ -41,6 +41,8 @@ import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.metastore.statistics.ColumnStatistics;
 import org.apache.drill.exec.expr.FilterPredicate;
 import org.apache.drill.exec.expr.StatisticsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +52,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class FilterEvaluatorUtils {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FilterEvaluatorUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(FilterEvaluatorUtils.class);
 
   private FilterEvaluatorUtils() {
   }
@@ -60,7 +62,7 @@ public class FilterEvaluatorUtils {
                                      int rowGroupIndex, OptionManager options, FragmentContext fragmentContext) {
     // Specifies type arguments explicitly to avoid compilation error caused by JDK-8066974
     List<SchemaPath> schemaPathsInExpr = new ArrayList<>(
-            expr.<Set<SchemaPath>, Void, RuntimeException>accept(new FieldReferenceFinder(), null));
+            expr.<Set<SchemaPath>, Void, RuntimeException>accept(FilterEvaluatorUtils.FieldReferenceFinder.INSTANCE, null));
 
     RowGroupMetadata rowGroupMetadata = new ArrayList<>(ParquetTableMetadataUtils.getRowGroupsMetadata(footer).values()).get(rowGroupIndex);
     NonInterestingColumnsMetadata nonInterestingColumnsMetadata = ParquetTableMetadataUtils.getNonInterestingColumnsMeta(footer);
@@ -128,6 +130,9 @@ public class FilterEvaluatorUtils {
    * Search through a LogicalExpression, finding all internal schema path references and returning them in a set.
    */
   public static class FieldReferenceFinder extends AbstractExprVisitor<Set<SchemaPath>, Void, RuntimeException> {
+
+    public static final FieldReferenceFinder INSTANCE = new FieldReferenceFinder();
+
     @Override
     public Set<SchemaPath> visitSchemaPath(SchemaPath path, Void value) {
       Set<SchemaPath> set = new HashSet<>();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFileTableMetadataProviderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetFileTableMetadataProviderBuilder.java
@@ -24,6 +24,7 @@ import org.apache.drill.exec.store.dfs.FileSelection;
 import org.apache.drill.exec.store.dfs.ReadEntryWithPath;
 import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -44,4 +45,7 @@ public interface ParquetFileTableMetadataProviderBuilder extends TableMetadataPr
   ParquetFileTableMetadataProviderBuilder withCorrectCorruptedDates(boolean autoCorrectCorruptedDates);
 
   ParquetFileTableMetadataProviderBuilder withSelection(FileSelection selection);
+
+  @Override
+  ParquetTableMetadataProvider build() throws IOException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataProviderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataProviderImpl.java
@@ -172,7 +172,7 @@ public class ParquetTableMetadataProviderImpl extends BaseParquetMetadataProvide
           }
         }
         if (!usedMetadataCache) {
-          parquetTableMetadata = Metadata.getParquetTableMetadata(processUserFileSystem, p.toString(), readerConfig);
+          parquetTableMetadata = Metadata.getParquetTableMetadata(processUserFileSystem, p, readerConfig);
         }
       } else {
         Path p = Path.getPathWithoutSchemeAndAuthority(selectionRoot);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetTableMetadataUtils.java
@@ -19,6 +19,9 @@ package org.apache.drill.exec.store.parquet;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.planner.common.DrillStatsTable;
+import org.apache.drill.exec.record.SchemaUtil;
+import org.apache.drill.metastore.metadata.BaseTableMetadata;
 import org.apache.drill.metastore.statistics.BaseStatisticsKind;
 import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
@@ -68,9 +71,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
- * Utility class for converting parquet metadata classes to metastore metadata classes.
+ * Utility class for converting parquet metadata classes to Metastore metadata classes.
  */
 @SuppressWarnings("WeakerAccess")
 public class ParquetTableMetadataUtils {
@@ -133,7 +138,8 @@ public class ParquetTableMetadataUtils {
         } else {
           newIndex = index++;
         }
-        rowGroups.put(file.getPath(), getRowGroupMetadata(tableMetadata, rowGroupMetadata, newIndex, file.getPath()));
+        Path filePath = Path.getPathWithoutSchemeAndAuthority(file.getPath());
+        rowGroups.put(filePath, getRowGroupMetadata(tableMetadata, rowGroupMetadata, newIndex, filePath));
       }
     }
 
@@ -160,7 +166,7 @@ public class ParquetTableMetadataUtils {
     Map<SchemaPath, TypeProtos.MajorType> columns = getRowGroupFields(tableMetadata, rowGroupMetadata);
     Map<SchemaPath, TypeProtos.MajorType> intermediateColumns = getIntermediateFields(tableMetadata, rowGroupMetadata);
 
-    TupleSchema schema = new TupleSchema();
+    TupleMetadata schema = new TupleSchema();
     columns.forEach(
         (schemaPath, majorType) -> SchemaPathUtils.addColumnMetadata(schema, schemaPath, majorType, intermediateColumns)
     );
@@ -465,39 +471,62 @@ public class ParquetTableMetadataUtils {
   public static Map<SchemaPath, TypeProtos.MajorType> getRowGroupFields(
       MetadataBase.ParquetTableMetadataBase parquetTableMetadata, MetadataBase.RowGroupMetadata rowGroup) {
     Map<SchemaPath, TypeProtos.MajorType> columns = new LinkedHashMap<>();
+    if (new MetadataVersion(parquetTableMetadata.getMetadataVersion()).compareTo(new MetadataVersion(4, 0)) > 0
+        && !((Metadata_V4.ParquetTableMetadata_v4) parquetTableMetadata).isAllColumnsInteresting()) {
+      // adds non-interesting fields from table metadata
+      for (MetadataBase.ColumnTypeMetadata columnTypeMetadata : parquetTableMetadata.getColumnTypeInfoList()) {
+        Metadata_V4.ColumnTypeMetadata_v4 metadata = (Metadata_V4.ColumnTypeMetadata_v4) columnTypeMetadata;
+        if (!metadata.isInteresting) {
+          TypeProtos.MajorType columnType = getColumnType(metadata.name, metadata.primitiveType, metadata.originalType, parquetTableMetadata);
+          SchemaPath columnPath = SchemaPath.getCompoundPath(metadata.name);
+          putType(columns, columnPath, columnType);
+        }
+      }
+    }
     for (MetadataBase.ColumnMetadata column : rowGroup.getColumns()) {
 
-      PrimitiveType.PrimitiveTypeName primitiveType = getPrimitiveTypeName(parquetTableMetadata, column);
-      OriginalType originalType = getOriginalType(parquetTableMetadata, column);
-      int precision = 0;
-      int scale = 0;
-      int definitionLevel = 1;
-      int repetitionLevel = 0;
-      MetadataVersion metadataVersion = new MetadataVersion(parquetTableMetadata.getMetadataVersion());
-      // only ColumnTypeMetadata_v3 and ColumnTypeMetadata_v4 store information about scale, precision, repetition level and definition level
-      if (parquetTableMetadata.hasColumnMetadata() && (metadataVersion.compareTo(new MetadataVersion(3, 0)) >= 0)) {
-        scale = parquetTableMetadata.getScale(column.getName());
-        precision = parquetTableMetadata.getPrecision(column.getName());
-        repetitionLevel = parquetTableMetadata.getRepetitionLevel(column.getName());
-        definitionLevel = parquetTableMetadata.getDefinitionLevel(column.getName());
-      }
-      TypeProtos.DataMode mode;
-      if (repetitionLevel >= 1) {
-        mode = TypeProtos.DataMode.REPEATED;
-      } else if (repetitionLevel == 0 && definitionLevel == 0) {
-        mode = TypeProtos.DataMode.REQUIRED;
-      } else {
-        mode = TypeProtos.DataMode.OPTIONAL;
-      }
-      TypeProtos.MajorType columnType =
-          TypeProtos.MajorType.newBuilder(ParquetReaderUtility.getType(primitiveType, originalType, precision, scale))
-              .setMode(mode)
-              .build();
+      TypeProtos.MajorType columnType = getColumnType(parquetTableMetadata, column);
 
       SchemaPath columnPath = SchemaPath.getCompoundPath(column.getName());
       putType(columns, columnPath, columnType);
     }
     return columns;
+  }
+
+  private static TypeProtos.MajorType getColumnType(
+      MetadataBase.ParquetTableMetadataBase parquetTableMetadata,MetadataBase.ColumnMetadata column) {
+    PrimitiveType.PrimitiveTypeName primitiveType = getPrimitiveTypeName(parquetTableMetadata, column);
+    OriginalType originalType = getOriginalType(parquetTableMetadata, column);
+    String[] name = column.getName();
+    return getColumnType(name, primitiveType, originalType, parquetTableMetadata);
+  }
+
+  private static TypeProtos.MajorType getColumnType(String[] name,
+      PrimitiveType.PrimitiveTypeName primitiveType, OriginalType originalType,
+      MetadataBase.ParquetTableMetadataBase parquetTableMetadata) {
+    int precision = 0;
+    int scale = 0;
+    int definitionLevel = 1;
+    int repetitionLevel = 0;
+    MetadataVersion metadataVersion = new MetadataVersion(parquetTableMetadata.getMetadataVersion());
+    // only ColumnTypeMetadata_v3 and ColumnTypeMetadata_v4 store information about scale, precision, repetition level and definition level
+    if (parquetTableMetadata.hasColumnMetadata() && (metadataVersion.compareTo(new MetadataVersion(3, 0)) >= 0)) {
+      scale = parquetTableMetadata.getScale(name);
+      precision = parquetTableMetadata.getPrecision(name);
+      repetitionLevel = parquetTableMetadata.getRepetitionLevel(name);
+      definitionLevel = parquetTableMetadata.getDefinitionLevel(name);
+    }
+    TypeProtos.DataMode mode;
+    if (repetitionLevel >= 1) {
+      mode = TypeProtos.DataMode.REPEATED;
+    } else if (repetitionLevel == 0 && definitionLevel == 0) {
+      mode = TypeProtos.DataMode.REQUIRED;
+    } else {
+      mode = TypeProtos.DataMode.OPTIONAL;
+    }
+    return TypeProtos.MajorType.newBuilder(ParquetReaderUtility.getType(primitiveType, originalType, precision, scale))
+        .setMode(mode)
+        .build();
   }
 
   /**
@@ -608,5 +637,25 @@ public class ParquetTableMetadataUtils {
         columns.put(columnPath, type);
       }
     }
+  }
+
+  /**
+   * Returns map with schema path and {@link ColumnStatistics} obtained from specified {@link DrillStatsTable}
+   * for all columns from specified {@link BaseTableMetadata}.
+   *
+   * @param schema     source of column names
+   * @param statistics source of column statistics
+   * @return map with schema path and {@link ColumnStatistics}
+   */
+  public static Map<SchemaPath, ColumnStatistics> getColumnStatistics(TupleMetadata schema, DrillStatsTable statistics) {
+    List<SchemaPath> schemaPaths = SchemaUtil.getSchemaPaths(schema);
+
+    return schemaPaths.stream()
+        .collect(
+            Collectors.toMap(
+                Function.identity(),
+                schemaPath -> new ColumnStatistics<>(
+                    DrillStatsTable.getEstimatedColumnStats(statistics, schemaPath),
+                    SchemaPathUtils.getColumnMetadata(schemaPath, schema).type())));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/FileMetadataCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/FileMetadataCollector.java
@@ -58,7 +58,7 @@ public class FileMetadataCollector {
   private final FileSystem fs;
   private final boolean allColumnsInteresting;
   private final boolean skipNonInteresting;
-  private final Set<String> columnSet;
+  private final Set<SchemaPath> columnSet;
 
   private final MessageType schema;
   private final ParquetReaderUtility.DateCorruptionStatus containsCorruptDates;
@@ -74,7 +74,7 @@ public class FileMetadataCollector {
                                FileSystem fs,
                                boolean allColumnsInteresting,
                                boolean skipNonInteresting,
-                               Set<String> columnSet,
+                               Set<SchemaPath> columnSet,
                                ParquetReaderConfig readerConfig) throws IOException {
     this.metadata = metadata;
     this.file = file;
@@ -165,7 +165,8 @@ public class FileMetadataCollector {
                                  PrimitiveType.PrimitiveTypeName primitiveTypeName,
                                  List<Metadata_V4.ColumnMetadata_v4> columnMetadataList) {
     SchemaPath columnSchemaName = SchemaPath.getCompoundPath(columnName);
-    boolean thisColumnIsInteresting = allColumnsInteresting || columnSet == null || columnSet.contains(columnSchemaName.getRootSegmentPath());
+    boolean thisColumnIsInteresting = allColumnsInteresting || columnSet == null
+        || columnSet.contains(SchemaPath.getSimplePath(columnSchemaName.getRootSegmentPath()));
 
     if (skipNonInteresting && !thisColumnIsInteresting) {
       return;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V4.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/metadata/Metadata_V4.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.util.DrillVersionInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -46,7 +47,9 @@ public class Metadata_V4 {
     MetadataSummary metadataSummary = new MetadataSummary();
     FileMetadata fileMetadata = new FileMetadata();
 
-    public ParquetTableMetadata_v4() {}
+    public ParquetTableMetadata_v4() {
+      this.metadataSummary = new MetadataSummary(MetadataVersion.Constants.V4_1, DrillVersionInfo.getVersion(), false);
+    }
 
     public ParquetTableMetadata_v4(MetadataSummary metadataSummary) {
       this.metadataSummary = metadataSummary;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/fragment/FragmentExecutor.java
@@ -312,7 +312,7 @@ public class FragmentExecutor implements Runnable {
       }
     } catch (InterruptedException e) {
       // Swallow interrupted exceptions since we intentionally interrupt the root when cancelling a query
-      logger.trace("Interruped root: {}", e);
+      logger.trace("Interrupted root: {}", root, e);
     } catch (Throwable t) {
       fail(t);
     } finally {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -479,6 +479,10 @@ drill.exec.options: {
     drill.exec.storage.implicit.filepath.column.label: "filepath",
     drill.exec.storage.implicit.fqn.column.label: "fqn",
     drill.exec.storage.implicit.suffix.column.label: "suffix",
+    drill.exec.storage.implicit.row_group_index.column.label: "rgi",
+    drill.exec.storage.implicit.row_group_start.column.label: "rgs",
+    drill.exec.storage.implicit.row_group_length.column.label: "rgl",
+    drill.exec.storage.implicit.last_modified_time.column.label: "lmt",
     drill.exec.testing.controls: "{}",
     drill.exec.memory.operator.output_batch_size : 16777216, # 16 MB
     drill.exec.memory.operator.output_batch_size_avail_mem_factor : 0.1,
@@ -702,10 +706,10 @@ drill.exec.options: {
     exec.statistics.tdigest_compression: 100,
     # ========= Metastore related options ===========
     metastore.enabled: false,
-    metastore.retrival.retry_attempts: 5
-    metastore.metadata.store.depth_level: "ROW_GROUP",
-    metastore.metadata.use_schema: false,
-    metastore.metadata.use_statistics: false,
+    metastore.retrieval.retry_attempts: 5
+    metastore.metadata.store.depth_level: "ALL",
+    metastore.metadata.use_schema: true,
+    metastore.metadata.use_statistics: true,
     metastore.metadata.ctas.auto-collect: "NONE",
     metastore.metadata.fallback_to_file_metadata: true
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestFunctionsQuery.java
@@ -1019,4 +1019,16 @@ public class TestFunctionsQuery extends BaseTestQuery {
     expectedException.expectMessage(containsString("Error from UDF"));
     test("select error_function()");
   }
+
+  @Test
+  public void testParentPathFunction() throws Exception {
+    testBuilder()
+        .sqlQuery("select parentPath('/a/b/cde/f') as col1," +
+            "parentPath('/a/b/cde/f/') as col2," +
+            "parentPath('/a') as col3")
+        .unOrdered()
+        .baselineColumns("col1", "col2", "col3")
+        .baselineValues("/a/b/cde", "/a/b/cde", "/")
+        .go();
+  }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.fn.impl;
 
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -29,9 +31,7 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.record.RecordBatchLoader;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.util.Text;
-import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.categories.OperatorTest;
-import org.apache.drill.PlanTestBase;
 import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -39,7 +39,8 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
-import org.apache.drill.test.TestBuilder;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -61,18 +62,21 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static org.apache.drill.test.TestBuilder.listOf;
+import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Category({SqlFunctionTest.class, OperatorTest.class, PlannerTest.class})
-public class TestAggregateFunctions extends BaseTestQuery {
+public class TestAggregateFunctions extends ClusterTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
   @BeforeClass
-  public static void setupFiles() {
+  public static void setUp() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
     dirTestWatcher.copyResourceToRoot(Paths.get("agg"));
   }
 
@@ -104,7 +108,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
   @Test
   public void testMaxWithZeroInput() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, false);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, false);
       testBuilder()
           .sqlQuery("select max(employee_id * 0.0) as max_val from cp.`employee.json`")
           .unOrdered()
@@ -112,7 +116,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
           .baselineValues(0.0)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
@@ -198,7 +202,8 @@ public class TestAggregateFunctions extends BaseTestQuery {
         "      group by l_partkey, l_suppkey) \n" +
         "   group by l_partkey )";
 
-    test("alter session set `planner.slice_target` = 1; alter session set `planner.enable_multiphase_agg` = false ;");
+    client.alterSession(ExecConstants.SLICE_TARGET, 1);
+    client.alterSession(PlannerSettings.MULTIPHASE.getOptionName(), false);
 
     testBuilder()
         .ordered()
@@ -207,7 +212,8 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .baselineValues(2000L)
         .build().run();
 
-    test("alter session set `planner.slice_target` = 1; alter session set `planner.enable_multiphase_agg` = true ;");
+    client.alterSession(ExecConstants.SLICE_TARGET, 1);
+    client.alterSession(PlannerSettings.MULTIPHASE.getOptionName(), true);
 
     testBuilder()
         .ordered()
@@ -216,7 +222,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .baselineValues(2000L)
         .build().run();
 
-    test("alter session set `planner.slice_target` = 100000");
+    client.alterSession(ExecConstants.SLICE_TARGET, 1000);
   }
 
   @Test
@@ -270,7 +276,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
   @Test
   public void testVarSampDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select var_samp(cast(employee_id as decimal(28, 20))) as dec20,\n" +
                 "var_samp(cast(employee_id as decimal(28, 0))) as dec6,\n" +
@@ -283,14 +289,14 @@ public class TestAggregateFunctions extends BaseTestQuery {
               111266.99999699896)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
   @Test
   public void testVarPopDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select var_pop(cast(employee_id as decimal(28, 20))) as dec20,\n" +
               "var_pop(cast(employee_id as decimal(28, 0))) as dec6,\n" +
@@ -303,14 +309,14 @@ public class TestAggregateFunctions extends BaseTestQuery {
               111170.66493206649)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
   @Test
   public void testStddevSampDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select stddev_samp(cast(employee_id as decimal(28, 20))) as dec20,\n" +
               "stddev_samp(cast(employee_id as decimal(28, 0))) as dec6,\n" +
@@ -324,14 +330,14 @@ public class TestAggregateFunctions extends BaseTestQuery {
           // Was taken sqrt of 111266.99999699895713760531784795216338 and decimal result is correct
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
   @Test
   public void testStddevPopDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select stddev_pop(cast(employee_id as decimal(28, 20))) as dec20,\n" +
               "stddev_pop(cast(employee_id as decimal(28, 0))) as dec6,\n" +
@@ -344,14 +350,14 @@ public class TestAggregateFunctions extends BaseTestQuery {
               333.4226520980038)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
   @Test
   public void testSumDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select sum(cast(employee_id as decimal(9, 0))) as colDecS0,\n" +
               "sum(cast(employee_id as decimal(12, 3))) as colDecS3,\n" +
@@ -362,14 +368,14 @@ public class TestAggregateFunctions extends BaseTestQuery {
           .baselineValues(BigDecimal.valueOf(668743), new BigDecimal("668743.000"), 668743L)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
   @Test
   public void testAvgDecimal() throws Exception {
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select avg(cast(employee_id as decimal(28, 20))) as colDec20,\n" +
               "avg(cast(employee_id as decimal(28, 0))) as colDec6,\n" +
@@ -382,7 +388,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
               578.9982683982684)
           .go();
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
@@ -419,15 +425,15 @@ public class TestAggregateFunctions extends BaseTestQuery {
             "min(cast(employee_id as decimal(9, 3))) min_col\n" +
             "from cp.`employee.json` limit 0";
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
-      alterSession(ExecConstants.EARLY_LIMIT0_OPT_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(ExecConstants.EARLY_LIMIT0_OPT_KEY, true);
 
       testBuilder()
           .sqlQuery(query)
           .schemaBaseLine(expectedSchema)
           .go();
 
-      alterSession(ExecConstants.EARLY_LIMIT0_OPT_KEY, false);
+      client.alterSession(ExecConstants.EARLY_LIMIT0_OPT_KEY, false);
 
       testBuilder()
         .sqlQuery(query)
@@ -435,8 +441,8 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .go();
 
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
-      resetSessionOption(ExecConstants.EARLY_LIMIT0_OPT_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(ExecConstants.EARLY_LIMIT0_OPT_KEY);
     }
   }
 
@@ -449,7 +455,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
     }
 
     try {
-      alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
+      client.alterSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY, true);
       testBuilder()
           .sqlQuery("select sum(cast(a as decimal(9,0))) as s,\n" +
               "avg(cast(a as decimal(9,0))) as av,\n" +
@@ -468,7 +474,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
           .go();
 
     } finally {
-      resetSessionOption(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
+      client.resetSession(PlannerSettings.ENABLE_DECIMAL_DATA_TYPE_KEY);
     }
   }
 
@@ -543,7 +549,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
   public void minMaxEmptyNonNullableInput() throws Exception {
     // test min and max functions on required type
 
-    final QueryDataBatch result = testSqlWithResults("select * from cp.`parquet/alltypes_required.parquet` limit 0")
+    final QueryDataBatch result = queryBuilder().sql("select * from cp.`parquet/alltypes_required.parquet` limit 0").results()
         .get(0);
 
     final Map<String, StringBuilder> functions = Maps.newHashMap();
@@ -592,7 +598,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
         "cp.`parquet/alltypes_optional.parquet`");
     for (String tableName : tableNames) {
       final QueryDataBatch result =
-          testSqlWithResults(String.format("select * from %s limit 1", tableName)).get(0);
+          queryBuilder().sql("select * from %s limit 1", tableName).results().get(0);
 
       final Map<String, StringBuilder> functions = new HashMap<>();
       functions.put("single_value", new StringBuilder());
@@ -600,7 +606,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
       final Map<String, Object> resultingValues = new HashMap<>();
       final List<String> columns = new ArrayList<>();
 
-      final RecordBatchLoader loader = new RecordBatchLoader(getAllocator());
+      final RecordBatchLoader loader = new RecordBatchLoader(cluster.allocator());
       loader.load(result.getHeader().getDef(), result.getData());
 
       for (VectorWrapper<?> vectorWrapper : loader.getContainer()) {
@@ -660,7 +666,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
 
             // disable interval types when stream agg is disabled due to DRILL-7241
             if (optionValue || !columnName.startsWith("`col_intrvl")) {
-              setSessionOption(PlannerSettings.STREAMAGG.getOptionName(), optionValue);
+              client.alterSession(PlannerSettings.STREAMAGG.getOptionName(), optionValue);
               testBuilder()
                   .sqlQuery("select single_value(t.%1$s) as %1$s\n" +
                       "from (select %1$s from %2$s limit 1) t group by t.%1$s", columnName, tableName)
@@ -671,18 +677,18 @@ public class TestAggregateFunctions extends BaseTestQuery {
           }
         }
       } finally {
-        resetSessionOption(PlannerSettings.STREAMAGG.getOptionName());
+        client.resetSession(PlannerSettings.STREAMAGG.getOptionName());
       }
     }
   }
 
-  private static Map<String, Object> getBaselineRecords(String tableName) throws Exception {
+  private Map<String, Object> getBaselineRecords(String tableName) throws Exception {
     QueryDataBatch result =
-        testSqlWithResults(String.format("select * from %s limit 1", tableName)).get(0);
+        queryBuilder().sql("select * from %s limit 1", tableName).results().get(0);
 
     Map<String, Object> resultingValues = new HashMap<>();
 
-    RecordBatchLoader loader = new RecordBatchLoader(getAllocator());
+    RecordBatchLoader loader = new RecordBatchLoader(cluster.allocator());
     loader.load(result.getHeader().getDef(), result.getData());
 
     for (VectorWrapper<?> vectorWrapper : loader.getContainer()) {
@@ -707,12 +713,12 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("any_a", "any_f", "any_m", "any_p")
-        .baselineValues(TestBuilder.listOf(TestBuilder.mapOf("b", 10L, "c", 15L),
-            TestBuilder.mapOf("b", 20L, "c", 45L)),
-            TestBuilder.listOf(TestBuilder.mapOf("g", TestBuilder.mapOf("h",
-                TestBuilder.listOf(TestBuilder.mapOf("k", 10L), TestBuilder.mapOf("k", 20L))))),
-            TestBuilder.listOf(TestBuilder.mapOf("n", TestBuilder.listOf(1L, 2L, 3L))),
-            TestBuilder.mapOf("q", TestBuilder.listOf(27L, 28L, 29L)))
+        .baselineValues(listOf(mapOf("b", 10L, "c", 15L),
+            mapOf("b", 20L, "c", 45L)),
+            listOf(mapOf("g", mapOf("h",
+                listOf(mapOf("k", 10L), mapOf("k", 20L))))),
+            listOf(mapOf("n", listOf(1L, 2L, 3L))),
+            mapOf("q", listOf(27L, 28L, 29L)))
         .go();
   }
 
@@ -723,9 +729,9 @@ public class TestAggregateFunctions extends BaseTestQuery {
         "cp.`parquet/alltypes_optional.parquet`");
     for (String tableName : tableNames) {
       QueryDataBatch result =
-          testSqlWithResults(String.format("select * from %s limit 1", tableName)).get(0);
+          queryBuilder().sql("select * from %s limit 1", tableName).results().get(0);
 
-      RecordBatchLoader loader = new RecordBatchLoader(getAllocator());
+      RecordBatchLoader loader = new RecordBatchLoader(cluster.allocator());
       loader.load(result.getHeader().getDef(), result.getData());
 
       List<String> columns = StreamSupport.stream(loader.getContainer().spliterator(), false)
@@ -735,7 +741,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
       result.release();
       for (String columnName : columns) {
         try {
-          test("select single_value(t.%1$s) as %1$s from %2$s t", columnName, tableName);
+          run("select single_value(t.%1$s) as %1$s from %2$s t", columnName, tableName);
         } catch (UserRemoteException e) {
           assertTrue("No expected current \"FUNCTION ERROR\" and/or \"Input for single_value function has more than one row\"",
               e.getMessage().matches("^FUNCTION ERROR(.|\\n)*Input for single_value function has more than one row(.|\\n)*"));
@@ -749,7 +755,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
     thrown.expect(UserRemoteException.class);
     thrown.expectMessage(containsString("FUNCTION ERROR"));
     thrown.expectMessage(containsString("Input for single_value function has more than one row"));
-    test("select single_value(t1.a) from cp.`store/json/test_anyvalue.json` t1");
+    run("select single_value(t1.a) from cp.`store/json/test_anyvalue.json` t1");
   }
 
   /*
@@ -765,21 +771,21 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .sqlQuery(query, 2)
         .unOrdered()
         .baselineColumns("col1")
-        .baselineValues(2l)
+        .baselineValues(2L)
         .go();
 
     testBuilder()
         .sqlQuery(query, 4)
         .unOrdered()
         .baselineColumns("col1")
-        .baselineValues(4l)
+        .baselineValues(4L)
         .go();
 
     testBuilder()
         .sqlQuery(query, 6)
         .unOrdered()
         .baselineColumns("col1")
-        .baselineValues(6l)
+        .baselineValues(6L)
         .go();
   }
 
@@ -792,28 +798,36 @@ public class TestAggregateFunctions extends BaseTestQuery {
         " where n_regionkey = 2 ";
 
     // Validate the plan
-    final String[] expectedPlan = {"(?s)(StreamAgg|HashAgg).*Filter"};
-    final String[] excludedPatterns = {"(?s)Filter.*(StreamAgg|HashAgg)"};
-    PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPatterns);
+    String expectedPlan = "(?s)(StreamAgg|HashAgg).*Filter";
+    String excludedPatterns = "(?s)Filter.*(StreamAgg|HashAgg)";
+    queryBuilder().sql(query)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
 
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5l)
+        .baselineValues(5L)
         .build().run();
 
     // having clause
-    final String query2 =
+    String query2 =
         " select count(*) cnt from cp.`tpch/nation.parquet` group by n_regionkey " +
         " having n_regionkey = 2 ";
-    PlanTestBase.testPlanMatchingPatterns(query2, expectedPlan, excludedPatterns);
+    queryBuilder().sql(query2)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
 
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5l)
+        .baselineValues(5L)
         .build().run();
   }
 
@@ -825,49 +839,62 @@ public class TestAggregateFunctions extends BaseTestQuery {
             " where n_regionkey + 100 - 100 = 2 ";
 
     // Validate the plan
-    final String[] expectedPlan = {"(?s)(StreamAgg|HashAgg).*Filter"};
-    final String[] excludedPatterns = {"(?s)Filter.*(StreamAgg|HashAgg)"};
-    PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPatterns);
+    String expectedPlan = "(?s)(StreamAgg|HashAgg).*Filter";
+    String excludedPatterns = "(?s)Filter.*(StreamAgg|HashAgg)";
+    queryBuilder().sql(query)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
 
     testBuilder()
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(5l)
+        .baselineValues(5L)
         .build().run();
   }
 
   @Test
   public void testNegPushFilterInExprPastAgg() throws Exception {
     // negative case: should not push filter, since it involves the aggregate result
-    final String query =
+    String query =
         " select cnt " +
             " from (select n_regionkey, count(*) cnt from cp.`tpch/nation.parquet` group by n_regionkey) " +
             " where cnt + 100 - 100 = 5 ";
 
     // Validate the plan
-    final String[] expectedPlan = {"(?s)Filter(?!StreamAgg|!HashAgg)"};
-    final String[] excludedPatterns = {"(?s)(StreamAgg|HashAgg).*Filter"};
-    PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPatterns);
+    String expectedPlan = "(?s)Filter(?!StreamAgg|!HashAgg)";
+    String excludedPatterns = "(?s)(StreamAgg|HashAgg).*Filter";
+    queryBuilder().sql(query)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
 
     // negative case: should not push filter, since it is expression of group key + agg result.
-    final String query2 =
+    String query2 =
         " select cnt " +
             " from (select n_regionkey, count(*) cnt from cp.`tpch/nation.parquet` group by n_regionkey) " +
             " where cnt + n_regionkey = 5 ";
-    PlanTestBase.testPlanMatchingPatterns(query2, expectedPlan, excludedPatterns);
-
+    queryBuilder().sql(query2)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
   }
 
   @Test // DRILL-3781
   @Category(UnlikelyTest.class)
   // GROUP BY System functions in schema table.
   public void testGroupBySystemFuncSchemaTable() throws Exception {
-    final String query = "select count(*) as cnt from sys.version group by CURRENT_DATE";
-    final String[] expectedPlan = {"(?s)(StreamAgg|HashAgg)"};
-    final String[] excludedPatterns = {};
+    String query = "select count(*) as cnt from sys.version group by CURRENT_DATE";
+    String expectedPlan = "(?s)(StreamAgg|HashAgg)";
 
-    PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPatterns);
+    queryBuilder().sql(query)
+        .planMatcher()
+        .include(expectedPlan)
+        .match();
   }
 
   @Test //DRILL-3781
@@ -878,27 +905,27 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .sqlQuery("select count(*) as cnt from cp.`nation/nation.tbl` group by CURRENT_DATE")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(25l)
+        .baselineValues(25L)
         .build().run();
 
     testBuilder()
         .sqlQuery("select count(*) as cnt from cp.`tpch/nation.parquet` group by CURRENT_DATE")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(25l)
+        .baselineValues(25L)
         .build().run();
 
     testBuilder()
         .sqlQuery("select count(*) as cnt from cp.`employee.json` group by CURRENT_DATE")
         .unOrdered()
         .baselineColumns("cnt")
-        .baselineValues(1155l)
+        .baselineValues(1155L)
         .build().run();
   }
 
   @Test
   public void test4443() throws Exception {
-    test("SELECT MIN(columns[1]) FROM cp.`agg/4443.csv` GROUP BY columns[0]");
+    run("SELECT MIN(columns[1]) FROM cp.`agg/4443.csv` GROUP BY columns[0]");
   }
 
   @Test
@@ -921,7 +948,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
         .sqlQuery(query)
         .unOrdered()
         .baselineColumns("col")
-        .baselineValues(5l)
+        .baselineValues(5L)
         .build()
         .run();
   }
@@ -955,9 +982,13 @@ public class TestAggregateFunctions extends BaseTestQuery {
             + "          lineitem.provider";
 
     // Validate the plan
-    final String[] expectedPlan = {"(?s)(Join).*inner"}; // With filter pushdown, left join will be converted into inner join
-    final String[] excludedPatterns = {"(?s)(Join).*(left)"};
-    PlanTestBase.testPlanMatchingPatterns(sql, expectedPlan, excludedPatterns);
+    String expectedPlan = "(?s)(Join).*inner"; // With filter pushdown, left join will be converted into inner join
+    String excludedPatterns = "(?s)(Join).*(left)";
+    queryBuilder().sql(sql)
+        .planMatcher()
+        .include(expectedPlan)
+        .exclude(excludedPatterns)
+        .match();
   }
 
   @Test // DRILL-2385: count on complex objects failed with missing function implementation
@@ -987,7 +1018,7 @@ public class TestAggregateFunctions extends BaseTestQuery {
             .baselineValues(3L)
             .go();
       } finally {
-        test("ALTER SESSION RESET `exec.enable_union_type`");
+        client.resetSession(ExecConstants.ENABLE_UNION_TYPE_KEY);
       }
     }
   }
@@ -1016,11 +1047,75 @@ public class TestAggregateFunctions extends BaseTestQuery {
   @Test // DRILL-5768
   public void testGroupByWithoutAggregate() throws Exception {
     try {
-      test("select * from cp.`tpch/nation.parquet` group by n_regionkey");
+      run("select * from cp.`tpch/nation.parquet` group by n_regionkey");
       fail("Exception was not thrown");
     } catch (UserRemoteException e) {
       assertTrue("No expected current \"Expression 'tpch/nation.parquet.**' is not being grouped\"",
-          e.getMessage().matches(".*Expression 'tpch/nation\\.parquet\\.\\*\\*' is not being grouped(.*\\n)*"));
+          e.getMessage().matches(".*Expression 'tpch/nation\\.parquet\\.\\*\\*' is not being grouped(.*\\n*.*)"));
     }
+  }
+
+  @Test
+  public void testCollectList() throws Exception {
+    testBuilder()
+        .sqlQuery("select collect_list('n_nationkey', n_nationkey, " +
+            "'n_name', n_name, 'n_regionkey', n_regionkey, 'n_comment', n_comment) as l from (select * from cp.`tpch/nation.parquet` limit 2)")
+        .unOrdered()
+        .baselineColumns("l")
+        .baselineValues(listOf(
+            mapOf("n_nationkey", 0, "n_name", "ALGERIA",
+                "n_regionkey", 0, "n_comment", " haggle. carefully final deposits detect slyly agai"),
+            mapOf("n_nationkey", 1, "n_name", "ARGENTINA", "n_regionkey", 1,
+                "n_comment", "al foxes promise slyly according to the regular accounts. bold requests alon")))
+        .go();
+  }
+
+  @Test
+  public void testCollectToListVarchar() throws Exception {
+    testBuilder()
+        .sqlQuery("select collect_to_list_varchar(`date`) as l from " +
+            "(select * from cp.`store/json/clicks.json` limit 2)")
+        .unOrdered()
+        .baselineColumns("l")
+        .baselineValues(listOf("2014-04-26", "2014-04-20"))
+        .go();
+  }
+
+  @Test
+  public void testSchemaFunction() throws Exception {
+    TupleMetadata schema = new SchemaBuilder()
+        .add("n_nationkey", TypeProtos.MinorType.INT)
+        .add("n_name", TypeProtos.MinorType.VARCHAR)
+        .add("n_regionkey", TypeProtos.MinorType.INT)
+        .add("n_comment", TypeProtos.MinorType.VARCHAR)
+        .build();
+
+    testBuilder()
+        .sqlQuery("select schema('n_nationkey', n_nationkey, " +
+            "'n_name', n_name, 'n_regionkey', n_regionkey, 'n_comment', n_comment) as l from " +
+            "(select * from cp.`tpch/nation.parquet` limit 2)")
+        .unOrdered()
+        .baselineColumns("l")
+        .baselineValues(schema.jsonString())
+        .go();
+  }
+
+  @Test
+  public void testMergeSchemaFunction() throws Exception {
+    String schema = new SchemaBuilder()
+        .add("n_nationkey", TypeProtos.MinorType.INT)
+        .add("n_name", TypeProtos.MinorType.VARCHAR)
+        .add("n_regionkey", TypeProtos.MinorType.INT)
+        .add("n_comment", TypeProtos.MinorType.VARCHAR)
+        .build()
+        .jsonString();
+
+    testBuilder()
+        .sqlQuery("select merge_schema('%s') as l from " +
+            "(select * from cp.`tpch/nation.parquet` limit 2)", schema)
+        .unOrdered()
+        .baselineColumns("l")
+        .baselineValues(schema)
+        .go();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAggWithAnyValue.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestAggWithAnyValue.java
@@ -42,7 +42,7 @@ public class TestAggWithAnyValue {
 
     @Test
     public void testStreamAggWithGroupBy() {
-      StreamingAggregate aggConf = new StreamingAggregate(null, parseExprs("age.`max`", "age"), parseExprs("any_value(a)", "any_a"), 2.0f);
+      StreamingAggregate aggConf = new StreamingAggregate(null, parseExprs("age.`max`", "age"), parseExprs("any_value(a)", "any_a"));
       List<String> inputJsonBatches = Lists.newArrayList(
           "[{ \"age\": {\"min\":20, \"max\":60}, \"city\": \"San Bruno\", \"de\": \"987654321987654321987654321.10987654321\"," +
               " \"a\": [{\"b\":50, \"c\":30},{\"b\":70, \"c\":40}], \"m\": [{\"n\": [10, 11, 12]}], \"f\": [{\"g\": {\"h\": [{\"k\": 70}, {\"k\": 80}]}}]," +

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestStreamingAggEmitOutcome.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestStreamingAggEmitOutcome.java
@@ -77,8 +77,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -125,8 +124,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -181,8 +179,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -241,8 +238,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -320,8 +316,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -396,8 +391,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -453,8 +447,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -505,8 +498,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -584,8 +576,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name", "id_left", "id"),
-      parseExprs("count(cost_left)", "total_count"),
-      1.0f);
+      parseExprs("count(cost_left)", "total_count"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -704,8 +695,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name", "id_left", "id"),
-      parseExprs("count(cost_left)", "total_count"),
-      1.0f);
+      parseExprs("count(cost_left)", "total_count"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -804,8 +794,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name"),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -835,8 +824,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         parseExprs("name_left", "name"),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -898,8 +886,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
       parseExprs("name_left", "name", "id_left", "id"),
-      parseExprs("count(cost_left)", "total_count"),
-      1.0f);
+      parseExprs("count(cost_left)", "total_count"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -951,8 +938,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -994,8 +980,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1051,8 +1036,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1112,8 +1096,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1185,8 +1168,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1252,8 +1234,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1309,8 +1290,7 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
         new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1359,9 +1339,8 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
         inputContainer, inputOutcomes, emptyInputRowSet.container().getSchema());
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
-        new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        new ArrayList<>(),
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1427,9 +1406,8 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
         inputContainer, inputOutcomes, emptyInputRowSet.container().getSchema());
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
-        new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        new ArrayList<>(),
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1461,9 +1439,8 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
         inputContainer, inputOutcomes, emptyInputRowSet.container().getSchema());
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
-        new ArrayList<NamedExpression>(),
-        parseExprs("sum(id_left+cost_left)", "total_sum"),
-        1.0f);
+        new ArrayList<>(),
+        parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
         operatorFixture.getFragmentContext());
@@ -1519,9 +1496,8 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
       inputContainer, inputOutcomes, inputContainerSv2, inputContainer.get(0).getSchema());
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
-      new ArrayList<NamedExpression>(),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      new ArrayList<>(),
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());
@@ -1579,9 +1555,8 @@ public class TestStreamingAggEmitOutcome extends BaseTestOpBatchEmitOutcome {
       inputContainer, inputOutcomes, inputContainer.get(0).getSchema());
 
     final StreamingAggregate streamAggrConfig = new StreamingAggregate(null,
-      new ArrayList<NamedExpression>(),
-      parseExprs("sum(id_left+cost_left)", "total_sum"),
-      1.0f);
+      new ArrayList<>(),
+      parseExprs("sum(id_left+cost_left)", "total_sum"));
 
     final StreamingAggBatch strAggBatch = new StreamingAggBatch(streamAggrConfig, mockInputBatch,
       operatorFixture.getFragmentContext());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/BasicPhysicalOpUnitTest.java
@@ -148,7 +148,7 @@ public class BasicPhysicalOpUnitTest extends PhysicalOpUnitTestBase {
 
   @Test
   public void testSimpleStreamAgg() {
-    StreamingAggregate aggConf = new StreamingAggregate(null, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"), 1.0f);
+    StreamingAggregate aggConf = new StreamingAggregate(null, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"));
     List<String> inputJsonBatches = Lists.newArrayList(
         "[{\"a\": 5, \"b\" : 1 }]",
         "[{\"a\": 5, \"b\" : 5},{\"a\": 3, \"b\" : 8}]");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/TestNullInputMiniPlan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/unit/TestNullInputMiniPlan.java
@@ -197,7 +197,7 @@ public class TestNullInputMiniPlan extends MiniPlanUnitTestBase{
 
   @Test
   public void testStreamingAggEmpty() throws Exception {
-    final PhysicalOperator hashAgg = new StreamingAggregate(null, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"), 1.0f);
+    final PhysicalOperator hashAgg = new StreamingAggregate(null, parseExprs("a", "a"), parseExprs("sum(b)", "b_sum"));
     testSingleInputNullBatchHandling(hashAgg);
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
@@ -1,0 +1,2824 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.sql;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.drill.categories.MetastoreTest;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.metastore.analyze.AnalyzeParquetInfoProvider;
+import org.apache.drill.exec.planner.physical.PlannerSettings;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.metastore.components.tables.BasicTablesRequests;
+import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
+import org.apache.drill.metastore.components.tables.TableMetadataUnit;
+import org.apache.drill.metastore.metadata.BaseTableMetadata;
+import org.apache.drill.metastore.metadata.FileMetadata;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.RowGroupMetadata;
+import org.apache.drill.metastore.metadata.SegmentMetadata;
+import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.statistics.BaseStatisticsKind;
+import org.apache.drill.metastore.statistics.ColumnStatistics;
+import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
+import org.apache.drill.metastore.statistics.ExactStatisticsConstants;
+import org.apache.drill.metastore.statistics.StatisticsHolder;
+import org.apache.drill.metastore.statistics.TableStatisticsKind;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@Category({SlowTest.class, MetastoreTest.class})
+public class TestMetastoreCommands extends ClusterTest {
+
+  private static final TupleMetadata SCHEMA = new SchemaBuilder()
+      .addNullable("dir0", TypeProtos.MinorType.VARCHAR)
+      .addNullable("dir1", TypeProtos.MinorType.VARCHAR)
+      .add("o_orderkey", TypeProtos.MinorType.INT)
+      .add("o_custkey", TypeProtos.MinorType.INT)
+      .add("o_orderstatus", TypeProtos.MinorType.VARCHAR)
+      .add("o_totalprice", TypeProtos.MinorType.FLOAT8)
+      .add("o_orderdate", TypeProtos.MinorType.DATE)
+      .add("o_orderpriority", TypeProtos.MinorType.VARCHAR)
+      .add("o_clerk", TypeProtos.MinorType.VARCHAR)
+      .add("o_shippriority", TypeProtos.MinorType.INT)
+      .add("o_comment", TypeProtos.MinorType.VARCHAR)
+      .build();
+
+  private static final Map<SchemaPath, ColumnStatistics> TABLE_COLUMN_STATISTICS = ImmutableMap.<SchemaPath, ColumnStatistics>builder()
+      .put(SchemaPath.getSimplePath("o_shippriority"),
+          getColumnStatistics(0, 0, 120L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_orderstatus"),
+          getColumnStatistics("F", "P", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderpriority"),
+          getColumnStatistics("1-URGENT", "5-LOW", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderkey"),
+          getColumnStatistics(1, 1319, 120L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_clerk"),
+          getColumnStatistics("Clerk#000000004", "Clerk#000000995", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_totalprice"),
+          getColumnStatistics(3266.69, 350110.21, 120L, TypeProtos.MinorType.FLOAT8))
+      .put(SchemaPath.getSimplePath("o_comment"),
+          getColumnStatistics(" about the final platelets. dependen",
+              "zzle. carefully enticing deposits nag furio", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_custkey"),
+          getColumnStatistics(25, 1498, 120L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("dir0"),
+          getColumnStatistics("1994", "1996", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("dir1"),
+          getColumnStatistics("Q1", "Q4", 120L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderdate"),
+          getColumnStatistics(757382400000L, 850953600000L, 120L, TypeProtos.MinorType.DATE))
+      .build();
+
+  private static final Map<SchemaPath, ColumnStatistics> DIR0_1994_SEGMENT_COLUMN_STATISTICS = ImmutableMap.<SchemaPath, ColumnStatistics>builder()
+      .put(SchemaPath.getSimplePath("o_shippriority"),
+          getColumnStatistics(0, 0, 40L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_orderstatus"),
+          getColumnStatistics("F", "F", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderpriority"),
+          getColumnStatistics("1-URGENT", "5-LOW", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderkey"),
+          getColumnStatistics(5, 1031, 40L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_clerk"),
+          getColumnStatistics("Clerk#000000004", "Clerk#000000973", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_totalprice"),
+          getColumnStatistics(3266.69, 350110.21, 40L, TypeProtos.MinorType.FLOAT8))
+      .put(SchemaPath.getSimplePath("o_comment"),
+          getColumnStatistics(" accounts nag slyly. ironic, ironic accounts wake blithel",
+              "yly final requests over the furiously regula", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_custkey"),
+          getColumnStatistics(25, 1469, 40L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("dir0"),
+          getColumnStatistics("1994", "1994", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("dir1"),
+          getColumnStatistics("Q1", "Q4", 40L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderdate"),
+          getColumnStatistics(757382400000L, 788140800000L, 40L, TypeProtos.MinorType.DATE))
+      .build();
+
+  private static final Map<SchemaPath, ColumnStatistics> DIR0_1994_Q1_SEGMENT_COLUMN_STATISTICS = ImmutableMap.<SchemaPath, ColumnStatistics>builder()
+      .put(SchemaPath.getSimplePath("o_shippriority"),
+          getColumnStatistics(0, 0, 10L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_orderstatus"),
+          getColumnStatistics("F", "F", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderpriority"),
+          getColumnStatistics("1-URGENT", "5-LOW", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderkey"),
+          getColumnStatistics(66, 833, 10L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("o_clerk"),
+          getColumnStatistics("Clerk#000000062", "Clerk#000000973", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_totalprice"),
+          getColumnStatistics(3266.69, 132531.73, 10L, TypeProtos.MinorType.FLOAT8))
+      .put(SchemaPath.getSimplePath("o_comment"),
+          getColumnStatistics(" special pinto beans use quickly furiously even depende",
+              "y pending requests integrate", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_custkey"),
+          getColumnStatistics(392, 1411, 10L, TypeProtos.MinorType.INT))
+      .put(SchemaPath.getSimplePath("dir0"),
+          getColumnStatistics("1994", "1994", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("dir1"),
+          getColumnStatistics("Q1", "Q1", 10L, TypeProtos.MinorType.VARCHAR))
+      .put(SchemaPath.getSimplePath("o_orderdate"),
+          getColumnStatistics(757382400000L, 764640000000L, 10L, TypeProtos.MinorType.DATE))
+      .build();
+
+  private static final MetadataInfo TABLE_META_INFO = MetadataInfo.builder()
+      .type(MetadataType.TABLE)
+      .key(MetadataInfo.GENERAL_INFO_KEY)
+      .build();
+
+  @ClassRule
+  public static TemporaryFolder defaultFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    builder.configProperty(ExecConstants.ZK_ROOT, defaultFolder.getRoot().getPath());
+    builder.sessionOption(ExecConstants.METASTORE_ENABLED, true);
+    builder.sessionOption(ExecConstants.SLICE_TARGET, 1);
+    startCluster(builder);
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"));
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet2"));
+  }
+
+  @Before
+  public void prepare() {
+    client.alterSession(ExecConstants.METASTORE_ENABLED, true);
+    client.alterSession(ExecConstants.METASTORE_USE_SCHEMA_METADATA, true);
+    client.alterSession(ExecConstants.METASTORE_USE_STATISTICS_METADATA, true);
+    client.alterSession(ExecConstants.SLICE_TARGET, 1);
+  }
+
+  @Test
+  public void testAnalyzeWithDisabledMetastore() throws Exception {
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"));
+    client.alterSession(ExecConstants.METASTORE_ENABLED, false);
+
+    try {
+      thrown.expect(UserRemoteException.class);
+      run("ANALYZE TABLE dfs.`multilevel/parquet` REFRESH METADATA");
+    } finally {
+      client.resetSession(ExecConstants.METASTORE_ENABLED);
+    }
+  }
+
+  @Test
+  public void testSelectWithDisabledMetastore() throws Exception {
+    String tableName = "region_parquet";
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+    try {
+      run("create table dfs.tmp.`%s` as\n" +
+          "select * from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` columns none REFRESH METADATA", tableName);
+
+      String query = "select mykey from dfs.tmp.`%s` where mykey is null";
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .match();
+
+      client.alterSession(ExecConstants.METASTORE_ENABLED, false);
+
+      queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      usedMetaPattern = "usedMetastore=false";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .match();
+    } finally {
+      cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .modify()
+          .delete(tableInfo.toFilter())
+          .execute();
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+      client.resetSession(ExecConstants.METASTORE_ENABLED);
+    }
+  }
+
+  @Test
+  public void testSimpleAnalyze() throws Exception {
+    String tableName = "multilevel/parquetSimpleAnalyze";
+
+    TableInfo tableInfo = getTableInfo(tableName, "default");
+
+    File table = dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    Path tablePath = new Path(table.toURI().getPath());
+
+    BaseTableMetadata expectedTableMetadata = getBaseTableMetadata(tableInfo, table);
+
+    TableInfo baseTableInfo = TableInfo.builder()
+        .name(tableName)
+        .storagePlugin("dfs")
+        .workspace("default")
+        .build();
+    SegmentMetadata dir0 = SegmentMetadata.builder()
+        .tableInfo(baseTableInfo)
+        .metadataInfo(MetadataInfo.builder()
+            .type(MetadataType.SEGMENT)
+            .identifier("1994")
+            .key("1994")
+            .build())
+        .path(new Path(tablePath, "1994"))
+        .schema(SCHEMA)
+        .lastModifiedTime(new File(table, "1994").lastModified())
+        .column(SchemaPath.getSimplePath("dir0"))
+        .columnsStatistics(DIR0_1994_SEGMENT_COLUMN_STATISTICS)
+        .metadataStatistics(Collections.singletonList(new StatisticsHolder<>(40L, TableStatisticsKind.ROW_COUNT)))
+        .locations(ImmutableSet.of(
+            new Path(tablePath, "1994/Q1/orders_94_q1.parquet"),
+            new Path(tablePath, "1994/Q2/orders_94_q2.parquet"),
+            new Path(tablePath, "1994/Q3/orders_94_q3.parquet"),
+            new Path(tablePath, "1994/Q4/orders_94_q4.parquet")))
+        .partitionValues(Collections.singletonList("1994"))
+        .build();
+
+    Set<Path> expectedTopLevelSegmentLocations = ImmutableSet.of(
+        new Path(tablePath, "1994"),
+        new Path(tablePath, "1995"),
+        new Path(tablePath, "1996"));
+
+    Set<Set<Path>> expectedSegmentFilesLocations = new HashSet<>();
+
+    Set<Path> segmentFiles = ImmutableSet.of(
+        new Path(tablePath, "1994/Q2/orders_94_q2.parquet"),
+        new Path(tablePath, "1994/Q4/orders_94_q4.parquet"),
+        new Path(tablePath, "1994/Q1/orders_94_q1.parquet"),
+        new Path(tablePath, "1994/Q3/orders_94_q3.parquet"));
+    expectedSegmentFilesLocations.add(segmentFiles);
+
+    segmentFiles = ImmutableSet.of(
+        new Path(tablePath, "1995/Q2/orders_95_q2.parquet"),
+        new Path(tablePath, "1995/Q4/orders_95_q4.parquet"),
+        new Path(tablePath, "1995/Q1/orders_95_q1.parquet"),
+        new Path(tablePath, "1995/Q3/orders_95_q3.parquet"));
+    expectedSegmentFilesLocations.add(segmentFiles);
+
+    segmentFiles = ImmutableSet.of(
+        new Path(tablePath, "1996/Q3/orders_96_q3.parquet"),
+        new Path(tablePath, "1996/Q2/orders_96_q2.parquet"),
+        new Path(tablePath, "1996/Q4/orders_96_q4.parquet"),
+        new Path(tablePath, "1996/Q1/orders_96_q1.parquet"));
+    expectedSegmentFilesLocations.add(segmentFiles);
+
+    long dir0q1lastModified = new File(new File(new File(table, "1994"), "Q1"), "orders_94_q1.parquet").lastModified();
+    FileMetadata dir01994q1File = FileMetadata.builder()
+        .tableInfo(baseTableInfo)
+        .metadataInfo(MetadataInfo.builder()
+            .type(MetadataType.FILE)
+            .identifier("1994/Q1/orders_94_q1.parquet")
+            .key("1994")
+            .build())
+        .schema(SCHEMA)
+        .lastModifiedTime(dir0q1lastModified)
+        .columnsStatistics(DIR0_1994_Q1_SEGMENT_COLUMN_STATISTICS)
+        .metadataStatistics(Collections.singletonList(new StatisticsHolder<>(10L, TableStatisticsKind.ROW_COUNT)))
+        .path(new Path(tablePath, "1994/Q1/orders_94_q1.parquet"))
+        .build();
+
+    RowGroupMetadata dir01994q1rowGroup = RowGroupMetadata.builder()
+        .tableInfo(baseTableInfo)
+        .metadataInfo(MetadataInfo.builder()
+            .type(MetadataType.ROW_GROUP)
+            .identifier("1994/Q1/orders_94_q1.parquet/0")
+            .key("1994")
+            .build())
+        .schema(SCHEMA)
+        .rowGroupIndex(0)
+        .hostAffinity(Collections.emptyMap())
+        .lastModifiedTime(dir0q1lastModified)
+        .columnsStatistics(DIR0_1994_Q1_SEGMENT_COLUMN_STATISTICS)
+        .metadataStatistics(Arrays.asList(
+            new StatisticsHolder<>(10L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(1196L, new BaseStatisticsKind(ExactStatisticsConstants.LENGTH, true)),
+            new StatisticsHolder<>(4L, new BaseStatisticsKind(ExactStatisticsConstants.START, true))))
+        .path(new Path(tablePath, "1994/Q1/orders_94_q1.parquet"))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.`%s` REFRESH METADATA", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      List<SegmentMetadata> topSegmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByColumn(tableInfo, null, "`dir0`");
+
+      SegmentMetadata actualDir0Metadata =
+          topSegmentMetadata.stream()
+              .filter(unit -> unit.getMetadataInfo().identifier().equals("1994"))
+              .findAny().orElseThrow(() -> new AssertionError("Segment is absent"));
+      Set<Path> locations = actualDir0Metadata.getLocations();
+      actualDir0Metadata.toBuilder().locations(locations);
+      assertEquals(dir0, actualDir0Metadata);
+
+      Set<Path> topLevelSegmentLocations = topSegmentMetadata.stream()
+          .map(SegmentMetadata::getLocation)
+          .collect(Collectors.toSet());
+
+      // verify top segments locations
+      assertEquals(
+          expectedTopLevelSegmentLocations,
+          topLevelSegmentLocations);
+
+      Set<Set<Path>> segmentFilesLocations = topSegmentMetadata.stream()
+          .map(SegmentMetadata::getLocations)
+          .collect(Collectors.toSet());
+
+      assertEquals(
+          expectedSegmentFilesLocations,
+          segmentFilesLocations);
+
+      // verify nested segments
+      List<SegmentMetadata> nestedSegmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByColumn(tableInfo, null, "`dir1`");
+
+      assertEquals(12, nestedSegmentMetadata.size());
+
+      SegmentMetadata dir01994q1Segment = SegmentMetadata.builder()
+          .tableInfo(baseTableInfo)
+          .metadataInfo(MetadataInfo.builder()
+              .type(MetadataType.SEGMENT)
+              .identifier("1994/Q1")
+              .key("1994")
+              .build())
+          .path(new Path(new Path(tablePath, "1994"), "Q1"))
+          .schema(SCHEMA)
+          .lastModifiedTime(new File(new File(table, "1994"), "Q1").lastModified())
+          .column(SchemaPath.getSimplePath("dir1"))
+          .columnsStatistics(DIR0_1994_Q1_SEGMENT_COLUMN_STATISTICS)
+          .metadataStatistics(Collections.singletonList(new StatisticsHolder<>(10L, TableStatisticsKind.ROW_COUNT)))
+          .locations(ImmutableSet.of(new Path(tablePath, "1994/Q1/orders_94_q1.parquet")))
+          .partitionValues(Arrays.asList("1994", "Q1"))
+          .build();
+
+      // verify segment for 1994
+      assertEquals(dir01994q1Segment,
+          nestedSegmentMetadata.stream()
+              .filter(unit -> unit.getMetadataInfo().identifier().equals("1994/Q1"))
+              .findAny()
+              .orElse(null));
+
+      // verify files metadata
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      // verify first file metadata
+      assertEquals(dir01994q1File,
+          filesMetadata.stream()
+              .filter(unit -> unit.getMetadataInfo().identifier().equals("1994/Q1/orders_94_q1.parquet"))
+              .findAny()
+              .orElse(null));
+
+      // verify row groups metadata
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+
+      // verify first row group dir01994q1rowGroup
+      assertEquals(dir01994q1rowGroup,
+          rowGroupsMetadata.stream()
+              .filter(unit -> unit.getMetadataInfo().identifier().equals("1994/Q1/orders_94_q1.parquet/0"))
+              .findAny()
+              .orElse(null));
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testTableMetadataWithLevels() throws Exception {
+    List<MetadataType> analyzeLevels =
+        Arrays.asList(MetadataType.ROW_GROUP, MetadataType.FILE, MetadataType.SEGMENT, MetadataType.TABLE);
+
+    String tableName = "multilevel/parquetLevels";
+    File tablePath = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    for (MetadataType analyzeLevel : analyzeLevels) {
+      BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+          .tableInfo(tableInfo)
+          .metadataInfo(TABLE_META_INFO)
+          .schema(SCHEMA)
+          .location(new Path(tablePath.toURI().getPath()))
+          .columnsStatistics(TABLE_COLUMN_STATISTICS)
+          .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+              new StatisticsHolder<>(analyzeLevel, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+          .partitionKeys(Collections.emptyMap())
+          .lastModifiedTime(tablePath.lastModified())
+          .build();
+
+      try {
+        run("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA '%s' level", tableName, analyzeLevel.name());
+
+        BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+            .getMetastoreRegistry()
+            .get()
+            .tables()
+            .basicRequests()
+            .tableMetadata(tableInfo);
+
+        assertEquals(expectedTableMetadata, actualTableMetadata);
+      } finally {
+        run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      }
+    }
+  }
+
+  @Test
+  public void testAnalyzeLowerLevelMetadata() throws Exception {
+    // checks that metadata for levels below specified in analyze statement is absent
+    String tableName = "multilevel/parquetLowerLevel";
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    List<MetadataType> analyzeLevels =
+        Arrays.asList(MetadataType.FILE, MetadataType.SEGMENT, MetadataType.TABLE);
+
+    for (MetadataType analyzeLevel : analyzeLevels) {
+      try {
+        run("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA '%s' level", tableName, analyzeLevel.name());
+
+        List<String> emptyMetadataLevels = Arrays.stream(MetadataType.values())
+            .filter(metadataType -> metadataType.compareTo(analyzeLevel) > 0
+                // for the case when there are no segment metadata, default segment is present
+                && metadataType.compareTo(MetadataType.SEGMENT) > 0
+                && metadataType.compareTo(MetadataType.ALL) < 0)
+            .map(Enum::name)
+            .collect(Collectors.toList());
+
+        BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
+            .tableInfo(tableInfo)
+            .metadataTypes(emptyMetadataLevels)
+            .build();
+
+        List<TableMetadataUnit> metadataUnitList = cluster.drillbit().getContext()
+            .getMetastoreRegistry()
+            .get()
+            .tables()
+            .read()
+            .filter(requestMetadata.filter())
+            .execute();
+
+        assertTrue(
+            String.format("Some metadata [%s] for [%s] analyze query level is present" + metadataUnitList, emptyMetadataLevels, analyzeLevel),
+            metadataUnitList.isEmpty());
+      } finally {
+        run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      }
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithColumns() throws Exception {
+    String tableName = "multilevel/parquetColumns";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    Map<SchemaPath, ColumnStatistics> updatedTableColumnStatistics = new HashMap<>();
+
+    SchemaPath orderStatusPath = SchemaPath.getSimplePath("o_orderstatus");
+    SchemaPath dir0Path = SchemaPath.getSimplePath("dir0");
+    SchemaPath dir1Path = SchemaPath.getSimplePath("dir1");
+
+    updatedTableColumnStatistics.put(orderStatusPath, TABLE_COLUMN_STATISTICS.get(orderStatusPath));
+    updatedTableColumnStatistics.put(dir0Path, TABLE_COLUMN_STATISTICS.get(dir0Path));
+    updatedTableColumnStatistics.put(dir1Path, TABLE_COLUMN_STATISTICS.get(dir1Path));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedTableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .interestingColumns(Collections.singletonList(orderStatusPath))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus) REFRESH METADATA 'row_group' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithNoColumns() throws Exception {
+    String tableName = "multilevel/parquetNoColumns";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    Map<SchemaPath, ColumnStatistics> updatedTableColumnStatistics = new HashMap<>();
+
+    SchemaPath dir0Path = SchemaPath.getSimplePath("dir0");
+    SchemaPath dir1Path = SchemaPath.getSimplePath("dir1");
+
+    updatedTableColumnStatistics.put(dir0Path, TABLE_COLUMN_STATISTICS.get(dir0Path));
+    updatedTableColumnStatistics.put(dir1Path, TABLE_COLUMN_STATISTICS.get(dir1Path));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedTableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .interestingColumns(Collections.emptyList())
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` columns NONE REFRESH METADATA 'row_group' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeWithFewerColumns() throws Exception {
+    String tableName = "multilevel/parquetFewerColumns";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    Map<SchemaPath, ColumnStatistics> updatedTableColumnStatistics = new HashMap<>();
+
+    SchemaPath orderStatusPath = SchemaPath.getSimplePath("o_orderstatus");
+    SchemaPath orderDatePath = SchemaPath.getSimplePath("o_orderdate");
+    SchemaPath dir0Path = SchemaPath.getSimplePath("dir0");
+    SchemaPath dir1Path = SchemaPath.getSimplePath("dir1");
+
+    updatedTableColumnStatistics.put(orderStatusPath, TABLE_COLUMN_STATISTICS.get(orderStatusPath));
+    updatedTableColumnStatistics.put(orderDatePath, TABLE_COLUMN_STATISTICS.get(orderDatePath));
+    updatedTableColumnStatistics.put(dir0Path, TABLE_COLUMN_STATISTICS.get(dir0Path));
+    updatedTableColumnStatistics.put(dir1Path, TABLE_COLUMN_STATISTICS.get(dir1Path));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedTableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .interestingColumns(Arrays.asList(orderStatusPath, orderDatePath))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus, o_orderdate) REFRESH METADATA 'row_group' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      // checks that analyze wasn't produced though interesting columns list differs, but it is a sublist of previously analyzed table
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus) REFRESH METADATA 'row_group' LEVEL", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(false, "Table metadata is up to date, analyze wasn't performed.")
+          .go();
+
+      actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeWithMoreColumns() throws Exception {
+    String tableName = "multilevel/parquetMoreColumns";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    Map<SchemaPath, ColumnStatistics> updatedTableColumnStatistics = new HashMap<>();
+
+    SchemaPath orderStatusPath = SchemaPath.getSimplePath("o_orderstatus");
+    SchemaPath orderDatePath = SchemaPath.getSimplePath("o_orderdate");
+    SchemaPath dir0Path = SchemaPath.getSimplePath("dir0");
+    SchemaPath dir1Path = SchemaPath.getSimplePath("dir1");
+
+    updatedTableColumnStatistics.put(orderStatusPath, TABLE_COLUMN_STATISTICS.get(orderStatusPath));
+    updatedTableColumnStatistics.put(dir0Path, TABLE_COLUMN_STATISTICS.get(dir0Path));
+    updatedTableColumnStatistics.put(dir1Path, TABLE_COLUMN_STATISTICS.get(dir1Path));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedTableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .interestingColumns(Collections.singletonList(orderStatusPath))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus) REFRESH METADATA 'row_group' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      // checks that analyze was produced since interesting columns list differs, and second columns list isn't a sublist of previously analyzed table
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus, o_orderdate) REFRESH METADATA 'row_group' LEVEL", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      updatedTableColumnStatistics.put(orderDatePath, TABLE_COLUMN_STATISTICS.get(orderDatePath));
+
+      assertEquals(
+          expectedTableMetadata.toBuilder()
+              .columnsStatistics(updatedTableColumnStatistics)
+              .interestingColumns(Arrays.asList(orderStatusPath, orderDatePath))
+              .build(),
+          actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeWithEmptyColumns() throws Exception {
+    String tableName = "multilevel/parquetEmptyColumns";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    Map<SchemaPath, ColumnStatistics> updatedTableColumnStatistics = new HashMap<>();
+
+    SchemaPath orderStatusPath = SchemaPath.getSimplePath("o_orderstatus");
+    SchemaPath orderDatePath = SchemaPath.getSimplePath("o_orderdate");
+    SchemaPath dir0Path = SchemaPath.getSimplePath("dir0");
+    SchemaPath dir1Path = SchemaPath.getSimplePath("dir1");
+
+    updatedTableColumnStatistics.put(orderStatusPath, TABLE_COLUMN_STATISTICS.get(orderStatusPath));
+    updatedTableColumnStatistics.put(orderDatePath, TABLE_COLUMN_STATISTICS.get(orderDatePath));
+    updatedTableColumnStatistics.put(dir0Path, TABLE_COLUMN_STATISTICS.get(dir0Path));
+    updatedTableColumnStatistics.put(dir1Path, TABLE_COLUMN_STATISTICS.get(dir1Path));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedTableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .interestingColumns(Arrays.asList(orderStatusPath, orderDatePath))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` columns(o_orderstatus, o_orderdate) REFRESH METADATA 'row_group' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      // checks that analyze wasn't produced though interesting columns list differs, but it is a sublist of previously analyzed table
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` columns NONE REFRESH METADATA 'row_group' LEVEL", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(false, "Table metadata is up to date, analyze wasn't performed.")
+          .go();
+
+      actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeUnchangedTable() throws Exception {
+    String tableName = "multilevel/parquetUnchanged";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    long lastModifiedTime = table.lastModified();
+
+    try {
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(false, "Table metadata is up to date, analyze wasn't performed.")
+          .go();
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      long postAnalyzeLastModifiedTime = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .metastoreTableInfo(tableInfo)
+          .lastModifiedTime();
+
+      assertEquals(lastModifiedTime, postAnalyzeLastModifiedTime);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testIncrementalAnalyzeNewParentSegment() throws Exception {
+    String tableName = "multilevel/parquetNewParentSegment";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    // updates statistics values due to new segment
+    Map<SchemaPath, ColumnStatistics> updatedStatistics = new HashMap<>(TABLE_COLUMN_STATISTICS);
+    updatedStatistics.replaceAll((logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics<>(
+            Arrays.asList(
+                new StatisticsHolder<>(160L, TableStatisticsKind.ROW_COUNT),
+                new StatisticsHolder<>(160L, ColumnStatisticsKind.NON_NULL_COUNT)))));
+
+    updatedStatistics.computeIfPresent(SchemaPath.getSimplePath("dir0"), (logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics<>(
+            Collections.singletonList(new StatisticsHolder<>("1993", ColumnStatisticsKind.MIN_VALUE)))));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(160L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+
+    try {
+      assertEquals(0, cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null).size());
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet", "1994"), Paths.get(tableName, "1993"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(20, segmentMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testIncrementalAnalyzeNewChildSegment() throws Exception {
+    String tableName = "multilevel/parquetNewChildSegment";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    // updates statistics values due to new segment
+    Map<SchemaPath, ColumnStatistics> updatedStatistics = new HashMap<>(TABLE_COLUMN_STATISTICS);
+    updatedStatistics.replaceAll((logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics(
+            Arrays.asList(
+                new StatisticsHolder<>(130L, TableStatisticsKind.ROW_COUNT),
+                new StatisticsHolder<>(130L, ColumnStatisticsKind.NON_NULL_COUNT)))));
+
+    updatedStatistics.computeIfPresent(SchemaPath.getSimplePath("dir1"), (logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics(
+            Collections.singletonList(new StatisticsHolder<>("Q5", ColumnStatisticsKind.MAX_VALUE)))));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(130L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+
+    try {
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel", "parquet", "1994", "Q4"), Paths.get(tableName, "1994", "Q5"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(16, segmentMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testIncrementalAnalyzeNewFile() throws Exception {
+    String tableName = "multilevel/parquetNewFile";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    // updates statistics values due to new segment
+    Map<SchemaPath, ColumnStatistics> updatedStatistics = new HashMap<>(TABLE_COLUMN_STATISTICS);
+    updatedStatistics.replaceAll((logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics(
+            Arrays.asList(
+                new StatisticsHolder<>(130L, TableStatisticsKind.ROW_COUNT),
+                new StatisticsHolder<>(130L, ColumnStatisticsKind.NON_NULL_COUNT)))));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(updatedStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(130L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+
+    try {
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentsMetadata.size());
+
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+
+      dirTestWatcher.copyResourceToTestTmp(
+          Paths.get("multilevel", "parquet", "1994", "Q4", "orders_94_q4.parquet"),
+          Paths.get(tableName, "1994", "Q4", "orders_94_q4_1.parquet"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      // verifies that segments count left unchanged
+      assertEquals(15, segmentsMetadata.size());
+
+      filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(13, filesMetadata.size());
+
+      rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(13, rowGroupsMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeRemovedParentSegment() throws Exception {
+    String tableName = "multilevel/parquetRemovedParent";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    BaseTableMetadata expectedTableMetadata = getBaseTableMetadata(tableInfo, table);
+
+    try {
+      dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet", "1994"), Paths.get(tableName, "1993"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(20, segmentMetadata.size());
+
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(16, filesMetadata.size());
+
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(16, rowGroupsMetadata.size());
+
+      FileUtils.deleteQuietly(new File(table, "1993"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeRemovedNestedSegment() throws Exception {
+    String tableName = "multilevel/parquetRemovedNestedSegment";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    BaseTableMetadata expectedTableMetadata = getBaseTableMetadata(tableInfo, table);
+
+    try {
+      dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet", "1994", "Q4"), Paths.get(tableName, "1994", "Q5"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(16, segmentMetadata.size());
+
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(13, filesMetadata.size());
+
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(13, rowGroupsMetadata.size());
+
+      FileUtils.deleteQuietly(new File(new File(table, "1994"), "Q5"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeRemovedFile() throws Exception {
+    String tableName = "multilevel/parquetRemovedFile";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    BaseTableMetadata expectedTableMetadata = getBaseTableMetadata(tableInfo, table);
+
+    try {
+      dirTestWatcher.copyResourceToTestTmp(
+          Paths.get("multilevel", "parquet", "1994", "Q4", "orders_94_q4.parquet"),
+          Paths.get(tableName, "1994", "Q4", "orders_94_q4_1.parquet"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(13, filesMetadata.size());
+
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(13, rowGroupsMetadata.size());
+
+      FileUtils.deleteQuietly(new File(new File(new File(table, "1994"), "Q4"), "orders_94_q4_1.parquet"));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testIncrementalAnalyzeUpdatedFile() throws Exception {
+    String tableName = "multilevel/parquetUpdatedFile";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    try {
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      List<FileMetadata> filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      List<RowGroupMetadata> rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+
+      File fileToUpdate = new File(new File(new File(table, "1994"), "Q4"), "orders_94_q4.parquet");
+      long lastModified = fileToUpdate.lastModified();
+      FileUtils.deleteQuietly(fileToUpdate);
+
+      // replaces original file
+      dirTestWatcher.copyResourceToTestTmp(
+          Paths.get("multilevel", "parquet", "1994", "Q1", "orders_94_q1.parquet"),
+          Paths.get(tableName, "1994", "Q4", "orders_94_q4.parquet"));
+
+      assertTrue(fileToUpdate.setLastModified(lastModified + 1000));
+
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      Map<SchemaPath, ColumnStatistics> tableColumnStatistics = new HashMap<>(TABLE_COLUMN_STATISTICS);
+      tableColumnStatistics.computeIfPresent(SchemaPath.getSimplePath("o_clerk"),
+          (logicalExpressions, columnStatistics) ->
+              columnStatistics.cloneWith(new ColumnStatistics(
+                  Collections.singletonList(new StatisticsHolder<>("Clerk#000000006", ColumnStatisticsKind.MIN_VALUE)))));
+
+      tableColumnStatistics.computeIfPresent(SchemaPath.getSimplePath("o_totalprice"),
+          (logicalExpressions, columnStatistics) ->
+              columnStatistics.cloneWith(new ColumnStatistics(
+                  Collections.singletonList(new StatisticsHolder<>(328207.15, ColumnStatisticsKind.MAX_VALUE)))));
+
+      BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+          .tableInfo(tableInfo)
+          .metadataInfo(TABLE_META_INFO)
+          .schema(SCHEMA)
+          .location(new Path(table.toURI().getPath()))
+          .columnsStatistics(tableColumnStatistics)
+          .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+              new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+          .partitionKeys(Collections.emptyMap())
+          .lastModifiedTime(lastModified + 1000)
+          .build();
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(15, segmentMetadata.size());
+
+      filesMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .filesMetadata(tableInfo, null, null);
+
+      assertEquals(12, filesMetadata.size());
+
+      rowGroupsMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, null, (String) null);
+
+      assertEquals(12, rowGroupsMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  public void testIncrementalAnalyzeWithDifferentMetadataLevel() throws Exception {
+    String tableName = "multilevel/parquetDifferentMetadataLevel";
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+    Path tablePath = new Path(table.toURI().getPath());
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(tablePath)
+        .columnsStatistics(TABLE_COLUMN_STATISTICS)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.FILE, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA 'file' LEVEL", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      List<RowGroupMetadata> rowGroupMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, (String) null, null);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      assertTrue(rowGroupMetadata.isEmpty());
+
+      // checks that analyze was produced since metadata level more specific
+      testBuilder()
+          .sqlQuery("ANALYZE TABLE dfs.tmp.`%s` REFRESH METADATA 'row_group' LEVEL", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.tmp.%s]", tableName))
+          .go();
+
+      actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      expectedTableMetadata = BaseTableMetadata.builder()
+          .tableInfo(tableInfo)
+          .metadataInfo(TABLE_META_INFO)
+          .schema(SCHEMA)
+          .location(tablePath)
+          .columnsStatistics(TABLE_COLUMN_STATISTICS)
+          .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+              new StatisticsHolder<>(MetadataType.ROW_GROUP, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+          .partitionKeys(Collections.emptyMap())
+          .lastModifiedTime(table.lastModified())
+          .build();
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      rowGroupMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, (String) null, null);
+
+      assertEquals(12, rowGroupMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testDefaultSegment() throws Exception {
+    String tableName = "multilevel/parquet/1994/Q1";
+    Path tablePath = new Path(dirTestWatcher.getRootDir().toURI().getPath(), tableName);
+
+    TableInfo tableInfo = getTableInfo(tableName, "default");
+
+    Map<SchemaPath, ColumnStatistics> tableColumnStatistics = new HashMap<>(TABLE_COLUMN_STATISTICS);
+    tableColumnStatistics.remove(SchemaPath.getSimplePath("dir0"));
+    tableColumnStatistics.remove(SchemaPath.getSimplePath("dir1"));
+
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_orderstatus"),
+            getColumnStatistics("F", "F", 120L, TypeProtos.MinorType.VARCHAR));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_orderkey"),
+            getColumnStatistics(66, 833, 833L, TypeProtos.MinorType.INT));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_clerk"),
+            getColumnStatistics("Clerk#000000062", "Clerk#000000973", 120L, TypeProtos.MinorType.VARCHAR));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_totalprice"),
+            getColumnStatistics(3266.69, 132531.73, 120L, TypeProtos.MinorType.FLOAT8));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_comment"),
+            getColumnStatistics(" special pinto beans use quickly furiously even depende",
+                "y pending requests integrate", 120L, TypeProtos.MinorType.VARCHAR));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_custkey"),
+            getColumnStatistics(392, 1411, 120L, TypeProtos.MinorType.INT));
+    tableColumnStatistics.put(SchemaPath.getSimplePath("o_orderdate"),
+            getColumnStatistics(757382400000L, 764640000000L, 120L, TypeProtos.MinorType.DATE));
+
+    tableColumnStatistics.replaceAll((logicalExpressions, columnStatistics) ->
+        columnStatistics.cloneWith(new ColumnStatistics(
+            Arrays.asList(
+                new StatisticsHolder<>(10L, TableStatisticsKind.ROW_COUNT),
+                new StatisticsHolder<>(10L, ColumnStatisticsKind.NON_NULL_COUNT)))));
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(new SchemaBuilder()
+            .add("o_orderkey", TypeProtos.MinorType.INT)
+            .add("o_custkey", TypeProtos.MinorType.INT)
+            .add("o_orderstatus", TypeProtos.MinorType.VARCHAR)
+            .add("o_totalprice", TypeProtos.MinorType.FLOAT8)
+            .add("o_orderdate", TypeProtos.MinorType.DATE)
+            .add("o_orderpriority", TypeProtos.MinorType.VARCHAR)
+            .add("o_clerk", TypeProtos.MinorType.VARCHAR)
+            .add("o_shippriority", TypeProtos.MinorType.INT)
+            .add("o_comment", TypeProtos.MinorType.VARCHAR)
+            .build())
+        .location(tablePath)
+        .columnsStatistics(tableColumnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(10L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(new File(dirTestWatcher.getRootDir().toURI().getPath(), tableName).lastModified())
+        .build();
+
+    SegmentMetadata defaultSegment = SegmentMetadata.builder()
+        .tableInfo(TableInfo.builder()
+            .name(tableName)
+            .storagePlugin("dfs")
+            .workspace("default")
+            .build())
+        .metadataInfo(MetadataInfo.builder()
+            .type(MetadataType.SEGMENT)
+            .key(MetadataInfo.DEFAULT_SEGMENT_KEY)
+            .build())
+        .lastModifiedTime(new File(new File(dirTestWatcher.getRootDir().toURI().getPath(), tableName), "orders_94_q1.parquet").lastModified())
+        .columnsStatistics(Collections.emptyMap())
+        .metadataStatistics(Collections.emptyList())
+        .path(new Path(dirTestWatcher.getRootDir().toURI().getPath(), tableName))
+        .locations(ImmutableSet.of(
+            new Path(tablePath, "orders_94_q1.parquet")))
+        .build();
+
+    try {
+      run("ANALYZE TABLE dfs.`%s` REFRESH METADATA", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+
+      List<SegmentMetadata> segmentMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .segmentsMetadataByMetadataKey(tableInfo, null, null);
+
+      assertEquals(1, segmentMetadata.size());
+
+      assertEquals(defaultSegment, segmentMetadata.get(0));
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithMapColumns() throws Exception {
+    String tableName = "complex";
+
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("store/parquet/complex/complex.parquet"), Paths.get(tableName));
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("trans_id", TypeProtos.MinorType.BIGINT)
+        .addNullable("date", TypeProtos.MinorType.VARCHAR)
+        .addNullable("time", TypeProtos.MinorType.VARCHAR)
+        .addNullable("amount", TypeProtos.MinorType.FLOAT8)
+        .addMap("user_info")
+            .addNullable("cust_id", TypeProtos.MinorType.BIGINT)
+            .addNullable("device", TypeProtos.MinorType.VARCHAR)
+            .addNullable("state", TypeProtos.MinorType.VARCHAR)
+            .resumeSchema()
+        .addMap("marketing_info")
+            .addNullable("camp_id", TypeProtos.MinorType.BIGINT)
+            .addArray("keywords", TypeProtos.MinorType.VARCHAR)
+            .resumeSchema()
+        .addMap("trans_info")
+            .addArray("prod_id", TypeProtos.MinorType.BIGINT)
+            .addNullable("purch_flag", TypeProtos.MinorType.VARCHAR)
+            .resumeSchema()
+        .build();
+
+    Map<SchemaPath, ColumnStatistics> columnStatistics = ImmutableMap.<SchemaPath, ColumnStatistics>builder()
+        .put(SchemaPath.getCompoundPath("user_info", "state"),
+            getColumnStatistics("ct", "nj", 5L, TypeProtos.MinorType.VARCHAR))
+        .put(SchemaPath.getSimplePath("date"),
+            getColumnStatistics("2013-05-16", "2013-07-26", 5L, TypeProtos.MinorType.VARCHAR))
+        .put(SchemaPath.getSimplePath("time"),
+            getColumnStatistics("04:56:59", "15:31:45", 5L, TypeProtos.MinorType.VARCHAR))
+        .put(SchemaPath.getCompoundPath("user_info", "cust_id"),
+            getColumnStatistics(11L, 86623L, 5L, TypeProtos.MinorType.BIGINT))
+        .put(SchemaPath.getSimplePath("amount"),
+            getColumnStatistics(20.25, 500.75, 5L, TypeProtos.MinorType.FLOAT8))
+        .put(SchemaPath.getCompoundPath("user_info", "device"),
+            getColumnStatistics("AOS4.2", "IOS7", 5L, TypeProtos.MinorType.VARCHAR))
+        .put(SchemaPath.getCompoundPath("marketing_info", "camp_id"),
+            getColumnStatistics(4L, 17L, 5L, TypeProtos.MinorType.BIGINT))
+        .put(SchemaPath.getSimplePath("trans_id"),
+            getColumnStatistics(0L, 4L, 5L, TypeProtos.MinorType.BIGINT))
+        .put(SchemaPath.getCompoundPath("trans_info", "purch_flag"),
+            getColumnStatistics("false", "true", 5L, TypeProtos.MinorType.VARCHAR))
+        .build();
+
+    BaseTableMetadata expectedTableMetadata = BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(schema)
+        .location(new Path(table.toURI().getPath()))
+        .columnsStatistics(columnStatistics)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(5L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+
+    try {
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      BaseTableMetadata actualTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertEquals(expectedTableMetadata, actualTableMetadata);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testDirPartitionPruning() throws Exception {
+    String tableName = "multilevel/parquetDir";
+
+    dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.tmp.`%s`\n" +
+          "where dir0=1994 and dir1 in ('Q1', 'Q2')";
+      long expectedRowCount = 20;
+      int expectedNumFiles = 2;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningRootSegment() throws Exception {
+    String tableName = "multilevel/parquetRootSegment";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.`%s`\n" +
+          "where dir0=1994";
+      long expectedRowCount = 40;
+      int expectedNumFiles = 4;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningVarCharPartition() throws Exception {
+    String tableName = "orders_ctas_varchar";
+
+    try {
+      run("create table dfs.%s (o_orderdate, o_orderpriority) partition by (o_orderpriority)\n"
+          + "as select o_orderdate, o_orderpriority from dfs.`multilevel/parquet/1994/Q1`", tableName);
+
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query = "select * from dfs.%s where o_orderpriority = '1-URGENT'";
+      long expectedRowCount = 3;
+      int expectedNumFiles = 1;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningBinaryPartition() throws Exception {
+    String tableName = "orders_ctas_binary";
+
+    try {
+      run("create table dfs.%s (o_orderdate, o_orderpriority) partition by (o_orderpriority)\n"
+          + "as select o_orderdate, convert_to(o_orderpriority, 'UTF8') as o_orderpriority\n"
+          + "from dfs.`multilevel/parquet/1994/Q1`", tableName);
+
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+      String query = String.format("select * from dfs.%s where o_orderpriority = '1-URGENT'", tableName);
+      long expectedRowCount = 3;
+      int expectedNumFiles = 1;
+
+      long actualRowCount = queryBuilder().sql(query).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningSingleLeafPartition() throws Exception {
+    String tableName = "multilevel/parquetSingleLeafPartition";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet2"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.`%s`\n" +
+          "where dir0=1995 and dir1='Q3'";
+      long expectedRowCount = 20;
+      int expectedNumFiles = 2;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningSingleNonLeafPartition() throws Exception {
+    String tableName = "multilevel/parquetSingleNonLeafPartition";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet2"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.`%s`\n" +
+          "where dir0=1995";
+      long expectedRowCount = 80;
+      int expectedNumFiles = 8;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningDir1Filter() throws Exception {
+    String tableName = "multilevel/parquetDir1";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet2"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.`%s`\n" +
+          "where dir1='Q3'";
+      long expectedRowCount = 40;
+      int expectedNumFiles = 4;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningNonExistentPartition() throws Exception {
+    String tableName = "multilevel/parquetNonExistentPartition";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet2"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.`%s`\n" +
+          "where dir0=1995 and dir1='Q6'";
+      long expectedRowCount = 0;
+      int expectedNumFiles = 1;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  @Ignore("Ignored due to schema change connected with absence of `dir0` partition field for one of files")
+  public void testAnalyzeMultilevelTable() throws Exception {
+    String tableName = "path with spaces";
+
+    try {
+      // table with directory and file at the same level
+      run("create table dfs.`%s` as select * from cp.`tpch/nation.parquet`", tableName);
+      run("create table dfs.`%1$s/%1$s` as select * from cp.`tpch/nation.parquet`", tableName);
+
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+
+      String query = "select * from  dfs.`%s`";
+      long expectedRowCount = 50;
+      int expectedNumFiles = 2;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("An incorrect result was obtained while querying a table with metadata cache files",
+          expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testFieldWithDots() throws Exception {
+    String tableName = "dfs.tmp.`complex_table`";
+    try {
+      run("create table %s as\n" +
+          "select cast(1 as int) as `column.with.dots`, t.`column`.`with.dots`\n" +
+          "from cp.`store/parquet/complex/complex.parquet` t limit 1", tableName);
+
+      String query = "select * from %s";
+      int expectedRowCount = 1;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include("usedMetastore=false")
+          .match();
+
+      run("analyze table %s REFRESH METADATA", tableName);
+
+      actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include("usedMetastore=true")
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testBooleanPartitionPruning() throws Exception {
+    String tableName = "dfs.tmp.`interval_bool_partition`";
+
+    try {
+      run("create table %s partition by (col_bln) as\n" +
+          "select * from cp.`parquet/alltypes_required.parquet`", tableName);
+
+      run("analyze table %s REFRESH METADATA", tableName);
+
+      String query = "select * from %s where col_bln = true";
+      int expectedRowCount = 2;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", expectedRowCount, actualRowCount);
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testIntWithNullsPartitionPruning() throws Exception {
+    String tableName = "t5";
+
+    try {
+      run("create table dfs.tmp.`%s/a` as\n" +
+          "select 100 as mykey from cp.`tpch/nation.parquet`\n" +
+          "union all\n" +
+          "select col_notexist from cp.`tpch/region.parquet`", tableName);
+
+      run("create table dfs.tmp.`%s/b` as\n" +
+          "select 200 as mykey from cp.`tpch/nation.parquet`\n" +
+          "union all\n" +
+          "select col_notexist from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      String query = "select mykey from dfs.tmp.`t5` where mykey = 100";
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 25, actualRowCount);
+
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningWithIsNull() throws Exception {
+    String tableName = "t6";
+
+    try {
+      run("create table dfs.tmp.`%s/a` as\n" +
+          "select col_notexist as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("create table dfs.tmp.`%s/b` as\n" +
+          "select case when true then 100 else null end as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      String query = "select mykey from dfs.tmp.`%s` where mykey is null";
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testPartitionPruningWithIsNotNull() throws Exception {
+    String tableName = "t7";
+
+    try {
+      run("create table dfs.tmp.`%s/a` as\n" +
+          "select col_notexist as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("create table dfs.tmp.`%s/b` as\n" +
+          "select  case when true then 100 else null end as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      String query = "select mykey from dfs.tmp.`%s` where mykey is null";
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testNonInterestingColumnInFilter() throws Exception {
+    String tableName = "t8";
+
+    try {
+      run("create table dfs.tmp.`%s/a` as\n" +
+          "select col_notexist as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("create table dfs.tmp.`%s/b` as\n" +
+          "select case when true then 100 else null end as mykey from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` columns none REFRESH METADATA", tableName);
+
+      String query = "select mykey from dfs.tmp.`%s` where mykey is null";
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+      assertEquals("Row count does not match the expected value", 5, actualRowCount);
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(usedMetaPattern, "Filter") // checks that filter wasn't removed since statistics is absent for filtering column
+          .exclude()
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+    }
+  }
+
+  @Test
+  public void testSelectAfterAnalyzeWithNonRowGroupLevel() throws Exception {
+    String tableName = "parquetAnalyzeWithNonRowGroupLevel";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA 'file' level", tableName);
+
+      String query = "select * from dfs.`%s`";
+      long expectedRowCount = 120;
+      int expectedNumFiles = 12;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=true";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithFallbackError() throws Exception {
+    String tableName = "parquetAnalyzeWithFallback";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA 'file' level", tableName);
+      client.alterSession(ExecConstants.METASTORE_FALLBACK_TO_FILE_METADATA, false);
+
+      queryBuilder()
+          .sql("select * from dfs.`%s`", tableName)
+          .planMatcher()
+          .include("usedMetastore=false")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+      client.resetSession(ExecConstants.METASTORE_FALLBACK_TO_FILE_METADATA);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithSchemaError() throws Exception {
+    String tableName = "parquetAnalyzeWithSchemaError";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.`%s` REFRESH METADATA", tableName);
+      client.alterSession(ExecConstants.METASTORE_USE_SCHEMA_METADATA, false);
+
+      queryBuilder()
+          .sql("select * from dfs.`%s`", tableName)
+          .planMatcher()
+          .include("usedMetastore=false")
+          .match();
+    } finally {
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+      client.resetSession(ExecConstants.METASTORE_USE_SCHEMA_METADATA);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithSchema() throws Exception {
+    String tableName = "parquetAnalyzeWithSchema";
+
+    String table = String.format("dfs.tmp.%s", tableName);
+
+    try {
+      client.alterSession(ExecConstants.METASTORE_USE_SCHEMA_METADATA, false);
+      client.alterSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE, true);
+      run("create table %s as select 'a' as c from (values(1))", table);
+      run("analyze table %s REFRESH METADATA", table);
+
+      run("create schema (o_orderstatus varchar) for table %s", table);
+
+      run("select * from %s", table);
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      client.resetSession(ExecConstants.METASTORE_USE_SCHEMA_METADATA);
+      client.resetSession(ExecConstants.STORE_TABLE_USE_SCHEMA_FILE);
+      run("drop table if exists %s", table);
+    }
+  }
+
+  @Test
+  public void testUseStatistics() throws Exception {
+    String tableName = "dfs.tmp.employeeUseStat";
+
+    try {
+      run("CREATE TABLE %s AS SELECT * from cp.`employee.json`", tableName);
+
+      client.alterSession(PlannerSettings.STATISTICS_USE.getOptionName(), true);
+
+      run("analyze table %s REFRESH METADATA", tableName);
+
+      String query = " select employee_id from %s where department_id = 2";
+
+      String expectedPlan1 = "Filter\\(condition.*\\).*rowcount = 96.25,.*";
+      String expectedPlan2 = "Scan.*columns=\\[`department_id`, `employee_id`].*rowcount = 1155.0.*";
+
+      queryBuilder().sql(query, tableName)
+          .detailedPlanMatcher()
+          .include(expectedPlan1, expectedPlan2)
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      client.resetSession(PlannerSettings.STATISTICS_USE.getOptionName());
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithDisabledStatistics() throws Exception {
+    String tableName = "dfs.tmp.employeeWithoutStat";
+
+    try {
+      run("CREATE TABLE %s AS SELECT * from cp.`employee.json`", tableName);
+
+      client.alterSession(PlannerSettings.STATISTICS_USE.getOptionName(), false);
+
+      run("analyze table %s REFRESH METADATA", tableName);
+
+      String query = "select employee_id from %s where department_id = 2";
+
+      // filter row count is greater since statistics wasn't used
+      String expectedPlan1 = "Filter\\(condition.*\\).*rowcount = 173.25,.*";
+      String expectedPlan2 = "Scan.*columns=\\[`department_id`, `employee_id`].*rowcount = 1155.0.*";
+
+      queryBuilder().sql(query, tableName)
+          .detailedPlanMatcher()
+          .include(expectedPlan1, expectedPlan2)
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      client.resetSession(PlannerSettings.STATISTICS_USE.getOptionName());
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithoutStatisticsWithStatsFile() throws Exception {
+    String tableName = "dfs.tmp.employeeWithStatsFile";
+
+    try {
+      run("CREATE TABLE %s AS SELECT * from cp.`employee.json`", tableName);
+
+      client.alterSession(PlannerSettings.STATISTICS_USE.getOptionName(), false);
+
+      run("analyze table %s REFRESH METADATA", tableName);
+
+      client.alterSession(PlannerSettings.STATISTICS_USE.getOptionName(), true);
+
+      run("ANALYZE TABLE %s COMPUTE STATISTICS", tableName);
+
+      String query = "select employee_id from %s where department_id = 2";
+
+      String expectedPlan1 = "Filter\\(condition.*\\).*rowcount = 96.25,.*";
+      String expectedPlan2 = "Scan.*columns=\\[`department_id`, `employee_id`].*rowcount = 1155.0.*";
+
+      queryBuilder().sql(query, tableName)
+          .detailedPlanMatcher()
+          .include(expectedPlan1, expectedPlan2)
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      client.resetSession(PlannerSettings.STATISTICS_USE.getOptionName());
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testAnalyzeWithSampleStatistics() throws Exception {
+    String tableName = "dfs.tmp.employeeWithStatsFile";
+
+    try {
+      run("CREATE TABLE %s AS SELECT * from cp.`employee.json`", tableName);
+
+      client.alterSession(PlannerSettings.STATISTICS_USE.getOptionName(), true);
+
+      run("ANALYZE TABLE %s COLUMNS(department_id) REFRESH METADATA COMPUTE STATISTICS SAMPLE 95 PERCENT", tableName);
+
+      String query = "select employee_id from %s where department_id = 2";
+
+      String expectedPlan1 = "Filter\\(condition.*\\).*rowcount = 96.25,";
+      String expectedPlan2 = "Scan.*columns=\\[`department_id`, `employee_id`].*rowcount = 1155.0";
+
+      queryBuilder().sql(query, tableName)
+          .detailedPlanMatcher()
+          .include(expectedPlan1, expectedPlan2)
+          .match();
+    } finally {
+      run("analyze table %s drop metadata if exists", tableName);
+      client.resetSession(PlannerSettings.STATISTICS_USE.getOptionName());
+      run("drop table if exists %s", tableName);
+    }
+  }
+
+  @Test
+  public void testDropMetadata() throws Exception {
+    String tableName = "tableDropMetadata";
+    TableInfo tableInfo = getTableInfo(tableName, "tmp");
+    try {
+      run("create table dfs.tmp.`%s` as\n" +
+          "select * from cp.`tpch/region.parquet`", tableName);
+
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      MetastoreTableInfo metastoreTableInfo = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .metastoreTableInfo(tableInfo);
+
+      assertTrue(metastoreTableInfo.isExists());
+
+      BaseTableMetadata baseTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertNotNull(baseTableMetadata);
+
+      List<RowGroupMetadata> rowGroupMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, (String) null, null);
+
+      assertEquals(1, rowGroupMetadata.size());
+
+      testBuilder()
+          .sqlQuery("analyze table dfs.tmp.`%s` drop metadata", tableName)
+          .unOrdered()
+          .baselineColumns("ok", "summary")
+          .baselineValues(true, String.format("Metadata for table [%s] dropped.", tableName))
+          .go();
+
+      metastoreTableInfo = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .metastoreTableInfo(tableInfo);
+
+      assertFalse(metastoreTableInfo.isExists());
+
+      baseTableMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .tableMetadata(tableInfo);
+
+      assertNull(baseTableMetadata);
+
+      rowGroupMetadata = cluster.drillbit().getContext()
+          .getMetastoreRegistry()
+          .get()
+          .tables()
+          .basicRequests()
+          .rowGroupsMetadata(tableInfo, (String) null, null);
+
+      assertEquals(0, rowGroupMetadata.size());
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("drop table if exists dfs.tmp.`%s`", tableName);
+      client.resetSession(ExecConstants.METASTORE_ENABLED);
+    }
+  }
+
+  @Test
+  public void testDropNonExistingMetadata() throws Exception {
+    String tableName = "parquetAnalyzeNonExistingMetadata";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    testBuilder()
+        .sqlQuery("analyze table dfs.`%s` drop metadata if exists", tableName)
+        .unOrdered()
+        .baselineColumns("ok", "summary")
+        .baselineValues(false, String.format("Metadata for table [%s] does not exist.", tableName))
+        .go();
+
+    thrown.expect(UserRemoteException.class);
+
+    run("analyze table dfs.`%s` drop metadata", tableName);
+  }
+
+  @Test
+  public void testIncorrectAnalyzeCommand() throws Exception {
+    String tableName = "parquetAnalyzeNonExistingMetadata";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("PARSE ERROR:");
+
+    run("analyze table dfs.tmp.`%1$s` REFRESH METADATA analyze table dfs.`%1$s` drop metadata", tableName);
+  }
+
+  @Test
+  public void testIncompleteAnalyzeCommand() throws Exception {
+    String tableName = "parquetAnalyzeNonExistingMetadata";
+
+    dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    thrown.expect(UserRemoteException.class);
+    thrown.expectMessage("PARSE ERROR:");
+
+    run("analyze table dfs.tmp.`%1$s`", tableName);
+  }
+
+  @Test
+  public void testAnalyzeOnTextTable() throws Exception {
+    String tableName = "textTable.csv";
+
+    dirTestWatcher.copyResourceToTestTmp(Paths.get("store/text/data/regions.csv"), Paths.get(tableName));
+
+    thrown.expect(UserRemoteException.class);
+
+    run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+  }
+
+  @Test
+  public void testAnalyzeOnView() throws Exception {
+    String viewName = "analyzeView";
+
+    run("create view dfs.tmp.`%s` as select * from cp.`tpch/nation.parquet`", viewName);
+
+    thrown.expect(UserRemoteException.class);
+
+    run("analyze table dfs.tmp.`%s` REFRESH METADATA", viewName);
+  }
+
+  @Test
+  public void testSelectWitOutdatedMetadataWithUpdatedFile() throws Exception {
+    String tableName = "outdatedParquetUpdatedFile";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      File fileToUpdate = new File(new File(new File(table, "1994"), "Q4"), "orders_94_q4.parquet");
+      long lastModified = fileToUpdate.lastModified();
+      FileUtils.deleteQuietly(fileToUpdate);
+
+      // replaces original file
+      dirTestWatcher.copyResourceToTestTmp(
+          Paths.get("multilevel", "parquet", "1994", "Q1", "orders_94_q1.parquet"),
+          Paths.get(tableName, "1994", "Q4", "orders_94_q4.parquet"));
+
+      assertTrue(fileToUpdate.setLastModified(lastModified + 1000));
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.tmp.`%s`\n" +
+              "where dir0=1994 and dir1 in ('Q4', 'Q2')";
+      long expectedRowCount = 20;
+      int expectedNumFiles = 2;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=false";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  @Test
+  public void testSelectWitOutdatedMetadataWithNewFile() throws Exception {
+    String tableName = "outdatedParquetNewFile";
+
+    File table = dirTestWatcher.copyResourceToTestTmp(Paths.get("multilevel/parquet"), Paths.get(tableName));
+
+    try {
+      run("analyze table dfs.tmp.`%s` REFRESH METADATA", tableName);
+
+      dirTestWatcher.copyResourceToTestTmp(
+          Paths.get("multilevel", "parquet", "1994", "Q1", "orders_94_q1.parquet"),
+          Paths.get(tableName, "1994", "Q4", "orders_94_q5.parquet"));
+
+      String query =
+          "select dir0, dir1, o_custkey, o_orderdate from dfs.tmp.`%s`\n" +
+              "where dir0=1994 and dir1 in ('Q4', 'Q2')";
+      long expectedRowCount = 30;
+      int expectedNumFiles = 3;
+
+      long actualRowCount = queryBuilder().sql(query, tableName).run().recordCount();
+
+      assertEquals(expectedRowCount, actualRowCount);
+      String numFilesPattern = "numFiles=" + expectedNumFiles;
+      String usedMetaPattern = "usedMetastore=false";
+
+      queryBuilder().sql(query, tableName)
+          .planMatcher()
+          .include(numFilesPattern, usedMetaPattern)
+          .exclude("Filter")
+          .match();
+    } finally {
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+
+      FileUtils.deleteQuietly(table);
+    }
+  }
+
+  private static <T> ColumnStatistics<T> getColumnStatistics(T minValue, T maxValue,
+      long rowCount, TypeProtos.MinorType minorType) {
+    return new ColumnStatistics<>(
+        Arrays.asList(
+            new StatisticsHolder<>(minValue, ColumnStatisticsKind.MIN_VALUE),
+            new StatisticsHolder<>(maxValue, ColumnStatisticsKind.MAX_VALUE),
+            new StatisticsHolder<>(rowCount, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(rowCount, ColumnStatisticsKind.NON_NULL_COUNT),
+            new StatisticsHolder<>(0L, ColumnStatisticsKind.NULLS_COUNT)),
+        minorType);
+  }
+
+  private TableInfo getTableInfo(String tableName, String workspace) {
+    return TableInfo.builder()
+        .name(tableName)
+        .owner(cluster.config().getString("user.name"))
+        .storagePlugin("dfs")
+        .workspace(workspace)
+        .type(AnalyzeParquetInfoProvider.TABLE_TYPE_NAME)
+        .build();
+  }
+
+  private BaseTableMetadata getBaseTableMetadata(TableInfo tableInfo, File table) {
+    return BaseTableMetadata.builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(TABLE_META_INFO)
+        .schema(SCHEMA)
+        .location(new Path(table.toURI().getPath()))
+        .columnsStatistics(TABLE_COLUMN_STATISTICS)
+        .metadataStatistics(Arrays.asList(new StatisticsHolder<>(120L, TableStatisticsKind.ROW_COUNT),
+            new StatisticsHolder<>(MetadataType.ALL, TableStatisticsKind.ANALYZE_METADATA_LEVEL)))
+        .partitionKeys(Collections.emptyMap())
+        .lastModifiedTime(table.lastModified())
+        .build();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -41,6 +41,7 @@ import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ProfileParser;
 import org.apache.drill.test.QueryBuilder;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -702,7 +703,7 @@ public class TestParquetFilterPushDown extends PlanTestBase {
   }
 
   private MetadataBase.ParquetTableMetadataBase getParquetMetaData(File file) throws IOException {
-    return Metadata.getParquetTableMetadata(fs, file.toURI().getPath(), ParquetReaderConfig.getDefaultInstance());
+    return Metadata.getParquetTableMetadata(fs, new Path(file.toURI().getPath()), ParquetReaderConfig.getDefaultInstance());
   }
 
   // =========  runtime pruning  ==========

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestPushDownAndPruningWithItemStar.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestPushDownAndPruningWithItemStar.java
@@ -47,7 +47,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
   public void testPushProjectIntoScanWithGroupByClause() throws Exception {
     String query = String.format("select o_orderdate, count(*) from (select * from `%s`.`%s`) group by o_orderdate", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=3, numRowGroups=3, usedMetadataFile=false, columns=\\[`o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=3", "numRowGroups=3", "usedMetadataFile=false", "columns=\\[`o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -56,14 +56,14 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select o_orderdate, count(*) from `%s`.`%s` group by o_orderdate", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
   public void testPushProjectIntoScanWithExpressionInProject() throws Exception {
     String query = String.format("select o_custkey + o_orderkey from (select * from `%s`.`%s`)", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=3, numRowGroups=3, usedMetadataFile=false, columns=\\[`o_custkey`, `o_orderkey`\\]"};
+    String[] expectedPlan = {"numFiles=3", "numRowGroups=3", "usedMetadataFile=false", "columns=\\[`o_custkey`, `o_orderkey`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -72,15 +72,15 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
       .sqlQuery(query)
       .unOrdered()
       .sqlBaselineQuery("select o_custkey + o_orderkey from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME)
-      .build();
+      .go();
   }
 
   @Test
   public void testPushProjectIntoScanWithExpressionInFilter() throws Exception {
     String query = String.format("select o_orderdate from (select * from `%s`.`%s`) where o_custkey + o_orderkey < 5", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=3, numRowGroups=3, usedMetadataFile=false,.* columns=\\[`o_orderdate`, " +
-      "`o_custkey`, `o_orderkey`\\]"};
+    String[] expectedPlan = {"numFiles=3", "numRowGroups=3", "usedMetadataFile=false",
+        "columns=\\[`o_orderdate`, `o_custkey`, `o_orderkey`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -89,7 +89,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
       .sqlQuery(query)
       .unOrdered()
       .sqlBaselineQuery("select o_orderdate from `%s`.`%s` where o_custkey + o_orderkey < 5", DFS_TMP_SCHEMA, TABLE_NAME)
-      .build();
+      .go();
   }
 
   @Test
@@ -97,7 +97,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String query = "select t.user_info.cust_id, t.user_info.device, t.marketing_info.camp_id, t.marketing_info.keywords[2] " +
       "from (select * from cp.`store/parquet/complex/complex.parquet`) t";
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false, " +
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false",
       "columns=\\[`user_info`.`cust_id`, `user_info`.`device`, `marketing_info`.`camp_id`, `marketing_info`.`keywords`\\[2\\]\\]"};
     String[] excludedPlan = {};
 
@@ -107,8 +107,8 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
       .sqlQuery(query)
       .unOrdered()
       .sqlBaselineQuery("select t.user_info.cust_id, t.user_info.device, t.marketing_info.camp_id, t.marketing_info.keywords[2] " +
-        "from cp.`store/parquet/complex/complex.parquet`", DFS_TMP_SCHEMA, TABLE_NAME)
-      .build();
+        "from cp.`store/parquet/complex/complex.parquet` t", DFS_TMP_SCHEMA, TABLE_NAME)
+      .go();
   }
 
   @Test
@@ -116,7 +116,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String query = "select t.trans_id from (select * from cp.`store/parquet/complex/complex.parquet`) t " +
       "where t.user_info.cust_id > 28 and t.user_info.device = 'IOS5' and t.marketing_info.camp_id > 5 and t.marketing_info.keywords[2] is not null";
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false,.* " +
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false",
       "columns=\\[`trans_id`, `user_info`.`cust_id`, `user_info`.`device`, `marketing_info`.`camp_id`, `marketing_info`.`keywords`\\[2\\]\\]"};
     String[] excludedPlan = {};
 
@@ -128,14 +128,14 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
       .sqlBaselineQuery("select t.trans_id from cp.`store/parquet/complex/complex.parquet` t " +
         "where t.user_info.cust_id > 28 and t.user_info.device = 'IOS5' and t.marketing_info.camp_id > 5 and t.marketing_info.keywords[2] is not null",
         DFS_TMP_SCHEMA, TABLE_NAME)
-      .build();
+      .go();
   }
 
   @Test
   public void testProjectIntoScanWithNestedStarSubQuery() throws Exception {
     String query = String.format("select *, o_orderdate from (select * from `%s`.`%s`)", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=3, numRowGroups=3, usedMetadataFile=false, columns=\\[`\\*\\*`, `o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=3", "numRowGroups=3", "usedMetadataFile=false", "columns=\\[`\\*\\*`, `o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -144,7 +144,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select *, o_orderdate from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -152,7 +152,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String subQuery = String.format("select * from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME);
     String query = String.format("select o_custkey + o_orderkey from (select * from (select * from (%s)))", subQuery);
 
-    String[] expectedPlan = {"numFiles=3, numRowGroups=3, usedMetadataFile=false, columns=\\[`o_custkey`, `o_orderkey`\\]"};
+    String[] expectedPlan = {"numFiles=3", "numRowGroups=3", "usedMetadataFile=false", "columns=\\[`o_custkey`, `o_orderkey`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -161,14 +161,14 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select o_custkey + o_orderkey from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
   public void testDirectoryPruning() throws Exception {
     String query = String.format("select * from (select * from `%s`.`%s`) where dir0 = 't1'", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false, columns=\\[`\\*\\*`, `dir0`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false", "columns=\\[`\\*\\*`, `dir0`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -177,7 +177,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select * from `%s`.`%s` where dir0 = 't1'", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -185,7 +185,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String subQuery = String.format("select * from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME);
     String query = String.format("select * from (select * from (select * from (%s))) where dir0 = 't1'", subQuery);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false, columns=\\[`\\*\\*`, `dir0`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false", "columns=\\[`\\*\\*`, `dir0`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -194,7 +194,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select * from `%s`.`%s` where dir0 = 't1'", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String subQuery = String.format("select * from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME);
     String query = String.format("select * from (select * from (select *, `o_orderdate` from (%s))) where dir0 = 't1'", subQuery);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false, columns=\\[`\\*\\*`, `o_orderdate`, `dir0`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false", "columns=\\[`\\*\\*`, `o_orderdate`, `dir0`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -210,16 +210,16 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     testBuilder()
       .sqlQuery(query)
       .unOrdered()
-      .sqlBaselineQuery("select * from `%s`.`%s` where dir0 = 't1'", DFS_TMP_SCHEMA, TABLE_NAME)
-      .build();
+      .sqlBaselineQuery("select *, `o_orderdate` from `%s`.`%s` where dir0 = 't1'", DFS_TMP_SCHEMA, TABLE_NAME)
+      .go();
   }
 
   @Test
   public void testFilterPushDownSingleCondition() throws Exception {
     String query = String.format("select * from (select * from `%s`.`%s`) where o_orderdate = date '1992-01-01'", DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false,.* columns=\\[`\\*\\*`, " +
-      "`o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false",
+        "columns=\\[`\\*\\*`, `o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -228,7 +228,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select * from `%s`.`%s` where o_orderdate = date '1992-01-01'", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -236,7 +236,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String query = String.format("select * from (select * from `%s`.`%s`) where o_orderdate = date '1992-01-01' or o_orderdate = date '1992-01-09'",
         DFS_TMP_SCHEMA, TABLE_NAME);
 
-    String[] expectedPlan = {"numFiles=2, numRowGroups=2, usedMetadataFile=false,.* columns=\\[`\\*\\*`, `o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=2", "numRowGroups=2", "usedMetadataFile=false", "columns=\\[`\\*\\*`, `o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -246,7 +246,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .unOrdered()
         .sqlBaselineQuery("select * from `%s`.`%s` where o_orderdate = date '1992-01-01' or o_orderdate = date '1992-01-09'",
             DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -254,8 +254,8 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String subQuery = String.format("select * from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME);
     String query = String.format("select * from (select * from (select * from (%s))) where o_orderdate = date '1992-01-01'", subQuery);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false,.* columns=\\[`\\*\\*`, " +
-      "`o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false",
+        "columns=\\[`\\*\\*`, `o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -264,7 +264,7 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select * from `%s`.`%s` where o_orderdate = date '1992-01-01'", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 
   @Test
@@ -272,8 +272,8 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
     String subQuery = String.format("select * from `%s`.`%s`", DFS_TMP_SCHEMA, TABLE_NAME);
     String query = String.format("select * from (select * from (select *, o_custkey from (%s))) where o_orderdate = date '1992-01-01'", subQuery);
 
-    String[] expectedPlan = {"numFiles=1, numRowGroups=1, usedMetadataFile=false,.* columns=\\[`\\*\\*`, " +
-      "`o_custkey`, `o_orderdate`\\]"};
+    String[] expectedPlan = {"numFiles=1", "numRowGroups=1", "usedMetadataFile=false",
+        "columns=\\[`\\*\\*`, `o_custkey`, `o_orderdate`\\]"};
     String[] excludedPlan = {};
 
     PlanTestBase.testPlanMatchingPatterns(query, expectedPlan, excludedPlan);
@@ -282,6 +282,6 @@ public class TestPushDownAndPruningWithItemStar extends PlanTestBase {
         .sqlQuery(query)
         .unOrdered()
         .sqlBaselineQuery("select *, o_custkey from `%s`.`%s` where o_orderdate = date '1992-01-01'", DFS_TMP_SCHEMA, TABLE_NAME)
-        .build();
+        .go();
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -316,8 +316,7 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     }
 
     @Override
-    public RuntimeFilterWritable getRuntimeFilter(long rfIdentifier, long maxWaitTime, TimeUnit timeUnit)
-    {
+    public RuntimeFilterWritable getRuntimeFilter(long rfIdentifier, long maxWaitTime, TimeUnit timeUnit) {
       return null;
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
@@ -308,8 +308,7 @@ public class PhysicalOpUnitTestBase extends ExecTest {
     }
 
     @Override
-    public RuntimeFilterWritable getRuntimeFilter(long rfIdentifier, long maxWaitTime, TimeUnit timeUnit)
-    {
+    public RuntimeFilterWritable getRuntimeFilter(long rfIdentifier, long maxWaitTime, TimeUnit timeUnit) {
       return null;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PrintingUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PrintingUtils.java
@@ -43,13 +43,8 @@ public final class PrintingUtils {
    * @param <T> The return type of the lambda function.
    * @return Data produced by the lambda function.
    */
-  public static <T> T print(final Supplier<T> supplier) {
-    return printAndThrow(new CheckedSupplier<T, RuntimeException>() {
-      @Override
-      public T get() throws RuntimeException {
-        return supplier.get();
-      }
-    });
+  public static <T> T print(Supplier<T> supplier) {
+    return printAndThrow(supplier::get);
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -657,6 +657,15 @@ public class QueryBuilder {
   }
 
   /**
+   * Submit an "EXPLAIN" statement, and return text form of the
+   * plan with all attributes.
+   * @throws Exception if the query fails
+   */
+  public String explainTextWithAllAttributes() throws Exception {
+    return explainDetailed(ClusterFixture.EXPLAIN_PLAN_TEXT);
+  }
+
+  /**
    * Submit an "EXPLAIN" statement, and return the JSON form of the
    * plan.
    *
@@ -672,6 +681,11 @@ public class QueryBuilder {
     return queryPlan(format);
   }
 
+  public String explainDetailed(String format) throws Exception {
+    queryText = "EXPLAIN PLAN INCLUDING ALL ATTRIBUTES FOR " + queryText;
+    return queryPlan(format);
+  }
+
   /**
    * Submits explain plan statement
    * and creates plan matcher instance based on return query plan.
@@ -681,6 +695,18 @@ public class QueryBuilder {
    */
   public PlanMatcher planMatcher() throws Exception {
     String plan = explainText();
+    return new PlanMatcher(plan);
+  }
+
+  /**
+   * Submits explain plan statement
+   * and creates plan matcher instance based on return query plan with all attributes.
+   *
+   * @return plan matcher
+   * @throws Exception if the query fails
+   */
+  public PlanMatcher detailedPlanMatcher() throws Exception {
+    String plan = explainTextWithAllAttributes();
     return new PlanMatcher(plan);
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -85,16 +85,16 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
     this.name = name;
     type = majorType.getMinorType();
     mode = majorType.getMode();
-    precision = majorType.getPrecision();
-    scale = majorType.getScale();
+    precision = majorType.hasPrecision() ? majorType.getPrecision() : -1;
+    scale = majorType.hasScale() ? majorType.getScale() : -1;
   }
 
   public AbstractColumnMetadata(String name, MinorType type, DataMode mode) {
     this.name = name;
     this.type = type;
     this.mode = mode;
-    precision = 0;
-    scale = 0;
+    precision = -1;
+    scale = -1;
   }
 
   public AbstractColumnMetadata(AbstractColumnMetadata from) {
@@ -182,11 +182,23 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
   @Override
   public void setExpectedWidth(int width) { }
 
+  /**
+   * Returns precision for current column. For the case when precision is not set
+   * or column type does not support precision, negative value will be returned.
+   *
+   * @return precision for current column
+   */
   @Override
-  public int precision() { return 0; }
+  public int precision() { return -1; }
 
+  /**
+   * Returns scale for current column. For the case when scale is not set
+   * or column type does not support scale, negative value will be returned.
+   *
+   * @return scale for current column
+   */
   @Override
-  public int scale() { return 0; }
+  public int scale() { return -1; }
 
   @Override
   public void setExpectedElementCount(int childCount) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/PrimitiveColumnMetadata.java
@@ -166,26 +166,16 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
 
   @Override
   public MajorType majorType() {
-
-    // Set the precision for all types. Some (naive) code in Drill
-    // checks if precision is set as a way to determine if the precision
-    // is non-zero. (DRILL-7308)
-    //
-    // If we try to set the precision only if non-zero, then other code
-    // fails, such as the TPC-H SF1 customer table test in the Functional
-    // test suite.
-    //
-    // So, the protocol is: if a type might use precision (DECIMAL, VARCHAR),
-    // the precision should be set, even if zero. Code that wants to know if
-    // the precision is zero should check for the zero value, it should NOT
-    // check if the precision is set or not.
-
-    return MajorType.newBuilder()
+    MajorType.Builder builder = MajorType.newBuilder()
         .setMinorType(type)
-        .setMode(mode)
-        .setPrecision(precision)
-        .setScale(scale)
-        .build();
+        .setMode(mode);
+    if (precision >= 0) {
+      builder.setPrecision(precision);
+    }
+    if (scale >= 0) {
+      builder.setScale(scale);
+    }
+    return builder.build();
   }
 
   @Override
@@ -227,9 +217,9 @@ public class PrimitiveColumnMetadata extends AbstractColumnMetadata {
         builder.append(type.name());
     }
 
-    if (precision() > 0) {
+    if (precision() >= 0) {
       builder.append("(").append(precision());
-      if (scale() > 0) {
+      if (scale() >= 0) {
         builder.append(", ").append(scale());
       }
       builder.append(")");

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/UntypedNullVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/UntypedNullVector.java
@@ -25,7 +25,7 @@ import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 
-/** UntypedNullVector is to represent a value vector with {@link org.apache.drill.common.types.MinorType#NULL}
+/** UntypedNullVector is to represent a value vector with {@link org.apache.drill.common.types.TypeProtos.MinorType#NULL}
  *  All values in the vector represent two semantic implications: 1) the value is unknown, 2) the type is unknown.
  *  Because of this, we only have to keep track of the number of values in value vector,
  *  and there is no allocated buffer to back up this value vector. Therefore, the majority of

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/ColumnWriter.java
@@ -42,7 +42,7 @@ public interface ColumnWriter {
 
   /**
    * Whether this writer allows nulls. This is not as simple as checking
-   * for the {@link org.apache.drill.common.types.DataMode#OPTIONAL} type in the schema. List entries
+   * for the {@link org.apache.drill.common.types.TypeProtos.DataMode#OPTIONAL} type in the schema. List entries
    * are nullable, if they are primitive, but not if they are maps or lists.
    * Unions are nullable, regardless of cardinality.
    *

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/OffsetVectorWriterImpl.java
@@ -313,7 +313,9 @@ public class OffsetVectorWriterImpl extends AbstractFixedWidthWriter implements 
     int offsetCount = valueCount + 1;
     mandatoryResize(offsetCount);
     fillEmpties(valueCount - lastWriteIndex - 1);
-    vector().getBuffer().writerIndex(offsetCount * VALUE_WIDTH);
+    if (valueCount > 0) {
+      vector().getBuffer().writerIndex(offsetCount * VALUE_WIDTH);
+    }
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/RepeatedMapReaderImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/RepeatedMapReaderImpl.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.vector.complex.impl;
 
 import org.apache.drill.exec.expr.holders.RepeatedMapHolder;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
@@ -52,6 +53,11 @@ public class RepeatedMapReaderImpl extends AbstractRepeatedMapReaderImpl<Repeate
       maxOffset = singleOffset + 1;
       setChildrenPosition(singleOffset);
     }
+  }
+
+  @Override
+  public MaterializedField getField() {
+    return vector.getField();
   }
 
   @Override

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/SingleMapReaderImpl.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/impl/SingleMapReaderImpl.java
@@ -21,6 +21,7 @@ package org.apache.drill.exec.vector.complex.impl;
 import java.util.Map;
 
 import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.MapVector;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
@@ -29,7 +30,7 @@ import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
 @SuppressWarnings("unused")
-public class SingleMapReaderImpl extends AbstractFieldReader{
+public class SingleMapReaderImpl extends AbstractFieldReader {
 
   private final MapVector vector;
   private final Map<String, FieldReader> fields = Maps.newHashMap();
@@ -81,6 +82,11 @@ public class SingleMapReaderImpl extends AbstractFieldReader{
   @Override
   public MajorType getType(){
     return vector.getField().getType();
+  }
+
+  @Override
+  public MaterializedField getField() {
+    return vector.getField();
   }
 
   @Override

--- a/logical/src/main/java/org/apache/drill/common/expression/FieldReference.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FieldReference.java
@@ -42,17 +42,19 @@ public class FieldReference extends SchemaPath {
 
   public FieldReference(SchemaPath sp) {
     super(sp);
-    checkData();
-  }
-
-  private void checkData() {
-    if (getRootSegment().getChild() != null) {
-      throw new UnsupportedOperationException("Field references must be singular names.");
-    }
   }
 
   public FieldReference(CharSequence value) {
     this(value, ExpressionPosition.UNKNOWN);
+  }
+
+  public FieldReference(CharSequence value, ExpressionPosition pos) {
+    super(new NameSegment(value), pos);
+  }
+
+  public FieldReference(String value, ExpressionPosition pos, MajorType dataType) {
+    this(value, pos);
+    this.overrideType = dataType;
   }
 
   /**
@@ -63,25 +65,8 @@ public class FieldReference extends SchemaPath {
    * @param safeString the unquoted field reference
    * @return the field reference expression
    */
-
   public static FieldReference getWithQuotedRef(CharSequence safeString) {
-    return new FieldReference(safeString, ExpressionPosition.UNKNOWN, false);
-  }
-
-  public FieldReference(CharSequence value, ExpressionPosition pos) {
-    this(value, pos, true);
-  }
-
-  public FieldReference(CharSequence value, ExpressionPosition pos, boolean check) {
-    super(new NameSegment(value), pos);
-    if (check) {
-      checkData();
-    }
-  }
-
-  public FieldReference(String value, ExpressionPosition pos, MajorType dataType) {
-    this(value, pos);
-    this.overrideType = dataType;
+    return new FieldReference(safeString, ExpressionPosition.UNKNOWN);
   }
 
   @Override
@@ -105,7 +90,7 @@ public class FieldReference extends SchemaPath {
         JsonProcessingException {
       String ref = this._parseString(jp, ctxt);
       ref = ref.replace("`", "");
-      return new FieldReference(ref, ExpressionPosition.UNKNOWN, true);
+      return new FieldReference(ref, ExpressionPosition.UNKNOWN);
     }
   }
 

--- a/logical/src/main/java/org/apache/drill/common/logical/data/MetadataAggregate.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/MetadataAggregate.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.logical.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.common.logical.data.visitors.LogicalVisitor;
+
+/**
+ * Implementation of {@link LogicalOperator} for {@code MetadataAggRel} rel node.
+ */
+@JsonTypeName("metadataAggregate")
+public class MetadataAggregate extends SingleInputOperator {
+
+  @JsonCreator
+  public MetadataAggregate() {
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(LogicalVisitor<T, X, E> logicalVisitor, X value) throws E {
+    throw new UnsupportedOperationException("MetadataController does not support visitors");
+  }
+}

--- a/logical/src/main/java/org/apache/drill/common/logical/data/MetadataController.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/MetadataController.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.logical.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.common.logical.data.visitors.LogicalVisitor;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Implementation of {@link LogicalOperator} for {@code MetadataControllerRel} rel node.
+ */
+@JsonTypeName("metadataController")
+public class MetadataController extends LogicalOperatorBase {
+  private final LogicalOperator left;
+  private final LogicalOperator right;
+
+  @JsonCreator
+  public MetadataController(LogicalOperator left, LogicalOperator right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(LogicalVisitor<T, X, E> logicalVisitor, X value) throws E {
+    throw new UnsupportedOperationException("MetadataController does not support visitors");
+  }
+
+  @Override
+  public Iterator<LogicalOperator> iterator() {
+    return Arrays.asList(left, right).iterator();
+  }
+}

--- a/logical/src/main/java/org/apache/drill/common/logical/data/MetadataHandler.java
+++ b/logical/src/main/java/org/apache/drill/common/logical/data/MetadataHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.logical.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.drill.common.logical.data.visitors.LogicalVisitor;
+
+/**
+ * Implementation of {@link LogicalOperator} for {@code MetadataHandlerRel} rel node.
+ */
+@JsonTypeName("metadataHandler")
+public class MetadataHandler extends SingleInputOperator {
+
+  @JsonCreator
+  public MetadataHandler() {
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(LogicalVisitor<T, X, E> logicalVisitor, X value) throws E {
+    throw new UnsupportedOperationException("MetadataHandler does not support visitors");
+  }
+}

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
@@ -178,6 +178,158 @@ public class TestBasicRequests extends IcebergBaseTest {
   }
 
   @Test
+  public void testSegmentMetadataByMetadataInfosAbsent() {
+    List<SegmentMetadata> segmentMetadata = basicRequests.segmentsMetadata(
+        nationTableInfo,
+        Collections.singletonList(MetadataInfo.builder()
+            .type(MetadataType.SEGMENT)
+            .key("part_int=4")
+            .identifier("part_int=4")
+            .build()));
+    assertTrue(segmentMetadata.isEmpty());
+  }
+
+  @Test
+  public void testSegmentMetadataByMetadataInfosExisting() {
+    List<SegmentMetadata> segmentMetadata = basicRequests.segmentsMetadata(
+        nationTableInfo,
+        Arrays.asList(
+            MetadataInfo.builder()
+                .type(MetadataType.SEGMENT)
+                .key("part_int=3")
+                .identifier("part_int=3/d3")
+                .build(),
+            MetadataInfo.builder()
+                .type(MetadataType.SEGMENT)
+                .key("part_int=3")
+                .identifier("part_int=3/d4")
+                .build())
+        );
+    assertEquals(2, segmentMetadata.size());
+  }
+
+  @Test
+  public void testMetadataUnitsByMetadataInfosAbsent() {
+    List<TableMetadataUnit> segmentMetadata = basicRequests.metadata(
+        nationTableInfo,
+        Collections.singletonList(MetadataInfo.builder()
+            .type(MetadataType.ROW_GROUP)
+            .key("part_int=4")
+            .identifier("part_int=4")
+            .build()));
+    assertTrue(segmentMetadata.isEmpty());
+  }
+
+  @Test
+  public void testMetadataUnitsByMetadataInfosExisting() {
+    List<TableMetadataUnit> segmentMetadata = basicRequests.metadata(
+        nationTableInfo,
+        Arrays.asList(
+            MetadataInfo.builder()
+                .type(MetadataType.SEGMENT)
+                .key("part_int=3")
+                .identifier("part_int=3/d3")
+                .build(),
+            MetadataInfo.builder()
+                .type(MetadataType.SEGMENT)
+                .key("part_int=3")
+                .identifier("part_int=3/d4")
+                .build(),
+            MetadataInfo.builder()
+                .type(MetadataType.PARTITION)
+                .key("part_int=3")
+                .identifier("part_int=4/d5")
+                .build())
+    );
+    assertEquals(2, segmentMetadata.size());
+  }
+
+  @Test
+  public void testFilesMetadataByMetadataInfosAbsent() {
+    List<FileMetadata> segmentMetadata = basicRequests.filesMetadata(
+        nationTableInfo,
+        Collections.singletonList(MetadataInfo.builder()
+            .type(MetadataType.FILE)
+            .key("part_int=4")
+            .identifier("part_int=4/part_varchar=g/0_0_3.parquet")
+            .build()));
+    assertTrue(segmentMetadata.isEmpty());
+  }
+
+  @Test
+  public void testFilesMetadataByMetadataInfosExisting() {
+    List<FileMetadata> segmentMetadata = basicRequests.filesMetadata(
+        nationTableInfo,
+        Arrays.asList(
+            MetadataInfo.builder()
+                .type(MetadataType.FILE)
+                .key("part_int=4")
+                .identifier("part_int=4/part_varchar=g/0_0_0.parquet")
+                .build(),
+            MetadataInfo.builder()
+                .type(MetadataType.FILE)
+                .key("part_int=3")
+                .identifier("part_int=3/part_varchar=g/0_0_1.parquet")
+                .build())
+    );
+    assertEquals(2, segmentMetadata.size());
+  }
+
+  @Test
+  public void testRowGroupsMetadataByMetadataKeysAndPathsAbsent() {
+    List<RowGroupMetadata> segmentMetadata = basicRequests.rowGroupsMetadata(
+        nationTableInfo,
+        Collections.singletonList("part_int=4"),
+        Collections.singletonList("/tmp/nation/part_int=4/part_varchar=g/0_0_3.parquet"));
+    assertTrue(segmentMetadata.isEmpty());
+  }
+
+  @Test
+  public void testRowGroupsByMetadataKeysAndPathsExisting() {
+    List<RowGroupMetadata> segmentMetadata = basicRequests.rowGroupsMetadata(
+        nationTableInfo,
+        Arrays.asList(
+            "part_int=4",
+            "part_int=3"),
+        Arrays.asList(
+            "/tmp/nation/part_int=4/part_varchar=g/0_0_0.parquet",
+            "/tmp/nation/part_int=3/part_varchar=g/0_0_1.parquet")
+    );
+    assertEquals(2, segmentMetadata.size());
+  }
+
+  @Test
+  public void testRowGroupsMetadataByMetadataInfosAbsent() {
+    List<RowGroupMetadata> segmentMetadata = basicRequests.rowGroupsMetadata(
+        nationTableInfo,
+        Collections.singletonList(MetadataInfo.builder()
+            .type(MetadataType.ROW_GROUP)
+            .key("part_int=4")
+            .identifier("part_int=4/part_varchar=g/0_0_3.parquet/1")
+            .build()));
+    assertTrue(segmentMetadata.isEmpty());
+  }
+
+  @Test
+  public void testRowGroupsMetadataByMetadataInfosExisting() {
+    List<RowGroupMetadata> segmentMetadata = basicRequests.rowGroupsMetadata(
+        nationTableInfo,
+        Arrays.asList(
+            MetadataInfo.builder()
+                .type(MetadataType.ROW_GROUP)
+                .key("part_int=4")
+                .identifier("part_int=4/part_varchar=g/0_0_0.parquet/1")
+                .build(),
+            MetadataInfo.builder()
+                .type(MetadataType.ROW_GROUP)
+                .key("part_int=3")
+                .identifier("part_int=3/part_varchar=g/0_0_1.parquet/1")
+                .build())
+    );
+    assertEquals(2, segmentMetadata.size());
+  }
+
+  @Test
   public void testPartitionsMetadataAbsent() {
     List<PartitionMetadata> partitionMetadata = basicRequests.partitionsMetadata(
       nationTableInfo,
@@ -340,6 +492,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationSegment1 = basicSegment.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/d3")
       .location("/tmp/nation/part_int=3/d3")
       .column("n_nation")
       .lastModifiedTime(1L)
@@ -347,6 +500,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationSegment2 = basicSegment.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/d4")
       .location("/tmp/nation/part_int=3/d4")
       .column("n_nation")
       .lastModifiedTime(2L)
@@ -354,6 +508,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationSegment3 = basicSegment.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=3/d5")
       .location("/tmp/nation/part_int=4/d5")
       .column("n_nation")
       .lastModifiedTime(3L)
@@ -369,18 +524,21 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationPartition1 = basicPartition.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/d5")
       .location("/tmp/nation/part_int=3/d5")
       .column("n_nation")
       .build();
 
     TableMetadataUnit nationPartition2 = basicPartition.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=4/d5")
       .location("/tmp/nation/part_int=4/d5")
       .column("n_nation")
       .build();
 
     TableMetadataUnit nationPartition3 = basicPartition.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=4/d6")
       .column("n_region")
       .location("/tmp/nation/part_int=4/d6")
       .build();
@@ -395,6 +553,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationFile1 = basicFile.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/part_varchar=g/0_0_0.parquet")
       .location("/tmp/nation/part_int=3/part_varchar=g")
       .path("/tmp/nation/part_int=3/part_varchar=g/0_0_0.parquet")
       .lastModifiedTime(1L)
@@ -402,6 +561,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationFile2 = basicFile.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/part_varchar=g/0_0_1.parquet")
       .location("/tmp/nation/part_int=3/part_varchar=g")
       .path("/tmp/nation/part_int=3/part_varchar=g/0_0_1.parquet")
       .lastModifiedTime(System.currentTimeMillis())
@@ -410,6 +570,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationFile3 = basicFile.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=4/part_varchar=g/0_0_0.parquet")
       .location("/tmp/nation/part_int=4/part_varchar=g")
       .path("/tmp/nation/part_int=4/part_varchar=g/0_0_0.parquet")
       .lastModifiedTime(3L)
@@ -425,6 +586,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationRowGroup1 = basicRowGroup.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/part_varchar=g/0_0_0.parquet/1")
       .location("/tmp/nation/part_int=3/part_varchar=g")
       .path("/tmp/nation/part_int=3/part_varchar=g/0_0_0.parquet")
       .rowGroupIndex(1)
@@ -432,6 +594,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationRowGroup2 = basicRowGroup.toBuilder()
       .metadataKey("part_int=3")
+      .metadataIdentifier("part_int=3/part_varchar=g/0_0_0.parquet/2")
       .location("/tmp/nation/part_int=3/part_varchar=g")
       .path("/tmp/nation/part_int=3/part_varchar=g/0_0_0.parquet")
       .rowGroupIndex(2)
@@ -439,6 +602,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationRowGroup3 = basicRowGroup.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=4/part_varchar=g/0_0_0.parquet/1")
       .location("/tmp/nation/part_int=4/part_varchar=g")
       .path("/tmp/nation/part_int=4/part_varchar=g/0_0_0.parquet")
       .rowGroupIndex(1)
@@ -446,6 +610,7 @@ public class TestBasicRequests extends IcebergBaseTest {
 
     TableMetadataUnit nationRowGroup4 = basicRowGroup.toBuilder()
       .metadataKey("part_int=4")
+      .metadataIdentifier("part_int=4/part_varchar=g/0_0_0.parquet/1")
       .location("/tmp/nation/part_int=4/part_varchar=g")
       .path("/tmp/nation/part_int=4/part_varchar=g/0_0_0.parquet")
       .rowGroupIndex(2)

--- a/metastore/metastore-api/pom.xml
+++ b/metastore/metastore-api/pom.xml
@@ -47,6 +47,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <exclusions>

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/MetastoreTableInfo.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/MetastoreTableInfo.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.metastore.components.tables;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.drill.metastore.metadata.TableInfo;
 
 import java.util.Objects;
@@ -33,7 +35,11 @@ public class MetastoreTableInfo {
   private final boolean exists;
   private final long metastoreVersion;
 
-  private MetastoreTableInfo(TableInfo tableInfo, Long lastModifiedTime, boolean exists, long metastoreVersion) {
+  @JsonCreator
+  public MetastoreTableInfo(@JsonProperty("tableInfo") TableInfo tableInfo,
+      @JsonProperty("lastModifiedTime") Long lastModifiedTime,
+      @JsonProperty("exists") boolean exists,
+      @JsonProperty("metastoreVersion") long metastoreVersion) {
     this.tableInfo = tableInfo;
     this.lastModifiedTime = lastModifiedTime;
     this.exists = exists;
@@ -46,18 +52,22 @@ public class MetastoreTableInfo {
     return new MetastoreTableInfo(tableInfo, lastModifiedTime, exists, metastoreVersion);
   }
 
+  @JsonProperty
   public TableInfo tableInfo() {
     return tableInfo;
   }
 
+  @JsonProperty
   public Long lastModifiedTime() {
     return lastModifiedTime;
   }
 
+  @JsonProperty
   public boolean isExists() {
     return exists;
   }
 
+  @JsonProperty
   public long metastoreVersion() {
     return metastoreVersion;
   }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/BaseMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/BaseMetadata.java
@@ -120,6 +120,30 @@ public abstract class BaseMetadata implements Metadata {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BaseMetadata)) {
+      return false;
+    }
+    BaseMetadata that = (BaseMetadata) o;
+    return lastModifiedTime == that.lastModifiedTime
+        && Objects.equals(tableInfo, that.tableInfo)
+        && Objects.equals(metadataInfo, that.metadataInfo)
+        && Objects.equals(columnsStatistics, that.columnsStatistics)
+        && Objects.equals(metadataStatistics, that.metadataStatistics)
+        && (schema == that.schema
+            || (schema != null && schema.isEquivalent(that.schema)));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableInfo, metadataInfo, schema,
+        columnsStatistics, metadataStatistics, lastModifiedTime);
+  }
+
+  @Override
   public TableMetadataUnit toMetadataUnit() {
     TableMetadataUnit.Builder builder = TableMetadataUnit.builder();
 
@@ -147,6 +171,8 @@ public abstract class BaseMetadata implements Metadata {
   }
 
   protected abstract void toMetadataUnitBuilder(TableMetadataUnit.Builder builder);
+
+  protected abstract BaseMetadataBuilder toBuilder();
 
   public static abstract class BaseMetadataBuilder<T extends BaseMetadataBuilder<T>> {
     protected TableInfo tableInfo;

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/FileMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/FileMetadata.java
@@ -21,6 +21,7 @@ import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Metadata which corresponds to the file level of table.
@@ -44,9 +45,53 @@ public class FileMetadata extends BaseMetadata implements LocationProvider {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    FileMetadata that = (FileMetadata) o;
+    return Objects.equals(path, that.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), path);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", FileMetadata.class.getSimpleName() + "[\n", "]")
+        .add("path=" + path)
+        .add("tableInfo=" + tableInfo)
+        .add("metadataInfo=" + metadataInfo)
+        .add("schema=" + schema)
+        .add("columnsStatistics=" + columnsStatistics)
+        .add("metadataStatistics=" + metadataStatistics)
+        .add("lastModifiedTime=" + lastModifiedTime)
+        .toString();
+  }
+
+  @Override
   protected void toMetadataUnitBuilder(TableMetadataUnit.Builder builder) {
     builder.path(path.toUri().getPath());
     builder.location(getLocation().toUri().getPath());
+  }
+
+  public FileMetadataBuilder toBuilder() {
+    return builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .schema(schema)
+        .columnsStatistics(columnsStatistics)
+        .metadataStatistics(metadataStatistics.values())
+        .lastModifiedTime(lastModifiedTime)
+        .path(path);
   }
 
   public static FileMetadataBuilder builder() {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataInfo.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataInfo.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.metastore.metadata;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 
 import java.util.Objects;
@@ -29,6 +33,8 @@ import java.util.StringJoiner;
  * For example, for table-level metadata, it will be
  * {@code MetadataInfo[MetadataType.TABLE, MetadataInfo.GENERAL_INFO_KEY, null]}.
  */
+@JsonTypeName("metadataInfo")
+@JsonDeserialize(builder = MetadataInfo.MetadataInfoBuilder.class)
 public class MetadataInfo {
 
   public static final String GENERAL_INFO_KEY = "GENERAL_INFO";
@@ -36,6 +42,7 @@ public class MetadataInfo {
   public static final String DEFAULT_COLUMN_PREFIX = "_$SEGMENT_";
   public static final String METADATA_TYPE = "metadataType";
   public static final String METADATA_KEY = "metadataKey";
+  public static final String METADATA_IDENTIFIER = "metadataIdentifier";
 
   private final MetadataType type;
   private final String key;
@@ -47,14 +54,17 @@ public class MetadataInfo {
     this.identifier = builder.identifier;
   }
 
+  @JsonProperty
   public MetadataType type() {
     return type;
   }
 
+  @JsonProperty
   public String key() {
     return key;
   }
 
+  @JsonProperty
   public String identifier() {
     return identifier;
   }
@@ -99,6 +109,7 @@ public class MetadataInfo {
     return new MetadataInfoBuilder();
   }
 
+  @JsonPOJOBuilder(withPrefix = "")
   public static class MetadataInfoBuilder {
     private MetadataType type;
     private String key;

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataType.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataType.java
@@ -25,46 +25,70 @@ import java.util.stream.Stream;
 public enum MetadataType {
 
   /**
-   * Metadata that can be applicable to any type.
+   * Metadata type which helps to indicate that there is no overflow of metadata.
    */
-  ALL,
+  NONE(0),
 
   /**
    * Table level metadata type.
    */
-  TABLE,
+  TABLE(1),
 
   /**
    * Segment level metadata type. It corresponds to the metadata
    * within specific directory for FS tables, or may correspond to partition for hive tables.
    */
-  SEGMENT,
+  SEGMENT(2),
 
   /**
    * Drill partition level metadata type. It corresponds to parts of table data which has the same
    * values within specific column, i.e. partitions discovered by Drill.
    */
-  PARTITION,
+  PARTITION(3),
 
   /**
    * File level metadata type.
    */
-  FILE,
+  FILE(4),
 
   /**
    * Row group level metadata type. Used for parquet tables.
    */
-  ROW_GROUP,
+  ROW_GROUP(5),
 
   /**
-   * Metadata type which helps to indicate that there is no overflow of metadata.
+   * Metadata that can be applicable to any type.
    */
-  NONE,
+  ALL(Integer.MAX_VALUE),
 
   /**
    * Metadata type which belongs to views.
    */
-  VIEW;
+  VIEW(-1);
+
+  /**
+   * Level of this metadata type compared to other metadata types.
+   * Metadata type with a greater level includes metadata types with the lower one.
+   * <p/>
+   * For example: {@link #ROW_GROUP} metadata type includes {@link #FILE} metadata type because
+   * {@link #ROW_GROUP} metadata level is 5 and {@link #FILE} is 4.
+   */
+  private final int metadataLevel;
+
+  MetadataType(int metadataLevel) {
+    this.metadataLevel = metadataLevel;
+  }
+
+  /**
+   * Checks whether this {@link MetadataType} includes the specified one.
+   * For example, {@link #SEGMENT} metadata type includes {@link #TABLE} metadata type.
+   *
+   * @param metadataType metadata type to check
+   * @return {@code true} if this {@link MetadataType} includes the specified one, {@code false} otherwise.
+   */
+  public boolean includes(MetadataType metadataType) {
+    return metadataLevel >= metadataType.metadataLevel;
+  }
 
   /**
    * Converts metadata type string representation into {@link MetadataType} instance.

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/PartitionMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/PartitionMetadata.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 /**
@@ -64,12 +65,62 @@ public class PartitionMetadata extends BaseMetadata {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    PartitionMetadata that = (PartitionMetadata) o;
+    return Objects.equals(column, that.column)
+        && Objects.equals(partitionValues, that.partitionValues)
+        && Objects.equals(locations, that.locations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), column, partitionValues, locations);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", PartitionMetadata.class.getSimpleName() + "[\n", "]")
+        .add("column=" + column)
+        .add("partitionValues=" + partitionValues)
+        .add("locations=" + locations)
+        .add("tableInfo=" + tableInfo)
+        .add("metadataInfo=" + metadataInfo)
+        .add("schema=" + schema)
+        .add("columnsStatistics=" + columnsStatistics)
+        .add("metadataStatistics=" + metadataStatistics)
+        .add("lastModifiedTime=" + lastModifiedTime)
+        .toString();
+  }
+
+  @Override
   protected void toMetadataUnitBuilder(TableMetadataUnit.Builder builder) {
     builder.column(column.toString());
     builder.partitionValues(partitionValues);
     builder.locations(locations.stream()
       .map(location -> location.toUri().getPath())
       .collect(Collectors.toList()));
+  }
+
+  public PartitionMetadataBuilder toBuilder() {
+    return builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .schema(schema)
+        .columnsStatistics(columnsStatistics)
+        .metadataStatistics(metadataStatistics.values())
+        .lastModifiedTime(lastModifiedTime)
+        .column(column)
+        .partitionValues(partitionValues)
+        .locations(locations);
   }
 
   public static PartitionMetadataBuilder builder() {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/RowGroupMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/RowGroupMetadata.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Metadata which corresponds to the row group level of table.
@@ -67,11 +68,61 @@ public class RowGroupMetadata extends BaseMetadata implements LocationProvider {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    RowGroupMetadata that = (RowGroupMetadata) o;
+    return rowGroupIndex == that.rowGroupIndex
+        && Objects.equals(hostAffinity, that.hostAffinity)
+        && Objects.equals(path, that.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), hostAffinity, rowGroupIndex, path);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", RowGroupMetadata.class.getSimpleName() + "[\n", "]")
+        .add("hostAffinity=" + hostAffinity)
+        .add("rowGroupIndex=" + rowGroupIndex)
+        .add("path=" + path)
+        .add("tableInfo=" + tableInfo)
+        .add("metadataInfo=" + metadataInfo)
+        .add("schema=" + schema)
+        .add("columnsStatistics=" + columnsStatistics)
+        .add("metadataStatistics=" + metadataStatistics)
+        .add("lastModifiedTime=" + lastModifiedTime)
+        .toString();
+  }
+
+  @Override
   protected void toMetadataUnitBuilder(TableMetadataUnit.Builder builder) {
     builder.hostAffinity(hostAffinity);
     builder.rowGroupIndex(rowGroupIndex);
     builder.path(path.toUri().getPath());
     builder.location(getLocation().toUri().getPath());
+  }
+
+  public RowGroupMetadataBuilder toBuilder() {
+    return builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .schema(schema)
+        .columnsStatistics(columnsStatistics)
+        .metadataStatistics(metadataStatistics.values())
+        .lastModifiedTime(lastModifiedTime)
+        .hostAffinity(hostAffinity)
+        .rowGroupIndex(rowGroupIndex)
+        .path(path);
   }
 
   public static RowGroupMetadataBuilder builder() {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/SegmentMetadata.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/SegmentMetadata.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 /**
@@ -66,6 +67,45 @@ public class SegmentMetadata extends BaseMetadata implements LocationProvider {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    SegmentMetadata that = (SegmentMetadata) o;
+    return Objects.equals(column, that.column)
+        && Objects.equals(path, that.path)
+        && Objects.equals(partitionValues, that.partitionValues)
+        && Objects.equals(locations, that.locations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), column, path, partitionValues, locations);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", SegmentMetadata.class.getSimpleName() + "[\n", "]")
+        .add("column=" + column)
+        .add("path=" + path)
+        .add("partitionValues=" + partitionValues)
+        .add("locations=" + locations)
+        .add("tableInfo=" + tableInfo)
+        .add("metadataInfo=" + metadataInfo)
+        .add("schema=" + schema)
+        .add("columnsStatistics=" + columnsStatistics)
+        .add("metadataStatistics=" + metadataStatistics)
+        .add("lastModifiedTime=" + lastModifiedTime)
+        .toString();
+  }
+
+  @Override
   protected void toMetadataUnitBuilder(TableMetadataUnit.Builder builder) {
     if (column != null) {
       builder.column(column.toString());
@@ -76,6 +116,20 @@ public class SegmentMetadata extends BaseMetadata implements LocationProvider {
     builder.locations(locations.stream()
       .map(location -> location.toUri().getPath())
       .collect(Collectors.toList()));
+  }
+
+  public SegmentMetadataBuilder toBuilder() {
+    return builder()
+        .tableInfo(tableInfo)
+        .metadataInfo(metadataInfo)
+        .path(path)
+        .locations(locations)
+        .schema(schema)
+        .columnsStatistics(columnsStatistics)
+        .metadataStatistics(metadataStatistics.values())
+        .lastModifiedTime(lastModifiedTime)
+        .column(column)
+        .partitionValues(partitionValues);
   }
 
   public static SegmentMetadataBuilder builder() {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableInfo.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableInfo.java
@@ -17,6 +17,11 @@
  */
 package org.apache.drill.metastore.metadata;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.expressions.FilterExpression;
 
@@ -26,6 +31,8 @@ import java.util.StringJoiner;
 /**
  * General table information.
  */
+@JsonTypeName("tableInfo")
+@JsonDeserialize(builder = TableInfo.TableInfoBuilder.class)
 public class TableInfo {
   public static final String UNKNOWN = "UNKNOWN";
   public static final TableInfo UNKNOWN_TABLE_INFO = TableInfo.builder()
@@ -54,22 +61,27 @@ public class TableInfo {
     this.owner = builder.owner;
   }
 
+  @JsonProperty
   public String storagePlugin() {
     return storagePlugin;
   }
 
+  @JsonProperty
   public String workspace() {
     return workspace;
   }
 
+  @JsonProperty
   public String name() {
     return name;
   }
 
+  @JsonProperty
   public String type() {
     return type;
   }
 
+  @JsonProperty
   public String owner() {
     return owner;
   }
@@ -125,6 +137,7 @@ public class TableInfo {
     return new TableInfoBuilder();
   }
 
+  @JsonPOJOBuilder(withPrefix = "")
   public static class TableInfoBuilder {
     private String storagePlugin;
     private String workspace;

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableMetadataProvider.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableMetadataProvider.java
@@ -93,7 +93,15 @@ public interface TableMetadataProvider {
 
   /**
    * Returns {@link NonInterestingColumnsMetadata} instance which provides metadata for non-interesting columns.
+   *
    * @return {@link NonInterestingColumnsMetadata} instance
    */
   NonInterestingColumnsMetadata getNonInterestingColumnsMetadata();
+
+  /**
+   * Whether metadata actuality should be checked.
+   *
+   * @return true if metadata actuality should be checked
+   */
+  boolean checkMetadataVersion();
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/BaseStatisticsKind.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/BaseStatisticsKind.java
@@ -20,6 +20,9 @@ package org.apache.drill.metastore.statistics;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+import java.util.StringJoiner;
+
 /**
  * Implementation of {@link StatisticsKind} which contain base
  * table statistics kinds with implemented {@code mergeStatistics()} method.
@@ -44,5 +47,31 @@ public class BaseStatisticsKind<T> implements StatisticsKind<T> {
   @Override
   public boolean isExact() {
     return exact;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BaseStatisticsKind)) {
+      return false;
+    }
+    BaseStatisticsKind<?> that = (BaseStatisticsKind<?>) o;
+    return exact == that.exact &&
+        Objects.equals(statisticKey, that.statisticKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(statisticKey, exact);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", BaseStatisticsKind.class.getSimpleName() + "[", "]")
+        .add("statisticKey='" + statisticKey + "'")
+        .add("exact=" + exact)
+        .toString();
   }
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/StatisticsHolder.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/StatisticsHolder.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Class-holder for statistics kind and its value.
@@ -65,19 +67,45 @@ public class StatisticsHolder<T> {
     return statisticsKind;
   }
 
-  public static StatisticsHolder of(String serialized) {
-    try {
-      return OBJECT_READER.readValue(serialized);
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Unable to convert statistics holder from json string" + serialized, e);
-    }
-  }
-
   public String jsonString() {
     try {
       return OBJECT_WRITER.writeValueAsString(this);
     } catch (JsonProcessingException e) {
       throw new IllegalStateException("Unable to convert statistics holder to json string", e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StatisticsHolder<?> that = (StatisticsHolder<?>) o;
+    return Objects.equals(statisticsValue, that.statisticsValue)
+        && Objects.equals(statisticsKind, that.statisticsKind);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(statisticsValue, statisticsKind);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(",\n", StatisticsHolder.class.getSimpleName() + "[\n", "]")
+        .add("statisticsValue=" + statisticsValue)
+        .add("statisticsKind=" + statisticsKind)
+        .toString();
+  }
+
+  public static StatisticsHolder of(String serialized) {
+    try {
+      return OBJECT_READER.readValue(serialized);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to convert statistics holder from json string: " + serialized, e);
     }
   }
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/TableStatisticsKind.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/TableStatisticsKind.java
@@ -18,6 +18,7 @@
 package org.apache.drill.metastore.statistics;
 
 import org.apache.drill.metastore.metadata.Metadata;
+import org.apache.drill.metastore.metadata.MetadataType;
 
 import java.util.Collection;
 
@@ -91,6 +92,29 @@ public class TableStatisticsKind<T> extends BaseStatisticsKind<T> implements Col
         @Override
         public Boolean getValue(Metadata metadata) {
           return Boolean.TRUE.equals(metadata.getStatistic(this));
+        }
+      };
+
+  /**
+   * Table statistics kind which represents metadata level for which analyze was produced.
+   */
+  public static final TableStatisticsKind<MetadataType> ANALYZE_METADATA_LEVEL =
+      new TableStatisticsKind<MetadataType>("analyzeMetadataLevel", false) {
+        @Override
+        public MetadataType mergeStatistics(Collection<? extends Metadata> statisticsList) {
+          MetadataType maxMetadataType = MetadataType.ALL;
+          for (Metadata statistics : statisticsList) {
+            MetadataType metadataType = statistics.getStatistic(this);
+            if (metadataType != null && metadataType.compareTo(maxMetadataType) < 0) {
+              maxMetadataType = metadataType;
+            }
+          }
+          return maxMetadataType;
+        }
+
+        @Override
+        public MetadataType getValue(Metadata metadata) {
+          return metadata.getStatistic(this);
         }
       };
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -655,6 +655,14 @@ public final class UserBitShared {
      * <code>SHP_SUB_SCAN = 65;</code>
      */
     SHP_SUB_SCAN(65),
+    /**
+     * <code>METADATA_HANDLER = 66;</code>
+     */
+    METADATA_HANDLER(66),
+    /**
+     * <code>METADATA_CONTROLLER = 67;</code>
+     */
+    METADATA_CONTROLLER(67),
     ;
 
     /**
@@ -917,6 +925,14 @@ public final class UserBitShared {
      * <code>SHP_SUB_SCAN = 65;</code>
      */
     public static final int SHP_SUB_SCAN_VALUE = 65;
+    /**
+     * <code>METADATA_HANDLER = 66;</code>
+     */
+    public static final int METADATA_HANDLER_VALUE = 66;
+    /**
+     * <code>METADATA_CONTROLLER = 67;</code>
+     */
+    public static final int METADATA_CONTROLLER_VALUE = 67;
 
 
     public final int getNumber() {
@@ -998,6 +1014,8 @@ public final class UserBitShared {
         case 62: return LTSV_SUB_SCAN;
         case 64: return EXCEL_SUB_SCAN;
         case 65: return SHP_SUB_SCAN;
+        case 66: return METADATA_HANDLER;
+        case 67: return METADATA_CONTROLLER;
         default: return null;
       }
     }
@@ -27897,7 +27915,7 @@ public final class UserBitShared {
       "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000" +
       "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014" +
       "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022" +
-      "\032\n\026CANCELLATION_REQUESTED\020\006*\242\n\n\020CoreOper" +
+      "\032\n\026CANCELLATION_REQUESTED\020\006*\321\n\n\020CoreOper" +
       "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST" +
       "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020" +
       "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH" +
@@ -27930,11 +27948,12 @@ public final class UserBitShared {
       "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR" +
       "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_" +
       "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>\022\022\n\016EXCEL_SUB_" +
-      "SCAN\020@\022\020\n\014SHP_SUB_SCAN\020A*g\n\nSaslStatus\022\020" +
-      "\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL" +
-      "_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL" +
-      "_FAILED\020\004B.\n\033org.apache.drill.exec.proto" +
-      "B\rUserBitSharedH\001"
+      "SCAN\020@\022\020\n\014SHP_SUB_SCAN\020A\022\024\n\020METADATA_HAN" +
+      "DLER\020B\022\027\n\023METADATA_CONTROLLER\020C*g\n\nSaslS" +
+      "tatus\022\020\n\014SASL_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022" +
+      "\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022" +
+      "\017\n\013SASL_FAILED\020\004B.\n\033org.apache.drill.exe" +
+      "c.protoB\rUserBitSharedH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -358,6 +358,8 @@ enum CoreOperatorType {
   LTSV_SUB_SCAN = 62;
   EXCEL_SUB_SCAN = 64;
   SHP_SUB_SCAN = 65;
+  METADATA_HANDLER = 66;
+  METADATA_CONTROLLER = 67;
 }
 
 /* Registry that contains list of jars, each jar contains its name and list of function signatures.


### PR DESCRIPTION
Jira: [DRILL-7273](https://issues.apache.org/jira/browse/DRILL-7273)

This pull request introduces commands and operators for collecting table metadata and storing it to the metastore.

Entry point for ANALYZE command is `MetastoreAnalyzeTableHandler` class. It creates plan which includes some metastore-specific operators for collecting metadata.

New operators are the following:
`MetadataAggBatch` - operator which adds aggregate calls for all incoming table columns to calculate required metadata and produces aggregations. If aggregation is performed on top of another aggregation, required aggregate calls for merging metadata will be added.

`MetadataHandlerBatch` - operator responsible for handling metadata returned by incoming aggregate operators and fetching required metadata form the metastore to produce further aggregations.

`MetadataControllerBatch` - responsible for converting obtained metadata, fetching absent metadata from the metastore and storing resulting metadata into the metastore.

`MetastoreAnalyzeTableHandler` has 2 classes which depending on the table type, provides the information required for building a suitable plan for collecting metadata: `AnalyzeInfoProvider` and `MetadataInfoCollector`.

`MetastoreAnalyzeTableHandler` based on segments count, forms plan in the following form:

```
MetadataControllerBatch
	...
		MetadataHandlerBatch
			MetadataAggBatch
				MetadataHandlerBatch
					MetadataAggBatch
						Scan
```
The lowest `MetadataAggBatch` creates required aggregate calls for every (or interesting only) table columns and produces aggregations with grouping by segment columns that correspond to specific table level.
`MetadataHandlerBatch` above it populates batch with additional information about metadata type and other info.
`MetadataAggBatch` above merges metadata calculated before to obtain metadata for parent metadata levels and also stores incoming data to populate it to the metastore later.

`MetadataControllerBatch` obtains all calculated metadata, converts it to the suitable form and sends it to the metastore.

For the case of incremental analyze, `MetastoreAnalyzeTableHandler` creates `Scan` with updated files only and provides `MetadataHandlerBatch` with information about metadata which should be fetched from the metastore, so existing actual metadata wouldn't be recalculated.