### PR TITLE
DRILL-6953: EVF-based version of the JSON reader

### DIFF
--- a/common/src/main/java/org/apache/drill/common/project/ProjectionType.java
+++ b/common/src/main/java/org/apache/drill/common/project/ProjectionType.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.physical.resultSet.project;
+package org.apache.drill.common.project;
 
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -415,14 +415,20 @@ public final class ExecConstants {
   public static final OptionValidator PARQUET_COMPLEX_BATCH_NUM_RECORDS_VALIDATOR = new RangeLongValidator(PARQUET_COMPLEX_BATCH_NUM_RECORDS, 1, ValueVector.MAX_ROW_COUNT -1,
       new OptionDescription("Complex Parquet Reader maximum number of records per batch."));
 
+  public static final String ENABLE_V2_JSON_READER_KEY = "store.json.enable_v2_reader";
+  public static final BooleanValidator ENABLE_V2_JSON_READER_VALIDATOR = new BooleanValidator(ENABLE_V2_JSON_READER_KEY,
+      new OptionDescription("Enable the experimental \"version 2\" JSON reader."));
   public static final String JSON_ALL_TEXT_MODE = "store.json.all_text_mode";
   public static final BooleanValidator JSON_READER_ALL_TEXT_MODE_VALIDATOR = new BooleanValidator(JSON_ALL_TEXT_MODE,
       new OptionDescription("Drill reads all data from the JSON files as VARCHAR. Prevents schema change errors."));
-  public static final BooleanValidator JSON_EXTENDED_TYPES = new BooleanValidator("store.json.extended_types",
+  public static final String JSON_EXTENDED_TYPES_KEY = "store.json.extended_types";
+  public static final BooleanValidator JSON_EXTENDED_TYPES = new BooleanValidator(JSON_EXTENDED_TYPES_KEY,
       new OptionDescription("Turns on special JSON structures that Drill serializes for storing more type information than the four basic JSON types."));
-  public static final BooleanValidator JSON_WRITER_UGLIFY = new BooleanValidator("store.json.writer.uglify",
+  public static final String JSON_WRITER_UGLIFY_KEY = "store.json.writer.uglify";
+  public static final BooleanValidator JSON_WRITER_UGLIFY = new BooleanValidator(JSON_WRITER_UGLIFY_KEY,
       new OptionDescription("Enables Drill to return compact JSON output files; Drill does not separate records. Default is false. (Drill 1.4+)"));
-  public static final BooleanValidator JSON_WRITER_SKIPNULLFIELDS = new BooleanValidator("store.json.writer.skip_null_fields",
+  public static final String JSON_WRITER_SKIPNULLFIELDS_KEY = "store.json.writer.skip_null_fields";
+  public static final BooleanValidator JSON_WRITER_SKIPNULLFIELDS = new BooleanValidator(JSON_WRITER_SKIPNULLFIELDS_KEY,
       new OptionDescription("Enables Drill to skip extraneous NULL fields in JSON output files when executing the CTAS statement. Default is true. (Drill 1.6+)"));
   public static final String JSON_READER_SKIP_INVALID_RECORDS_FLAG = "store.json.reader.skip_invalid_records";
   public static final BooleanValidator JSON_SKIP_MALFORMED_RECORDS_VALIDATOR = new BooleanValidator(JSON_READER_SKIP_INVALID_RECORDS_FLAG,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
@@ -47,9 +47,9 @@ public class OperatorStats {
   private long[] schemaCountByInput;
 
 
-  private boolean inProcessing = false;
-  private boolean inSetup = false;
-  private boolean inWait = false;
+  private boolean inProcessing;
+  private boolean inSetup;
+  private boolean inWait;
 
   protected long processingNanos;
   protected long setupNanos;
@@ -185,7 +185,7 @@ public class OperatorStats {
   public synchronized void batchReceived(int inputIndex, long records, boolean newSchema) {
     recordsReceivedByInput[inputIndex] += records;
     batchesReceivedByInput[inputIndex]++;
-    if(newSchema){
+    if (newSchema) {
       schemaCountByInput[inputIndex]++;
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/VectorContainerAccessor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/VectorContainerAccessor.java
@@ -34,6 +34,14 @@ import org.apache.drill.exec.record.selection.SelectionVector4;
  * Wraps a vector container and optional selection vector in an interface
  * simpler than the entire {@link RecordBatch}. This implementation hosts
  * a container only.
+ * <p>
+ * Separates the idea of a batch schema and data batch. The accessor
+ * can identify a schema even if it has no batches. This occurs for
+ * readers that can identify the schema, but produce no actual data.
+ * <p>
+ * This version is designed for the the scan operator which will
+ * produce a series of different vector containers (which, oddly, must
+ * all contain the same vectors.)
  */
 
 public class VectorContainerAccessor implements BatchAccessor {
@@ -69,7 +77,9 @@ public class VectorContainerAccessor implements BatchAccessor {
 
   public void addBatch(VectorContainer container) {
     setSchema(container);
-    batchCount++;
+    if (container != null) {
+      batchCount++;
+    }
   }
 
   public int batchCount() { return batchCount; }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/AbstractReadColProj.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/AbstractReadColProj.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet.ColumnReadProjection;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
 
@@ -40,7 +40,7 @@ public abstract class AbstractReadColProj implements ColumnReadProjection {
   public ColumnConversionFactory conversionFactory() { return null; }
 
   @Override
-  public ColumnMetadata providedSchema() { return readSchema; }
+  public ColumnMetadata outputSchema() { return readSchema; }
 
   @Override
   public ProjectionSet mapProjection() { return ProjectionSetFactory.projectAll(); }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/EmptyProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/EmptyProjectionSet.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
 import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 
@@ -45,4 +46,9 @@ public class EmptyProjectionSet implements ProjectionSet {
 
   @Override
   public boolean isEmpty() { return true; }
+
+  @Override
+  public ProjectionType projectionType(String colName) {
+    return ProjectionType.UNPROJECTED;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
@@ -18,10 +18,14 @@
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
+<<<<<<< HEAD
 import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedColumnImpl;
+=======
+>>>>>>> DRILL-6953: EVF-based version of the JSON reader
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;
@@ -137,4 +141,9 @@ public class ExplicitProjectionSet extends AbstractProjectionSet {
 
   @Override
   public boolean isEmpty() { return requestedProj.projections().isEmpty(); }
+
+  @Override
+  public ProjectionType projectionType(String colName) {
+    return requestedProj.projectionType(colName);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ExplicitProjectionSet.java
@@ -21,11 +21,7 @@ import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
-<<<<<<< HEAD
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedColumnImpl;
-=======
->>>>>>> DRILL-6953: EVF-based version of the JSON reader
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ProjectedDictColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ProjectedDictColumn.java
@@ -17,8 +17,8 @@
  */
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ProjectedReadColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/ProjectedReadColumn.java
@@ -17,8 +17,8 @@
  */
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
@@ -58,7 +58,7 @@ public class ProjectedReadColumn extends AbstractReadColProj {
   }
 
   @Override
-  public ColumnMetadata providedSchema() {
+  public ColumnMetadata outputSchema() {
     return outputSchema == null ? readSchema : outputSchema;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/WildcardProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/projSet/WildcardProjectionSet.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.physical.impl.scan.project.projSet;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
 
@@ -64,4 +65,14 @@ public class WildcardProjectionSet extends AbstractProjectionSet {
 
   @Override
   public boolean isEmpty() { return false; }
+
+  @Override
+  public ProjectionType projectionType(String colName) {
+    ColumnMetadata colSchema = providedSchema == null ? null :
+      providedSchema.metadata(colName);
+    if (colSchema == null || isSpecial(colSchema)) {
+      return isStrict ? ProjectionType.UNPROJECTED : ProjectionType.GENERAL;
+    }
+    return ProjectionType.GENERAL;
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.physical.impl.validate;
 
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.SimpleVectorWrapper;
 import org.apache.drill.exec.record.VectorAccessible;
@@ -245,6 +246,11 @@ public class BatchValidator {
     ErrorReporter reporter = errorReporter(batch);
     new BatchValidator(reporter).validateBatch(batch, batch.getRecordCount());
     return reporter.errorCount() == 0;
+  }
+
+
+  public static void validate(RowSet rowSet) {
+    validate(rowSet.container());
   }
 
   private static ErrorReporter errorReporter(VectorAccessible batch) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ProjectionSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ProjectionSet.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.physical.resultSet;
 
 import org.apache.drill.common.exceptions.CustomErrorContext;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.vector.accessor.convert.ColumnConversionFactory;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
@@ -87,7 +87,7 @@ public interface ProjectionSet {
     boolean isProjected();
 
     ColumnMetadata readSchema();
-    ColumnMetadata providedSchema();
+    ColumnMetadata outputSchema();
     ColumnConversionFactory conversionFactory();
     ProjectionSet mapProjection();
 
@@ -104,4 +104,17 @@ public interface ProjectionSet {
   ColumnReadProjection readProjection(ColumnMetadata col);
   ColumnReadProjection readDictProjection(ColumnMetadata col);
   boolean isEmpty();
+
+  /**
+   * Allows a reader to "sniff" the projection type for a column before
+   * actually creating the column. For example, JSON uses this so that
+   * it can create a "dummy" parser if a column is not projected. Doing
+   * so avoids having to create an actual column which, in JSON, could
+   * lead to schema conflicts, even if the column itself is unprojected.
+   * (A scalar column would conflict with a map, say.)
+   *
+   * @param colName name of a column within the tuple
+   * @return the type of projection, if any
+   */
+  ProjectionType projectionType(String colName);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
@@ -108,7 +108,7 @@ public class ColumnBuilder {
     } else {
       colProj = parent.projectionSet().readProjection(columnSchema);
     }
-    switch (colProj.providedSchema().structureType()) {
+    switch (colProj.outputSchema().structureType()) {
     case DICT:
       return buildDict(parent, colProj);
     case TUPLE:
@@ -141,7 +141,7 @@ public class ColumnBuilder {
    */
 
   private ColumnState buildPrimitive(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     ValueVector vector;
     if (!colProj.isProjected() && !allowCreation(parent)) {
@@ -216,7 +216,7 @@ public class ColumnBuilder {
    */
 
   private ColumnState buildMap(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // When dynamically adding columns, must add the (empty)
     // map by itself, then add columns to the map via separate
@@ -235,7 +235,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildSingleMap(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     MapVector vector;
     VectorState vectorState;
@@ -260,7 +260,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildMapArray(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // Create the map's offset vector.
 
@@ -331,7 +331,7 @@ public class ColumnBuilder {
    * @return column
    */
   private ColumnState buildUnion(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
     assert columnSchema.isVariant() && ! columnSchema.isArray();
 
     // Create the union vector.
@@ -366,7 +366,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildList(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // If the list has declared a single type, and has indicated that this
     // is the only type expected, then build the list as a nullable array
@@ -400,7 +400,7 @@ public class ColumnBuilder {
    */
 
   private ColumnState buildSimpleList(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // The variant must have the one and only type.
 
@@ -459,7 +459,7 @@ public class ColumnBuilder {
    */
 
   private ColumnState buildUnionList(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // The variant must start out empty.
 
@@ -507,7 +507,7 @@ public class ColumnBuilder {
 
   private ColumnState buildRepeatedList(ContainerState parent,
       ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     assert columnSchema.type() == MinorType.LIST;
     assert columnSchema.mode() == DataMode.REPEATED;
@@ -561,7 +561,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildDict(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // When dynamically adding columns, must add the (empty)
     // dict by itself, then add columns to the dict via separate
@@ -580,7 +580,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildDictArray(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // Create the dict's offset vector.
 
@@ -643,7 +643,7 @@ public class ColumnBuilder {
   }
 
   private ColumnState buildSingleDict(ContainerState parent, ColumnReadProjection colProj) {
-    ColumnMetadata columnSchema = colProj.providedSchema();
+    ColumnMetadata columnSchema = colProj.outputSchema();
 
     // Create the dict's offset vector.
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ContainerState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ContainerState.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.resultSet.impl;
 
 import java.util.Collection;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.impl.scan.project.projSet.ProjectionSetFactory;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
@@ -85,6 +86,10 @@ public abstract class ContainerState {
   protected LoaderInternals loader() { return loader; }
   public ResultVectorCache vectorCache() { return vectorCache; }
   public ProjectionSet projectionSet() { return projectionSet; }
+
+  public ProjectionType projectionType(String columnName) {
+    return projectionSet.projectionType(columnName);
+  }
 
   public ColumnState addColumn(ColumnMetadata columnSchema) {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/model/single/SimpleReaderBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/model/single/SimpleReaderBuilder.java
@@ -176,15 +176,13 @@ public class SimpleReaderBuilder extends ReaderBuilder {
         buildMapMembers(vector,
             descrip.parent.childProvider(descrip.metadata)));
 
-    // Single map
-
-    if (! isArray) {
+    if (isArray) {
+      // Repeated map
+      return ArrayReaderImpl.buildTuple(descrip.metadata, va, mapReader);
+    } else {
+      // Single map
       return mapReader;
     }
-
-    // Repeated map
-
-    return ArrayReaderImpl.buildTuple(descrip.metadata, va, mapReader);
   }
 
   protected List<AbstractObjectReader> buildMapMembers(AbstractMapVector mapVector, MetadataProvider provider) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/ImpliedTupleRequest.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/ImpliedTupleRequest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.common.expression.PathSegment;
+import org.apache.drill.common.project.ProjectionType;
 
 /**
  * Represents a wildcard: SELECT * when used at the root tuple.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedColumnImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedColumnImpl.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.drill.common.expression.PathSegment.NameSegment;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 
 /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedTuple.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedTuple.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.resultSet.project;
 import java.util.List;
 
 import org.apache.drill.common.expression.PathSegment;
+import org.apache.drill.common.project.ProjectionType;
 
 /**
  * Represents the set of columns projected for a tuple (row or map.)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedTupleImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/project/RequestedTupleImpl.java
@@ -26,6 +26,7 @@ import org.apache.drill.common.expression.PathSegment;
 import org.apache.drill.common.expression.PathSegment.ArraySegment;
 import org.apache.drill.common.expression.PathSegment.NameSegment;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.record.metadata.TupleNameSpace;
 
 /**
@@ -274,14 +275,13 @@ public class RequestedTupleImpl implements RequestedTuple {
 
       member.projectAllElements();
       return;
-    } else if (member.hasIndex(index)) {
-      throw UserException
-        .validationError()
-        .message("Duplicate array index in project list: %s[%d]",
-            member.fullName(), index)
-        .build(logger);
     }
-    member.addIndex(index);
+    if (!member.hasIndex(index)) {
+
+      // Allow duplicate indexes. Example: z[0], z[0]['orange']
+
+      member.addIndex(index);
+    }
 
     // Drills SQL parser does not support map arrays: a[0].c
     // But, the SchemaPath does support them, so no harm in

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -199,8 +199,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     }
   }
 
-  protected void buildSchema() throws SchemaChangeException {
-  }
+  protected void buildSchema() throws SchemaChangeException { }
 
   @Override
   public void kill(boolean sendUpstream) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
@@ -206,16 +206,20 @@ public class BatchSchema implements Iterable<MaterializedField> {
    * @param t2
    * @return
    */
-  private boolean majorTypeEqual(MajorType t1, MajorType t2) {
+  private static boolean majorTypeEqual(MajorType t1, MajorType t2) {
     if (t1.equals(t2)) {
       return true;
     }
+    // TODO: the next two checks are redundant: equals does them.
     if (!t1.getMinorType().equals(t2.getMinorType())) {
       return false;
     }
     if (!t1.getMode().equals(t2.getMode())) {
       return false;
     }
+    // TODO: this does not do anything. The call to equals() above
+    // checks subtypes in a different way.
+    // Also, can just return the result of equals(), no need for an if.
     if (!Sets.newHashSet(t1.getSubTypeList()).equals(Sets.newHashSet(t2.getSubTypeList()))) {
       return false;
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorContainer.java
@@ -166,7 +166,7 @@ public class VectorContainer implements VectorAccessible {
     final ValueVector vector;
     if (id != null) {
       vector = getValueAccessorById(id.getFieldIds()).getValueVector();
-      if (id.getFieldIds().length == 1 && !vector.getField().getType().equals(field.getType())) {
+      if (id.getFieldIds().length == 1 && !vector.getField().isEquivalent(field)) {
         final ValueVector newVector = TypeHelper.getNewVector(field, this.getAllocator(), callBack);
         replace(vector, newVector);
         return (T) newVector;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector2.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/selection/SelectionVector2.java
@@ -38,10 +38,12 @@ public class SelectionVector2 implements AutoCloseable {
   public static final int RECORD_SIZE = 2;
 
   private final BufferAllocator allocator;
-  // Indicates number of indexes stored in the SV2 buffer which may be less than actual number of rows stored in
-  // RecordBatch container owning this SV2 instance
+  // Indicates number of indexes stored in the SV2 buffer which may be less
+  // than the actual number of rows stored in RecordBatch container owning
+  // this SV2 instance
   private int recordCount;
-  // Indicates actual number of rows in the RecordBatch container which owns this SV2 instance
+  // Indicates actual number of rows in the RecordBatch
+  // container which owns this SV2 instance
   private int batchActualRecordCount = -1;
   private DrillBuf buffer = DeadBuf.DEAD_BUFFER;
 
@@ -82,12 +84,11 @@ public class SelectionVector2 implements AutoCloseable {
     DrillBuf bufferHandle = buffer;
 
     if (clear) {
-      /* Increment the ref count for this buffer */
+      // Increment the ref count for this buffer
       bufferHandle.retain(1);
 
-      /* We are passing ownership of the buffer to the
-       * caller. clear the buffer from within our selection vector
-       */
+      // We are passing ownership of the buffer to the
+      // caller. clear the buffer from within our selection vector
       clear();
     }
 
@@ -95,7 +96,7 @@ public class SelectionVector2 implements AutoCloseable {
   }
 
   public void setBuffer(DrillBuf bufferHandle) {
-    /* clear the existing buffer */
+    // clear the existing buffer
     clear();
 
     buffer = bufferHandle;
@@ -104,6 +105,10 @@ public class SelectionVector2 implements AutoCloseable {
 
   public char getIndex(int index) {
     return buffer.getChar(index * RECORD_SIZE);
+  }
+
+  public void setIndex(int index, char value) {
+    buffer.setChar(index * RECORD_SIZE, value);
   }
 
   public long getDataAddr() {
@@ -135,10 +140,9 @@ public class SelectionVector2 implements AutoCloseable {
     newSV.batchActualRecordCount = batchActualRecordCount;
     newSV.buffer = buffer;
 
-    /* Since buffer and newSV.buffer essentially point to the
-     * same buffer, if we don't do a retain() on the newSV's
-     * buffer, it might get freed.
-     */
+    // Since buffer and newSV.buffer essentially point to the
+    // same buffer, if we don't do a retain() on the newSV's
+    // buffer, it might get freed.
     newSV.buffer.retain(1);
     clear();
     return newSV;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
@@ -172,7 +172,11 @@ public class QueryResultHandler {
       resultsListener.dataArrived(batch, throttle);
       // That releases batch if successful.
     } catch (Exception e) {
-      batch.release();
+      try {
+        batch.release();
+      } catch (IllegalStateException e2) {
+        // Ignore, released twice
+      }
       resultsListener.submissionFailed(UserException.systemError(e).build(logger));
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SystemOptionManager.java
@@ -179,6 +179,7 @@ public class SystemOptionManager extends BaseOptionManager implements AutoClosea
       new OptionDefinition(ExecConstants.PARQUET_FLAT_BATCH_NUM_RECORDS_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, true, true)),
       new OptionDefinition(ExecConstants.PARQUET_FLAT_BATCH_MEMORY_SIZE_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, true, true)),
       new OptionDefinition(ExecConstants.PARQUET_COMPLEX_BATCH_NUM_RECORDS_VALIDATOR, new OptionMetaData(OptionValue.AccessibleScopes.SYSTEM_AND_SESSION, true, true)),
+      new OptionDefinition(ExecConstants.ENABLE_V2_JSON_READER_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_ALL_TEXT_MODE_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_WRITER_NAN_INF_NUMBERS_VALIDATOR),
       new OptionDefinition(ExecConstants.JSON_READER_NAN_INF_NUMBERS_VALIDATOR),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/WorkspaceSchemaFactory.java
@@ -579,7 +579,7 @@ public class WorkspaceSchemaFactory {
     public CreateTableEntry createStatsTable(String tableName) {
       ensureNotStatsTable(tableName);
       final String statsTableName = getStatsTableName(tableName);
-      FormatPlugin formatPlugin = plugin.getFormatPlugin(JSONFormatPlugin.DEFAULT_NAME);
+      FormatPlugin formatPlugin = plugin.getFormatPlugin(JSONFormatPlugin.PLUGIN_NAME);
       return createOrAppendToTable(statsTableName, formatPlugin, Collections.emptyList(),
           StorageStrategy.DEFAULT);
     }
@@ -588,7 +588,7 @@ public class WorkspaceSchemaFactory {
     public CreateTableEntry appendToStatsTable(String tableName) {
       ensureNotStatsTable(tableName);
       final String statsTableName = getStatsTableName(tableName);
-      FormatPlugin formatPlugin = plugin.getFormatPlugin(JSONFormatPlugin.DEFAULT_NAME);
+      FormatPlugin formatPlugin = plugin.getFormatPlugin(JSONFormatPlugin.PLUGIN_NAME);
       return createOrAppendToTable(statsTableName, formatPlugin, Collections.emptyList(),
           StorageStrategy.DEFAULT);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -72,6 +72,7 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
   public static final String PLUGIN_NAME = "json";
   private static final String DEFAULT_EXTN = "json";
   private static final boolean IS_COMPRESSIBLE = true;
+
   public static class JsonReaderCreator extends FileReaderFactory {
 
     private final JsonOptions options;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONRecordReader.java
@@ -45,6 +45,14 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 
+/**
+ * Old-style JSON record reader. Not used when reading JSON files,
+ * but is used by some "mini-plan" unit tests, and by the VALUES
+ * reader. As a result, this reader cannot be removed and must be
+ * maintained until the other uses are converted to the new-style
+ * JSON reader.
+ */
+
 public class JSONRecordReader extends AbstractRecordReader {
   private static final Logger logger = LoggerFactory.getLogger(JSONRecordReader.class);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonBatchReader.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.server.options.OptionSet;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.TypeNegotiator;
+import org.apache.hadoop.mapred.FileSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JsonBatchReader implements ManagedReader<FileSchemaNegotiator> {
+
+  private static final Logger logger = LoggerFactory.getLogger(JsonBatchReader.class);
+
+  private DrillFileSystem fileSystem;
+  private FileSplit split;
+  private final JsonOptions options;
+  private JsonLoader jsonLoader;
+  private InputStream stream;
+
+  private RowSetLoader tableLoader;
+
+  public JsonBatchReader(JsonOptions options) {
+   this.options = options == null ? new JsonOptions() : options;
+  }
+
+  @Override
+  public boolean open(FileSchemaNegotiator negotiator) {
+    this.fileSystem = negotiator.fileSystem();
+    this.split = negotiator.split();
+    OperatorContext opContext = negotiator.context();
+    OptionSet optionMgr = opContext.getFragmentContext().getOptions();
+    Object embeddedContent = null;
+    options.allTextMode = embeddedContent == null && optionMgr.getBoolean(ExecConstants.JSON_ALL_TEXT_MODE);
+    options.readNumbersAsDouble = embeddedContent == null && optionMgr.getBoolean(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
+    options.unionEnabled = embeddedContent == null && optionMgr.getBoolean(ExecConstants.ENABLE_UNION_TYPE_KEY);
+    options.skipMalformedRecords = optionMgr.getBoolean(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
+    // Printing of malformed records is always enabled.
+//    options.printSkippedMalformedJSONRecordLineNumber = optionMgr.getBoolean(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
+    options.allowNanInf = true;
+
+    try {
+      stream = fileSystem.openPossiblyCompressedStream(split.getPath());
+    } catch (IOException e) {
+      throw UserException
+          .dataReadError(e)
+          .addContext("Failure to open JSON file", split.getPath().toString())
+          .build(logger);
+    }
+    final ResultSetLoader rsLoader = negotiator.build();
+    tableLoader = rsLoader.writer();
+    RowSetLoader rootWriter = tableLoader;
+
+    // Bind the type negotiator that will resolve ambiguous types
+    // using information from any previous readers in this scan.
+
+    options.typeNegotiator = new TypeNegotiator() {
+      @Override
+      public MajorType typeOf(List<String> path) {
+        ResultVectorCache cache = rsLoader.vectorCache();
+        for (int i = 0; i < path.size() - 1; i++) {
+          cache = cache.childCache(path.get(i));
+        }
+        return cache.getType(path.get(path.size()-1));
+      }
+    };
+
+    // Create the JSON loader (high-level parser).
+
+    jsonLoader = new JsonLoaderImpl(stream, rootWriter, options);
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    boolean more = true;
+    while (! tableLoader.isFull()) {
+      if (! tableLoader.start()) {
+        throw new IllegalStateException("Caller must check isFull()");
+      }
+      if (! jsonLoader.next()) {
+        more = false;
+        break;
+      }
+      tableLoader.save();
+    }
+    jsonLoader.endBatch();
+    return more;
+  }
+
+  @Override
+  public void close() {
+    if (stream != null) {
+      try {
+        stream.close();
+      } catch (Exception e) {
+
+        // Ignore errors
+
+        logger.warn("Ignored failure closing JSON file: " + split.getPath().toString(), e);
+      } finally {
+        stream = null;
+      }
+    }
+    if (jsonLoader != null) {
+      try {
+        jsonLoader.close();
+      } catch (Exception e) {
+
+        // Ignore errors
+
+        logger.warn("Ignored failure closing JSON loader for file: " + split.getPath().toString(), e);
+      } finally {
+        jsonLoader = null;
+      }
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonBatchReader.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JsonBatchReader implements ManagedReader<FileSchemaNegotiator> {
-
   private static final Logger logger = LoggerFactory.getLogger(JsonBatchReader.class);
 
   private DrillFileSystem fileSystem;
@@ -52,7 +51,7 @@ public class JsonBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private RowSetLoader tableLoader;
 
   public JsonBatchReader(JsonOptions options) {
-   this.options = options == null ? new JsonOptions() : options;
+    this.options = options == null ? new JsonOptions() : options;
   }
 
   @Override
@@ -66,8 +65,9 @@ public class JsonBatchReader implements ManagedReader<FileSchemaNegotiator> {
     options.readNumbersAsDouble = embeddedContent == null && optionMgr.getBoolean(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
     options.unionEnabled = embeddedContent == null && optionMgr.getBoolean(ExecConstants.ENABLE_UNION_TYPE_KEY);
     options.skipMalformedRecords = optionMgr.getBoolean(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
+    options.enableEscapeAnyChar = optionMgr.getBoolean(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR);
     // Printing of malformed records is always enabled.
-//    options.printSkippedMalformedJSONRecordLineNumber = optionMgr.getBoolean(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
+    // options.printSkippedMalformedJSONRecordLineNumber = optionMgr.getBoolean(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
     options.allowNanInf = true;
 
     try {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonLoader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json;
+
+/**
+ * Enhanced second-generation JSON loader which takes an input
+ * source and creates a series of record batches using the
+ * {@link ResultSetLoader} abstraction.
+ */
+
+public interface JsonLoader {
+
+  /**
+   * Read one record of data.
+   *
+   * @return <true> if a record was loaded, <false> if EOF.
+   * @throws UserException for most errors
+   * @throws RuntimeException for unexpected errors, most often due
+   * to code errors
+   */
+
+  boolean next();
+
+  /**
+   * Indicates that a batch is complete. Tells the loader to materialize
+   * any deferred null fields.
+   */
+
+  void endBatch();
+
+  /**
+   * Releases resources held by this class, but does not close resources
+   * passed into the class, such as the input stream or result set
+   * loader.
+   */
+
+  void close();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/AbstractParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/AbstractParser.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+
+abstract class AbstractParser implements JsonElementParser {
+
+  protected static abstract class LeafParser extends AbstractParser {
+
+    public LeafParser(JsonLoaderImpl.JsonElementParser parent, String fieldName) {
+      super(parent, fieldName);
+    }
+  }
+
+  protected final JsonLoaderImpl loader;
+  private final JsonElementParser parent;
+  private final String key;
+
+  public AbstractParser(JsonLoaderImpl loader, String fieldName) {
+    this.loader = loader;
+    this.parent = null;
+    this.key = fieldName;
+  }
+
+  public AbstractParser(JsonElementParser parent, String fieldName) {
+    this.parent = parent;
+    this.loader = (JsonLoaderImpl) parent.loader();
+    this.key = fieldName;
+  }
+
+  @Override
+  public String key() { return key; }
+
+  @Override
+  public JsonElementParser parent() { return parent; }
+
+  @Override
+  public JsonLoader loader() { return loader; }
+
+  @Override
+  public boolean isAnonymous() { return false; }
+
+  protected MaterializedField schemaFor(String key,
+      MinorType type, DataMode mode) {
+    return MaterializedField.create(key,
+        Types.withMode(type, mode));
+  }
+
+  protected List<String> makePath() {
+    JsonElementParser parser = this;
+    List<String> path = new ArrayList<>();
+    while (parser != null) {
+      if (! parser.isAnonymous()) {
+        path.add(parser.key());
+      }
+      parser = parser.parent();
+    }
+    Collections.reverse(path);
+    return path;
+  }
+
+  public String fullName() {
+    StringBuilder buf = new StringBuilder();
+    int count = 0;
+    for (String seg : makePath()) {
+      if (count > 0) {
+        buf.append(".");
+      }
+      buf.append("`");
+      buf.append(seg);
+      buf.append("`");
+      count++;
+    }
+    return buf.toString();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder()
+      .append("[")
+      .append(getClass().getSimpleName())
+      .append(" name=")
+      .append(fullName());
+    if (schema() != null) {
+      buf.append(", schema=")
+        .append(schema().toString());
+    }
+    return buf.append("]").toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ArrayParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ArrayParser.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Parses [ ((value | null)(, (value | null))* )? ]<br>
+ */
+
+abstract class ArrayParser extends ContainerParser {
+
+  /**
+   * Parses [ value, value ... ]<br>
+   * Where value is a scalar. The states for each value ensure that the
+   * types are consistent (Drill does not support heterogeneous arrays.)
+   */
+
+  protected static class ScalarArrayParser extends ArrayParser {
+
+    private final JsonElementParser scalarParser;
+
+    public ScalarArrayParser(JsonLoaderImpl.JsonElementParser parent, String fieldName,
+        ArrayWriter writer,
+        JsonElementParser scalarParser) {
+      super(parent, fieldName, writer);
+      this.scalarParser = scalarParser;
+    }
+
+    @Override
+    protected void parseContents(JsonToken token) {
+      scalarParser.parse();
+    }
+  }
+
+  /**
+   * Parses [ ((item | null)(, (item | null)* )? ]
+   */
+
+  protected static class ObjectArrayParser extends ArrayParser {
+
+    private final ObjectParser objectParser;
+
+    public ObjectArrayParser(JsonLoaderImpl.JsonElementParser parent, String fieldName,
+        ArrayWriter writer, ObjectParser objectParser) {
+      super(parent, fieldName, writer);
+      this.objectParser = objectParser;
+    }
+
+    @Override
+    protected void parseContents(JsonToken token) {
+      objectParser.parse();
+    }
+  }
+
+  protected final ArrayWriter writer;
+
+  public ArrayParser(JsonElementParser parent, String fieldName,
+      ArrayWriter writer) {
+    super(parent, fieldName);
+    this.writer = writer;
+  }
+
+  @Override
+  public boolean parse() {
+    JsonToken token = loader.tokenizer.requireNext();
+    switch (token) {
+    case VALUE_NULL:
+      return true;
+    case START_ARRAY:
+      writer.setNull(false);
+      break;
+    default:
+      throw loader.syntaxError(token);
+    }
+
+    for (;;) {
+      token = loader.tokenizer.requireNext();
+      switch (token) {
+      case END_ARRAY:
+        return true;
+
+      default:
+        loader.tokenizer.unget(token);
+        parseContents(token);
+        writer.save();
+        break;
+      }
+    }
+  }
+
+  protected abstract void parseContents(JsonToken token);
+
+  @Override
+  public boolean isAnonymous() { return true; }
+
+  @Override
+  public ColumnMetadata schema() { return writer.schema(); }
+
+  @Override
+  protected ObjectWriter newWriter(String key, MinorType type,
+      DataMode mode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected JsonElementParser nullArrayParser(String key) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ContainerParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ContainerParser.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+public abstract class ContainerParser extends AbstractParser {
+
+  public ContainerParser(JsonLoaderImpl loader, String key) {
+    super(loader, key);
+  }
+
+  public ContainerParser(JsonElementParser parent, String key) {
+    super(parent, key);
+  }
+
+  /**
+   * The field type has been determined. Build a writer for that field given
+   * the field name, type and mode (optional or repeated). The result set loader
+   * that backs this JSON loader will handle field projection, returning a dummy
+   * parser if the field is not projected.
+   *
+   * @param key name of the field
+   * @param type Drill data type
+   * @param mode cardinality: either Optional (for map fields) or Repeated
+   * (for array members). (JSON does not allow Required fields)
+   * @return the object writer for the field, which may be a tuple, scalar
+   * or array writer, depending on type
+   */
+
+  protected abstract ObjectWriter newWriter(String key,
+      MinorType type, DataMode mode);
+
+  /**
+   * Create a parser for a scalar array implemented as a repeated type.
+   *
+   * @param parent
+   * @param token
+   * @param key
+   * @return
+   */
+
+  protected JsonElementParser detectScalarArrayParser(JsonToken token, String key) {
+    MinorType type = typeForToken(token);
+    ArrayWriter arrayWriter = newWriter(key, type, DataMode.REPEATED).array();
+    JsonElementParser elementState = scalarParserForToken(token, key, arrayWriter.scalar());
+    return new ArrayParser.ScalarArrayParser(this, key, arrayWriter, elementState);
+  }
+
+  protected ObjectParser objectParser(String key) {
+    return new ObjectParser(this, key,
+        newWriter(key, MinorType.MAP, DataMode.REQUIRED).tuple());
+  }
+
+  protected JsonElementParser typedScalar(JsonToken token, String key) {
+    MinorType type = typeForToken(token);
+    ScalarWriter scalarWriter = newWriter(key, type, DataMode.OPTIONAL).scalar();
+    return scalarParserForToken(token, key, scalarWriter);
+  }
+
+  protected ArrayParser objectArrayParser(String key) {
+    ArrayWriter arrayWriter = newWriter(key, MinorType.MAP, DataMode.REPEATED).array();
+    return new ArrayParser.ObjectArrayParser(this, key, arrayWriter,
+        new ObjectParser(this, key, arrayWriter.tuple()));
+  }
+
+  protected JsonElementParser listParser(String key) {
+    return new ListParser(this, key,
+        newWriter(key, MinorType.LIST, DataMode.OPTIONAL).array());
+  }
+
+  protected RepeatedListParser repeatedListParser(String key) {
+     return new RepeatedListParser(this, key,
+         newWriter(key, MinorType.LIST, DataMode.REPEATED).array());
+  }
+
+  protected JsonElementParser textArrayParser(String key) {
+    ObjectWriter childWriter = newWriter(key(),
+        MinorType.VARCHAR, DataMode.REPEATED);
+    JsonElementParser elementParser = new ScalarParser.TextParser(
+        this, key(), childWriter.array().scalar());
+    return new ArrayParser.ScalarArrayParser(this,
+        key(), childWriter.array(), elementParser);
+  }
+
+  /**
+   * Detect the type of an array member by "sniffing" the first element.
+   * Creates a simple repeated type if requested and possible. Else, creates
+   * an array depending on the array contents. May have to look ahead
+   * multiple tokens if the array is multi-dimensional.
+   * <p>
+   * Note that repeated types can only appear directly inside maps; they
+   * cannot be used inside a list.
+   *
+   * @param parent the object parser that will hold the array element
+   * @param key field name
+   * @return the parse state for this array
+   */
+
+  protected JsonElementParser detectArrayParser(String key) {
+
+    // If using the experimental list support, create a parser
+    // for that mode. (Lists are generic and require much less fiddling
+    // than the repeated type/repeated list path.)
+
+    if (loader.options.useListType) {
+      return listParser(key);
+    }
+
+    // Implement JSON lists using the standard repeated types or the
+    // repeated list type.
+    // Detect the type of that array. Or, detect that the the first value
+    // dictates that a list be used because this is a nested list, contains
+    // nulls, etc.
+
+    JsonToken token = loader.tokenizer.requireNext();
+    JsonElementParser listParser;
+    switch (token) {
+    case START_ARRAY:
+
+      // Can't use an array, must use a list since this is nested
+      // or null.
+
+      listParser = repeatedListParser(key);
+      break;
+
+    case VALUE_NULL:
+    case END_ARRAY:
+
+      // Don't know what this is. Defer judgment until later.
+
+      listParser = nullArrayParser(key);
+      break;
+
+    case START_OBJECT:
+      listParser = objectArrayParser(key);
+      break;
+
+    default:
+      listParser = detectScalarArrayParser(token, key);
+      break;
+    }
+    loader.tokenizer.unget(token);
+    return listParser;
+  }
+
+  protected abstract JsonElementParser nullArrayParser(String key);
+
+  public MinorType typeForToken(JsonToken token) {
+    if (loader.options.allTextMode) {
+      return MinorType.VARCHAR;
+    }
+    switch (token) {
+    case VALUE_FALSE:
+    case VALUE_TRUE:
+      return MinorType.BIT;
+
+    case VALUE_NUMBER_INT:
+      if (! loader.options.readNumbersAsDouble) {
+        return MinorType.BIGINT;
+      } // else fall through
+
+    case VALUE_NUMBER_FLOAT:
+      return MinorType.FLOAT8;
+
+    case VALUE_STRING:
+      return MinorType.VARCHAR;
+
+    default:
+      throw loader.syntaxError(token);
+    }
+  }
+
+  public AbstractParser scalarParserForToken(JsonToken token, String key, ScalarWriter writer) {
+    if (loader.options.allTextMode) {
+      return new ScalarParser.TextParser(this, key, writer);
+    }
+    switch (token) {
+    case VALUE_FALSE:
+    case VALUE_TRUE:
+      return new ScalarParser.BooleanParser(this, key, writer);
+
+    case VALUE_NUMBER_INT:
+      if (! loader.options.readNumbersAsDouble) {
+        return new ScalarParser.IntParser(this, key, writer);
+      } // else fall through
+
+    case VALUE_NUMBER_FLOAT:
+      return new ScalarParser.FloatParser(this, key, writer);
+
+    case VALUE_STRING:
+      return new ScalarParser.StringParser(this, key, writer);
+
+    default:
+      throw loader.syntaxError(token);
+    }
+  }
+
+  protected ScalarParser scalarParserForType(MinorType type, String key, ScalarWriter scalarWriter) {
+    switch (type) {
+    case BIGINT:
+      return new ScalarParser.IntParser(this, key, scalarWriter);
+    case FLOAT8:
+      return new ScalarParser.FloatParser(this, key, scalarWriter);
+    case TINYINT:
+      return new ScalarParser.BooleanParser(this, key, scalarWriter);
+    case VARCHAR:
+      return new ScalarParser.StringParser(this, key, scalarWriter);
+    default:
+      throw loader.syntaxError("Unsupported Drill type " + type.toString());
+    }
+  }
+
+  protected void replaceChild(String key, JsonElementParser newParser) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/DummyValueParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/DummyValueParser.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.AbstractParser.LeafParser;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Parse and ignore an unprojected value. The parsing just "free wheels", we
+ * care only about matching brackets, but not about other details.
+ */
+
+class DummyValueParser extends LeafParser {
+
+  public DummyValueParser(JsonLoaderImpl.JsonElementParser parent, String fieldName) {
+    super(parent, fieldName);
+  }
+
+  @Override
+  public boolean parse() {
+    JsonToken token = loader.tokenizer.requireNext();
+    switch (token) {
+    case START_ARRAY:
+    case START_OBJECT:
+      parseTail();
+      break;
+
+    case VALUE_NULL:
+    case VALUE_EMBEDDED_OBJECT:
+    case VALUE_FALSE:
+    case VALUE_TRUE:
+    case VALUE_NUMBER_FLOAT:
+    case VALUE_NUMBER_INT:
+    case VALUE_STRING:
+      break;
+
+    default:
+      throw loader.syntaxError(token);
+    }
+    return true;
+  }
+
+  public void parseTail() {
+
+    // Parse (field: value)* }
+
+    for (;;) {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+
+      // Not exactly precise, but the JSON parser handles the
+      // details.
+
+      case END_OBJECT:
+      case END_ARRAY:
+        return;
+
+      case START_OBJECT:
+      case START_ARRAY:
+        parseTail(); // Recursively ignore objects
+        break;
+
+      default:
+        break; // Ignore all else
+      }
+    }
+  }
+
+  @Override
+  public ColumnMetadata schema() { return null; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonLoaderImpl.java
@@ -1,0 +1,528 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Revised JSON loader that is based on the
+ * {@link ResultSetLoader} abstraction. Represents the JSON parse as a
+ * set of parse states, each of which represents some point in the traversal
+ * of the JSON syntax. Parse nodes also handle options such as all text mode
+ * vs. type-specific parsing. Think of this implementation as a
+ * recursive-descent parser, with the parser itself discovered and
+ * "compiled" on the fly as we see incoming data.
+ * <p>
+ * Actual parsing is handled by the Jackson parser class. The input source is
+ * represented as an {@link InputStream} so that this mechanism can parse files
+ * or strings.
+ * <p>
+ * The JSON parser mechanism runs two state machines intertwined:
+ * <ol>
+ * <li>The actual parser (to parse each JSON object, array or scalar according
+ * to its inferred type.</li>
+ * <li>The type discovery machine, which is made complex because JSON may include
+ * long runs of nulls. (See below.)</li>
+ * </ol>
+ *
+ * <h4>Schema Discovery</h4>
+ *
+ * Fields are discovered on the fly. Types are inferred from the first JSON token
+ * for a field. Type inference is less than perfect: it cannot handle type changes
+ * such as first seeing 10, then 12.5, or first seeing "100", then 200.
+ * <p>
+ * When a field first contains null or an empty list, "null deferral" logic
+ * adds a special state that "waits" for an actual data type to present itself.
+ * This allows the parser to handle a series of nulls, empty arrays, or arrays
+ * of nulls (when using lists) at the start of the file. If no type ever appears,
+ * the loader forces the field to "text mode", hoping that the field is scalar.
+ * <p>
+ * To slightly help the null case, if the projection list shows that a column
+ * must be an array or a map, then that information is used to guess the type
+ * of a null column.
+ * <p>
+ * The code includes a prototype mechanism to provide type hints for columns.
+ * At present, it is just used to handle nulls that are never "resolved" by the
+ * end of a batch. Would be much better to use the hints (or a full schema) to
+ * avoid the huge mass of code needed to handle nulls.
+ *
+ * <h4>Comparison to Original JSON Reader</h4>
+ *
+ * This class replaces the {@link JsonReader} class used in Drill versions 1.12
+ * and before. Compared with the previous version, this implementation:
+ * <ul>
+ * <li>Materializes parse states as classes rather than as methods and
+ * boolean flags as in the prior version.</li>
+ * <li>Reports errors as {@link UserException} objects, complete with context
+ * information, rather than as generic Java exception as in the prior version.</li>
+ * <li>Moves parse options into a separate {@link JsonOptions} class.</li>
+ * <li>Iteration protocol is simpler: simply call {@link #next()} until it returns
+ * <tt>false</tt>. Errors are reported out-of-band via an exception.</li>
+ * <li>The result set loader abstraction is perfectly happy with an empty schema.
+ * For this reason, this version (unlike the original) does not make up a dummy
+ * column if the schema would otherwise be empty.</li>
+ * <li>Projection pushdown is handled by the {@link ResultSetLoader} rather than
+ * the JSON loader. This class always creates a vector writer, but the result set
+ * loader will return a dummy (no-op) writer for non-projected columns.</li>
+ * <li>Like the original version, this version "free wheels" over unprojected objects
+ * and arrays; watching only for matching brackets, but ignoring all else.</li>
+ * <li>Writes boolean values as SmallInt values, rather than as bits in the
+ * prior version.</li>
+ * <li>This version also "free-wheels" over all unprojected values. If the user
+ * finds that they have inconsistent data in some field f, then the user can
+ * project fields except f; Drill will ignore the inconsistent values in f.</li>
+ * <li>Because of this free-wheeling capability, this version does not need a
+ * "counting" reader; this same reader handles the case in which no fields are
+ * projected for <tt>SEELCT COUNT(*)</tt> queries.</li>
+ * <li>Runs of null values result in a "deferred null state" that patiently
+ * waits for an actual value token to appear, and only then "realizes" a parse
+ * state for that type.</li>
+ * <li>Provides the same limited error recovery as the original version. See
+ * <a href="https://issues.apache.org/jira/browse/DRILL-4653">DRILL-4653</a>
+ * and
+ * <a href="https://issues.apache.org/jira/browse/DRILL-5953">DRILL-5953</a>.
+ * </li>
+ * </ul>
+ */
+
+public class JsonLoaderImpl implements JsonLoader {
+
+  protected static final Logger logger = LoggerFactory.getLogger(JsonLoaderImpl.class);
+
+  public static final String ROOT_NAME = "<root>";
+
+  public interface TypeNegotiator {
+    MajorType typeOf(List<String> path);
+  }
+
+  public static class JsonOptions {
+    public String context;
+    public boolean allTextMode;
+    public boolean extended = true;
+    public boolean readNumbersAsDouble;
+
+    /**
+     * Allow Infinity and NaN for float values.
+     */
+
+    public boolean allowNanInf;
+
+    /**
+     * Describes whether or not this reader can unwrap a single root array record
+     * and treat it like a set of distinct records.
+     */
+    public boolean skipOuterList = true;
+    public boolean skipMalformedRecords;
+    public boolean unionEnabled;
+
+    public TypeNegotiator typeNegotiator;
+
+    /**
+     * By default, the JSON parser uses repeated types: either a repeated
+     * scalar, repeated map or repeated list. If this flag is enabled, the
+     * parser will use the experimental list vector type which can form
+     * a list of any type (including lists), and allows array values to
+     * be null. The code for lists existed in bits and pieces in Drill 1.12,
+     * was extended to work for JSON in Drill 1.13, but remains to be
+     * supported in the rest of Drill.
+     */
+
+    public boolean useListType;
+    public boolean detectTypeEarly;
+  }
+
+  @SuppressWarnings("serial")
+  static class RecoverableJsonException extends RuntimeException {
+  }
+
+  interface JsonElementParser {
+    String key();
+    JsonLoader loader();
+    JsonElementParser parent();
+    boolean isAnonymous();
+    boolean parse();
+    ColumnMetadata schema();
+  }
+
+  /**
+   * Parses ^[ ... ]$
+   */
+
+  protected static class RootArrayParser extends ContainerParser {
+
+    private final RowSetLoader rootWriter;
+    private final ObjectParser rootTuple;
+
+    public RootArrayParser(JsonLoaderImpl loader, RowSetLoader rootWriter) {
+      super(loader, ROOT_NAME);
+      this.rootWriter = rootWriter;
+      rootTuple = new ObjectParser(this, key() + "[]", rootWriter);
+    }
+
+    @Override
+    public boolean parse() {
+      rootWriter.start();
+      JsonToken token = loader.tokenizer.requireNext();
+      if (token == JsonToken.END_ARRAY) {
+        return false;
+      }
+      loader.tokenizer.unget(token);
+      rootTuple.parse();
+      return true;
+    }
+
+    @Override
+    public ColumnMetadata schema() { return null; }
+
+    @Override
+    protected ObjectWriter newWriter(String key, MinorType type,
+        DataMode mode) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected JsonElementParser nullArrayParser(String key) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Parses:
+   * <ul>
+   * <li>^{ ... }$</li>
+   * <li>^{ ... } { ... } ...$</li>
+   * </ul>
+   */
+
+  protected static class RootTupleState extends ObjectParser {
+
+    public RootTupleState(JsonLoaderImpl loader, RowSetLoader rootWriter) {
+      super(loader, rootWriter);
+    }
+
+    @Override
+    public boolean isAnonymous() { return true; }
+
+    @Override
+    public ColumnMetadata schema() { return null; }
+  }
+
+  interface NullTypeMarker {
+    void forceResolution();
+  }
+
+  final JsonParser parser;
+  private final RowSetLoader rootWriter;
+  protected final JsonOptions options;
+  protected final TokenIterator tokenizer;
+  private JsonElementParser rootState;
+  private int errorRecoveryCount;
+
+  // Using a simple list. Won't perform well if we have hundreds of
+  // null fields; but then we've never seen such a pathologically bad
+  // case... Usually just one or two fields have deferred nulls.
+
+  private final List<JsonLoaderImpl.NullTypeMarker> nullStates = new ArrayList<>();
+
+  public JsonLoaderImpl(InputStream stream, RowSetLoader rootWriter, JsonOptions options) {
+    try {
+      ObjectMapper mapper = new ObjectMapper()
+          .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
+          .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+      if (options.allowNanInf) {
+        mapper.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
+      }
+
+      parser = mapper.getFactory().createParser(stream);
+    } catch (JsonParseException e) {
+      throw UserException
+          .internalError(e)
+          .addContext("Failed to create the JSON parser")
+          .addContext("Source", options.context)
+          .build(logger);
+    } catch (IOException e) {
+      throw ioException(e);
+    }
+    this.rootWriter = rootWriter;
+    this.options = options;
+    tokenizer = new TokenIterator(this);
+    rootState = makeRootState();
+  }
+
+  private JsonElementParser makeRootState() {
+    JsonToken token = tokenizer.next();
+    if (token == null) {
+      return null;
+    }
+    switch (token) {
+
+    // File contains an array of records.
+
+    case START_ARRAY:
+      if (options.skipOuterList) {
+        return new RootArrayParser(this, rootWriter);
+      } else {
+        throw UserException
+          .dataReadError()
+          .message("JSON includes an outer array, but outer array support is not enabled")
+          .addContext("Location", tokenizer.context())
+          .build(logger);
+      }
+
+    // File contains a sequence of one or more records,
+    // presumably sequentially.
+
+    case START_OBJECT:
+      tokenizer.unget(token);
+      return new RootTupleState(this, rootWriter);
+
+    // Not a valid JSON file for Drill.
+
+    default:
+      throw syntaxError(token);
+    }
+  }
+
+  @Override
+  public boolean next() {
+    if (rootState == null) {
+      return false;
+    }
+
+    // From original code.
+    // Does this ever actually occur?
+
+    if (parser.isClosed()) {
+      rootState = null;
+      return false;
+    }
+    for (;;) {
+      try {
+        return rootState.parse();
+      } catch (RecoverableJsonException e) {
+        if (! recover()) {
+          return false;
+        }
+      }
+    }
+  }
+
+  public void addNullMarker(JsonLoaderImpl.NullTypeMarker marker) {
+    nullStates.add(marker);
+  }
+
+  public void removeNullMarker(JsonLoaderImpl.NullTypeMarker marker) {
+    nullStates.remove(marker);
+  }
+
+  /**
+   * Finish reading a batch of data. We may have pending "null" columns:
+   * a column for which we've seen only nulls, or an array that has
+   * always been empty. The batch needs to finish, and needs a type,
+   * but we still don't know the type. Since we must decide on one,
+   * we do the following:
+   * <ul>
+   * <li>If given a type negotiator, ask it the type. Perhaps a
+   * prior reader in the same scanner determined the type in a
+   * previous file.</li>
+   * <li>Guess Varchar, and switch to text mode.</li>
+   * </ul>
+   *
+   * Note that neither of these choices is perfect. There is no guarantee
+   * that prior files either were seen, or have the same type as this
+   * file. Also, switching to text mode means results will vary
+   * from run to run depending on the order that we see empty and
+   * non-empty values for this column. Plus, since the system is
+   * distributed, the decision made here may conflict with that made in
+   * some other fragment.
+   * <p>
+   * The only real solution is for the user to provide schema
+   * information to resolve the ambiguity; but Drill has no way to
+   * gather that information at present.
+   * <p>
+   * Bottom line: the user is responsible for not giving Drill
+   * ambiguous data that would require Drill to predict the future.
+   */
+
+  @Override
+  public void endBatch() {
+    List<NullTypeMarker> copy = new ArrayList<>();
+    copy.addAll(nullStates);
+    for (NullTypeMarker marker : copy) {
+      marker.forceResolution();
+    }
+    assert nullStates.isEmpty();
+  }
+
+  /**
+   * Attempt recovery from a JSON syntax error by skipping to the next
+   * record. The Jackson parser is quite limited in its recovery abilities.
+   *
+   * @return <tt>true<tt> if another record can be read, <tt>false</tt>
+   * if EOF.
+   * @throws UserException if the error is unrecoverable
+   * @see <a href="https://issues.apache.org/jira/browse/DRILL-4653">DRILL-4653</a>
+   * @see <a href="https://issues.apache.org/jira/browse/DRILL-5953">DRILL-5953</a>
+   */
+
+  private boolean recover() {
+    logger.warn("Attempting recovery from JSON syntax error. " + tokenizer.context());
+    boolean firstAttempt = true;
+    for (;;) {
+      for (;;) {
+        try {
+          if (parser.isClosed()) {
+            throw unrecoverableError();
+          }
+          JsonToken token = tokenizer.next();
+          if (token == null) {
+            if (firstAttempt) {
+              throw unrecoverableError();
+            }
+            return false;
+          }
+          if (token == JsonToken.NOT_AVAILABLE) {
+            return false;
+          }
+          if (token == JsonToken.END_OBJECT) {
+            break;
+          }
+          firstAttempt = false;
+        } catch (RecoverableJsonException e) {
+          // Ignore, keep trying
+        }
+      }
+      try {
+        JsonToken token = tokenizer.next();
+        if (token == null || token == JsonToken.NOT_AVAILABLE) {
+          return false;
+        }
+        if (token == JsonToken.START_OBJECT) {
+          logger.warn("Attempting to resume JSON parse. " + tokenizer.context());
+          tokenizer.unget(token);
+          errorRecoveryCount++;
+          return true;
+        }
+      } catch (RecoverableJsonException e) {
+        // Ignore, keep trying
+      }
+    }
+  }
+
+  public int recoverableErrorCount() { return errorRecoveryCount; }
+
+  private UserException unrecoverableError() {
+    throw UserException
+        .dataReadError()
+        .message("Unrecoverable JSON syntax error.")
+        .addContext("Location", tokenizer.context())
+        .build(logger);
+  }
+
+  UserException syntaxError(JsonToken token, String context, String expected) {
+    if (options.skipMalformedRecords) {
+      throw new RecoverableJsonException();
+    } else {
+      return UserException
+          .dataReadError()
+          .message("JSON encountered a value of the wrong type")
+          .message("Field", context)
+          .message("Expected type", expected)
+          .message("Actual token", token.toString())
+          .addContext("Location", tokenizer.context())
+          .build(logger);
+    }
+  }
+
+  UserException syntaxError(JsonToken token) {
+    return UserException
+        .dataReadError()
+        .message("JSON syntax error.")
+        .addContext("Current token", token.toString())
+        .addContext("Location", tokenizer.context())
+        .build(logger);
+  }
+
+  UserException syntaxError(String message) {
+    return UserException
+        .dataReadError()
+        .message(message)
+        .addContext("Location", tokenizer.context())
+        .build(logger);
+  }
+
+  UserException ioException(IOException e) {
+    return UserException
+        .dataReadError(e)
+        .addContext("I/O error reading JSON")
+        .addContext("Location", parser == null ? options.context : tokenizer.context())
+        .build(logger);
+  }
+
+  UserException typeError(UnsupportedConversionError e) {
+    return UserException
+        .dataReadError()
+        .message(e.getMessage())
+        .addContext("I/O error reading JSON")
+        .addContext("Location", parser == null ? options.context : tokenizer.context())
+        .build(logger);
+  }
+
+  UserException typeError(UnsupportedConversionError e, String msg) {
+    return UserException
+        .dataReadError()
+        .message(msg)
+        .addContext("Details", e.getMessage())
+        .addContext("I/O error reading JSON")
+        .addContext("Location", parser == null ? options.context : tokenizer.context())
+        .build(logger);
+  }
+
+  @Override
+  public void close() {
+    if (errorRecoveryCount > 0) {
+      logger.warn("Read JSON input {} with {} recoverable error(s).",
+          options.context, errorRecoveryCount);
+    }
+    try {
+      parser.close();
+    } catch (IOException e) {
+      logger.warn("Ignored failure when closing JSON source " + options.context, e);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonLoaderImpl.java
@@ -164,6 +164,7 @@ public class JsonLoaderImpl implements JsonLoader {
 
     public boolean useListType;
     public boolean detectTypeEarly;
+    public boolean enableEscapeAnyChar;
   }
 
   @SuppressWarnings("serial")

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ListParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ListParser.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+import org.apache.drill.exec.vector.accessor.VariantWriter;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Implement a JSON array as a Drill list. The list introduces a new level of container.
+ *
+ * @param parent
+ * @param token
+ * @param key
+ * @return
+ */
+
+public class ListParser extends ArrayParser {
+
+  /**
+   * Represents a rather odd state: we have seen a value of one or more nulls,
+   * but we have not yet seen a value that would give us a type. This state
+   * acts as a placeholder; waiting to see the type, at which point it replaces
+   * itself with the actual typed state. If a batch completes with only nulls
+   * for this field, then the field becomes a Text field and all values in
+   * subsequent batches will be read in "text mode" for that one field in
+   * order to avoid a schema change.
+   * <p>
+   * Note what this state does <i>not</i> do: it does not create a nullable
+   * int field per Drill's normal (if less than ideal) semantics. First, JSON
+   * <b>never</b> produces an int field, so nullable int is less than ideal.
+   * Second, nullable int has no basis in reality and so is a poor choice
+   * on that basis.
+   */
+
+  protected static class NullElementParser extends AbstractParser.LeafParser
+      implements JsonLoaderImpl.NullTypeMarker {
+
+    private final ListParser listParser;
+
+    public NullElementParser(ListParser parentState, String fieldName) {
+      super(parentState, fieldName);
+      this.listParser = parentState;
+      loader.addNullMarker(this);
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+
+      // If value is the null token, we still don't know the type.
+
+      if (token == JsonToken.VALUE_NULL) {
+        return true;
+      }
+
+      // Replace this parser with a typed parser.
+
+      JsonLoaderImpl.JsonElementParser newParser = listParser.detectElementParser(token);
+      loader.tokenizer.unget(token);
+      return resolve(newParser).parse();
+    }
+
+    @Override
+    public void forceResolution() {
+      JsonElementParser newParser = listParser.inferElementFromHint();
+      if (newParser != null) {
+        JsonLoaderImpl.logger.info("Using hints to determine type of JSON list {}. " +
+            " Found type {}",
+            fullName(), newParser.schema().type().name());
+      } else {
+        JsonLoaderImpl.logger.warn("Ambiguous type! JSON list {}" +
+            " contains all nulls. Assuming text mode.",
+            fullName());
+        ObjectWriter elementWriter = listParser.newWriter(MinorType.VARCHAR);
+        newParser = new ScalarParser.TextParser(listParser, key(), elementWriter.scalar());
+      }
+      resolve(newParser);
+    }
+
+    private JsonElementParser resolve(JsonElementParser newParser) {
+      listParser.replaceChild(newParser);
+      loader.removeNullMarker(this);
+      return newParser;
+    }
+
+    @Override
+    public boolean isAnonymous() { return true; }
+
+    @Override
+    public ColumnMetadata schema() { return null; }
+  }
+
+  private JsonElementParser elementParser;
+
+  public ListParser(ContainerParser parent, String key, ArrayWriter writer) {
+    super(parent, key, writer);
+    elementParser = new NullElementParser(this, key);
+  }
+
+  @Override
+  protected void parseContents(JsonToken token) {
+    elementParser.parse();
+  }
+
+  /**
+   * Figure out which element parser is needed for this list based on the
+   * first token in the list. If the token is <tt>null</tt>, then use a temporary
+   * type-deferral parser.
+   *
+   * @param token token of first item in the list
+   * @return parser for the elements in the list
+   */
+
+  protected JsonElementParser detectElementParser(JsonToken token) {
+    String childKey = key() + "[]";
+    switch (token) {
+    case START_ARRAY:
+      return new ListParser(this, childKey,
+          newWriter(MinorType.LIST).array());
+
+    case START_OBJECT:
+      return objectElementParser(childKey);
+
+    case VALUE_NULL:
+      JsonElementParser elementParser = inferFromType();
+      if (elementParser == null) {
+        // Don't know what this is a list of yet.
+
+        elementParser = new NullElementParser(this, childKey);
+      }
+      return elementParser;
+
+    default:
+      return detectScalarElementParser(token, childKey);
+    }
+  }
+
+  /**
+   * Determine which scalar element parser to use based on the JSON token
+   * for the first scalar element.
+   *
+   * @param token token seen in the JSON stream
+   * @param key name of the field
+   * @return an element parser for the scalar
+   */
+
+  private JsonElementParser detectScalarElementParser(JsonToken token, String key) {
+    MinorType type = typeForToken(token);
+    ScalarWriter childWriter = newWriter(type).scalar();
+    return scalarParserForToken(token, key, childWriter);
+  }
+
+  protected ObjectParser objectElementParser(String key) {
+    TupleWriter tupleWriter = newWriter(MinorType.MAP).tuple();
+    return new ObjectParser(this, key, tupleWriter);
+  }
+
+  /**
+   * Create a writer to be used for array elements.
+   *
+   * @param type the inferred Drill type for the elements
+   * @return a column writer of the requested type
+   */
+
+  protected ObjectWriter newWriter(MinorType type) {
+    VariantWriter variant = writer.variant();
+    if (variant.hasType(type) || variant.variantSchema().size() == 0) {
+      return variant.member(type);
+    }
+    if (! loader.options.unionEnabled) {
+      throw loader.syntaxError(
+          String.format("JSON array for column %s is of type %s, " +
+                        "but a conflicting type of %s found. " +
+                        "Consider enabling the union type.",
+              key(),
+              variant.variantSchema().types().iterator().next(),
+              type.name()));
+    }
+    return variant.member(type);
+  }
+
+  /**
+   * If the experimental type system is enabled, infer the type of a null column
+   * using the type system.
+   *
+   * @return the parser state, if any, created from the hint
+   */
+
+  private JsonElementParser inferFromType() {
+    if (! loader.options.detectTypeEarly) {
+      return null;
+    }
+    return inferElementFromHint();
+  }
+
+  private JsonElementParser inferElementFromHint() {
+    if (loader.options.typeNegotiator == null) {
+      return null;
+    }
+    MajorType type = loader.options.typeNegotiator.typeOf(makePath());
+    if (type == null) {
+      return null;
+    }
+    if (type.getMode() != DataMode.REPEATED) {
+      JsonLoaderImpl.logger.warn("Cardinality conflict! JSON source {}, list {} " +
+          "has a hint of cardinality {}, but JSON requires REPEATED. " +
+          "Hint ignored.",
+          loader.options.context, fullName(), type.getMode().name());
+    }
+    String key = key() + "[]";
+    ObjectWriter elementWriter = newWriter(type.getMinorType());
+    switch (type.getMinorType()) {
+    case MAP:
+      return new ObjectParser(this, key, elementWriter.tuple());
+
+    case LIST:
+      return new ListParser(this, key, elementWriter.array());
+
+    default:
+      return scalarParserForType(type.getMinorType(), key, elementWriter.scalar());
+    }
+  }
+
+  protected void replaceChild(JsonElementParser newParser) {
+    elementParser = newParser;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/NullTypeParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/NullTypeParser.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.NullTypeMarker;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Represents a rather odd state: we have seen a value of one or more nulls,
+ * but we have not yet seen a value that would give us a type. This state
+ * acts as a placeholder; waiting to see the type, at which point it replaces
+ * itself with the actual typed state. If a batch completes with only nulls
+ * for this field, then the field becomes a Text field and all values in
+ * subsequent batches will be read in "text mode" for that one field in
+ * order to avoid a schema change.
+ * <p>
+ * Note what this state does <i>not</i> do: it does not create a nullable
+ * int field per Drill's normal (if less than ideal) semantics. First, JSON
+ * <b>never</b> produces an int field, so nullable int is less than ideal.
+ * Second, nullable int has no basis in reality and so is a poor choice
+ * on that basis.
+ */
+
+class NullTypeParser extends AbstractParser.LeafParser implements NullTypeMarker {
+
+  private final ObjectParser objectParser;
+
+  public NullTypeParser(ObjectParser parentState, String fieldName) {
+    super(parentState, fieldName);
+    this.objectParser = parentState;
+    loader.addNullMarker(this);
+  }
+
+  @Override
+  public boolean parse() {
+    JsonToken token = loader.tokenizer.requireNext();
+
+    // If value is the null token, we still don't know the type.
+
+    if (token == JsonToken.VALUE_NULL) {
+      return true;
+    }
+
+    // Replace this parser with a typed parser.
+
+    loader.tokenizer.unget(token);
+    return resolve(objectParser.detectValueParser(key())).parse();
+  }
+
+  @Override
+  public void forceResolution() {
+    JsonElementParser newParser = objectParser.inferMemberFromHint(makePath());
+    if (newParser != null) {
+      JsonLoaderImpl.logger.info("Using hints to determine type of JSON field {}. " +
+          " Found type {}",
+          fullName(), newParser.schema().type().name());
+    } else {
+      JsonLoaderImpl.logger.warn("Ambiguous type! JSON field {}" +
+          " contains all nulls. Assuming VARCHAR.",
+          fullName());
+      newParser = new ScalarParser.TextParser(parent(), key(),
+          objectParser.newWriter(key(), MinorType.VARCHAR, DataMode.OPTIONAL).scalar());
+    }
+    resolve(newParser);
+  }
+
+  private JsonElementParser resolve(JsonElementParser newParser) {
+    objectParser.replaceChild(key(), newParser);
+    loader.removeNullMarker(this);
+    return newParser;
+  }
+
+  @Override
+  public ColumnMetadata schema() { return null; }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ObjectParser.java
@@ -1,0 +1,511 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.drill.common.map.CaseInsensitiveMap;
+import org.apache.drill.common.project.ProjectionType;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.NullTypeMarker;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.TupleWriter;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Parses { name : value ... }
+ * <p>
+ * Creates a map of known fields. Each time a field is parsed,
+ * looks up the field in the map. If not found, the value is "sniffed"
+ * to determine its type, and a matching state and vector writer created.
+ * Thereafter, the previous state is reused. The states ensure that the
+ * correct token appears for each subsequent value, causing type errors
+ * to be reported as syntax errors rather than as cryptic internal errors.
+ * <p>
+ * As it turns out, most of the semantic action occurs at the tuple level:
+ * that is where fields are defined, types inferred, and projection is
+ * computed.
+ *
+ * <h4>Nulls</h4>
+ *
+ * Much code here deals with null types, especially leading nulls, leading
+ * empty arrays, and so on. The object parser creates a parser for each
+ * value; a parser which "does the right thing" based on the data type.
+ * For example, for a Boolean, the parser recognizes <tt>true</tt>,
+ * <tt>false</tt> and <tt>null</tt>.
+ * <p>
+ * But what happens if the first value for a field is <tt>null</tt>? We
+ * don't know what kind of parser to create because we don't have a schema.
+ * Instead, we have to create a temporary placeholder parser that will consume
+ * nulls, waiting for a real type to show itself. Once that type appears, the
+ * null parser can replace itself with the correct form. Each vector's
+ * "fill empties" logic will back-fill the newly created vector with nulls
+ * for prior rows.
+ * <p>
+ * Two null parsers are needed: one when we see an empty list, and one for
+ * when we only see <tt>null</tt>. The one for <tt>null<tt> must morph into
+ * the one for empty lists if we see:<br>
+ * <tt>{a: null} {a: [ ]  }</tt><br>
+ * <p>
+ * If we get all the way through the batch, but have still not seen a type,
+ * then we have to guess. A prototype type system can tell us, otherwise we
+ * guess <tt>VARCHAR</tt>. (<tt>VARCHAR</tt> is the right choice for all-text
+ * mode, it is as good a guess as any for other cases.)
+ *
+ * <h4>Projection List Hints</h4>
+ *
+ * To help, we consult the projection list, if any, for a column. If the
+ * projection is of the form <tt>a[0]</tt>, we know the column had better
+ * be an array. Similarly, if the projection list has <tt>b.c</tt>, then
+ * <tt>b</tt> had better be an object.
+ *
+ * <h4>Array Handling</h4>
+ *
+ * The code here handles arrays in two ways. JSON normally uses the
+ * <tt>LIST</tt> type. But, that can be expensive if lists are
+ * well-behaved. So, the code here also implements arrays using the
+ * classic <tt>REPEATED</tt> types. The repeated type option is disabled
+ * by default. It can be enabled, for efficiency, if Drill ever supports
+ * a JSON schema. If an array is well-behaved, mark that column as able
+ * to use a repeated type.
+ */
+
+class ObjectParser extends ContainerParser {
+
+  /**
+   * Parses: [] | null [ ... ]
+   * <p>
+   * This state remains in effect as long as the input contains empty arrays or
+   * null values. However, once the array contains a non-empty array, this parser
+   * detects the type of the array based on this value and replaces this state
+   * with the new, resolved array parser based on the token seen.
+   * <p>
+   * The above implies that we look only at the first token to determine array
+   * type. If that first token is <tt>null</tt>, then we can't handle the token
+   * because arrays don't allow nulls (unless the array is an outer dimension of
+   * a multi-dimensional array, but we don't know that yet.)
+   * <p>
+   * If at the end of a batch, no non-empty array was seen, assumes that the
+   * array, when seen, will be an array of scalars, and replaces this state with
+   * a text array (as in all-text mode.)
+   */
+
+  protected static class NullArrayParser extends AbstractParser.LeafParser implements NullTypeMarker {
+
+    private final ObjectParser objectParser;
+
+    public NullArrayParser(ObjectParser parentState, String key) {
+      super(parentState, key);
+      this.objectParser = parentState;
+      loader.addNullMarker(this);
+    }
+
+    /**
+     * Parse null | [] | [ some_token
+     */
+
+    @Override
+    public boolean parse() {
+      JsonToken startToken = loader.tokenizer.requireNext();
+      // Position: ^ ?
+      switch (startToken) {
+      case VALUE_NULL:
+        // Position: null ^
+        // The value of this array is null, which is the same
+        // as an empty array.
+        return true;
+      case START_ARRAY:
+        // Position: [ ^
+        break;
+      default:
+        // Position: ~[ ^
+        // This is supposed to be an array.
+        throw loader.syntaxError(startToken);
+      }
+
+      JsonToken valueToken = loader.tokenizer.requireNext();
+      // Position: [ ? ^
+      switch (valueToken) {
+      case END_ARRAY:
+        // Position: [ ] ^
+        // An empty array, which we an absorb without knowing
+        // the array type.
+        return true;
+      case VALUE_NULL:
+        // Position: [ null ^
+        // We don't have a type, so we don't have a backing vector to
+        // set to null. Besides, null is only allowed in the upper
+        // dimensions of multi-dimensional arrays. (This statement would
+        // not be true if we were using lists, or if we created the array's
+        // offset vector separate from the associated data vector.
+        // Ready for a schema yet?
+        throw loader.syntaxError("Drill does not support leading nulls in JSON arrays.");
+      default:
+        loader.tokenizer.unget(valueToken);
+        // Position: [ ^ ?
+        // Let's try to resolve the next token to tell us the array type.
+        // The above has weeded out the "we don't know" cases.
+        JsonElementParser newParser = resolve(objectParser.detectArrayParser(key()));
+        loader.tokenizer.unget(startToken);
+        // Position: [ ^ ?
+        // Replace this parser with the new one, then use that new
+        // parser to reparse this array.
+        objectParser.replaceChild(key(), newParser);
+        loader.removeNullMarker(this);
+        return newParser.parse();
+      }
+    }
+
+    @Override
+    public void forceResolution() {
+      ArrayParser newParser = objectParser.inferScalarArrayFromHint(makePath());
+      if (newParser != null) {
+        JsonLoaderImpl.logger.info("Using hints to determine type of JSON array {}. " +
+            " Found type {}",
+            fullName(), newParser.writer.scalar().schema().type().name());
+      } else {
+        JsonLoaderImpl.logger.warn("Ambiguous type! JSON array {}" +
+            " contains all nulls. Assuming VARCHAR.",
+            fullName());
+        ArrayWriter arrayWriter = objectParser.newWriter(key(), MinorType.VARCHAR, DataMode.REPEATED).array();
+        JsonElementParser elementParser = new ScalarParser.TextParser(objectParser, key(), arrayWriter.scalar());
+        newParser = new ArrayParser.ScalarArrayParser(objectParser, key(), arrayWriter, elementParser);
+      }
+      resolve(newParser);
+    }
+
+    private JsonElementParser resolve(JsonElementParser newParser) {
+      objectParser.replaceChild(key(), newParser);
+      loader.removeNullMarker(this);
+      return newParser;
+    }
+
+    @Override
+    public ColumnMetadata schema() { return null; }
+  }
+
+  private final TupleWriter writer;
+  private final Map<String, JsonElementParser> members = CaseInsensitiveMap.newHashMap();
+
+  public ObjectParser(JsonLoaderImpl loader, TupleWriter writer) {
+    super(loader, JsonLoaderImpl.ROOT_NAME);
+    this.writer = writer;
+  }
+
+  public ObjectParser(JsonElementParser parent, String fieldName, TupleWriter writer) {
+    super(parent, fieldName);
+    this.writer = writer;
+  }
+
+  @Override
+  public boolean parse() {
+    JsonToken token = loader.tokenizer.next();
+    if (token == null) {
+      // Position: EOF ^
+      return false;
+    }
+    // Position: ? ^
+    switch (token) {
+    case NOT_AVAILABLE:
+      return false; // Should never occur
+
+    case VALUE_NULL:
+      // Position: null ^
+      // Same as omitting the object
+      return true;
+
+    case START_OBJECT:
+      // Position: { ^
+      break;
+
+    default:
+      // Position ~{ ^
+      // Not a valid object.
+      throw loader.syntaxError(token); // Nothing else is valid
+    }
+
+    // Parse (field: value)* }
+
+    for (;;) {
+      token = loader.tokenizer.requireNext();
+      // Position: { (key: value)* ? ^
+      switch (token) {
+      case END_OBJECT:
+        // Position: { (key: value)* } ^
+        return true;
+
+      case FIELD_NAME:
+        // Position: { (key: value)* key: ^
+        parseMember();
+        break;
+
+      default:
+        // Position: { (key: value)* ~(key | }) ^
+        // Invalid JSON.
+        // Actually, we probably won't get here, the JSON parser
+        // itself will throw an exception.
+        throw loader.syntaxError(token);
+      }
+    }
+  }
+
+  /**
+   * Parse a field. Two cases. First, this is a field we've already seen. If so,
+   * look up the parser for that field and use it. If this is the first time we've
+   * seen the field, "sniff" tokens to determine field type, create a parser,
+   * then parse.
+   */
+
+  private void parseMember() {
+    // Position: key: ^ ?
+    final String key = loader.tokenizer.textValue().trim();
+    JsonElementParser fieldState = members.get(key);
+    if (fieldState == null) {
+      // New key; sniff the value to determine the parser to use
+      // (which also tell us the kind of column to create in Drill.)
+      // Position: key: ^
+      fieldState = detectValueParser(key);
+      members.put(key, fieldState);
+    }
+    // Parse the field value using the parser for that field.
+    // The structure implies that fields don't change types: the type of
+    // the first value (sniffed above) must be repeated for every subsequent
+    // object.
+    // Position: key: ^ value ...
+    fieldState.parse();
+  }
+
+  /**
+   * If the column is not projected, create a dummy parser to "free wheel"
+   * over the value. Otherwise,
+   * look ahead a token or two to determine the the type of the field.
+   * Then the caller will backtrack to parse the field.
+   *
+   * @param key name of the field
+   * @return parser for the field
+   */
+
+  JsonElementParser detectValueParser(final String key) {
+    if (key.isEmpty()) {
+      throw loader.syntaxError("Drill does not allow empty keys in JSON key/value pairs");
+    }
+    ProjectionType projType = writer.projectionType(key);
+    if (projType == ProjectionType.UNPROJECTED) {
+      return new DummyValueParser(this, key);
+    }
+
+    // For other types of projection, the projection
+    // mechanism will catch conflicts.
+
+    JsonToken token = loader.tokenizer.requireNext();
+    // Position: key: ? ^
+    JsonElementParser valueParser;
+    switch (token) {
+    case START_ARRAY:
+      // Position: key: [ ^
+      valueParser = detectArrayParser(key);
+      break;
+
+    case START_OBJECT:
+      // Position: key: { ^
+      valueParser = objectParser(key);
+      break;
+
+    case VALUE_NULL:
+
+      // Position: key: null ^
+      // Use the projection type as a hint. Note that this is not a panacea,
+      // and may even lead to seemingly-random behavior. In one query, we can
+      // pick out arrays or array lists when confronted with a list of nulls
+      // (because we use the projection hint), but in other queries, the user
+      // will get a schema change exception (because we could not guess the type
+      // because the projection list differed.) It is not clear if such behavior
+      // is a bug or feature...
+
+      valueParser = inferParser(key, projType);
+      break;
+
+    default:
+      // Position: key: ? ^
+      valueParser = typedScalar(token, key);
+    }
+    loader.tokenizer.unget(token);
+    // Position: key: ^ ?
+    return valueParser;
+  }
+
+  @Override
+  protected ObjectWriter newWriter(String key,
+        MinorType type, DataMode mode) {
+    int index = writer.addColumn(schemaFor(key, type, mode));
+    return writer.column(index);
+  }
+
+  @Override
+  protected JsonElementParser nullArrayParser(String key) {
+    return new ObjectParser.NullArrayParser(this, key);
+  }
+
+  @Override
+  protected void replaceChild(String key, JsonElementParser newParser) {
+    assert members.containsKey(key);
+    members.put(key, newParser);
+  }
+
+  /**
+   * The JSON itself provides a null value, so we can't determine the column
+   * type. Use some additional inference methods. (These are experimental. What
+   * is really needed is an up-front schema.)
+   *
+   * @param key
+   * @param projType
+   * @return
+   */
+
+  private JsonElementParser inferParser(String key, ProjectionType projType) {
+    JsonElementParser valueParser = inferFromType(key);
+    if (valueParser == null) {
+      valueParser = inferFromProjection(key, projType);
+    }
+    if (valueParser == null) {
+      valueParser = new NullTypeParser(this, key);
+    }
+    return valueParser;
+  }
+
+  /**
+   * Use information from the projection list to infer the general shape of
+   * a field that contains nulls. This information is weak, but it is better
+   * than nothing. Plus, if the shape we guess here is inconsistent with the
+   * project list, the query will simply fail during the projection step.
+   *
+   * @param key name of the key
+   * @param projType projection type hint from the projection system
+   * @return a parser for the value
+   */
+
+  private JsonElementParser inferFromProjection(String key, ProjectionType projType) {
+    switch (projType) {
+    case ARRAY:
+      return new ObjectParser.NullArrayParser(this, key);
+
+    case TUPLE:
+      return objectParser(key);
+
+    case TUPLE_ARRAY:
+
+      // Note: Drill syntax does not support this
+      // case yet.
+
+      return objectArrayParser(key);
+
+    default:
+      return null;
+    }
+  }
+
+  /**
+   * Experimental feature. If a type hint mechanism is provided, use that
+   * to resolve the type of null columns. Really, this should be done earlier,
+   * and we should ensure that the suggested type matches the actual JSON
+   * type. But, for now, we consult the hint only if we'd otherwise not know
+   * the type.
+   *
+   * @param key
+   * @return
+   */
+
+  private JsonElementParser inferFromType(String key) {
+    if (! loader.options.detectTypeEarly) {
+      return null;
+    }
+    List<String> path = makePath();
+    path.add(key);
+    return inferMemberFromHint(path);
+  }
+
+  JsonElementParser inferMemberFromHint(List<String> path) {
+    if (loader.options.typeNegotiator == null) {
+      return null;
+    }
+    MajorType type = loader.options.typeNegotiator.typeOf(path);
+    if (type == null) {
+      return null;
+    }
+    DataMode mode = type.getMode();
+    String key = path.get(path.size() - 1);
+    MinorType dataType = type.getMinorType();
+    switch (dataType) {
+    case MAP:
+      if (mode == DataMode.REPEATED) {
+        return objectArrayParser(key);
+      } else {
+        return objectParser(key);
+      }
+    case LIST:
+      return listParser(key);
+
+    default:
+    }
+    if (mode == DataMode.REQUIRED) {
+      JsonLoaderImpl.logger.warn("Cardinality conflict! JSON source {}, column {} " +
+          "has a hint of cardinality {}, but JSON requires OPTIONAL. " +
+          "Hint ignored.",
+          loader.options.context, fullName(), mode.name());
+      mode = DataMode.OPTIONAL;
+    }
+    ObjectWriter memberWriter = newWriter(key, dataType, mode);
+    if (mode == DataMode.OPTIONAL) {
+      return scalarParserForType(dataType, key, memberWriter.scalar());
+    } else {
+      ArrayWriter arrayWriter = memberWriter.array();
+      JsonElementParser elementParser = scalarParserForType(type.getMinorType(), key, arrayWriter.scalar());
+      return new ArrayParser.ScalarArrayParser(this, key, arrayWriter, elementParser);
+    }
+  }
+
+  private ArrayParser inferScalarArrayFromHint(List<String> path) {
+    if (loader.options.typeNegotiator == null) {
+      return null;
+    }
+    MajorType type = loader.options.typeNegotiator.typeOf(path);
+    if (type == null) {
+      return null;
+    }
+    if (type.getMode() != DataMode.REPEATED) {
+      JsonLoaderImpl.logger.warn("Cardinality conflict! JSON source {}, array {} " +
+          "has a hint of cardinality {}, but JSON requires REPEATED. " +
+          "Hint ignored.",
+          loader.options.context, fullName(), type.getMode().name());
+    }
+    String key = path.get(path.size() - 1);
+    ArrayWriter arrayWriter = newWriter(key, type.getMinorType(), DataMode.REPEATED).array();
+    JsonElementParser elementState = scalarParserForType(type.getMinorType(), key, arrayWriter.scalar());
+    return new ArrayParser.ScalarArrayParser(this, key, arrayWriter, elementState);
+  }
+
+  @Override
+  public ColumnMetadata schema() { return writer.schema(); }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RepeatedListParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RepeatedListParser.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.NullTypeMarker;
+import org.apache.drill.exec.vector.accessor.ArrayWriter;
+import org.apache.drill.exec.vector.accessor.ObjectWriter;
+import org.apache.drill.exec.vector.accessor.writer.RepeatedListWriter;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Parses [ ([ .*)? ]
+ */
+
+class RepeatedListParser extends ArrayParser {
+
+  protected static class NullInnerArrayParser extends AbstractParser.LeafParser implements NullTypeMarker
+  {
+    private final RepeatedListParser listParser;
+
+    public NullInnerArrayParser(RepeatedListParser parentState, String key) {
+      super(parentState, key);
+      this.listParser = parentState;
+      loader.addNullMarker(this);
+    }
+
+    /**
+     * Parse null | [] | ([ some_token)? ]
+     */
+
+    @Override
+    public boolean parse() {
+      // Position: [ ^
+      JsonToken token = parseEmptyEntry();
+      if (token != JsonToken.START_ARRAY) {
+        return true;
+      }
+
+      JsonElementParser newParser = detectChildType();
+      // Position: [ [ ^ ?
+      loader.tokenizer.unget(token);
+      // Position: [ ^ [ ?
+      listParser.replaceChild(key(), newParser);
+      loader.removeNullMarker(this);
+      return newParser.parse();
+    }
+
+    private JsonToken parseEmptyEntry() {
+
+      // Parse null* [|]
+
+      JsonToken token = loader.tokenizer.requireNext();
+      // Position: [ ? ^
+      switch (token) {
+      case VALUE_NULL:
+
+        // Null value in the outer array is
+        // the same as an empty inner array.
+
+        // Position: [ null ^
+        break;
+
+      case START_ARRAY:
+        JsonToken token2 = loader.tokenizer.requireNext();
+        // Position: [ [ ? ^
+        if (token2 == JsonToken.END_ARRAY) {
+          // Position: [ [ ] ^
+          return token2;
+        }
+        loader.tokenizer.unget(token2);
+        // Position: [ [ ^ ?
+        break;
+
+      case END_ARRAY:
+        loader.tokenizer.unget(token);
+        // Position: [ (null | [])* ^ ]
+        break;
+
+      default:
+        throw loader.syntaxError(token);
+      }
+      return token;
+    }
+
+    /**
+     * Detect the type of a nested array. We've seen [[ so far.
+     * The next token is not ]; it should tell us the kind of
+     * the inner array.
+     *
+     * @param key field name
+     * @return parser for the list
+     */
+
+    private JsonElementParser detectChildType() {
+      JsonToken token = loader.tokenizer.peek();
+      // Position: [ [ ^ ?
+      switch (token) {
+      case VALUE_NULL:
+      case END_ARRAY:
+
+        // Should have been handled above.
+
+        throw new IllegalStateException();
+      case START_ARRAY:
+        // Position: [ [ [ ^
+        return listParser.detectArrayParser(key());
+      case START_OBJECT:
+        // Position: [ [ { ^
+        return listParser.objectArrayParser(key());
+      default:
+        // Position: [ [ scalar ^
+        return listParser.detectScalarArrayParser(token, key());
+      }
+    }
+
+    @Override
+    public void forceResolution() {
+
+      // This is a tough one. We've seen [[]]] or [[null]] to any depth.
+      // (That is, we may have seen [[[]]] or [[[[null]]]].)
+      // But, we don't know the type of the inner element. It could well be another
+      // array. We're at the end of the batch and must choose something.
+      // Let's choose array of Varchar since that will match either strings
+      // or all text mode. We'll force the field into text mode, but this works
+      // only if the contents turn out to be scalars, and the same decision is
+      // made in other files (which is very unlikely.)
+      // This is why JSON needs a schema. It is naive to think Drill can parse
+      // arbitrary JSON without a schema.
+
+      JsonLoaderImpl.logger.warn("Ambiguous type! JSON repeated array {}" +
+          " contains all nulls. Assuming text mode.",
+          fullName());
+      listParser.replaceChild(key(), listParser.textArrayParser(key()));
+      loader.removeNullMarker(this);
+    }
+
+    @Override
+    public ColumnMetadata schema() { return null; }
+  }
+
+  private JsonElementParser childParser;
+
+  public RepeatedListParser(JsonElementParser parent, String key, ArrayWriter writer) {
+    super(parent, key, writer);
+    childParser = new NullInnerArrayParser(this, key);
+  }
+
+  @Override
+  protected void parseContents(JsonToken token) {
+    childParser.parse();
+  }
+
+  @Override
+  protected ObjectWriter newWriter(String key, MinorType type,
+      DataMode mode) {
+    assert mode == DataMode.REPEATED;
+    RepeatedListWriter listWriter = (RepeatedListWriter) writer;
+    return listWriter.defineElement(schemaFor(writer.schema().name(), type, mode));
+  }
+
+  @Override
+  protected JsonElementParser nullArrayParser(String key) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  protected void replaceChild(String key, JsonElementParser newParser) {
+    childParser = newParser;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ScalarParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ScalarParser.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonElementParser;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+abstract class ScalarParser extends AbstractParser.LeafParser {
+
+  /**
+   * Parses true | false | null
+   */
+
+  public static class BooleanParser extends ScalarParser {
+
+    public BooleanParser(JsonElementParser parent, String key,
+        ScalarWriter writer) {
+      super(parent, key, writer);
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+      case VALUE_NULL:
+        setNull();
+        break;
+      case VALUE_TRUE:
+        try {
+          writer.setBoolean(true);
+        } catch (UnsupportedConversionError e) {
+          throw loader.typeError(e);
+        }
+        break;
+      case VALUE_FALSE:
+        try {
+          writer.setBoolean(false);
+        } catch (UnsupportedConversionError e) {
+          throw loader.typeError(e);
+        }
+        break;
+      default:
+        throw loader.syntaxError(token, key(), "Boolean");
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Parses integer | null
+   */
+
+  public static class IntParser extends ScalarParser {
+
+    public IntParser(JsonElementParser parent, String key,
+        ScalarWriter writer) {
+      super(parent, key, writer);
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+      case VALUE_NULL:
+        setNull();
+        break;
+      case VALUE_NUMBER_INT:
+        writer.setLong(loader.tokenizer.longValue());
+        break;
+      default:
+        throw loader.syntaxError(token, key(), "Integer");
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Parses float | integer | null
+   * <p>
+   * The integer value is allowed only after seeing a float value which
+   * sets the type.
+   */
+
+  public static class FloatParser extends ScalarParser {
+
+    public FloatParser(JsonElementParser parent, String key,
+        ScalarWriter writer) {
+      super(parent, key, writer);
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+      case VALUE_NULL:
+        setNull();
+        break;
+      case VALUE_NUMBER_FLOAT:
+      case VALUE_NUMBER_INT:
+        writer.setDouble(loader.tokenizer.doubleValue());
+        break;
+      default:
+        throw loader.syntaxError(token, key(), "Float");
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Parses "str" | null
+   */
+
+  public static class StringParser extends ScalarParser {
+
+    public StringParser(JsonElementParser parent, String key,
+        ScalarWriter writer) {
+      super(parent, key, writer);
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+      case VALUE_NULL:
+        setNull();
+        break;
+      case VALUE_STRING:
+        writer.setString(loader.tokenizer.stringValue());
+        break;
+      default:
+        throw loader.syntaxError(token, key(), "String");
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Parses "str" | true | false | integer | float
+   * <p>
+   * Returns the result as a string.
+   * <p>
+   * If the top level value is a scalar:
+   * <ul>
+   * <li><tt>null</tt> is mapped to a Drill NULL.</li>
+   * <li>Strings are stored in Drill unquoted.</li>
+   * </ul>
+   * If the top level is a map or array, then scalars within
+   * that structure:
+   * <ul>
+   * <li><tt>null</tt> is mapped to the literal "null".</li>
+   * <li>Strings are quoted.</li>
+   * </ul>
+   */
+
+  public static class TextParser extends ScalarParser {
+
+    private final boolean isArray;
+
+    public TextParser(JsonElementParser parent, String key,
+        ScalarWriter writer) {
+      super(parent, key, writer);
+      this.isArray = writer.schema().isArray();
+    }
+
+    @Override
+    public boolean parse() {
+      JsonToken token = loader.tokenizer.requireNext();
+      switch (token) {
+      case VALUE_NULL:
+        if (isArray) {
+          try {
+            writer.setString("");
+          } catch (UnsupportedConversionError e) {
+            throw loader.typeError(e);
+          }
+        } else {
+          setNull();
+        }
+        return true;
+
+      case VALUE_EMBEDDED_OBJECT:
+      case VALUE_FALSE:
+      case VALUE_TRUE:
+      case VALUE_NUMBER_FLOAT:
+      case VALUE_NUMBER_INT:
+      case VALUE_STRING:
+        writer.setString(loader.tokenizer.textValue());
+        return true;
+
+      default:
+        throw loader.syntaxError(token);
+      }
+    }
+  }
+
+  protected final ScalarWriter writer;
+
+  public ScalarParser(JsonElementParser parent, String key, ScalarWriter writer) {
+    super(parent, key);
+    this.writer = writer;
+  }
+
+  public void setNull() {
+    try {
+      writer.setNull();
+    } catch (UnsupportedConversionError e) {
+      throw loader.typeError(e, "Null value encountered in JSON input where Drill does not allow nulls.");
+    }
+  }
+
+  @Override
+  public ColumnMetadata schema() { return writer.schema(); }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/TokenIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/TokenIterator.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import java.io.IOException;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.RecoverableJsonException;
+import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class TokenIterator {
+  public static final int MAX_LOOKAHEAD = 30;
+
+  private final JsonLoaderImpl loader;
+  private final JsonParser parser;
+  private JsonToken[] lookahead = new JsonToken[MAX_LOOKAHEAD];
+  private int count;
+
+  public TokenIterator(JsonLoaderImpl loader) {
+    this.loader = loader;
+    this.parser = loader.parser;
+  }
+
+  public JsonToken next() {
+    if (count > 0) {
+      return lookahead[--count];
+    }
+    try {
+      return parser.nextToken();
+    } catch (JsonParseException e) {
+      if (loader.options.skipMalformedRecords) {
+        throw new RecoverableJsonException();
+      } else {
+        throw UserException
+          .dataReadError(e)
+          .addContext("Location", context())
+          .build(JsonLoaderImpl.logger);
+      }
+    } catch (IOException e) {
+      throw loader.ioException(e);
+    }
+  }
+
+  public String context() {
+    JsonLocation location = parser.getCurrentLocation();
+    if (location == null) {
+      return loader.options.context;
+    }
+    String token;
+    try {
+      token = parser.getText();
+    } catch (IOException e) {
+      token = "<unknown>";
+    }
+    return new StringBuilder()
+        .append(loader.options.context)
+        .append(", line ")
+        .append(location.getLineNr())
+        .append(", column ")
+        .append(location.getColumnNr())
+        .append(", near token \"")
+        .append(token)
+        .append("\"")
+        .toString();
+  }
+
+  public JsonToken requireNext() {
+    JsonToken token = next();
+    if (token == null) {
+      throw UserException
+        .dataReadError()
+        .message("Premature EOF of JSON file")
+        .addContext("Location", context())
+        .build(JsonLoaderImpl.logger);
+    }
+    return token;
+  }
+
+  public JsonToken peek() {
+    JsonToken token = requireNext();
+    unget(token);
+    return token;
+  }
+
+  public void unget(JsonToken token) {
+    if (count == lookahead.length) {
+      throw UserException
+        .dataReadError()
+        .message("Excessive JSON array nesting")
+        .addContext("Max allowed", lookahead.length)
+        .addContext("Location", context())
+        .build(JsonLoaderImpl.logger);
+    }
+    lookahead[count++] = token;
+  }
+
+  public String textValue() {
+    try {
+      return parser.getText();
+    } catch (IOException e) {
+      throw loader.ioException(e);
+    }
+  }
+
+  public long longValue() {
+    try {
+      return parser.getLongValue();
+    } catch (IOException e) {
+      throw loader.ioException(e);
+    } catch (UnsupportedConversionError e) {
+      throw loader.typeError(e);
+    }
+  }
+
+  public String stringValue() {
+    try {
+      return parser.getValueAsString();
+    } catch (IOException e) {
+      throw loader.ioException(e);
+    } catch (UnsupportedConversionError e) {
+      throw loader.typeError(e);
+    }
+  }
+
+  public double doubleValue() {
+    try {
+      return parser.getValueAsDouble();
+    } catch (IOException e) {
+      throw loader.ioException(e);
+    } catch (UnsupportedConversionError e) {
+      throw loader.typeError(e);
+    }
+  }
+}

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -624,6 +624,7 @@ drill.exec.options: {
     # Property name and value should be separated by =.
     # Properties should be separated by new line (\n).
     store.hive.conf.properties: "",
+    store.json.enable_v2_reader: false,
     store.json.all_text_mode: false,
     store.json.writer.allow_nan_inf: true,
     store.json.reader.allow_nan_inf: true,

--- a/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestStarQueries.java
@@ -22,6 +22,7 @@ import org.apache.drill.categories.SqlTest;
 import org.apache.drill.categories.UnlikelyTest;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.BatchSchemaBuilder;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -49,7 +50,9 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select n_name, *, n_name, n_name from cp.`tpch/nation.parquet`")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarCommaSameColumnRepeated/q1.tsv")
-      .baselineTypes(TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_name", "n_nationkey", "n_name0", "n_regionkey", "n_comment", "n_name00", "n_name1")
       .build().run();
 
@@ -57,7 +60,9 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select n_name, *, n_name, n_name from cp.`tpch/nation.parquet` limit 2")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarCommaSameColumnRepeated/q2.tsv")
-      .baselineTypes(TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_name", "n_nationkey", "n_name0", "n_regionkey", "n_comment", "n_name00", "n_name1")
       .build().run();
 
@@ -65,8 +70,10 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select *, n_name, *, n_name, n_name from cp.`tpch/nation.parquet`")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarCommaSameColumnRepeated/q3.tsv")
-      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
-            TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "n_name0",
             "n_nationkey0", "n_name1", "n_regionkey0", "n_comment0", "n_name00", "n_name10")
       .build().run();
@@ -75,8 +82,10 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select *, n_name, *, n_name, n_name from cp.`tpch/nation.parquet` limit 2")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarCommaSameColumnRepeated/q4.tsv")
-      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
-            TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "n_name0",
             "n_nationkey0", "n_name1", "n_regionkey0", "n_comment0", "n_name00", "n_name10")
       .build().run();
@@ -89,8 +98,10 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select *, n_name as extra, *, n_name as extra from cp.`tpch/nation.parquet`")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarMultipleStarsRegularColumnAsAlias/q1.tsv")
-      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
-              TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "extra", "n_nationkey0", "n_name0", "n_regionkey0", "n_comment0", "extra0")
       .build().run();
 
@@ -98,8 +109,10 @@ public class TestStarQueries extends BaseTestQuery {
       .sqlQuery("select *, n_name as extra, *, n_name as extra from cp.`tpch/nation.parquet` limit 2")
       .ordered()
       .csvBaselineFile("testframework/testStarQueries/testSelStarMultipleStarsRegularColumnAsAlias/q2.tsv")
-      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR,
-              TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+      .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                     TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                     TypeProtos.MinorType.VARCHAR)
       .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "extra", "n_nationkey0", "n_name0", "n_regionkey0", "n_comment0", "extra0")
       .build().run();
   }
@@ -111,7 +124,9 @@ public class TestStarQueries extends BaseTestQuery {
     .sqlQuery("select *, *, n_name from cp.`tpch/nation.parquet`")
     .ordered()
     .csvBaselineFile("testframework/testStarQueries/testSelStarMultipleStars/q1.tsv")
-    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                   TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                   TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
     .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "n_nationkey0", "n_name0", "n_regionkey0", "n_comment0", "n_name1")
     .build().run();
 
@@ -119,7 +134,9 @@ public class TestStarQueries extends BaseTestQuery {
     .sqlQuery("select *, *, n_name from cp.`tpch/nation.parquet` limit 2")
     .ordered()
     .csvBaselineFile("testframework/testStarQueries/testSelStarMultipleStars/q2.tsv")
-    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                   TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                   TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
     .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "n_nationkey0", "n_name0", "n_regionkey0", "n_comment0", "n_name1")
     .build().run();
   }
@@ -131,59 +148,107 @@ public class TestStarQueries extends BaseTestQuery {
     .sqlQuery("select *, n_nationkey, *, n_name from cp.`tpch/nation.parquet` limit 2")
     .ordered()
     .csvBaselineFile("testframework/testStarQueries/testSelStarWithAdditionalColumnLimit/q1.tsv")
-    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.VARCHAR)
+    .baselineTypes(TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT,
+                   TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.INT,
+                   TypeProtos.MinorType.VARCHAR, TypeProtos.MinorType.INT, TypeProtos.MinorType.VARCHAR,
+                   TypeProtos.MinorType.VARCHAR)
     .baselineColumns("n_nationkey", "n_name", "n_regionkey", "n_comment", "n_nationkey0", "n_nationkey1", "n_name0", "n_regionkey0", "n_comment0", "n_name1")
     .build().run();
   }
 
-  @Test
-  public void testSelStarOrderBy() throws Exception{
-    testBuilder()
-        .ordered()
-        .sqlQuery(" select * from cp.`employee.json` order by last_name")
-        .sqlBaselineQuery(" select employee_id, full_name,first_name,last_name,position_id,position_title,store_id," +
-            " department_id,birth_date,hire_date,salary,supervisor_id,education_level,marital_status,gender,management_role " +
-            " from cp.`employee.json` " +
-            " order by last_name ")
-        .build().run();
+  public static final String ENABLE_V2_READER = "ALTER SESSION SET `" + ExecConstants.ENABLE_V2_JSON_READER_KEY + "` = %s";
 
+  @Test
+  public void testSelStarOrderBy() throws Exception {
+    // See DRILL-7522
+    String query = "select * from cp.`employee.json` order by last_name";
+    String baselineQueryHead = "select employee_id, full_name, first_name, last_name, position_id, position_title, store_id," +
+            " department_id, birth_date, hire_date, ";
+    String baselineQueryTail = "salary, supervisor_id, education_level, marital_status, gender, management_role " +
+            " from cp.`employee.json` " +
+            " order by last_name";
+    try {
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "false")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + baselineQueryTail)
+          .build().run();
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "true")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + "end_date, " + baselineQueryTail)
+          .build().run();
+    } finally {
+      resetSessionOption(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+    }
   }
 
   @Test
   @Category(UnlikelyTest.class)
-  public void testSelStarOrderByLimit() throws Exception{
-    testBuilder()
-        .ordered()
-        .sqlQuery(" select * from cp.`employee.json` order by last_name limit 2")
-        .sqlBaselineQuery(" select employee_id, full_name,first_name,last_name,position_id,position_title,store_id," +
-            " department_id,birth_date,hire_date,salary,supervisor_id,education_level,marital_status,gender,management_role " +
-            " from cp.`employee.json` " +
-            " order by last_name limit 2")
-        .build().run();
-
+  public void testSelStarOrderByLimit() throws Exception {
+    // See DRILL-7522
+    String query = "select * from cp.`employee.json` order by last_name limit 2";
+    String baselineQueryHead = "select employee_id, full_name, first_name, last_name, position_id, position_title, store_id, " +
+            "department_id, birth_date, hire_date, ";
+    String baselineQueryTail = "salary, supervisor_id, education_level, marital_status, " +
+            "gender, management_role " +
+            "from cp.`employee.json` " +
+            "order by last_name limit 2";
+    try {
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "false")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + baselineQueryTail)
+          .build().run();
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "true")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + "end_date, " + baselineQueryTail)
+          .build().run();
+    } finally {
+      resetSessionOption(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+    }
   }
 
   @Test
-  public void testSelStarPlusRegCol() throws Exception{
+  public void testSelStarPlusRegCol() throws Exception {
     testBuilder()
         .unOrdered()
         .sqlQuery("select *, n_nationkey as key2 from cp.`tpch/nation.parquet` order by n_name limit 2")
         .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey, n_nationkey as key2 from cp.`tpch/nation.parquet` order by n_name limit 2")
         .build().run();
-
   }
 
   @Test
-  public void testSelStarWhereOrderBy() throws Exception{
-    testBuilder()
-        .ordered()
-        .sqlQuery("select * from cp.`employee.json` where first_name = 'James' order by last_name")
-        .sqlBaselineQuery("select employee_id, full_name,first_name,last_name,position_id,position_title,store_id," +
-            " department_id,birth_date,hire_date,salary,supervisor_id,education_level,marital_status,gender,management_role " +
-            " from cp.`employee.json` " +
-            " where first_name = 'James' order by last_name")
-        .build().run();
+  public void testSelStarWhereOrderBy() throws Exception {
+    // See DRILL-7522
+    String query = "select * from cp.`employee.json` where first_name = 'James' order by last_name";
+    String baselineQueryHead = "select employee_id, full_name, first_name, last_name, position_id, position_title, store_id," +
+        " department_id, birth_date, hire_date, ";
+    String baselineQueryTail = "salary, supervisor_id, education_level, marital_status, gender,management_role " +
+        " from cp.`employee.json` " +
+        " where first_name = 'James' order by last_name";
 
+    try {
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "false")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + baselineQueryTail)
+          .build().run();
+      testBuilder()
+          .ordered()
+          .optionSettingQueriesForTestQuery(ENABLE_V2_READER, "true")
+          .sqlQuery(query)
+          .sqlBaselineQuery(baselineQueryHead + "end_date, " + baselineQueryTail)
+          .build().run();
+    } finally {
+      resetSessionOption(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+    }
   }
 
   @Test
@@ -192,9 +257,10 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
         .ordered()
         .sqlQuery("select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
-        .sqlBaselineQuery("select n.n_nationkey, n.n_name,n.n_regionkey,n.n_comment,r.r_regionkey,r.r_name, r.r_comment from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlBaselineQuery("select n.n_nationkey, n.n_name,n.n_regionkey,n.n_comment,r.r_regionkey,r.r_name, r.r_comment " +
+                          "from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                           "where n.n_regionkey = r.r_regionkey order by n.n_name")
         .build().run();
-
   }
 
   @Test
@@ -202,33 +268,37 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
         .ordered()
         .sqlQuery("select n.* from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
-        .sqlBaselineQuery("select n.n_nationkey, n.n_name, n.n_regionkey, n.n_comment from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlBaselineQuery("select n.n_nationkey, n.n_name, n.n_regionkey, n.n_comment " +
+                          "from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                          "where n.n_regionkey = r.r_regionkey order by n.n_name")
         .build().run();
-
   }
 
   @Test
   public void testSelRightStarJoin() throws Exception {
     testBuilder()
         .ordered()
-        .sqlQuery("select r.* from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
-        .sqlBaselineQuery("select r.r_regionkey, r.r_name, r.r_comment from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlQuery("select r.* from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                  "where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlBaselineQuery("select r.r_regionkey, r.r_name, r.r_comment " +
+                          "from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                          "where n.n_regionkey = r.r_regionkey order by n.n_name")
         .build().run();
-
   }
 
   @Test
   public void testSelStarRegColConstJoin() throws Exception {
     testBuilder()
         .ordered()
-        .sqlQuery("select *, n.n_nationkey as n_nationkey0, 1 + 2 as constant from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlQuery("select *, n.n_nationkey as n_nationkey0, 1 + 2 as constant " +
+                  "from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                  "where n.n_regionkey = r.r_regionkey order by n.n_name")
         .sqlBaselineQuery(" select n.n_nationkey, n.n_name, n.n_regionkey, n.n_comment, r.r_regionkey, r.r_name, r.r_comment, " +
             " n.n_nationkey as n_nationkey0, 1 + 2 as constant " +
             " from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
             " where n.n_regionkey = r.r_regionkey " +
             " order by n.n_name")
         .build().run();
-
   }
 
   @Test
@@ -236,9 +306,10 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
         .unOrdered()
         .sqlQuery("select n.*, r.* from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey")
-        .sqlBaselineQuery("select n.n_nationkey,n.n_name,n.n_regionkey,n.n_comment,r.r_regionkey,r.r_name,r.r_comment from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey order by n.n_name")
+        .sqlBaselineQuery("select n.n_nationkey,n.n_name,n.n_regionkey,n.n_comment,r.r_regionkey,r.r_name,r.r_comment " +
+                          "from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r " +
+                          "where n.n_regionkey = r.r_regionkey order by n.n_name")
         .build().run();
-
   }
 
   @Test
@@ -247,9 +318,9 @@ public class TestStarQueries extends BaseTestQuery {
         .unOrdered()
         .sqlQuery("select * from cp.`tpch/nation.parquet` n1, cp.`tpch/nation.parquet` n2 where n1.n_nationkey = n2.n_nationkey")
         .sqlBaselineQuery("select n1.n_nationkey,n1.n_name,n1.n_regionkey,n1.n_comment,n2.n_nationkey,n2.n_name,n2.n_regionkey, n2.n_comment " +
-            "from cp.`tpch/nation.parquet` n1, cp.`tpch/nation.parquet` n2 where n1.n_nationkey = n2.n_nationkey")
+                          "from cp.`tpch/nation.parquet` n1, cp.`tpch/nation.parquet` n2 " +
+                          "where n1.n_nationkey = n2.n_nationkey")
         .build().run();
-
   }
 
   @Test // DRILL-1293
@@ -295,7 +366,8 @@ public class TestStarQueries extends BaseTestQuery {
   @Test(expected = UserException.class)  // Should get "At line 1, column 8: Column 'n_nationkey' is ambiguous"
   public void testSelStarAmbiguousJoin() throws Exception {
     try {
-      test("select x.n_nationkey, x.n_name, x.n_regionkey, x.r_name from (select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey) x " );
+      test("select x.n_nationkey, x.n_name, x.n_regionkey, x.r_name from " +
+           "(select * from cp.`tpch/nation.parquet` n, cp.`tpch/region.parquet` r where n.n_regionkey = r.r_regionkey) x " );
     } catch (UserException e) {
       // Expected
       throw e;
@@ -312,9 +384,12 @@ public class TestStarQueries extends BaseTestQuery {
   public void testSelStarSubQPrefix() throws Exception {
     test("select t.n_nationkey, t.n_name, t.n_regionkey from (select * from cp.`tpch/nation.parquet`) t where t.n_regionkey > 1 order by t.n_name" );
 
-    test("select n.n_regionkey, count(*) as cnt from ( select * from ( select * from cp.`tpch/nation.parquet`) t where t.n_nationkey < 10 ) n where n.n_nationkey >1 group by n.n_regionkey order by n.n_regionkey ; ");
+    test("select n.n_regionkey, count(*) as cnt from " +
+         "( select * from ( select * from cp.`tpch/nation.parquet`) t where t.n_nationkey < 10 ) n " +
+         "where n.n_nationkey >1 group by n.n_regionkey order by n.n_regionkey ; ");
 
-    test("select t.n_regionkey, count(*) as cnt from (select * from cp.`tpch/nation.parquet`) t where t.n_nationkey > 1 group by t.n_regionkey order by t.n_regionkey;" );
+    test("select t.n_regionkey, count(*) as cnt from (select * from cp.`tpch/nation.parquet`) t " +
+         "where t.n_nationkey > 1 group by t.n_regionkey order by t.n_regionkey;" );
   }
 
   @Test  // Select * in SubQuery : regular columns appear in select clause, where, group by, order by.
@@ -384,7 +459,6 @@ public class TestStarQueries extends BaseTestQuery {
          " where x.n_nationkey > 5 \n" +
          " group by x.n_regionkey \n" +
          " order by cnt limit 5; ");
-
   }
 
   @Test // DRILL-595 : Join two CTE, each having select * : regular columns appear in the select , where and on clause, group by, order by.
@@ -411,19 +485,22 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
         .ordered()
         .sqlQuery("select *  from cp.`tpch/nation.parquet` order by substr(n_name, 2, 5) limit 3")
-        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey from cp.`tpch/nation.parquet` order by substr(n_name, 2, 5) limit 3 ")
+        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey " +
+                          "from cp.`tpch/nation.parquet` order by substr(n_name, 2, 5) limit 3 ")
         .build().run();
 
     testBuilder()
         .ordered()
         .sqlQuery("select *, n_nationkey + 5 as myexpr from cp.`tpch/nation.parquet` limit 3")
-        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey, n_nationkey + 5 as myexpr from cp.`tpch/nation.parquet` order by n_nationkey limit 3")
+        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey, n_nationkey + 5 as myexpr " +
+                          "from cp.`tpch/nation.parquet` order by n_nationkey limit 3")
         .build().run();
 
     testBuilder()
         .ordered()
         .sqlQuery("select *  from cp.`tpch/nation.parquet` where n_nationkey + 5 > 10 limit 3")
-        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey  from cp.`tpch/nation.parquet` where n_nationkey + 5 > 10 order by n_nationkey limit 3")
+        .sqlBaselineQuery("select n_comment, n_name, n_nationkey, n_regionkey  from cp.`tpch/nation.parquet` " +
+                          "where n_nationkey + 5 > 10 order by n_nationkey limit 3")
         .build().run();
   }
 
@@ -435,7 +512,7 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
     .sqlQuery("select * from dfs.`multilevel/parquet` where dir0=1994 and dir1='Q1' order by dir0 limit 1")
     .ordered()
-    .baselineColumns("dir0", "dir1", "o_clerk", "o_comment", "o_custkey", "o_orderdate", "o_orderkey",  "o_orderpriority", "o_orderstatus", "o_shippriority",  "o_totalprice")
+    .baselineColumns("dir0", "dir1", "o_clerk", "o_comment", "o_custkey", "o_orderdate", "o_orderkey", "o_orderpriority", "o_orderstatus", "o_shippriority",  "o_totalprice")
     .baselineValues("1994", "Q1", "Clerk#000000743", "y pending requests integrate", 1292, mydate, 66, "5-LOW", "F",  0, 104190.66)
     .build().run();
   }
@@ -446,14 +523,16 @@ public class TestStarQueries extends BaseTestQuery {
     testBuilder()
         .unOrdered()
         .sqlQuery("select * from cp.`tpch/nation.parquet` where n_regionkey in (select r_regionkey from cp.`tpch/region.parquet`)")
-        .sqlBaselineQuery("select n_nationkey, n_name, n_regionkey, n_comment from cp.`tpch/nation.parquet` where n_regionkey in (select r_regionkey from cp.`tpch/region.parquet`)")
+        .sqlBaselineQuery("select n_nationkey, n_name, n_regionkey, n_comment from cp.`tpch/nation.parquet` " +
+                          "where n_regionkey in (select r_regionkey from cp.`tpch/region.parquet`)")
         .build().run();
 
     // multiple columns in "IN" subquery predicates.
     testBuilder()
         .unOrdered()
         .sqlQuery("select * from cp.`tpch/nation.parquet` where (n_nationkey, n_name) in ( select n_nationkey, n_name from cp.`tpch/nation.parquet`)")
-        .sqlBaselineQuery("select n_nationkey, n_name, n_regionkey, n_comment from cp.`tpch/nation.parquet` where (n_nationkey, n_name) in ( select n_nationkey, n_name from cp.`tpch/nation.parquet`)")
+        .sqlBaselineQuery("select n_nationkey, n_name, n_regionkey, n_comment from cp.`tpch/nation.parquet` " +
+                          "where (n_nationkey, n_name) in ( select n_nationkey, n_name from cp.`tpch/nation.parquet`)")
         .build().run();
 
     // Multiple in subquery predicates.
@@ -558,5 +637,4 @@ public class TestStarQueries extends BaseTestQuery {
         .build()
         .run();
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestScanLevelProjection.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/TestScanLevelProjection.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.scan.ScanTestUtils;
 import org.apache.drill.exec.physical.impl.scan.project.AbstractUnresolvedColumn.UnresolvedColumn;
@@ -35,7 +36,6 @@ import org.apache.drill.exec.physical.impl.scan.project.ScanLevelProjection.Scan
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet.ColumnReadProjection;
 import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/projSet/TestProjectionSet.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/project/projSet/TestProjectionSet.java
@@ -27,12 +27,12 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 
 import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.impl.scan.project.projSet.TypeConverter.CustomTypeTransform;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet;
 import org.apache.drill.exec.physical.resultSet.ProjectionSet.ColumnReadProjection;
 import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
-import org.apache.drill.exec.physical.resultSet.project.ProjectionType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -82,7 +82,7 @@ public class TestProjectionSet extends BaseTest {
     // Verify properties of an unprojected column
 
     assertSame(aSchema, aCol.readSchema());
-    assertSame(aSchema, aCol.providedSchema());
+    assertSame(aSchema, aCol.outputSchema());
     assertNull(aCol.conversionFactory());
     assertSame(EmptyProjectionSet.PROJECT_NONE, aCol.mapProjection());
     assertNull(aCol.projectionType());
@@ -111,7 +111,7 @@ public class TestProjectionSet extends BaseTest {
     ColumnReadProjection aCol = projSet.readProjection(aSchema);
     assertTrue(aCol.isProjected());
     assertSame(aSchema, aCol.readSchema());
-    assertSame(aSchema, aCol.providedSchema());
+    assertSame(aSchema, aCol.outputSchema());
     assertNull(aCol.conversionFactory());
     assertNull(aCol.mapProjection());
     assertNull(aCol.projectionType());
@@ -169,28 +169,28 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection aCol = projSet.readProjection(readSchema.metadata("a"));
     assertTrue(aCol.isProjected());
-    assertSame(outputSchema.metadata("a"), aCol.providedSchema());
+    assertSame(outputSchema.metadata("a"), aCol.outputSchema());
     assertNotNull(aCol.conversionFactory());
 
     // Column b marked as special by reader
 
     ColumnReadProjection bCol = projSet.readProjection(readSchema.metadata("b"));
     assertFalse(bCol.isProjected());
-    assertSame(readSchema.metadata("b"), bCol.providedSchema());
+    assertSame(readSchema.metadata("b"), bCol.outputSchema());
     assertNull(bCol.conversionFactory());
 
     // Column c marked as special by provided schema
 
     ColumnReadProjection cCol = projSet.readProjection(readSchema.metadata("c"));
     assertFalse(cCol.isProjected());
-    assertSame(readSchema.metadata("c"), cCol.providedSchema());
+    assertSame(readSchema.metadata("c"), cCol.outputSchema());
     assertNull(cCol.conversionFactory());
 
     // Column d needs no conversion
 
     ColumnReadProjection dCol = projSet.readProjection(readSchema.metadata("d"));
     assertTrue(dCol.isProjected());
-    assertSame(outputSchema.metadata("d"), dCol.providedSchema());
+    assertSame(outputSchema.metadata("d"), dCol.outputSchema());
     assertNull(dCol.conversionFactory());
   }
 
@@ -232,7 +232,7 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection mCol = projSet.readProjection(readSchema.metadata("m"));
     assertTrue(mCol.isProjected());
-    assertSame(outputSchema.metadata("m"), mCol.providedSchema());
+    assertSame(outputSchema.metadata("m"), mCol.outputSchema());
     assertNull(mCol.conversionFactory());
     ProjectionSet mProj = mCol.mapProjection();
 
@@ -241,7 +241,7 @@ public class TestProjectionSet extends BaseTest {
     ColumnReadProjection eCol = mProj.readProjection(mReadSchema.metadata("e"));
     assertTrue(eCol.isProjected());
     assertSame(mReadSchema.metadata("e"), eCol.readSchema());
-    assertSame(mOutputSchema.metadata("e"), eCol.providedSchema());
+    assertSame(mOutputSchema.metadata("e"), eCol.outputSchema());
     assertNotNull(eCol.conversionFactory());
 
     // Column m.f marked as special by reader
@@ -258,7 +258,7 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection hCol = mProj.readProjection(mReadSchema.metadata("h"));
     assertTrue(hCol.isProjected());
-    assertSame(mReadSchema.metadata("h"), hCol.providedSchema());
+    assertSame(mReadSchema.metadata("h"), hCol.outputSchema());
     assertNull(hCol.conversionFactory());
   }
 
@@ -289,14 +289,14 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection aCol = projSet.readProjection(readSchema.metadata("a"));
     assertTrue(aCol.isProjected());
-    assertSame(outputSchema.metadata("a"), aCol.providedSchema());
+    assertSame(outputSchema.metadata("a"), aCol.outputSchema());
     assertNotNull(aCol.conversionFactory());
 
     // Column b not in provided schema
 
     ColumnReadProjection bCol = projSet.readProjection(readSchema.metadata("b"));
     assertFalse(bCol.isProjected());
-    assertSame(readSchema.metadata("b"), bCol.providedSchema());
+    assertSame(readSchema.metadata("b"), bCol.outputSchema());
     assertNull(bCol.conversionFactory());
   }
 
@@ -336,7 +336,7 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection mCol = projSet.readProjection(readSchema.metadata("m"));
     assertTrue(mCol.isProjected());
-    assertSame(outputSchema.metadata("m"), mCol.providedSchema());
+    assertSame(outputSchema.metadata("m"), mCol.outputSchema());
     assertNull(mCol.conversionFactory());
     ProjectionSet mProj = mCol.mapProjection();
 
@@ -344,7 +344,7 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection cCol = mProj.readProjection(mReadSchema.metadata("c"));
     assertTrue(cCol.isProjected());
-    assertSame(mOutputSchema.metadata("c"), cCol.providedSchema());
+    assertSame(mOutputSchema.metadata("c"), cCol.outputSchema());
     assertNull(cCol.conversionFactory());
 
     // Column m.d is not in the provided schema
@@ -385,7 +385,7 @@ public class TestProjectionSet extends BaseTest {
     ColumnReadProjection aCol = projSet.readProjection(aSchema);
     assertTrue(aCol.isProjected());
     assertSame(aSchema, aCol.readSchema());
-    assertSame(aSchema, aCol.providedSchema());
+    assertSame(aSchema, aCol.outputSchema());
     assertNull(aCol.conversionFactory());
     assertNull(aCol.mapProjection());
     assertEquals(ProjectionType.GENERAL, aCol.projectionType());
@@ -429,7 +429,7 @@ public class TestProjectionSet extends BaseTest {
     ColumnReadProjection m1Col = projSet.readProjection(m1Schema);
     assertTrue(m1Col.isProjected());
     assertSame(m1Schema, m1Col.readSchema());
-    assertSame(m1Schema, m1Col.providedSchema());
+    assertSame(m1Schema, m1Col.outputSchema());
     assertNull(m1Col.conversionFactory());
     assertEquals(ProjectionType.TUPLE, m1Col.projectionType());
 
@@ -449,7 +449,7 @@ public class TestProjectionSet extends BaseTest {
     assertEquals(ProjectionType.GENERAL, m2Col.projectionType());
     assertTrue(m2Col.isProjected());
     assertSame(m2Schema, m2Col.readSchema());
-    assertSame(m2Schema, m2Col.providedSchema());
+    assertSame(m2Schema, m2Col.outputSchema());
     assertNull(m2Col.conversionFactory());
     assertTrue(m2Col.mapProjection() instanceof WildcardProjectionSet);
     assertEquals(ProjectionType.GENERAL, m2Col.projectionType());
@@ -571,7 +571,7 @@ public class TestProjectionSet extends BaseTest {
 
     ColumnReadProjection col = projSet.readProjection(readColSchema);
     assertTrue(col.isProjected());
-    assertSame(outputSchema.metadata("a"), col.providedSchema());
+    assertSame(outputSchema.metadata("a"), col.outputSchema());
     assertNotNull(col.conversionFactory());
 
     // Project none
@@ -594,7 +594,7 @@ public class TestProjectionSet extends BaseTest {
     col = projSet.readProjection(readColSchema);
     assertTrue(col.isProjected());
     assertSame(readColSchema, col.readSchema());
-    assertSame(outputSchema.metadata("a"), col.providedSchema());
+    assertSame(outputSchema.metadata("a"), col.outputSchema());
     assertNotNull(col.conversionFactory());
 
     assertFalse(projSet.readProjection(readSchema.metadata("b")).isProjected());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOmittedValues.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderOmittedValues.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.validate.BatchValidator;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -137,7 +138,6 @@ public class TestResultSetLoaderOmittedValues extends SubOperatorTest {
     // Harvest the row and verify.
 
     RowSet actual = fixture.wrap(rsLoader.harvest());
-//    actual.print();
 
     TupleMetadata expectedSchema = new SchemaBuilder()
         .add("a", MinorType.INT)
@@ -210,6 +210,7 @@ public class TestResultSetLoaderOmittedValues extends SubOperatorTest {
     // Harvest and verify
 
     RowSet result = fixture.wrap(rsLoader.harvest());
+    BatchValidator.validate(result);
     assertEquals(rowNumber - 1, result.rowCount());
     RowSetReader reader = result.reader();
     int rowIndex = 0;
@@ -248,9 +249,9 @@ public class TestResultSetLoaderOmittedValues extends SubOperatorTest {
     // Verify that holes were preserved.
 
     result = fixture.wrap(rsLoader.harvest());
+    BatchValidator.validate(result);
     assertEquals(rowNumber, rsLoader.totalRowCount());
     assertEquals(rowNumber - startRowNumber + 1, result.rowCount());
-//    result.print();
     reader = result.reader();
     rowIndex = 0;
     while (reader.next()) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedTuple.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedTuple.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.RequestedColumn;
 import org.apache.drill.exec.physical.resultSet.project.RequestedTuple.TupleProjectionType;
@@ -335,15 +336,30 @@ public class TestProjectedTuple extends BaseTest {
     assertTrue(indexes[3]);
   }
 
+  /**
+   * Duplicate array entries are allowed to handle the
+   * use case of a[1], a[1].z. Each element is reported once;
+   * the project operator will create copies as needed.
+   */
+
   @Test
   public void testArrayDups() {
-    try {
-      RequestedTupleImpl.parse(
-          RowSetTestUtils.projectList("a[1]", "a[3]", "a[1]"));
-      fail();
-    } catch (UserException e) {
-      // Expected
-    }
+    RequestedTuple projSet = RequestedTupleImpl.parse(
+        RowSetTestUtils.projectList("a[1]", "a[3]", "a[1]", "a[3].z"));
+
+    List<RequestedColumn> cols = projSet.projections();
+    assertEquals(1, cols.size());
+
+    RequestedColumn a = cols.get(0);
+    assertEquals("a", a.name());
+    assertTrue(a.isArray());
+    boolean indexes[] = a.indexes();
+    assertNotNull(indexes);
+    assertEquals(4, indexes.length);
+    assertFalse(indexes[0]);
+    assertTrue(indexes[1]);
+    assertFalse(indexes[2]);
+    assertTrue(indexes[3]);
   }
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectionType.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectionType.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.test.BaseTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/BaseTestJsonLoader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/BaseTestJsonLoader.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.OptionBuilder;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.SubOperatorTest;
+
+public abstract class BaseTestJsonLoader extends SubOperatorTest {
+
+  static class JsonTester {
+    public OptionBuilder loaderOptions = new OptionBuilder();
+    private final JsonOptions options;
+    private ResultSetLoader tableLoader;
+
+    public JsonTester(JsonOptions options) {
+      this.options = options;
+    }
+
+    public JsonTester() {
+      this(new JsonOptions());
+    }
+
+    public RowSet parseFile(String resourcePath) {
+      try {
+        return parse(ClusterFixture.getResource(resourcePath));
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    public RowSet parse(String json) {
+      tableLoader = new ResultSetLoaderImpl(fixture.allocator(),
+          loaderOptions.build());
+      InputStream inStream = new
+          ReaderInputStream(new StringReader(json));
+      options.context = "test Json";
+      JsonLoader loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+      readBatch(tableLoader, loader);
+      try {
+        inStream.close();
+      } catch (IOException e) {
+        fail();
+      }
+      loader.close();
+      return DirectRowSet.fromContainer(tableLoader.harvest());
+    }
+
+    public void close() {
+      tableLoader.close();
+    }
+  }
+
+  protected static class MultiBatchJson {
+
+    private final ResultSetLoader tableLoader;
+    private final InputStream inStream;
+    private final JsonLoader loader;
+
+    public MultiBatchJson(JsonOptions options, String json) {
+      options.context = "test Json";
+      inStream = new
+          ReaderInputStream(new StringReader(json));
+      tableLoader = new ResultSetLoaderImpl(fixture.allocator());
+      loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+    }
+
+    public MultiBatchJson(String json) {
+      this(new JsonOptions(), json);
+    }
+
+    public RowSet parse(int rowCount) {
+      readBatch(tableLoader, loader, rowCount);
+      return fixture.wrap(tableLoader.harvest());
+    }
+
+    public RowSet parse() {
+      readBatch(tableLoader, loader);
+      return fixture.wrap(tableLoader.harvest());
+    }
+
+    public void close() {
+      try {
+        inStream.close();
+      } catch (IOException e) {
+        fail();
+      }
+      loader.close();
+      tableLoader.close();
+    }
+  }
+
+  protected static boolean readBatch(ResultSetLoader tableLoader, JsonLoader loader) {
+    tableLoader.startBatch();
+    RowSetLoader writer = tableLoader.writer();
+    boolean more = false;
+    while (writer.start()) {
+      more = loader.next();
+      if (! more) {
+        break;
+      }
+      writer.save();
+    }
+    loader.endBatch();
+    return more;
+  }
+
+  protected static void readBatch(ResultSetLoader tableLoader, JsonLoader loader, int count) {
+    tableLoader.startBatch();
+    RowSetLoader writer = tableLoader.writer();
+    for (int i = 0; i < count; i++) {
+      writer.start();
+      assertTrue(loader.next());
+      writer.save();
+    }
+    loader.endBatch();
+  }
+
+  static void expectError(JsonTester tester, String json) {
+    try {
+      tester.parse(json);
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("test Json"));
+    }
+    tester.close();
+  }
+
+  protected JsonTester jsonTester() {
+    return new JsonTester();
+  }
+
+  protected JsonTester jsonTester(JsonOptions options) {
+    return new JsonTester(options);
+  }
+
+  protected void expectError(String json) {
+    JsonTester tester = jsonTester();
+    expectError(tester, json);
+  }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/BaseTestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/BaseTestJsonReader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.junit.Assert.fail;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.rpc.RpcException;
+import org.apache.drill.test.ClusterTest;
+
+public class BaseTestJsonReader extends ClusterTest {
+
+  protected void enableV2Reader(boolean enable) throws Exception {
+    client.alterSession(ExecConstants.ENABLE_V2_JSON_READER_KEY, enable);
+  }
+
+  protected void resetV2Reader() throws Exception {
+    client.resetSession(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+  }
+
+  protected interface TestWrapper {
+    void apply() throws Exception;
+  }
+
+  protected void runBoth(TestWrapper wrapper) throws Exception {
+    try {
+      enableV2Reader(false);
+      wrapper.apply();
+      enableV2Reader(true);
+      wrapper.apply();
+    } finally {
+      resetV2Reader();
+    }
+  }
+
+  protected RowSet runTest(String sql) {
+    try {
+      return client.queryBuilder().sql(sql).rowSet();
+    } catch (RpcException e) {
+      fail(e.getMessage());
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderAllText.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderAllText.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderAllText extends BaseTestJsonLoader {
+
+  @Test
+  @Ignore("Turns out all text can't handle structures")
+  public void testRootTupleAllTextComplex() {
+    final JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    final JsonTester tester = jsonTester(options);
+    final String json =
+      "{id: 1, name: \"Fred\", balance: 100.0, extra: [\"a\",   \"\\\"b,\\\", said I\" ]}\n" +
+      "{id: 2, name: \"Barney\", extra: {a:  10 , b:20}}\n" +
+      "{id: 3, name: \"Wilma\", balance: 500.00, extra: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.VARCHAR)
+        .addNullable("name", MinorType.VARCHAR)
+        .addNullable("balance", MinorType.VARCHAR)
+        .addNullable("extra", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow("1", "Fred", "100.0", "[\"a\", \"\\\"b,\\\", said I\"]")
+        .addRow("2", "Barney", null, "{\"a\": 10, \"b\": 20}")
+        .addRow("3", "Wilma", "500.00", null)
+        .build();
+    new RowSetComparison(expected)
+      .verifyAndClearAll(results);
+    tester.close();
+  }
+
+  @Test
+  public void testRootTupleAllText() {
+    final JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    final JsonTester tester = jsonTester(options);
+    final String json =
+      "{id: 1, name: \"Fred\", balance: 100.0, extra: true}\n" +
+      "{id: 2, name: \"Barney\", extra: 10}\n" +
+      "{id: 3, name: \"Wilma\", balance: 500.00, extra: null}\n" +
+      "{id: 4, name: \"Betty\", balance: 12.00, extra: \"Hello\"}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.VARCHAR)
+        .addNullable("name", MinorType.VARCHAR)
+        .addNullable("balance", MinorType.VARCHAR)
+        .addNullable("extra", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow("1", "Fred", "100.0", "true")
+        .addRow("2", "Barney", null, "10")
+        .addRow("3", "Wilma", "500.00", null)
+        .addRow("4", "Betty", "12.00", "Hello")
+        .build();
+    new RowSetComparison(expected)
+      .verifyAndClearAll(results);
+    tester.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderArray.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderArray.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.doubleArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.intArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderArray extends BaseTestJsonLoader {
+
+  @Test
+  public void testBooleanArray() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [true, false]}\n" +
+        "{a: []} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(intArray(1, 0))
+        .addRow(intArray())
+        .addRow(intArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testIntegerArray() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [1, 100]}\n" +
+        "{a: []} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(longArray(1L, 100L))
+        .addSingleCol(longArray())
+        .addSingleCol(longArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testFloatArray() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [1.0, 100]}\n" +
+        "{a: []} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(doubleArray(1D, 100D))
+        .addRow(doubleArray())
+        .addRow(doubleArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testIntegerArrayAsFloat() {
+    final JsonOptions options = new JsonOptions();
+    options.readNumbersAsDouble = true;
+    final JsonTester tester = jsonTester(options);
+    final String json =
+        "{a: [1, 100]}\n" +
+        "{a: []}\n" +
+        "{a: null}\n" +
+        "{a: [12.5, 123.45]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(doubleArray(1.0, 100.0))
+        .addRow(doubleArray())
+        .addRow(doubleArray())
+        .addRow(doubleArray(12.5, 123.45))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testIntererFloatConflictInArray() {
+    expectError("{a: [10, 12.5]");
+  }
+
+  @Test
+  public void testStringArray() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [\"\", \"foo\"]}\n" +
+        "{a: []} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray("", "foo"))
+        .addSingleCol(strArray())
+        .addSingleCol(strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testAllTextArray() {
+    final JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    final JsonTester tester = jsonTester(options);
+    final String json =
+        "{a: [\"foo\", true, false, 10, null, 20.0] }";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray("foo", "true", "false", "10", "", "20.0"))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testTupleArray() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{id: 1, customer: {name: \"fred\"}, orders: [\n" +
+        "  {id: 1001, status: \"closed\"},\n" +
+        "  {id: 1002, status: \"open\"}]}\n" +
+        "{id: 2, customer: {name: \"barney\"}, orders: []}\n" +
+        "{id: 3, customer: {name: \"wilma\"}, orders: null}\n" +
+        "{id: 4, customer: {name: \"betty\"}}\n" +
+        "{id: 5, customer: {name: \"pebbles\"}, orders: [\n" +
+        "  {id: 1003, status: \"canceled\"}]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.BIGINT)
+        .addMap("customer")
+          .addNullable("name", MinorType.VARCHAR)
+          .resumeSchema()
+        .addMapArray("orders")
+          .addNullable("id", MinorType.BIGINT)
+          .addNullable("status", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(1L, mapValue("fred"), mapArray(
+            mapValue(1001L, "closed"),
+            mapValue(1002L, "open")))
+        .addRow(2L, mapValue("barney"), mapArray())
+        .addRow(3L, mapValue("wilma"), mapArray())
+        .addRow(4L, mapValue("betty"), mapArray())
+        .addRow(5L, mapValue("pebbles"), mapArray(
+            mapValue(1003L, "canceled")))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredTupleArray() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: []} {a: null} {a: [{name: \"fred\"}, {name: \"barney\"}]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMapArray("a")
+          .addNullable("name", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(mapArray())
+        .addSingleCol(mapArray())
+        .addSingleCol(mapArray(
+            mapValue("fred"), mapValue("barney")))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testTupleArrayNullCols() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [{b: null}, {b:null}]} " +
+        "{a: [{b: null}]} " +
+        "{a: [{b: null}, {b:null}, {b:null}]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMapArray("a")
+          .addNullable("b", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(mapArray(singleMap(null), singleMap(null)))
+        .addSingleCol(mapArray(singleMap(null)))
+        .addSingleCol(mapArray(singleMap(null), singleMap(null), singleMap(null)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testTupleArrayNullColsNested() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [{b: {c: null}}, {b: {c: null}}]} " +
+        "{a: [{b: {c: null}}]} " +
+        "{a: [{b: {c: null}}, {b: {c: null}}, {b: {c: null}}]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMapArray("a")
+          .addMap("b")
+            .addNullable("c", MinorType.VARCHAR)
+            .resumeMap()
+          .resumeSchema()
+        .buildSchema();
+    Object[] mapValue = singleMap(singleMap(null));
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(mapArray(mapValue, mapValue))
+        .addSingleCol(mapArray(mapValue))
+        .addSingleCol(mapArray(mapValue, mapValue, mapValue))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testArrays() {
+    final String json =
+        "{a: null, b: []}\n" +
+        "{a: [true, false], b: [10, 20], c: [10.5, 12.25], d: [\"foo\", \"bar\"]}";
+    final ResultSetLoader tableLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final InputStream inStream = new
+        ReaderInputStream(new StringReader(json));
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    final JsonLoader loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+    readBatch(tableLoader, loader);
+    final RowSet result = fixture.wrap(tableLoader.harvest());
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIT)
+        .addArray("b", MinorType.BIGINT)
+        .addArray("c", MinorType.FLOAT8)
+        .addArray("d", MinorType.VARCHAR)
+        .buildSchema();
+
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(intArray(), longArray(), doubleArray(), strArray())
+        .addRow(intArray(1, 0), longArray(10L, 20L), doubleArray(10.5, 12.25), strArray("foo", "bar"))
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+
+    try {
+      inStream.close();
+    } catch (final IOException e) {
+      fail();
+    }
+    loader.close();
+    tableLoader.close();
+  }
+
+  /**
+   * Drill supports 1-D arrays using repeated types. Drill does not
+   * support 2-D or higher arrays. Instead, Drill reverts to "text
+   * mode" for such arrays, capturing them as JSON text, allowing the
+   * client to interpret them.
+   */
+
+  @Test
+  @Ignore("All text mode does not handle structures")
+  public void testArraysOld() {
+    final String oneDArray = "[[1, 2], [3, 4]]";
+    final String twoDArray = "[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]";
+    final String json =
+        "{a: [10, 11]," +
+        " b: " + oneDArray + "," +
+        " c: " + twoDArray + "}\n" +
+
+        // 2- and 3-D arrays are all text. So, allow changes
+        // to cardinality.
+
+        "{a: [20, 21]," +
+        " b: " + twoDArray + "," +
+        " c: " + oneDArray + "}";
+    final ResultSetLoader tableLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final InputStream inStream = new
+        ReaderInputStream(new StringReader(json));
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    final JsonLoader loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    readBatch(tableLoader, loader);
+    final RowSet result = fixture.wrap(tableLoader.harvest());
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT)
+        .addNullable("b", MinorType.VARCHAR)
+        .addNullable("c", MinorType.VARCHAR)
+        .buildSchema();
+
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(new long[] {10, 11}, oneDArray, twoDArray)
+        .addRow(new long[] {20, 21}, twoDArray, oneDArray)
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+
+    try {
+      inStream.close();
+    } catch (final IOException e) {
+      fail();
+    }
+    loader.close();
+    tableLoader.close();
+  }
+
+  @Test
+  public void testEmptyArray() {
+    final String json =
+        "{a: [], b: \"first\"} " +
+        "{a: [], b: \"second\"} " +
+        "{a: [], b: \"third\"}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    final RowSet results = tester.parse(json);
+
+    // Order of columns reverses because array is not
+    // materialized until end of batch.
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("b", MinorType.VARCHAR)
+        .addArray("a", MinorType.VARCHAR)
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow("first", strArray())
+        .addRow("second", strArray())
+        .addRow("third", strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testEmptyNestedArray() {
+    final String json =
+        "{a: {b: []}, c: \"first\"} " +
+        "{a: {b: []}, c: \"second\"} " +
+        "{a: {b: []}, c: \"third\"}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("a")
+          .addArray("b", MinorType.VARCHAR)
+          .resumeSchema()
+        .addNullable("c", MinorType.VARCHAR)
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(singleMap(strArray()), "first")
+        .addRow(singleMap(strArray()), "second")
+        .addRow(singleMap(strArray()), "third")
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderBasics.java
@@ -1,0 +1,534 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.project.projSet.ProjectionSetFactory;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.OptionBuilder;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl.ResultSetOptions;
+import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.physical.rowSet.RowSetReader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests the JSON loader itself: the various syntax combinations that the loader understands
+ * or rejects. Assumes that the JSON parser itself works, and that the underlying result set
+ * loader properly handles column types, projections and so on.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderBasics extends BaseTestJsonLoader {
+
+  @Test
+  public void testEmpty() {
+    final JsonTester tester = jsonTester();
+    final RowSet results = tester.parse("");
+    assertEquals(0, results.rowCount());
+    results.clear();
+    tester.close();
+  }
+
+  @Test
+  public void testEmptyTuple() {
+    final JsonTester tester = jsonTester();
+    final String json = "{} {} {}";
+    final RowSet results = tester.parse(json);
+    assertEquals(3, results.rowCount());
+    results.clear();
+    tester.close();
+  }
+
+  @Test
+  public void testBoolean() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: true} {a: false} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(1)
+        .addRow(0)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testInteger() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: 0} {a: 100} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(0L)
+        .addRow(100L)
+        .addSingleCol(null)
+        .build();
+
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testFloat() {
+    final JsonTester tester = jsonTester();
+
+    // Note: integers allowed after first float.
+
+    final String json = "{a: 0.0} {a: 100.5} {a: 5} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(0D)
+        .addRow(100.5D)
+        .addRow(5D)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testExtendedFloat() {
+    final JsonOptions options = new JsonOptions();
+    options.allowNanInf = true;
+    final JsonTester tester = jsonTester(options);
+    final String json =
+        "{a: 0.0} {a: 100.5} {a: -200.5} {a: NaN}\n" +
+        "{a: Infinity} {a: -Infinity} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(0D)
+        .addRow(100.5D)
+        .addRow(-200.5D)
+        .addRow(Double.NaN)
+        .addRow(Double.POSITIVE_INFINITY)
+        .addRow(Double.NEGATIVE_INFINITY)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testIntegerAsFloat() {
+    final JsonOptions options = new JsonOptions();
+    options.readNumbersAsDouble = true;
+    final JsonTester tester = jsonTester(options);
+    final String json = "{a: 0} {a: 100} {a: null} {a: 123.45}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(0D)
+        .addRow(100D)
+        .addSingleCol(null)
+        .addRow(123.45D)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testString() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: \"\"} {a: \"hi\"} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow("")
+        .addRow("hi")
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testRootTuple() {
+    final JsonTester tester = jsonTester();
+    final String json =
+      "{id: 1, name: \"Fred\", balance: 100.0}\n" +
+      "{id: 2, name: \"Barney\"}\n" +
+      "{id: 3, name: \"Wilma\", balance: 500.00}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.BIGINT)
+        .addNullable("name", MinorType.VARCHAR)
+        .addNullable("balance", MinorType.FLOAT8)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(1L, "Fred", 100.00D)
+        .addRow(2L, "Barney", null)
+        .addRow(3L, "Wilma", 500.0D)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testMissingEndObject() {
+    expectError("{a: 0} {a: 100");
+  }
+
+  @Test
+  public void testMissingValue() {
+    expectError("{a: 0} {a: ");
+  }
+
+  @Test
+  public void testMissingEndOuterArray() {
+    expectError("[{a: 0}, {a: 100}");
+  }
+
+  @Test
+  public void testNullInArray() {
+    expectError("{a: [10, 20, null]}");
+  }
+
+  @Test
+  public void testEmptyKey() {
+    expectError("{\"\": 10}");
+  }
+
+  @Test
+  public void testBlankKey() {
+    expectError("{\"  \": 10}");
+  }
+
+  @Test
+  public void testLeadingTrailingWhitespace() {
+    final JsonTester tester = jsonTester();
+    final String json = "{\" a\": 10, \" b\": 20, \" c \": 30}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addNullable("b", MinorType.BIGINT)
+        .addNullable("c", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(10L, 20L, 30L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Verify that names are case insensitive, first name determine's
+   * Drill's column name.
+   */
+
+  @Test
+  public void testCaseInsensitive() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: 10} {A: 20} {\" a \": 30}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(10L)
+        .addRow(20L)
+        .addRow(30L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Verify that the first name wins when determining case.
+   */
+
+  @Test
+  public void testCaseInsensitive2() {
+    final JsonTester tester = jsonTester();
+    final String json = "{Bob: 10} {bOb: 20} {BoB: 30}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("Bob", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(10L)
+        .addRow(20L)
+        .addRow(30L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Verify that, when names are duplicated, the last value wins.
+   */
+
+  @Test
+  public void testDuplicateNames() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: 10, A: 20, \" a \": 30}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(30L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testNestedTuple() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{id: 1, customer: { name: \"fred\" }}\n" +
+        "{id: 2, customer: { name: \"barney\" }}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.BIGINT)
+        .addMap("customer")
+          .addNullable("name", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(1L, mapValue("fred"))
+        .addRow(2L, mapValue("barney"))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testNullTuple() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{id: 1, customer: {name: \"fred\"}}\n" +
+        "{id: 2, customer: {name: \"barney\"}}\n" +
+        "{id: 3, customer: null}\n" +
+        "{id: 4}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("id", MinorType.BIGINT)
+        .addMap("customer")
+          .addNullable("name", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(1L, mapValue("fred"))
+        .addRow(2L, mapValue("barney"))
+        .addRow(3L, mapValue((String) null))
+        .addRow(4L, mapValue((String) null))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testRootArray() {
+    final JsonTester tester = jsonTester();
+    final String json = "[{a: 0}, {a: 100}, {a: null}]";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(0L)
+        .addRow(100L)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testRootArrayDisallowed() {
+    final JsonOptions options = new JsonOptions();
+    options.skipOuterList = false;
+    final JsonTester tester = jsonTester(options);
+    final String json = "[{a: 0}, {a: 100}, {a: null}]";
+    expectError(tester, json);
+  }
+
+  /**
+   * Verify that non-projected maps are just "free-wheeled", the JSON loader
+   * just seeks the matching end brace, ignoring content semantics.
+   */
+
+  @Test
+  public void testNonProjected() {
+    final String json =
+        "{a: 10, b: {c: 100, c: 200, d: {x: null, y: 30}}}\n" +
+        "{a: 20, b: { }}\n" +
+        "{a: 30, b: null}\n" +
+        "{a: 40, b: {c: \"foo\", d: [{}, {x: {}}]}}\n" +
+        "{a: 50, b: [{c: 100, c: 200, d: {x: null, y: 30}}, 10]}\n" +
+        "{a: 60, b: []}\n" +
+        "{a: 70, b: null}\n" +
+        "{a: 80, b: [\"foo\", [{}, {x: {}}]]}\n" +
+        "{a: 90, b: 55.5} {a: 100, b: 10} {a: 110, b: \"foo\"}";
+    final ResultSetOptions rsOptions = new OptionBuilder()
+        .setProjection(
+            ProjectionSetFactory.build(RowSetTestUtils.projectList("a")))
+        .build();
+    final ResultSetLoader tableLoader = new ResultSetLoaderImpl(fixture.allocator(), rsOptions);
+    final InputStream inStream = new
+        ReaderInputStream(new StringReader(json));
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    final JsonLoader loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    readBatch(tableLoader, loader);
+    final RowSet result = fixture.wrap(tableLoader.harvest());
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    assertTrue(expectedSchema.isEquivalent(result.schema()));
+    final RowSetReader reader = result.reader();
+    for (int i = 10; i <= 110; i += 10) {
+      assertTrue(reader.next());
+      assertEquals(i, reader.scalar(0).getLong());
+    }
+    assertFalse(reader.next());
+    result.clear();
+
+    try {
+      inStream.close();
+    } catch (final IOException e) {
+      fail();
+    }
+    loader.close();
+    tableLoader.close();
+  }
+
+  /**
+   * Test the JSON parser's limited recovery abilities.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/DRILL-4653">DRILL-4653</a>
+   */
+
+  @Test
+  public void testErrorRecovery() {
+    final JsonOptions options = new JsonOptions();
+    options.skipMalformedRecords = true;
+    final JsonTester tester = jsonTester(options);
+    final String json = "{\"a: 10}\n{a: 20}\n{a: 30}";
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+//        .addRow(20L) // Recovery will eat the second record.
+        .addRow(30L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Test handling of unrecoverable parse errors. This test must change if
+   * we resolve DRILL-5953 and allow better recovery.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/DRILL-5953">DRILL-5953</a>
+   */
+
+  @Test
+  public void testUnrecoverableError() {
+    final JsonOptions options = new JsonOptions();
+    options.skipMalformedRecords = true;
+    final JsonTester tester = jsonTester(options);
+    expectError(tester, "{a: }\n{a: 20}\n{a: 30}");
+  }
+
+  /**
+   * Test based on TestJsonReader.testAllTextMode
+   * Verifies the complex case of an array of maps that contains an array of
+   * strings (from all text mode). Also verifies projection.
+   */
+
+  @Test
+  public void testMapSelect() {
+    final JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    final JsonTester tester = jsonTester(options);
+    tester.loaderOptions.setProjection(
+        ProjectionSetFactory.build(RowSetTestUtils.projectList("field_5")));
+    final RowSet results = tester.parseFile("store/json/schema_change_int_to_string.json");
+//    results.print();
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMapArray("field_5")
+          .addArray("inner_list", MinorType.VARCHAR)
+          .addArray("inner_list_2", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(mapArray())
+        .addSingleCol(mapArray(
+            mapValue(strArray("1", "", "6"), strArray()),
+            mapValue(strArray("3", "8"), strArray()),
+            mapValue(strArray("12", "", "4", "null", "5"), strArray())))
+        .addSingleCol(mapArray(
+            mapValue(strArray("5", "", "6.0", "1234"), strArray()),
+            mapValue(strArray("7", "8.0", "12341324"), strArray("1", "2", "2323.443e10", "hello there")),
+            mapValue(strArray("3", "4", "5"), strArray("10", "11", "12"))))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  // TODO: Union support
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderLists.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderLists.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.listValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleList;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.exec.vector.NullableBigIntVector;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.complex.ListVector;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests of the experimental JSON list support using the incomplete
+ * list vector. The tests here show that the list vector works for
+ * JSON. There are known problems, however, in other operators.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderLists extends BaseTestJsonLoader {
+
+  /**
+   * Test scalar list support.
+   */
+
+  @Test
+  public void testScalarList() {
+
+    // Read the one and only record into a batch. When we saw the
+    // null value for b, we should have used the knowledge that b must
+    // be a map (based on the projection of a.b), to make it an map
+    // (which contains no columns.)
+
+    final String json =
+        "{a: 1, b: [10, null, 20]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addList("b")
+          .addType(MinorType.BIGINT)
+          .resumeSchema()
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(1L, longArray(10L, null, 20L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testScalarListLeadingNull() {
+    final String json =
+        "{a: 1, b: [null, 10, 20]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addList("b")
+          .addType(MinorType.BIGINT)
+          .resumeSchema()
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(1L, longArray(null, 10L, 20L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testScalarListAllNull() {
+    final String json =
+        "{a: 1, b: [null, null, null]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addList("b")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(1L, strArray(null, null, null))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testEmptyArray() {
+    final String json =
+        "{a: []} {a: []} {a: []}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addType(MinorType.VARCHAR)
+         .resumeSchema()
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addSingleCol(strArray())
+        .addSingleCol(strArray())
+        .addSingleCol(strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testDeferredListAsText() {
+    final String json = "{a: []} {a: null} {a: []} {a: [10, 20]} {a: [\"foo\", \"bar\"]}";
+    final ResultSetLoader tableLoader = new ResultSetLoaderImpl(fixture.allocator());
+    final InputStream inStream = new
+        ReaderInputStream(new StringReader(json));
+    final JsonOptions options = new JsonOptions();
+    options.useListType = true;
+    options.context = "test Json";
+    final JsonLoader loader = new JsonLoaderImpl(inStream, tableLoader.writer(), options);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    readBatch(tableLoader, loader, 2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addType(MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray())
+        .addSingleCol(strArray())
+        .build();
+    RowSetUtilities.verify(expected,
+        fixture.wrap(tableLoader.harvest()));
+
+    // Second batch, read remaining records as text mode.
+
+    readBatch(tableLoader, loader);
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray())
+        .addSingleCol(strArray("10", "20"))
+        .addSingleCol(strArray("foo", "bar"))
+        .build();
+    RowSetUtilities.verify(expected,
+        fixture.wrap(tableLoader.harvest()));
+
+    try {
+      inStream.close();
+    } catch (final IOException e) {
+      fail();
+    }
+    loader.close();
+    tableLoader.close();
+  }
+
+  @Test
+  public void testListPromotionFromNull() {
+    final String json = "{a: null} {a: []} {a: null} {a: [10, 20]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addType(MinorType.BIGINT)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(longArray())
+        .addSingleCol(null)
+        .addSingleCol(longArray(10L, 20L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testConflictingListTypes() {
+    final JsonOptions options = new JsonOptions();
+    options.skipOuterList = false;
+    final JsonTester tester = jsonTester(options);
+    final String json = "{a: [10]} {a: [\"oops\"]}";
+    expectError(tester, json);
+  }
+
+  @Test
+  public void testObjectList() {
+    final String json =
+        "{a: [{b: \"fred\", c: 10}, null, {b: \"barney\", c: 20}]}\n" +
+        "{a: []} {a: null} {a: [{b: \"wilma\", c: 30}]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addMap()
+            .addNullable("b", MinorType.VARCHAR)
+            .addNullable("c", MinorType.BIGINT)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(mapArray(mapValue("fred", 10L), null, mapValue("barney", 20L)))
+        .addSingleCol(mapArray())
+        .addSingleCol(null)
+        .addSingleCol(mapArray(mapValue("wilma", 30L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testDeferredObjectList() {
+    final String json =
+        "{a: null} {a: []} {a: [null]}\n" +
+        "{a: [{b: \"fred\", c: 10}, null, {b: \"barney\", c: 20}]}\n" +
+        "{a: []} {a: null} {a: [{b: \"wilma\", c: 30}]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addMap()
+            .addNullable("b", MinorType.VARCHAR)
+            .addNullable("c", MinorType.BIGINT)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(mapArray())
+        .addSingleCol(mapArray((Object[]) null))
+        .addSingleCol(mapArray(mapValue("fred", 10L), null, mapValue("barney", 20L)))
+        .addSingleCol(mapArray())
+        .addSingleCol(null)
+        .addSingleCol(mapArray(mapValue("wilma", 30L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testListofListofScalar() {
+    final String json =
+        "{a: [[1, 2], [3, 4]]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    // Verify metadata
+
+    final ListVector outer = (ListVector) results.container().getValueVector(0).getValueVector();
+    final MajorType outerType = outer.getField().getType();
+    assertEquals(1, outerType.getSubTypeCount());
+    assertEquals(MinorType.LIST, outerType.getSubType(0));
+    assertEquals(1, outer.getField().getChildren().size());
+
+    final ListVector inner = (ListVector) outer.getDataVector();
+    assertSame(inner.getField(), outer.getField().getChildren().iterator().next());
+    final MajorType innerType = inner.getField().getType();
+    assertEquals(1, innerType.getSubTypeCount());
+    assertEquals(MinorType.BIGINT, innerType.getSubType(0));
+    assertEquals(1, inner.getField().getChildren().size());
+
+    final ValueVector data = inner.getDataVector();
+    assertSame(data.getField(), inner.getField().getChildren().iterator().next());
+    assertEquals(MinorType.BIGINT, data.getField().getType().getMinorType());
+    assertEquals(DataMode.OPTIONAL, data.getField().getType().getMode());
+    assertTrue(data instanceof NullableBigIntVector);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addList()
+            .addType(MinorType.BIGINT)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(listValue(listValue(1L, 2L), listValue(3L, 4L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testListofListofScalarWithNulls() {
+    final String json =
+        "{a: null}\n" +
+        "{a: []}\n" +
+        "{a: [null]}\n" +
+        "{a: [[]]}\n" +
+        "{a: [[null]]}\n" +
+        "{a: [null, [\"a\", \"string\"]]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addList()
+            .addType(MinorType.VARCHAR)
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(listValue())
+        .addSingleCol(singleList(null))
+        .addSingleCol(singleList(listValue()))
+        .addSingleCol(singleList(singleList(null)))
+        .addSingleCol(listValue(null, strArray("a", "string")))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testListofListofObject() {
+    final String json =
+        "{a: [[{a: 1, b: 2}, {a: 3, b: 4}],\n" +
+             "[{a: 5, b: 6}, {a: 7, b: 8}]]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addList()
+            .addMap()
+              .addNullable("a", MinorType.BIGINT)
+              .addNullable("b", MinorType.BIGINT)
+              .resumeUnion()
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(listValue(listValue(mapValue(1L, 2L), mapValue(3L, 4L)),
+                                listValue(mapValue(5L, 6L), mapValue(7L, 8L))))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testListofListofObjectWithNulls() {
+    final String json =
+        "{a: [[{a: null, b: null}, {a: 1, b: 2}, null, {a: 3}],\n" +
+             "null, [{b: 6}]]}\n" +
+        "{a: null}\n" +
+        "{a: []}\n" +
+        "{a: [[], null]}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    options.useListType = true;
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addList("a")
+          .addList()
+            .addMap()
+              .addNullable("a", MinorType.BIGINT)
+              .addNullable("b", MinorType.BIGINT)
+              .resumeUnion()
+            .resumeUnion()
+          .resumeSchema()
+        .buildSchema();
+
+    // Logically expected results.
+
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(listValue(listValue(mapValue(null, null),
+                                          mapValue(1L, 2L),
+                                          null,
+                                          mapValue(3L, null)),
+                                null,
+                                singleList(mapValue(null, 6L))))
+        .addSingleCol(null)
+        .addSingleCol(listValue())
+        .addSingleCol(listValue(listValue(), null))
+        .build();
+    new RowSetComparison(expected).verify(results);
+    expected.clear();
+
+    // Physical description of results
+
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(listValue(listValue(mapValue(null, null),
+                                          mapValue(1L, 2L),
+                                          mapValue(null, null), // Maps can't really be null
+                                          mapValue(3L, null)),
+                                null, // List entries can be null
+                                singleList(mapValue(null, 6L))))
+        .addSingleCol(null)
+        .addSingleCol(listValue())
+        .addSingleCol(listValue(listValue(), null))
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderNulls.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderNulls.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.doubleArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.impl.scan.project.projSet.ProjectionSetFactory;
+import org.apache.drill.exec.physical.resultSet.impl.RowSetTestUtils;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.TypeNegotiator;
+import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Drill requires types to be known on the first row. JSON files can be quite lazy about
+ * revealing the type: there may be many missing values, null values, or empty arrays
+ * before the parser finally sees a token that suggests the column type. The JSON loader
+ * has "null deferral" logic to postpone picking a column type until a type token finally
+ * appears (or until the end of the batch, when the pick is forced.)
+ * <p>
+ * Empty arrays for multi-dimensional lists are tested in
+ * {@link TestJsonLoaderRepeatedLists}.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderNulls extends BaseTestJsonLoader {
+
+  @Test
+  public void testAllNulls() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: null} {a: null} {a: null}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.VARCHAR)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testAllNullsInNested() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: {b: null}} {a: {b: null}} {a: {b: null}}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("a")
+          .addNullable("b", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(singleMap(null))
+        .addSingleCol(singleMap(null))
+        .addSingleCol(singleMap(null))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredScalarNull() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: null} {a: null} {a: 10}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .addRow(10L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredScalarNullInNested() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: {b: null}} {a: {b: null}} {a: {b: 10}}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("a")
+          .addNullable("b", MinorType.BIGINT)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(singleMap(null))
+        .addSingleCol(singleMap(null))
+        .addSingleCol(singleMap(10L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredScalarNullAsText() {
+    final String json = "{a: null} {a: null} {a: null} {a: 10} {a: \"foo\"}";
+    final MultiBatchJson tester = new MultiBatchJson(json);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    RowSet results = tester.parse(2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.VARCHAR)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as text mode.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol("10")
+        .addSingleCol("foo")
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredScalarNullAsType() {
+    final String json = "{a: null} {a: null} {a: null} {a: 10} {a: 20}";
+
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    options.typeNegotiator = new TypeNegotiator() {
+
+      // Only one field.
+
+      @Override
+      public MajorType typeOf(List<String> path) {
+        assertEquals(1, path.size());
+        assertEquals("a", path.get(0));
+        return Types.optional(MinorType.BIGINT);
+      }
+    };
+    final MultiBatchJson tester = new MultiBatchJson(options, json);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    RowSet results = tester.parse(2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as given type.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(10L)
+        .addSingleCol(20L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  @Test
+  public void testNestedDeferredScalarNullAsType() {
+    final String json =
+        "{a: {b: null, c: null, d: null}, e: null}\n" +
+        "{a: {b: null, c: null, d: null}, e: null}\n" +
+        "{a: {b: null, c: null, d: null}, e: null}\n" +
+        "{a: {b: 10, c: \"fred\", d: [1.5, 2.5]}, e: 10.25}\n";
+
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    options.typeNegotiator = new TypeNegotiator() {
+
+      // Find types for three fields.
+
+      @Override
+      public MajorType typeOf(List<String> path) {
+        final String name = Joiner.on(".").join(path);
+        switch (name) {
+        case "a.b": return Types.optional(MinorType.BIGINT);
+        case "a.c": return Types.optional(MinorType.VARCHAR);
+        case "a.d": return Types.repeated(MinorType.FLOAT8);
+        case "e": return null;
+        default:
+          fail("Unexpected path: " + name);
+          return null;
+        }
+      }
+    };
+    final MultiBatchJson tester = new MultiBatchJson(options, json);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    RowSet results = tester.parse(2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("a")
+          .addNullable("b", MinorType.BIGINT)
+          .addNullable("c", MinorType.VARCHAR)
+          .addArray("d", MinorType.FLOAT8)
+          .resumeSchema()
+        .addNullable("e", MinorType.VARCHAR)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(mapValue(null, null, doubleArray()), null)
+        .addRow(mapValue(null, null, doubleArray()), null)
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as given type.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(mapValue(null, null, doubleArray()), null)
+        .addRow(mapValue(10L, "fred", doubleArray(1.5, 2.5)), "10.25")
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredScalarArray() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: []} {a: null} {a: [10, 20]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(longArray())
+        .addSingleCol(longArray())
+        .addSingleCol(longArray(10L, 20L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredArrayAsText() {
+    final String json = "{a: []} {a: null} {a: []} {a: [10, 20]} {a: [\"foo\", \"bar\"]}";
+    final MultiBatchJson tester = new MultiBatchJson(json);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    RowSet results = tester.parse(2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray())
+        .addSingleCol(strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as text mode.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(strArray())
+        .addSingleCol(strArray("10", "20"))
+        .addSingleCol(strArray("foo", "bar"))
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  @Test
+  public void testDeferredArrayAsType() {
+    final String json =
+        "{a: [], b: []}\n" +
+        "{a: null, b: null}\n" +
+        "{a: [], b: []}\n" +
+        "{a: [10, 20], b: [10.5, \"fred\"]}\n" +
+        "{a: [30, 40], b: [null, false]}";
+
+    final JsonOptions options = new JsonOptions();
+    options.context = "test Json";
+    options.typeNegotiator = new TypeNegotiator() {
+      @Override
+      public MajorType typeOf(List<String> path) {
+        assertEquals(1, path.size());
+        switch (path.get(0)) {
+
+        // Note: type for b is optional, not compatible with
+        // an array, so is ignored but the type will be used.
+
+        case "a": return Types.optional(MinorType.BIGINT);
+
+        // No hint for b, text mode will be used.
+
+        case "b": return null;
+        default:
+          fail();
+          return null;
+        }
+      }
+    };
+    final MultiBatchJson tester = new MultiBatchJson(options, json);
+
+    // Read first two records into a batch. Since we've not yet seen
+    // a type, the null field will be realized as a text field.
+
+    RowSet results = tester.parse(2);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT)
+        .addArray("b", MinorType.VARCHAR)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(longArray(), strArray())
+        .addRow(longArray(), strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as long.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addRow(longArray(), strArray())
+        .addRow(longArray(10L, 20L), strArray("10.5", "fred"))
+        .addRow(longArray(30L, 40L), strArray("", "false"))
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  /**
+   * Double deferral. First null causes a deferred null. Then,
+   * the empty array causes a deferred array. Finally, the third
+   * array announces the type.
+   */
+
+  @Test
+  public void testDeferredNullToArray() {
+    final JsonTester tester = jsonTester();
+    final String json = "{a: null} {a: []} {a: [10, 20]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(longArray())
+        .addSingleCol(longArray())
+        .addSingleCol(longArray(10L, 20L))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Test that the JSON reader uses a projection hint to
+   * determine that a null type is an array.
+   */
+
+  @Test
+  public void testArrayProjectionHint() {
+
+    // Read the one and only record into a batch. When we saw the
+    // null value for b, we should have used the knowledge that b must
+    // be an array (based on the projection of b[0]), to make it an array.
+    // Then, at the end of the batch, we guess that the array is of
+    // type VARCHAR.
+
+    final String json =
+        "{a: 1, b: null}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    tester.loaderOptions.setProjection(
+        ProjectionSetFactory.build(RowSetTestUtils.projectList("a", "b[0]")));
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addArray("b", MinorType.VARCHAR)
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(1L, strArray())
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  /**
+   * Test that the JSON reader uses a projection hint to
+   * determine that a null type is a map.
+   */
+
+  @Test
+  public void testObjectProjectionHint() {
+
+    // Read the one and only record into a batch. When we saw the
+    // null value for b, we should have used the knowledge that b must
+    // be a map (based on the projection of a.b), to make it a map
+    // (which contains no columns.)
+
+    final String json =
+        "{a: 1, b: null}";
+    final JsonOptions options = new JsonOptions();
+    final JsonTester tester = jsonTester(options);
+    tester.loaderOptions.setProjection(
+        ProjectionSetFactory.build(RowSetTestUtils.projectList("a", "b.c")));
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.BIGINT)
+        .addMap("b")
+          .resumeSchema()
+        .buildSchema();
+
+    final RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(1L, mapValue())
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderRepeatedLists.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonLoaderRepeatedLists.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.doubleArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.intArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.objArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleObjArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * JSON supports repeated list. But, tests with the rest of the code
+ * suggest that this type is not supported by some other operators.
+ * Hence, the functionality is best tested in isolation with just
+ * the JSON reader and scan framework, without the rest of Drill.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonLoaderRepeatedLists extends BaseTestJsonLoader {
+
+  @Test
+  public void testBoolean2D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[true, false], [false, true]]}\n" +
+        "{a: [[true], [false]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(intArray(1, 0), intArray(0, 1)))
+        .addSingleCol(objArray(intArray(1), intArray(0)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testInt2D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[1, 10], [2, 20]]}\n" +
+        "{a: [[1], [-1]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(longArray(1L, 10L), longArray(2L, 20L)))
+        .addSingleCol(objArray(longArray(1L), longArray(-1L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testFloat2D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[1.25, 10.5], [2.25, 20.5]]}\n" +
+        "{a: [[1], [-1]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.FLOAT8, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(doubleArray(1.25D, 10.5D), doubleArray(2.25D, 20.5D)))
+        .addSingleCol(objArray(doubleArray(1D), doubleArray(-1D)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testString2D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[\"first\", \"second\"], [\"third\", \"fourth\"]]}\n" +
+        "{a: [[\"fifth\"], [\"sixth\"]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(strArray("first", "second"), strArray("third", "fourth")))
+        .addSingleCol(objArray(strArray("fifth"), strArray("sixth")))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  @Test
+  public void testObject2D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[{b: 1, c: \"first\"},\n" +
+        "      {b: 2, c: \"second\"}],\n" +
+        "     [{b: 3, c: \"third\"},\n" +
+        "      {b: 4, c: \"fourth\"}]]}\n" +
+        "{a: [[{b: 5, c: \"fifth\"}],\n" +
+        "     [{b: 6, c: \"sixth\"}]]}";
+    final RowSet results = tester.parse(json);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addRepeatedList("a")
+          .addMapArray()
+            .addNullable("b", MinorType.BIGINT)
+            .addNullable("c", MinorType.VARCHAR)
+            .resumeList()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(
+            objArray(
+                objArray(mapValue(1L, "first"), mapValue(2L, "second")),
+                objArray(mapValue(3L, "third"), mapValue(4L, "fourth"))))
+        .addSingleCol(
+            objArray(
+                singleObjArray(mapValue(5L, "fifth")),
+                singleObjArray(mapValue(6L, "sixth"))))
+        .build();
+
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Leading empties forces the parser to defer determining
+   * the actual type until a non-null, non-empty token appears.
+   */
+
+  @Test
+  public void testLeadingEmpties() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[]]}\n" +
+        "{a: [[], null]}\n" +
+        "{a: [[1, 10], [2, 20]]}\n";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(singleObjArray(longArray()))
+        .addSingleCol(objArray(longArray(), longArray()))
+        .addSingleCol(objArray(longArray(1L, 10L), longArray(2L, 20L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Trailing empties are easier, we know the type, just fill
+   * in an empty array.
+   */
+
+  @Test
+  public void testTrailingEmpties() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[1, 10], [2, 20]]}\n" +
+        "{a: [[]]}\n" +
+        "{a: [[], null]}\n" +
+        "{a: [[1], [-1]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(longArray(1L, 10L), longArray(2L, 20L)))
+        .addSingleCol(singleObjArray(longArray()))
+        .addSingleCol(objArray(longArray(), longArray()))
+        .addSingleCol(objArray(longArray(1L), longArray(-1L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Trailing nulls forces the parser to defer knowledge of the
+   * type again and again, gradually learning more about the type
+   * on each new row.
+   */
+
+  @Test
+  public void testLeadingAmbiguity() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: null}\n" +
+        "{a: []}\n" +
+        "{a: [[]]}\n" +
+        "{a: [[1, 10], [2, 20]]}\n";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray())
+        .addSingleCol(objArray())
+        .addSingleCol(singleObjArray(longArray()))
+        .addSingleCol(objArray(longArray(1L, 10L), longArray(2L, 20L)))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * Drill can't handle a null in an array before Drill knows
+   * that the array is multi-dimensional. Drill could, in theory,
+   * handle this case by introducing yet another intermediate state
+   * that "remembers" that the array can contain nulls. That is left
+   * as an exercise for later.
+   */
+
+  @Test
+  public void testleadingNulls() {
+    expectError("{a: [null]} {a: [[10]]}");
+  }
+
+  /**
+   * The same set of records work, however, if presented in
+   * an order that shows Drill the array is 2D before it
+   * presents a null for the inner array. This kind of
+   * ambiguity will likely drive production users nuts...
+   */
+
+  @Test
+  public void testTrailingNulls() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[10]]} {a: [null]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(singleObjArray(longArray(10L)))
+        .addSingleCol(singleObjArray(longArray())) // null same as []
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * The repeated list allows higher-dimensional arrays
+   * (AKA tensors). Encoding these in JSON and Java is a bit
+   * tedious, however...
+   */
+
+  @Test
+  public void testInt3D() {
+    final JsonTester tester = jsonTester();
+    final String json =
+        "{a: [[[1, 2], [3, 4]],\n" +
+        "     [[5, 6], [7, 8]]]}";
+    final RowSet results = tester.parse(json);
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.BIGINT, 3)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(
+            objArray(
+                objArray(
+                    longArray(1L, 2L), longArray(3L, 4L)),
+                objArray(
+                    longArray(5L, 6L), longArray(7L, 8L))))
+        .build();
+    RowSetUtilities.verify(expected, results);
+    tester.close();
+  }
+
+  /**
+   * The empty array support tested above works as long as the
+   * "answer" to the array type can be found within the batch.
+   * However, there is an ambiguity if the first batch never reveals
+   * the type. All we can do is guess. We guess "text mode" so that
+   * the answer is compatible with a scalar value in the next batch.
+   */
+
+  @Test
+  public void testUnresolvedAmbiguity() {
+    final String json =
+        "{a: null}\n" +
+        "{a: []}\n" +
+        "{a: [[]]}\n" +
+        "{a: [[1, 10], [2, 20]]}\n";
+    final MultiBatchJson tester = new MultiBatchJson(json);
+
+    // Read first three records into a batch. Since we've not yet seen
+    // a type, the 2D array type will be resolved as a text field.
+
+    RowSet results = tester.parse(3);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR, 2)
+        .buildSchema();
+    RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray())
+        .addSingleCol(objArray())
+        .addSingleCol(singleObjArray(strArray()))
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, read remaining records as text mode.
+
+    results = tester.parse();
+    expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray(strArray("1", "10"), strArray("2", "20")))
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    tester.close();
+  }
+
+  /**
+   * But, if the next batch contains another array, all heck breaks
+   * loose...
+   */
+
+  @Test
+  public void testAmbiguityWrongGuess() {
+    final String json =
+        "{a: null}\n" +
+        "{a: []}\n" +
+        "{a: [[]]}\n" +
+        "{a: [[[]]]}\n";
+    final MultiBatchJson tester = new MultiBatchJson(json);
+
+    // Read first three records into a batch. Since we've not yet seen
+    // a type, the 2D array type will be resolved as a text field.
+
+    final RowSet results = tester.parse(3);
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("a", MinorType.VARCHAR, 2)
+        .buildSchema();
+    final RowSet expected = new RowSetBuilder(fixture.allocator(), expectedSchema)
+        .addSingleCol(objArray())
+        .addSingleCol(objArray())
+        .addSingleCol(singleObjArray(strArray()))
+        .build();
+    RowSetUtilities.verify(expected, results);
+
+    // Second batch, fail due to conflict of array and text mode.
+
+    try {
+      tester.parse();
+      fail();
+    } catch (final UserException e) {
+      // Expected;
+    }
+
+    tester.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderFns.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderFns.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import java.nio.file.Paths;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.complex.writer.TestJsonReader;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests of Drill selected Drill functions using JSON as an input source.
+ * (Split from the original <tt>TestJsonReader</tt>.) Relative to the Drill 1.12
+ * version, the tests here:
+ * <ul>
+ * <li>Are rewritten to use the {@link ClusterFixture} framework.</li>
+ * <li>Add data verification where missing.</li>
+ * <li>Clean up handling of session options.</li>
+ * </ul>
+ * When running tests, consider these to be secondary. First verify the core
+ * JSON reader itself (using {@link TestJsonReader}), then run these tests to
+ * ensure vectors populated by JSON work with downstream functions.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonReaderFns extends BaseTestJsonReader {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+    dirTestWatcher.copyResourceToRoot(Paths.get("store", "json"));
+    dirTestWatcher.copyResourceToRoot(Paths.get("vector","complex", "writer"));
+  }
+
+  @Test
+  public void testEmptyList() throws Exception {
+    runBoth(() -> doTestEmptyList());
+  }
+
+  private void doTestEmptyList() throws Exception {
+    final String sql = "select count(a[0]) as ct from dfs.`store/json/emptyLists`";
+
+    final RowSet results = runTest(sql);
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("ct", MinorType.BIGINT)
+        .build();
+
+    final RowSet expected = client.rowSetBuilder(schema)
+        .addRow(6L)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  // Expansion of former testRepeatedCount()
+
+  @Test
+  public void testRepeatedCountStr() throws Exception {
+    runBoth(() -> doTestRepeatedCountStr());
+  }
+
+  private void doTestRepeatedCountStr() throws Exception {
+    final RowSet results = runTest("select repeated_count(str_list) from cp.`store/json/json_basic_repeated_varchar.json`");
+    final RowSet expected = client.rowSetBuilder(countSchema())
+        .addSingleCol(5)
+        .addSingleCol(1)
+        .addSingleCol(3)
+        .addSingleCol(1)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedCountInt() throws Exception {
+    runBoth(() -> doTestRepeatedCountInt());
+  }
+
+  private void doTestRepeatedCountInt() throws Exception {
+    final RowSet results = runTest("select repeated_count(INT_col) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(countSchema())
+        .addSingleCol(12)
+        .addSingleCol(4)
+        .addSingleCol(4)
+        .addSingleCol(4)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedCountFloat4() throws Exception {
+    runBoth(() -> doTestRepeatedCountFloat4());
+  }
+
+  private void doTestRepeatedCountFloat4() throws Exception {
+    final RowSet results = runTest("select repeated_count(FLOAT4_col) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(countSchema())
+        .addSingleCol(7)
+        .addSingleCol(4)
+        .addSingleCol(4)
+        .addSingleCol(4)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedCountVarchar() throws Exception {
+    runBoth(() -> doTestRepeatedCountVarchar());
+  }
+
+  private void doTestRepeatedCountVarchar() throws Exception {
+    final RowSet results = runTest("select repeated_count(VARCHAR_col) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(countSchema())
+        .addSingleCol(4)
+        .addSingleCol(3)
+        .addSingleCol(3)
+        .addSingleCol(3)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedCountBit() throws Exception {
+    runBoth(() -> doTestRepeatedCountBit());
+  }
+
+  private void doTestRepeatedCountBit() throws Exception {
+    final RowSet results = runTest("select repeated_count(BIT_col) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(countSchema())
+        .addSingleCol(7)
+        .addSingleCol(7)
+        .addSingleCol(5)
+        .addSingleCol(3)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  private TupleMetadata countSchema() {
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("EXPR$0", MinorType.INT)
+        .build();
+    return expectedSchema;
+  }
+
+
+  // Reimplementation of testRepeatedContains()
+
+  @Test
+  public void testRepeatedContainsStr() throws Exception {
+    runBoth(() -> doTestRepeatedContainsStr());
+  }
+
+  private void doTestRepeatedContainsStr() throws Exception {
+    final RowSet results = runTest("select repeated_contains(str_list, 'asdf') from cp.`store/json/json_basic_repeated_varchar.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(2) // WRONG! Should be 1 (true). See DRILL-6034
+        .addSingleCol(0)
+        .addSingleCol(1)
+        .addSingleCol(0)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedContainsInt() throws Exception {
+    runBoth(() -> doTestRepeatedContainsInt());
+  }
+
+  private void doTestRepeatedContainsInt() throws Exception {
+    final RowSet results = runTest("select repeated_contains(INT_col, -2147483648) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(1)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedContainsFloat4() throws Exception {
+    runBoth(() -> doTestRepeatedContainsFloat4());
+  }
+
+  private void doTestRepeatedContainsFloat4() throws Exception {
+    final RowSet results = runTest("select repeated_contains(FLOAT4_col, -1000000000000.0) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(1)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedContainsVarchar() throws Exception {
+    runBoth(() -> doTestRepeatedContainsVarchar());
+  }
+
+  private void doTestRepeatedContainsVarchar() throws Exception {
+    final RowSet results = runTest("select repeated_contains(VARCHAR_col, 'qwerty' ) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(1)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .addSingleCol(0)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedContainsBitTrue() throws Exception {
+    runBoth(() -> doTestRepeatedContainsBitTrue());
+  }
+
+  private void doTestRepeatedContainsBitTrue() throws Exception {
+    final RowSet results = runTest("select repeated_contains(BIT_col, true) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(11) // WRONG! Should be 1 (true). See DRILL-6034
+        .addSingleCol(2)
+        .addSingleCol(0)
+        .addSingleCol(3)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  @Test
+  public void testRepeatedContainsBitFalse() throws Exception {
+    runBoth(() -> doTestRepeatedContainsBitFalse());
+  }
+
+  private void doTestRepeatedContainsBitFalse() throws Exception {
+    final RowSet results = runTest("select repeated_contains(BIT_col, false) from cp.`parquet/alltypes_repeated.json`");
+    final RowSet expected = client.rowSetBuilder(bitCountSchema())
+        .addSingleCol(5) // WRONG! Should be 1 (true). See DRILL-6034
+        .addSingleCol(5)
+        .addSingleCol(5)
+        .addSingleCol(0)
+        .build();
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
+  private TupleMetadata bitCountSchema() {
+    return new SchemaBuilder()
+        .add("EXPR$0", MinorType.BIT)
+        .buildSchema();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonReaderQueries.java
@@ -1,0 +1,634 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.TestBuilder.listOf;
+import static org.apache.drill.test.TestBuilder.mapOf;
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Paths;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.util.DrillFileUtils;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.exception.SchemaChangeException;
+import org.apache.drill.exec.physical.rowSet.DirectRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
+import org.apache.drill.shaded.guava.com.google.common.io.Files;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.QueryBuilder.QuerySummary;
+import org.apache.drill.test.QueryResultSet;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Reimplementation of selected tests from the
+ * TestJsonReader test suite.
+ */
+
+@Category(RowSetTests.class)
+public class TestJsonReaderQueries extends BaseTestJsonReader {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    startCluster(ClusterFixture.builder(dirTestWatcher));
+    dirTestWatcher.copyResourceToRoot(Paths.get("store", "json"));
+    dirTestWatcher.copyResourceToRoot(Paths.get("vector","complex", "writer"));
+    dirTestWatcher.copyResourceToRoot(Paths.get("jsoninput/drill_3353"));
+  }
+
+  /**
+   * Reimplementation of a Drill 1.12 unit test to actually verify results.
+   * Doing so is non-trivial as inline comments explain. This test shows the
+   * limits "schema-free" processing when the schema changes.
+   * @throws Exception
+   */
+
+  @Test
+  @Ignore("Too fragile to keep working")
+  public void schemaChange() throws Exception {
+    String sql = "select b from dfs.`vector/complex/writer/schemaChange/`";
+//    runAndPrint(sql);
+    QueryResultSet results = client.queryBuilder().sql(sql).resultSet();
+
+    // Query will scan two files:
+    // f1:
+    // {"a": "foo","b": null}
+    // {"a": "bar","b": null}
+    // f2:
+    // {"a": "foo2","b": null}
+    // {"a": "bar2","b": {"x":1, "y":2}}
+
+    // When f1 is read, we didn't know the type of b, so it will default to Varchar
+    // (Assuming text mode for that column.)
+    //
+    // On reading f2, we discover that b is a map (which we discover the
+    // second record.)
+    //
+    // The scanner handles schema persistence, but not (at present) for maps.
+    // If we did have schema persistence, then if f2 was first, we'd remember
+    // the map schema when we read f1.
+    //
+    // This crazy behavior is the best we can do without a schema. Bottom line:
+    // Drill needs a user-provided schema to make sense of these cases because
+    // "Drill can't predict the future" (TM).
+    //
+    // See TestCSV* for a way to implement this test case
+
+    TupleMetadata f2Schema = new SchemaBuilder()
+        .addMap("b")
+          .addNullable("x", MinorType.BIGINT)
+          .addNullable("y", MinorType.BIGINT)
+          .resumeSchema()
+        .build();
+    RowSet f2Expected = client.rowSetBuilder(f2Schema)
+        .addSingleCol(mapValue(null, null))
+        .addSingleCol(mapValue(1L, 2L))
+        .build();
+
+    TupleMetadata f1Schema = new SchemaBuilder()
+        .addNullable("b", MinorType.VARCHAR)
+        .build();
+    RowSet f1Expected = client.rowSetBuilder(f1Schema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+
+    // First batch is empty; presents only schema. But,
+    // since file order is non-deterministic, we don't know
+    // which one.
+
+    RowSet batch = results.next();
+    assertNotNull(batch);
+    assertEquals(0, batch.rowCount());
+    boolean mapFirst;
+    if (batch.schema().metadata("b").type() == MinorType.MAP) {
+      RowSet expected = client.rowSetBuilder(f2Schema)
+          .build();
+      RowSetUtilities.verify(expected, batch);
+      mapFirst = true;
+    } else {
+      RowSet expected = client.rowSetBuilder(f1Schema)
+          .build();
+      RowSetUtilities.verify(expected, batch);
+      mapFirst = false;
+    }
+    for (int i = 0; i < 2; i++) {
+      batch = results.next();
+      assertNotNull(batch);
+      if (i == 0 && mapFirst || i == 1 && ! mapFirst) {
+        RowSetUtilities.verify(f2Expected, batch);
+      } else {
+        RowSetUtilities.verify(f1Expected, batch);
+      }
+    }
+    assertNull(results.next());
+    results.close();
+  }
+
+  /**
+   * Reimplementation of the Drill 1.12 test. Tests the odd case in which
+   * we project both a single column from inside a map, as well as the
+   * entire map.
+   *
+   *
+   * As it turns out, the original functionality
+   * was broken, that the test had incorrect expected results that reflected the broken
+   * functionality.
+   * <p>
+   * The query selects two fields which are deeply nested:
+   * <ul>
+   * <li><tt>t.field_4.inner_3</tt> where <tt>field_4</tt> is a map and
+   * <tt>inner_3</tt> is another map.</li>
+   * <li><tt>t.field_4</tt> is a map with three total items.</li>
+   * </ul>
+   * The original expected results
+   * @throws Exception
+   */
+
+  @Test
+  @Ignore("broken")
+  public void testFieldSelectionBug() throws Exception {
+    runBoth(() -> doTestFieldSelectionBug());
+  }
+
+  private void doTestFieldSelectionBug() throws Exception {
+    String sql = "select t.field_4.inner_3 as col_1, t.field_4 as col_2 from cp.`store/json/schema_change_int_to_string.json` t";
+    try {
+      client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
+
+      testBuilder()
+          .sqlQuery(sql)
+          .unOrdered()
+          .baselineColumns("col_1", "col_2")
+          .baselineValues(
+              mapOf(),
+              mapOf(
+                  "inner_1", listOf(),
+                  "inner_3", mapOf()))
+          .baselineValues(
+              mapOf("inner_object_field_1", "2"),
+              mapOf(
+                  "inner_1", listOf("1", "2", "3"),
+                  "inner_2", "3",
+                  "inner_3", mapOf("inner_object_field_1", "2")))
+          .baselineValues(
+              mapOf(),
+              mapOf(
+                  "inner_1", listOf("4", "5", "6"),
+                  "inner_2", "3",
+                  "inner_3", mapOf()))
+          .go();
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+    }
+  }
+
+  @Test
+  public void testReadCompressed() throws Exception {
+    runBoth(() -> doTestReadCompressed());
+  }
+
+  private void doTestReadCompressed() throws Exception {
+    String filepath = "compressed_json.json";
+    File f = new File(dirTestWatcher.getRootDir(), filepath);
+    PrintWriter out = new PrintWriter(f);
+    out.println("{\"a\" :5}");
+    out.close();
+
+    gzipIt(f);
+    testBuilder()
+        .sqlQuery("select * from dfs.`%s.gz`", filepath)
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(5l)
+        .build().run();
+
+    // test reading the uncompressed version as well
+    testBuilder()
+        .sqlQuery("select * from dfs.`%s`", filepath)
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(5l)
+        .build().run();
+  }
+
+  public static void gzipIt(File sourceFile) throws IOException {
+
+    // modified from: http://www.mkyong.com/java/how-to-compress-a-file-in-gzip-format/
+    byte[] buffer = new byte[1024];
+    GZIPOutputStream gzos =
+        new GZIPOutputStream(new FileOutputStream(sourceFile.getPath() + ".gz"));
+
+    FileInputStream in =
+        new FileInputStream(sourceFile);
+
+    int len;
+    while ((len = in.read(buffer)) > 0) {
+      gzos.write(buffer, 0, len);
+    }
+    in.close();
+    gzos.finish();
+    gzos.close();
+  }
+
+  @Test
+  public void testDrill_1419() throws Exception {
+    runBoth(() -> doTestDrill_1419());
+  }
+
+  private void doTestDrill_1419() throws Exception {
+    String sql = "select t.trans_id, t.trans_info.prod_id[0],t.trans_info.prod_id[1] from cp.`store/json/clicks.json` t limit 5";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    TupleMetadata schema = new SchemaBuilder()
+        .addNullable("trans_id", MinorType.BIGINT)
+        .addNullable("EXPR$1", MinorType.BIGINT)
+        .addNullable("EXPR$2", MinorType.BIGINT)
+        .build();
+
+    RowSet expected = client.rowSetBuilder(schema)
+        .addRow(31920L, 174L, 2L)
+        .addRow(31026L, null, null)
+        .addRow(33848L, 582L, null)
+        .addRow(32383L, 710L, 47L)
+        .addRow(32359L, 0L, 8L)
+        .build();
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testSingleColumnRead_vector_fill_bug() throws Exception {
+    runBoth(() -> doTestSingleColumnRead_vector_fill_bug());
+  }
+
+  private void doTestSingleColumnRead_vector_fill_bug() throws Exception {
+    String sql = "select * from cp.`store/json/single_column_long_file.json`";
+    QuerySummary results = client.queryBuilder().sql(sql).run();
+    assertEquals(13_512, results.recordCount());
+  }
+
+  @Test
+  public void testNonExistentColumnReadAlone() throws Exception {
+    runBoth(() -> doTestNonExistentColumnReadAlone());
+  }
+
+  private void doTestNonExistentColumnReadAlone() throws Exception {
+    String sql = "select non_existent_column from cp.`store/json/single_column_long_file.json`";
+    QuerySummary results = client.queryBuilder().sql(sql).run();
+    assertEquals(13_512, results.recordCount());
+  }
+
+  @Test
+  public void testAllTextMode() throws Exception {
+    runBoth(() -> doTestAllTextMode());
+  }
+
+  private void doTestAllTextMode() throws Exception {
+    client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
+    try {
+      String sql = "select * from cp.`store/json/schema_change_int_to_string.json`";
+      QuerySummary results = client.queryBuilder().sql(sql).run();
+
+      // This is a pretty lame test as it does not verify results. However,
+      // enough other all-text mode tests do verify results. Here, we just
+      // make sure that the query does not die with a schema change exception.
+
+      assertEquals(3, results.recordCount());
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+    }
+  }
+
+  private void testExistentColumns(RowSet result) throws SchemaChangeException {
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("field_1", MinorType.BIGINT)
+        .addMap("field_3")
+          .addNullable("inner_1", MinorType.BIGINT)
+          .addNullable("inner_2", MinorType.BIGINT)
+          .resumeSchema()
+        .addMap("field_4")
+          .addArray("inner_1", MinorType.BIGINT)
+          .addNullable("inner_2", MinorType.BIGINT)
+          .resumeSchema()
+        .build();
+
+    RowSet expected = client.rowSetBuilder(expectedSchema)
+        .addRow(longArray(1L), mapValue(null, null), mapValue(longArray(), null))
+        .addRow(longArray(5L), mapValue(2L, null), mapValue(longArray(1L, 2L, 3L), 3L))
+        .addRow(longArray(5L, 10L, 15L), mapValue(5L, 3L), mapValue(longArray(4L, 5L, 6L), 3L))
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+  }
+
+  @Test
+  public void readComplexWithStar() throws Exception {
+    runBoth(() -> doReadComplexWithStar());
+  }
+
+  private void doReadComplexWithStar() throws Exception {
+    RowSet results = runTest("select * from cp.`store/json/test_complex_read_with_star.json`");
+    testExistentColumns(results);
+  }
+
+  @Test
+  public void testNullWhereListExpectedNumeric() throws Exception {
+    runBoth(() -> doTestNullWhereListExpectedNumeric());
+  }
+
+  private void doTestNullWhereListExpectedNumeric() throws Exception {
+    String sql = "select * from cp.`store/json/null_where_list_expected.json`";
+    RowSet results = runTest(sql);
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addArray("list_1", MinorType.BIGINT)
+        .build();
+
+    RowSet expected = client.rowSetBuilder(expectedSchema)
+        .addSingleCol(longArray(1L, 2L, 3L))
+        .addSingleCol(longArray())
+        .addSingleCol(longArray(4L, 5L, 6L))
+        .build();
+
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testNullWhereMapExpectedNumeric() throws Exception {
+    runBoth(() -> doTestNullWhereMapExpectedNumeric());
+  }
+
+  private void doTestNullWhereMapExpectedNumeric() throws Exception {
+    String sql = "select * from cp.`store/json/null_where_map_expected.json`";
+    RowSet results = runTest(sql);
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("map_1")
+          .addNullable("f_1", MinorType.BIGINT)
+          .addNullable("f_2", MinorType.BIGINT)
+          .addNullable("f_3", MinorType.BIGINT)
+          .resumeSchema()
+        .build();
+
+    RowSet expected = client.rowSetBuilder(expectedSchema)
+        .addSingleCol(mapValue(1L, 2L, 3L))
+        .addSingleCol(mapValue(null, null, null))
+        .addSingleCol(mapValue(3L, 4L, 5L))
+        .build();
+
+    RowSetUtilities.verify(expected, results);
+  }
+
+  @Test
+  public void testNullWhereMapExpectedText() throws Exception {
+    runBoth(() -> doTestNullWhereMapExpectedText());
+  }
+
+  private void doTestNullWhereMapExpectedText() throws Exception {
+    client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
+    try {
+      String sql = "select * from cp.`store/json/null_where_map_expected.json`";
+      RowSet results = runTest(sql);
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .addMap("map_1")
+            .addNullable("f_1", MinorType.VARCHAR)
+            .addNullable("f_2", MinorType.VARCHAR)
+            .addNullable("f_3", MinorType.VARCHAR)
+            .resumeSchema()
+          .build();
+
+      RowSet expected = client.rowSetBuilder(expectedSchema)
+          .addSingleCol(mapValue("1", "2", "3"))
+          .addSingleCol(mapValue(null, null, null))
+          .addSingleCol(mapValue("3", "4", "5"))
+          .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+    }
+  }
+
+  @Test
+  public void testNullWhereListExpectedText() throws Exception {
+    runBoth(() -> doTestNullWhereListExpectedText());
+  }
+
+  private void doTestNullWhereListExpectedText() throws Exception {
+    client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
+    try {
+      String sql = "select * from cp.`store/json/null_where_list_expected.json`";
+      RowSet results = runTest(sql);
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+          .addArray("list_1", MinorType.VARCHAR)
+          .build();
+
+      RowSet expected = client.rowSetBuilder(expectedSchema)
+          .addSingleCol(strArray("1", "2", "3"))
+          .addSingleCol(strArray())
+          .addSingleCol(strArray("4", "5", "6"))
+          .build();
+
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+    }
+  }
+
+  @Test
+  public void ensureProjectionPushdown() throws Exception {
+    runBoth(() -> doEnsureProjectionPushdown());
+  }
+
+  private void doEnsureProjectionPushdown() throws Exception {
+    // Tests to make sure that we are correctly eliminating schema changing columns.
+    // If completes, means that the projection pushdown was successful.
+
+    client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, false);
+    try {
+      String sql = "select t.field_1, t.field_3.inner_1, t.field_3.inner_2, t.field_4.inner_1 "
+                  + "from cp.`store/json/schema_change_int_to_string.json` t";
+      assertEquals(3, client.queryBuilder().sql(sql).run().recordCount());
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+    }
+  }
+
+  /**
+   * Old description: The project pushdown rule is correctly adding the
+   * projected columns to the scan, however it is not removing the redundant
+   * project operator after the scan, this tests runs a physical plan generated
+   * from one of the tests to ensure that the project is filtering out the
+   * correct data in the scan alone.
+   * <p>
+   * Revised functionality: the scan operator does all of the requested project
+   * operations, producing five columns.
+   */
+
+  @Test
+  public void testProjectPushdown() throws Exception {
+    try {
+      enableV2Reader(true);
+      client.alterSession(ExecConstants.JSON_ALL_TEXT_MODE, false);
+      String plan = Files.asCharSource(DrillFileUtils.getResourceAsFile(
+          "/store/json/project_pushdown_json_physical_plan.json"),
+          Charsets.UTF_8).read();
+//      client.queryBuilder().physical(plan).printCsv();
+      DirectRowSet results = client.queryBuilder().physical(plan).rowSet();
+//      results.print();
+
+      // Projects all columns (since the revised scan operator handles missing-column
+      // projection.) Note that the result includes two batches, including the first empty
+      // batch.
+
+      TupleMetadata schema = new SchemaBuilder()
+          .addArray("field_1", MinorType.BIGINT)
+          .addMap("field_3")
+            .addNullable("inner_1", MinorType.BIGINT)
+            .addNullable("inner_2", MinorType.BIGINT)
+            .resumeSchema()
+          .addMap("field_4")
+            .addArray("inner_1", MinorType.BIGINT)
+            .resumeSchema()
+          .addNullable("non_existent_at_root", MinorType.VARCHAR)
+          .addMap("non_existent")
+            .addMap("nested")
+              .addNullable("field", MinorType.VARCHAR)
+              .resumeMap()
+            .resumeSchema()
+          .build();
+
+      Object nullMap = singleMap(singleMap(null));
+      RowSet expected = client.rowSetBuilder(schema)
+          .addRow(longArray(1L), mapValue(null, null), singleMap(longArray()), null, nullMap )
+          .addRow(longArray(5L), mapValue(2L, null), singleMap(longArray(1L, 2L, 3L)), null, nullMap)
+          .addRow(longArray(5L, 10L, 15L), mapValue(5L, 3L), singleMap(longArray(4L, 5L, 6L)), null, nullMap)
+          .build();
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      client.resetSession(ExecConstants.JSON_ALL_TEXT_MODE);
+      resetV2Reader();
+    }
+  }
+
+  @Test
+  public void testJsonDirectoryWithEmptyFile() throws Exception {
+    runBoth(() -> doTestJsonDirectoryWithEmptyFile());
+  }
+
+  private void doTestJsonDirectoryWithEmptyFile() throws Exception {
+    testBuilder()
+        .sqlQuery("select * from dfs.`store/json/jsonDirectoryWithEmpyFile`")
+        .unOrdered()
+        .baselineColumns("a")
+        .baselineValues(1l)
+        .build()
+        .run();
+  }
+
+  // Only works in V2 reader.
+  // Disabled because it depends on the (random) read order
+
+  @Test
+  @Ignore("unstable")
+  public void drill_4032() throws Exception {
+    try {
+      enableV2Reader(true);
+      File table_dir = dirTestWatcher.makeTestTmpSubDir(Paths.get("drill_4032"));
+      table_dir.mkdir();
+      try (PrintWriter os = new PrintWriter(new FileWriter(new File(table_dir, "a.json")))) {
+        os.write("{\"col1\": \"val1\", \"col2\": null}");
+        os.write("{\"col1\": \"val2\", \"col2\": {\"col3\":\"abc\", \"col4\":\"xyz\"}}");
+      }
+      try (PrintWriter os = new PrintWriter(new FileWriter(new File(table_dir, "b.json")))) {
+        os.write("{\"col1\": \"val3\", \"col2\": null}");
+        os.write("{\"col1\": \"val4\", \"col2\": null}");
+      }
+      String sql = "select t.col1, t.col2.col3 from dfs.tmp.drill_4032 t order by col1";
+//      String sql = "select t.col1, t.col2.col3 from dfs.tmp.drill_4032 t";
+      RowSet results = runTest(sql);
+      results.print();
+
+      TupleMetadata schema = new SchemaBuilder()
+          .addNullable("col1", MinorType.VARCHAR)
+          .addNullable("EXPR$1", MinorType.VARCHAR)
+          .build();
+
+      RowSet expected = client.rowSetBuilder(schema)
+          .addRow("val1", null)
+          .addRow("val2", "abc")
+          .addRow("val3", null)
+          .addRow("val4", null)
+          .build();
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      resetV2Reader();
+    }
+  }
+
+  /** Test <pre>
+   * { "a": 5.2 }
+   * { "a": 6 }</pre>
+   * In Drill 1.16 and before, triggered an exception. In Drill 1.17
+   * and later, the second number, an integer, is converted to a
+   * double.
+   */
+
+  @Test
+  public void testMixedNumberTypes() throws Exception {
+    try {
+      enableV2Reader(true);
+      String sql = "select * from cp.`jsoninput/mixed_number_types.json`";
+      RowSet results = runTest(sql);
+      TupleMetadata schema = new SchemaBuilder()
+          .addNullable("a", MinorType.FLOAT8)
+          .build();
+
+      RowSet expected = client.rowSetBuilder(schema)
+          .addSingleCol(5.2D)
+          .addSingleCol(6.0D)
+          .build();
+      RowSetUtilities.verify(expected, results);
+    } finally {
+      resetV2Reader();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonRecordReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonRecordReader.java
@@ -17,39 +17,81 @@
  */
 package org.apache.drill.exec.store.json;
 
-import org.apache.drill.test.BaseTestQuery;
-import org.apache.drill.categories.UnlikelyTest;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.exec.proto.UserBitShared;
-import org.apache.drill.exec.ExecConstants;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Assert;
-import org.junit.experimental.categories.Category;
-
-import java.nio.file.Paths;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Paths;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.test.BaseTestQuery;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Original JSON reader tests. Left in original form; not converted
+ * to the newer formats.
+ */
+
+@Category(RowSetTests.class)
 public class TestJsonRecordReader extends BaseTestQuery {
   @BeforeClass
   public static void setupTestFiles() {
     dirTestWatcher.copyResourceToRoot(Paths.get("jsoninput/drill_3353"));
   }
 
+  private void enableV2Reader(boolean enable) throws Exception {
+    alterSession(ExecConstants.ENABLE_V2_JSON_READER_KEY, enable);
+  }
+
+  private void resetV2Reader() throws Exception {
+    resetSessionOption(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+  }
+
+  public interface TestWrapper {
+    void apply() throws Exception;
+  }
+
+  public void runBoth(TestWrapper wrapper) throws Exception {
+    try {
+      enableV2Reader(false);
+      wrapper.apply();
+      enableV2Reader(true);
+      wrapper.apply();
+    } finally {
+      resetV2Reader();
+    }
+  }
+
   @Test
   public void testComplexJsonInput() throws Exception {
+    runBoth(() -> doTestComplexJsonInput());
+  }
+
+  private void doTestComplexJsonInput() throws Exception {
     test("select `integer`, x['y'] as x1, x['y'] as x2, z[0], z[0]['orange'], z[1]['pink']  from cp.`jsoninput/input2.json` limit 10 ");
   }
 
   @Test
   public void testContainingArray() throws Exception {
+    runBoth(() -> doTestContainingArray());
+  }
+
+  private void doTestContainingArray() throws Exception {
     test("select * from cp.`store/json/listdoc.json`");
   }
 
   @Test
   public void testComplexMultipleTimes() throws Exception {
+    runBoth(() -> doTestComplexMultipleTimes());
+  }
+
+  private void doTestComplexMultipleTimes() throws Exception {
     for (int i = 0; i < 5; i++) {
       test("select * from cp.`join/merge_join.json`");
     }
@@ -57,6 +99,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
 
   @Test
   public void trySimpleQueryWithLimit() throws Exception {
+    runBoth(() -> doTrySimpleQueryWithLimit());
+  }
+
+  private void doTrySimpleQueryWithLimit() throws Exception {
     test("select * from cp.`limit/test1.json` limit 10");
   }
 
@@ -64,6 +110,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
   // DRILL-1634 : retrieve an element in a nested array in a repeated map.
   // RepeatedMap (Repeated List (Repeated varchar))
   public void testNestedArrayInRepeatedMap() throws Exception {
+    runBoth(() -> doTestNestedArrayInRepeatedMap());
+  }
+
+  private void doTestNestedArrayInRepeatedMap() throws Exception {
     test("select a[0].b[0] from cp.`jsoninput/nestedArray.json`");
     test("select a[0].b[1] from cp.`jsoninput/nestedArray.json`");
     test("select a[1].b[1] from cp.`jsoninput/nestedArray.json`"); // index out of the range. Should return empty list.
@@ -71,19 +121,31 @@ public class TestJsonRecordReader extends BaseTestQuery {
 
   @Test
   public void testEmptyMapDoesNotFailValueCapacityCheck() throws Exception {
+    runBoth(() -> doTestEmptyMapDoesNotFailValueCapacityCheck());
+  }
+
+  private void doTestEmptyMapDoesNotFailValueCapacityCheck() throws Exception {
     final String sql = "select * from cp.`store/json/value-capacity.json`";
     test(sql);
   }
 
   @Test
   public void testEnableAllTextMode() throws Exception {
-    testNoResult("alter session set `store.json.all_text_mode`= true");
+    runBoth(() -> doTestEnableAllTextMode());
+  }
+
+  private void doTestEnableAllTextMode() throws Exception {
+    alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
     test("select * from cp.`jsoninput/big_numeric.json`");
-    testNoResult("alter session set `store.json.all_text_mode`= false");
+    resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
   }
 
   @Test
   public void testExceptionHandling() throws Exception {
+    runBoth(() -> doTestExceptionHandling());
+  }
+
+  private void doTestExceptionHandling() throws Exception {
     try {
       test("select * from cp.`jsoninput/DRILL-2350.json`");
     } catch (UserException e) {
@@ -101,6 +163,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
   @Category(UnlikelyTest.class)
   // DRILL-1832
   public void testJsonWithNulls1() throws Exception {
+    runBoth(() -> doTestJsonWithNulls1());
+  }
+
+  private void doTestJsonWithNulls1() throws Exception {
     final String query = "select * from cp.`jsoninput/twitter_43.json`";
     testBuilder().sqlQuery(query).unOrdered()
         .jsonBaselineFile("jsoninput/drill-1832-1-result.json").go();
@@ -110,10 +176,16 @@ public class TestJsonRecordReader extends BaseTestQuery {
   @Category(UnlikelyTest.class)
   // DRILL-1832
   public void testJsonWithNulls2() throws Exception {
+    runBoth(() -> doTestJsonWithNulls2());
+  }
+
+  private void doTestJsonWithNulls2() throws Exception {
     final String query = "select SUM(1) as `sum_Number_of_Records_ok` from cp.`jsoninput/twitter_43.json` having (COUNT(1) > 0)";
     testBuilder().sqlQuery(query).unOrdered()
         .jsonBaselineFile("jsoninput/drill-1832-2-result.json").go();
   }
+
+  // V1-only test. In V2, this works. See TestJsonReaderQueries.
 
   @Test
   public void testMixedNumberTypes() throws Exception {
@@ -136,6 +208,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
 
   @Test
   public void testMixedNumberTypesInAllTextMode() throws Exception {
+    runBoth(() -> doTestMixedNumberTypesInAllTextMode());
+  }
+
+  private void doTestMixedNumberTypesInAllTextMode() throws Exception {
     testNoResult("alter session set `store.json.all_text_mode`= true");
     testBuilder()
         .sqlQuery("select * from cp.`jsoninput/mixed_number_types.json`")
@@ -146,34 +222,42 @@ public class TestJsonRecordReader extends BaseTestQuery {
   @Test
   public void testMixedNumberTypesWhenReadingNumbersAsDouble() throws Exception {
     try {
-      testNoResult("alter session set `store.json.read_numbers_as_double`= true");
+      alterSession(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE, true);
       testBuilder()
           .sqlQuery("select * from cp.`jsoninput/mixed_number_types.json`")
           .unOrdered().baselineColumns("a").baselineValues(5.2D)
           .baselineValues(6D).build().run();
     } finally {
-      testNoResult("alter session set `store.json.read_numbers_as_double`= false");
+      resetSessionOption(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
     }
   }
 
   @Test
   public void drill_3353() throws Exception {
     try {
-      testNoResult("alter session set `store.json.all_text_mode` = true");
-      test("create table dfs.tmp.drill_3353 as select a from dfs.`jsoninput/drill_3353` where e = true");
-      String query = "select t.a.d cnt from dfs.tmp.drill_3353 t where t.a.d is not null";
-      test(query);
-      testBuilder().sqlQuery(query).unOrdered().baselineColumns("cnt")
-          .baselineValues("1").go();
+      alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
+       test("create table dfs.tmp.drill_3353 as select a from dfs.`jsoninput/drill_3353` where e = true");
+      runBoth(() -> doDrill_3353());
     } finally {
-      testNoResult("alter session set `store.json.all_text_mode` = false");
+      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
     }
+  }
+
+  private void doDrill_3353() throws Exception {
+    String query = "select t.a.d cnt from dfs.tmp.drill_3353 t where t.a.d is not null";
+    test(query);
+    testBuilder().sqlQuery(query).unOrdered().baselineColumns("cnt")
+        .baselineValues("1").go();
   }
 
   @Test
   @Category(UnlikelyTest.class)
   // See DRILL-3476
   public void testNestedFilter() throws Exception {
+    runBoth(() -> doTestNestedFilter());
+  }
+
+  private void doTestNestedFilter() throws Exception {
     String query = "select a from cp.`jsoninput/nestedFilter.json` t where t.a.b = 1";
     String baselineQuery = "select * from cp.`jsoninput/nestedFilter.json` t where t.a.b = 1";
     testBuilder().sqlQuery(query).unOrdered().sqlBaselineQuery(baselineQuery)
@@ -185,22 +269,20 @@ public class TestJsonRecordReader extends BaseTestQuery {
   // See DRILL-4653
   /* Test for CountingJSONReader */
   public void testCountingQuerySkippingInvalidJSONRecords() throws Exception {
+    runBoth(() -> doTestCountingQuerySkippingInvalidJSONRecords());
+  }
+
+  private void doTestCountingQuerySkippingInvalidJSONRecords() throws Exception {
     try {
-      String set = "alter session set `"
-          + ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG + "` = true";
-      String set1 = "alter session set `"
-          + ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG
-          + "` = true";
+      alterSession(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG, true);
+      alterSession(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG, true);
       String query = "select count(*) from cp.`jsoninput/drill4653/file.json`";
 
-      testNoResult(set);
-      testNoResult(set1);
-      testBuilder().unOrdered().sqlQuery(query).sqlBaselineQuery(query).build()
+       testBuilder().unOrdered().sqlQuery(query).sqlBaselineQuery(query).build()
           .run();
     } finally {
-      String set = "alter session set `"
-          + ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG + "` = false";
-      testNoResult(set);
+      resetSessionOption(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
+      resetSessionOption(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
     }
   }
 
@@ -209,6 +291,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
   // See DRILL-4653
   /* Test for CountingJSONReader */
   public void testCountingQueryNotSkippingInvalidJSONRecords() throws Exception {
+    runBoth(() -> doTestCountingQueryNotSkippingInvalidJSONRecords());
+  }
+
+  private void doTestCountingQueryNotSkippingInvalidJSONRecords() throws Exception {
     try {
       String query = "select count(*) from cp.`jsoninput/drill4653/file.json`";
       testBuilder().unOrdered().sqlQuery(query).sqlBaselineQuery(query).build()
@@ -225,23 +311,21 @@ public class TestJsonRecordReader extends BaseTestQuery {
   // See DRILL-4653
   /* Test for JSONReader */
   public void testNotCountingQuerySkippingInvalidJSONRecords() throws Exception {
+    runBoth(() -> doTestNotCountingQuerySkippingInvalidJSONRecords());
+  }
+
+  private void doTestNotCountingQuerySkippingInvalidJSONRecords() throws Exception {
     try {
 
-      String set = "alter session set `"
-          + ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG + "` = true";
-      String set1 = "alter session set `"
-          + ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG
-          + "` = true";
+      alterSession(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG, true);
+      alterSession(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG, true);
       String query = "select sum(balance) from cp.`jsoninput/drill4653/file.json`";
-      testNoResult(set);
-      testNoResult(set1);
       testBuilder().unOrdered().sqlQuery(query).sqlBaselineQuery(query).build()
           .run();
     }
     finally {
-      String set = "alter session set `"
-          + ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG + "` = false";
-      testNoResult(set);
+      resetSessionOption(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
+      resetSessionOption(ExecConstants.JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG);
     }
   }
 
@@ -251,6 +335,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
   /* Test for JSONReader */
   public void testNotCountingQueryNotSkippingInvalidJSONRecords()
       throws Exception {
+    runBoth(() -> doTestNotCountingQueryNotSkippingInvalidJSONRecords());
+  }
+
+  private void doTestNotCountingQueryNotSkippingInvalidJSONRecords() throws Exception {
     try {
       String query = "select sum(balance) from cp.`jsoninput/drill4653/file.json`";
       testBuilder().unOrdered().sqlQuery(query).sqlBaselineQuery(query).build()
@@ -267,6 +355,10 @@ public class TestJsonRecordReader extends BaseTestQuery {
   // See DRILL-7362
   /* Test for CountingJSONReader */
   public void testContainingArrayCount() throws Exception {
+    runBoth(() -> doTestContainingArrayCount());
+  }
+
+  private void doTestContainingArrayCount() throws Exception {
     testBuilder()
       .sqlQuery("select count(*) as cnt from cp.`store/json/listdoc.json`")
       .unOrdered()

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonScanOp.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/json/TestJsonScanOp.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.json;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.longArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapArray;
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+import static org.apache.drill.test.rowSet.RowSetUtilities.singleMap;
+import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.impl.scan.BaseScanOperatorExecTest.BaseScanFixtureBuilder;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils.ScanFixture;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.easy.json.JsonLoader;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl;
+import org.apache.drill.exec.store.easy.json.parser.JsonLoaderImpl.JsonOptions;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(RowSetTests.class)
+public class TestJsonScanOp extends SubOperatorTest {
+
+  private static class TestJsonReader implements ManagedReader<SchemaNegotiator> {
+
+    private ResultSetLoader tableLoader;
+    private final String filePath;
+    private InputStream stream;
+    private JsonLoader jsonLoader;
+    private final JsonOptions options;
+
+    public TestJsonReader(String filePath, JsonOptions options) {
+      this.filePath = filePath;
+      this.options = options;
+    }
+
+    @Override
+    public boolean open(SchemaNegotiator negotiator) {
+      stream = new BufferedInputStream(getClass().getResourceAsStream(filePath));
+      tableLoader = negotiator.build();
+      jsonLoader = new JsonLoaderImpl(stream, tableLoader.writer(), options);
+      return true;
+    }
+
+    @Override
+    public boolean next() {
+      boolean more = true;
+      while (tableLoader.writer().start()) {
+        if (! jsonLoader.next()) {
+          more = false;
+          break;
+        }
+        tableLoader.writer().save();
+      }
+      jsonLoader.endBatch();
+      return more;
+    }
+
+    @Override
+    public void close() {
+      try {
+        stream.close();
+      } catch (IOException e) {
+        // Ignore;
+      }
+    }
+  }
+
+  /**
+   * Test the case where the reader does not play the "first batch contains
+   * only schema" game, and instead returns data. The Scan operator will
+   * split the first batch into two: one with schema only, another with
+   * data.
+   */
+
+  @Test
+  public void testScanOperator() {
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder();
+    JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    builder.addReader(new TestJsonReader("/store/json/schema_change_int_to_string.json", options));
+    builder.setProjection("field_3", "field_5");
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scanOp = scanFixture.scanOp;
+
+    assertTrue(scanOp.buildSchema());
+    RowSet result = fixture.wrap(scanOp.batchAccessor().container());
+    result.clear();
+    assertTrue(scanOp.next());
+    result = fixture.wrap(scanOp.batchAccessor().container());
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("field_3")
+          .addNullable("inner_1", MinorType.VARCHAR)
+          .addNullable("inner_2", MinorType.VARCHAR)
+          .addMapArray("inner_3")
+            .addNullable("inner_object_field_1", MinorType.VARCHAR)
+            .resumeMap()
+          .resumeSchema()
+        .addMapArray("field_5")
+          .addArray("inner_list", MinorType.VARCHAR)
+          .addArray("inner_list_2", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    RowSetUtilities.strArray();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(mapValue(null, null, mapArray()),
+                mapArray())
+        .addRow(mapValue("2", null, mapArray()),
+                mapArray(
+                  mapValue(strArray("1", "", "6"), strArray()),
+                  mapValue(strArray("3", "8"), strArray()),
+                  mapValue(strArray("12", "", "4", "null", "5"), strArray())))
+        .addRow(mapValue("5", "3", mapArray(singleMap(null), singleMap("10"))),
+            mapArray(
+                mapValue(strArray("5", "", "6.0", "1234"), strArray()),
+                mapValue(strArray("7", "8.0", "12341324"),
+                         strArray("1", "2", "2323.443e10", "hello there")),
+                mapValue(strArray("3", "4", "5"), strArray("10", "11", "12"))))
+        .build();
+
+    RowSetUtilities.verify(expected, result);
+    scanFixture.close();
+  }
+
+  @Test
+  public void testScanProjectMapSubset() {
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder();
+    JsonOptions options = new JsonOptions();
+    builder.addReader(new TestJsonReader("/store/json/schema_change_int_to_string.json", options));
+    builder.setProjection("field_3.inner_1", "field_3.inner_2");
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scanOp = scanFixture.scanOp;
+
+    assertTrue(scanOp.buildSchema());
+    RowSet result = fixture.wrap(scanOp.batchAccessor().container());
+    assertTrue(scanOp.next());
+    result = fixture.wrap(scanOp.batchAccessor().container());
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addMap("field_3")
+          .addNullable("inner_1", MinorType.BIGINT)
+          .addNullable("inner_2", MinorType.BIGINT)
+          .resumeSchema()
+        .build();
+
+    RowSet expected = fixture.rowSetBuilder(schema)
+        .addSingleCol(mapValue(null, null))
+        .addSingleCol(mapValue(2L, null))
+        .addSingleCol(mapValue(5L, 3L))
+        .build();
+    RowSetUtilities.verify(expected, result);
+    scanFixture.close();
+  }
+
+  @Test
+  public void testScanProjectMapArraySubsetAndNull() {
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder();
+    JsonOptions options = new JsonOptions();
+    options.allTextMode = true;
+    builder.addReader(new TestJsonReader("/store/json/schema_change_int_to_string.json", options));
+    builder.setProjection("field_5.inner_list", "field_5.dummy");
+    builder.builder().setNullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scanOp = scanFixture.scanOp;
+
+    assertTrue(scanOp.buildSchema());
+    RowSet result = fixture.wrap(scanOp.batchAccessor().container());
+    assertTrue(scanOp.next());
+    result = fixture.wrap(scanOp.batchAccessor().container());
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addMapArray("field_5")
+          .addArray("inner_list", MinorType.VARCHAR)
+          .addNullable("dummy", MinorType.VARCHAR)
+          .resumeSchema()
+        .build();
+
+    RowSet expected = fixture.rowSetBuilder(schema)
+        .addSingleCol(mapArray())
+        .addSingleCol(mapArray(
+            mapValue(strArray("1", "", "6"), null),
+            mapValue(strArray("3", "8"), null),
+            mapValue(strArray("12", "", "4", "null", "5"), null)))
+        .addSingleCol(mapArray(
+            mapValue(strArray("5", "", "6.0", "1234"), null),
+            mapValue(strArray("7", "8.0", "12341324"), null),
+            mapValue(strArray("3", "4", "5"), null)))
+        .build();
+    RowSetUtilities.verify(expected, result);
+    scanFixture.close();
+  }
+
+  @Test
+  public void testScanProject() {
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder();
+    JsonOptions options = new JsonOptions();
+    builder.addReader(new TestJsonReader("/store/json/schema_change_int_to_string.json", options));
+
+    // Projection omits field_2 which has an ambiguous type. Since
+    // the field is not materialized, the ambiguity is benign.
+    // (If this test triggers an error, perhaps a change has caused
+    // the column to become materialized.)
+
+    builder.setProjection("field_1", "field_3.inner_1", "field_3.inner_2", "field_4.inner_1",
+        "non_existent_at_root", "non_existent.nested.field");
+    builder.builder().setNullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scanOp = scanFixture.scanOp;
+
+    assertTrue(scanOp.buildSchema());
+    RowSet result = fixture.wrap(scanOp.batchAccessor().container());
+    assertTrue(scanOp.next());
+    result = fixture.wrap(scanOp.batchAccessor().container());
+
+    // Projects all columns (since the revised scan operator handles missing-column
+    // projection.) Note that the result includes two batches, including the first empty
+    // batch.
+
+    TupleMetadata schema = new SchemaBuilder()
+        .addArray("field_1", MinorType.BIGINT)
+        .addMap("field_3")
+          .addNullable("inner_1", MinorType.BIGINT)
+          .addNullable("inner_2", MinorType.BIGINT)
+          .resumeSchema()
+        .addMap("field_4")
+          .addArray("inner_1", MinorType.BIGINT)
+          .resumeSchema()
+        .addNullable("non_existent_at_root", MinorType.VARCHAR)
+        .addMap("non_existent")
+          .addMap("nested")
+            .addNullable("field", MinorType.VARCHAR)
+            .resumeMap()
+          .resumeSchema()
+        .build();
+
+    Object nullMap = singleMap(singleMap(null));
+    RowSet expected = fixture.rowSetBuilder(schema)
+        .addRow(longArray(1L), mapValue(null, null), singleMap(longArray()), null, nullMap )
+        .addRow(longArray(5L), mapValue(2L, null), singleMap(longArray(1L, 2L, 3L)), null, nullMap)
+        .addRow(longArray(5L, 10L, 15L), mapValue(5L, 3L), singleMap(longArray(4L, 5L, 6L)), null, nullMap)
+        .build();
+    RowSetUtilities.verify(expected, result);
+    scanFixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/vector/complex/writer/TestJsonReader.java
@@ -20,43 +20,41 @@ package org.apache.drill.exec.vector.complex.writer;
 import static org.apache.drill.test.TestBuilder.listOf;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
 
-import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.util.DrillFileUtils;
 import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.proto.UserBitShared;
-import org.apache.drill.exec.record.RecordBatchLoader;
-import org.apache.drill.exec.record.VectorWrapper;
-import org.apache.drill.exec.rpc.user.QueryDataBatch;
 import org.apache.drill.exec.store.easy.json.JSONRecordReader;
 import org.apache.drill.exec.util.JsonStringHashMap;
 import org.apache.drill.exec.util.Text;
-import org.apache.drill.exec.vector.IntVector;
-import org.apache.drill.exec.vector.RepeatedBigIntVector;
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.io.Files;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Some tests previously here have moved, and been rewritten to use
+ * the newer test framework. Find them in
+ * <tt>org.apache.drill.exec.store.json</tt>:
+ * <ul>
+ * <li><tt>TestJsonReaderFns</tt></li>
+ * <li><tt>TestJsonReaderQuery</tt></li>
+ * </ul>
+ */
+@Category(RowSetTests.class)
 public class TestJsonReader extends BaseTestQuery {
   private static final Logger logger = LoggerFactory.getLogger(TestJsonReader.class);
 
@@ -66,60 +64,44 @@ public class TestJsonReader extends BaseTestQuery {
     dirTestWatcher.copyResourceToRoot(Paths.get("vector","complex", "writer"));
   }
 
-  @Test
-  public void testEmptyList() throws Exception {
-    final String root = "store/json/emptyLists";
-
-    testBuilder()
-        .sqlQuery("select count(a[0]) as ct from dfs.`%s`", root, root)
-        .ordered()
-        .baselineColumns("ct")
-        .baselineValues(6l)
-        .build()
-        .run();
+  private void enableV2Reader(boolean enable) throws Exception {
+    alterSession(ExecConstants.ENABLE_V2_JSON_READER_KEY, enable);
   }
 
-  @Test
+  private void resetV2Reader() throws Exception {
+    resetSessionOption(ExecConstants.ENABLE_V2_JSON_READER_KEY);
+  }
+
+  public interface TestWrapper {
+    void apply() throws Exception;
+  }
+
+  public void runBoth(TestWrapper wrapper) throws Exception {
+    try {
+      enableV2Reader(false);
+      wrapper.apply();
+      enableV2Reader(true);
+      wrapper.apply();
+    } finally {
+      resetV2Reader();
+    }
+  }
+
+   @Test
   public void schemaChange() throws Exception {
-    // Verifies that the schema change does not cause a
-    // crash. A pretty minimal test.
-    // TODO: Verify actual results.
+    runBoth(() -> doSchemaChange());
+  }
+
+  private void doSchemaChange() throws Exception {
     test("select b from dfs.`vector/complex/writer/schemaChange/`");
   }
 
   @Test
-  public void testFieldSelectionBug() throws Exception {
-    try {
-      testBuilder()
-          .sqlQuery("select t.field_4.inner_3 as col_1, t.field_4 as col_2 from cp.`store/json/schema_change_int_to_string.json` t")
-          .unOrdered()
-          .optionSettingQueriesForTestQuery("alter session set `store.json.all_text_mode` = true")
-          .baselineColumns("col_1", "col_2")
-          .baselineValues(
-              mapOf(),
-              mapOf(
-                  "inner_1", listOf(),
-                  "inner_3", mapOf()))
-          .baselineValues(
-              mapOf("inner_object_field_1", "2"),
-              mapOf(
-                  "inner_1", listOf("1", "2", "3"),
-                  "inner_2", "3",
-                  "inner_3", mapOf("inner_object_field_1", "2")))
-          .baselineValues(
-              mapOf(),
-              mapOf(
-                  "inner_1", listOf("4", "5", "6"),
-                  "inner_2", "3",
-                  "inner_3", mapOf()))
-          .go();
-    } finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
+  public void testSplitAndTransferFailure() throws Exception {
+    runBoth(() -> doTestSplitAndTransferFailure());
   }
 
-  @Test
-  public void testSplitAndTransferFailure() throws Exception {
+  private void doTestSplitAndTransferFailure() throws Exception {
     final String testVal = "a string";
     testBuilder()
         .sqlQuery("select flatten(config) as flat from cp.`store/json/null_list.json`")
@@ -150,6 +132,10 @@ public class TestJsonReader extends BaseTestQuery {
   @Test
   @Ignore("DRILL-1824")
   public void schemaChangeValidate() throws Exception {
+    runBoth(() -> doSchemaChangeValidate());
+  }
+
+  private void doSchemaChangeValidate() throws Exception {
     testBuilder()
       .sqlQuery("select b from dfs.`vector/complex/writer/schemaChange/`")
       .unOrdered()
@@ -181,251 +167,7 @@ public class TestJsonReader extends BaseTestQuery {
     }
   }
 
-  @Test
-  public void testReadCompressed() throws Exception {
-    String filepath = "compressed_json.json";
-    File f = new File(dirTestWatcher.getRootDir(), filepath);
-    PrintWriter out = new PrintWriter(f);
-    out.println("{\"a\" :5}");
-    out.close();
-
-    gzipIt(f);
-    testBuilder()
-        .sqlQuery("select * from dfs.`%s.gz`", filepath)
-        .unOrdered()
-        .baselineColumns("a")
-        .baselineValues(5l)
-        .build().run();
-
-    // test reading the uncompressed version as well
-    testBuilder()
-        .sqlQuery("select * from dfs.`%s`", filepath)
-        .unOrdered()
-        .baselineColumns("a")
-        .baselineValues(5l)
-        .build().run();
-  }
-
-  public static void gzipIt(File sourceFile) throws IOException {
-
-    // modified from: http://www.mkyong.com/java/how-to-compress-a-file-in-gzip-format/
-    byte[] buffer = new byte[1024];
-    GZIPOutputStream gzos =
-        new GZIPOutputStream(new FileOutputStream(sourceFile.getPath() + ".gz"));
-
-    FileInputStream in =
-        new FileInputStream(sourceFile);
-
-    int len;
-    while ((len = in.read(buffer)) > 0) {
-      gzos.write(buffer, 0, len);
-    }
-    in.close();
-    gzos.finish();
-    gzos.close();
-  }
-
-  @Test
-  public void testDrill_1419() throws Exception {
-    String[] queries = {"select t.trans_id, t.trans_info.prod_id[0],t.trans_info.prod_id[1] from cp.`store/json/clicks.json` t limit 5"};
-    long[] rowCounts = {5};
-    String filename = "/store/json/clicks.json";
-    runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-  }
-
-  @Test
-  public void testRepeatedCount() throws Exception {
-    test("select repeated_count(str_list) from cp.`store/json/json_basic_repeated_varchar.json`");
-    test("select repeated_count(INT_col) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_count(FLOAT4_col) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_count(VARCHAR_col) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_count(BIT_col) from cp.`parquet/alltypes_repeated.json`");
-  }
-
-  @Test
-  public void testRepeatedContains() throws Exception {
-    test("select repeated_contains(str_list, 'asdf') from cp.`store/json/json_basic_repeated_varchar.json`");
-    test("select repeated_contains(INT_col, -2147483648) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_contains(FLOAT4_col, -1000000000000.0) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_contains(VARCHAR_col, 'qwerty' ) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_contains(BIT_col, true) from cp.`parquet/alltypes_repeated.json`");
-    test("select repeated_contains(BIT_col, false) from cp.`parquet/alltypes_repeated.json`");
-  }
-
-  @Test
-  public void testSingleColumnRead_vector_fill_bug() throws Exception {
-    String[] queries = {"select * from cp.`store/json/single_column_long_file.json`"};
-    long[] rowCounts = {13512};
-    String filename = "/store/json/single_column_long_file.json";
-    runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-  }
-
-  @Test
-  public void testNonExistentColumnReadAlone() throws Exception {
-    String[] queries = {"select non_existent_column from cp.`store/json/single_column_long_file.json`"};
-    long[] rowCounts = {13512};
-    String filename = "/store/json/single_column_long_file.json";
-    runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-  }
-
-  @Test
-  public void testAllTextMode() throws Exception {
-    try {
-      alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
-      String[] queries = {"select * from cp.`store/json/schema_change_int_to_string.json`"};
-      long[] rowCounts = {3};
-      String filename = "/store/json/schema_change_int_to_string.json";
-      runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-    } finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
-  }
-
-  @Test
-  public void readComplexWithStar() throws Exception {
-    List<QueryDataBatch> results = testSqlWithResults("select * from cp.`store/json/test_complex_read_with_star.json`");
-    assertEquals(1, results.size());
-
-    RecordBatchLoader batchLoader = new RecordBatchLoader(getAllocator());
-    QueryDataBatch batch = results.get(0);
-
-    assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
-    assertEquals(3, batchLoader.getSchema().getFieldCount());
-    testExistentColumns(batchLoader);
-
-    batch.release();
-    batchLoader.clear();
-  }
-
-  @Test
-  public void testNullWhereListExpected() throws Exception {
-    try {
-      alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
-      String[] queries = {"select * from cp.`store/json/null_where_list_expected.json`"};
-      long[] rowCounts = {3};
-      String filename = "/store/json/null_where_list_expected.json";
-      runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-    }
-    finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
-  }
-
-  @Test
-  public void testNullWhereMapExpected() throws Exception {
-    try {
-      alterSession(ExecConstants.JSON_ALL_TEXT_MODE, true);
-      String[] queries = {"select * from cp.`store/json/null_where_map_expected.json`"};
-      long[] rowCounts = {3};
-      String filename = "/store/json/null_where_map_expected.json";
-      runTestsOnFile(filename, UserBitShared.QueryType.SQL, queries, rowCounts);
-    }
-    finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
-  }
-
-  @Test
-  public void ensureProjectionPushdown() throws Exception {
-    try {
-      // Tests to make sure that we are correctly eliminating schema changing
-      // columns. If completes, means that the projection pushdown was
-      // successful.
-      test("alter system set `store.json.all_text_mode` = false; "
-          + "select  t.field_1, t.field_3.inner_1, t.field_3.inner_2, t.field_4.inner_1 "
-          + "from cp.`store/json/schema_change_int_to_string.json` t");
-    } finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
-  }
-
-  // The project pushdown rule is correctly adding the projected columns to the
-  // scan, however it is not removing the redundant project operator after the
-  // scan, this tests runs a physical plan generated from one of the tests to
-  // ensure that the project is filtering out the correct data in the scan alone.
-  @Test
-  public void testProjectPushdown() throws Exception {
-    try {
-      String[] queries = {Files.asCharSource(DrillFileUtils.getResourceAsFile(
-          "/store/json/project_pushdown_json_physical_plan.json"), Charsets.UTF_8).read()};
-      String filename = "/store/json/schema_change_int_to_string.json";
-      alterSession(ExecConstants.JSON_ALL_TEXT_MODE, false);
-      long[] rowCounts = {3};
-      runTestsOnFile(filename, UserBitShared.QueryType.PHYSICAL, queries, rowCounts);
-
-      List<QueryDataBatch> results = testPhysicalWithResults(queries[0]);
-      assertEquals(1, results.size());
-      // "`field_1`", "`field_3`.`inner_1`", "`field_3`.`inner_2`", "`field_4`.`inner_1`"
-
-      RecordBatchLoader batchLoader = new RecordBatchLoader(getAllocator());
-      QueryDataBatch batch = results.get(0);
-      assertTrue(batchLoader.load(batch.getHeader().getDef(), batch.getData()));
-
-      // this used to be five. It is now four. This is because the plan doesn't
-      // have a project. Scanners are not responsible for projecting non-existent
-      // columns (as long as they project one column)
-      //
-      // That said, the JSON format plugin does claim it can do project
-      // push-down, which means it will ensure columns for any column
-      // mentioned in the project list, in a form consistent with the schema
-      // path. In this case, `non_existent`.`nested`.`field` appears in
-      // the query. But, even more oddly, the missing field is inserted only
-      // if all text mode is true, omitted if all text mode is false.
-      // Seems overly complex.
-      assertEquals(3, batchLoader.getSchema().getFieldCount());
-      testExistentColumns(batchLoader);
-
-      batch.release();
-      batchLoader.clear();
-    } finally {
-      resetSessionOption(ExecConstants.JSON_ALL_TEXT_MODE);
-    }
-  }
-
-  @Test
-  public void testJsonDirectoryWithEmptyFile() throws Exception {
-    testBuilder()
-        .sqlQuery("select * from dfs.`store/json/jsonDirectoryWithEmpyFile`")
-        .unOrdered()
-        .baselineColumns("a")
-        .baselineValues(1l)
-        .build()
-        .run();
-  }
-
-  private void testExistentColumns(RecordBatchLoader batchLoader) throws SchemaChangeException {
-    VectorWrapper<?> vw = batchLoader.getValueAccessorById(
-        RepeatedBigIntVector.class,
-        batchLoader.getValueVectorId(SchemaPath.getCompoundPath("field_1")).getFieldIds()
-    );
-    assertEquals("[1]", vw.getValueVector().getAccessor().getObject(0).toString());
-    assertEquals("[5]", vw.getValueVector().getAccessor().getObject(1).toString());
-    assertEquals("[5,10,15]", vw.getValueVector().getAccessor().getObject(2).toString());
-
-    vw = batchLoader.getValueAccessorById(
-        IntVector.class,
-        batchLoader.getValueVectorId(SchemaPath.getCompoundPath("field_3", "inner_1")).getFieldIds()
-    );
-    assertNull(vw.getValueVector().getAccessor().getObject(0));
-    assertEquals(2l, vw.getValueVector().getAccessor().getObject(1));
-    assertEquals(5l, vw.getValueVector().getAccessor().getObject(2));
-
-    vw = batchLoader.getValueAccessorById(
-        IntVector.class,
-        batchLoader.getValueVectorId(SchemaPath.getCompoundPath("field_3", "inner_2")).getFieldIds()
-    );
-    assertNull(vw.getValueVector().getAccessor().getObject(0));
-    assertNull(vw.getValueVector().getAccessor().getObject(1));
-    assertEquals(3l, vw.getValueVector().getAccessor().getObject(2));
-
-    vw = batchLoader.getValueAccessorById(
-        RepeatedBigIntVector.class,
-        batchLoader.getValueVectorId(SchemaPath.getCompoundPath("field_4", "inner_1")).getFieldIds()
-    );
-    assertEquals("[]", vw.getValueVector().getAccessor().getObject(0).toString());
-    assertEquals("[1,2,3]", vw.getValueVector().getAccessor().getObject(1).toString());
-    assertEquals("[4,5,6]", vw.getValueVector().getAccessor().getObject(2).toString());
-  }
+  // TODO: Union not yet supported in V2.
 
   @Test
   public void testSelectStarWithUnionType() throws Exception {
@@ -479,6 +221,8 @@ public class TestJsonReader extends BaseTestQuery {
     }
   }
 
+  // TODO: Union not yet supported in V2.
+
   @Test
   public void testSelectFromListWithCase() throws Exception {
     try {
@@ -495,6 +239,8 @@ public class TestJsonReader extends BaseTestQuery {
       resetSessionOption(ExecConstants.ENABLE_UNION_TYPE_KEY);
     }
   }
+
+  // TODO: Union not yet supported in V2.
 
   @Test
   public void testTypeCase() throws Exception {
@@ -516,6 +262,8 @@ public class TestJsonReader extends BaseTestQuery {
     }
   }
 
+  // TODO: Union not yet supported in V2.
+
   @Test
   public void testSumWithTypeCase() throws Exception {
     try {
@@ -534,6 +282,8 @@ public class TestJsonReader extends BaseTestQuery {
     }
   }
 
+  // TODO: Union not yet supported in V2.
+
   @Test
   public void testUnionExpressionMaterialization() throws Exception {
     try {
@@ -550,6 +300,8 @@ public class TestJsonReader extends BaseTestQuery {
       resetSessionOption(ExecConstants.ENABLE_UNION_TYPE_KEY);
     }
   }
+
+  // TODO: Union not yet supported in V2.
 
   @Test
   public void testSumMultipleBatches() throws Exception {
@@ -574,6 +326,8 @@ public class TestJsonReader extends BaseTestQuery {
       resetSessionOption(ExecConstants.ENABLE_UNION_TYPE_KEY);
     }
   }
+
+  // TODO: Union not yet supported in V2.
 
   @Test
   public void testSumFilesWithDifferentSchema() throws Exception {
@@ -604,6 +358,8 @@ public class TestJsonReader extends BaseTestQuery {
     }
   }
 
+  // V1 version of the test. See TsetJsonReaderQueries for the V2 version.
+
   @Test
   public void drill_4032() throws Exception {
     File table_dir = dirTestWatcher.makeTestTmpSubDir(Paths.get("drill_4032"));
@@ -623,19 +379,23 @@ public class TestJsonReader extends BaseTestQuery {
 
   @Test
   public void drill_4479() throws Exception {
-    try {
-      File table_dir = dirTestWatcher.makeTestTmpSubDir(Paths.get("drill_4479"));
-      table_dir.mkdir();
-      BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(new File(table_dir, "mostlynulls.json")));
-      // Create an entire batch of null values for 3 columns
-      for (int i = 0; i < JSONRecordReader.DEFAULT_ROWS_PER_BATCH; i++) {
-        os.write("{\"a\": null, \"b\": null, \"c\": null}".getBytes());
-      }
-      // Add a row with {bigint,  float, string} values
-      os.write("{\"a\": 123456789123, \"b\": 99.999, \"c\": \"Hello World\"}".getBytes());
-      os.flush();
-      os.close();
+    File table_dir = dirTestWatcher.makeTestTmpSubDir(Paths.get("drill_4479"));
+    table_dir.mkdir();
+    BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(new File(table_dir, "mostlynulls.json")));
+    // Create an entire batch of null values for 3 columns
+    for (int i = 0; i < JSONRecordReader.DEFAULT_ROWS_PER_BATCH; i++) {
+      os.write("{\"a\": null, \"b\": null, \"c\": null}".getBytes());
+    }
+    // Add a row with {bigint,  float, string} values
+    os.write("{\"a\": 123456789123, \"b\": 99.999, \"c\": \"Hello World\"}".getBytes());
+    os.flush();
+    os.close();
 
+    runBoth(() -> doDrill_4479());
+  }
+
+  private void doDrill_4479() throws Exception {
+    try {
       testBuilder()
         .sqlQuery("select c, count(*) as cnt from dfs.tmp.drill_4479 t group by c")
         .ordered()
@@ -673,6 +433,10 @@ public class TestJsonReader extends BaseTestQuery {
       writer.write("{ \"a\": { \"b\": { \"c\": [] }, \"c\": [] } }");
     }
 
+    runBoth(() -> doTestFlattenEmptyArrayWithAllTextMode());
+  }
+
+  private void doTestFlattenEmptyArrayWithAllTextMode() throws Exception {
     try {
       String query = "select flatten(t.a.b.c) as c from dfs.`empty_array_all_text_mode.json` t";
 
@@ -701,6 +465,10 @@ public class TestJsonReader extends BaseTestQuery {
       writer.write("{ \"a\": { \"b\": { \"c\": [] }, \"c\": [] } }");
     }
 
+    runBoth(() -> doTestFlattenEmptyArrayWithUnionType());
+  }
+
+  private void doTestFlattenEmptyArrayWithUnionType() throws Exception {
     try {
       String query = "select flatten(t.a.b.c) as c from dfs.`empty_array.json` t";
 
@@ -732,6 +500,10 @@ public class TestJsonReader extends BaseTestQuery {
       writer.write("{\"rk\": \"a\", \"m\": {\"a\":\"1\"}}");
     }
 
+    runBoth(() -> doTestKvgenWithUnionAll(fileName));
+  }
+
+  private void doTestKvgenWithUnionAll(String fileName) throws Exception {
     String query = String.format("select kvgen(m) as res from (select m from dfs.`%s` union all " +
         "select convert_from('{\"a\" : null}' ,'json') as m from (values(1)))", fileName);
     assertEquals("Row count should match", 2, testSql(query));
@@ -744,6 +516,10 @@ public class TestJsonReader extends BaseTestQuery {
       writer.write("{\"rk.q\": \"a\", \"m\": {\"a.b\":\"1\", \"a\":{\"b\":\"2\"}, \"c\":\"3\"}}");
     }
 
+    runBoth(() -> doTestFieldWithDots(fileName));
+  }
+
+  private void doTestFieldWithDots(String fileName) throws Exception {
     testBuilder()
       .sqlQuery("select t.m.`a.b` as a,\n" +
         "t.m.a.b as b,\n" +
@@ -756,6 +532,8 @@ public class TestJsonReader extends BaseTestQuery {
       .baselineValues("1", "2", "1", null, "a")
       .go();
   }
+
+  // TODO: Union not yet supported in V2.
 
   @Test // DRILL-6020
   public void testUntypedPathWithUnion() throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetComparison.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetComparison.java
@@ -76,6 +76,14 @@ public class RowSetComparison {
    */
   private MathContext scale = new MathContext(3);
   /**
+  * Floats and doubles do not compare exactly. This delta is used
+  * by JUnit for such comparisons. This is not a general solution;
+  * it assumes that tests won't create values that require more than
+  * three digits of precision.
+  */
+  private double delta = 0.001;
+
+  /**
    * Tests can skip the first n rows.
    */
   private int offset;
@@ -333,6 +341,18 @@ public class RowSetComparison {
         assertEquals(label + " - byte lengths differ", expected.length, actual.length);
         assertTrue(label, Arrays.areEqual(expected, actual));
         break;
+
+      // Double must be handled specially since BigDecimal cannot handle
+      // INF or NAN double values.
+
+      case DOUBLE:
+        assertEquals(label, ec.getDouble(), ac.getDouble(), delta);
+        break;
+
+      // repeated_contains is claimed to return a boolean,
+      // actually returns a count, but in a bit field. To test
+      // this function, we must treat BIT as an integer.
+
       default:
         assertEquals(label, getScalar(ec), getScalar(ac));
     }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/rowSet/RowSetUtilities.java
@@ -28,7 +28,10 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetWriter;
+import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.vector.accessor.ScalarWriter;
 import org.apache.drill.exec.vector.accessor.ValueType;
@@ -280,5 +283,9 @@ public class RowSetUtilities {
       map.put(entry[i], entry[i + 1]);
     }
     return map;
+  }
+
+  public static void assertSchemasEqual(TupleMetadata expected, BatchSchema actual) {
+    assertEquals(expected, MetadataUtils.fromFields(actual));
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.record.metadata;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.drill.common.types.TypeProtos.DataMode;
@@ -343,5 +344,21 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
    */
   private String escapeSpecialSymbols(String value) {
     return value.replaceAll("(\\\\)|(`)", "\\\\$0");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(getClass().isInstance(o))) {
+      return false;
+    }
+    AbstractColumnMetadata other = (AbstractColumnMetadata) o;
+    return Objects.equals(name, other.name) &&
+           type == other.type &&
+           mode == other.mode &&
+           precision == other.precision &&
+           scale == other.scale;
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractMapColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractMapColumnMetadata.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.record.metadata;
 
-import java.util.stream.Collectors;
-
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
+
+import java.util.stream.Collectors;
 
 /**
  * Describes a base column type for map, dict, repeated map and repeated dict. All are tuples that have a tuple
@@ -146,6 +146,6 @@ public abstract class AbstractMapColumnMetadata extends AbstractColumnMetadata {
       return false;
     }
     AbstractMapColumnMetadata other = (AbstractMapColumnMetadata) o;
-    return schema.equals(other.mapSchema());
+    return schema.equals(other.tupleSchema());
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractMapColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractMapColumnMetadata.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.record.metadata;
 
+import java.util.stream.Collectors;
+
 import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.MaterializedField;
-
-import java.util.stream.Collectors;
 
 /**
  * Describes a base column type for map, dict, repeated map and repeated dict. All are tuples that have a tuple
@@ -139,4 +139,13 @@ public abstract class AbstractMapColumnMetadata extends AbstractColumnMetadata {
    * @return column type
    */
   protected abstract String getStringType();
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    AbstractMapColumnMetadata other = (AbstractMapColumnMetadata) o;
+    return schema.equals(other.mapSchema());
+  }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/TupleSchema.java
@@ -17,18 +17,19 @@
  */
 package org.apache.drill.exec.record.metadata;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import org.apache.drill.exec.record.MaterializedField;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.drill.exec.record.MaterializedField;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Defines the schema of a tuple: either the top-level row or a nested
@@ -230,5 +231,25 @@ public class TupleSchema extends AbstractPropertied implements TupleMetadata {
   @Override
   public Map<String, String> properties() {
     return super.properties();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(o instanceof TupleMetadata)) {
+      return false;
+    }
+    TupleMetadata other = (TupleMetadata) o;
+    if (size() != other.size()) {
+      return false;
+    }
+    for (int i = 0; i < size(); i++) {
+      if (!metadata(i).equals(other.metadata(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/TupleWriter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.vector.accessor;
 
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -67,6 +68,20 @@ public interface TupleWriter extends ColumnWriter {
       super("Undefined column: " + colName);
     }
   }
+
+  /**
+   * Allows a client to "sniff" the projection set to determine if a
+   * field is projected. Some clients can omit steps if they know that
+   * a field is not needed. Others will simply create the column, allowing
+   * the implementation to create a dummy writer if the column is not
+   * projected.
+   *
+   * @param columnName name of an existing or new column
+   * @return whether the column is projected, and, if so, the implied
+   * type of the projected column
+   */
+
+  ProjectionType projectionType(String columnName);
 
   /**
    * Add a column to the tuple (row or map) that backs this writer. Support for

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.project.ProjectionType;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -147,6 +148,8 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
     ObjectWriter addColumn(TupleWriter tuple, ColumnMetadata column);
 
     ObjectWriter addColumn(TupleWriter tuple, MaterializedField field);
+
+    ProjectionType projectionType(String columnName);
   }
 
   /**
@@ -184,7 +187,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   protected final List<AbstractObjectWriter> writers;
   protected ColumnWriterIndex vectorIndex;
   protected ColumnWriterIndex childIndex;
-  protected AbstractTupleWriter.TupleWriterListener listener;
+  protected TupleWriterListener listener;
   protected State state = State.IDLE;
 
   protected AbstractTupleWriter(TupleMetadata schema, List<AbstractObjectWriter> writers) {
@@ -238,6 +241,12 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
       }
     }
     return colIndex;
+  }
+
+  @Override
+  public ProjectionType projectionType(String columnName) {
+    return listener == null ? ProjectionType.GENERAL
+        : listener.projectionType(columnName);
   }
 
   @Override


### PR DESCRIPTION
Reimplements the JSON reader on top of the EVF. Does not yet
handle a provided schema. New JSON parser does not yet reflect
any changes made to the "V1" JSON parser in the last year.
Does not yet handle the Union and List-of-union types.
Enabling those encountered many issues elsewhere in Drill.

Provides more robust (but still limited) handling of JSON
type ambigutities. Handles runs of nulls before the first
non-null value (within the first batch.) Handles runs of
empty arrays before the first non-empty array (again, within
the first batch.) Handles the case where a null value turns out
to be an object or array. Handles reasonable conversions between
types.

Handling ambiguities makes the new parser more complex than
the "V1" version. The new one uses explict states for each
kind of JSON object, where as the old one used implicit states
expressed via if-statements, which can be a bit hard to follow
as the states get more complex.

The new "V2" JSON scan is controlled by a new option:
store.json.enable_v2_reader, which is false by default in this
PR.

Adds a "projection type" to the column writer so that the
JSON parser can receive a "hint" as to the expected type.
The hint is from the form of the projected column: `a[0]`,
`a.b` or just `a`.

Reimplements a number of JSON tests to test both the original
"V1" and the new "V2" versions of the JSON reader. Adds many
new tests for the new features of the "V2" parser.

Jira - [DRILL-6953](https://issues.apache.org/jira/browse/DRILL-6953).