### PR TITLE
DRILL-7391: Wrong result when doing left outer join on CSV table

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -1213,4 +1213,16 @@ public class TestExampleQueries extends BaseTestQuery {
         .baselineValues("ALGERIA", "AFRICA")
         .go();
   }
+
+  @Test  // DRILL-7391
+  public void testItemPushdownPastLeftOuterJoin() throws Exception {
+    String query = "select t1.columns[0] as a, t2.columns[0] as b from cp.`store/text/data/regions.csv` t1 "
+        + " left outer join cp.`store/text/data/regions.csv` t2 on t1.columns[0] = t2.columns[0]";
+
+    PlanTestBase.testPlanMatchingPatterns(query,
+        new String[]{},
+        // exclude pattern where Project is projecting the 'columns' field
+        new String[]{"Project.*columns"});
+
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
       avoid_bad_dependencies plugin found in the file.
     -->
     <calcite.groupId>com.github.vvysotskyi.drill-calcite</calcite.groupId>
-    <calcite.version>1.20.0-drill-r1</calcite.version>
+    <calcite.version>1.20.0-drill-r2</calcite.version>
     <avatica.version>1.15.0</avatica.version>
     <janino.version>3.0.11</janino.version>
     <sqlline.version>1.9.0</sqlline.version>


### PR DESCRIPTION
Jira: [DRILL-7391](https://issues.apache.org/jira/browse/DRILL-7391).

Actual fixes were done in Calcite ([CALCITE-3390](https://issues.apache.org/jira/browse/CALCITE-3390), [CALCITE-3457](https://issues.apache.org/jira/browse/CALCITE-3457)), this PR just adds unit test and updates Calcite version to include these fixes.