### PR TITLE
DRILL-5844: Incorrect values of TABLE_TYPE returned from method DatabaseMetaData.getTables of JDBC API

### DIFF
--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
@@ -239,4 +239,15 @@ public class TestJdbcPluginWithH2IT extends ClusterTest {
     String plan = queryBuilder().sql(query).explainJson();
     assertEquals(5, queryBuilder().physical(plan).run().recordCount());
   }
+
+  @Test
+  public void testJdbcTableTypes() throws Exception {
+    String query = "select distinct table_type from information_schema.`tables`";
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("table_type")
+        .baselineValuesForSingleColumn("SYSTEM TABLE", "TABLE")
+        .go();
+  }
 }

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -329,4 +329,16 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
     String query = "select * from information_schema.`views`";
     run(query);
   }
+
+  @Test
+  public void testJdbcTableTypes() throws Exception {
+    String query = "select distinct table_type from information_schema.`tables` " +
+        "where table_schema like 'mysql%'";
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("table_type")
+        .baselineValuesForSingleColumn("SYSTEM VIEW", "TABLE", "VIEW")
+        .go();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/FilterEvaluator.java
@@ -179,7 +179,7 @@ public interface FilterEvaluator {
         SHRD_COL_TABLE_SCHEMA, schemaName,
         SCHS_COL_SCHEMA_NAME, schemaName,
         SHRD_COL_TABLE_NAME, tableName,
-        TBLS_COL_TABLE_TYPE, tableType.toString());
+        TBLS_COL_TABLE_TYPE, tableType.jdbcName);
 
       return filter.evaluate(recordValues) != InfoSchemaFilter.Result.FALSE;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/RecordCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/RecordCollector.java
@@ -158,7 +158,7 @@ public interface RecordCollector {
 
       return drillSchema.getTableNamesAndTypes().stream()
         .filter(entry -> filterEvaluator.shouldVisitTable(schemaPath, entry.getKey(), entry.getValue()))
-        .map(entry -> new Records.Table(IS_CATALOG_NAME, schemaPath, entry.getKey(), entry.getValue().toString()))
+        .map(entry -> new Records.Table(IS_CATALOG_NAME, schemaPath, entry.getKey(), entry.getValue().jdbcName))
         .collect(Collectors.toList());
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/metadata/TestMetadataProvider.java
@@ -179,7 +179,7 @@ public class TestMetadataProvider extends BaseTestQuery {
   public void tablesWithSystemTableFilter() throws Exception {
     // test("SELECT * FROM INFORMATION_SCHEMA.`TABLES` WHERE TABLE_TYPE IN ('SYSTEM_TABLE')"); // SQL equivalent
 
-    GetTablesResp resp = client.getTables(null, null, null, Collections.singletonList("SYSTEM_TABLE")).get();
+    GetTablesResp resp = client.getTables(null, null, null, Collections.singletonList("SYSTEM TABLE")).get();
 
     assertEquals(RequestStatus.OK, resp.getStatus());
     List<TableMetadata> tables = resp.getTablesList();

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcMetadata.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcMetadata.java
@@ -78,7 +78,7 @@ public class TestJdbcMetadata extends JdbcTestActionBase {
     this.testAction(new JdbcAction(){
       @Override
       public ResultSet getResult(Connection c) throws SQLException {
-        return c.getMetaData().getTables("DRILL", "sys", "opt%", new String[]{"SYSTEM_TABLE", "SYSTEM_VIEW"});
+        return c.getMetaData().getTables("DRILL", "sys", "opt%", new String[]{"SYSTEM TABLE", "SYSTEM_VIEW"});
       }
     }, 2);
   }


### PR DESCRIPTION
Incorrect values of TABLE_TYPE returned from method DatabaseMetaData.getTables of JDBC API.

According to JDBC API, the typical types are "TABLE", "VIEW", "SYSTEM TABLE", "GLOBAL TEMPORARY", "LOCAL TEMPORARY", "ALIAS", "SYNONYM". Therefore "SYSTEM_TABLE" should be replaced by "SYSTEM TABLE".

Jira - [DRILL-5844](https://issues.apache.org/jira/browse/DRILL-5844).