### PR TITLE
DRILL-7456: Batch count fixes for 12 operators

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -58,6 +58,8 @@ import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.DrillBuf;
 
@@ -65,7 +67,7 @@ import io.netty.buffer.DrillBuf;
  * Record batch used for a particular scan. Operators against one or more
  */
 public class ScanBatch implements CloseableRecordBatch {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ScanBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(ScanBatch.class);
   private static final ControlsInjector injector = ControlsInjectorFactory.getInjector(ScanBatch.class);
 
   /** Main collection of fields' value vectors. */
@@ -79,7 +81,7 @@ public class ScanBatch implements CloseableRecordBatch {
   private BatchSchema schema;
   private final Mutator mutator;
   private boolean done;
-  private Iterator<Map<String, String>> implicitColumns;
+  private final Iterator<Map<String, String>> implicitColumns;
   private Map<String, String> implicitValues;
   private final BufferAllocator allocator;
   private final List<Map<String, String>> implicitColumnList;
@@ -179,18 +181,19 @@ public class ScanBatch implements CloseableRecordBatch {
   }
 
   /**
-   * This method is to perform scan specific actions when the scan needs to clean/reset readers and return NONE status
+   * This method is to perform scan specific actions when the scan needs to
+   * clean/reset readers and return NONE status
+   *
    * @return NONE
    */
   private IterOutcome cleanAndReturnNone() {
     if (isRepeatableScan) {
       readers = readerList.iterator();
-      return IterOutcome.NONE;
     } else {
       releaseAssets(); // All data has been read. Release resource.
       done = true;
-      return IterOutcome.NONE;
     }
+    return IterOutcome.NONE;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -17,12 +17,9 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
-import static org.apache.drill.exec.record.JoinBatchMemoryManager.LEFT_INDEX;
-
 import java.util.ArrayList;
 
-import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.commons.lang3.tuple.Pair;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.physical.impl.common.HashPartition;
 import org.apache.drill.exec.planner.common.JoinControl;
@@ -31,10 +28,12 @@ import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.ValueVector;
 
-import com.carrotsearch.hppc.IntArrayList;
+import static org.apache.drill.exec.record.JoinBatchMemoryManager.LEFT_INDEX;
 
 public class HashJoinProbeTemplate implements HashJoinProbe {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinProbeTemplate.java
@@ -17,9 +17,12 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
+import static org.apache.drill.exec.record.JoinBatchMemoryManager.LEFT_INDEX;
+
 import java.util.ArrayList;
 
-import com.carrotsearch.hppc.IntArrayList;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.physical.impl.common.HashPartition;
 import org.apache.drill.exec.planner.common.JoinControl;
@@ -28,14 +31,12 @@ import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
-import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.exec.vector.ValueVector;
 
-import static org.apache.drill.exec.record.JoinBatchMemoryManager.LEFT_INDEX;
+import com.carrotsearch.hppc.IntArrayList;
 
-public abstract class HashJoinProbeTemplate implements HashJoinProbe {
+public class HashJoinProbeTemplate implements HashJoinProbe {
 
   VectorContainer container; // the outgoing container
 
@@ -50,13 +51,13 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
   // joinControl determines how to handle INTERSECT_DISTINCT vs. INTERSECT_ALL
   private JoinControl joinControl;
 
-  private HashJoinBatch outgoingJoinBatch = null;
+  private HashJoinBatch outgoingJoinBatch;
 
   // Number of records to process on the probe side
-  private int recordsToProcess = 0;
+  private int recordsToProcess;
 
   // Number of records processed on the probe side
-  private int recordsProcessed = 0;
+  private int recordsProcessed;
 
   // Number of records in the output container
   private int outputRecords;
@@ -71,7 +72,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
   private ProbeState probeState = ProbeState.PROBE_PROJECT;
 
   // For outer or right joins, this is a list of unmatched records that needs to be projected
-  private IntArrayList unmatchedBuildIndexes = null;
+  private IntArrayList unmatchedBuildIndexes;
 
   private  HashPartition partitions[];
 
@@ -79,14 +80,14 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
   // probing later on the same chain of duplicates
   private HashPartition currPartition;
 
-  private int currRightPartition = 0; // for returning RIGHT/FULL
+  private int currRightPartition; // for returning RIGHT/FULL
   IntVector read_left_HV_vector; // HV vector that was read from the spilled batch
-  private int cycleNum = 0; // 1-primary, 2-secondary, 3-tertiary, etc.
+  private int cycleNum; // 1-primary, 2-secondary, 3-tertiary, etc.
   private HashJoinBatch.HashJoinSpilledPartition spilledInners[]; // for the outer to find the partition
   private boolean buildSideIsEmpty = true;
   private int numPartitions = 1; // must be 2 to the power of bitsInMask
-  private int partitionMask = 0; // numPartitions - 1
-  private int bitsInMask = 0; // number of bits in the MASK
+  private int partitionMask; // numPartitions - 1
+  private int bitsInMask; // number of bits in the MASK
   private int numberOfBuildSideColumns;
   private int targetOutputRecords;
   private boolean semiJoin;
@@ -96,6 +97,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
     this.targetOutputRecords = targetOutputRecords;
   }
 
+  @Override
   public int getOutputCount() {
     return outputRecords;
   }
@@ -143,7 +145,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
     this.recordsProcessed = 0;
 
     // A special case - if the left was an empty file
-    if ( leftStartState == IterOutcome.NONE ){
+    if (leftStartState == IterOutcome.NONE){
       changeToFinalProbeState();
     } else {
       this.recordsToProcess = probeBatch.getRecordCount();
@@ -151,16 +153,16 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
 
     // for those outer partitions that need spilling (cause their matching inners spilled)
     // initialize those partitions' current batches and hash-value vectors
-    for ( HashPartition partn : this.partitions) {
+    for (HashPartition partn : this.partitions) {
       partn.allocateNewCurrentBatchAndHV();
     }
 
     currRightPartition = 0; // In case it's a Right/Full outer join
 
     // Initialize the HV vector for the first (already read) left batch
-    if ( this.cycleNum > 0 ) {
-      if ( read_left_HV_vector != null ) { read_left_HV_vector.clear();}
-      if ( leftStartState != IterOutcome.NONE ) { // Skip when outer spill was empty
+    if (this.cycleNum > 0) {
+      if (read_left_HV_vector != null) { read_left_HV_vector.clear();}
+      if (leftStartState != IterOutcome.NONE) { // Skip when outer spill was empty
         read_left_HV_vector = (IntVector) probeBatch.getContainer().getLast();
       }
     }
@@ -178,6 +180,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
       destVector.copyEntry(container.getRecordCount(), srcVector, buildSrcIndex);
     }
   }
+
   /**
    * Append the given probe side row into the outgoing container, following the build side part
    * @param probeSrcContainer The container for the left/outer side
@@ -190,6 +193,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
       destVector.copyEntry(container.getRecordCount(), srcVector, probeSrcIndex);
     }
   }
+
   /**
    *  A special version of the VectorContainer's appendRow for the HashJoin; (following a probe) it
    *  copies the build and probe sides into the outgoing container. (It uses a composite
@@ -204,12 +208,14 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
   private int outputRow(ArrayList<VectorContainer> buildSrcContainers, int compositeBuildSrcIndex,
                         VectorContainer probeSrcContainer, int probeSrcIndex) {
 
-    if ( buildSrcContainers != null ) {
+    if (buildSrcContainers != null) {
       int buildBatchIndex = compositeBuildSrcIndex >>> 16;
       int buildOffset = compositeBuildSrcIndex & 65535;
       appendBuild(buildSrcContainers.get(buildBatchIndex), buildOffset);
     }
-    if ( probeSrcContainer != null ) { appendProbe(probeSrcContainer, probeSrcIndex); }
+    if (probeSrcContainer != null) {
+      appendProbe(probeSrcContainer, probeSrcIndex);
+    }
     return container.incRecordCount();
   }
 
@@ -221,7 +227,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
     while (outputRecords < targetOutputRecords && recordsProcessed < recordsToProcess) {
       outputRecords =
         outputRow(partitions[currBuildPart].getContainers(), unmatchedBuildIndexes.get(recordsProcessed),
-          null /* no probeBatch */, 0 /* no probe index */ );
+          null /* no probeBatch */, 0 /* no probe index */);
       recordsProcessed++;
     }
   }
@@ -248,8 +254,8 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
             recordsToProcess = 0;
             changeToFinalProbeState();
             // in case some outer partitions were spilled, need to spill their last batches
-            for ( HashPartition partn : partitions ) {
-              if ( ! partn.isSpilled() ) { continue; } // skip non-spilled
+            for (HashPartition partn : partitions) {
+              if (! partn.isSpilled()) { continue; } // skip non-spilled
               partn.completeAnOuterBatch(false);
               // update the partition's spill record with the outer side
               HashJoinBatch.HashJoinSpilledPartition sp = spilledInners[partn.getPartitionNum()];
@@ -262,7 +268,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
 
           case OK_NEW_SCHEMA:
             if (probeBatch.getSchema().equals(probeSchema)) {
-              for ( HashPartition partn : partitions ) { partn.updateBatches(); }
+              for (HashPartition partn : partitions) { partn.updateBatches(); }
 
             } else {
               throw SchemaChangeException.schemaChanged("Hash join does not support schema changes in probe side.",
@@ -278,7 +284,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
             if (recordsToProcess == 0) {
               continue;
             }
-            if ( cycleNum > 0 ) {
+            if (cycleNum > 0) {
               read_left_HV_vector = (IntVector) probeBatch.getContainer().getLast(); // Needed ?
             }
         }
@@ -287,8 +293,8 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
       int probeIndex = -1;
       // Check if we need to drain the next row in the probe side
       if (getNextRecord) {
-        if ( !buildSideIsEmpty ) {
-          int hashCode = ( cycleNum == 0 ) ?
+        if (!buildSideIsEmpty) {
+          int hashCode = (cycleNum == 0) ?
             partitions[0].getProbeHashCode(recordsProcessed)
             : read_left_HV_vector.getAccessor().get(recordsProcessed);
           int currBuildPart = hashCode & partitionMask;
@@ -299,7 +305,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
           currPartition = partitions[currBuildPart]; // inner if not spilled, else outer
 
           // If the matching inner partition was spilled
-          if ( outgoingJoinBatch.isSpilledInner(currBuildPart) ) {
+          if (outgoingJoinBatch.isSpilledInner(currBuildPart)) {
             // add this row to its outer partition (may cause a spill, when the batch is full)
 
             currPartition.appendOuterRow(hashCode, recordsProcessed);
@@ -312,8 +318,8 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
 
         }
 
-        if ( semiJoin ) {
-          if ( probeIndex != -1 ) {
+        if (semiJoin) {
+          if (probeIndex != -1) {
             // output the probe side only
             outputRecords =
               outputRow(null, 0, probeBatch.getContainer(), recordsProcessed);
@@ -392,7 +398,6 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
         }
       }
     }
-
   }
 
   /**
@@ -408,7 +413,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
     outputRecords = 0;
 
     // When handling spilled partitions, the state becomes DONE at the end of each partition
-    if ( probeState == ProbeState.DONE ) {
+    if (probeState == ProbeState.DONE) {
       return outputRecords; // that is zero
     }
 
@@ -422,7 +427,7 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
       do {
 
         if (unmatchedBuildIndexes == null) { // first time for this partition ?
-          if ( buildSideIsEmpty ) { return outputRecords; } // in case of an empty right
+          if (buildSideIsEmpty) { return outputRecords; } // in case of an empty right
           // Get this partition's list of build indexes that didn't match any record on the probe side
           unmatchedBuildIndexes = partitions[currRightPartition].getNextUnmatchedIndex();
           recordsProcessed = 0;
@@ -432,14 +437,14 @@ public abstract class HashJoinProbeTemplate implements HashJoinProbe {
         // Project the list of unmatched records on the build side
         executeProjectRightPhase(currRightPartition);
 
-        if ( recordsProcessed < recordsToProcess ) { // more records in this partition?
+        if (recordsProcessed < recordsToProcess) { // more records in this partition?
           return outputRecords;  // outgoing is full; report and come back later
         } else {
           currRightPartition++; // on to the next right partition
           unmatchedBuildIndexes = null;
         }
 
-      }   while ( currRightPartition < numPartitions );
+      }   while (currRightPartition < numPartitions);
 
       probeState = ProbeState.DONE; // last right partition was handled; we are done now
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
@@ -147,10 +147,7 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
       incoming.getContainer().zeroVectors();
       outgoingSv.setRecordCount(0);
       outgoingSv.setBatchActualRecordCount(0);
-      // Must allocate vectors to allow for offset vectors which
-      // require a zero in the 0th position.
-      container.allocateNew();
-      container.setRecordCount(0);
+      container.setEmpty();
       // Release buffer for sv2 (if any)
       if (incomingSv != null) {
         incomingSv.clear();
@@ -162,16 +159,9 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
       tp.transfer();
     }
 
-    // Must report the actual value count as the record
-    // count. This is NOT the input record count when the input
-    // is an SV2.
-    int inputValueCount = incoming.getContainer().getRecordCount();
-    container.setRecordCount(inputValueCount);
-
     // Allocate SV2 vectors for the record count size since we transfer all the vectors buffer from input record
     // batch to output record batch and later an SV2Remover copies the needed records.
     outgoingSv.allocateNew(inputRecordCount);
-    outgoingSv.setBatchActualRecordCount(inputValueCount);
     limit(inputRecordCount);
 
     // Release memory for incoming sv (if any)
@@ -224,7 +214,7 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
       }
     }
 
-    outgoingSv.setRecordCount(svIndex);
+    setOutgoingRecordCount(inputRecordCount, svIndex);
   }
 
   private void updateOutputSV2(int svIndex, int incomingIndex) {
@@ -241,6 +231,16 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
     } else {
       return partitionColumn.getAccessor().get(incomingIndex);
     }
+  }
+
+  private void setOutgoingRecordCount(int inputRecordCount, int outputCount) {
+    outgoingSv.setRecordCount(outputCount);
+    // Must report the actual value count as the record
+    // count. This is NOT the input record count when the input
+    // is an SV2.
+    int inputValueCount = incoming.getContainer().getRecordCount();
+    container.setRecordCount(inputValueCount);
+    outgoingSv.setBatchActualRecordCount(inputValueCount);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -886,7 +886,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
     doAlloc(0);
     container.buildSchema(SelectionVectorMode.NONE);
-    container.setValueCount(0);
+    container.setEmpty();
     wasNone = true;
     return IterOutcome.OK_NEW_SCHEMA;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectorTemplate.java
@@ -34,6 +34,7 @@ public abstract class ProjectorTemplate implements Projector {
 
   private ImmutableList<TransferPair> transfers;
   private SelectionVector2 vector2;
+  @SuppressWarnings("unused")
   private SelectionVector4 vector4;
   private SelectionVectorMode svMode;
 
@@ -97,8 +98,10 @@ public abstract class ProjectorTemplate implements Projector {
     case TWO_BYTE:
       vector2 = incoming.getSelectionVector2();
       break;
-    default:
+    case NONE:
       break;
+    default:
+      throw new UnsupportedOperationException();
     }
     this.transfers = ImmutableList.copyOf(transfers);
     doSetup(context, incoming, outgoing);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/AbstractSV4Copier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/AbstractSV4Copier.java
@@ -23,8 +23,10 @@ import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.selection.SelectionVector4;
 
 public abstract class AbstractSV4Copier extends AbstractCopier {
-  // Storing VectorWrapper reference instead of ValueVector[]. With EMIT outcome support underlying operator
-  // operator can generate multiple output batches with no schema changes which will change the ValueVector[]
+  // Storing VectorWrapper reference instead of ValueVector[]. With EMIT outcome
+  // support underlying operator
+  // operator can generate multiple output batches with no schema changes which
+  // will change the ValueVector[]
   // reference but not VectorWrapper reference.
   protected VectorWrapper<?>[] vvIn;
   private SelectionVector4 sv4;
@@ -32,21 +34,18 @@ public abstract class AbstractSV4Copier extends AbstractCopier {
   @Override
   public void setup(VectorAccessible incoming, VectorContainer outgoing) {
     super.setup(incoming, outgoing);
-    this.sv4 = incoming.getSelectionVector4();
+    sv4 = incoming.getSelectionVector4();
 
-    final int count = outgoing.getNumberOfColumns();
+    int count = outgoing.getNumberOfColumns();
     vvIn = new VectorWrapper[count];
 
-    {
-      int index = 0;
-
-      for (VectorWrapper vectorWrapper: incoming) {
-        vvIn[index] = vectorWrapper;
-        index++;
-      }
+    int index = 0;
+    for (VectorWrapper<?> vectorWrapper: incoming) {
+      vvIn[index++] = vectorWrapper;
     }
   }
 
+  @Override
   public void copyEntryIndirect(int inIndex, int outIndex) {
     copyEntry(sv4.get(inIndex), outIndex);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericCopier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericCopier.java
@@ -42,7 +42,7 @@ public class GenericCopier implements Copier {
     {
       int index = 0;
 
-      for (VectorWrapper vectorWrapper: incoming) {
+      for (VectorWrapper<?> vectorWrapper: incoming) {
         vvIn[index] = vectorWrapper.getValueVector();
         index++;
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV4Copier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/GenericSV4Copier.java
@@ -27,7 +27,7 @@ public class GenericSV4Copier extends AbstractSV4Copier {
 
   public GenericSV4Copier(RecordBatch incomingBatch, VectorContainer outputContainer,
                           SchemaChangeCallBack callBack) {
-    for(VectorWrapper<?> vv : incomingBatch){
+    for (VectorWrapper<?> vv : incomingBatch) {
       ValueVector v = vv.getValueVectors()[0];
       v.makeTransferPair(outputContainer.addOrGet(v.getField(), callBack));
     }
@@ -37,7 +37,7 @@ public class GenericSV4Copier extends AbstractSV4Copier {
   public void copyEntry(int inIndex, int outIndex) {
     int inOffset = inIndex & 0xFFFF;
     int inVector = inIndex >>> 16;
-    for ( int i = 0;  i < vvIn.length;  i++ ) {
+    for (int i = 0;  i < vvIn.length;  i++) {
       ValueVector[] vectorsFromIncoming = vvIn[i].getValueVectors();
       vvOut[i].copyEntry(outIndex, vectorsFromIncoming[inVector], inOffset);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/RemovingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/RemovingRecordBatch.java
@@ -43,14 +43,18 @@ public class RemovingRecordBatch extends AbstractSingleRecordBatch<SelectionVect
 
   @Override
   protected boolean setupNewSchema() throws SchemaChangeException {
-    // Don't clear off container just because an OK_NEW_SCHEMA was received from upstream. For cases when there is just
-    // change in container type but no actual schema change, RemovingRecordBatch should consume OK_NEW_SCHEMA and
-    // send OK to downstream instead. Since the output of RemovingRecordBatch is always going to be a regular container
+    // Don't clear off container just because an OK_NEW_SCHEMA was received from
+    // upstream. For cases when there is just
+    // change in container type but no actual schema change, RemovingRecordBatch
+    // should consume OK_NEW_SCHEMA and
+    // send OK to downstream instead. Since the output of RemovingRecordBatch is
+    // always going to be a regular container
     // change in incoming container type is not actual schema change.
     container.zeroVectors();
     copier = GenericCopierFactory.createAndSetupCopier(incoming, container, callBack);
 
-    // If there is an actual schema change then below condition will be true and it will send OK_NEW_SCHEMA
+    // If there is an actual schema change then below condition will be true and
+    // it will send OK_NEW_SCHEMA
     // downstream too
     if (container.isSchemaChanged()) {
       container.buildSchema(SelectionVectorMode.NONE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/trace/TraceRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/trace/TraceRecordBatch.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.cache.VectorAccessibleSerializable;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.Trace;
@@ -38,24 +37,27 @@ import org.apache.drill.exec.util.Utilities;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** TraceRecordBatch contains value vectors which are exactly the same
+/**
+ * Contains value vectors which are exactly the same
  * as the incoming record batch's value vectors. If the incoming
  * record batch has a selection vector (type 2) then TraceRecordBatch
  * will also contain a selection vector.
- *
+ * <p>
  * Purpose of this record batch is to dump the data associated with all
  * the value vectors and selection vector to disk.
- *
+ * <p>
  * This record batch does not modify any data or schema, it simply
  * consumes the incoming record batch's data, dump to disk and pass the
  * same set of value vectors (and selection vectors) to its parent record
- * batch
+ * batch.
  */
 public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TraceRecordBatch.class);
+  static final Logger logger = LoggerFactory.getLogger(TraceRecordBatch.class);
 
-  private SelectionVector2 sv = null;
+  private SelectionVector2 sv;
 
   private final BufferAllocator localAllocator;
 
@@ -75,13 +77,14 @@ public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
     localAllocator = context.getNewChildAllocator("trace", 200, 0, Long.MAX_VALUE);
     String fileName = getFileName();
 
-    /* Create the log file we will dump to and initialize the file descriptors */
+    // Create the log file we will dump to and initialize the file descriptors
     try {
       Configuration conf = new Configuration();
-      conf.set(FileSystem.FS_DEFAULT_NAME_KEY, context.getConfig().getString(ExecConstants.TRACE_DUMP_FILESYSTEM));
+      conf.set(FileSystem.FS_DEFAULT_NAME_KEY,
+          context.getConfig().getString(ExecConstants.TRACE_DUMP_FILESYSTEM));
       FileSystem fs = FileSystem.get(conf);
 
-      /* create the file */
+      // create the file
       fos = fs.create(new Path(fileName));
     } catch (IOException e) {
         throw new ExecutionSetupException("Unable to create file: " + fileName + " check permissions or if directory exists", e);
@@ -91,15 +94,15 @@ public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
   @Override
   public int getRecordCount() {
     if (sv == null) {
-      return incoming.getRecordCount();
+      return container.getRecordCount();
     } else {
       return sv.getCount();
     }
   }
 
   /**
-   * Function is invoked for every record batch and it simply dumps the buffers associated with all the value vectors in
-   * this record batch to a log file.
+   * Invoked for every record batch and it simply dumps the buffers
+   * associated with all the value vectors in this record batch to a log file.
    */
   @Override
   protected IterOutcome doWork() {
@@ -110,7 +113,7 @@ public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
     } else {
       sv = null;
     }
-    WritableBatch batch = WritableBatch.getBatchNoHVWrap(incoming.getRecordCount(), incoming, incomingHasSv2);
+    WritableBatch batch = WritableBatch.getBatchNoHVWrap(incoming.getContainer().getRecordCount(), incoming, incomingHasSv2);
     VectorAccessibleSerializable wrap = new VectorAccessibleSerializable(batch, sv, oContext.getAllocator());
 
     try {
@@ -121,28 +124,31 @@ public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
     batch.reconstructContainer(localAllocator, container);
     if (incomingHasSv2) {
       sv = wrap.getSv2();
+      container.setRecordCount(sv.getBatchActualRecordCount());
+    } else {
+      container.setRecordCount(batch.getDef().getRecordCount());
     }
     return getFinalOutcome(false);
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
-    /* Trace operator does not deal with hyper vectors yet */
+  protected boolean setupNewSchema() {
+    // Trace operator does not deal with hyper vectors yet
     if (incoming.getSchema().getSelectionVectorMode() == SelectionVectorMode.FOUR_BYTE) {
-      throw new SchemaChangeException("Trace operator does not work with hyper vectors");
+      throw new UnsupportedOperationException("Trace operator does not work with hyper vectors");
     }
 
-    /*
-     * we have a new schema, clear our existing container to load the new value vectors
-     */
+    // we have a new schema, clear our existing container to load the new value vectors
+
     container.clear();
 
-    /* Add all the value vectors in the container */
+    // Add all the value vectors in the container
     for (VectorWrapper<?> vv : incoming) {
       TransferPair tp = vv.getValueVector().getTransferPair(oContext.getAllocator());
       container.add(tp.getTo());
     }
     container.buildSchema(incoming.getSchema().getSelectionVectorMode());
+    container.setRecordCount(incoming.getRecordCount());
     return true;
   }
 
@@ -157,12 +163,12 @@ public class TraceRecordBatch extends AbstractSingleRecordBatch<Trace> {
 
   @Override
   public void close() {
-    /* Release the selection vector */
+    // Release the selection vector
     if (sv != null) {
       sv.clear();
     }
 
-    /* Close the file descriptors */
+    // Close the file descriptors
     try {
       fos.close();
     } catch (IOException e) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -338,11 +338,10 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
     public int getRemainingRecords() {
       return (totalRecordsToProcess - recordsProcessed);
     }
-
   }
 
   private class UnionInputIterator implements Iterator<Pair<IterOutcome, BatchStatusWrappper>> {
-    private final Stack<BatchStatusWrappper> batchStatusStack = new Stack<>();
+    private Stack<BatchStatusWrappper> batchStatusStack = new Stack<>();
 
     UnionInputIterator(IterOutcome leftOutCome, RecordBatch left, IterOutcome rightOutCome, RecordBatch right) {
       if (rightOutCome == IterOutcome.OK_NEW_SCHEMA) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
@@ -374,8 +374,7 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
     TransferPair tp = resetUnnestTransferPair();
     container.add(TypeHelper.getNewVector(tp.getTo().getField(), oContext.getAllocator()));
     container.buildSchema(SelectionVectorMode.NONE);
-    container.allocateNew();
-    container.setValueCount(0);
+    container.setEmpty();
     return true;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.unorderedreceiver;
 
-import io.netty.buffer.ByteBuf;
-
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -51,9 +49,13 @@ import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.testing.ControlsInjector;
 import org.apache.drill.exec.testing.ControlsInjectorFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
 
 public class UnorderedReceiverBatch implements CloseableRecordBatch {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnorderedReceiverBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(UnorderedReceiverBatch.class);
   private static final ControlsInjector injector = ControlsInjectorFactory.getInjector(UnorderedReceiverBatch.class);
 
   private final RecordBatchLoader batchLoader;
@@ -78,11 +80,15 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
     }
   }
 
-  public UnorderedReceiverBatch(final ExchangeFragmentContext context, final RawFragmentBatchProvider fragProvider, final UnorderedReceiver config) throws OutOfMemoryException {
+  public UnorderedReceiverBatch(ExchangeFragmentContext context,
+      RawFragmentBatchProvider fragProvider, UnorderedReceiver config)
+          throws OutOfMemoryException {
     this.fragProvider = fragProvider;
     this.context = context;
-    // In normal case, batchLoader does not require an allocator. However, in case of splitAndTransfer of a value vector,
-    // we may need an allocator for the new offset vector. Therefore, here we pass the context's allocator to batchLoader.
+    // In normal case, batchLoader does not require an allocator. However, in
+    // case of splitAndTransfer of a value vector,
+    // we may need an allocator for the new offset vector. Therefore, here we
+    // pass the context's allocator to batchLoader.
     oContext = context.newOperatorContext(config);
     this.batchLoader = new RecordBatchLoader(oContext.getAllocator());
 
@@ -90,8 +96,10 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
     this.stats.setLongStat(Metric.NUM_SENDERS, config.getNumSenders());
     this.config = config;
 
-    // Register this operator's buffer allocator so that incoming buffers are owned by this allocator
-    context.getBuffers().getCollector(config.getOppositeMajorFragmentId()).setAllocator(oContext.getAllocator());
+    // Register this operator's buffer allocator so that incoming buffers are
+    // owned by this allocator
+    context.getBuffers().getCollector(config.getOppositeMajorFragmentId())
+      .setAllocator(oContext.getAllocator());
   }
 
   @Override
@@ -110,7 +118,7 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
   }
 
   @Override
-  public void kill(final boolean sendUpstream) {
+  public void kill(boolean sendUpstream) {
     if (sendUpstream) {
       informSenders();
     }
@@ -133,12 +141,12 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
   }
 
   @Override
-  public TypedFieldId getValueVectorId(final SchemaPath path) {
+  public TypedFieldId getValueVectorId(SchemaPath path) {
     return batchLoader.getValueVectorId(path);
   }
 
   @Override
-  public VectorWrapper<?> getValueAccessorById(final Class<?> clazz, final int... ids) {
+  public VectorWrapper<?> getValueAccessorById(Class<?> clazz, int... ids) {
     return batchLoader.getValueAccessorById(clazz, ids);
   }
 
@@ -146,8 +154,9 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
     try {
       injector.injectInterruptiblePause(context.getExecutionControls(), "waiting-for-data", logger);
       return fragProvider.getNext();
-    } catch(final InterruptedException e) {
-      // Preserve evidence that the interruption occurred so that code higher up on the call stack can learn of the
+    } catch(InterruptedException e) {
+      // Preserve evidence that the interruption occurred so that code higher up
+      // on the call stack can learn of the
       // interruption and respond to it if it wants to.
       Thread.currentThread().interrupt();
 
@@ -190,8 +199,8 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
         return lastOutcome;
       }
 
-      final RecordBatchDef rbd = batch.getHeader().getDef();
-      final boolean schemaChanged = batchLoader.load(rbd, batch.getBody());
+      RecordBatchDef rbd = batch.getHeader().getDef();
+      boolean schemaChanged = batchLoader.load(rbd, batch.getBody());
       // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
       // SchemaChangeException, so check/clean catch clause below.
       stats.addLongStat(Metric.BYTES_RECEIVED, batch.getByteCount());
@@ -230,7 +239,9 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
 
   @Override
   public VectorContainer getOutgoingContainer() {
-    throw new UnsupportedOperationException(String.format(" You should not call getOutgoingContainer() for class %s", this.getClass().getCanonicalName()));
+    throw new UnsupportedOperationException(
+        String.format("You should not call getOutgoingContainer() for class %s",
+            getClass().getCanonicalName()));
   }
 
   @Override
@@ -240,15 +251,15 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
 
   private void informSenders() {
     logger.info("Informing senders of request to terminate sending.");
-    final FragmentHandle handlePrototype = FragmentHandle.newBuilder()
+    FragmentHandle handlePrototype = FragmentHandle.newBuilder()
             .setMajorFragmentId(config.getOppositeMajorFragmentId())
             .setQueryId(context.getHandle().getQueryId())
             .build();
-    for (final MinorFragmentEndpoint providingEndpoint : config.getProvidingEndpoints()) {
-      final FragmentHandle sender = FragmentHandle.newBuilder(handlePrototype)
+    for (MinorFragmentEndpoint providingEndpoint : config.getProvidingEndpoints()) {
+      FragmentHandle sender = FragmentHandle.newBuilder(handlePrototype)
               .setMinorFragmentId(providingEndpoint.getId())
               .build();
-      final FinishedReceiver finishedReceiver = FinishedReceiver.newBuilder()
+      FinishedReceiver finishedReceiver = FinishedReceiver.newBuilder()
               .setReceiver(context.getHandle())
               .setSender(sender)
               .build();
@@ -262,19 +273,19 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
   private class OutcomeListener implements RpcOutcomeListener<Ack> {
 
     @Override
-    public void failed(final RpcException ex) {
+    public void failed(RpcException ex) {
       logger.warn("Failed to inform upstream that receiver is finished");
     }
 
     @Override
-    public void success(final Ack value, final ByteBuf buffer) {
+    public void success(Ack value, ByteBuf buffer) {
       // Do nothing
     }
 
     @Override
-    public void interrupted(final InterruptedException e) {
+    public void interrupted(InterruptedException e) {
       if (context.getExecutorState().shouldContinue()) {
-        final String errMsg = "Received an interrupt RPC outcome while sending ReceiverFinished message";
+        String errMsg = "Received an interrupt RPC outcome while sending ReceiverFinished message";
         logger.error(errMsg, e);
         context.getExecutorState().fail(new RpcException(errMsg, e));
       }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.physical.impl.unorderedreceiver;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -51,8 +53,6 @@ import org.apache.drill.exec.testing.ControlsInjector;
 import org.apache.drill.exec.testing.ControlsInjectorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.ByteBuf;
 
 public class UnorderedReceiverBatch implements CloseableRecordBatch {
   private static final Logger logger = LoggerFactory.getLogger(UnorderedReceiverBatch.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/NoFrameSupportTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/NoFrameSupportTemplate.java
@@ -17,10 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
-import java.util.List;
-
-import javax.inject.Named;
-
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.OperatorContext;
@@ -32,6 +28,9 @@ import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.ValueVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.util.List;
 
 
 /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/NoFrameSupportTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/NoFrameSupportTemplate.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
+import java.util.List;
+
+import javax.inject.Named;
+
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.OperatorContext;
@@ -26,18 +30,19 @@ import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.vector.BaseDataValueVector;
 import org.apache.drill.exec.vector.ValueVector;
-
-import javax.inject.Named;
-import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
- * WindowFramer implementation that doesn't support the FRAME clause (will assume the default frame).
- * <br>According to the SQL standard, LEAD, LAG, ROW_NUMBER, NTILE and all ranking functions don't support the FRAME clause.
- * This class will handle such functions.
+ * WindowFramer implementation that doesn't support the FRAME clause (will
+ * assume the default frame). <p>
+ * According to the SQL standard, LEAD, LAG, ROW_NUMBER, NTILE and all ranking
+ * functions don't support the FRAME clause. This class will handle such
+ * functions.
  */
 public abstract class NoFrameSupportTemplate implements WindowFramer {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NoFrameSupportTemplate.class);
+  private static final Logger logger = LoggerFactory.getLogger(NoFrameSupportTemplate.class);
 
   private VectorContainer container;
   private VectorContainer internal;
@@ -53,8 +58,8 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
   private Partition partition; // current partition being processed
 
   @Override
-  public void setup(final List<WindowDataBatch> batches, final VectorContainer container, final OperatorContext oContext,
-                    final boolean requireFullPartition, final WindowPOP popConfig) throws SchemaChangeException {
+  public void setup(List<WindowDataBatch> batches, VectorContainer container, OperatorContext oContext,
+                    boolean requireFullPartition, WindowPOP popConfig) throws SchemaChangeException {
     this.container = container;
     this.batches = batches;
 
@@ -81,9 +86,7 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
   @Override
   public void doWork() throws DrillException {
     int currentRow = 0;
-
-    this.current = batches.get(0);
-
+    current = batches.get(0);
     outputCount = current.getRecordCount();
 
     while (currentRow < outputCount) {
@@ -108,10 +111,9 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
     }
   }
 
-  private void newPartition(final WindowDataBatch current, final int currentRow) throws SchemaChangeException {
+  private void newPartition(WindowDataBatch current, int currentRow) throws SchemaChangeException {
     partition = new Partition();
     updatePartitionSize(partition, currentRow);
-
     setupPartition(current, container);
   }
 
@@ -131,16 +133,19 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
   }
 
   /**
-   * process all rows (computes and writes function values) of current batch that are part of current partition.
-   * @param currentRow first unprocessed row
+   * Process all rows (computes and writes function values) of current batch
+   * that are part of current partition.
+   *
+   * @param currentRow
+   *          first unprocessed row
    * @return index of next unprocessed row
-   * @throws DrillException if it can't write into the container
+   * @throws DrillException
+   *           if it can't write into the container
    */
-  private int processPartition(final int currentRow) throws DrillException {
+  private int processPartition(int currentRow) throws DrillException {
     logger.trace("process partition {}, currentRow: {}, outputCount: {}", partition, currentRow, outputCount);
 
     setupCopyNext(current, container);
-
     copyPrevFromInternal();
 
     // copy remaining from current
@@ -198,15 +203,14 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
     }
   }
 
-  private void processRow(final int row) throws DrillException {
+  private void processRow(int row) throws DrillException {
     if (partition.isFrameDone()) {
       // because all peer rows share the same frame, we only need to compute and aggregate the frame once
-      final long peers = countPeers(row);
+      long peers = countPeers(row);
       partition.newFrame(peers);
     }
 
     outputRow(row, partition);
-
     partition.rowAggregated();
   }
 
@@ -214,7 +218,7 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
    * updates partition's length after computing the number of rows for the current the partition starting at the specified
    * row of the first batch. If !requiresFullPartition, this method will only count the rows in the current batch
    */
-  private void updatePartitionSize(final Partition partition, final int start) {
+  private void updatePartitionSize(Partition partition, int start) {
     logger.trace("compute partition size starting from {} on {} batches", start, batches.size());
 
     long length = 0;
@@ -226,7 +230,7 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
 
     outer:
     for (WindowDataBatch batch : batches) {
-      final int recordCount = batch.getRecordCount();
+      int recordCount = batch.getRecordCount();
 
       // check first container from start row, and subsequent containers from first row
       for (; row < recordCount; row++, length++) {
@@ -262,18 +266,18 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
   }
 
   /**
-   * count number of peer rows for current row
+   * Count number of peer rows for current row
    * @param start starting row of the current frame
    * @return num peer rows for current row
    * @throws SchemaChangeException
    */
-  private long countPeers(final int start) throws SchemaChangeException {
+  private long countPeers(int start) throws SchemaChangeException {
     long length = 0;
 
     // a single frame can include rows from multiple batches
     // start processing first batch and, if necessary, move to next batches
     for (WindowDataBatch batch : batches) {
-      final int recordCount = batch.getRecordCount();
+      int recordCount = batch.getRecordCount();
 
       // for every remaining row in the partition, count it if it's a peer row
       for (int row = (batch == current) ? start : 0; row < recordCount; row++, length++) {
@@ -308,12 +312,14 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
         + "]";
   }
 
-
   /**
-   * called once for each row after we evaluate all peer rows. Used to write a value in the row
+   * Called once for each row after we evaluate all peer rows. Used to write a
+   * value in the row
    *
-   * @param outIndex index of row
-   * @param partition object used by "computed" window functions
+   * @param outIndex
+   *          index of row
+   * @param partition
+   *          object used by "computed" window functions
    */
   public abstract void outputRow(@Named("outIndex") int outIndex,
                                  @Named("partition") Partition partition)
@@ -331,10 +337,13 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
                        throws SchemaChangeException;
 
   /**
-   * copies value(s) from inIndex row to outIndex row. Mostly used by LEAD. inIndex always points to the row next to
-   * outIndex
-   * @param inIndex source row of the copy
-   * @param outIndex destination row of the copy.
+   * Copies value(s) from inIndex row to outIndex row. Mostly used by LEAD.
+   * inIndex always points to the row next to outIndex
+   *
+   * @param inIndex
+   *          source row of the copy
+   * @param outIndex
+   *          destination row of the copy.
    */
   public abstract void copyNext(@Named("inIndex") int inIndex,
                                 @Named("outIndex") int outIndex)
@@ -344,10 +353,13 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
                        throws SchemaChangeException;
 
   /**
-   * copies value(s) from inIndex row to outIndex row. Mostly used by LAG. inIndex always points to the previous row
+   * Copies value(s) from inIndex row to outIndex row. Mostly used by LAG.
+   * inIndex always points to the previous row
    *
-   * @param inIndex source row of the copy
-   * @param outIndex destination row of the copy.
+   * @param inIndex
+   *          source row of the copy
+   * @param outIndex
+   *          destination row of the copy.
    */
   public abstract void copyPrev(@Named("inIndex") int inIndex,
                                 @Named("outIndex") int outIndex)
@@ -364,12 +376,12 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
                        throws SchemaChangeException;
 
   /**
-   * reset all window functions
+   * Reset all window functions
    */
   public abstract boolean resetValues() throws SchemaChangeException;
 
   /**
-   * compares two rows from different batches (can be the same), if they have the same value for the partition by
+   * Compares two rows from different batches (can be the same), if they have the same value for the partition by
    * expression
    * @param b1Index index of first row
    * @param b1 batch for first row
@@ -385,7 +397,7 @@ public abstract class NoFrameSupportTemplate implements WindowFramer {
                           throws SchemaChangeException;
 
   /**
-   * compares two rows from different batches (can be the same), if they have the same value for the order by
+   * Compares two rows from different batches (can be the same), if they have the same value for the order by
    * expression
    * @param b1Index index of first row
    * @param b1 batch for first row

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/Partition.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/Partition.java
@@ -17,13 +17,17 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * Used internally to keep track of partitions and frames.<br>
- * A partition can be partial, which means we don't know "yet" the total number of records that are part of this partition.
- * Even for partial partitions, we know the number of rows that are part of current frame
+ * Used internally to keep track of partitions and frames.<p>
+ * A partition can be partial, which means we don't know "yet" the total number
+ * of records that are part of this partition. Even for partial partitions, we
+ * know the number of rows that are part of current frame
  */
 public class Partition {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Partition.class);
+  private static final Logger logger = LoggerFactory.getLogger(Partition.class);
 
   private boolean partial; // true if we don't know yet the full length of this partition
   private long length; // size of this partition (if partial is true, then this is a partial length of the partition)
@@ -48,10 +52,13 @@ public class Partition {
   public long getLength() {
     return length;
   }
+
   /**
-   * @param length number of rows in this partition
-   * @param partial if true, then length is not the full length of the partition but just the number of rows in the
-   *                current batch
+   * @param length
+   *          number of rows in this partition
+   * @param partial
+   *          if true, then length is not the full length of the partition but
+   *          just the number of rows in the current batch
    */
   public void updateLength(long length, boolean partial) {
     this.length += length;
@@ -62,7 +69,6 @@ public class Partition {
   public void rowAggregated() {
     remaining--;
     peers--;
-
     row_number++;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
+import java.util.List;
+
+import javax.inject.Named;
+
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.compile.TemplateClassDefinition;
 import org.apache.drill.exec.exception.SchemaChangeException;
@@ -25,15 +29,15 @@ import org.apache.drill.exec.physical.config.WindowPOP;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
 
-import javax.inject.Named;
-import java.util.List;
-
 public interface WindowFramer {
-  TemplateClassDefinition<WindowFramer> NOFRAME_TEMPLATE_DEFINITION = new TemplateClassDefinition<>(WindowFramer.class, NoFrameSupportTemplate.class);
-  TemplateClassDefinition<WindowFramer> FRAME_TEMPLATE_DEFINITION = new TemplateClassDefinition<>(WindowFramer.class, FrameSupportTemplate.class);
+  TemplateClassDefinition<WindowFramer> NOFRAME_TEMPLATE_DEFINITION =
+      new TemplateClassDefinition<>(WindowFramer.class, NoFrameSupportTemplate.class);
+  TemplateClassDefinition<WindowFramer> FRAME_TEMPLATE_DEFINITION =
+      new TemplateClassDefinition<>(WindowFramer.class, FrameSupportTemplate.class);
 
-  void setup(final List<WindowDataBatch> batches, final VectorContainer container, final OperatorContext operatorContext,
-             final boolean requireFullPartition, final WindowPOP popConfig) throws SchemaChangeException;
+  void setup(final List<WindowDataBatch> batches, final VectorContainer container,
+      final OperatorContext operatorContext, final boolean requireFullPartition,
+      final WindowPOP popConfig) throws SchemaChangeException;
 
   /**
    * process the inner batch and write the aggregated values in the container

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
@@ -17,10 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
-import java.util.List;
-
-import javax.inject.Named;
-
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.compile.TemplateClassDefinition;
 import org.apache.drill.exec.exception.SchemaChangeException;
@@ -28,6 +24,9 @@ import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.config.WindowPOP;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
+
+import javax.inject.Named;
+import java.util.List;
 
 public interface WindowFramer {
   TemplateClassDefinition<WindowFramer> NOFRAME_TEMPLATE_DEFINITION =

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/PriorityQueueCopierTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/PriorityQueueCopierTemplate.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.xsort;
 
-import io.netty.buffer.DrillBuf;
-
 import java.io.IOException;
 import java.util.List;
 
@@ -28,23 +26,24 @@ import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.record.VectorAccessible;
-import org.apache.drill.exec.record.VectorWrapper;
+import org.apache.drill.exec.record.VectorAccessibleUtilities;
 import org.apache.drill.exec.record.selection.SelectionVector4;
-import org.apache.drill.exec.vector.AllocationHelper;
+
+import io.netty.buffer.DrillBuf;
 
 public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PriorityQueueCopierTemplate.class);
 
   private SelectionVector4 vector4;
   private List<BatchGroup> batchGroups;
   private VectorAccessible hyperBatch;
   private VectorAccessible outgoing;
   private int size;
-  private int queueSize = 0;
+  private int queueSize;
 
   @Override
-  public void setup(FragmentContext context, BufferAllocator allocator, VectorAccessible hyperBatch, List<BatchGroup> batchGroups,
-                    VectorAccessible outgoing) throws SchemaChangeException {
+  public void setup(FragmentContext context, BufferAllocator allocator,
+      VectorAccessible hyperBatch, List<BatchGroup> batchGroups,
+      VectorAccessible outgoing) throws SchemaChangeException {
     this.hyperBatch = hyperBatch;
     this.batchGroups = batchGroups;
     this.outgoing = outgoing;
@@ -90,20 +89,14 @@ public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier
   }
 
   private void setValueCount(int count) {
-    for (VectorWrapper w: outgoing) {
-      w.getValueVector().getMutator().setValueCount(count);
-    }
+    VectorAccessibleUtilities.setValueCount(outgoing, count);
   }
 
   @Override
   public void close() throws IOException {
     vector4.clear();
-    for (final VectorWrapper<?> w: outgoing) {
-      w.getValueVector().clear();
-    }
-    for (final VectorWrapper<?> w : hyperBatch) {
-      w.clear();
-    }
+    VectorAccessibleUtilities.clear(outgoing);
+    VectorAccessibleUtilities.clear(hyperBatch);
 
     for (BatchGroup batchGroup : batchGroups) {
       batchGroup.close();
@@ -123,9 +116,7 @@ public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier
   }
 
   private void allocateVectors(int targetRecordCount) {
-    for (VectorWrapper w: outgoing) {
-      AllocationHelper.allocateNew(w.getValueVector(), targetRecordCount);
-    }
+    VectorAccessibleUtilities.allocateVectors(outgoing, targetRecordCount);
   }
 
   private void siftDown() {
@@ -162,8 +153,8 @@ public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier
     return doEval(sv1, sv2);
   }
 
-  public abstract void doSetup(@Named("context") FragmentContext context, @Named("incoming") VectorAccessible incoming, @Named("outgoing") VectorAccessible outgoing);
+  public abstract void doSetup(@Named("context") FragmentContext context,
+      @Named("incoming") VectorAccessible incoming, @Named("outgoing") VectorAccessible outgoing);
   public abstract int doEval(@Named("leftIndex") int leftIndex, @Named("rightIndex") int rightIndex);
   public abstract void doCopy(@Named("inIndex") int inIndex, @Named("outIndex") int outIndex);
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/PriorityQueueCopierTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/PriorityQueueCopierTemplate.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.physical.impl.xsort;
 
+import io.netty.buffer.DrillBuf;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -29,7 +31,6 @@ import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorAccessibleUtilities;
 import org.apache.drill.exec.record.selection.SelectionVector4;
 
-import io.netty.buffer.DrillBuf;
 
 public abstract class PriorityQueueCopierTemplate implements PriorityQueueCopier {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
@@ -22,14 +22,17 @@ import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 
 /**
- * Implements an AbstractUnaryRecordBatch where the incoming record batch is known at the time of creation
+ * Implements an AbstractUnaryRecordBatch where the incoming record batch is
+ * known at the time of creation
+ *
  * @param <T>
  */
 public abstract class AbstractSingleRecordBatch<T extends PhysicalOperator> extends AbstractUnaryRecordBatch<T> {
 
   protected final RecordBatch incoming;
 
-  public AbstractSingleRecordBatch(T popConfig, FragmentContext context, RecordBatch incoming) throws OutOfMemoryException {
+  public AbstractSingleRecordBatch(T popConfig, FragmentContext context,
+      RecordBatch incoming) throws OutOfMemoryException {
     super(popConfig, context);
     this.incoming = incoming;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
@@ -23,6 +23,8 @@ import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The base class for operators that have a single input. The concrete implementations provide the
@@ -34,9 +36,9 @@ import org.apache.drill.exec.vector.SchemaChangeCallBack;
  * @param <T>
  */
 public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> extends AbstractRecordBatch<T> {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
+  private static final Logger logger = LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
-  protected boolean outOfMemory = false;
+  protected boolean outOfMemory;
   protected SchemaChangeCallBack callBack = new SchemaChangeCallBack();
   private IterOutcome lastKnownOutcome;
 
@@ -140,18 +142,17 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
   protected abstract IterOutcome doWork();
 
   /**
-   * Default behavior to handle NULL input (aka FAST NONE): incoming return NONE before return a OK_NEW_SCHEMA:
-   * This could happen when the underneath Scan operators do not produce any batch with schema.
-   *
+   * Default behavior to handle NULL input (aka FAST NONE): incoming return NONE
+   * before return a OK_NEW_SCHEMA: This could happen when the underneath Scan
+   * operators do not produce any batch with schema.
    * <p>
-   * Notice that NULL input is different from input with an empty batch. In the later case, input provides
-   * at least a batch, thought it's empty.
-   *</p>
-   *
+   * Notice that NULL input is different from input with an empty batch. In the
+   * later case, input provides at least a batch, thought it's empty.
+   * </p>
    * <p>
-   * This behavior could be override in each individual operator, if the operator's semantics is to
-   * inject a batch with schema.
-   *</p>
+   * This behavior could be override in each individual operator, if the
+   * operator's semantics is to inject a batch with schema.
+   * </p>
    *
    * @return IterOutcome.NONE.
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
@@ -24,11 +24,10 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.impl.sort.RecordBatchData;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
-
-import org.apache.drill.shaded.guava.com.google.common.collect.Range;
-import org.apache.drill.shaded.guava.com.google.common.collect.TreeRangeMap;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
+import org.apache.drill.shaded.guava.com.google.common.collect.Range;
+import org.apache.drill.shaded.guava.com.google.common.collect.TreeRangeMap;
 
 /**
  * RecordIterator iterates over incoming record batches one record at a time.
@@ -36,7 +35,6 @@ import org.apache.drill.exec.record.selection.SelectionVector4;
  * RecordIterator will hold onto multiple record batches in order to support resetting beyond record batch boundary.
  */
 public class RecordIterator implements VectorAccessible {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RecordIterator.class);
 
   private final RecordBatch incoming;
   private final AbstractRecordBatch<?> outgoing;
@@ -48,10 +46,10 @@ public class RecordIterator implements VectorAccessible {
   private int markedInnerPosition;
   private long markedOuterPosition;
   private IterOutcome lastOutcome;
-  private int inputIndex;           // For two way merge join 0:left, 1:right
+  private final int inputIndex;           // For two way merge join 0:left, 1:right
   private boolean lastBatchRead;    // True if all batches are consumed.
   private boolean initialized;
-  private OperatorContext oContext;
+  private final OperatorContext oContext;
   private final boolean enableMarkAndReset;
 
   private final VectorContainer container; // Holds VectorContainer of current record batch
@@ -217,6 +215,7 @@ public class RecordIterator implements VectorAccessible {
               container.addOrGet(w.getField());
             }
             container.buildSchema(rbd.getContainer().getSchema().getSelectionVectorMode());
+            container.setEmpty();
             initialized = true;
           }
           if (innerRecordCount > 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
@@ -24,10 +24,11 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.impl.sort.RecordBatchData;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
-import org.apache.drill.exec.record.selection.SelectionVector2;
-import org.apache.drill.exec.record.selection.SelectionVector4;
+
 import org.apache.drill.shaded.guava.com.google.common.collect.Range;
 import org.apache.drill.shaded.guava.com.google.common.collect.TreeRangeMap;
+import org.apache.drill.exec.record.selection.SelectionVector2;
+import org.apache.drill.exec.record.selection.SelectionVector4;
 
 /**
  * RecordIterator iterates over incoming record batches one record at a time.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -32,6 +32,7 @@ import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
@@ -124,9 +125,15 @@ public class VectorContainer implements VectorAccessible {
    * Transfer vectors from containerIn to this.
    */
   public void transferIn(VectorContainer containerIn) {
-    Preconditions.checkArgument(this.wrappers.size() == containerIn.wrappers.size());
-    for (int i = 0; i < this.wrappers.size(); ++i) {
-      containerIn.wrappers.get(i).transfer(this.wrappers.get(i));
+    rawTransferIn(containerIn);
+    setRecordCount(containerIn.getRecordCount());
+  }
+
+  @VisibleForTesting
+  public void rawTransferIn(VectorContainer containerIn) {
+    Preconditions.checkArgument(wrappers.size() == containerIn.wrappers.size());
+    for (int i = 0; i < wrappers.size(); ++i) {
+      containerIn.wrappers.get(i).transfer(wrappers.get(i));
     }
   }
 
@@ -237,14 +244,14 @@ public class VectorContainer implements VectorAccessible {
     * @param srcIndex The index of the row to copy from the source {@link VectorContainer}.
     * @return Position one above where the row was appended
     */
-    public int appendRow(VectorContainer srcContainer, int srcIndex) {
-      for (int vectorIndex = 0; vectorIndex < wrappers.size(); vectorIndex++) {
-        ValueVector destVector = wrappers.get(vectorIndex).getValueVector();
-        ValueVector srcVector = srcContainer.wrappers.get(vectorIndex).getValueVector();
-        destVector.copyEntry(recordCount, srcVector, srcIndex);
-      }
-      return incRecordCount();
+  public int appendRow(VectorContainer srcContainer, int srcIndex) {
+    for (int vectorIndex = 0; vectorIndex < wrappers.size(); vectorIndex++) {
+      ValueVector destVector = wrappers.get(vectorIndex).getValueVector();
+      ValueVector srcVector = srcContainer.wrappers.get(vectorIndex).getValueVector();
+      destVector.copyEntry(recordCount, srcVector, srcIndex);
     }
+    return incRecordCount();
+  }
 
   public TypedFieldId add(ValueVector vv) {
     schemaChanged();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.record;
 
+import io.netty.buffer.DrillBuf;
+
 import java.util.List;
 
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -24,10 +26,9 @@ import org.apache.drill.exec.proto.UserBitShared.RecordBatchDef;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.vector.ValueVector;
+
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-
-import io.netty.buffer.DrillBuf;
 
 /**
  * A specialized version of record batch that can moves out buffers and preps

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.exec.record;
 
-import io.netty.buffer.DrillBuf;
-
 import java.util.List;
 
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -26,15 +24,16 @@ import org.apache.drill.exec.proto.UserBitShared.RecordBatchDef;
 import org.apache.drill.exec.proto.UserBitShared.SerializedField;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.vector.ValueVector;
-
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
+import io.netty.buffer.DrillBuf;
+
 /**
- * A specialized version of record batch that can moves out buffers and preps them for writing.
+ * A specialized version of record batch that can moves out buffers and preps
+ * them for writing.
  */
 public class WritableBatch implements AutoCloseable {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WritableBatch.class);
 
   private final RecordBatchDef def;
   private final DrillBuf[] buffers;
@@ -74,7 +73,8 @@ public class WritableBatch implements AutoCloseable {
   public void reconstructContainer(BufferAllocator allocator, VectorContainer container) {
     Preconditions.checkState(!cleared,
         "Attempted to reconstruct a container from a WritableBatch after it had been cleared");
-    if (buffers.length > 0) { /* If we have DrillBuf's associated with value vectors */
+    // If we have DrillBuf's associated with value vectors
+    if (buffers.length > 0) {
       int len = 0;
       for (DrillBuf b : buffers) {
         len += b.capacity();
@@ -82,7 +82,7 @@ public class WritableBatch implements AutoCloseable {
 
       DrillBuf newBuf = allocator.buffer(len);
       try {
-        /* Copy data from each buffer into the compound buffer */
+        // Copy data from each buffer into the compound buffer
         int offset = 0;
         for (DrillBuf buf : buffers) {
           newBuf.setBytes(offset, buf);
@@ -94,9 +94,9 @@ public class WritableBatch implements AutoCloseable {
 
         int bufferOffset = 0;
 
-        /*
-         * For each value vector slice up the appropriate size from the compound buffer and load it into the value vector
-         */
+        // For each value vector slice up the appropriate size from the
+        // compound buffer and load it into the value vector
+
         int vectorIndex = 0;
 
         for (VectorWrapper<?> vv : container) {
@@ -120,16 +120,11 @@ public class WritableBatch implements AutoCloseable {
       svMode = SelectionVectorMode.NONE;
     }
     container.buildSchema(svMode);
-
-    /* Set the record count in the value vector */
-    for (VectorWrapper<?> v : container) {
-      ValueVector.Mutator m = v.getValueVector().getMutator();
-      m.setValueCount(def.getRecordCount());
-    }
+    container.setValueCount(def.getRecordCount());
   }
 
   public void clear() {
-    if(cleared) {
+    if (cleared) {
       return;
     }
     for (DrillBuf buf : buffers) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
@@ -17,6 +17,11 @@
  */
 package org.apache.drill.exec.rpc.user;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DrillBuf;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,21 +34,17 @@ import org.apache.drill.exec.proto.UserBitShared.QueryResult;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.BaseRpcOutcomeListener;
+import org.apache.drill.exec.rpc.user.UserClient.UserToBitConnection;
 import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.RpcBus;
 import org.apache.drill.exec.rpc.RpcConnectionHandler;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
-import org.apache.drill.exec.rpc.user.UserClient.UserToBitConnection;
+
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Queues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DrillBuf;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 
 /**
  * Encapsulates the future management of query submissions.  This entails a

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
@@ -17,11 +17,6 @@
  */
 package org.apache.drill.exec.rpc.user;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DrillBuf;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
-
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,15 +29,21 @@ import org.apache.drill.exec.proto.UserBitShared.QueryResult;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
 import org.apache.drill.exec.rpc.BaseRpcOutcomeListener;
-import org.apache.drill.exec.rpc.user.UserClient.UserToBitConnection;
 import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.RpcBus;
 import org.apache.drill.exec.rpc.RpcConnectionHandler;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
-
+import org.apache.drill.exec.rpc.user.UserClient.UserToBitConnection;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Queues;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DrillBuf;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 
 /**
  * Encapsulates the future management of query submissions.  This entails a
@@ -56,8 +57,8 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Queues;
  * handle this case and then do a switcheroo.
  */
 public class QueryResultHandler {
-  private static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(QueryResultHandler.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(QueryResultHandler.class);
 
   /**
    * Current listener for results, for each active query.
@@ -74,7 +75,7 @@ public class QueryResultHandler {
   }
 
   public RpcConnectionHandler<UserToBitConnection> getWrappedConnectionHandler(
-      final RpcConnectionHandler<UserToBitConnection> handler) {
+      RpcConnectionHandler<UserToBitConnection> handler) {
     return new ChannelClosedHandler(handler);
   }
 
@@ -82,11 +83,11 @@ public class QueryResultHandler {
    * Maps internal low-level API protocol to {@link UserResultsListener}-level API protocol.
    * handles data result messages
    */
-  public void resultArrived( ByteBuf pBody ) throws RpcException {
-    final QueryResult queryResult = RpcBus.get( pBody, QueryResult.PARSER );
+  public void resultArrived(ByteBuf pBody) throws RpcException {
+    QueryResult queryResult = RpcBus.get(pBody, QueryResult.PARSER);
 
-    final QueryId queryId = queryResult.getQueryId();
-    final QueryState queryState = queryResult.getQueryState();
+    QueryId queryId = queryResult.getQueryId();
+    QueryState queryState = queryResult.getQueryState();
 
     if (logger.isDebugEnabled()) {
       logger.debug("resultArrived: queryState: {}, queryId = {}", queryState,
@@ -95,18 +96,18 @@ public class QueryResultHandler {
 
     assert queryResult.hasQueryState() : "received query result without QueryState";
 
-    final boolean isFailureResult = QueryState.FAILED == queryState;
+    boolean isFailureResult = QueryState.FAILED == queryState;
     // CANCELED queries are handled the same way as COMPLETED
-    final boolean isTerminalResult;
-    switch ( queryState ) {
+    boolean isTerminalResult;
+    switch (queryState) {
       case FAILED:
       case CANCELED:
       case COMPLETED:
         isTerminalResult = true;
         break;
       default:
-        logger.error( "Unexpected/unhandled QueryState " + queryState
-          + " (for query " + queryId +  ")" );
+        logger.error("Unexpected/unhandled QueryState " + queryState
+          + " (for query " + queryId +  ")");
         isTerminalResult = false;
         break;
     }
@@ -127,19 +128,19 @@ public class QueryResultHandler {
 
         try {
           resultsListener.queryCompleted(queryState);
-        } catch ( Exception e ) {
+        } catch (Exception e) {
           resultsListener.submissionFailed(UserException.systemError(e).build(logger));
         }
       } else {
         logger.warn("queryState {} was ignored", queryState);
       }
     } finally {
-      if ( isTerminalResult ) {
+      if (isTerminalResult) {
         // TODO:  What exactly are we checking for?  How should we really check
         // for it?
-        if ( (! ( resultsListener instanceof BufferingResultsListener )
-          || ((BufferingResultsListener) resultsListener).output != null ) ) {
-          queryIdToResultsListenersMap.remove( queryId, resultsListener );
+        if ((! (resultsListener instanceof BufferingResultsListener)
+          || ((BufferingResultsListener) resultsListener).output != null)) {
+          queryIdToResultsListenersMap.remove(queryId, resultsListener);
         }
       }
     }
@@ -149,50 +150,52 @@ public class QueryResultHandler {
    * Maps internal low-level API protocol to {@link UserResultsListener}-level API protocol.
    * handles query data messages
    */
-  public void batchArrived( ConnectionThrottle throttle,
-                            ByteBuf pBody, ByteBuf dBody ) throws RpcException {
-    final QueryData queryData = RpcBus.get( pBody, QueryData.PARSER );
+  public void batchArrived(ConnectionThrottle throttle,
+                            ByteBuf pBody, ByteBuf dBody) throws RpcException {
+    QueryData queryData = RpcBus.get(pBody, QueryData.PARSER);
     // Current batch coming in.
-    final DrillBuf drillBuf = (DrillBuf) dBody;
-    final QueryDataBatch batch = new QueryDataBatch( queryData, drillBuf );
+    DrillBuf drillBuf = (DrillBuf) dBody;
+    QueryDataBatch batch = new QueryDataBatch(queryData, drillBuf);
 
-    final QueryId queryId = queryData.getQueryId();
+    QueryId queryId = queryData.getQueryId();
 
     if (logger.isDebugEnabled()) {
       logger.debug("batchArrived: queryId = {}", QueryIdHelper.getQueryId(queryId));
     }
-    logger.trace( "batchArrived: batch = {}", batch );
+    logger.trace("batchArrived: batch = {}", batch);
 
-    final UserResultsListener resultsListener = newUserResultsListener(queryId);
+    UserResultsListener resultsListener = newUserResultsListener(queryId);
 
     // A data case--pass on via dataArrived
     try {
       resultsListener.dataArrived(batch, throttle);
       // That releases batch if successful.
-    } catch ( Exception e ) {
+    } catch (Exception e) {
       batch.release();
       resultsListener.submissionFailed(UserException.systemError(e).build(logger));
     }
   }
 
   /**
-   * Return {@link UserResultsListener} associated with queryId. Will create a new {@link BufferingResultsListener}
-   * if no listener found.
-   * @param queryId queryId we are getting the listener for
+   * Return {@link UserResultsListener} associated with queryId. Will create a
+   * new {@link BufferingResultsListener} if no listener found.
+   *
+   * @param queryId
+   *          queryId we are getting the listener for
    * @return {@link UserResultsListener} associated with queryId
    */
   private UserResultsListener newUserResultsListener(QueryId queryId) {
-    UserResultsListener resultsListener = queryIdToResultsListenersMap.get( queryId );
-    logger.trace( "For QueryId [{}], retrieved results listener {}", queryId, resultsListener );
-    if ( null == resultsListener ) {
+    UserResultsListener resultsListener = queryIdToResultsListenersMap.get(queryId);
+    logger.trace("For QueryId [{}], retrieved results listener {}", queryId, resultsListener);
+    if (null == resultsListener) {
       // WHO?? didn't get query ID response and set submission listener yet,
       // so install a buffering listener for now
 
       BufferingResultsListener bl = new BufferingResultsListener();
-      resultsListener = queryIdToResultsListenersMap.putIfAbsent( queryId, bl );
+      resultsListener = queryIdToResultsListenersMap.putIfAbsent(queryId, bl);
       // If we had a successful insertion, use that reference.  Otherwise, just
       // throw away the new buffering listener.
-      if ( null == resultsListener ) {
+      if (null == resultsListener) {
         resultsListener = bl;
       }
     }
@@ -201,7 +204,7 @@ public class QueryResultHandler {
 
   private static class BufferingResultsListener implements UserResultsListener {
 
-    private ConcurrentLinkedQueue<QueryDataBatch> results = Queues.newConcurrentLinkedQueue();
+    private final ConcurrentLinkedQueue<QueryDataBatch> results = Queues.newConcurrentLinkedQueue();
     private volatile UserException ex;
     private volatile QueryState queryState;
     private volatile UserResultsListener output;
@@ -252,8 +255,10 @@ public class QueryResultHandler {
     @Override
     public void submissionFailed(UserException ex) {
       assert queryState == null;
-      // there is one case when submissionFailed() is called even though the query didn't fail on the server side
-      // it happens when UserResultsListener.batchArrived() throws an exception that will be passed to
+      // there is one case when submissionFailed() is called even though the
+      // query didn't fail on the server side
+      // it happens when UserResultsListener.batchArrived() throws an exception
+      // that will be passed to
       // submissionFailed() by QueryResultHandler.dataArrived()
       queryState = QueryState.FAILED;
       synchronized (this) {
@@ -335,7 +340,7 @@ public class QueryResultHandler {
     }
 
     @Override
-    public void interrupted(final InterruptedException ex) {
+    public void interrupted(InterruptedException ex) {
       if (!isTerminal.compareAndSet(false, true)) {
         logger.warn("Received multiple responses to run query request.");
         return;
@@ -350,26 +355,27 @@ public class QueryResultHandler {
   }
 
   /**
-   * When a {@link UserToBitConnection connection} to a server is successfully created, this handler adds a
-   * listener to that connection that listens to connection closure. If the connection is closed, all active
+   * When a {@link UserToBitConnection connection} to a server is successfully
+   * created, this handler adds a listener to that connection that listens to
+   * connection closure. If the connection is closed, all active
    * {@link UserResultsListener result listeners} are failed.
    */
   private class ChannelClosedHandler implements RpcConnectionHandler<UserToBitConnection> {
 
     private final RpcConnectionHandler<UserToBitConnection> parentHandler;
 
-    public ChannelClosedHandler(final RpcConnectionHandler<UserToBitConnection> parentHandler) {
+    public ChannelClosedHandler(RpcConnectionHandler<UserToBitConnection> parentHandler) {
       this.parentHandler = parentHandler;
     }
 
     @Override
-    public void connectionSucceeded(final UserToBitConnection connection) {
+    public void connectionSucceeded(UserToBitConnection connection) {
       connection.getChannel().closeFuture().addListener(
           new GenericFutureListener<Future<? super Void>>() {
             @Override
             public void operationComplete(Future<? super Void> future)
                 throws Exception {
-              for (final UserResultsListener listener : queryIdToResultsListenersMap.values()) {
+              for (UserResultsListener listener : queryIdToResultsListenersMap.values()) {
                 listener.submissionFailed(UserException.connectionError()
                     .message("Connection %s closed unexpectedly. Drillbit down?",
                         connection.getName())

--- a/exec/java-exec/src/test/java/org/apache/drill/TestAggNullable.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestAggNullable.java
@@ -26,7 +26,6 @@ import org.junit.experimental.categories.Category;
 
 @Category(OperatorTest.class)
 public class TestAggNullable extends BaseTestQuery {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestAggNullable.class);
 
   private static void enableAggr(boolean ha, boolean sa) throws Exception {
 
@@ -72,5 +71,4 @@ public class TestAggNullable extends BaseTestQuery {
     assertEquals(String.format("Received unexpected number of rows in output: expected=%d, received=%s",
         expectedRecordCount, actualRecordCount), expectedRecordCount, actualRecordCount);
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestExampleQueries.java
@@ -37,6 +37,7 @@ import org.junit.experimental.categories.Category;
 
 @Category({SqlFunctionTest.class, OperatorTest.class, PlannerTest.class, UnlikelyTest.class})
 public class TestExampleQueries extends BaseTestQuery {
+
   @BeforeClass
   public static void setupTestFiles() {
     dirTestWatcher.copyResourceToRoot(Paths.get("tpchmulti"));

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -17,6 +17,10 @@
  */
 package org.apache.drill;
 
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Paths;
+
 import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.categories.SqlTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -30,13 +34,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.nio.file.Paths;
-
-import static org.junit.Assert.assertEquals;
-
 @Category({SqlTest.class, PlannerTest.class})
 public class TestStarQueries extends BaseTestQuery {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestStarQueries.class);
 
   @BeforeClass
   public static void setupTestFiles() {
@@ -298,7 +297,7 @@ public class TestStarQueries extends BaseTestQuery {
     try {
       test("select x.n_nationkey, x.n_name, x.n_regionkey, x.r_name from (select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey) x " );
     } catch (UserException e) {
-      logger.info("***** Test resulted in expected failure: " + e.getMessage());
+      // Expected
       throw e;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -17,10 +17,6 @@
  */
 package org.apache.drill;
 
-import static org.junit.Assert.assertEquals;
-
-import java.nio.file.Paths;
-
 import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.categories.SqlTest;
 import org.apache.drill.categories.UnlikelyTest;
@@ -33,6 +29,10 @@ import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
 
 @Category({SqlTest.class, PlannerTest.class})
 public class TestStarQueries extends BaseTestQuery {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestUnionAll.java
@@ -347,7 +347,6 @@ public class TestUnionAll extends BaseTestQuery {
         .baselineColumns("n_nationkey", "n_regionkey", "n_name")
         .build().run();
 
-
     testBuilder()
         .sqlQuery(query2)
         .unOrdered()
@@ -355,7 +354,7 @@ public class TestUnionAll extends BaseTestQuery {
         .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR)
         .baselineColumns("n_nationkey", "n_regionkey", "n_name")
         .build().run();
-    }
+  }
 
   @Test // see DRILL-1977, DRILL-2376, DRILL-2377, DRILL-2378, DRILL-2379
   @Category(UnlikelyTest.class)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
@@ -25,24 +25,25 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.drill.categories.PlannerTest;
-import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.physical.rowSet.RowSet;
-import org.apache.drill.exec.physical.rowSet.RowSetReader;
-import org.apache.drill.exec.proto.BitControl.PlanFragment;
-import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
-import org.apache.drill.exec.proto.UserBitShared.QueryType;
-import org.apache.drill.exec.proto.UserProtos.QueryPlanFragments;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.QueryBuilder.QuerySummary;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.categories.PlannerTest;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.proto.BitControl.PlanFragment;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.proto.UserBitShared.QueryType;
+import org.apache.drill.exec.proto.UserProtos.QueryPlanFragments;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
  * Class to test different planning use cases (separate from query execution)
@@ -127,7 +128,6 @@ public class DrillSeparatePlanningTest extends ClusterTest {
       PlanFragment rootFragment = planFragments.getFragments(0);
       assertFalse(rootFragment.getLeafFragment());
 
-      client.queryBuilder().plan(planFragments.getFragmentsList()).print();
       QuerySummary summary = client.queryBuilder().plan(planFragments.getFragmentsList()).run();
       assertEquals(3, summary.recordCount());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/DrillSeparatePlanningTest.java
@@ -25,25 +25,24 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.apache.drill.categories.PlannerTest;
+import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.exec.proto.BitControl.PlanFragment;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.proto.UserBitShared.QueryType;
+import org.apache.drill.exec.proto.UserProtos.QueryPlanFragments;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.QueryBuilder.QuerySummary;
-import org.apache.drill.exec.physical.rowSet.RowSet;
-import org.apache.drill.exec.physical.rowSet.RowSetReader;
-import org.apache.drill.categories.PlannerTest;
-import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.proto.BitControl.PlanFragment;
-import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
-import org.apache.drill.exec.proto.UserBitShared.QueryType;
-import org.apache.drill.exec.proto.UserProtos.QueryPlanFragments;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
  * Class to test different planning use cases (separate from query execution)
@@ -51,6 +50,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
  */
 @Category({SlowTest.class, PlannerTest.class})
 public class DrillSeparatePlanningTest extends ClusterTest {
+
   @BeforeClass
   public static void setupFiles() {
     dirTestWatcher.copyResourceToRoot(Paths.get("multilevel", "json"));
@@ -127,6 +127,7 @@ public class DrillSeparatePlanningTest extends ClusterTest {
       PlanFragment rootFragment = planFragments.getFragments(0);
       assertFalse(rootFragment.getLeafFragment());
 
+      client.queryBuilder().plan(planFragments.getFragmentsList()).print();
       QuerySummary summary = client.queryBuilder().plan(planFragments.getFragmentsList()).run();
       assertEquals(3, summary.recordCount());
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -77,9 +77,6 @@ public class MockRecordBatch implements CloseableRecordBatch {
     this.allocator = context.getAllocator();
     this.container = new VectorContainer(allocator, schema);
     this.allOutcomes = iterOutcomes;
-    this.currentContainerIndex = 0;
-    this.currentOutcomeIndex = 0;
-    this.isDone = false;
   }
 
   @Deprecated
@@ -193,7 +190,7 @@ public class MockRecordBatch implements CloseableRecordBatch {
   @Override
   public IterOutcome next() {
 
-    if(isDone) {
+    if (isDone) {
       return IterOutcome.NONE;
     }
 
@@ -213,16 +210,18 @@ public class MockRecordBatch implements CloseableRecordBatch {
       switch (rowSet.indirectionType()) {
         case NONE:
         case TWO_BYTE:
-          container.transferIn(input);
-          if ( input.hasRecordCount() ) { // in case special test of uninitialized input container
-            container.setRecordCount(input.getRecordCount());
+          if (input.hasRecordCount()) { // in case special test of uninitialized input container
+            container.transferIn(input);
+          } else {
+            // Not normally a valid condition, supported here just for testing
+            container.rawTransferIn(input);
           }
           SelectionVector2 inputSv2 = ((RowSet.SingleRowSet) rowSet).getSv2();
 
           if (sv2 != null) {
             // Operators assume that new values for an Sv2 are transferred in.
             sv2.allocateNewSafe(inputSv2.getCount());
-            for (int i=0; i<inputSv2.getCount(); ++i) {
+            for (int i=0; i < inputSv2.getCount(); ++i) {
               sv2.setIndex(i, inputSv2.getIndex(i));
             }
             sv2.setRecordCount(inputSv2.getCount());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -126,7 +126,8 @@ public class TestHashAggrSpill extends DrillTest {
   }
 
   /**
-   * Test Secondary and Tertiary spill cycles - Happens when some of the spilled partitions cause more spilling as they are read back
+   * Test Secondary and Tertiary spill cycles - Happens when some of the spilled
+   * partitions cause more spilling as they are read back
    *
    * @throws Exception
    */
@@ -139,7 +140,8 @@ public class TestHashAggrSpill extends DrillTest {
   }
 
   /**
-   * Test with the "fallback" option disabled: When not enough memory available to allow spilling, then fail (Resource error) !!
+   * Test with the "fallback" option disabled: When not enough memory available
+   * to allow spilling, then fail (Resource error) !!
    *
    * @throws Exception
    */
@@ -158,8 +160,10 @@ public class TestHashAggrSpill extends DrillTest {
   }
 
   /**
-   * Test with the "fallback" option ON: When not enough memory is available to allow spilling (internally need enough memory to
-   * create multiple partitions), then behave like the pre-1.11 Hash Aggregate: Allocate unlimited memory, no spill.
+   * Test with the "fallback" option ON: When not enough memory is available to
+   * allow spilling (internally need enough memory to create multiple
+   * partitions), then behave like the pre-1.11 Hash Aggregate: Allocate
+   * unlimited memory, no spill.
    *
    * @throws Exception
    */

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -57,8 +57,6 @@ public class TestHashAggrSpill extends DrillTest {
 
   /**
    *  A template for Hash Aggr spilling tests
-   *
-   * @throws Exception
    */
   private void testSpill(long maxMem, long numPartitions, long minBatches, int maxParallel, boolean fallback, boolean predict,
                          String sql, long expectedRows, int cycle, int fromPart, int toPart) throws Exception {
@@ -84,8 +82,6 @@ public class TestHashAggrSpill extends DrillTest {
   /**
    * Test "normal" spilling: Only 2 (or 3) partitions (out of 4) would require spilling
    * ("normal spill" means spill-cycle = 1 )
-   *
-   * @throws Exception
    */
   @Test
   public void testSimpleHashAggrSpill() throws Exception {
@@ -96,8 +92,6 @@ public class TestHashAggrSpill extends DrillTest {
   /**
    * Test with "needed memory" prediction turned off
    * (i.e., exercise code paths that catch OOMs from the Hash Table and recover)
-   *
-   * @throws Exception
    */
   @Test
   @Ignore("DRILL-7301")
@@ -128,8 +122,6 @@ public class TestHashAggrSpill extends DrillTest {
   /**
    * Test Secondary and Tertiary spill cycles - Happens when some of the spilled
    * partitions cause more spilling as they are read back
-   *
-   * @throws Exception
    */
   @Test
   public void testHashAggrSecondaryTertiarySpill() throws Exception {
@@ -142,8 +134,6 @@ public class TestHashAggrSpill extends DrillTest {
   /**
    * Test with the "fallback" option disabled: When not enough memory available
    * to allow spilling, then fail (Resource error) !!
-   *
-   * @throws Exception
    */
   @Test
   public void testHashAggrFailWithFallbackDisabed() throws Exception {
@@ -164,8 +154,6 @@ public class TestHashAggrSpill extends DrillTest {
    * allow spilling (internally need enough memory to create multiple
    * partitions), then behave like the pre-1.11 Hash Aggregate: Allocate
    * unlimited memory, no spill.
-   *
-   * @throws Exception
    */
   @Test
   public void testHashAggrSuccessWithFallbackEnabled() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
@@ -388,7 +388,6 @@ public class TestFlatten extends BaseTestQuery {
           "        select flatten(categories) catl from dfs.`tmp/yelp_academic_dataset_business.json` b\n" +
           "    )  celltbl");
     }
-
   }
 
   @Test
@@ -397,7 +396,6 @@ public class TestFlatten extends BaseTestQuery {
     if(RUN_ADVANCED_TESTS){
       test("select id, flatten(evnts) as rpt from dfs.`tmp/drill1665.json`");
     }
-
   }
 
   @Test
@@ -479,7 +477,6 @@ public class TestFlatten extends BaseTestQuery {
         .unOrdered()
         .jsonBaselineFile("flatten/drill-2106-result.json")
         .go();
-
   }
 
   @Test // see DRILL-2146

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/flatten/TestFlatten.java
@@ -276,7 +276,7 @@ public class TestFlatten extends BaseTestQuery {
   @Test
   @Category(UnlikelyTest.class)
   public void drill1652() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select uid, flatten(transactions) from dfs.`tmp/bigfile.json`");
     }
   }
@@ -330,7 +330,7 @@ public class TestFlatten extends BaseTestQuery {
   public void testKVGenFlatten2() throws Exception {
     // currently runs
     // TODO - re-verify results by hand
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select flatten(kvgen(visited_cellid_counts)) as mytb from dfs.`tmp/mapkv.json`");
     }
   }
@@ -351,7 +351,7 @@ public class TestFlatten extends BaseTestQuery {
 
     // FIXED BY RETURNING PROPER SCHEMA DURING FAST SCHEMA STEP
     // these types of problems are being solved more generally as we develp better support for chaning schema
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select celltbl.catl from (\n" +
           "        select flatten(categories) catl from dfs.`tmp/yelp_academic_dataset_business.json` b limit 100\n" +
           "    )  celltbl where celltbl.catl = 'Doctors'");
@@ -360,7 +360,7 @@ public class TestFlatten extends BaseTestQuery {
 
   @Test
   public void countAggFlattened() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select celltbl.catl, count(celltbl.catl) from ( " +
           "select business_id, flatten(categories) catl from dfs.`tmp/yelp_academic_dataset_business.json` b limit 100 " +
           ")  celltbl group by celltbl.catl limit 10 ");
@@ -369,21 +369,21 @@ public class TestFlatten extends BaseTestQuery {
 
   @Test
   public void flattenAndAdditionalColumn() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select business_id, flatten(categories) from dfs.`tmp/yelp_academic_dataset_business.json` b");
     }
   }
 
   @Test
   public void testFailingFlattenAlone() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select flatten(categories) from dfs.`tmp/yelp_academic_dataset_business.json` b  ");
     }
   }
 
   @Test
   public void testDistinctAggrFlattened() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test(" select distinct(celltbl.catl) from (\n" +
           "        select flatten(categories) catl from dfs.`tmp/yelp_academic_dataset_business.json` b\n" +
           "    )  celltbl");
@@ -393,7 +393,7 @@ public class TestFlatten extends BaseTestQuery {
   @Test
   @Category(UnlikelyTest.class)
   public void testDrill1665() throws Exception {
-    if(RUN_ADVANCED_TESTS){
+    if (RUN_ADVANCED_TESTS) {
       test("select id, flatten(evnts) as rpt from dfs.`tmp/drill1665.json`");
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
@@ -17,20 +17,20 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.test.DrillTestWrapper;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.drill.test.DrillTestWrapper;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/window/TestWindowFrame.java
@@ -17,25 +17,26 @@
  */
 package org.apache.drill.exec.physical.impl.window;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.drill.test.DrillTestWrapper;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
+import org.apache.drill.test.BaseTestQuery;
+import org.apache.drill.test.DrillTestWrapper;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 public class TestWindowFrame extends BaseTestQuery {
+
   @BeforeClass
   public static void setupMSortBatchSize() throws IOException {
     // make sure memory sorter outputs 20 rows per batch

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -17,13 +17,9 @@
  */
 package org.apache.drill.exec.sql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.record.RecordBatchLoader;
@@ -31,6 +27,8 @@ import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.test.BaseTestQuery;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -17,19 +17,20 @@
  */
 package org.apache.drill.exec.sql;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.drill.PlanTestBase;
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.record.RecordBatchLoader;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.test.BaseTestQuery;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -69,7 +70,8 @@ public class TestAnalyze extends BaseTestQuery {
           .baselineValues("`sales_district_id`", 110.0, 110.0, 23L, 8.0)
           .go();
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -96,7 +98,8 @@ public class TestAnalyze extends BaseTestQuery {
           .baselineValues("`birth_date`", 1155.0, 1155.0, 52L, 10.0)
           .go();
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -124,8 +127,9 @@ public class TestAnalyze extends BaseTestQuery {
               .baselineValues("`birth_date`", 1138.0, 1138.0, 38L, 10.001597699312988)
               .go();
     } finally {
-      test("ALTER SESSION SET `exec.statistics.deterministic_sampling` = false");
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("exec.statistics.deterministic_sampling");
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -143,7 +147,9 @@ public class TestAnalyze extends BaseTestQuery {
       test("ALTER SESSION SET `planner.statistics.use` = true");
       test("SELECT * FROM dfs.tmp.`lineitem` l JOIN dfs.tmp.`orders` o ON l.l_orderkey = o.o_orderkey");
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
+      resetSessionOption("planner.statistics.use");
     }
   }
 
@@ -166,7 +172,8 @@ public class TestAnalyze extends BaseTestQuery {
       verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.employee_basic4 COMPUTE STATISTICS",
           "16");
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -204,7 +211,8 @@ public class TestAnalyze extends BaseTestQuery {
           .baselineValues("`dir1`", 120.0, 120.0, 4L, 2.0)
           .go();
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -214,21 +222,26 @@ public class TestAnalyze extends BaseTestQuery {
     final String tmpLocation = "/multilevel/parquet";
     test("ALTER SESSION SET `planner.slice_target` = 1");
     test("ALTER SESSION SET `store.format` = 'parquet'");
-    test("CREATE TABLE dfs.tmp.parquetStale AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
-         "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", tmpLocation);
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS",
-        "Table parquetStale has not changed since last ANALYZE!");
-    // Verify we recompute statistics once a new file/directory is added. Update the directory some
-    // time after ANALYZE so that the timestamps are different.
-    Thread.sleep(1000);
-    final String Q4 = "/multilevel/parquet/1996/Q4";
-    test("CREATE TABLE dfs.tmp.`parquetStale/1996/Q5` AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
-         "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", Q4);
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
-    Thread.sleep(1000);
-    test("DROP TABLE dfs.tmp.`parquetStale/1996/Q5`");
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+    try {
+      test("CREATE TABLE dfs.tmp.parquetStale AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
+           "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", tmpLocation);
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS",
+          "Table parquetStale has not changed since last ANALYZE!");
+      // Verify we recompute statistics once a new file/directory is added. Update the directory some
+      // time after ANALYZE so that the timestamps are different.
+      Thread.sleep(1000);
+      final String Q4 = "/multilevel/parquet/1996/Q4";
+      test("CREATE TABLE dfs.tmp.`parquetStale/1996/Q5` AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
+           "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", Q4);
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+      Thread.sleep(1000);
+      test("DROP TABLE dfs.tmp.`parquetStale/1996/Q5`");
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+    } finally {
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
+    }
   }
 
   @Test
@@ -236,99 +249,104 @@ public class TestAnalyze extends BaseTestQuery {
     //Test ndv/rowcount for scan
     test("ALTER SESSION SET `planner.slice_target` = 1");
     test("ALTER SESSION SET `store.format` = 'parquet'");
-    test("CREATE TABLE dfs.tmp.employeeUseStat AS SELECT * from cp.`employee.json`");
-    test("CREATE TABLE dfs.tmp.departmentUseStat AS SELECT * from cp.`department.json`");
-    test("ANALYZE TABLE dfs.tmp.employeeUseStat COMPUTE STATISTICS");
-    test("ANALYZE TABLE dfs.tmp.departmentUseStat COMPUTE STATISTICS");
-    test("ALTER SESSION SET `planner.statistics.use` = true");
-    String query = " select employee_id from dfs.tmp.employeeUseStat where department_id = 2";
-    String[] expectedPlan1 = {"Filter\\(condition.*\\).*rowcount = 96.25,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan1, new String[]{});
+    try {
+      test("CREATE TABLE dfs.tmp.employeeUseStat AS SELECT * from cp.`employee.json`");
+      test("CREATE TABLE dfs.tmp.departmentUseStat AS SELECT * from cp.`department.json`");
+      test("ANALYZE TABLE dfs.tmp.employeeUseStat COMPUTE STATISTICS");
+      test("ANALYZE TABLE dfs.tmp.departmentUseStat COMPUTE STATISTICS");
+      test("ALTER SESSION SET `planner.statistics.use` = true");
+      String query = " select employee_id from dfs.tmp.employeeUseStat where department_id = 2";
+      String[] expectedPlan1 = {"Filter\\(condition.*\\).*rowcount = 96.25,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan1, new String[]{});
 
-    query = " select employee_id from dfs.tmp.employeeUseStat where department_id IN (2, 5)";
-    String[] expectedPlan2 = {"Filter\\(condition.*\\).*rowcount = 192.5,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan2, new String[]{});
+      query = " select employee_id from dfs.tmp.employeeUseStat where department_id IN (2, 5)";
+      String[] expectedPlan2 = {"Filter\\(condition.*\\).*rowcount = 192.5,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan2, new String[]{});
 
-    query = "select employee_id from dfs.tmp.employeeUseStat where department_id IN (2, 5) and employee_id = 5";
-    String[] expectedPlan3 = {"Filter\\(condition.*\\).*rowcount = 1.0,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan3, new String[]{});
+      query = "select employee_id from dfs.tmp.employeeUseStat where department_id IN (2, 5) and employee_id = 5";
+      String[] expectedPlan3 = {"Filter\\(condition.*\\).*rowcount = 1.0,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan3, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
-        + " on emp.department_id = dept.department_id";
-    String[] expectedPlan4 = {"HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan4, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
+          + " on emp.department_id = dept.department_id";
+      String[] expectedPlan4 = {"HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan4, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
-            + " on emp.department_id = dept.department_id where dept.department_id = 5";
-    String[] expectedPlan5 = {"HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan5, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
+              + " on emp.department_id = dept.department_id where dept.department_id = 5";
+      String[] expectedPlan5 = {"HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan5, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
-            + " on emp.department_id = dept.department_id"
-            + " where dept.department_id = 5 and emp.employee_id = 10";
-    String[] expectedPlan6 = {"MergeJoin\\(condition.*\\).*rowcount = 1.0,.*",
-            "Filter\\(condition=\\[AND\\(=\\(\\$1, 10\\), =\\(\\$0, 5\\)\\)\\]\\).*rowcount = 1.0,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
-            "Filter\\(condition=\\[=\\(\\$0, 5\\)\\]\\).*rowcount = 1.0,.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan6, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
+              + " on emp.department_id = dept.department_id"
+              + " where dept.department_id = 5 and emp.employee_id = 10";
+      String[] expectedPlan6 = {"MergeJoin\\(condition.*\\).*rowcount = 1.0,.*",
+              "Filter\\(condition=\\[AND\\(=\\(\\$1, 10\\), =\\(\\$0, 5\\)\\)\\]\\).*rowcount = 1.0,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
+              "Filter\\(condition=\\[=\\(\\$0, 5\\)\\]\\).*rowcount = 1.0,.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan6, new String[]{});
 
-    query = " select emp.employee_id, count(*)"
-            + " from dfs.tmp.employeeUseStat emp"
-            + " group by emp.employee_id";
-    String[] expectedPlan7 = {"HashAgg\\(group=\\[\\{0\\}\\], EXPR\\$1=\\[COUNT\\(\\)\\]\\).*rowcount = 1155.0,.*",
-            "Scan.*columns=\\[`employee_id`\\].*rowcount = 1155.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan7, new String[]{});
+      query = " select emp.employee_id, count(*)"
+              + " from dfs.tmp.employeeUseStat emp"
+              + " group by emp.employee_id";
+      String[] expectedPlan7 = {"HashAgg\\(group=\\[\\{0\\}\\], EXPR\\$1=\\[COUNT\\(\\)\\]\\).*rowcount = 1155.0,.*",
+              "Scan.*columns=\\[`employee_id`\\].*rowcount = 1155.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan7, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
-            + " on emp.department_id = dept.department_id "
-            + " group by emp.employee_id";
-    String[] expectedPlan8 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 730.0992454469841,.*",
-            "HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan8, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
+              + " on emp.department_id = dept.department_id "
+              + " group by emp.employee_id";
+      String[] expectedPlan8 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 730.0992454469841,.*",
+              "HashJoin\\(condition.*\\).*rowcount = 1155.0,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan8, new String[]{});
 
-    query = "select emp.employee_id, dept.department_description"
-            + " from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
-            + " on emp.department_id = dept.department_id "
-            + " group by emp.employee_id, emp.store_id, dept.department_description "
-            + " having dept.department_description = 'FINANCE'";
-    String[] expectedPlan9 = {"HashAgg\\(group=\\[\\{0, 1, 2\\}\\]\\).*rowcount = 60.84160378724867.*",
-            "HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`, `store_id`\\].*rowcount = 1155.0.*",
-            "Filter\\(condition=\\[=\\(\\$1, 'FINANCE'\\)\\]\\).*rowcount = 1.0,.*",
-            "Scan.*columns=\\[`department_id`, `department_description`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan9, new String[]{});
+      query = "select emp.employee_id, dept.department_description"
+              + " from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept"
+              + " on emp.department_id = dept.department_id "
+              + " group by emp.employee_id, emp.store_id, dept.department_description "
+              + " having dept.department_description = 'FINANCE'";
+      String[] expectedPlan9 = {"HashAgg\\(group=\\[\\{0, 1, 2\\}\\]\\).*rowcount = 60.84160378724867.*",
+              "HashJoin\\(condition.*\\).*rowcount = 96.25,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`, `store_id`\\].*rowcount = 1155.0.*",
+              "Filter\\(condition=\\[=\\(\\$1, 'FINANCE'\\)\\]\\).*rowcount = 1.0,.*",
+              "Scan.*columns=\\[`department_id`, `department_description`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan9, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept\n"
-            + " on emp.department_id = dept.department_id "
-            + " group by emp.employee_id, emp.store_id "
-            + " having emp.store_id = 7";
-    String[] expectedPlan10 = {"HashAgg\\(group=\\[\\{0, 1\\}\\]\\).*rowcount = 29.203969817879365.*",
-            "HashJoin\\(condition.*\\).*rowcount = 46.2,.*",
-            "Filter\\(condition=\\[=\\(\\$2, 7\\)\\]\\).*rowcount = 46.2,.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`, `store_id`\\].*rowcount = 1155.0.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan10, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept\n"
+              + " on emp.department_id = dept.department_id "
+              + " group by emp.employee_id, emp.store_id "
+              + " having emp.store_id = 7";
+      String[] expectedPlan10 = {"HashAgg\\(group=\\[\\{0, 1\\}\\]\\).*rowcount = 29.203969817879365.*",
+              "HashJoin\\(condition.*\\).*rowcount = 46.2,.*",
+              "Filter\\(condition=\\[=\\(\\$2, 7\\)\\]\\).*rowcount = 46.2,.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`, `store_id`\\].*rowcount = 1155.0.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan10, new String[]{});
 
-    query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept\n"
-            + " on emp.department_id = dept.department_id "
-            + " group by emp.employee_id "
-            + " having emp.employee_id = 7";
-    String[] expectedPlan11 = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 1.0.*",
-            "HashJoin\\(condition.*\\).*rowcount = 1.0,.*",
-            "Filter\\(condition=\\[=\\(\\$1, 7\\)\\]\\).*rowcount = 1.0.*",
-            "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*",
-            "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan11, new String[]{});
+      query = " select emp.employee_id from dfs.tmp.employeeUseStat emp join dfs.tmp.departmentUseStat dept\n"
+              + " on emp.department_id = dept.department_id "
+              + " group by emp.employee_id "
+              + " having emp.employee_id = 7";
+      String[] expectedPlan11 = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 1.0.*",
+              "HashJoin\\(condition.*\\).*rowcount = 1.0,.*",
+              "Filter\\(condition=\\[=\\(\\$1, 7\\)\\]\\).*rowcount = 1.0.*",
+              "Scan.*columns=\\[`department_id`\\].*rowcount = 12.0.*",
+              "Scan.*columns=\\[`department_id`, `employee_id`\\].*rowcount = 1155.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan11, new String[]{});
+    } finally {
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
+    }
   }
 
   @Test
@@ -337,35 +355,41 @@ public class TestAnalyze extends BaseTestQuery {
     test("ALTER SESSION SET `store.format` = 'parquet'");
     test("ALTER SESSION SET `planner.statistics.use` = true");
     final String tmpLocation = "/multilevel/parquet";
-    // copy the data into the temporary location
-    test("DROP TABLE dfs.tmp.parquetStale");
-    test("CREATE TABLE dfs.tmp.parquetStale AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
-            "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", tmpLocation);
-    String query = "select count(distinct o_orderkey) from dfs.tmp.parquetStale";
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
-    test("REFRESH TABLE METADATA dfs.tmp.parquetStale");
-    // Verify we recompute statistics once a new file/directory is added. Update the directory some
-    // time after ANALYZE so that the timestamps are different.
-    Thread.sleep(1000);
-    final String Q4 = "/multilevel/parquet/1996/Q4";
-    test("CREATE TABLE dfs.tmp.`parquetStale/1996/Q5` AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
-            "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", Q4);
-    // query should use STALE statistics
-    String[] expectedStalePlan = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 119.0.*",
-        "Scan.*rowcount = 130.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedStalePlan, new String[]{});
-    // Query should use Parquet Metadata, since statistics not available. In this case, NDV is computed as
-    // 1/10*rowcount (Calcite default). Hence, NDV is 13.0 instead of the correct 119.0
-    test("DROP TABLE dfs.tmp.`parquetStale/.stats.drill`");
-    String[] expectedPlan1 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 13.0.*",
-        "Scan.*rowcount = 130.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan1, new String[]{});
-    // query should use the new statistics. NDV remains unaffected since we copy the Q4 into Q5
-    verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
-    String[] expectedPlan2 = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 119.0.*",
-        "Scan.*rowcount = 130.0.*"};
-    PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan2, new String[]{});
-    test("DROP TABLE dfs.tmp.`parquetStale/1996/Q5`");
+    try {
+      // copy the data into the temporary location
+      test("DROP TABLE dfs.tmp.parquetStale");
+      test("CREATE TABLE dfs.tmp.parquetStale AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
+              "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", tmpLocation);
+      String query = "select count(distinct o_orderkey) from dfs.tmp.parquetStale";
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+      test("REFRESH TABLE METADATA dfs.tmp.parquetStale");
+      // Verify we recompute statistics once a new file/directory is added. Update the directory some
+      // time after ANALYZE so that the timestamps are different.
+      Thread.sleep(1000);
+      final String Q4 = "/multilevel/parquet/1996/Q4";
+      test("CREATE TABLE dfs.tmp.`parquetStale/1996/Q5` AS SELECT o_orderkey, o_custkey, o_orderstatus, " +
+              "o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment from dfs.`%s`", Q4);
+      // query should use STALE statistics
+      String[] expectedStalePlan = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 119.0.*",
+          "Scan.*rowcount = 130.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedStalePlan, new String[]{});
+      // Query should use Parquet Metadata, since statistics not available. In this case, NDV is computed as
+      // 1/10*rowcount (Calcite default). Hence, NDV is 13.0 instead of the correct 119.0
+      test("DROP TABLE dfs.tmp.`parquetStale/.stats.drill`");
+      String[] expectedPlan1 = {"HashAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 13.0.*",
+          "Scan.*rowcount = 130.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan1, new String[]{});
+      // query should use the new statistics. NDV remains unaffected since we copy the Q4 into Q5
+      verifyAnalyzeOutput("ANALYZE TABLE dfs.tmp.parquetStale COMPUTE STATISTICS", "9");
+      String[] expectedPlan2 = {"StreamAgg\\(group=\\[\\{0\\}\\]\\).*rowcount = 119.0.*",
+          "Scan.*rowcount = 130.0.*"};
+      PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan2, new String[]{});
+      test("DROP TABLE dfs.tmp.`parquetStale/1996/Q5`");
+    } finally {
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
+      resetSessionOption("planner.statistics.use");
+    }
   }
 
   // Test basic histogram creation functionality for int, bigint, double, date, timestamp and boolean data types.
@@ -436,9 +460,10 @@ public class TestAnalyze extends BaseTestQuery {
       String[] expectedPlan6 = {"Filter\\(condition.*\\).*rowcount = 1.0,.*",
         "Scan.*columns=\\[`store_id`\\].*rowcount = 1128.0.*"};
       PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan6, new String[]{});
-
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
+      resetSessionOption("planner.statistics.use");
     }
   }
 
@@ -462,7 +487,8 @@ public class TestAnalyze extends BaseTestQuery {
               .baselineValues("`c_acctbal`", 11)
               .go();
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 
@@ -498,10 +524,10 @@ public class TestAnalyze extends BaseTestQuery {
               .go();
 
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
-
 
   @Test
   public void testHistogramWithIntervalPredicate() throws Exception {
@@ -516,7 +542,8 @@ public class TestAnalyze extends BaseTestQuery {
       String[] expectedPlan1 = {"Filter\\(condition.*\\).*rowcount = 59?.*,.*", "Scan.*columns=\\[`o_orderdate`\\].*rowcount = 15000.0.*"};
       PlanTestBase.testPlanWithAttributesMatchingPatterns(query, expectedPlan1, new String[]{});
     } finally {
-      test("ALTER SESSION SET `planner.slice_target` = " + ExecConstants.SLICE_TARGET_DEFAULT);
+      resetSessionOption("planner.slice_target");
+      resetSessionOption("store.format");
     }
   }
 

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -579,21 +579,21 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     /**
      * Fill in missing values up to, but not including, the given
      * index.
-     * 
+     *
      * @param index the index about to be written, or the total
      * vector length about to be set
      */
-    
+
     @VisibleForTesting
     protected void fillEmpties(int index) {
       values.getMutator().fillEmpties(lastSet, index);
       while (index > bits.getValueCapacity()) {
         bits.reAlloc();
       }
-      
+
       // Set last set to the given index; which the caller
       // will write to
-      
+
       lastSet = index;
     }
 
@@ -753,7 +753,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
       values.getMutator().setValueCount(valueCount);
       bits.getMutator().setValueCount(valueCount);
     }
-    
+
     <#if type.major == "VarLen">
     /** Enables this wrapper container class to participate in bulk mutator logic */
     private final class VarLenBulkInputCallbackImpl implements VarLenBulkInput.BulkInputCallback<VarLenBulkEntry> {
@@ -853,7 +853,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     public void setSetCount(int n) {
       <#if type.major = "VarLen">lastSet = n - 1;</#if>
     }
-    
+
     // For nullable vectors, exchanging buffers (done elsewhere)
     // requires also exchanging mutator state (done here.)
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/NullableVector.java
@@ -25,7 +25,11 @@ public interface NullableVector extends ValueVector {
 
   public interface Mutator extends ValueVector.Mutator {
 
-    // Used by the vector accessors to force the last set value.
+    /**
+     * Used by the vector accessors to force the last set value.
+     * @param n the value of the last set field used to
+     * fill empties
+     */
 
     void setSetCount(int n);
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/impl/VectorPrinter.java
@@ -34,7 +34,7 @@ public class VectorPrinter {
     if (capacity == 0) {
       return;
     }
-    int length = Math.min(maxPrint, capacity);
+    int length = Math.max(maxPrint, vector.getAccessor().getValueCount());
     printOffsets(vector, 0, length);
   }
 


### PR DESCRIPTION
Enables batch validation for 12 additional operators:

* MergingRecordBatch
* OrderedPartitionRecordBatch
* RangePartitionRecordBatch
* TraceRecordBatch
* UnionAllRecordBatch
* UnorderedReceiverBatch
* UnpivotMapsRecordBatch
* WindowFrameRecordBatch
* TopNBatch
* HashJoinBatch
* ExternalSortBatch
* WriterRecordBatch

Fixes issues found with those checks so that this set of
operators passes all checks.

Includes code cleanup in many files touched during this
work.