### PR TITLE
DRILL-7393: Revisit Drill tests to ensure that patching is executed b…

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
+++ b/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
@@ -24,154 +24,157 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtConstructor;
 import javassist.CtMethod;
 import javassist.CtNewMethod;
-import javassist.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GuavaPatcher {
   private static final Logger logger = LoggerFactory.getLogger(GuavaPatcher.class);
 
-  private static boolean patched;
+  private static boolean patchingAttempted;
 
   public static synchronized void patch() {
-    if (!patched) {
-      try {
-        patchStopwatch();
-        patchCloseables();
-        patchPreconditions();
-        patched = true;
-      } catch (Throwable e) {
-        logger.warn("Unable to patch Guava classes.", e);
-      }
+    if (!patchingAttempted) {
+      patchingAttempted = true;
+      patchStopwatch();
+      patchCloseables();
+      patchPreconditions();
     }
   }
 
   /**
    * Makes Guava stopwatch look like the old version for compatibility with hbase-server (for test purposes).
    */
-  private static void patchStopwatch() throws Exception {
+  private static void patchStopwatch() {
+    try {
+      ClassPool cp = ClassPool.getDefault();
+      CtClass cc = cp.get("com.google.common.base.Stopwatch");
 
-    ClassPool cp = ClassPool.getDefault();
-    CtClass cc = cp.get("com.google.common.base.Stopwatch");
-
-    // Expose the constructor for Stopwatch for old libraries who use the pattern new Stopwatch().start().
-    for (CtConstructor c : cc.getConstructors()) {
-      if (!Modifier.isStatic(c.getModifiers())) {
-        c.setModifiers(Modifier.PUBLIC);
+      // Expose the constructor for Stopwatch for old libraries who use the pattern new Stopwatch().start().
+      for (CtConstructor c : cc.getConstructors()) {
+        if (!Modifier.isStatic(c.getModifiers())) {
+          c.setModifiers(Modifier.PUBLIC);
+        }
       }
+
+      // Add back the Stopwatch.elapsedMillis() method for old consumers.
+      CtMethod newMethod = CtNewMethod.make(
+          "public long elapsedMillis() { return elapsed(java.util.concurrent.TimeUnit.MILLISECONDS); }", cc);
+      cc.addMethod(newMethod);
+
+      // Load the modified class instead of the original.
+      cc.toClass();
+
+      logger.info("Google's Stopwatch patched for old HBase Guava version.");
+    } catch (Exception e) {
+      logger.warn("Unable to patch Guava classes.", e);
     }
-
-    // Add back the Stopwatch.elapsedMillis() method for old consumers.
-    CtMethod newMethod = CtNewMethod.make(
-        "public long elapsedMillis() { return elapsed(java.util.concurrent.TimeUnit.MILLISECONDS); }", cc);
-    cc.addMethod(newMethod);
-
-    // Load the modified class instead of the original.
-    cc.toClass();
-
-    logger.info("Google's Stopwatch patched for old HBase Guava version.");
   }
 
-  private static void patchCloseables() throws Exception {
+  private static void patchCloseables() {
+    try {
+      ClassPool cp = ClassPool.getDefault();
+      CtClass cc = cp.get("com.google.common.io.Closeables");
 
-    ClassPool cp = ClassPool.getDefault();
-    CtClass cc = cp.get("com.google.common.io.Closeables");
+      // Add back the Closeables.closeQuietly() method for old consumers.
+      CtMethod newMethod = CtNewMethod.make(
+          "public static void closeQuietly(java.io.Closeable closeable) { try{closeable.close();}catch(Exception e){} }",
+          cc);
+      cc.addMethod(newMethod);
 
+      // Load the modified class instead of the original.
+      cc.toClass();
 
-    // Add back the Closeables.closeQuietly() method for old consumers.
-    CtMethod newMethod = CtNewMethod.make(
-        "public static void closeQuietly(java.io.Closeable closeable) { try{closeable.close();}catch(Exception e){} }",
-        cc);
-    cc.addMethod(newMethod);
-
-    // Load the modified class instead of the original.
-    cc.toClass();
-
-    logger.info("Google's Closeables patched for old HBase Guava version.");
+      logger.info("Google's Closeables patched for old HBase Guava version.");
+    } catch (Exception e) {
+      logger.warn("Unable to patch Guava classes.", e);
+    }
   }
 
   /**
    * Patches Guava Preconditions with missing methods, added for the Apache Iceberg.
    */
-  private static void patchPreconditions() throws NotFoundException, CannotCompileException {
-    ClassPool cp = ClassPool.getDefault();
-    CtClass cc = cp.get("com.google.common.base.Preconditions");
+  private static void patchPreconditions() {
+    try {
+      ClassPool cp = ClassPool.getDefault();
+      CtClass cc = cp.get("com.google.common.base.Preconditions");
 
-    // Javassist does not support varargs, generate methods with varying number of arguments
-    int startIndex = 1;
-    int endIndex = 5;
+      // Javassist does not support varargs, generate methods with varying number of arguments
+      int startIndex = 1;
+      int endIndex = 5;
 
-    List<String> methodsWithVarargsTemplates = Arrays.asList(
-      "public static void checkArgument(boolean expression, String errorMessageTemplate, %s) {\n"
-        + "    if (!expression) {\n"
-        + "      throw new IllegalArgumentException(format(errorMessageTemplate, new Object[] { %s }));\n"
-        + "    }\n"
-        + "  }",
+      List<String> methodsWithVarargsTemplates = Arrays.asList(
+          "public static void checkArgument(boolean expression, String errorMessageTemplate, %s) {\n"
+              + "    if (!expression) {\n"
+              + "      throw new IllegalArgumentException(format(errorMessageTemplate, new Object[] { %s }));\n"
+              + "    }\n"
+              + "  }",
 
-      "public static Object checkNotNull(Object reference, String errorMessageTemplate, %s) {\n"
-        + "    if (reference == null) {\n"
-        + "      throw new NullPointerException(format(errorMessageTemplate, new Object[] { %s }));\n"
-        + "    } else {\n"
-        + "      return reference;\n"
-        + "    }\n"
-        + "  }",
+          "public static Object checkNotNull(Object reference, String errorMessageTemplate, %s) {\n"
+              + "    if (reference == null) {\n"
+              + "      throw new NullPointerException(format(errorMessageTemplate, new Object[] { %s }));\n"
+              + "    } else {\n"
+              + "      return reference;\n"
+              + "    }\n"
+              + "  }",
 
-      "public static void checkState(boolean expression, String errorMessageTemplate, %s) {\n"
-        + "    if (!expression) {\n"
-        + "      throw new IllegalStateException(format(errorMessageTemplate, new Object[] { %s }));\n"
-        + "    }\n"
-        + "  }"
-    );
+          "public static void checkState(boolean expression, String errorMessageTemplate, %s) {\n"
+              + "    if (!expression) {\n"
+              + "      throw new IllegalStateException(format(errorMessageTemplate, new Object[] { %s }));\n"
+              + "    }\n"
+              + "  }"
+      );
 
-    List<String> methodsWithPrimitives = Arrays.asList(
-      "public static void checkArgument(boolean expression, String errorMessageTemplate, int arg1) {\n"
-        + "    if (!expression) {\n"
-        + "      throw new IllegalArgumentException(format(errorMessageTemplate, new Object[] { new Integer(arg1) }));\n"
-        + "    }\n"
-        + "  }",
-      "public static Object checkNotNull(Object reference, String errorMessageTemplate, int arg1) {\n"
-        + "    if (reference == null) {\n"
-        + "      throw new NullPointerException(format(errorMessageTemplate, new Object[] { new Integer(arg1) }));\n"
-        + "    } else {\n"
-        + "      return reference;\n"
-        + "    }\n"
-        + "  }"
-    );
+      List<String> methodsWithPrimitives = Arrays.asList(
+          "public static void checkArgument(boolean expression, String errorMessageTemplate, int arg1) {\n"
+              + "    if (!expression) {\n"
+              + "      throw new IllegalArgumentException(format(errorMessageTemplate, new Object[] { new Integer(arg1) }));\n"
+              + "    }\n"
+              + "  }",
+          "public static Object checkNotNull(Object reference, String errorMessageTemplate, int arg1) {\n"
+              + "    if (reference == null) {\n"
+              + "      throw new NullPointerException(format(errorMessageTemplate, new Object[] { new Integer(arg1) }));\n"
+              + "    } else {\n"
+              + "      return reference;\n"
+              + "    }\n"
+              + "  }"
+      );
 
-    List<String> newMethods = IntStream.rangeClosed(startIndex, endIndex)
-      .mapToObj(
-        i -> {
-          List<String> args = IntStream.rangeClosed(startIndex, i)
-            .mapToObj(j -> "arg" + j)
-            .collect(Collectors.toList());
+      List<String> newMethods = IntStream.rangeClosed(startIndex, endIndex)
+          .mapToObj(
+              i -> {
+                List<String> args = IntStream.rangeClosed(startIndex, i)
+                    .mapToObj(j -> "arg" + j)
+                    .collect(Collectors.toList());
 
-          String methodInput = args.stream()
-            .map(arg -> "Object " + arg)
-            .collect(Collectors.joining(", "));
+                String methodInput = args.stream()
+                    .map(arg -> "Object " + arg)
+                    .collect(Collectors.joining(", "));
 
-          String arrayInput = String.join(", ", args);
+                String arrayInput = String.join(", ", args);
 
-          return methodsWithVarargsTemplates.stream()
-            .map(method -> String.format(method, methodInput, arrayInput))
-            .collect(Collectors.toList());
-        })
-      .flatMap(Collection::stream)
-      .collect(Collectors.toList());
+                return methodsWithVarargsTemplates.stream()
+                    .map(method -> String.format(method, methodInput, arrayInput))
+                    .collect(Collectors.toList());
+              })
+          .flatMap(Collection::stream)
+          .collect(Collectors.toList());
 
-    newMethods.addAll(methodsWithPrimitives);
+      newMethods.addAll(methodsWithPrimitives);
 
-    for (String method : newMethods) {
-      CtMethod newMethod = CtNewMethod.make(method, cc);
-      cc.addMethod(newMethod);
+      for (String method : newMethods) {
+        CtMethod newMethod = CtNewMethod.make(method, cc);
+        cc.addMethod(newMethod);
+      }
+
+      cc.toClass();
+      logger.info("Google's Preconditions were patched to hold new methods.");
+    } catch (Exception e) {
+      logger.warn("Unable to patch Guava classes.", e);
     }
-
-    cc.toClass();
-    logger.info("Google's Preconditions were patched to hold new methods.");
   }
 }

--- a/common/src/main/java/org/apache/drill/common/util/ProtobufPatcher.java
+++ b/common/src/main/java/org/apache/drill/common/util/ProtobufPatcher.java
@@ -25,7 +25,6 @@ import javassist.CtMethod;
 import javassist.CtNewConstructor;
 import javassist.CtNewMethod;
 import javassist.Modifier;
-import javassist.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,14 +39,10 @@ public class ProtobufPatcher {
    */
   public static synchronized void patch() {
     if (!patchingAttempted) {
-      try {
-        patchingAttempted = true;
-        patchByteString();
-        patchGeneratedMessageLite();
-        patchGeneratedMessageLiteBuilder();
-      } catch (Exception e) {
-        logger.warn("Unable to patch Protobuf.", e);
-      }
+      patchingAttempted = true;
+      patchByteString();
+      patchGeneratedMessageLite();
+      patchGeneratedMessageLiteBuilder();
     }
   }
 
@@ -56,73 +51,75 @@ public class ProtobufPatcher {
    * that were made final in version 3.6+ of protobuf.
    * This method removes the final modifiers. It also creates and loads classes
    * that were made private nested in protobuf 3.6+ to be accessible by the old fully qualified name.
-   *
-   * @throws NotFoundException if unable to find a method or class to patch.
-   * @throws CannotCompileException if unable to compile the patched class.
    */
-  private static void patchByteString() throws NotFoundException, CannotCompileException {
-    ClassPool classPool = ClassPool.getDefault();
-    CtClass byteString = classPool.get("com.google.protobuf.ByteString");
-    removeFinal(byteString.getDeclaredMethod("toString"));
-    removeFinal(byteString.getDeclaredMethod("hashCode"));
-    removeFinal(byteString.getDeclaredMethod("iterator"));
+  private static void patchByteString() {
+    try {
+      ClassPool classPool = ClassPool.getDefault();
+      CtClass byteString = classPool.get("com.google.protobuf.ByteString");
+      removeFinal(byteString.getDeclaredMethod("toString"));
+      removeFinal(byteString.getDeclaredMethod("hashCode"));
+      removeFinal(byteString.getDeclaredMethod("iterator"));
 
-    // Need to inherit from these classes to make them accessible by the old path.
-    CtClass googleLiteralByteString = classPool.get("com.google.protobuf.ByteString$LiteralByteString");
-    removePrivate(googleLiteralByteString);
-    CtClass googleBoundedByteString = classPool.get("com.google.protobuf.ByteString$BoundedByteString");
-    removePrivate(googleBoundedByteString);
-    removeFinal(googleBoundedByteString);
-    for (CtMethod ctMethod : googleLiteralByteString.getDeclaredMethods()) {
-      removeFinal(ctMethod);
+      // Need to inherit from these classes to make them accessible by the old path.
+      CtClass googleLiteralByteString = classPool.get("com.google.protobuf.ByteString$LiteralByteString");
+      removePrivate(googleLiteralByteString);
+      CtClass googleBoundedByteString = classPool.get("com.google.protobuf.ByteString$BoundedByteString");
+      removePrivate(googleBoundedByteString);
+      removeFinal(googleBoundedByteString);
+      for (CtMethod ctMethod : googleLiteralByteString.getDeclaredMethods()) {
+        removeFinal(ctMethod);
+      }
+      byteString.toClass();
+      googleLiteralByteString.toClass();
+      googleBoundedByteString.toClass();
+
+      // Adding the classes back to the old path.
+      CtClass literalByteString = classPool.makeClass("com.google.protobuf.LiteralByteString");
+      literalByteString.setSuperclass(googleLiteralByteString);
+      literalByteString.toClass();
+      CtClass boundedByteString = classPool.makeClass("com.google.protobuf.BoundedByteString");
+      boundedByteString.setSuperclass(googleBoundedByteString);
+      boundedByteString.toClass();
+    } catch (Exception e) {
+      logger.warn("Unable to patch Protobuf.", e);
     }
-    byteString.toClass();
-    googleLiteralByteString.toClass();
-    googleBoundedByteString.toClass();
-
-    // Adding the classes back to the old path.
-    CtClass literalByteString = classPool.makeClass("com.google.protobuf.LiteralByteString");
-    literalByteString.setSuperclass(googleLiteralByteString);
-    literalByteString.toClass();
-    CtClass boundedByteString = classPool.makeClass("com.google.protobuf.BoundedByteString");
-    boundedByteString.setSuperclass(googleBoundedByteString);
-    boundedByteString.toClass();
   }
 
   /**
    * MapR-DB client extends {@link com.google.protobuf.GeneratedMessageLite} and overrides some methods,
    * that were made final in version 3.6+ of protobuf.
    * This method removes the final modifiers.
-   *
-   * @throws NotFoundException if unable to find a method or class to patch.
-   * @throws CannotCompileException if unable to compile the patched method body.
    */
-  private static void patchGeneratedMessageLite() throws NotFoundException, CannotCompileException {
-    ClassPool classPool = ClassPool.getDefault();
-    CtClass generatedMessageLite = classPool.get("com.google.protobuf.GeneratedMessageLite");
-    removeFinal(generatedMessageLite.getDeclaredMethod("getParserForType"));
-    removeFinal(generatedMessageLite.getDeclaredMethod("isInitialized"));
+  private static void patchGeneratedMessageLite() {
+    try {
+      ClassPool classPool = ClassPool.getDefault();
+      CtClass generatedMessageLite = classPool.get("com.google.protobuf.GeneratedMessageLite");
+      removeFinal(generatedMessageLite.getDeclaredMethod("getParserForType"));
+      removeFinal(generatedMessageLite.getDeclaredMethod("isInitialized"));
 
-    // The method was removed, but it is used in com.mapr.fs.proto.Dbserver.
-    // Adding it back.
-    generatedMessageLite.addMethod(CtNewMethod.make("protected void makeExtensionsImmutable() { }", generatedMessageLite));
+      // The method was removed, but it is used in com.mapr.fs.proto.Dbserver.
+      // Adding it back.
+      generatedMessageLite.addMethod(CtNewMethod.make("protected void makeExtensionsImmutable() { }", generatedMessageLite));
 
-    // A constructor with this signature was removed. Adding it back.
-    generatedMessageLite.addConstructor(CtNewConstructor.make("protected GeneratedMessageLite(com.google.protobuf.GeneratedMessageLite.Builder builder) { }", generatedMessageLite));
+      // A constructor with this signature was removed. Adding it back.
+      generatedMessageLite.addConstructor(CtNewConstructor.make("protected GeneratedMessageLite(com.google.protobuf.GeneratedMessageLite.Builder builder) { }", generatedMessageLite));
 
-    // This single method was added instead of several abstract methods.
-    // MapR-DB client doesn't use it, but it was added in overridden equals() method.
-    // Adding default implementation.
-    CtMethod dynamicMethod = generatedMessageLite.getDeclaredMethod("dynamicMethod", new CtClass[] {
-        classPool.get("com.google.protobuf.GeneratedMessageLite$MethodToInvoke"),
-        classPool.get("java.lang.Object"),
-        classPool.get("java.lang.Object")});
-    addImplementation(dynamicMethod, "if ($1.equals(com.google.protobuf.GeneratedMessageLite.MethodToInvoke.GET_DEFAULT_INSTANCE)) {" +
-                                  "  return this;" +
-                                  "} else {" +
-                                  "  return null;" +
-                                  "}");
-    generatedMessageLite.toClass();
+      // This single method was added instead of several abstract methods.
+      // MapR-DB client doesn't use it, but it was added in overridden equals() method.
+      // Adding default implementation.
+      CtMethod dynamicMethod = generatedMessageLite.getDeclaredMethod("dynamicMethod", new CtClass[]{
+          classPool.get("com.google.protobuf.GeneratedMessageLite$MethodToInvoke"),
+          classPool.get("java.lang.Object"),
+          classPool.get("java.lang.Object")});
+      addImplementation(dynamicMethod, "if ($1.equals(com.google.protobuf.GeneratedMessageLite.MethodToInvoke.GET_DEFAULT_INSTANCE)) {" +
+          "  return this;" +
+          "} else {" +
+          "  return null;" +
+          "}");
+      generatedMessageLite.toClass();
+    } catch (Exception e) {
+      logger.warn("Unable to patch Protobuf.", e);
+    }
   }
 
   /**
@@ -130,17 +127,18 @@ public class ProtobufPatcher {
    * that were made final in version 3.6+ of protobuf.
    * This method removes the final modifiers.
    * Also, adding back a default constructor that was removed.
-   *
-   * @throws NotFoundException if unable to find a method or class to patch.
-   * @throws CannotCompileException if unable to add a default constructor.
    */
-  private static void patchGeneratedMessageLiteBuilder() throws NotFoundException, CannotCompileException {
-    ClassPool classPool = ClassPool.getDefault();
-    CtClass builder = classPool.get("com.google.protobuf.GeneratedMessageLite$Builder");
-    removeFinal(builder.getDeclaredMethod("isInitialized"));
-    removeFinal(builder.getDeclaredMethod("clear"));
-    builder.addConstructor(CtNewConstructor.defaultConstructor(builder));
-    builder.toClass();
+  private static void patchGeneratedMessageLiteBuilder() {
+    try {
+      ClassPool classPool = ClassPool.getDefault();
+      CtClass builder = classPool.get("com.google.protobuf.GeneratedMessageLite$Builder");
+      removeFinal(builder.getDeclaredMethod("isInitialized"));
+      removeFinal(builder.getDeclaredMethod("clear"));
+      builder.addConstructor(CtNewConstructor.defaultConstructor(builder));
+      builder.toClass();
+    } catch (Exception e) {
+      logger.warn("Unable to patch Protobuf.", e);
+    }
   }
 
   /**
@@ -176,7 +174,7 @@ public class ProtobufPatcher {
   /**
    * Removes abstract modifier and adds implementation to a given method.
    *
-   * @param ctMethod method to process.
+   * @param ctMethod   method to process.
    * @param methodBody method implementation.
    * @throws CannotCompileException if unable to compile given method body.
    */

--- a/common/src/test/java/org/apache/drill/common/TestVersion.java
+++ b/common/src/test/java/org/apache/drill/common/TestVersion.java
@@ -21,13 +21,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 /**
  * Test class for {@code Version}
  *
  */
-public class TestVersion {
+public class TestVersion extends BaseTest {
 
   @Test
   public void testSnapshotVersion() {

--- a/common/src/test/java/org/apache/drill/common/exceptions/TestUserException.java
+++ b/common/src/test/java/org/apache/drill/common/exceptions/TestUserException.java
@@ -19,13 +19,14 @@ package org.apache.drill.common.exceptions;
 
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * Test various use cases when creating user exceptions
  */
-public class TestUserException {
+public class TestUserException extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory
       .getLogger("--ignore.as.this.is.for.testing.exceptions--");
 

--- a/common/src/test/java/org/apache/drill/common/map/TestCaseInsensitiveMap.java
+++ b/common/src/test/java/org/apache/drill/common/map/TestCaseInsensitiveMap.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.common.map;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -28,7 +29,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestCaseInsensitiveMap {
+public class TestCaseInsensitiveMap extends BaseTest {
 
   @Test
   public void putAndGet() {

--- a/common/src/test/java/org/apache/drill/common/util/function/TestCheckedFunction.java
+++ b/common/src/test/java/org/apache/drill/common/util/function/TestCheckedFunction.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.common.util.function;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,7 +25,7 @@ import org.junit.rules.ExpectedException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TestCheckedFunction {
+public class TestCheckedFunction extends BaseTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();

--- a/common/src/test/java/org/apache/drill/test/BaseTest.java
+++ b/common/src/test/java/org/apache/drill/test/BaseTest.java
@@ -20,6 +20,10 @@ package org.apache.drill.test;
 import org.apache.drill.common.util.GuavaPatcher;
 import org.apache.drill.common.util.ProtobufPatcher;
 
+/**
+ * Contains patchers that must be executed at the very beginning of test runs.
+ * All Drill test classes should be inherited from it to avoid exceptions (e.g. NoSuchMethodError etc.).
+ */
 public class BaseTest {
 
   static {
@@ -30,9 +34,8 @@ public class BaseTest {
      */
     ProtobufPatcher.patch();
     /*
-     * HBase client uses older version of Guava's Stopwatch API,
-     * while Drill ships with 18.x which has changes the scope of
-     * these API to 'package', this code make them accessible.
+     * Some libraries, such as Hadoop or HBase, depend on incompatible versions of Guava.
+     * This code adds back some methods to so that the libraries can work with single Guava version.
      */
     GuavaPatcher.patch();
   }

--- a/common/src/test/java/org/apache/drill/test/BaseTest.java
+++ b/common/src/test/java/org/apache/drill/test/BaseTest.java
@@ -15,24 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.expr;
+package org.apache.drill.test;
 
-import org.apache.drill.BaseTestQuery;
-import org.apache.drill.common.util.TestTools;
-import org.junit.Test;
+import org.apache.drill.common.util.GuavaPatcher;
+import org.apache.drill.common.util.ProtobufPatcher;
 
-public class TestPrune extends BaseTestQuery {
+public class BaseTest {
 
-  String MULTILEVEL = TestTools.getWorkingPath() + "/../java-exec/src/test/resources/multilevel";
-
-  @Test
-  public void pruneCompound() throws Exception {
-    test(String.format("select * from dfs.`%s/csv` where x is null and dir1 in ('Q1', 'Q2')", MULTILEVEL));
+  static {
+    /*
+     * HBase and MapR-DB clients use older version of protobuf,
+     * and override some methods that became final in recent versions.
+     * This code removes these final modifiers.
+     */
+    ProtobufPatcher.patch();
+    /*
+     * HBase client uses older version of Guava's Stopwatch API,
+     * while Drill ships with 18.x which has changes the scope of
+     * these API to 'package', this code make them accessible.
+     */
+    GuavaPatcher.patch();
   }
-
-  @Test
-  public void pruneSimple() throws Exception {
-    test(String.format("select * from dfs.`%s/csv` where dir1 in ('Q1', 'Q2')", MULTILEVEL));
-  }
-
 }

--- a/common/src/test/java/org/apache/drill/test/Drill2130CommonHamcrestConfigurationTest.java
+++ b/common/src/test/java/org/apache/drill/test/Drill2130CommonHamcrestConfigurationTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class Drill2130CommonHamcrestConfigurationTest {
+public class Drill2130CommonHamcrestConfigurationTest extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130CommonHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")

--- a/common/src/test/java/org/apache/drill/test/DrillTest.java
+++ b/common/src/test/java/org/apache/drill/test/DrillTest.java
@@ -23,7 +23,6 @@ import java.lang.management.MemoryMXBean;
 import java.util.List;
 
 import org.apache.drill.common.util.DrillStringUtils;
-import org.apache.drill.common.util.GuavaPatcher;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -37,12 +36,11 @@ import org.slf4j.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class DrillTest {
+public class DrillTest extends BaseTest {
 
   protected static final ObjectMapper objectMapper;
 
   static {
-    GuavaPatcher.patch();
     System.setProperty("line.separator", "\n");
     objectMapper = new ObjectMapper();
   }

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/MaprDBTestsSuite.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/MaprDBTestsSuite.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.dfs.FileSystemConfig;
 import org.apache.drill.hbase.HBaseTestsSuite;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -46,7 +47,7 @@ import com.mapr.drill.maprdb.tests.json.TestSimpleJson;
   TestSimpleJson.class,
   TestScanRanges.class
 })
-public class MaprDBTestsSuite {
+public class MaprDBTestsSuite extends BaseTest {
   public static final int INDEX_FLUSH_TIMEOUT = 60000;
 
   private static final boolean IS_DEBUG = ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/TestFieldPathHelper.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/TestFieldPathHelper.java
@@ -21,10 +21,11 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.store.mapr.db.json.FieldPathHelper;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.ojai.FieldPath;
 
-public class TestFieldPathHelper {
+public class TestFieldPathHelper extends BaseTest {
 
   @Test
   public void simeTests() {

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/HBaseTestsSuite.java
@@ -22,9 +22,8 @@ import java.lang.management.ManagementFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.drill.exec.ZookeeperTestUtil;
-import org.apache.drill.common.util.GuavaPatcher;
-import org.apache.drill.common.util.ProtobufPatcher;
 import org.apache.drill.hbase.test.Drill2130StorageHBaseHamcrestConfigurationTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -53,13 +52,8 @@ import org.junit.runners.Suite.SuiteClasses;
   TestHBaseTableProvider.class,
   TestOrderedBytesConvertFunctions.class
 })
-public class HBaseTestsSuite {
+public class HBaseTestsSuite extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HBaseTestsSuite.class);
-
-  static {
-    ProtobufPatcher.patch();
-    GuavaPatcher.patch();
-  }
 
   private static final boolean IS_DEBUG = ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;
 

--- a/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/test/Drill2130StorageHBaseHamcrestConfigurationTest.java
+++ b/contrib/storage-hbase/src/test/java/org/apache/drill/hbase/test/Drill2130StorageHBaseHamcrestConfigurationTest.java
@@ -21,9 +21,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class Drill2130StorageHBaseHamcrestConfigurationTest {
+public class Drill2130StorageHBaseHamcrestConfigurationTest extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130StorageHBaseHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/inspectors/SkipFooterRecordsInspectorTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/inspectors/SkipFooterRecordsInspectorTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.hive.inspectors;
 
 import org.apache.drill.exec.store.hive.readers.inspectors.SkipFooterRecordsInspector;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.mapred.RecordReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SkipFooterRecordsInspectorTest {
+public class SkipFooterRecordsInspectorTest extends BaseTest {
 
   private static RecordReader<Object, Object> recordReader;
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestColumnListCache.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestColumnListCache.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.hive.schema;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.exec.store.hive.ColumnListsCache;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @Category({SlowTest.class})
-public class TestColumnListCache {
+public class TestColumnListCache extends BaseTest {
 
   @Test
   public void testTableColumnsIndex() {

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestSchemaConversion.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/schema/TestSchemaConversion.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.PrimitiveColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.store.hive.HiveUtilities;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +37,7 @@ import org.junit.rules.ExpectedException;
 import static org.junit.Assert.assertEquals;
 
 @Category({SlowTest.class})
-public class TestSchemaConversion {
+public class TestSchemaConversion extends BaseTest {
   private static final HiveToRelDataTypeConverter dataTypeConverter
       = new HiveToRelDataTypeConverter(new SqlTypeFactoryImpl(new DrillRelDataTypeSystem()));
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/test/Drill2130StorageHiveCoreHamcrestConfigurationTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/test/Drill2130StorageHiveCoreHamcrestConfigurationTest.java
@@ -17,13 +17,14 @@
  */
 package org.apache.drill.exec.test;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class Drill2130StorageHiveCoreHamcrestConfigurationTest {
+public class Drill2130StorageHiveCoreHamcrestConfigurationTest extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130StorageHiveCoreHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/TestKafkaSuit.java
@@ -24,6 +24,7 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.store.kafka.cluster.EmbeddedKafkaCluster;
 import org.apache.drill.exec.store.kafka.decoders.MessageReaderFactoryTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -50,7 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Category({KafkaStorageTest.class, SlowTest.class})
 @RunWith(Suite.class)
 @SuiteClasses({KafkaQueriesTest.class, MessageIteratorTest.class, MessageReaderFactoryTest.class, KafkaFilterPushdownTest.class})
-public class TestKafkaSuit {
+public class TestKafkaSuit extends BaseTest {
   private static final Logger logger = LoggerFactory.getLogger(LoggerFactory.class);
 
   private static final String LOGIN_CONF_RESOURCE_PATHNAME = "login.conf";

--- a/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/decoders/MessageReaderFactoryTest.java
+++ b/contrib/storage-kafka/src/test/java/org/apache/drill/exec/store/kafka/decoders/MessageReaderFactoryTest.java
@@ -20,12 +20,13 @@ package org.apache.drill.exec.store.kafka.decoders;
 import org.apache.drill.categories.KafkaStorageTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError.ErrorType;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({KafkaStorageTest.class})
-public class MessageReaderFactoryTest {
+public class MessageReaderFactoryTest extends BaseTest {
 
   @Test
   public void testShouldThrowExceptionAsMessageReaderIsNull() {

--- a/contrib/storage-kudu/src/test/java/org/apache/drill/store/kudu/TestKuduConnect.java
+++ b/contrib/storage-kudu/src/test/java/org/apache/drill/store/kudu/TestKuduConnect.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.drill.categories.KuduStorageTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.apache.kudu.ColumnSchema;
@@ -41,7 +42,7 @@ import org.junit.experimental.categories.Category;
 
 @Ignore("requires remote kudu server")
 @Category(KuduStorageTest.class)
-public class TestKuduConnect {
+public class TestKuduConnect extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestKuduConnect.class);
 
   public static final String KUDU_MASTER = "172.31.1.99";

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuit.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.test.BaseTest;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.AfterClass;
@@ -67,7 +68,7 @@ import de.flapdoodle.embed.process.runtime.Network;
 @SuiteClasses({ TestMongoFilterPushDown.class, TestMongoProjectPushDown.class,
     TestMongoQueries.class, TestMongoChunkAssignment.class })
 @Category({SlowTest.class, MongoStorageTest.class})
-public class MongoTestSuit implements MongoTestConstants {
+public class MongoTestSuit extends BaseTest implements MongoTestConstants {
 
   private static final Logger logger = LoggerFactory.getLogger(MongoTestSuit.class);
   protected static MongoClient mongoClient;

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoChunkAssignment.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoChunkAssignment.java
@@ -34,6 +34,7 @@ import org.apache.drill.exec.store.mongo.common.ChunkInfo;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,7 +42,7 @@ import org.junit.experimental.categories.Category;
 import com.mongodb.ServerAddress;
 
 @Category({SlowTest.class, MongoStorageTest.class})
-public class TestMongoChunkAssignment {
+public class TestMongoChunkAssignment extends BaseTest {
   static final String HOST_A = "A";
   static final String HOST_B = "B";
   static final String HOST_C = "C";

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/DrillApplicationMaster.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/appMaster/DrillApplicationMaster.java
@@ -55,9 +55,8 @@ public class DrillApplicationMaster {
      */
     ProtobufPatcher.patch();
     /*
-     * HBase client uses older version of Guava's Stopwatch API,
-     * while Drill ships with 18.x which has changes the scope of
-     * these API to 'package', this code make them accessible.
+     * Some libraries, such as Hadoop or HBase, depend on incompatible versions of Guava.
+     * This code adds back some methods to so that the libraries can work with single Guava version.
      */
     GuavaPatcher.patch();
   }

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/client/DrillOnYarn.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/client/DrillOnYarn.java
@@ -84,9 +84,8 @@ public class DrillOnYarn {
      */
     ProtobufPatcher.patch();
     /*
-     * HBase client uses older version of Guava's Stopwatch API,
-     * while Drill ships with 18.x which has changes the scope of
-     * these API to 'package', this code make them accessible.
+     * Some libraries, such as Hadoop or HBase, depend on incompatible versions of Guava.
+     * This code adds back some methods to so that the libraries can work with single Guava version.
      */
     GuavaPatcher.patch();
   }

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/client/TestClient.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/client/TestClient.java
@@ -24,9 +24,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class TestClient {
+public class TestClient extends BaseTest {
 
   /**
    * Unchecked exception to allow capturing "exit" events without actually

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/client/TestCommandLineOptions.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/client/TestCommandLineOptions.java
@@ -17,12 +17,13 @@
  */
 package org.apache.drill.yarn.client;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class TestCommandLineOptions {
+public class TestCommandLineOptions extends BaseTest {
   @Test
   public void testOptions() {
     CommandLineOptions opts = new CommandLineOptions();

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/core/TestConfig.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/core/TestConfig.java
@@ -33,11 +33,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import com.typesafe.config.Config;
 
-public class TestConfig {
+public class TestConfig extends BaseTest {
 
   /**
    * Mock config that lets us tinker with loading and environment access for

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/TestScripts.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/scripts/TestScripts.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.yarn.scripts.ScriptUtils.DrillbitRun;
 import org.apache.drill.yarn.scripts.ScriptUtils.RunResult;
 import org.apache.drill.yarn.scripts.ScriptUtils.ScriptRunner;
@@ -50,7 +51,7 @@ import org.junit.Test;
 
 // Turned of by default: works only in a developer setup
 @Ignore
-public class TestScripts {
+public class TestScripts extends BaseTest {
   static ScriptUtils context;
 
   @BeforeClass

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/zk/TestAmRegistration.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/zk/TestAmRegistration.java
@@ -21,10 +21,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.curator.test.TestingServer;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.yarn.appMaster.AMRegistrar.AMRegistrationException;
 import org.junit.Test;
 
-public class TestAmRegistration {
+public class TestAmRegistration extends BaseTest {
   private static final String TEST_CLUSTER_ID = "drillbits";
   private static final String TEST_ZK_ROOT = "drill";
   private static final String TEST_AM_HOST = "localhost";

--- a/drill-yarn/src/test/java/org/apache/drill/yarn/zk/TestZkRegistry.java
+++ b/drill-yarn/src/test/java/org/apache/drill/yarn/zk/TestZkRegistry.java
@@ -34,6 +34,7 @@ import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.drill.exec.coord.DrillServiceInstanceHelper;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.work.foreman.DrillbitStatusListener;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.yarn.appMaster.EventContext;
 import org.apache.drill.yarn.appMaster.RegistryHandler;
 import org.apache.drill.yarn.appMaster.Task;
@@ -47,7 +48,7 @@ import org.junit.Test;
  * test in isolation using the Curator-provided test server.
  */
 
-public class TestZkRegistry {
+public class TestZkRegistry extends BaseTest {
   private static final String BARNEY_HOST = "barney";
   private static final String WILMA_HOST = "wilma";
   private static final String TEST_HOST = "host";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/Drillbit.java
@@ -85,9 +85,8 @@ public class Drillbit implements AutoCloseable {
      */
     ProtobufPatcher.patch();
     /*
-     * HBase client uses older version of Guava's Stopwatch API,
-     * while Drill ships with 18.x which has changes the scope of
-     * these API to 'package', this code make them accessible.
+     * Some libraries, such as Hadoop or HBase, depend on incompatible versions of Guava.
+     * This code adds back some methods to so that the libraries can work with single Guava version.
      */
     GuavaPatcher.patch();
     Environment.logEnv("Drillbit environment: ", logger);

--- a/exec/java-exec/src/test/java/org/apache/drill/BaseTestInheritance.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/BaseTestInheritance.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill;
+
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.BaseTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BaseTestInheritance extends BaseTest {
+
+  @Test
+  @Category(UnlikelyTest.class)
+  public void verifyInheritance() {
+    // Get all BaseTest inheritors
+    Reflections reflections = new Reflections("org.apache.drill", new SubTypesScanner(false));
+    Set<Class<? extends BaseTest>> baseTestInheritors = reflections.getSubTypesOf(BaseTest.class);
+
+    // Get all tests that are not inherited from BaseTest
+    Set<String> testClasses = reflections.getSubTypesOf(Object.class).stream()
+        .filter(c -> !c.isInterface())
+        .filter(c -> c.getSimpleName().toLowerCase().contains("test"))
+        .filter(c -> Arrays.stream(c.getDeclaredMethods())
+                .anyMatch(m -> m.getAnnotation(Test.class) != null))
+        .filter(c -> !baseTestInheritors.contains(c))
+        .map(Class::getName)
+        .collect(Collectors.toSet());
+
+    Assert.assertEquals("Found test classes that are not inherited from BaseTest:", Collections.emptySet(), testClasses);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/TestImplicitCasting.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestImplicitCasting.java
@@ -20,6 +20,7 @@ package org.apache.drill;
 import org.apache.drill.categories.SqlTest;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.resolver.TypeCastRules;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -30,7 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @Category(SqlTest.class)
-public class TestImplicitCasting {
+public class TestImplicitCasting extends BaseTest {
   @Test
   public void testTimeStampAndTime() {
     final List<TypeProtos.MinorType> inputTypes = Lists.newArrayList();

--- a/exec/java-exec/src/test/java/org/apache/drill/common/scanner/TestClassPathScanner.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/common/scanner/TestClassPathScanner.java
@@ -44,13 +44,14 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.store.SystemPlugin;
 import org.apache.drill.exec.store.ischema.InfoSchemaStoragePlugin;
 import org.apache.drill.exec.store.sys.SystemTablePlugin;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({SlowTest.class})
-public class TestClassPathScanner {
+public class TestClassPathScanner extends BaseTest {
 
   private static ScanResult result;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestOpSerialization.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestOpSerialization.java
@@ -44,13 +44,14 @@ import org.apache.drill.exec.store.direct.DirectSubScan;
 import org.apache.drill.exec.store.mock.MockSubScanPOP;
 import org.apache.drill.exec.store.pojo.DynamicPojoRecordReader;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
-public class TestOpSerialization {
+public class TestOpSerialization extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestOpSerialization.class);
   private DrillConfig config;
   private PhysicalPlanReader reader;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/TestSSLConfig.java
@@ -22,6 +22,7 @@ import org.apache.drill.categories.SecurityTest;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ssl.SSLConfig;
 import org.apache.drill.exec.ssl.SSLConfigBuilder;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.ConfigBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(SecurityTest.class)
-public class TestSSLConfig {
+public class TestSSLConfig extends BaseTest {
 
   @Test
   public void testMissingKeystorePath() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/ConnectTriesPropertyTestClusterBits.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.server.Drillbit;
 
 import org.apache.drill.exec.server.RemoteServiceSet;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,7 +41,7 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
-public class ConnectTriesPropertyTestClusterBits {
+public class ConnectTriesPropertyTestClusterBits extends BaseTest {
 
   public static StringBuilder bitInfo;
   public static final String fakeBitsInfo = "127.0.0.1:5000,127.0.0.1:5001";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillSqlLineApplicationTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/client/DrillSqlLineApplicationTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.client;
 
 import org.apache.drill.common.util.DrillVersionInfo;
+import org.apache.drill.test.BaseTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import sqlline.Application;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class DrillSqlLineApplicationTest {
+public class DrillSqlLineApplicationTest extends BaseTest {
 
   private static Application application;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestEvaluationVisitor.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/compile/TestEvaluationVisitor.java
@@ -27,9 +27,10 @@ import org.apache.drill.exec.expr.ValueVectorReadExpression;
 import org.apache.drill.exec.expr.ValueVectorWriteExpression;
 import org.apache.drill.exec.physical.impl.project.Projector;
 import org.apache.drill.exec.record.TypedFieldId;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class TestEvaluationVisitor {
+public class TestEvaluationVisitor extends BaseTest {
 
   @Test
   public void testEvaluation() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
@@ -30,13 +30,14 @@ import org.apache.curator.test.TestingServer;
 import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
 import org.apache.drill.exec.serialization.InstanceSerializer;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class TestEphemeralStore {
+public class TestEphemeralStore extends BaseTest {
   private final static String root = "/test";
   private final static String path = "test-key";
   private final static String value = "testing";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEventDispatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEventDispatcher.java
@@ -24,12 +24,13 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.drill.exec.coord.store.TransientStoreConfig;
 import org.apache.drill.exec.coord.store.TransientStoreEvent;
 import org.apache.drill.exec.serialization.InstanceSerializer;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class TestEventDispatcher {
+public class TestEventDispatcher extends BaseTest {
 
   private final static String key = "some-key";
   private final static String value = "some-data";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestPathUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestPathUtils.java
@@ -17,10 +17,11 @@
  */
 package org.apache.drill.exec.coord.zk;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestPathUtils {
+public class TestPathUtils extends BaseTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullSegmentThrowsNPE() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZKACL.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZKACL.java
@@ -31,6 +31,7 @@ import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.BootStrapContext;
 import org.apache.drill.exec.server.options.SystemOptionManager;
+import org.apache.drill.test.BaseTest;
 import org.apache.zookeeper.data.ACL;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,7 +44,7 @@ import java.util.List;
 
 @Ignore("See DRILL-6823")
 @Category(SecurityTest.class)
-public class TestZKACL {
+public class TestZKACL extends BaseTest {
 
   private TestingServer server;
   private final static String cluster_config_znode = "test-cluster_config_znode";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestZookeeperClient.java
@@ -34,6 +34,7 @@ import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.exception.VersionMismatchException;
 import org.apache.drill.exec.store.sys.store.DataChangeVersion;
+import org.apache.drill.test.BaseTest;
 import org.apache.zookeeper.CreateMode;
 import org.junit.After;
 import org.junit.Assert;
@@ -46,7 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestZookeeperClient {
+public class TestZookeeperClient extends BaseTest {
   private final static String root = "/test";
   private final static String path = "test-key";
   private final static String abspath = PathUtils.join(root, path);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/dotdrill/TestDotDrillUtil.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/dotdrill/TestDotDrillUtil.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -34,7 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class TestDotDrillUtil {
+public class TestDotDrillUtil extends BaseTest {
 
   private static File tempDir;
   private static Path tempPath;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/FunctionInitializerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/FunctionInitializerTest.java
@@ -21,6 +21,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.exec.udf.dynamic.JarBuilder;
 import org.apache.drill.exec.util.JarUtil;
+import org.apache.drill.test.BaseTest;
 import org.codehaus.janino.Java.CompilationUnit;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(SqlFunctionTest.class)
-public class FunctionInitializerTest {
+public class FunctionInitializerTest extends BaseTest {
 
   @ClassRule
   public static final TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestSqlPatterns.java
@@ -30,13 +30,14 @@ import java.util.List;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import io.netty.buffer.DrillBuf;
 
-public class TestSqlPatterns {
+public class TestSqlPatterns extends BaseTest {
   BufferAllocator allocator;
   DrillBuf drillBuf;
   CharsetEncoder charsetEncoder;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/registry/FunctionRegistryHolderTest.java
@@ -21,6 +21,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap
 import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
 import org.apache.drill.categories.SqlFunctionTest;
 import org.apache.drill.exec.expr.fn.DrillFuncHolder;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @Category(SqlFunctionTest.class)
-public class FunctionRegistryHolderTest {
+public class FunctionRegistryHolderTest extends BaseTest {
 
   private static final String built_in = "built-in";
   private static final String udf_jar = "DrillUDF-1.0.jar";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashPartitionTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashPartitionTest.java
@@ -46,6 +46,7 @@ import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.OperatorFixture;
 import org.apache.drill.exec.physical.rowSet.DirectRowSet;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -57,7 +58,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class HashPartitionTest {
+public class HashPartitionTest extends BaseTest {
   @Rule
   public final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashTableAllocationTrackerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/common/HashTableAllocationTrackerTest.java
@@ -18,12 +18,13 @@
 package org.apache.drill.exec.physical.impl.common;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.drill.exec.physical.impl.common.HashTable.BATCH_SIZE;
 
-public class HashTableAllocationTrackerTest {
+public class HashTableAllocationTrackerTest extends BaseTest {
   @Test
   public void testDoubleGetNextCall() {
     final HashTableConfig config = new HashTableConfig(100, true, .5f, Lists.newArrayList(), Lists.newArrayList(), Lists.newArrayList());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestBatchSizePredictorImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestBatchSizePredictorImpl.java
@@ -18,10 +18,11 @@
 package org.apache.drill.exec.physical.impl.join;
 
 import org.apache.drill.exec.vector.IntVector;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestBatchSizePredictorImpl {
+public class TestBatchSizePredictorImpl extends BaseTest {
   @Test
   public void testComputeMaxBatchSizeHash()
   {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestBuildSidePartitioningImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestBuildSidePartitioningImpl.java
@@ -20,10 +20,11 @@ package org.apache.drill.exec.physical.impl.join;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.common.map.CaseInsensitiveMap;
 import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestBuildSidePartitioningImpl {
+public class TestBuildSidePartitioningImpl extends BaseTest {
   @Test
   public void testSimpleReserveMemoryCalculationNoHashFirstCycle() {
     testSimpleReserveMemoryCalculationNoHashHelper(true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinHelperSizeCalculatorImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinHelperSizeCalculatorImpl.java
@@ -20,10 +20,11 @@ package org.apache.drill.exec.physical.impl.join;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestHashJoinHelperSizeCalculatorImpl {
+public class TestHashJoinHelperSizeCalculatorImpl extends BaseTest {
   @Test
   public void simpleCalculateSize() {
     final long intSize =

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinMemoryCalculator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashJoinMemoryCalculator.java
@@ -17,9 +17,10 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class TestHashJoinMemoryCalculator {
+public class TestHashJoinMemoryCalculator extends BaseTest {
   @Test // Make sure no exception is thrown
   public void testMakeDebugString()
   {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashTableSizeCalculatorConservativeImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashTableSizeCalculatorConservativeImpl.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.join;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.exec.record.RecordBatchSizer;
 import org.apache.drill.exec.vector.UInt4Vector;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * This is a test for the more conservative hash table memory calculator {@link HashTableSizeCalculatorConservativeImpl}.
  */
-public class TestHashTableSizeCalculatorConservativeImpl {
+public class TestHashTableSizeCalculatorConservativeImpl extends BaseTest {
   @Test
   public void testCalculateHashTableSize() {
     final int maxNumRecords = 40;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashTableSizeCalculatorLeanImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestHashTableSizeCalculatorLeanImpl.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.join;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.exec.record.RecordBatchSizer;
 import org.apache.drill.exec.vector.UInt4Vector;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * This is a test for the more accurate hash table memory calculator {@link HashTableSizeCalculatorLeanImpl}.
  */
-public class TestHashTableSizeCalculatorLeanImpl {
+public class TestHashTableSizeCalculatorLeanImpl extends BaseTest {
   @Test
   public void testCalculateHashTableSize() {
     final int maxNumRecords = 40;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestPartitionStat.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestPartitionStat.java
@@ -17,11 +17,12 @@
  */
 package org.apache.drill.exec.physical.impl.join;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestPartitionStat
-{
+public class TestPartitionStat extends BaseTest {
+
   @Test
   public void simpleAddBatchTest() {
     final PartitionStatImpl partitionStat = new PartitionStatImpl();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestPostBuildCalculationsImpl.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestPostBuildCalculationsImpl.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.join;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class TestPostBuildCalculationsImpl {
+public class TestPostBuildCalculationsImpl extends BaseTest {
   @Test
   public void testProbeTooBig() {
     final int minProbeRecordsPerBatch = 10;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/projSet/TestProjectionSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/projSet/TestProjectionSet.java
@@ -39,6 +39,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
 import org.apache.drill.exec.vector.accessor.convert.ConvertStringToInt;
 import org.apache.drill.exec.vector.accessor.convert.StandardConversions;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -57,7 +58,7 @@ import org.junit.experimental.categories.Category;
  */
 
 @Category(RowSetTests.class)
-public class TestProjectionSet {
+public class TestProjectionSet extends BaseTest {
 
   /**
    * Empty projection, no schema

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/svremover/AbstractGenericCopierTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/svremover/AbstractGenericCopierTest.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.record.BatchSchemaBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.OperatorFixture;
 import org.apache.drill.exec.physical.rowSet.DirectRowSet;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -38,7 +39,7 @@ import org.apache.drill.test.rowSet.RowSetComparison;
 import org.junit.Rule;
 import org.junit.Test;
 
-public abstract class AbstractGenericCopierTest {
+public abstract class AbstractGenericCopierTest extends BaseTest {
   @Rule
   public final BaseDirTestWatcher baseDirTestWatcher = new BaseDirTestWatcher();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedTuple.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedTuple.java
@@ -33,6 +33,7 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,7 +49,7 @@ import org.junit.experimental.categories.Category;
  */
 
 @Category(RowSetTests.class)
-public class TestProjectedTuple {
+public class TestProjectedTuple extends BaseTest {
 
   @Test
   public void testProjectionAll() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectionType.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectionType.java
@@ -24,11 +24,12 @@ import static org.junit.Assert.assertTrue;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(RowSetTests.class)
-public class TestProjectionType {
+public class TestProjectionType extends BaseTest {
 
   @Test
   public void testQueries() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/common/TestNumericEquiDepthHistogram.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/common/TestNumericEquiDepthHistogram.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.planner.common;
 import org.apache.drill.categories.PlannerTest;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.BoundType;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.Assert;
@@ -27,7 +28,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Range;
 
 
 @Category(PlannerTest.class)
-public class TestNumericEquiDepthHistogram {
+public class TestNumericEquiDepthHistogram extends BaseTest {
 
   @Test
   public void testHistogramWithUniqueEndpoints() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/fragment/TestHardAffinityFragmentParallelizer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/fragment/TestHardAffinityFragmentParallelizer.java
@@ -23,6 +23,7 @@ import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(PlannerTest.class)
-public class TestHardAffinityFragmentParallelizer {
+public class TestHardAffinityFragmentParallelizer extends BaseTest {
 
   // Create a set of test endpoints
   private static final DrillbitEndpoint N1_EP1 = newDrillbitEndpoint("node1", 30010);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/DrillOptiqTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/DrillOptiqTest.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.drill.categories.PlannerTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.planner.types.DrillRelDataTypeSystem;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,7 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 @Category(PlannerTest.class)
-public class DrillOptiqTest {
+public class DrillOptiqTest extends BaseTest {
 
   /* Method checks if we raise the appropriate error while dealing with RexNode that cannot be converted to
    * equivalent Drill expressions

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/FilterSplitTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/planner/logical/FilterSplitTest.java
@@ -31,9 +31,10 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class FilterSplitTest {
+public class FilterSplitTest extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FilterSplitTest.class);
 
   final JavaTypeFactory t = new JavaTypeFactoryImpl();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestMaterializedField.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestMaterializedField.java
@@ -23,12 +23,13 @@ import org.apache.drill.common.types.Types;
 
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(VectorTest.class)
-public class TestMaterializedField {
+public class TestMaterializedField extends BaseTest {
 
   private static final String PARENT_NAME = "parent";
   private static final String PARENT_SECOND_NAME = "parent2";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/TestSchemaProvider.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/metadata/schema/TestSchemaProvider.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.record.metadata.schema;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestSchemaProvider {
+public class TestSchemaProvider extends BaseTest {
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/TestResourcePoolTree.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/TestResourcePoolTree.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.resourcemgr.config.ResourcePoolTree;
 import org.apache.drill.exec.resourcemgr.config.ResourcePoolTreeImpl;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
 import org.apache.drill.exec.server.options.OptionValue;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestResourcePoolTree {
+public final class TestResourcePoolTree extends BaseTest {
 
   private static final Map<String, Object> poolTreeConfig = new HashMap<>();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectionpolicy/TestBestFitSelectionPolicy.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectionpolicy/TestBestFitSelectionPolicy.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.resourcemgr.config.QueryQueueConfig;
 import org.apache.drill.exec.resourcemgr.config.RMCommonDefaults;
 import org.apache.drill.exec.resourcemgr.config.ResourcePool;
 import org.apache.drill.exec.resourcemgr.config.exception.QueueSelectionException;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestBestFitSelectionPolicy {
+public final class TestBestFitSelectionPolicy extends BaseTest {
 
   private static QueueSelectionPolicy selectionPolicy;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectionpolicy/TestDefaultSelectionPolicy.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectionpolicy/TestDefaultSelectionPolicy.java
@@ -22,6 +22,7 @@ import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.resourcemgr.config.ResourcePool;
 import org.apache.drill.exec.resourcemgr.config.exception.QueueSelectionException;
+import org.apache.drill.test.BaseTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestDefaultSelectionPolicy {
+public final class TestDefaultSelectionPolicy extends BaseTest {
 
   private static QueueSelectionPolicy selectionPolicy;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestAclSelector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestAclSelector.java
@@ -22,6 +22,7 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.categories.ResourceManagerTest;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category(ResourceManagerTest.class)
-public final class TestAclSelector {
+public final class TestAclSelector extends BaseTest {
 
   private static final List<String> groupsValue = new ArrayList<>();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestComplexSelectors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestComplexSelectors.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
 import org.apache.drill.exec.server.options.OptionValue;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestComplexSelectors {
+public final class TestComplexSelectors extends BaseTest {
 
   private static final Map<String, String> tagSelectorConfig1 = new HashMap<>();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestNotEqualSelector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestNotEqualSelector.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
 import org.apache.drill.exec.server.options.OptionValue;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestNotEqualSelector {
+public final class TestNotEqualSelector extends BaseTest {
 
   private ResourcePoolSelector testCommonHelper(Map<String, ? extends Object> selectorValue) throws RMConfigException {
     Config testConfig = ConfigFactory.empty()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestResourcePoolSelectors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestResourcePoolSelectors.java
@@ -21,13 +21,14 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.drill.categories.ResourceManagerTest;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertTrue;
 
 @Category(ResourceManagerTest.class)
-public class TestResourcePoolSelectors {
+public class TestResourcePoolSelectors extends BaseTest {
 
   @Test
   public void testNullSelectorConfig() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestTagSelector.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/resourcemgr/config/selectors/TestTagSelector.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.resourcemgr.config.exception.RMConfigException;
 import org.apache.drill.exec.server.options.OptionValue;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(ResourceManagerTest.class)
-public final class TestTagSelector {
+public final class TestTagSelector extends BaseTest {
 
   private ResourcePoolSelector testCommonHelper(Object tagValue) throws RMConfigException {
     Config testConfig = ConfigFactory.empty()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/control/ConnectionManagerRegistryTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/control/ConnectionManagerRegistryTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.rpc.control;
 
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.test.BaseTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class ConnectionManagerRegistryTest {
+public class ConnectionManagerRegistryTest extends BaseTest {
 
   private static final DrillbitEndpoint localEndpoint = DrillbitEndpoint.newBuilder()
     .setAddress("10.0.0.1")

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/control/TestLocalControlConnectionManager.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/rpc/control/TestLocalControlConnectionManager.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.rpc.Acks;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.work.batch.ControlMessageHandler;
+import org.apache.drill.test.BaseTest;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -42,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestLocalControlConnectionManager {
+public class TestLocalControlConnectionManager extends BaseTest {
 
   private static final DrillbitEndpoint localEndpoint = DrillbitEndpoint.newBuilder()
     .setAddress("10.0.0.1")

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestFailureUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestFailureUtils.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.server;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ import java.io.IOException;
 
 import static org.apache.drill.exec.server.FailureUtils.DIRECT_MEMORY_OOM_MESSAGE;
 
-public class TestFailureUtils {
+public class TestFailureUtils extends BaseTest {
   @Test
   public void testIsDirectMemoryOOM() {
     Assert.assertTrue(FailureUtils.isDirectMemoryOOM(new OutOfMemoryException()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/OptionValueTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/OptionValueTest.java
@@ -17,10 +17,11 @@
  */
 package org.apache.drill.exec.server.options;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class OptionValueTest {
+public class OptionValueTest extends BaseTest {
   @Test
   public void createBooleanKindTest() {
     final OptionValue createdValue = OptionValue.create(

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/PersistedOptionValueTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/PersistedOptionValueTest.java
@@ -22,12 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.serialization.JacksonSerializer;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 
-public class PersistedOptionValueTest {
+public class PersistedOptionValueTest extends BaseTest {
   /**
    * DRILL-5809
    * Note: If this test breaks you are probably breaking backward and forward compatibility. Verify with the community

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/TestConfigLinkage.java
@@ -22,6 +22,7 @@ import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.sys.SystemTable;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertEquals;
  * */
 
 @Category({OptionsTest.class, SlowTest.class})
-public class TestConfigLinkage {
+public class TestConfigLinkage extends BaseTest {
   public static final String MOCK_PROPERTY = "mock.prop";
 
   @Rule

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/StatusResourcesTest.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.server.rest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.ClientFixture;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterFixtureBuilder;
@@ -31,7 +32,7 @@ import org.junit.Test;
 import static org.apache.drill.exec.server.options.TestConfigLinkage.MOCK_PROPERTY;
 import static org.apache.drill.exec.server.options.TestConfigLinkage.createMockPropOptionDefinition;
 
-public class StatusResourcesTest {
+public class StatusResourcesTest extends BaseTest {
   @Rule
   public final BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestMainLoginPageModel.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestMainLoginPageModel.java
@@ -24,6 +24,7 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.rest.LogInLogOutResources.MainLoginPageModel;
 import org.apache.drill.exec.work.WorkManager;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test for {@link LogInLogOutResources.MainLoginPageModel} with various configurations done in DrillConfig
  */
-public class TestMainLoginPageModel {
+public class TestMainLoginPageModel extends BaseTest {
 
   @Mock
   WorkManager workManager;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/WebSessionResourcesTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/WebSessionResourcesTest.java
@@ -25,6 +25,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.rpc.TransportCheck;
 import org.apache.drill.exec.rpc.user.UserSession;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import java.net.SocketAddress;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.verify;
  * Validates {@link WebSessionResources} close works as expected w.r.t {@link io.netty.channel.AbstractChannel.CloseFuture}
  * associated with it.
  */
-public class WebSessionResourcesTest {
+public class WebSessionResourcesTest extends BaseTest {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WebSessionResourcesTest.class);
 
   private WebSessionResources webSessionResources;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -30,6 +30,7 @@ import org.apache.drill.exec.server.rest.WebServerConstants;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoAuthenticator;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoLoginService;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
@@ -68,7 +69,7 @@ import static org.mockito.Mockito.verify;
  */
 @Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
-public class TestDrillSpnegoAuthenticator {
+public class TestDrillSpnegoAuthenticator extends BaseTest {
 
   private static KerberosHelper spnegoHelper;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoAuthentication.java
@@ -35,6 +35,7 @@ import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.auth.DrillHttpSecurityHandlerProvider;
 import org.apache.drill.exec.server.rest.auth.DrillSpnegoLoginService;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
 import org.apache.kerby.kerberos.kerb.client.JaasKrbUtil;
@@ -65,7 +66,7 @@ import static org.junit.Assert.assertTrue;
  */
 @Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
-public class TestSpnegoAuthentication {
+public class TestSpnegoAuthentication extends BaseTest {
 
   private static KerberosHelper spnegoHelper;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestSpnegoConfig.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.rpc.security.KerberosHelper;
 import org.apache.drill.exec.rpc.user.security.testing.UserAuthenticatorTestImpl;
 import org.apache.drill.exec.server.rest.auth.SpnegoConfig;
 import org.apache.drill.test.BaseDirTestWatcher;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertTrue;
  */
 @Ignore("See DRILL-5387")
 @Category(SecurityTest.class)
-public class TestSpnegoConfig {
+public class TestSpnegoConfig extends BaseTest {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSpnegoConfig.class);
 
   private static KerberosHelper spnegoHelper;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestSqlBracketlessSyntax.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestSqlBracketlessSyntax.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.planner.sql.DrillConvertletTable;
 import org.apache.drill.exec.planner.sql.parser.CompoundIdentifierConverter;
 import org.apache.drill.exec.planner.sql.parser.impl.DrillParserImpl;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.DrillAssert;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -35,7 +36,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(SqlTest.class)
-public class TestSqlBracketlessSyntax {
+public class TestSqlBracketlessSyntax extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestSqlBracketlessSyntax.class);
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/StorageStrategyTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/StorageStrategyTest.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.drill.exec.ExecTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class StorageStrategyTest {
+public class StorageStrategyTest extends BaseTest {
   private static final FsPermission FULL_PERMISSION = FsPermission.getDirDefault();
   private static final StorageStrategy PERSISTENT_STRATEGY = new StorageStrategy("002", false);
   private static final StorageStrategy TEMPORARY_STRATEGY = new StorageStrategy("077", true);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
@@ -32,6 +32,7 @@ import org.apache.drill.exec.store.TestOutputMutator;
 import org.apache.drill.exec.vector.complex.impl.SingleMapReaderImpl;
 import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.test.BaseTest;
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
 import org.bson.BsonBoolean;
@@ -52,7 +53,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TestBsonRecordReader {
+public class TestBsonRecordReader extends BaseTest {
   private BufferAllocator allocator;
   private VectorContainerWriter writer;
   private TestOutputMutator mutator;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestDrillFileSystem.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestDrillFileSystem.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.dfs;
 import org.apache.drill.exec.ops.OpProfileDef;
 import org.apache.drill.exec.ops.OperatorStats;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,7 +34,7 @@ import java.io.PrintWriter;
 
 import static org.junit.Assert.assertTrue;
 
-public class TestDrillFileSystem {
+public class TestDrillFileSystem extends BaseTest {
 
   private static String tempFilePath;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestFormatPluginOptionExtractor.java
@@ -23,6 +23,7 @@ import org.apache.drill.common.scanner.RunTimeScan;
 import org.apache.drill.common.scanner.persistence.ScanResult;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
 import org.apache.drill.exec.store.image.ImageFormatConfig;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -31,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 
-public class TestFormatPluginOptionExtractor {
+public class TestFormatPluginOptionExtractor extends BaseTest {
 
   @Test
   public void test() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestComplexColumnInSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestComplexColumnInSchema.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.parquet;
 import org.apache.drill.categories.ParquetTest;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -40,7 +41,7 @@ import java.io.IOException;
  * This test checks correctness of complex column detection in the Parquet file schema.
  */
 @Category({ParquetTest.class, UnlikelyTest.class})
-public class TestComplexColumnInSchema {
+public class TestComplexColumnInSchema extends BaseTest {
 
   /*
   Parquet schema:

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataVersion.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetMetadataVersion.java
@@ -21,6 +21,7 @@ import org.apache.drill.categories.ParquetTest;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.exec.store.parquet.metadata.MetadataVersion;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -28,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({ParquetTest.class, UnlikelyTest.class})
-public class TestParquetMetadataVersion {
+public class TestParquetMetadataVersion extends BaseTest {
 
   @Test
   public void testFirstLetter() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderConfig.java
@@ -23,6 +23,7 @@ import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.options.SystemOptionManager;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.ParquetReadOptions;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @Category({ParquetTest.class, UnlikelyTest.class})
-public class TestParquetReaderConfig {
+public class TestParquetReaderConfig extends BaseTest {
 
   @Test
   public void testDefaultsDeserialization() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderUtility.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetReaderUtility.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.parquet;
 
 import org.apache.drill.categories.ParquetTest;
 import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
@@ -38,7 +39,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @Category({ParquetTest.class, UnlikelyTest.class})
-public class TestParquetReaderUtility {
+public class TestParquetReaderUtility extends BaseTest {
 
   private static final String path = "src/test/resources/store/parquet/complex/complex.parquet";
   private static ParquetMetadata footer;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/store/TestAssignment.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/store/TestAssignment.java
@@ -26,6 +26,7 @@ import org.apache.drill.exec.store.schedule.AssignmentCreator;
 import org.apache.drill.exec.store.schedule.CompleteFileWork;
 import org.apache.drill.exec.store.schedule.EndpointByteMap;
 import org.apache.drill.exec.store.schedule.EndpointByteMapImpl;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -36,7 +37,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class TestAssignment {
+public class TestAssignment extends BaseTest {
 
   private static final long FILE_SIZE = 1000;
   private static List<DrillbitEndpoint> endpoints;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/test/Drill2130JavaExecHamcrestConfigurationTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/test/Drill2130JavaExecHamcrestConfigurationTest.java
@@ -21,10 +21,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 
-public class Drill2130JavaExecHamcrestConfigurationTest {
+public class Drill2130JavaExecHamcrestConfigurationTest extends BaseTest {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory
       .getLogger(Drill2130JavaExecHamcrestConfigurationTest.class);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/DrillExceptionUtilTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/DrillExceptionUtilTest.java
@@ -22,11 +22,12 @@ import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.ErrorHelper;
 import org.apache.drill.common.util.DrillExceptionUtil;
 import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class DrillExceptionUtilTest {
+public class DrillExceptionUtilTest extends BaseTest {
   private static final String ERROR_MESSAGE = "Exception Test";
   private static final String NESTED_ERROR_MESSAGE = "Nested Exception";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/FileSystemUtilTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/FileSystemUtilTestBase.java
@@ -21,6 +21,7 @@ import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.drill.exec.ExecTest;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.BeforeClass;
@@ -33,7 +34,7 @@ import java.util.Arrays;
  * Base test class for file system util classes that will during test initialization
  * setup file system connection and create directories and files needed for unit tests.
  */
-public class FileSystemUtilTestBase {
+public class FileSystemUtilTestBase extends BaseTest {
 
   /*
     Directory and file structure created during test initialization:

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestApproximateStringMatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestApproximateStringMatcher.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.util;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestApproximateStringMatcher {
+public class TestApproximateStringMatcher extends BaseTest {
     @Test
     public void testStringMatcher() {
         List<String> names = new ArrayList<>();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestArrayWrappedIntIntMap.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestArrayWrappedIntIntMap.java
@@ -17,11 +17,12 @@
  */
 package org.apache.drill.exec.util;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestArrayWrappedIntIntMap {
+public class TestArrayWrappedIntIntMap extends BaseTest {
   @Test
   public void testSimple() {
     ArrayWrappedIntIntMap map = new ArrayWrappedIntIntMap();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestValueVectorElementFormatter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/TestValueVectorElementFormatter.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.util;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
-public class TestValueVectorElementFormatter {
+public class TestValueVectorElementFormatter extends BaseTest {
 
   @Mock
   private OptionManager options;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/TestSplitAndTransfer.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TransferPair;
 import org.apache.drill.exec.vector.NullableVarCharVector.Accessor;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 
 
-public class TestSplitAndTransfer {
+public class TestSplitAndTransfer extends BaseTest {
   @Test
   public void test() throws Exception {
     final DrillConfig drillConfig = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/GenericAccessorTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/GenericAccessorTest.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.vector.accessor;
 import org.apache.drill.categories.VectorTest;
 import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(VectorTest.class)
-public class GenericAccessorTest {
+public class GenericAccessorTest extends BaseTest {
 
   public static final Object NON_NULL_VALUE = "Non-null value";
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/TestTimePrintMillis.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/accessor/TestTimePrintMillis.java
@@ -18,10 +18,11 @@
 package org.apache.drill.exec.vector.accessor;
 
 import org.apache.drill.exec.vector.accessor.sql.TimePrintMillis;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestTimePrintMillis {
+public class TestTimePrintMillis extends BaseTest {
 
   @Test
   public void testPrintingMillis() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestPromotableWriter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestPromotableWriter.java
@@ -25,9 +25,10 @@ import org.apache.drill.exec.util.BatchPrinter;
 import org.apache.drill.exec.vector.complex.impl.VectorContainerWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ComplexWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
-public class TestPromotableWriter {
+public class TestPromotableWriter extends BaseTest {
 
   @Test
   public void list() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestRepeated.java
@@ -31,6 +31,7 @@ import org.apache.drill.exec.vector.complex.impl.ComplexWriterImpl;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +39,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class TestRepeated {
+public class TestRepeated extends BaseTest {
   // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestRepeated.class);
 
   private static final DrillConfig drillConfig = DrillConfig.create();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
@@ -42,11 +42,12 @@ import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.vector.VarCharVector;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.Iterator;
 
-public class BloomFilterTest {
+public class BloomFilterTest extends BaseTest {
   public static DrillConfig c = DrillConfig.create();
 
   class TestRecordBatch implements RecordBatch {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/fragment/FragmentStatusReporterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/fragment/FragmentStatusReporterTest.java
@@ -26,6 +26,7 @@ import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.proto.UserBitShared.FragmentState;
 import org.apache.drill.exec.rpc.control.ControlTunnel;
 import org.apache.drill.exec.rpc.control.Controller;
+import org.apache.drill.test.BaseTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class FragmentStatusReporterTest {
+public class FragmentStatusReporterTest extends BaseTest {
 
   private FragmentStatusReporter statusReporter;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ExampleTest.java
@@ -66,7 +66,7 @@ import ch.qos.logback.classic.Level;
 // real test.
 
 @Ignore
-public class ExampleTest {
+public class ExampleTest extends BaseTest {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExampleTest.class);
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestRowSetComparison.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/test/TestRowSetComparison.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.test.rowSet.RowSetComparison;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(RowSetTests.class)
-public class TestRowSetComparison {
+public class TestRowSetComparison extends BaseTest {
   private BufferAllocator allocator;
 
   @Before

--- a/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
+++ b/exec/jdbc-all/src/test/java/org/apache/drill/jdbc/ITTestShadedJar.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.jdbc;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -44,7 +45,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class ITTestShadedJar {
+public class ITTestShadedJar extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ITTestShadedJar.class);
 
   private static DrillbitClassLoader drillbitLoader;

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionTransactionMethodsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/ConnectionTransactionMethodsTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import java.sql.SQLException;
  * methods.
  */
 @Category(JdbcTest.class)
-public class ConnectionTransactionMethodsTest {
+public class ConnectionTransactionMethodsTest extends BaseTest {
 
   private static Connection connection;
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DatabaseMetaDataTest.java
@@ -34,6 +34,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import org.junit.experimental.categories.Category;
  * {@link DatabaseMetaDataGetColumnsTest})).
  */
 @Category(JdbcTest.class)
-public class DatabaseMetaDataTest {
+public class DatabaseMetaDataTest extends BaseTest {
 
   protected static Connection connection;
   protected static DatabaseMetaData dbmd;

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/DrillColumnMetaDataListTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/DrillColumnMetaDataListTest.java
@@ -37,6 +37,7 @@ import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.jdbc.impl.DrillColumnMetaDataList;
 import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +47,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @Category(JdbcTest.class)
-public class DrillColumnMetaDataListTest {
+public class DrillColumnMetaDataListTest extends BaseTest {
 
   private DrillColumnMetaDataList emptyList;
 

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/impl/TypeConvertingSqlAccessorTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/impl/TypeConvertingSqlAccessorTest.java
@@ -25,6 +25,7 @@ import org.apache.drill.exec.vector.accessor.InvalidAccessException;
 import org.apache.drill.exec.vector.accessor.SqlAccessor;
 import org.apache.drill.jdbc.SQLConversionOverflowException;
 import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,7 +40,7 @@ import static org.junit.Assert.assertThat;
  * (Also see {@link org.apache.drill.jdbc.ResultSetGetMethodConversionsTest}.
  */
 @Category(JdbcTest.class)
-public class TypeConvertingSqlAccessorTest {
+public class TypeConvertingSqlAccessorTest extends BaseTest {
 
   /**
    * Base test stub(?) for accessors underlying TypeConvertingSqlAccessor.

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2130JavaJdbcHamcrestConfigurationTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2130JavaJdbcHamcrestConfigurationTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.jdbc.test;
 
 import org.apache.drill.categories.JdbcTest;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -26,7 +27,7 @@ import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @Category(JdbcTest.class)
-public class Drill2130JavaJdbcHamcrestConfigurationTest {
+public class Drill2130JavaJdbcHamcrestConfigurationTest extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Drill2130JavaJdbcHamcrestConfigurationTest.class);
 
   @SuppressWarnings("unused")

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2288GetColumnsMetadataWhenNoRowsTest.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/Drill2288GetColumnsMetadataWhenNoRowsTest.java
@@ -31,6 +31,7 @@ import java.sql.Statement;
 import org.apache.drill.jdbc.Driver;
 import org.apache.drill.categories.JdbcTest;
 import org.apache.drill.jdbc.JdbcTestBase;
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import org.junit.experimental.categories.Category;
  * scan yielded an empty (zero-row) result set.
  */
 @Category(JdbcTest.class)
-public class Drill2288GetColumnsMetadataWhenNoRowsTest {
+public class Drill2288GetColumnsMetadataWhenNoRowsTest extends BaseTest {
   private static Connection connection;
 
   @BeforeClass

--- a/exec/memory/base/src/test/java/org/apache/drill/exec/memory/BoundsCheckingTest.java
+++ b/exec/memory/base/src/test/java/org/apache/drill/exec/memory/BoundsCheckingTest.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.memory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -31,8 +32,7 @@ import io.netty.util.IllegalReferenceCountException;
 
 import static org.junit.Assert.fail;
 
-public class BoundsCheckingTest
-{
+public class BoundsCheckingTest extends BaseTest {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BoundsCheckingTest.class);
 
   private static boolean old;

--- a/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestAccountant.java
+++ b/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestAccountant.java
@@ -21,12 +21,13 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.drill.categories.MemoryTest;
 import org.apache.drill.exec.memory.Accountant.AllocationOutcome;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(MemoryTest.class)
-public class TestAccountant {
+public class TestAccountant extends BaseTest {
 
   @Test
   public void basic() {

--- a/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestBaseAllocator.java
+++ b/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestBaseAllocator.java
@@ -27,12 +27,13 @@ import io.netty.buffer.DrillBuf.TransferResult;
 
 import org.apache.drill.categories.MemoryTest;
 import org.apache.drill.exec.exception.OutOfMemoryException;
+import org.apache.drill.test.BaseTest;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(MemoryTest.class)
-public class TestBaseAllocator {
+public class TestBaseAllocator extends BaseTest {
   // private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestBaseAllocator.class);
 
   private final static int MAX_ALLOCATION = 8 * 1024;

--- a/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestEndianess.java
+++ b/exec/memory/base/src/test/java/org/apache/drill/exec/memory/TestEndianess.java
@@ -23,11 +23,12 @@ import io.netty.buffer.ByteBuf;
 import org.apache.drill.categories.MemoryTest;
 import org.apache.drill.common.DrillAutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(MemoryTest.class)
-public class TestEndianess {
+public class TestEndianess extends BaseTest {
 
   @Test
   public void testLittleEndian() {

--- a/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/TestMetadataProperties.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/TestMetadataProperties.java
@@ -30,11 +30,12 @@ import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.expr.BasicTypeHelper;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(RowSetTests.class)
-public class TestMetadataProperties {
+public class TestMetadataProperties extends BaseTest {
 
   @Test
   public void testBasics() {

--- a/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestParserErrorHandling.java
@@ -17,13 +17,14 @@
  */
 package org.apache.drill.exec.record.metadata.schema.parser;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
-public class TestParserErrorHandling {
+public class TestParserErrorHandling extends BaseTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();

--- a/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestSchemaParser.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestSchemaParser.java
@@ -21,6 +21,7 @@ import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.BaseTest;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TestSchemaParser {
+public class TestSchemaParser extends BaseTest {
 
   @Test
   public void checkQuotedIdWithEscapes() throws Exception {

--- a/exec/vector/src/test/java/org/apache/drill/exec/vector/VariableLengthVectorTest.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/vector/VariableLengthVectorTest.java
@@ -21,14 +21,14 @@ import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.memory.RootAllocator;
 import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * This test uses {@link VarCharVector} to test the template code in VariableLengthVector.
  */
-public class VariableLengthVectorTest
-{
+public class VariableLengthVectorTest extends BaseTest {
   /**
    * If the vector contains 1000 records, setting a value count of 1000 should work.
    */

--- a/exec/vector/src/test/java/org/apache/drill/exec/vector/VectorTest.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/vector/VectorTest.java
@@ -34,13 +34,14 @@ import org.apache.drill.exec.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.drill.exec.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.drill.exec.vector.complex.writer.FieldWriter;
 import org.apache.drill.exec.vector.complex.writer.IntWriter;
+import org.apache.drill.test.BaseTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.netty.buffer.DrillBuf;
 
-public class VectorTest {
+public class VectorTest extends BaseTest {
 
   private static RootAllocator allocator;
 

--- a/logical/src/test/java/org/apache/drill/common/expression/SchemaPathTest.java
+++ b/logical/src/test/java/org/apache/drill/common/expression/SchemaPathTest.java
@@ -17,11 +17,12 @@
  */
 package org.apache.drill.common.expression;
 
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class SchemaPathTest {
+public class SchemaPathTest extends BaseTest {
 
   @Test
   public void testUnIndexedWithOutArray() {

--- a/logical/src/test/java/org/apache/drill/common/expression/fn/JodaDateValidatorTest.java
+++ b/logical/src/test/java/org/apache/drill/common/expression/fn/JodaDateValidatorTest.java
@@ -18,6 +18,7 @@
 package org.apache.drill.common.expression.fn;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+import org.apache.drill.test.BaseTest;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
@@ -30,7 +31,7 @@ import static org.apache.drill.common.expression.fn.JodaDateValidator.toJodaForm
 import static org.joda.time.DateTime.parse;
 import static org.joda.time.format.DateTimeFormat.forPattern;
 
-public class JodaDateValidatorTest {
+public class JodaDateValidatorTest extends BaseTest {
 
   private static final Map<String, String> TEST_CASES = Maps.newHashMap();
 

--- a/logical/src/test/java/org/apache/drill/common/logical/data/OrderTest.java
+++ b/logical/src/test/java/org/apache/drill/common/logical/data/OrderTest.java
@@ -25,11 +25,12 @@ import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class OrderTest {
+public class OrderTest extends BaseTest {
 
   //////////
   // Order.Ordering tests:

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/IcebergBaseTest.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/IcebergBaseTest.java
@@ -21,12 +21,11 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.categories.MetastoreTest;
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.util.GuavaPatcher;
 import org.apache.drill.metastore.iceberg.config.IcebergConfigConstants;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
@@ -36,19 +35,13 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 
 @Category(MetastoreTest.class)
-public abstract class IcebergBaseTest {
+public abstract class IcebergBaseTest extends BaseTest {
 
   @ClassRule
   public static TemporaryFolder defaultFolder = new TemporaryFolder();
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-
-  @BeforeClass
-  public static void setup() {
-    // patches Guava Preconditions class with missing methods
-    GuavaPatcher.patch();
-  }
 
   /**
    * Creates Hadoop configuration and sets local file system as default.

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
@@ -20,6 +20,7 @@ package org.apache.drill.metastore.components.tables;
 import org.apache.drill.categories.MetastoreTest;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Category(MetastoreTest.class)
-public class TestBasicTablesRequests {
+public class TestBasicTablesRequests extends BaseTest {
 
   @Test
   public void testRequestMetadataWithoutRequestColumns() {

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesTransformer.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesTransformer.java
@@ -25,6 +25,7 @@ import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.drill.metastore.metadata.PartitionMetadata;
 import org.apache.drill.metastore.metadata.RowGroupMetadata;
 import org.apache.drill.metastore.metadata.SegmentMetadata;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(MetastoreTest.class)
-public class TestBasicTablesTransformer {
+public class TestBasicTablesTransformer extends BaseTest {
 
   @Test
   public void testTables() {

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestMetastoreTableInfo.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestMetastoreTableInfo.java
@@ -19,6 +19,7 @@ package org.apache.drill.metastore.components.tables;
 
 import org.apache.drill.categories.MetastoreTest;
 import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -26,7 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category(MetastoreTest.class)
-public class TestMetastoreTableInfo {
+public class TestMetastoreTableInfo extends BaseTest {
 
   @Test
   public void testAbsentTable() {

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestTableMetadataUnitConversion.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestTableMetadataUnitConversion.java
@@ -34,6 +34,7 @@ import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.drill.metastore.statistics.ColumnStatistics;
 import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
 import org.apache.drill.metastore.statistics.StatisticsHolder;
+import org.apache.drill.test.BaseTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -53,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @Category(MetastoreTest.class)
-public class TestTableMetadataUnitConversion {
+public class TestTableMetadataUnitConversion extends BaseTest {
 
   private static Data data;
 

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/metadata/MetadataSerDeTest.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/metadata/MetadataSerDeTest.java
@@ -24,6 +24,7 @@ import org.apache.drill.metastore.statistics.ColumnStatistics;
 import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
 import org.apache.drill.metastore.statistics.StatisticsHolder;
 import org.apache.drill.metastore.statistics.TableStatisticsKind;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(MetastoreTest.class)
-public class MetadataSerDeTest {
+public class MetadataSerDeTest extends BaseTest {
 
   @Test
   public void testStatisticsHolderSerialization() {

--- a/pom.xml
+++ b/pom.xml
@@ -753,26 +753,7 @@
               <goals>
                 <goal>test</goal>
               </goals>
-            <!-- TODO: Remove excludedGroups after DRILL-7393 is fixed. -->
-            <configuration>
-              <excludedGroups>org.apache.drill.categories.MetastoreTest,${excludedGroups}</excludedGroups>
-            </configuration>
           </execution>
-          <!--
-              All Metastore tests must run in separate a JVM to ensure
-              that Guava Preconditions class is patched before execution.
-              TODO: Remove execution block for metastore-test after DRILL-7393 is fixed.
-          -->
-            <execution>
-              <id>metastore-test</id>
-              <phase>test</phase>
-              <goals>
-                <goal>test</goal>
-              </goals>
-              <configuration>
-                <groups>org.apache.drill.categories.MetastoreTest</groups>
-              </configuration>
-            </execution>
           </executions>
           <dependencies>
             <dependency>


### PR DESCRIPTION
…efore any test run

- Added BaseTest with patchers and extended all tests from it.
- Added a test to java-exec module to ensure that all tests there are inherited from BaseTest.
- Revised exception handling in the patchers, now it's individual for each patching method.

JIRA: [DRILL-7393](https://issues.apache.org/jira/browse/DRILL-7393)