### PR TITLE
DRILL-7436: Fix record count, vector structure issues in several operators

### DIFF
--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -77,6 +77,9 @@ public interface MongoTestConstants {
   String TEST_BOOLEAN_FILTER_QUERY_TEMPLATE4 = "select `employee_id` from mongo.%s.`%s` where (position_id = 16 and isFTE = true) or last_name = 'Yonce'";
 
   String TEST_STAR_QUERY_UNSHARDED_DB = "select * from mongo.%s.`%s`";
-  String TEST_STAR_QUERY_UNSHARDED_DB_PROJECT_FILTER = "select t.name as name,t.topping.type as type from mongo.%s.`%s` t where t.sales >= 150";
-  String TEST_STAR_QUERY_UNSHARDED_DB_GROUP_PROJECT_FILTER = "select t.topping.type as type,count(t.topping.type) as typeCount from mongo.%s.`%s` t group by t.topping.type order by typeCount";
+  // This query is invalid. See DRILL-7420. Topping is a repeated map.
+  // Drill should not allow projecting a repeated map to the top level; this should
+  // require a flatten or lateral query.
+  String TEST_STAR_QUERY_UNSHARDED_DB_PROJECT_FILTER = "select t.name as name, t.topping.type as type from mongo.%s.`%s` t where t.sales >= 150";
+  String TEST_STAR_QUERY_UNSHARDED_DB_GROUP_PROJECT_FILTER = "select t.topping.type as type, count(t.topping.type) as typeCount from mongo.%s.`%s` t group by t.topping.type order by typeCount";
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
@@ -24,9 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.AfterClass;
@@ -44,6 +44,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
@@ -212,8 +213,10 @@ public class MongoTestSuit implements MongoTestConstants {
           .net(new Net(LOCALHOST, MONGOS_PORT, Network.localhostIsIPv6()))
           .cmdOptions(cmdOptions).build();
 
-      IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaults(
-          Command.MongoD).build();
+      // Configure to write Mongo message to the log. Change this to
+      // defaults() if needed for debugging; will write to the console instead.
+      IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaultsWithLogger(
+          Command.MongoD, logger).build();
       mongodExecutable = MongodStarter.getInstance(runtimeConfig).prepare(
           mongodConfig);
       mongod = mongodExecutable.start();

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoQueries.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoQueries.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.mongo;
 
 import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -86,6 +87,7 @@ public class TestMongoQueries extends MongoTestBase {
   }
 
   @Test
+  @Ignore("DRILL-7428") // Query is invalid, Drill bug allows it.
   public void testUnShardedDBInShardedClusterWithProjectionAndFilter() throws Exception {
     testBuilder()
         .sqlQuery(String.format(TEST_STAR_QUERY_UNSHARDED_DB_PROJECT_FILTER, DONUTS_DB, DONUTS_COLLECTION))
@@ -95,6 +97,7 @@ public class TestMongoQueries extends MongoTestBase {
   }
 
   @Test
+  @Ignore("DRILL-7428") // Query is invalid, Drill bug allows it.
   public void testUnShardedDBInShardedClusterWithGroupByProjectionAndFilter() throws Exception {
     testBuilder()
         .sqlQuery(String.format(TEST_STAR_QUERY_UNSHARDED_DB_GROUP_PROJECT_FILTER, DONUTS_DB, DONUTS_COLLECTION))

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestTableGenerator.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestTableGenerator.java
@@ -21,18 +21,20 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import de.flapdoodle.embed.mongo.MongoImportProcess;
+import org.apache.drill.shaded.guava.com.google.common.io.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.drill.shaded.guava.com.google.common.io.Resources;
-
+import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongoImportExecutable;
+import de.flapdoodle.embed.mongo.MongoImportProcess;
 import de.flapdoodle.embed.mongo.MongoImportStarter;
 import de.flapdoodle.embed.mongo.config.IMongoImportConfig;
 import de.flapdoodle.embed.mongo.config.MongoImportConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.runtime.Network;
 
 public class TestTableGenerator implements MongoTestConstants {
@@ -56,8 +58,15 @@ public class TestTableGenerator implements MongoTestConstants {
         .net(new Net(MONGOS_PORT, Network.localhostIsIPv6())).db(dbName)
         .collection(collection).upsert(upsert).dropCollection(drop)
         .jsonArray(jsonArray).importFile(jsonFile).build();
+    // Configure to write Mongo message to the log. Change this to
+    // .getDefaultInstance() if needed for debugging; will write to
+    // the console instead.
+    IRuntimeConfig rtConfig = new RuntimeConfigBuilder()
+        .defaultsWithLogger(Command.MongoImport, logger)
+        .daemonProcess(false)
+        .build();
     MongoImportExecutable importExecutable = MongoImportStarter
-        .getDefaultInstance().prepare(mongoImportConfig);
+        .getInstance(rtConfig).prepare(mongoImportConfig);
     MongoImportProcess importProcess = importExecutable.start();
 
     // import is in a separate process, we should wait until the process exit

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/annotations/FunctionTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/annotations/FunctionTemplate.java
@@ -17,6 +17,12 @@
  */
 package org.apache.drill.exec.expr.annotations;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.expr.fn.FunctionAttributes;
@@ -29,12 +35,6 @@ import org.apache.drill.exec.expr.fn.output.PadReturnTypeInference;
 import org.apache.drill.exec.expr.fn.output.ReturnTypeInference;
 import org.apache.drill.exec.expr.fn.output.SameInOutLengthReturnTypeInference;
 import org.apache.drill.exec.expr.fn.output.StringCastReturnTypeInference;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.List;
 
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -76,16 +76,20 @@ public @interface FunctionTemplate {
   FunctionCostCategory costCategory() default FunctionCostCategory.SIMPLE;
 
   /**
-   * <p>Set Operand type-checking strategy for an operator which takes no operands and need to be invoked
-   * without parentheses. E.g.: session_id is a niladic function.</p>
+   * <p>Set Operand type-checking strategy for an operator which takes no operands
+   * and need to be invoked without parentheses. E.g.: session_id is a niladic
+   * function.</p>
    *
-   * <p>Niladic functions override columns that have names same as any niladic function. Such columns cannot be
-   * queried without the table qualification. Value of the niladic function is returned when table
-   * qualification is not used.</p>
+   * <p>Niladic functions override columns that have names same as any niladic
+   * function. Such columns cannot be queried without the table qualification.
+   * Value of the niladic function is returned when table qualification is not
+   * used.</p>
    *
    * <p>For e.g. in the case of session_id:<br/>
-   * select session_id from table -> returns the value of niladic function session_id<br/>
-   * select t1.session_id from table t1 -> returns session_id column value from table<p>
+   * select session_id from table -> returns the value of niladic function
+   * session_id<br/>
+   * select t1.session_id from table t1 -> returns session_id column value from
+   * table</p>
    */
   boolean isNiladic() default false;
   boolean checkPrecisionRange() default false;
@@ -101,7 +105,7 @@ public @interface FunctionTemplate {
   boolean isVarArg() default false;
 
   /**
-   * This enum will be used to estimate the average size of the output
+   * Estimates the average size of the output
    * produced by a function that produces variable length output
    */
   enum OutputWidthCalculatorType {
@@ -194,7 +198,6 @@ public @interface FunctionTemplate {
     public TypeProtos.MajorType getType(List<LogicalExpression> logicalExpressions, FunctionAttributes attributes) {
       return inference.getType(logicalExpressions, attributes);
     }
-
   }
 
   enum FunctionCostCategory {
@@ -213,6 +216,5 @@ public @interface FunctionTemplate {
     public static FunctionCostCategory getDefault() {
       return SIMPLE;
     }
-
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillFuncHolder.java
@@ -17,18 +17,9 @@
  */
 package org.apache.drill.exec.expr.fn;
 
-import com.sun.codemodel.JAssignmentTarget;
-import com.sun.codemodel.JCodeModel;
-import com.sun.codemodel.JExpression;
-import com.sun.codemodel.JInvocation;
-import org.apache.drill.exec.expr.holders.RepeatedListHolder;
-import org.apache.drill.exec.expr.holders.ValueHolder;
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.base.Strings;
-import com.sun.codemodel.JBlock;
-import com.sun.codemodel.JExpr;
-import com.sun.codemodel.JType;
-import com.sun.codemodel.JVar;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ExpressionPosition;
@@ -50,16 +41,28 @@ import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
 import org.apache.drill.exec.expr.fn.output.OutputWidthCalculator;
 import org.apache.drill.exec.expr.holders.ListHolder;
 import org.apache.drill.exec.expr.holders.MapHolder;
+import org.apache.drill.exec.expr.holders.RepeatedListHolder;
 import org.apache.drill.exec.expr.holders.RepeatedMapHolder;
+import org.apache.drill.exec.expr.holders.ValueHolder;
 import org.apache.drill.exec.ops.UdfUtilities;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.List;
+import com.sun.codemodel.JAssignmentTarget;
+import com.sun.codemodel.JBlock;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JInvocation;
+import com.sun.codemodel.JType;
+import com.sun.codemodel.JVar;
 
 public abstract class DrillFuncHolder extends AbstractFuncHolder {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillFuncHolder.class);
+  static final Logger logger = LoggerFactory.getLogger(DrillFuncHolder.class);
 
   private final FunctionAttributes attributes;
   private final FunctionInitializer initializer;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillSimpleFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillSimpleFuncHolder.java
@@ -19,7 +19,8 @@ package org.apache.drill.exec.expr.fn;
 
 import static org.apache.drill.shaded.guava.com.google.common.base.Preconditions.checkNotNull;
 
-import com.sun.codemodel.JOp;
+import java.util.List;
+
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.FunctionHolderExpression;
 import org.apache.drill.common.types.TypeProtos.DataMode;
@@ -29,16 +30,15 @@ import org.apache.drill.exec.expr.ClassGenerator.BlockType;
 import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
+import org.apache.drill.exec.vector.ValueHolderHelper;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JMod;
+import com.sun.codemodel.JOp;
 import com.sun.codemodel.JVar;
-import org.apache.drill.exec.vector.ValueHolderHelper;
-
-import java.util.List;
 
 public class DrillSimpleFuncHolder extends DrillFuncHolder {
 
@@ -56,12 +56,15 @@ public class DrillSimpleFuncHolder extends DrillFuncHolder {
   private String setupBody() {
     return meth("setup", false);
   }
+
   private String evalBody() {
     return meth("eval");
   }
+
   private String resetBody() {
     return meth("reset", false);
   }
+
   private String cleanupBody() {
     return meth("cleanup", false);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/UnionFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/UnionFunctions.java
@@ -245,8 +245,8 @@ public class UnionFunctions {
     }
   }
 
-  @SuppressWarnings("unused")
-  @FunctionTemplate(names = {"castUNION", "castToUnion"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.NULL_IF_NULL)
+  @FunctionTemplate(names = {"castUNION", "castToUnion"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.NULL_IF_NULL)
   public static class CastUnionToUnion implements DrillSimpleFunc{
 
     @Param FieldReader in;
@@ -263,8 +263,8 @@ public class UnionFunctions {
     }
   }
 
-  @SuppressWarnings("unused")
-  @FunctionTemplate(name = "ASSERT_LIST", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.INTERNAL)
+  @FunctionTemplate(name = "ASSERT_LIST", scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls=NullHandling.INTERNAL)
   public static class CastUnionList implements DrillSimpleFunc {
 
     @Param UnionHolder in;
@@ -286,8 +286,8 @@ public class UnionFunctions {
     }
   }
 
-  @SuppressWarnings("unused")
-  @FunctionTemplate(name = "IS_LIST", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.INTERNAL)
+  @FunctionTemplate(name = "IS_LIST", scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls=NullHandling.INTERNAL)
   public static class UnionIsList implements DrillSimpleFunc {
 
     @Param UnionHolder in;
@@ -306,8 +306,8 @@ public class UnionFunctions {
     }
   }
 
-  @SuppressWarnings("unused")
-  @FunctionTemplate(name = "ASSERT_MAP", scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.INTERNAL)
+  @FunctionTemplate(name = "ASSERT_MAP", scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls=NullHandling.INTERNAL)
   public static class CastUnionMap implements DrillSimpleFunc {
 
     @Param UnionHolder in;
@@ -329,8 +329,8 @@ public class UnionFunctions {
     }
   }
 
-  @SuppressWarnings("unused")
-  @FunctionTemplate(names = {"IS_MAP", "IS_STRUCT"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"IS_MAP", "IS_STRUCT"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE, nulls=NullHandling.INTERNAL)
   public static class UnionIsMap implements DrillSimpleFunc {
 
     @Param UnionHolder in;
@@ -349,7 +349,8 @@ public class UnionFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"isnotnull", "is not null"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"isnotnull", "is not null"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class IsNotNull implements DrillSimpleFunc {
 
     @Param UnionHolder input;
@@ -364,7 +365,9 @@ public class UnionFunctions {
     }
   }
 
-  @FunctionTemplate(names = {"isnull", "is null"}, scope = FunctionTemplate.FunctionScope.SIMPLE, nulls = FunctionTemplate.NullHandling.INTERNAL)
+  @FunctionTemplate(names = {"isnull", "is null"},
+      scope = FunctionTemplate.FunctionScope.SIMPLE,
+      nulls = FunctionTemplate.NullHandling.INTERNAL)
   public static class IsNull implements DrillSimpleFunc {
 
     @Param UnionHolder input;
@@ -378,5 +381,4 @@ public class UnionFunctions {
       out.value = input.isSet == 1 ? 0 : 1;
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterTemplate2.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterTemplate2.java
@@ -32,18 +32,21 @@ public abstract class FilterTemplate2 implements Filterer {
   private SelectionVector2 incomingSelectionVector;
   private SelectionVectorMode svMode;
   private TransferPair[] transfers;
+  private RecordBatch outgoing;
 
   @Override
-  public void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing, TransferPair[] transfers) throws SchemaChangeException {
+  public void setup(FragmentContext context, RecordBatch incoming,
+      RecordBatch outgoing, TransferPair[] transfers) throws SchemaChangeException {
     this.transfers = transfers;
     this.outgoingSelectionVector = outgoing.getSelectionVector2();
     this.svMode = incoming.getSchema().getSelectionVectorMode();
+    this.outgoing = outgoing;
 
-    switch(svMode){
+    switch(svMode) {
     case NONE:
       break;
     case TWO_BYTE:
-      this.incomingSelectionVector = incoming.getSelectionVector2();
+      incomingSelectionVector = incoming.getSelectionVector2();
       break;
     default:
       // SV4 is handled in FilterTemplate4
@@ -52,47 +55,57 @@ public abstract class FilterTemplate2 implements Filterer {
     doSetup(context, incoming, outgoing);
   }
 
-  private void doTransfers(){
-    for(TransferPair t : transfers){
+  private void doTransfers() {
+    for (TransferPair t : transfers) {
       t.transfer();
     }
   }
 
   @Override
-  public void filterBatch(int recordCount) throws SchemaChangeException{
+  public void filterBatch(int recordCount) throws SchemaChangeException {
     if (recordCount == 0) {
       outgoingSelectionVector.setRecordCount(0);
+      outgoingSelectionVector.setBatchActualRecordCount(0);
+
+      // Must allocate vectors, then set count to zero. Allocation
+      // is needed since offset vectors must contain at least one
+      // item (the required value of 0 in index location 0.)
+      outgoing.getContainer().allocateNew();
+      outgoing.getContainer().setValueCount(0);
       return;
     }
     if (! outgoingSelectionVector.allocateNewSafe(recordCount)) {
       throw new OutOfMemoryException("Unable to allocate filter batch");
     }
 
-    switch(svMode){
+    switch(svMode) {
     case NONE:
       // Set the actual recordCount in outgoing selection vector to help SVRemover copy the entire
       // batch if possible at once rather than row-by-row
       outgoingSelectionVector.setBatchActualRecordCount(recordCount);
       filterBatchNoSV(recordCount);
+      doTransfers();
+      outgoing.getContainer().setRecordCount(recordCount);
       break;
     case TWO_BYTE:
       // Set the actual recordCount in outgoing selection vector to help SVRemover copy the entire
       // batch if possible at once rather than row-by-row
-      outgoingSelectionVector.setBatchActualRecordCount(incomingSelectionVector.getBatchActualRecordCount());
+      int actualRowCount = incomingSelectionVector.getBatchActualRecordCount();
+      outgoingSelectionVector.setBatchActualRecordCount(actualRowCount);
       filterBatchSV2(recordCount);
+      doTransfers();
+      outgoing.getContainer().setRecordCount(actualRowCount);
       break;
     default:
       throw new UnsupportedOperationException();
     }
-    doTransfers();
   }
 
   private void filterBatchSV2(int recordCount) throws SchemaChangeException {
     int svIndex = 0;
-    final int count = recordCount;
-    for(int i = 0; i < count; i++){
-      char index = incomingSelectionVector.getIndex(i);
-      if(doEval(index, 0)){
+    for (int i = 0; i < recordCount; i++) {
+      int index = incomingSelectionVector.getIndex(i);
+      if (doEval(index, 0)) {
         outgoingSelectionVector.setIndex(svIndex, index);
         svIndex++;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
@@ -17,7 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.limit;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
+
+import java.util.List;
+
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
@@ -29,20 +32,20 @@ import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.vector.IntVector;
-
-import java.util.List;
-
-import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Helps to perform limit in a partition within a record batch. Currently only integer type of partition column is
- * supported. This is mainly used for Lateral/Unnest subquery where each output batch from Unnest will contain an
+ * Helps to perform limit in a partition within a record batch. Currently only
+ * integer type of partition column is supported. This is mainly used for
+ * Lateral/Unnest subquery where each output batch from Unnest will contain an
  * implicit column for rowId for each row.
  */
 public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<PartitionLimit> {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LimitRecordBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(LimitRecordBatch.class);
 
-  private SelectionVector2 outgoingSv;
+  private final SelectionVector2 outgoingSv;
   private SelectionVector2 incomingSv;
 
   // Start offset of the records
@@ -50,8 +53,8 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
   private int numberOfRecords;
   private final List<TransferPair> transfers = Lists.newArrayList();
 
-  // Partition RowId which is currently being processed, this will help to handle cases when rows for a partition id
-  // flows across 2 batches
+  // Partition RowId which is currently being processed, this will help to
+  // handle cases when rows for a partition id flows across 2 batches
   private int partitionId;
   private IntVector partitionColumn;
 
@@ -84,20 +87,20 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
     container.clear();
     transfers.clear();
 
-    for(final VectorWrapper<?> v : incoming) {
-      final TransferPair pair = v.getValueVector().makeTransferPair(
+    for(VectorWrapper<?> v : incoming) {
+      TransferPair pair = v.getValueVector().makeTransferPair(
         container.addOrGet(v.getField(), callBack));
       transfers.add(pair);
 
-      // Hold the transfer pair target vector for partitionColumn, since before applying limit it transfer all rows
-      // from incoming to outgoing batch
+      // Hold the transfer pair target vector for partitionColumn, since before
+      // applying limit it transfer all rows from incoming to outgoing batch
       String fieldName = v.getField().getName();
       if (fieldName.equals(popConfig.getPartitionColumn())) {
         partitionColumn = (IntVector) pair.getTo();
       }
     }
 
-    final BatchSchema.SelectionVectorMode svMode = incoming.getSchema().getSelectionVectorMode();
+    BatchSchema.SelectionVectorMode svMode = incoming.getSchema().getSelectionVectorMode();
 
     switch(svMode) {
       case NONE:
@@ -118,15 +121,17 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
   }
 
   /**
-   * Gets the outcome to return from super implementation and then in case of EMIT outcome it refreshes the state of
-   * operator. Refresh is done to again apply limit on all the future incoming batches which will be part of next
+   * Gets the outcome to return from super implementation and then in case of
+   * EMIT outcome it refreshes the state of operator. Refresh is done to again
+   * apply limit on all the future incoming batches which will be part of next
    * record boundary.
+   *
    * @param hasRemainder
    * @return - IterOutcome to send downstream
    */
   @Override
   protected IterOutcome getFinalOutcome(boolean hasRemainder) {
-    final IterOutcome outcomeToReturn = super.getFinalOutcome(hasRemainder);
+    IterOutcome outcomeToReturn = super.getFinalOutcome(hasRemainder);
 
     // EMIT outcome means leaf operator is UNNEST, hence refresh the state no matter limit is reached or not.
     if (outcomeToReturn == EMIT) {
@@ -137,12 +142,15 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
 
   @Override
   protected IterOutcome doWork() {
-    final int inputRecordCount = incoming.getRecordCount();
+    int inputRecordCount = incoming.getRecordCount();
     if (inputRecordCount == 0) {
-      setOutgoingRecordCount(0);
-      for (VectorWrapper vw : incoming) {
-        vw.clear();
-      }
+      incoming.getContainer().zeroVectors();
+      outgoingSv.setRecordCount(0);
+      outgoingSv.setBatchActualRecordCount(0);
+      // Must allocate vectors to allow for offset vectors which
+      // require a zero in the 0th position.
+      container.allocateNew();
+      container.setRecordCount(0);
       // Release buffer for sv2 (if any)
       if (incomingSv != null) {
         incomingSv.clear();
@@ -150,13 +158,20 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
       return getFinalOutcome(false);
     }
 
-    for (final TransferPair tp : transfers) {
+    for (TransferPair tp : transfers) {
       tp.transfer();
     }
+
+    // Must report the actual value count as the record
+    // count. This is NOT the input record count when the input
+    // is an SV2.
+    int inputValueCount = incoming.getContainer().getRecordCount();
+    container.setRecordCount(inputValueCount);
 
     // Allocate SV2 vectors for the record count size since we transfer all the vectors buffer from input record
     // batch to output record batch and later an SV2Remover copies the needed records.
     outgoingSv.allocateNew(inputRecordCount);
+    outgoingSv.setBatchActualRecordCount(inputValueCount);
     limit(inputRecordCount);
 
     // Release memory for incoming sv (if any)
@@ -167,10 +182,13 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
   }
 
   /**
-   * limit call when incoming batch has number of records more than the start offset such that it can produce some
-   * output records. After first call of this method recordStartOffset should be 0 since we have already skipped the
+   * limit call when incoming batch has number of records more than the start
+   * offset such that it can produce some output records. After first call of
+   * this method recordStartOffset should be 0 since we have already skipped the
    * required number of records as part of first incoming record batch.
-   * @param inputRecordCount - number of records in incoming batch
+   *
+   * @param inputRecordCount
+   *          - number of records in incoming batch
    */
   private void limit(int inputRecordCount) {
     boolean outputAllRecords = (numberOfRecords == Integer.MIN_VALUE);
@@ -179,7 +197,7 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
     // If partitionId is not -1 that means it's set to previous batch last partitionId
     partitionId = (partitionId == -1) ? getCurrentRowId(0) : partitionId;
 
-    for (int i=0; i < inputRecordCount;) {
+    for (int i = 0; i < inputRecordCount;) {
       // Get rowId from current right row
       int currentRowId = getCurrentRowId(i);
 
@@ -191,8 +209,8 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
           continue;
         }
 
-        // Once the start offset records are skipped then consider rows until numberOfRecords is reached for that
-        // partition
+        // Once the start offset records are skipped then consider rows until
+        // numberOfRecords is reached for that partition
         if (outputAllRecords) {
           updateOutputSV2(svIndex++, i);
         } else if (numberOfRecords > 0) {
@@ -206,7 +224,7 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
       }
     }
 
-    setOutgoingRecordCount(svIndex);
+    outgoingSv.setRecordCount(svIndex);
   }
 
   private void updateOutputSV2(int svIndex, int incomingIndex) {
@@ -225,15 +243,12 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
     }
   }
 
-  private void setOutgoingRecordCount(int outputCount) {
-    outgoingSv.setRecordCount(outputCount);
-    container.setRecordCount(outputCount);
-  }
-
   /**
-   * Reset the states for recordStartOffset, numberOfRecords and based on the {@link PartitionLimit} passed to the
-   * operator. It also resets the partitionId since after EMIT outcome there will be new partitionId to consider.
-   * This method is called for the each EMIT outcome received no matter if limit is reached or not.
+   * Reset the states for recordStartOffset, numberOfRecords and based on the
+   * {@link PartitionLimit} passed to the operator. It also resets the
+   * partitionId since after EMIT outcome there will be new partitionId to
+   * consider. This method is called for the each EMIT outcome received no
+   * matter if limit is reached or not.
    */
   private void refreshLimitState() {
     refreshConfigParameter();
@@ -241,8 +256,10 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
   }
 
   /**
-   * Only resets the recordStartOffset and numberOfRecord based on {@link PartitionLimit} passed to the operator. It
-   * is explicitly called after the limit for each partitionId is met or partitionId changes within an EMIT boundary.
+   * Only resets the recordStartOffset and numberOfRecord based on
+   * {@link PartitionLimit} passed to the operator. It is explicitly called
+   * after the limit for each partitionId is met or partitionId changes within
+   * an EMIT boundary.
    */
   private void refreshConfigParameter() {
     // Make sure startOffset is non-negative

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
@@ -17,7 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.project;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import java.util.List;
+
+import javax.inject.Named;
+
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
@@ -25,23 +28,19 @@ import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
-
-import javax.inject.Named;
-import java.util.List;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public abstract class ProjectorTemplate implements Projector {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProjectorTemplate.class);
 
   private ImmutableList<TransferPair> transfers;
   private SelectionVector2 vector2;
   private SelectionVector4 vector4;
   private SelectionVectorMode svMode;
 
-  public ProjectorTemplate() {
-  }
+  public ProjectorTemplate() { }
 
   @Override
-  public final int projectRecords(RecordBatch incomingRecordBatch, int startIndex, final int recordCount,
+  public final int projectRecords(RecordBatch incomingRecordBatch, int startIndex, int recordCount,
                                   int firstOutputIndex) {
     assert incomingRecordBatch != this; // mixed up incoming and outgoing batches?
     switch (svMode) {
@@ -49,7 +48,7 @@ public abstract class ProjectorTemplate implements Projector {
       throw new UnsupportedOperationException();
 
     case TWO_BYTE:
-      final int count = recordCount;
+      int count = recordCount;
       for (int i = 0; i < count; i++, firstOutputIndex++) {
         try {
           doEval(vector2.getIndex(i), firstOutputIndex);
@@ -60,7 +59,7 @@ public abstract class ProjectorTemplate implements Projector {
       return recordCount;
 
     case NONE:
-      final int countN = recordCount;
+      int countN = recordCount;
       int i;
       for (i = startIndex; i < startIndex + countN; i++, firstOutputIndex++) {
         try {
@@ -69,7 +68,7 @@ public abstract class ProjectorTemplate implements Projector {
           throw new UnsupportedOperationException(e);
         }
       }
-      final int totalBatchRecordCount = incomingRecordBatch.getRecordCount();
+      int totalBatchRecordCount = incomingRecordBatch.getRecordCount();
       if (startIndex + recordCount < totalBatchRecordCount || startIndex > 0 ) {
         for (TransferPair t : transfers) {
           t.splitAndTransfer(startIndex, i - startIndex);
@@ -77,7 +76,7 @@ public abstract class ProjectorTemplate implements Projector {
         return i - startIndex;
       }
       for (TransferPair t : transfers) {
-          t.transfer();
+        t.transfer();
       }
       return recordCount;
 
@@ -87,15 +86,18 @@ public abstract class ProjectorTemplate implements Projector {
   }
 
   @Override
-  public final void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException{
+  public final void setup(FragmentContext context, RecordBatch incoming,
+      RecordBatch outgoing, List<TransferPair> transfers)  throws SchemaChangeException{
 
     this.svMode = incoming.getSchema().getSelectionVectorMode();
     switch (svMode) {
     case FOUR_BYTE:
-      this.vector4 = incoming.getSelectionVector4();
+      vector4 = incoming.getSelectionVector4();
       break;
     case TWO_BYTE:
-      this.vector2 = incoming.getSelectionVector2();
+      vector2 = incoming.getSelectionVector2();
+      break;
+    default:
       break;
     }
     this.transfers = ImmutableList.copyOf(transfers);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/AbstractCopier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/AbstractCopier.java
@@ -33,7 +33,7 @@ public abstract class AbstractCopier implements Copier {
   public void setup(VectorAccessible incoming, VectorContainer outgoing) {
     this.outgoing = outgoing;
 
-    final int count = outgoing.getNumberOfColumns();
+    int count = outgoing.getNumberOfColumns();
     vvOut = new ValueVector[count];
 
     for (int index = 0; index < count; index++) {
@@ -62,9 +62,9 @@ public abstract class AbstractCopier implements Copier {
   }
 
   private int insertRecords(int outgoingPosition, int index, int recordCount) {
-    final int endIndex = index + recordCount;
+    int endIndex = index + recordCount;
 
-    for(int svIndex = index; svIndex < endIndex; svIndex++, outgoingPosition++){
+    for (int svIndex = index; svIndex < endIndex; svIndex++, outgoingPosition++) {
       copyEntryIndirect(svIndex, outgoingPosition);
     }
 
@@ -73,11 +73,7 @@ public abstract class AbstractCopier implements Copier {
   }
 
   protected void updateCounts(int numRecords) {
-    outgoing.setRecordCount(numRecords);
-
-    for (int vectorIndex = 0; vectorIndex < vvOut.length; vectorIndex++) {
-      vvOut[vectorIndex].getMutator().setValueCount(numRecords);
-    }
+    outgoing.setValueCount(numRecords);
   }
 
   public abstract void copyEntryIndirect(int inIndex, int outIndex);
@@ -85,7 +81,7 @@ public abstract class AbstractCopier implements Copier {
   public abstract void copyEntry(int inIndex, int outIndex);
 
   public static void allocateOutgoing(VectorContainer outgoing, int recordCount) {
-    for(VectorWrapper<?> out : outgoing) {
+    for (VectorWrapper<?> out : outgoing) {
       TypeProtos.MajorType type = out.getField().getType();
 
       if (!Types.isFixedWidthType(type) || Types.isRepeated(type)) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllerTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllerTemplate.java
@@ -17,17 +17,17 @@
  */
 package org.apache.drill.exec.physical.impl.union;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import java.util.List;
+
+import javax.inject.Named;
+
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TransferPair;
-
-import javax.inject.Named;
-import java.util.List;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public abstract class UnionAllerTemplate implements UnionAller {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnionAllerTemplate.class);
 
   private ImmutableList<TransferPair> transfers;
 
@@ -48,7 +48,8 @@ public abstract class UnionAllerTemplate implements UnionAller {
   }
 
   @Override
-  public final void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing, List<TransferPair> transfers) throws SchemaChangeException{
+  public final void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing,
+      List<TransferPair> transfers) throws SchemaChangeException{
     this.transfers = ImmutableList.copyOf(transfers);
     doSetup(context, incoming, outgoing);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -34,9 +34,11 @@ import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
 import org.apache.drill.exec.server.options.OptionValue;
 import org.apache.drill.exec.util.record.RecordBatchStats.RecordBatchStatsContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements CloseableRecordBatch {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
+  private static final Logger logger = LoggerFactory.getLogger(AbstractRecordBatch.class);
 
   protected final VectorContainer container;
   protected final T popConfig;
@@ -55,12 +57,12 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     this(popConfig, context, true, context.newOperatorContext(popConfig));
   }
 
-  protected AbstractRecordBatch(final T popConfig, final FragmentContext context, final boolean buildSchema) throws OutOfMemoryException {
+  protected AbstractRecordBatch(T popConfig, FragmentContext context, boolean buildSchema) throws OutOfMemoryException {
     this(popConfig, context, buildSchema, context.newOperatorContext(popConfig));
   }
 
-  protected AbstractRecordBatch(final T popConfig, final FragmentContext context, final boolean buildSchema,
-      final OperatorContext oContext) {
+  protected AbstractRecordBatch(T popConfig, FragmentContext context, boolean buildSchema,
+      OperatorContext oContext) {
     this.context = context;
     this.popConfig = popConfig;
     this.oContext = oContext;
@@ -109,14 +111,14 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     return popConfig;
   }
 
-  public final IterOutcome next(final RecordBatch b) {
+  public final IterOutcome next(RecordBatch b) {
     if(!context.getExecutorState().shouldContinue()) {
       return IterOutcome.STOP;
     }
     return next(0, b);
   }
 
-  public final IterOutcome next(final int inputIndex, final RecordBatch b){
+  public final IterOutcome next(int inputIndex, RecordBatch b){
     IterOutcome next;
     stats.stopProcessing();
     try{
@@ -187,7 +189,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
           break;
       }
       return lastOutcome;
-    } catch (final SchemaChangeException e) {
+    } catch (SchemaChangeException e) {
       lastOutcome = IterOutcome.STOP;
       throw new DrillRuntimeException(e);
     } catch (Exception e) {
@@ -213,7 +215,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
   }
 
   @Override
-  public void kill(final boolean sendUpstream) {
+  public void kill(boolean sendUpstream) {
     killIncoming(sendUpstream);
   }
 
@@ -235,21 +237,18 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
   }
 
   @Override
-  public TypedFieldId getValueVectorId(final SchemaPath path) {
+  public TypedFieldId getValueVectorId(SchemaPath path) {
     return container.getValueVectorId(path);
   }
 
   @Override
-  public VectorWrapper<?> getValueAccessorById(final Class<?> clazz, final int... ids) {
+  public VectorWrapper<?> getValueAccessorById(Class<?> clazz, int... ids) {
     return container.getValueAccessorById(clazz, ids);
   }
 
   @Override
   public WritableBatch getWritableBatch() {
-//    logger.debug("Getting writable batch.");
-    final WritableBatch batch = WritableBatch.get(this);
-    return batch;
-
+    return WritableBatch.get(this);
   }
 
   @Override
@@ -259,7 +258,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
 
   @Override
   public VectorContainer getContainer() {
-    return  container;
+    return container;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractTableFunctionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractTableFunctionRecordBatch.java
@@ -34,7 +34,6 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
  */
 public abstract class AbstractTableFunctionRecordBatch<T extends PhysicalOperator> extends
     AbstractUnaryRecordBatch<T> implements TableFunctionContract{
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
   protected RecordBatch incoming;
   protected LateralContract lateral;
@@ -60,4 +59,3 @@ public abstract class AbstractTableFunctionRecordBatch<T extends PhysicalOperato
     lateral = incoming;
   }
 }
-

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
@@ -63,9 +63,7 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
     IterOutcome upstream = next(incoming);
     if (state != BatchState.FIRST && upstream == IterOutcome.OK && incoming.getRecordCount() == 0) {
       do {
-        for (final VectorWrapper<?> w : incoming) {
-          w.clear();
-        }
+        incoming.getContainer().zeroVectors();
       } while ((upstream = next(incoming)) == IterOutcome.OK && incoming.getRecordCount() == 0);
     }
     if (state == BatchState.FIRST) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -530,4 +530,20 @@ public class VectorContainer implements VectorAccessible {
     sb.append("]");
     return sb.toString();
   }
+
+  /**
+   * Safely set this container to an empty batch. An empty batch is not
+   * fully empty: offset vectors must contain a single 0 entry in their
+   * first position.
+   */
+  public void setEmpty() {
+    // May not be needed; retaining for safety.
+    zeroVectors();
+    // Better to only allocate minimum-size offset vectors,
+    // but no good way to do that presently.
+    allocateNew();
+    // The "fill empties" logic will set the zero
+    // in the offset vectors that need it.
+    setValueCount(0);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -36,15 +36,17 @@ import org.apache.drill.exec.store.easy.json.reader.CountingJsonReader;
 import org.apache.drill.exec.vector.BaseValueVector;
 import org.apache.drill.exec.vector.complex.fn.JsonReader;
 import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public class JSONRecordReader extends AbstractRecordReader {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JSONRecordReader.class);
+  private static final Logger logger = LoggerFactory.getLogger(JSONRecordReader.class);
 
   public static final long DEFAULT_ROWS_PER_BATCH = BaseValueVector.INITIAL_VALUE_ALLOCATION;
 
@@ -57,7 +59,7 @@ public class JSONRecordReader extends AbstractRecordReader {
   private final DrillFileSystem fileSystem;
   private JsonProcessor jsonReader;
   private int recordCount;
-  private long runningRecordCount = 0;
+  private long runningRecordCount;
   private final FragmentContext fragmentContext;
   private final boolean enableAllTextMode;
   private final boolean enableNanInf;
@@ -67,7 +69,7 @@ public class JSONRecordReader extends AbstractRecordReader {
   private long parseErrorCount;
   private final boolean skipMalformedJSONRecords;
   private final boolean printSkippedMalformedJSONRecordLineNumber;
-  ReadState write = null;
+  private ReadState write;
 
   /**
    * Create a JSON Record Reader that uses a file based input stream.

--- a/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestTpchDistributedStreaming.java
@@ -25,7 +25,6 @@ import org.junit.experimental.categories.Category;
 
 @Category({SlowTest.class})
 public class TestTpchDistributedStreaming extends BaseTestQuery {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTpchDistributedStreaming.class);
 
   private void testDistributed(String fileName) throws Exception{
     String query = getFile(fileName);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/validate/TestBatchValidator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/validate/TestBatchValidator.java
@@ -151,7 +151,7 @@ public class TestBatchValidator extends SubOperatorTest {
 
   private static void checkForError(SingleRowSet batch, String expectedError) {
     CapturingReporter cr = new CapturingReporter();
-    new BatchValidator(cr).validateBatch(batch.vectorAccessible(), batch.rowCount());
+    new BatchValidator(cr, true).validateBatch(batch.vectorAccessible(), batch.rowCount());
     assertTrue(cr.errors.size() > 0);
     Pattern p = Pattern.compile(expectedError);
     Matcher m = p.matcher(cr.errors.get(0));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
@@ -35,9 +35,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.drill.exec.util.JsonStringHashMap;
-import org.apache.drill.exec.util.Text;
-import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.exception.SchemaChangeException;
@@ -46,17 +43,21 @@ import org.apache.drill.exec.record.RecordBatchLoader;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.store.easy.json.JSONRecordReader;
+import org.apache.drill.exec.util.JsonStringHashMap;
+import org.apache.drill.exec.util.Text;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.RepeatedBigIntVector;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
+import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
-import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestJsonReader extends BaseTestQuery {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestJsonReader.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestJsonReader.class);
 
   @BeforeClass
   public static void setupTestFiles() {

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -82,12 +82,12 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public FieldReader getReader(){
+  public FieldReader getReader() {
     return reader;
   }
 
   @Override
-  public int getValueCapacity(){
+  public int getValueCapacity() {
     return Math.min(bits.getValueCapacity(), values.getValueCapacity());
   }
 
@@ -118,7 +118,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public int getBufferSize(){
+  public int getBufferSize() {
     return values.getBufferSize() + bits.getBufferSize();
   }
 
@@ -133,7 +133,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public int getAllocatedSize(){
+  public int getAllocatedSize() {
     return bits.getAllocatedSize() + values.getAllocatedSize();
   }
 
@@ -170,7 +170,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
   @Override
   public void allocateNew() {
-    if(!allocateNewSafe()){
+    if (!allocateNewSafe()) {
       throw new OutOfMemoryException("Failure while allocating buffer.");
     }
   }
@@ -216,7 +216,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
   <#if type.major != "VarLen">
   @Override
-  public int getValueWidth(){
+  public int getValueWidth() {
     return bits.getValueWidth() + ${type.width};
   }
   </#if>
@@ -245,12 +245,12 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public int getByteCapacity(){
+  public int getByteCapacity() {
     return values.getByteCapacity();
   }
 
   @Override
-  public int getCurrentSizeInBytes(){
+  public int getCurrentSizeInBytes() {
     return values.getCurrentSizeInBytes();
   }
 
@@ -301,12 +301,12 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   }
 
   @Override
-  public TransferPair getTransferPair(BufferAllocator allocator){
+  public TransferPair getTransferPair(BufferAllocator allocator) {
     return new TransferImpl(getField(), allocator);
   }
 
   @Override
-  public TransferPair getTransferPair(String ref, BufferAllocator allocator){
+  public TransferPair getTransferPair(String ref, BufferAllocator allocator) {
     return new TransferImpl(getField().withPath(ref), allocator);
   }
 
@@ -315,9 +315,10 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     return new TransferImpl((Nullable${minor.class}Vector) to);
   }
 
-  public void transferTo(Nullable${minor.class}Vector target){
+  public void transferTo(Nullable${minor.class}Vector target) {
     bits.transferTo(target.bits);
     values.transferTo(target.values);
+    target.mutator.setCount = mutator.setCount;
     <#if type.major == "VarLen">
     target.mutator.lastSet = mutator.lastSet;
     </#if>
@@ -335,21 +336,21 @@ public final class ${className} extends BaseDataValueVector implements <#if type
   private class TransferImpl implements TransferPair {
     private final Nullable${minor.class}Vector to;
 
-    public TransferImpl(MaterializedField field, BufferAllocator allocator){
+    public TransferImpl(MaterializedField field, BufferAllocator allocator) {
       to = new Nullable${minor.class}Vector(field, allocator);
     }
 
-    public TransferImpl(Nullable${minor.class}Vector to){
+    public TransferImpl(Nullable${minor.class}Vector to) {
       this.to = to;
     }
 
     @Override
-    public Nullable${minor.class}Vector getTo(){
+    public Nullable${minor.class}Vector getTo() {
       return to;
     }
 
     @Override
-    public void transfer(){
+    public void transfer() {
       transferTo(to);
     }
 
@@ -374,7 +375,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     return mutator;
   }
 
-  public ${minor.class}Vector convertToRequiredVector(){
+  public ${minor.class}Vector convertToRequiredVector() {
     ${minor.class}Vector v = new ${minor.class}Vector(getField().getOtherNullableVersion(), allocator);
     if (v.data != null) {
       v.data.release(1);
@@ -392,14 +393,14 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     return bits.getValueCapacity();
   }
 
-  public void copyFrom(int fromIndex, int thisIndex, Nullable${minor.class}Vector from){
+  public void copyFrom(int fromIndex, int thisIndex, Nullable${minor.class}Vector from) {
     final Accessor fromAccessor = from.getAccessor();
     if (!fromAccessor.isNull(fromIndex)) {
       mutator.set(thisIndex, fromAccessor.get(fromIndex));
     }
   }
 
-  public void copyFromSafe(int fromIndex, int thisIndex, ${minor.class}Vector from){
+  public void copyFromSafe(int fromIndex, int thisIndex, ${minor.class}Vector from) {
     <#if type.major == "VarLen">
     mutator.fillEmpties(thisIndex);
     </#if>
@@ -407,7 +408,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     bits.getMutator().setSafe(thisIndex, 1);
   }
 
-  public void copyFromSafe(int fromIndex, int thisIndex, Nullable${minor.class}Vector from){
+  public void copyFromSafe(int fromIndex, int thisIndex, Nullable${minor.class}Vector from) {
     <#if type.major == "VarLen">
     mutator.fillEmpties(thisIndex);
     </#if>
@@ -485,12 +486,12 @@ public final class ${className} extends BaseDataValueVector implements <#if type
       return isSet(index) == 0;
     }
 
-    public int isSet(int index){
+    public int isSet(int index) {
       return bAccessor.get(index);
     }
 
     <#if type.major == "VarLen">
-    public long getStartEnd(int index){
+    public long getStartEnd(int index) {
       return vAccessor.getStartEnd(index);
     }
 
@@ -500,7 +501,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     }
 
     </#if>
-    public void get(int index, Nullable${minor.class}Holder holder){
+    public void get(int index, Nullable${minor.class}Holder holder) {
       vAccessor.get(index, holder);
       holder.isSet = bAccessor.get(index);
 
@@ -543,12 +544,12 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
     private Mutator() { }
 
-    public ${valuesName} getVectorWithValues(){
+    public ${valuesName} getVectorWithValues() {
       return values;
     }
 
     @Override
-    public void setIndexDefined(int index){
+    public void setIndexDefined(int index) {
       bits.getMutator().set(index, 1);
     }
 
@@ -587,7 +588,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     private void fillEmpties(int index) {
       final ${valuesName}.Mutator valuesMutator = values.getMutator();
       valuesMutator.fillEmpties(lastSet, index+1);
-      while(index > bits.getValueCapacity()) {
+      while (index > bits.getValueCapacity()) {
         bits.reAlloc();
       }
       lastSet = index;
@@ -834,7 +835,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
     </#if>
     @Override
-    public void generateTestData(int valueCount){
+    public void generateTestData(int valueCount) {
       bits.getMutator().generateTestDataAlt(valueCount);
       values.getMutator().generateTestData(valueCount);
       <#if type.major = "VarLen">lastSet = valueCount;</#if>
@@ -842,7 +843,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     }
 
     @Override
-    public void reset(){
+    public void reset() {
       setCount = 0;
       <#if type.major = "VarLen">lastSet = -1;</#if>
     }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
@@ -191,16 +191,19 @@ public class MaterializedField {
   }
 
   /**
-   * Equals method doesn't check for the children list of fields here. When a batch is sent over network then it is
-   * serialized along with the Materialized Field which also contains information about the internal vectors like
-   * offset and bits. While deserializing, these vectors are treated as children of parent vector. If a operator on
-   * receiver side like Sort receives a schema in buildSchema phase and then later on receives another batch, that
-   * will result in schema change and query will fail. This is because second batch schema will contain information
-   * about internal vectors like offset and bits which will not be present in first batch schema. For ref: See
-   * TestSort#testSortWithRepeatedMapWithExchanges
+   * Equals method doesn't check for the children list of fields here. When a
+   * batch is sent over network then it is serialized along with the
+   * Materialized Field which also contains information about the internal
+   * vectors like offset and bits. While deserializing, these vectors are
+   * treated as children of parent vector. If a operator on receiver side like
+   * Sort receives a schema in buildSchema phase and then later on receives
+   * another batch, that will result in schema change and query will fail. This
+   * is because second batch schema will contain information about internal
+   * vectors like offset and bits which will not be present in first batch
+   * schema. For ref: See TestSort#testSortWithRepeatedMapWithExchanges
    *
-   * @param obj
-   * @return
+   * @param obj the other materialized field
+   * @return true if the types are equal
    */
   @Override
   public boolean equals(Object obj) {
@@ -219,51 +222,59 @@ public class MaterializedField {
   }
 
   /**
-   * Determine if one column is logically equivalent to another. This is
-   * a tricky issue. The rules here:
+   * Determine if one column is logically equivalent to another. This is a
+   * tricky issue. The rules here:
    * <ul>
    * <li>The other schema is assumed to be non-null (unlike
    * <tt>equals()</tt>).</li>
-   * <li>Names must be identical, ignoring case. (Drill, like SQL, is
-   * case insensitive.)
+   * <li>Names must be identical, ignoring case. (Drill, like SQL, is case
+   * insensitive.)
    * <li>Type, mode, precision and scale must be identical.</li>
-   * <li>Child columns are ignored unless the type is a map. That is, the
-   * hidden "$bits" and "$offsets" vector columns are not compared, as
-   * one schema may be an "original" (without these hidden columns) while
-   * the other may come from a vector (which has the hidden columns added.
-   * The standard <tt>equals()</tt> comparison does consider hidden
-   * columns.</li>
+   * <li>Child columns are ignored unless the type is a map. That is, the hidden
+   * "$bits" and "$offsets" vector columns are not compared, as one schema may
+   * be an "original" (without these hidden columns) while the other may come
+   * from a vector (which has the hidden columns added. The standard
+   * <tt>equals()</tt> comparison does consider hidden columns.</li>
    * <li>For maps, the child columns are compared recursively. This version
-   * requires that the two sets of columns appear in the same order. (It
-   * assumes it is being used in a context where column indexes make
-   * sense.) Operators that want to reconcile two maps that differ only in
-   * column order need a different comparison.</li>
+   * requires that the two sets of columns appear in the same order. (It assumes
+   * it is being used in a context where column indexes make sense.) Operators
+   * that want to reconcile two maps that differ only in column order need a
+   * different comparison.</li>
    * </ul>
    * <ul>
-   * Note: Materialized Field and ValueVector has 1:1 mapping which means for each ValueVector there is a materialized
-   * field associated with it. So when we replace or add a ValueVector in a VectorContainer then we create new
-   * Materialized Field object for the new vector. This works fine for Primitive type ValueVectors but for ValueVector
-   * which are of type {@link org.apache.drill.exec.vector.complex.AbstractContainerVector} there is some differences on
-   * how Materialized field and ValueVector objects are updated inside the container which both ValueVector and
-   * Materialized Field object both mutable.
+   * Note: Materialized Field and ValueVector has 1:1 mapping which means for
+   * each ValueVector there is a materialized field associated with it. So when
+   * we replace or add a ValueVector in a VectorContainer then we create new
+   * Materialized Field object for the new vector. This works fine for Primitive
+   * type ValueVectors but for ValueVector which are of type
+   * {@link org.apache.drill.exec.vector.complex.AbstractContainerVector} there
+   * is some differences on how Materialized field and ValueVector objects are
+   * updated inside the container which both ValueVector and Materialized Field
+   * object both mutable.
    * <p>
-   * For example: For cases of MapVector it can so happen that only the children field type changed but
-   * the parent Map type and name remained same. In these cases we replace the children field ValueVector from parent
-   * MapVector inside main batch container, with new type of vector. Thus the reference of parent MaprVector inside
-   * batch container remains same but the reference of children field ValueVector stored inside MapVector get's updated.
-   * During this update it also replaces the Materialized field for that children field which is stored in childrens
-   * list of the parent MapVector Materialized Field.
-   * Since the children list of parent Materialized Field is updated, this make this class mutable. Hence there should
-   * not be any check for object reference equality here but instead there should be deep comparison which is what
-   * this method is now performing. Since if we have object reference check then in above cases it will return true for
-   * 2 Materialized Field object whose children field list is different which is not correct. Same holds true for
+   * For example: For cases of MapVector it can so happen that only the children
+   * field type changed but the parent Map type and name remained same. In these
+   * cases we replace the children field ValueVector from parent MapVector
+   * inside main batch container, with new type of vector. Thus the reference of
+   * parent MaprVector inside batch container remains same but the reference of
+   * children field ValueVector stored inside MapVector get's updated. During
+   * this update it also replaces the Materialized field for that children field
+   * which is stored in childrens list of the parent MapVector Materialized
+   * Field. Since the children list of parent Materialized Field is updated,
+   * this make this class mutable. Hence there should not be any check for
+   * object reference equality here but instead there should be deep comparison
+   * which is what this method is now performing. Since if we have object
+   * reference check then in above cases it will return true for 2 Materialized
+   * Field object whose children field list is different which is not correct.
+   * Same holds true for
    * {@link MaterializedField#isEquivalent(MaterializedField)} method.
    * </p>
    * </ul>
    *
-   * @param other another field
-   * @return <tt>true</tt> if the columns are identical according to the
-   * above rules, <tt>false</tt> if they differ
+   * @param other
+   *          another field
+   * @return <tt>true</tt> if the columns are identical according to the above
+   *         rules, <tt>false</tt> if they differ
    */
 
   public boolean isEquivalent(MaterializedField other) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/MapVector.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.vector.complex;
 
-import io.netty.buffer.DrillBuf;
-
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -43,10 +41,11 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.exec.vector.complex.RepeatedMapVector.MapSingleCopier;
 import org.apache.drill.exec.vector.complex.impl.SingleMapReaderImpl;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
-
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Ordering;
 import org.apache.drill.shaded.guava.com.google.common.primitives.Ints;
+
+import io.netty.buffer.DrillBuf;
 
 public class MapVector extends AbstractMapVector {
 
@@ -99,7 +98,7 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    for (final ValueVector v : this) {
+    for (ValueVector v : this) {
       v.setInitialCapacity(numRecords);
     }
   }
@@ -110,7 +109,7 @@ public class MapVector extends AbstractMapVector {
       return 0;
     }
     long buffer = 0;
-    for (final ValueVector v : this) {
+    for (ValueVector v : this) {
       buffer += v.getBufferSize();
     }
 
@@ -120,20 +119,20 @@ public class MapVector extends AbstractMapVector {
   @Override
   public int getAllocatedSize() {
     int size = 0;
-    for (final ValueVector v : this) {
+    for (ValueVector v : this) {
       size += v.getAllocatedSize();
     }
     return size;
   }
 
   @Override
-  public int getBufferSizeFor(final int valueCount) {
+  public int getBufferSizeFor(int valueCount) {
     if (valueCount == 0) {
       return 0;
     }
 
     long bufferSize = 0;
-    for (final ValueVector v : this) {
+    for (ValueVector v : this) {
       bufferSize += v.getBufferSizeFor(valueCount);
     }
 
@@ -197,7 +196,7 @@ public class MapVector extends AbstractMapVector {
         // (This is similar to what happens in ScanBatch where the children cannot be added till they are
         // read). To take care of this, we ensure that the hashCode of the MaterializedField does not
         // include the hashCode of the children but is based only on MaterializedField$key.
-        final ValueVector newVector = to.addOrGet(child, vector.getField().getType(), vector.getClass());
+        ValueVector newVector = to.addOrGet(child, vector.getField().getType(), vector.getClass());
         if (allocate && to.size() != preSize) {
           newVector.allocateNew();
         }
@@ -207,7 +206,7 @@ public class MapVector extends AbstractMapVector {
 
     @Override
     public void transfer() {
-      for (final TransferPair p : pairs) {
+      for (TransferPair p : pairs) {
         p.transfer();
       }
       to.valueCount = from.valueCount;
@@ -241,7 +240,7 @@ public class MapVector extends AbstractMapVector {
       return 0;
     }
 
-    final Ordering<ValueVector> natural = new Ordering<ValueVector>() {
+    Ordering<ValueVector> natural = new Ordering<ValueVector>() {
       @Override
       public int compare(@Nullable ValueVector left, @Nullable ValueVector right) {
         return Ints.compare(
@@ -261,12 +260,12 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void load(SerializedField metadata, DrillBuf buf) {
-    final List<SerializedField> fields = metadata.getChildList();
+    List<SerializedField> fields = metadata.getChildList();
     valueCount = metadata.getValueCount();
 
     int bufOffset = 0;
-    for (final SerializedField child : fields) {
-      final MaterializedField fieldDef = MaterializedField.create(child);
+    for (SerializedField child : fields) {
+      MaterializedField fieldDef = MaterializedField.create(child);
 
       ValueVector vector = getChild(fieldDef.getName());
       if (vector == null) {
@@ -362,7 +361,7 @@ public class MapVector extends AbstractMapVector {
 
     @Override
     public void setValueCount(int valueCount) {
-      for (final ValueVector v : getChildren()) {
+      for (ValueVector v : getChildren()) {
         v.getMutator().setValueCount(valueCount);
       }
       setMapValueCount(valueCount);
@@ -377,7 +376,7 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void clear() {
-    for (final ValueVector v : getChildren()) {
+    for (ValueVector v : getChildren()) {
       v.clear();
     }
     valueCount = 0;
@@ -385,8 +384,8 @@ public class MapVector extends AbstractMapVector {
 
   @Override
   public void close() {
-    final Collection<ValueVector> vectors = getChildren();
-    for (final ValueVector v : vectors) {
+    Collection<ValueVector> vectors = getChildren();
+    for (ValueVector v : vectors) {
       v.close();
     }
     vectors.clear();

--- a/logical/src/main/java/org/apache/drill/common/expression/IfExpression.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/IfExpression.java
@@ -21,20 +21,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 
 public class IfExpression extends LogicalExpressionBase {
-  static final Logger logger = LoggerFactory.getLogger(IfExpression.class);
 
   public final IfCondition ifCondition;
   public final LogicalExpression elseExpression;
@@ -57,7 +53,6 @@ public class IfExpression extends LogicalExpressionBase {
       this.condition = condition;
       this.expression = expression;
     }
-
   }
 
   @Override
@@ -96,7 +91,6 @@ public class IfExpression extends LogicalExpressionBase {
       Preconditions.checkNotNull(conditions);
       return new IfExpression(pos, conditions, elseExpression, outputType);
     }
-
   }
 
   @Override
@@ -155,5 +149,4 @@ public class IfExpression extends LogicalExpressionBase {
 
     return cost / i;
   }
-
 }


### PR DESCRIPTION
Jira - [DRILL-7436](https://issues.apache.org/jira/browse/DRILL-7436).

Adds additional vector checks to the `BatchValidator`.

Enables checking for the following operators:

* `FilterRecordBatch`
* `PartitionLimitRecordBatch`
* `UnnestRecordBatch`
* `HashAggBatch`
* `RemovingRecordBatch`

Fixes vector count issues for each of these.

Fixes empty-batch (record count = 0) handling in several of the
above operators. Added a method to `VectorContainer` to correctly
create an empty batch. (An empty batch, counter-intuitively,
needs vectors allocated to hold the 0 value in the first
position of each offset vector.)

Disables verbose logging for MongoDB tests. Details are written to
the log rather than the console.

Disables two invalid Mongo tests. See DRILL-7428.

Adjusts the expression tree materializer to not add the LATE type
to Union vectors. (See DRILL-7435.)

Ensures that Union vectors contain valid vectors for each subtype.
The present fix is a work-around, see DRILL-7434 for a better
long-term fix.

Cleans up code formatting and other minor issues in each file touched
during the fixes in this PR.