### PR TITLE
DRILL-7458: Base framework for storage plugins

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserException.java
@@ -96,6 +96,10 @@ public class UserException extends DrillRuntimeException {
     return new Builder(DrillPBError.ErrorType.SYSTEM, cause);
   }
 
+  public static Builder systemError() {
+    return new Builder(DrillPBError.ErrorType.SYSTEM, null);
+  }
+
   /**
    * Creates a new user exception builder.
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -93,6 +93,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.util.concurrent.SettableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.channel.EventLoopGroup;
 
@@ -103,7 +105,7 @@ import io.netty.channel.EventLoopGroup;
 public class DrillClient implements Closeable, ConnectionThrottle {
   public static final String DEFAULT_CLIENT_NAME = "Apache Drill Java client";
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillClient.class);
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private final DrillConfig config;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/registry/RemoteFunctionRegistry.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,7 +86,7 @@ import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 public class RemoteFunctionRegistry implements AutoCloseable {
 
   private static final String REGISTRY_PATH = "registry";
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RemoteFunctionRegistry.class);
+  private static final Logger logger = LoggerFactory.getLogger(RemoteFunctionRegistry.class);
   private static final ObjectMapper mapper = new ObjectMapper().enable(INDENT_OUTPUT);
 
   private final TransientStoreListener unregistrationListener;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -36,6 +36,7 @@ import org.apache.drill.exec.proto.ExecProtos;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.work.filter.RuntimeFilterWritable;
 
@@ -204,6 +205,14 @@ public interface FragmentContext extends UdfUtilities, AutoCloseable {
    * throw an <code>OutOfMemoryException</code>.
    */
   void requestMemory(RecordBatch requestor);
+
+  /*
+   * Get instance of the storage plugin registry to resolve storage plugin
+   * configs to their matching storage plugins.
+   *
+   * @return the storage plugin registry
+   */
+  StoragePluginRegistry getStorageRegistry();
 
   interface ExecutorState {
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -68,6 +68,7 @@ import org.apache.drill.exec.server.options.OptionList;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.PartitionExplorer;
 import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.util.ImpersonationUtil;
 import org.apache.drill.exec.work.batch.IncomingBuffers;
@@ -254,6 +255,11 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   @Override
   public PhysicalPlanReader getPlanReader() {
     return context.getPlanReader();
+  }
+
+  @Override
+  public StoragePluginRegistry getStorageRegistry() {
+    return context.getStorage();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/OperatorCreatorRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/OperatorCreatorRegistry.java
@@ -26,9 +26,11 @@ import java.util.Set;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.scanner.persistence.ScanResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OperatorCreatorRegistry {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OperatorCreatorRegistry.class);
+  private static final Logger logger = LoggerFactory.getLogger(OperatorCreatorRegistry.class);
 
   private volatile Map<Class<?>, Constructor<?>> constructorRegistry = new HashMap<Class<?>, Constructor<?>>();
   private volatile Map<Class<?>, Object> instanceRegistry = new HashMap<Class<?>, Object>();
@@ -46,7 +48,18 @@ public class OperatorCreatorRegistry {
     }
 
     Constructor<?> c = constructorRegistry.get(operator);
-    if(c == null) {
+
+    // Storage plugins can extend a base sub scan. Search for parent-class
+    // constructors.
+
+    while (c == null) {
+      Class<?> parent = operator.getSuperclass();
+      if (parent == Object.class) {
+        break;
+      }
+      c = constructorRegistry.get(parent);
+    }
+    if (c == null) {
       throw new ExecutionSetupException(
           String.format("Failure finding OperatorCreator constructor for config %s", operator.getCanonicalName()));
     }
@@ -97,5 +110,4 @@ public class OperatorCreatorRegistry {
       }
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PhysicalPlanReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PhysicalPlanReader.java
@@ -46,9 +46,11 @@ import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PhysicalPlanReader {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PhysicalPlanReader.class);
+  private static final Logger logger = LoggerFactory.getLogger(PhysicalPlanReader.class);
 
   private final ObjectReader physicalPlanReader;
   private final ObjectMapper mapper;
@@ -61,6 +63,7 @@ public class PhysicalPlanReader {
     ObjectMapper lpMapper = lpPersistance.getMapper();
 
     // Endpoint serializer/deserializer.
+    @SuppressWarnings("unchecked")
     SimpleModule serDeModule = new SimpleModule("PhysicalOperatorModule")
         .addSerializer(DrillbitEndpoint.class, new DrillbitEndpointSerDe.Se())
         .addDeserializer(DrillbitEndpoint.class, new DrillbitEndpointSerDe.De())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -251,26 +251,6 @@ public enum PlannerPhase {
     this.description = description;
   }
 
-  /**
-   * Filter push-down is best done during logical planning so that the result can
-   * influence parallelization in the physical phase. The specific phase differs
-   * depending on which planning mode is enabled. This check hides those details
-   * from storage plugins that simply want to know "should I add my filter
-   * push-down rules in the given phase?"
-   *
-   * @return true if filter push-down rules should be applied in this phase
-   */
-  public boolean isFilterPushDownPhase() {
-    switch (this) {
-    case LOGICAL_PRUNE_AND_JOIN: // HEP is disabled
-    case PARTITION_PRUNING:      // HEP partition push-down enabled
-    case LOGICAL_PRUNE:          // HEP partition push-down disabled
-      return true;
-    default:
-      return false;
-    }
-  }
-
   public abstract RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins);
 
   private static RuleSet getStorageRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -105,6 +105,7 @@ import java.util.Set;
 public enum PlannerPhase {
 
   LOGICAL_PRUNE_AND_JOIN("Logical Planning (with join and partition pruning)") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           getDrillBasicRules(context),
@@ -116,6 +117,7 @@ public enum PlannerPhase {
   },
 
   WINDOW_REWRITE("Window Function rewrites") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return RuleSets.ofList(
           RuleInstance.CALC_INSTANCE,
@@ -125,6 +127,7 @@ public enum PlannerPhase {
   },
 
   SUBQUERY_REWRITE("Sub-queries rewrites") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return RuleSets.ofList(
           RuleInstance.SUB_QUERY_FILTER_REMOVE_RULE,
@@ -135,6 +138,7 @@ public enum PlannerPhase {
   },
 
   LOGICAL_PRUNE("Logical Planning (with partition pruning)") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           getDrillBasicRules(context),
@@ -145,6 +149,7 @@ public enum PlannerPhase {
   },
 
   JOIN_PLANNING("LOPT Join Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       List<RelOptRule> rules = Lists.newArrayList();
       if (context.getPlannerSettings().isJoinOptimizationEnabled()) {
@@ -160,6 +165,7 @@ public enum PlannerPhase {
   },
 
   ROWKEYJOIN_CONVERSION("Convert Join to RowKeyJoin") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       List<RelOptRule> rules = Lists.newArrayList();
       if (context.getPlannerSettings().isRowKeyJoinConversionEnabled()) {
@@ -173,6 +179,7 @@ public enum PlannerPhase {
   },
 
   SUM_CONVERSION("Convert SUM to $SUM0") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           RuleSets.ofList(
@@ -184,24 +191,28 @@ public enum PlannerPhase {
   },
 
   PARTITION_PRUNING("Partition Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   PHYSICAL_PARTITION_PRUNING("Physical Partition Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getPhysicalPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   DIRECTORY_PRUNING("Directory Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getDirPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   LOGICAL("Logical Planning (no pruning or join).") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           PlannerPhase.getDrillBasicRules(context),
@@ -211,6 +222,7 @@ public enum PlannerPhase {
   },
 
   PHYSICAL("Physical Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           PlannerPhase.getPhysicalRules(context),
@@ -220,12 +232,14 @@ public enum PlannerPhase {
   },
 
   PRE_LOGICAL_PLANNING("Planning with Hep planner only for rules, which are failed for Volcano planner") {
+    @Override
     public RuleSet getRules (OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.getSetOpTransposeRules();
     }
   },
 
   TRANSITIVE_CLOSURE("Transitive closure") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return getJoinTransitiveClosureRules();
     }
@@ -237,21 +251,40 @@ public enum PlannerPhase {
     this.description = description;
   }
 
+  /**
+   * Filter push-down is best done during logical planning so that the result can
+   * influence parallelization in the physical phase. The specific phase differs
+   * depending on which planning mode is enabled. This check hides those details
+   * from storage plugins that simply want to know "should I add my filter
+   * push-down rules in the given phase?"
+   *
+   * @return true if filter push-down rules should be applied in this phase
+   */
+  public boolean isFilterPushDownPhase() {
+    switch (this) {
+    case LOGICAL_PRUNE_AND_JOIN: // HEP is disabled
+    case PARTITION_PRUNING:      // HEP partition push-down enabled
+    case LOGICAL_PRUNE:          // HEP partition push-down disabled
+      return true;
+    default:
+      return false;
+    }
+  }
+
   public abstract RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins);
 
   private static RuleSet getStorageRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins,
       PlannerPhase phase) {
     final Builder<RelOptRule> rules = ImmutableSet.builder();
-    for(StoragePlugin plugin : plugins){
-      if(plugin instanceof AbstractStoragePlugin){
+    for (StoragePlugin plugin : plugins) {
+      if (plugin instanceof AbstractStoragePlugin) {
         rules.addAll(((AbstractStoragePlugin) plugin).getOptimizerRules(context, phase));
-      }else{
+      } else {
         rules.addAll(plugin.getOptimizerRules(context));
       }
     }
     return RuleSets.ofList(rules.build());
   }
-
 
   static final RelOptRule DRILL_JOIN_TO_MULTIJOIN_RULE =
       new JoinToMultiJoinRule(DrillJoinRel.class, DrillRelFactories.LOGICAL_BUILDER);
@@ -412,9 +445,7 @@ public enum PlannerPhase {
 
     return RuleSets.ofList(pruneRules);
   }
-  /**
-   *
-   */
+
   static RuleSet getIndexRules(OptimizerRulesContext optimizerRulesContext) {
     final PlannerSettings ps = optimizerRulesContext.getPlannerSettings();
     if (!ps.isIndexPlanningEnabled()) {
@@ -480,7 +511,6 @@ public enum PlannerPhase {
         .build();
 
     return RuleSets.ofList(pruneRules);
-
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillStatsTable.java
@@ -59,13 +59,15 @@ import org.apache.drill.metastore.statistics.StatisticsHolder;
 import org.apache.drill.metastore.statistics.StatisticsKind;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wraps the stats table info including schema and tableName. Also materializes stats from storage
  * and keeps them in memory.
  */
 public class DrillStatsTable {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillStatsTable.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillStatsTable.class);
   // All the statistics versions till date
   public enum STATS_VERSION {V0, V1}
   // The current version
@@ -81,9 +83,9 @@ public class DrillStatsTable {
   private final Map<SchemaPath, Histogram> histogram = new HashMap<>();
   private double rowCount = -1;
   private final Map<SchemaPath, Long> nnRowCount = new HashMap<>();
-  private boolean materialized = false;
+  private boolean materialized;
   private DrillTable table;
-  private TableStatistics statistics = null;
+  private TableStatistics statistics;
 
   public DrillStatsTable(DrillTable table, String schemaName, String tableName, Path tablePath, FileSystem fs) {
     this.schemaName = schemaName;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -54,7 +54,6 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.drill.shaded.guava.com.google.common.base.Preconditions.checkNotNull;
 
 public class DrillbitContext implements AutoCloseable {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillbitContext.class);
 
   private final BootStrapContext context;
   private final PhysicalPlanReader reader;
@@ -270,11 +269,11 @@ public class DrillbitContext implements AutoCloseable {
 
   /**
    * Use the operator table built during startup when "exec.udf.use_dynamic" option
-   * is set to false.
+   * is set to false.<p>
    * This operator table has standard SQL functions, operators and drill
    * built-in user defined functions (UDFs).
    * It does not include dynamic user defined functions (UDFs) that get added/removed
-   * at run time.
+   * at run time.<p>
    * This operator table is meant to be used for high throughput,
    * low latency operational queries, for which cost of building operator table is
    * high, both in terms of CPU and heap memory usage.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+
+import org.apache.drill.common.JSONOptions;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.base.ScanStats;
+import org.apache.drill.exec.physical.base.SubScan;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.SessionOptionManager;
+import org.apache.drill.exec.store.AbstractStoragePlugin;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.base.BaseStoragePlugin.StoragePluginOptions;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Base group scan for storage plugins. A group scan is a "logical" scan: it is
+ * the representation of the scan used during the logical and physical planning
+ * phases. The group scan is converted to a "sub scan" (an executable scan
+ * specification) for inclusion in the physical plan sent to Drillbits for
+ * execution. The group scan represents the entire scan of a table or data
+ * source. The sub scan divides that scan into files, storage blocks or other
+ * forms of parallelism.
+ * <p>
+ * You can use this class directly for the simplest of cases: a single minor
+ * fragment that requires only schema, table and column names. This lets you get
+ * something working quickly. You can then extend the scan spec if you need to
+ * pass along more information, or extend this class to handle extended
+ * plan-time behavior such as filter push-down.
+ *
+ * <h4>Serialization</h4>
+ *
+ * The group scan is Jackson-serialized to create the logical plan. The logical
+ * plan is not normally seen during normal SQL execution, but is used internally
+ * for testing. Each subclass must choose which fields to serialize and which to
+ * make ephemeral in-memory state. This is tricky. There are multiple cases:
+ * <p>
+ * <ol>
+ * <li>Materialize and serialize the data. This class serializes a "scan
+ * specification" as the "scanSpec" attribute in JSON. Subclasses can add fields
+ * to this class (if used only by the group scan) or to the scan spec (if shared
+ * with the sub scan.)</li>
+ * <li>Serialized ephemeral data. The base class marks the scan stats as a JSON
+ * field, however the scan stats are usually recomputed each time they are
+ * needed since they change as the scan is refined. This class will serialize
+ * the storage plugin config, and gets that from the storage plugin itself.</li>
+ * <li>Non-serialized materialized data. A base class of this class includes an
+ * id which is not directly serialized. This class holds a reference to the
+ * storage plugin.</li>
+ * <li>Cached data. Advanced storage plugins work with an external system and
+ * will want to cache metadata from that system. Such metadata should be cached
+ * on the storage plugin, not in this class.</li>
+ * </ol>
+ * <p>
+ * Jackson will use the constructor marked with <tt>@JsonCreator</tt> to
+ * deserialize your group scan. If you create a subclass, and add fields, start
+ * with the constructor from this class, then add your custom fields after the
+ * fields defined here.
+ *
+ * <h4>Life Cycle</h4>
+ *
+ * Drill uses Calcite for planning. Calcite is very complex: it applies a series
+ * of rules to transform the query, then chooses the lowest cost among the
+ * available transforms. As a result, the group scan object is continually
+ * created and recreated. The following is a rough outline of these events.
+ *
+ * <h5>Create the Group Scan</h5>
+ *
+ * The storage plugin provides a {@link SchemaFactory} which provides a
+ * {@link SchemaConfig} which represents the set of (logical) tables available
+ * from the plugin.
+ * <p>
+ * Calcite offers table names to the schema. If the table is valid, the schema
+ * creates a {@link BaseScanSpec} to describe the schema, table and other
+ * information unique to the plugin. The schema then creates a group scan using
+ * the following constructor:
+ * {@link #BaseGroupScan(BaseStoragePlugin, String, BaseScanSpec)}.
+ *
+ * <h5>Column Resolution</h5>
+ *
+ * Calcite makes multiple attempts to refine the set of columns from the scan.
+ * If we have the following query:<br>
+ * <code><pre>
+ * SELECT a AS x, b FROM myTable</pre></code><br>
+ * Then Calcite will offer the following set of columns as planning proceeds:
+ *
+ * <ol>
+ * <li>['**'] (The default starter set.)</li>
+ * <li>['**', 'a', 'b', 'x'] (alias not yet resolved.)</li>
+ * <li>['a', 'b'] (aliases resolved)</li>
+ * </ol>
+ *
+ * Each time the column set changes, Calcite makes a copy of the group scan by
+ * calling {@link AbstractGroupScan#clone(List<SchemaPath>)}. This class
+ * automates the process by calling two constructors. First, it calls
+ * {@link BaseScanSpec#BaseScanSpec(BaseScanSpec, List<SchemaPath>)} to create a
+ * new scan spec with the columns included.
+ * <p>
+ * The easiest solution is simply to provide the needed constructors. For
+ * special cases, you can override the <tt>clone()</tt> method itself.
+ *
+ * <h5>Intermediate Copies</h5>
+ *
+ * At multiple points, Calcite will create a simple copy of the node by invoking
+ * {@link GroupScan#getNewWithChildren(List<PhysicalOperator>)}. Scans never
+ * have children, so this method should just make a copy. This base class
+ * automatically invokes the the copy constructor
+ * {@link #BaseGroupScan(BaseGroupScan)}. The code will invoke that constructor
+ * on your derived class using Java introspection.
+ * <p>
+ * At some point, Drill serializes the scan spec to JSON, then recreates the
+ * group scan via one of the
+ * {@link AbstractStoragePlugin#getPhysicalScan(String userName, JSONOptions selection, SessionOptionManager sessionOptions, MetadataProviderManager metadataProviderManager)}
+ * methods. Each offer different levels of detail. The base scan will
+ * automatically deserialize the scan spec, then call
+ * {@link BaseStoragePlugin#newGroupScan(String, BaseScanSpec, SessionOptionManager, MetadataProviderManager)}
+ * or the simpler {@link BaseStoragePlugin#newGroupScan(String, BaseScanSpec)}
+ * to create a group scan. You must override one of these methods if you create
+ * your own subclass.
+ *
+ * <h5>Node Assignment</h5>
+ *
+ * Drill calls {@link #getMaxParallelizationWidth()} to determine how much it
+ * can parallelize the scan. Drill calls {@link #applyAssignments(List)} to
+ * declare the actual number of minor fragments (offered as Drillbit endpoints.)
+ * Since most non-file scans don't care about node affinity, they can simply use
+ * the {@link #endpointCount} variable to determine the number of minor
+ * fragments which Drill will create.
+ * <p>
+ * Drill then calls {@link #getSpecificScan(int)}. If your scan is a simple
+ * single scan, you can set the
+ * {@link StoragePluginOptions#maxParallelizationWidth} value to 1 and assume
+ * that Drill will create a single sub scan. Otherwise, you must pack your
+ * "slices" (however this plugin defines them) into the available number of
+ * minor fragments. This is done by having the sub scan hold a list of "slices",
+ * then having the scan operator iterate over those slices.
+ *
+ * <h4>The Storage Plugin</h4>
+ *
+ * Group scans are ephemeral and serialized. They should hold only data that
+ * describes the scan. Group scans <i>should not</i> hold metadata about the
+ * underlying system because of the complexity of recreating that data on each
+ * of the many copies that occur.
+ * <p>
+ * Instead, the implementation should cache metadata in the storage plugin. Each
+ * storage plugin instance exists for the duration of a single query: either at
+ * plan time or (if requested) at runtime (one instance per minor fragment.) A
+ * good practice is:
+ * <ul>
+ * <li>The group scan asks the storage plugin for metadata as needed to process
+ * each group scan operation.</li>
+ * <li>The storage plugin retrieves the metadata from the external system and
+ * caches it; returning the cached copies on subsequent requests.</li>
+ * <li>The sub scan (execution description) should avoid asking for metadata to
+ * avoid caching metadata in each of the many execution minor fragments.</li>
+ * <li>Cached information is lost once planning completes for a query. If
+ * additional caching is needed, the storage plugin can implement a shared cache
+ * (with proper concurrency controls) which is shared across multiple plugin
+ * instances. (Note, however, than planning is also distributed; each query may
+ * be planned on a different Drillbit (Foreman), so even a shared cache will
+ * hold as many copies as there are Drillbits (one copy per Drillbit.)</li>
+ * </ul>
+ * <p>
+ * The storage plugin is the only part of the data for a query that persists
+ * across the entire planning session. Group scans are created and deleted.
+ * Although some of these are done via copies (and so could preserve data), the
+ * <tt>getPhysicalScan()</tt> step is not a copy and discards all data except
+ * that in the scan spec.
+ *
+ * <h4>The Scan Specification</h4>
+ *
+ * Drill has the idea of a scan specification, as mentioned above. The "Base"
+ * classes run with the idea to define a {@link BaseScanSpec} that holds data
+ * shared between the group and sub scans. This approach avoids the need to copy
+ * and serialize the data in two places, and allows the automatic copies
+ * described above.
+ * <p>
+ * Your subclass should include other query-specific data needed at both plan
+ * and run time such as file locations, partition information, filter push-downs
+ * and so on.
+ * <p>
+ * Some existing plugins copy the data from group to sub scan, but this is not
+ * necessary if you use the scan spec class.
+ *
+ * <h4>Costs</h4>
+ *
+ * Calcite is a cost-based optimizer. This means it uses the cost associated
+ * with a group scan instance to pick which of several options to use.
+ * <p>
+ * You must provide a scan cost estimate in terms of rows, data and CPU. For
+ * some systems (such as Hive), these numbers are available. For others (such as
+ * local files), the data size may be available, from which we can estimate a
+ * row count by assuming some reasonable average row width. In other cases (such
+ * as REST), we may not have any good estimate at all.
+ * <p>
+ * In these cases, it helps to know how Drill uses the cost estimates. The scan
+ * must occur, so there is no decsion about whether to use the scan or not. But,
+ * Drill has to decide which scan to put on which side of a join (the so-called
+ * "build" and "probe" sides.) Further, Drill needs to know if the table is
+ * small enough to "broadcast" the contents to all nodes.
+ * <p>
+ * So, at the least, the estimate must identify "small" vs. "large" tables. If
+ * the scan is known to be small enough to broadcast (because it is for, say, a
+ * small lookup list), then provide a small row and data estimate, say 100 rows
+ * and 1K.
+ * <p>
+ * If, however, the data size is potentially large, then provide a large
+ * estimate (10K rows, 100M data, say) to force Drill to not consider broadcast,
+ * and to avoid putting the table on the build side of a join unless some other
+ * table is even larger.
+ *
+ * <h5>Projection Push-Down</h5>
+ *
+ * Suppose your plugin accepts projection push-down. You indicate this by
+ * setting {@link StoragePluginOptions#supportsProjectPushDown} to <tt>true</tt>
+ * in your storage plugin.
+ * <p>
+ * Calcite must decide whether to actually do the push down. While this seems
+ * like an obvious improvement, Calcite wants the numbers. So, the cost of a
+ * scan should be lower (if only by a bit) with project push-down than without.
+ * (Also, the cost of a project operator will be removed with push-down, biasing
+ * the choice in favor of push-down.
+ *
+ * <h5>Filter Push-Down</h5>
+ *
+ * If your plugin supports filter push-down, then the cost with filters applied
+ * must be lower than the cost without the filter push-down, or Calcite may not
+ * choose to do the push-down. Filter push-down should reduce the number of rows
+ * scanned, and that reduction (or even a crude estimate, such as 50%) needs to
+ * be reflected in the cost.
+ * <p>
+ * Your filter push-down competes with Drill's own filter operator. If the
+ * filter operator, along with a scan without push down, is less expensive than
+ * a scan with push down, then Calcite will choose the former. Thus, the
+ * selectivity of filter push down must exceed the selectivity which Drill uses
+ * internally. (Drill uses the default selectivity defined by Calcite.)
+ *
+ * <h4>EXPLAIN PLAN</tt>
+ *
+ * The group scan appears in the output of the <tt>EXPLAIN PLAN FOR</tt>
+ * command. Drill calls the {@ink #toString()} method to obtain the string. The
+ * format of the string should follow Drill's conventions. The easiest way to to
+ * that is to instead override {@link #buildPlanString(PlanStringBuilder)} and
+ * add your custom fields to those already included from this base class.
+ * <p>
+ * If your fields have structure, ensure that the <tt>toString()</tt> method of
+ * those classes also uses {@link PlanStringBuilder}, or create the encoding
+ * yourself in your own <tt>buildPlanString</tt> method. Test by calling the
+ * method or by examining the output of an <tt>EXPLAIN</tt>.
+ */
+
+public abstract class BaseGroupScan extends AbstractGroupScan {
+
+  protected final BaseStoragePlugin<?> storagePlugin;
+  protected final List<SchemaPath> columns;
+  protected ScanStats scanStats;
+  protected int endpointCount;
+  protected OptionManager sessionOptions;
+
+  public BaseGroupScan(BaseStoragePlugin<?> storagePlugin,
+      String userName, List<SchemaPath> columns) {
+    super(userName);
+    this.storagePlugin = storagePlugin;
+    this.columns = columns;
+  }
+
+  public BaseGroupScan(BaseGroupScan from) {
+    this(from.storagePlugin, from.getUserName(), from.getColumns());
+    this.endpointCount = from.endpointCount;
+    this.sessionOptions = from.sessionOptions;
+  }
+
+  public BaseGroupScan(
+      StoragePluginConfig config,
+      String userName,
+      List<SchemaPath> columns,
+      StoragePluginRegistry engineRegistry) {
+    super(userName);
+    this.storagePlugin = BaseStoragePlugin.resolvePlugin(engineRegistry, config);
+    this.columns = columns;
+  }
+
+  @JsonProperty("config")
+  public StoragePluginConfig getConfig() { return storagePlugin.getConfig(); }
+
+  @JsonProperty("columns")
+  @Override
+  public List<SchemaPath> getColumns() {
+    return columns;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends BaseStoragePlugin<?>> T storagePlugin() {
+    return (T) storagePlugin;
+  }
+
+  public StoragePluginOptions pluginOptions() {
+    return storagePlugin.options();
+  }
+
+  @Override
+  public boolean canPushdownProjects(List<SchemaPath> columns) {
+    return pluginOptions().supportsProjectPushDown;
+  }
+
+  /**
+   * During parallelization, Drill calls this method with a list of endpoints
+   * which (it seems) correspond to minor fragments. Since non-file storage
+   * plugins generally don't care which node runs which slice of a scan, we
+   * retain only the endpoint count. Later, in {@link #getSpecificScan(int)},
+   * Drill will ask for subscans with minor fragment IDs from 0 to the number of
+   * endpoints specified here.
+   */
+  @Override
+  public void applyAssignments(List<DrillbitEndpoint> endpoints) {
+    endpointCount = endpoints.size();
+  }
+
+  /**
+   * Return the maximum parallelization width. This number is usually the number
+   * of distinct sub-scans this group scan can produce. The actual number of
+   * minor fragments may be less. (For example, if running in a test, the minor
+   * fragment count may be just 1.) In that case, the
+   * {{@link #getSpecificScan(int)} may need to combine logical sub-scans into a
+   * single physical sub scan. That is, a sub scan operator should hold a list
+   * of actual scans, and the scan operator should be ready to perform multiple
+   * actual scans per sub-scan operator.
+   *
+   * @return the number of sub-scans that this group scan will produce
+   */
+  @JsonIgnore
+  @Override
+  public abstract int getMaxParallelizationWidth();
+
+  @JsonIgnore
+  @Override
+  public ScanStats getScanStats() {
+    if (scanStats == null) {
+      scanStats = computeScanStats();
+    }
+    return scanStats;
+  }
+
+  /**
+   * Compute the statistics for the scan used to plan the query. In general, the
+   * most critical aspect is to give a rough estimate of row count: a small row
+   * count will encourage the planner to broadcast rows to all Drillbits,
+   * something that is undesirable if the row count is actually large.
+   * Otherwise, more accurate estimates are better.
+   */
+  protected abstract ScanStats computeScanStats();
+
+  /**
+   * Create a sub scan for the given minor fragment. Override this
+   * if you define a custom sub scan. Uses the default
+   * {@link BaseSubScan} by default.
+   * <p>
+   * The group can may have a single "slice". If so, then the
+   * {@link #getMaxParallelizationWidth()} should have returned 1,
+   * and this method will be called only once, with
+   * <code>minorFragmentId = 0</code>.
+   * <p>
+   * However, if the group can can partition work into sub-units
+   * (let's call them "slices"), then this method must pack
+   * <i><b>n</b></i> slices into <i><b>m</b></i> minor fragments
+   * where <i><b>n</b></i> >= <i><b>m</b></i>.
+   */
+  @Override
+  public abstract SubScan getSpecificScan(int minorFragmentId);
+
+  @JsonIgnore
+  @Override
+  public String getDigest() { return toString(); }
+
+  /**
+   * Create a copy of the group scan with with candidate projection
+   * columns. Calls
+   * {@link BaseScanFactory#groupWithColumns()}
+   * by default.
+   */
+  @Override
+  public GroupScan clone(List<SchemaPath> columns) {
+    return pluginOptions().scanFactory.groupWithColumnsShim(this, columns);
+  }
+
+  /**
+   * Create a copy of the group scan with (non-existent) children.
+   * Calls
+   * {@link BaseScanFactory#copyGroupShim()}
+   * by default.
+   */
+  @Override
+  public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
+    Preconditions.checkArgument(children.isEmpty());
+    return pluginOptions().scanFactory.copyGroupShim(this);
+  }
+
+  /**
+   * Create a string representation of the scan formatted for the
+   * <tt>EXPLAIN PLAN FOR</tt> output. Do not override this method,
+   * override {@link #buildPlanString(PlanStringBuilder)} instead.
+   */
+  @Override
+  public String toString() {
+    PlanStringBuilder builder = new PlanStringBuilder(this);
+    buildPlanString(builder);
+    return builder.toString();
+  }
+
+  /**
+   * Build an <tt>EXPLAIN PLAN FOR</tt> string using the builder
+   * provided. Call the <tt>super</tt> method first, then add
+   * fields for the subclass.
+   * @param builder simple builder to create the required
+   * format
+   */
+  public void buildPlanString(PlanStringBuilder builder) {
+    builder.field("user", getUserName());
+    builder.field("columns", columns);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
@@ -102,7 +102,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * identify fields (getters) to be serialized, and {@code @JsonIgnore}
  * for those that should not be serialized.
  */
-
 public abstract class BaseGroupScan extends AbstractGroupScan {
 
   protected final BaseStoragePlugin<?> storagePlugin;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseGroupScan.java
@@ -28,8 +28,6 @@ import org.apache.drill.exec.physical.base.ScanStats;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.apache.drill.exec.server.options.OptionManager;
-import org.apache.drill.exec.store.SchemaConfig;
-import org.apache.drill.exec.store.SchemaFactory;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.base.BaseStoragePlugin.StoragePluginOptions;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
@@ -64,10 +62,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <h4>Serialization</h4>
  *
  * Drill provides the ability to serialize the logical plan. This is most
- * easily seen by issuing the <code>EXPLAIN PLAN FOR</code> command for a
+ * easily seen by issuing the {@code EXPLAIN PLAN FOR} command for a
  * query. The Jackson-serialized representation of the group scan appears
- * in the JSON partition of the <code>EXPLAIN</code> output, while the
- * <code>toString()</code> output appears in the text output of that
+ * in the JSON partition of the {@code EXPLAIN} output, while the
+ * {@code toString()} output appears in the text output of that
  * command.
  * <p>
  * Care must be taken when serializing: include only the <i>logical</i>
@@ -97,211 +95,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <li>Cached data (such as the cached scan stats, etc.</li>
  * </ul>
  * <p>
- * Jackson will use the constructor marked with <tt>@JsonCreator</tt> to
+ * Jackson will use the constructor marked with {@code @JsonCreator} to
  * deserialize your group scan. If you create a subclass, and add fields, start
  * with the constructor from this class, then add your custom fields after the
- * fields defined here. Make liberal use of <code>@JsonProperty</code> to
- * identify fields (getters) to be serialized, and <code>@JsonIgnore</code>
+ * fields defined here. Make liberal use of {@code @JsonProperty} to
+ * identify fields (getters) to be serialized, and {@code @JsonIgnore}
  * for those that should not be serialized.
- *
- * <h4>Life Cycle</h4>
- *
- * Drill uses Calcite for planning. Calcite is a bit complex: it applies a series
- * of rules to transform the query, then chooses the lowest cost among the
- * available transforms. As a result, the group scan object is continually
- * created and recreated. The following is a rough outline of these events.
- *
- * <h5>Create the Group Scan</h5>
- *
- * The storage plugin provides a {@link SchemaFactory} which provides a
- * {@link SchemaConfig} which represents the set of (logical) tables available
- * from the plugin.
- * <p>
- * Calcite offers table names to the schema. If the table is valid, the schema
- * creates a {@link BaseScanSpec} to describe the schema, table and other
- * information unique to the plugin. The schema then creates a group scan using
- * the following constructor:
- * {@link #BaseGroupScan(BaseStoragePlugin, String, BaseScanSpec)}.
- *
- * <h5>Column Resolution</h5>
- *
- * Calcite makes multiple attempts to refine the set of columns from the scan.
- * If we have the following query:<br>
- * <code><pre>
- * SELECT a AS x, b FROM myTable</pre></code><br>
- * Then Calcite will offer the following set of columns as planning proceeds:
- *
- * <ol>
- * <li>['**'] (The default starter set.)</li>
- * <li>['**', 'a', 'b', 'x'] (alias not yet resolved.)</li>
- * <li>['a', 'b'] (aliases resolved)</li>
- * </ol>
- *
- * Each time the column set changes, Calcite makes a copy of the group scan by
- * calling {@link AbstractGroupScan#clone(List<SchemaPath>)}. This class
- * automates the process by calling two constructors. First, it calls
- * {@link BaseScanSpec#BaseScanSpec(BaseScanSpec, List<SchemaPath>)} to create a
- * new scan spec with the columns included.
- * <p>
- * The easiest solution is simply to provide the needed constructors. For
- * special cases, you can override the <tt>clone()</tt> method itself.
- * <p>
- * Since Calcite is cost-based, it is important that the cost of the scan
- * decrease after columns are pushed down. This can be done by reducing
- * the disk I/O cost or reducing the CPU factor from 1.0 to, say, 0.75.
- * See {@link DummyGroupScan} for an example.
- *
- * <h5>Intermediate Copies</h5>
- *
- * At multiple points during logical planning, Calcite will create
- * a simple copy of the node by invoking
- * {@link GroupScan#getNewWithChildren(List<PhysicalOperator>)}. Scans never
- * have children, so this method should just make a copy. This base class
- * delegates to {@link BaseStoragePlugin.ScanFactory} to make the copy.
- * <p>
- * Calcite uses the schema to look up a table and obtain a scan spec.
- * The scan spec is then serialized to JSON and passed back to the plugin
- * to be deserialized and to create a group scan for the scan spec. The
- * {#link BaseStoragePlugin} and {@link BaseStoragePlugin.ScanFactory}
- * classes hide the details.
- *
- * <h4>Filter Push-Down</h5>
- *
- * If a plugin allows filter push-down, the plugin must add logical planning
- * rules to implement the push down. The rules rewrite the group scan with
- * the push-downs included (and optionally remove the filters from the
- * query.) See {@link BaseFilterPushDownStragy} for details.
- *
- * <h5>Node Assignment</h5>
- *
- * Drill calls {@link #getMaxParallelizationWidth()} to determine how much it
- * can parallelize the scan. If this method returns 1, Drill assumes that this
- * is a single-threaded scan. If the return is 2 or greater, Drill will create
- * a parallelized scan. This base class assumes a single-threaded scan.
- * Override {@link #getMinParallelizationWidth()} and
- * {@link #getMaxParallelizationWidth()} to enable parallelism.
- * <p>
- * Drill then calls {@link #applyAssignments(List)} to
- * declare the actual number of minor fragments (offered as Drillbit endpoints.)
- * Since most non-file scans don't care about node affinity, they can simply use
- * the {@link #endpointCount} variable to determine the number of minor
- * fragments which Drill will create.
- * <p>
- * Drill then calls {@link #getSpecificScan(int)}. The number of minor fragments
- * is the same as the number of endpoints offered above, which is determined by
- * the min/max parallelization width and Drill configuration.
- * <p>
- * Your group scan may create a set of scan "segments". For example, to read
- * a distributed database, there might be one segment per database server node.
- * The physical planning process maps the segments into minor fragments.
- * Ideally there will be one segment per minor fragment, but there may be
- * multiple if Drill can offer fewer endpoints than requested. Thus, each
- * specific scan might host multiple segments. Each plugin determines what
- * that means for the target engine. At runtime, each segment translates to
- * a distinct batch reader.
- *
- * <h4>The Storage Plugin</h4>
- *
- * Group scans are ephemeral and serialized. They should hold only data that
- * describes the scan. Group scans <i>should not</i> hold metadata about the
- * underlying system because of the complexity of recreating that data on each
- * of the many copies that occur.
- * <p>
- * Instead, the implementation should cache metadata in the storage plugin. Each
- * storage plugin instance exists for the duration of a single query: either at
- * plan time or (if requested) at runtime (one instance per minor fragment.) A
- * good practice is:
- * <ul>
- * <li>The group scan asks the storage plugin for metadata as needed to process
- * each group scan operation.</li>
- * <li>The storage plugin retrieves the metadata from the external system and
- * caches it; returning the cached copies on subsequent requests.</li>
- * <li>The sub scan (execution description) should avoid asking for metadata to
- * avoid caching metadata in each of the many execution minor fragments.</li>
- * <li>Cached information is lost once planning completes for a query. If
- * additional caching is needed, the storage plugin can implement a shared cache
- * (with proper concurrency controls) which is shared across multiple plugin
- * instances. (Note, however, than planning is also distributed; each query may
- * be planned on a different Drillbit (Foreman), so even a shared cache will
- * hold as many copies as there are Drillbits (one copy per Drillbit.)</li>
- * </ul>
- * <p>
- * The storage plugin is the only part of the data for a query that persists
- * across the entire planning session. Group scans are created and deleted.
- * Although some of these are done via copies (and so could preserve data), the
- * <tt>getPhysicalScan()</tt> step is not a copy and discards all data except
- * that in the scan spec. Note, however, that if a query contains a join or
- * a union, then the query will contain multiple group scans (one per table)
- * but a single storage plugin instance.
- *
- * <h4>The Scan Specification</h4>
- *
- * Drill has the idea of a scan specification, as mentioned above. The scan
- * spec transfers information from the schema table lookup to the group scan.
- * Each plugin defines its own scan spec; there is no base class. At the
- * least, include the table definition (whatever that means for the plugin.)
- * The scan spec must be Jackson serializable.
- * <p>
- * Some plugins use the scan spec directly in the group scan (store it as
- * a field), others do not. Choose the simplest design for your needs.
- * <p>
- * Your subclass should include other query-specific data needed at both plan
- * and run time such as file locations, partition information, filter push-downs
- * and so on.
- *
- * <h4>Costs</h4>
- *
- * Calcite is a cost-based optimizer. This means it uses the cost associated
- * with a group scan instance to pick which of several options to use.
- * <p>
- * You must provide a scan cost estimate in terms of rows, data and CPU. For
- * some systems (such as Hive), these numbers are available. For others (such as
- * local files), the data size may be available, from which we can estimate a
- * row count by assuming some reasonable average row width. In other cases (such
- * as REST), we may not have any good estimate at all.
- * <p>
- * In these cases, it helps to know how Drill uses the cost estimates. The scan
- * must occur, so there is no decision about whether to use the scan or not. But,
- * Drill has to decide which scan to put on which side of a join (the so-called
- * "build" and "probe" sides.) Further, Drill needs to know if the table is
- * small enough to "broadcast" the contents to all nodes.
- * <p>
- * So, at the least, the estimate must identify "small" vs. "large" tables. If
- * the scan is known to be small enough to broadcast (because it is for, say, a
- * small lookup list), then provide a small row and data estimate, say 100 rows
- * and 1K.
- * <p>
- * If, however, the data size is potentially large, then provide a large
- * estimate (10K rows, 100M data, say) to force Drill to not consider broadcast,
- * and to avoid putting the table on the build side of a join unless some other
- * table is even larger.
- * <p>
- * Logical planning will include projection (column) push-down and optionally
- * filter push-down. Each of these <i>must</i> reduce scan cost so that
- * Calcite decides that doing them improves query performance.
- *
- * <h4>Projection Push-Down</h4>
- *
- * This base class assumes that the scan supports projection push-down. You
- * get this "for free" if you use the EVF-based scan framework (that is,
- * the result set loader and associated classes.) You are, however,
- * responsible for updating costs based on projection push-down.
- *
- * <h4>EXPLAIN PLAN</tt>
- *
- * The group scan appears in the output of the <tt>EXPLAIN PLAN FOR</tt>
- * command. Drill calls the {@ink #toString()} method to obtain the string. The
- * format of the string should follow Drill's conventions. The easiest way to to
- * that is to instead override {@link #buildPlanString(PlanStringBuilder)} and
- * add your custom fields to those already included from this base class.
- * <p>
- * If your fields have structure, ensure that the <tt>toString()</tt> method of
- * those classes also uses {@link PlanStringBuilder}, or create the encoding
- * yourself in your own <tt>buildPlanString</tt> method. Test by calling the
- * method or by examining the output of an <tt>EXPLAIN</tt>.
- * <p>
- * Include only the logical planning fields. That is, include only the
- * fields that also appear in the JSON serialized form of the group scan.
  */
 
 public abstract class BaseGroupScan extends AbstractGroupScan {
@@ -376,15 +175,14 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
    * Return the maximum parallelization width. This number is usually the number
    * of distinct sub-scans this group scan can produce. The actual number of
    * minor fragments may be less. (For example, if running in a test, the minor
-   * fragment count may be just 1.) In that case, the
+   * fragment count may be just 1.) In that case,
    * {{@link #getSpecificScan(int)} may need to combine logical sub-scans into a
    * single physical sub scan. That is, a sub scan operator should hold a list
    * of actual scans, and the scan operator should be ready to perform multiple
    * actual scans per sub-scan operator.
    * <p>
    * For convenience, returns 1 by default, which is the minimum. Derived
-   * classes should return a different number if they support filter push-down
-   * and parallelization.
+   * classes should return a different number parallelization.
    *
    * @return the number of sub-scans that this group scan will produce
    */
@@ -418,7 +216,7 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
    * The group can may have a single "slice". If so, then the
    * {@link #getMaxParallelizationWidth()} should have returned 1,
    * and this method will be called only once, with
-   * <code>minorFragmentId = 0</code>.
+   * {@code minorFragmentId = 0}.
    * <p>
    * However, if the group can can partition work into sub-units
    * (let's call them "slices"), then this method must pack
@@ -434,8 +232,7 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
 
   /**
    * Create a copy of the group scan with with candidate projection
-   * columns. Calls
-   * {@link BaseScanFactory#groupWithColumns()}
+   * columns. Calls {@link BaseScanFactory#groupWithColumns()}
    * by default.
    */
   @Override
@@ -445,9 +242,7 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
 
   /**
    * Create a copy of the group scan with (non-existent) children.
-   * Calls
-   * {@link BaseScanFactory#copyGroupShim()}
-   * by default.
+   * Calls {@link BaseScanFactory#copyGroup()} by default.
    */
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
@@ -457,7 +252,7 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
 
   /**
    * Create a string representation of the scan formatted for the
-   * <tt>EXPLAIN PLAN FOR</tt> output. Do not override this method,
+   * {@code EXPLAIN PLAN FOR} output. Do not override this method,
    * override {@link #buildPlanString(PlanStringBuilder)} instead.
    */
   @Override
@@ -468,8 +263,8 @@ public abstract class BaseGroupScan extends AbstractGroupScan {
   }
 
   /**
-   * Build an <tt>EXPLAIN PLAN FOR</tt> string using the builder
-   * provided. Call the <tt>super</tt> method first, then add
+   * Build an {@code EXPLAIN PLAN FOR} string using the builder
+   * provided. Call the {@code super} method first, then add
    * fields for the subclass.
    * @param builder simple builder to create the required
    * format

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanBatchCreator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.impl.BatchCreator;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+public class BaseScanBatchCreator implements BatchCreator<BaseSubScan> {
+
+  @Override
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+      BaseSubScan subScan, List<RecordBatch> children)
+      throws ExecutionSetupException {
+    Preconditions.checkArgument(children == null || children.isEmpty());
+    BaseStoragePlugin<?> plugin = (BaseStoragePlugin<?>) context.getStorageRegistry()
+        .getPlugin(subScan.getConfig());
+    return plugin.createScan(context, subScan);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.SessionOptionManager;
+
+/**
+ * Creates the multiple classes needed to plan and execute a scan. Centralizes
+ * most implementation-specific object creation in one location to avoid needing
+ * to implement many methods just for type-specific creation.
+ *
+ * @param <PLUGIN> the storage plugin class
+ * @param <SPEC> the scan specification class
+ * @param <GROUP> the group scan class
+ * @param <SUB> the sub scan class
+ */
+
+public abstract class BaseScanFactory<
+      PLUGIN extends BaseStoragePlugin<?>,
+      SPEC,
+      GROUP extends BaseGroupScan,
+      SUB extends BaseSubScan> {
+
+  @SuppressWarnings("unchecked")
+  protected BaseGroupScan newGroupScanShim(BaseStoragePlugin<?> plugin,
+      String userName, Object scanSpec,
+      SessionOptionManager sessionOptions, MetadataProviderManager metadataProviderManager) {
+    return newGroupScan(
+        (PLUGIN) plugin, userName, (SPEC) scanSpec,
+        sessionOptions, metadataProviderManager);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected ScanFrameworkBuilder scanBuilderShim(BaseStoragePlugin<?> plugin,
+      OptionManager options, BaseSubScan subScan) {
+    return scanBuilder((PLUGIN) plugin, options, (SUB) subScan);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected GROUP groupWithColumnsShim(BaseGroupScan group, List<SchemaPath> columns) {
+    return groupWithColumns((GROUP) group, columns);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected GROUP copyGroupShim(BaseGroupScan group) {
+    return copyGroup((GROUP) group);
+  }
+
+  public abstract GROUP newGroupScan(PLUGIN storagePlugin, String userName, SPEC scanSpec,
+      SessionOptionManager sessionOptions,
+      MetadataProviderManager metadataProviderManager);
+
+  public abstract GROUP groupWithColumns(GROUP group, List<SchemaPath> columns);
+
+  public GROUP copyGroup(GROUP group) {
+    // Default implementation works for immutable group scans
+    return group;
+  }
+
+  public abstract ScanFrameworkBuilder scanBuilder(PLUGIN storagePlugin, OptionManager options, SUB subScan);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseScanFactory.java
@@ -35,7 +35,6 @@ import org.apache.drill.exec.server.options.SessionOptionManager;
  * @param <GROUP> the group scan class
  * @param <SUB> the sub scan class
  */
-
 public abstract class BaseScanFactory<
       PLUGIN extends BaseStoragePlugin<?>,
       SPEC,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseStoragePlugin.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.io.IOException;
+
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.JSONOptions;
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.ops.ExecutorFragmentContext;
+import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
+import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
+import org.apache.drill.exec.record.CloseableRecordBatch;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.server.options.SessionOptionManager;
+import org.apache.drill.exec.store.AbstractStoragePlugin;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.SchemaFactory;
+import org.apache.drill.exec.store.StoragePlugin;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
+    extends AbstractStoragePlugin {
+
+  static final Logger logger = LoggerFactory.getLogger(BaseStoragePlugin.class);
+  static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+
+  public static class StoragePluginOptions {
+    public boolean supportsRead;
+    public boolean supportsWrite;
+    public boolean supportsProjectPushDown;
+    public MajorType nullType;
+    public int readerId;
+    public int writerId;
+    public TypeReference<?> scanSpecType;
+    public ObjectMapper objectMapper = DEFAULT_MAPPER;
+    public BaseScanFactory<?,?,?,?> scanFactory;
+  }
+
+  protected final C config;
+  protected final StoragePluginOptions options;
+  protected SchemaFactory schemaFactory;
+  public static final String DEFAULT_SCHEMA_NAME = "default";
+
+  protected BaseStoragePlugin(DrillbitContext context, C config, String name, StoragePluginOptions options) {
+    super(context, name);
+    this.config = config;
+    this.options = options;
+    Preconditions.checkNotNull(options.scanSpecType);
+    Preconditions.checkNotNull(options.scanFactory);
+  }
+
+  @Override
+  public StoragePluginConfig getConfig() { return config; }
+
+  public C config() { return config; }
+
+  public StoragePluginOptions options() { return options; }
+
+  @Override
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent)
+      throws IOException {
+    schemaFactory.registerSchemas(schemaConfig, parent);
+  }
+
+  @Override
+  public boolean supportsRead() { return options.supportsRead; }
+
+  @Override
+  public boolean supportsWrite() { return options.supportsWrite; }
+
+  @Override
+  public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection,
+      SessionOptionManager sessionOptions, MetadataProviderManager metadataProviderManager) throws IOException {
+    // If this fails, be sure to set the proper class in options.scanSpecClass.
+    // Do this in the constructor of your storage plugin
+    Object scanSpec = selection.getListWith(options.objectMapper, options.scanSpecType);
+    BaseGroupScan groupScan = options.scanFactory.newGroupScanShim(this, userName,
+        scanSpec, sessionOptions, metadataProviderManager);
+    groupScan.sessionOptions = sessionOptions;
+    return groupScan;
+  }
+
+  public <T extends BaseSubScan> CloseableRecordBatch createScan(ExecutorFragmentContext context, BaseSubScan subScan)
+      throws ExecutionSetupException {
+    try {
+      final ScanFrameworkBuilder builder =
+            options.scanFactory.scanBuilderShim(this, context.getOptions(), subScan);
+      return builder.buildScanOperator(context, subScan);
+    } catch (final UserException e) {
+      // Rethrow user exceptions directly
+      throw e;
+    } catch (final Throwable e) {
+      // Wrap all others
+      throw new ExecutionSetupException(e);
+    }
+  }
+
+  public void initFramework(ScanFrameworkBuilder builder, BaseSubScan subScan) {
+    builder.setProjection(subScan.columns());
+    builder.setUserName(subScan.getUserName());
+    if (options.nullType != null) {
+      builder.setNullType(options.nullType);
+    }
+
+    // Provide custom error context
+
+    String pluginKind;
+    JsonTypeName jsonName = config.getClass().getAnnotation(JsonTypeName.class);
+    if (jsonName == null) {
+      pluginKind = config.getClass().getSimpleName();
+    } else {
+      pluginKind = jsonName.value();
+    }
+    builder.setContext(
+        new ChildErrorContext(builder.errorContext()) {
+          @Override
+          public void addContext(UserException.Builder builder) {
+            builder.addContext("Storage plugin config name:", pluginKind);
+            builder.addContext("Format plugin class:",
+                getClass().getSimpleName());
+            builder.addContext("Plugin name:", getName());
+          }
+        });
+  }
+
+  /**
+   * Given a storage plugin registry and a storage plugin config, look
+   * up the storage plugin. Handles errors by converting them to Drill's
+   * usual {@link UserException} form.
+   */
+  public static BaseStoragePlugin<?> resolvePlugin(StoragePluginRegistry engineRegistry,
+      StoragePluginConfig config) {
+    try {
+      StoragePlugin plugin = engineRegistry.getPlugin(config);
+      if (plugin == null) {
+        throw UserException.systemError(null)
+          .message("Cannot find storage plugin for", config.getClass().getCanonicalName())
+          .build(logger);
+      }
+      if (!(plugin instanceof BaseStoragePlugin)) {
+        throw UserException.systemError(null)
+          .message("Storage plugin %s is of wrong class: %s but should be %s",
+              plugin.getName(), plugin.getClass().getCanonicalName(),
+              BaseStoragePlugin.class.getSimpleName())
+          .build(logger);
+      }
+      return (BaseStoragePlugin<?>) plugin;
+    } catch (ExecutionSetupException e) {
+      throw UserException.systemError(e)
+        .message("Cannot find storage plugin for", config.getClass().getCanonicalName())
+        .build(logger);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseStoragePlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseStoragePlugin.java
@@ -56,7 +56,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @param <C> the storage plugin configuration class
  */
-
 public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
     extends AbstractStoragePlugin {
 
@@ -108,7 +107,7 @@ public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
      * more convenient to set this field after calling the
      * super class constructor.
      */
-    public BaseScanFactory<?,?,?,?> scanFactory;
+    public BaseScanFactory<?, ?, ?, ?> scanFactory;
   }
 
   protected final C config;
@@ -154,16 +153,16 @@ public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
     return groupScan;
   }
 
-  public <T extends BaseSubScan> CloseableRecordBatch createScan(ExecutorFragmentContext context, BaseSubScan subScan)
+  public CloseableRecordBatch createScan(ExecutorFragmentContext context, BaseSubScan subScan)
       throws ExecutionSetupException {
     try {
-      final ScanFrameworkBuilder builder =
+      ScanFrameworkBuilder builder =
             options.scanFactory.scanBuilderShim(this, context.getOptions(), subScan);
       return builder.buildScanOperator(context, subScan);
-    } catch (final UserException e) {
+    } catch (UserException e) {
       // Rethrow user exceptions directly
       throw e;
-    } catch (final Throwable e) {
+    } catch (Throwable e) {
       // Wrap all others
       throw new ExecutionSetupException(e);
     }
@@ -209,11 +208,11 @@ public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
       StoragePlugin plugin = engineRegistry.getPlugin(config);
       if (plugin == null) {
         throw UserException.systemError(null)
-          .message("Cannot find storage plugin for", config.getClass().getCanonicalName())
+          .message("Cannot find storage plugin for %s", config.getClass().getCanonicalName())
           .build(logger);
       }
       if (!(plugin instanceof BaseStoragePlugin)) {
-        throw UserException.systemError(null)
+        throw UserException.systemError()
           .message("Storage plugin %s is of wrong class: %s but should be %s",
               plugin.getName(), plugin.getClass().getCanonicalName(),
               BaseStoragePlugin.class.getSimpleName())
@@ -222,7 +221,7 @@ public abstract class BaseStoragePlugin<C extends StoragePluginConfig>
       return (BaseStoragePlugin<?>) plugin;
     } catch (ExecutionSetupException e) {
       throw UserException.systemError(e)
-        .message("Cannot find storage plugin for", config.getClass().getCanonicalName())
+        .message("Cannot find storage plugin for %s", config.getClass().getCanonicalName())
         .build(logger);
     }
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
@@ -50,7 +50,7 @@ public class BaseSubScan extends AbstractSubScan {
 
   public BaseSubScan(BaseGroupScan groupScan) {
     super(groupScan.getUserName());
-    storagePlugin = groupScan.storagePlugin();
+    this.storagePlugin = groupScan.storagePlugin();
     this.columns = groupScan.getColumns();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * scan. The config allows creating a storage plugin instance, as needed,
  * to implement the scan.
  *
- * @see {@link BaseGroupScan} for additional details of the scan
+ * @see BaseGroupScan {@code BaseGroupScan} for additional details of the scan
  * life-cycle.
  */
 
@@ -61,7 +61,7 @@ public class BaseSubScan extends AbstractSubScan {
       @JsonProperty("columns") List<SchemaPath> columns,
       @JacksonInject StoragePluginRegistry engineRegistry) {
     super(userName);
-    storagePlugin = BaseStoragePlugin.resolvePlugin(engineRegistry, config);
+    this.storagePlugin = BaseStoragePlugin.resolvePlugin(engineRegistry, config);
     this.columns = columns;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/BaseSubScan.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.physical.base.AbstractSubScan;
+import org.apache.drill.exec.physical.base.PhysicalVisitor;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Specification for a specific execution-time scan. Holds the information
+ * passed form the Planner to the Drillbit so that the Drillbit can execute
+ * the scan. Holds the config of the storage plugin associated with the
+ * scan. The config allows creating a storage plugin instance, as needed,
+ * to implement the scan.
+ *
+ * @see {@link BaseGroupScan} for additional details of the scan
+ * life-cycle.
+ */
+
+@JsonTypeName("base-sub-scan")
+public class BaseSubScan extends AbstractSubScan {
+
+  protected final BaseStoragePlugin<?> storagePlugin;
+  protected final List<SchemaPath> columns;
+
+  public BaseSubScan(BaseGroupScan groupScan) {
+    super(groupScan.getUserName());
+    storagePlugin = groupScan.storagePlugin();
+    this.columns = groupScan.getColumns();
+  }
+
+  @JsonCreator
+  public BaseSubScan(
+      @JsonProperty("userName") String userName,
+      @JsonProperty("config") StoragePluginConfig config,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JacksonInject StoragePluginRegistry engineRegistry) {
+    super(userName);
+    storagePlugin = BaseStoragePlugin.resolvePlugin(engineRegistry, config);
+    this.columns = columns;
+  }
+
+  @JsonProperty("config")
+  public StoragePluginConfig getConfig() { return storagePlugin.getConfig(); }
+
+  @JsonProperty("columns")
+  public List<SchemaPath> columns() { return columns; }
+
+  @SuppressWarnings("unchecked")
+  public <T extends BaseStoragePlugin<?>> T storagePlugin() {
+    return (T) storagePlugin;
+  }
+
+  @Override
+  @JsonIgnore
+  public int getOperatorType() {
+    return storagePlugin.options().readerId;
+  }
+
+  @Override
+  public <T, X, E extends Throwable> T accept(PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
+    return physicalVisitor.visitSubScan(this, value);
+  }
+
+  @Override
+  public String toString() {
+    PlanStringBuilder builder = new PlanStringBuilder(this);
+    buildPlanString(builder);
+    return builder.toString();
+  }
+
+  public void buildPlanString(PlanStringBuilder builder) {
+    builder.field("user", getUserName());
+    builder.field("columns", columns);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/PlanStringBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/PlanStringBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+public class PlanStringBuilder {
+
+  private final StringBuilder buf = new StringBuilder();
+  int fieldCount = 0;
+
+  public PlanStringBuilder(Object node) {
+    this(node.getClass().getSimpleName());
+  }
+
+  public PlanStringBuilder(String node) {
+    buf.append(node).append(" [");
+  }
+
+  public PlanStringBuilder field(String key, String value) {
+    if (value != null) {
+      startField(key);
+      buf.append("\"").append(value).append("\"");
+    }
+    return this;
+  }
+
+  public PlanStringBuilder unquotedField(String key, String value) {
+    if (value != null) {
+      startField(key);
+      buf.append(value);
+    }
+    return this;
+  }
+
+  public PlanStringBuilder field(String key, Object value) {
+    if (value != null) {
+      startField(key);
+      buf.append(value.toString());
+    }
+    return this;
+  }
+
+  public PlanStringBuilder field(String key, int value) {
+    startField(key);
+    buf.append(value);
+    return this;
+  }
+
+  private void startField(String key) {
+    if (fieldCount++ != 0) {
+      buf.append(", ");
+    }
+    buf.append(key).append("=");
+  }
+
+  @Override
+  public String toString() { return buf.append("]").toString(); }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ConstantHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ConstantHolder.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.store.base.PlanStringBuilder;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Description of a constant argument of an expression.
+ */
+
+@JsonPropertyOrder({"type", "value"})
+public class ConstantHolder {
+  @JsonProperty("type")
+  public final MinorType type;
+  @JsonProperty("value")
+  public final Object value;
+
+  @JsonCreator
+  public ConstantHolder(
+      @JsonProperty("type") MinorType type,
+      @JsonProperty("value") Object value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  public ConstantHolder convertTo(MinorType toType) {
+    if (type == toType) {
+      return this;
+    }
+    switch (toType) {
+    case INT:
+      return toInt();
+    case BIGINT:
+      return toBigInt();
+    case TIMESTAMP:
+      return toTimestamp(null);
+    case VARCHAR:
+      return toVarChar();
+    default:
+      throw conversionError(toType);
+    }
+  }
+
+  public ConstantHolder normalize(MinorType toType) {
+    try {
+      return convertTo(toType);
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  public ConstantHolder toInt() {
+    int intValue;
+    switch (type) {
+      case INT:
+        return this;
+      case BIGINT: {
+        long value = (long) this.value;
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+          throw conversionError(MinorType.INT);
+        }
+        intValue = (int) value;
+        break;
+      }
+      case VARCHAR:
+        try {
+          intValue = Integer.parseInt((String) value);
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.INT);
+        }
+        break;
+      default:
+        throw conversionError(MinorType.INT);
+    }
+    return new ConstantHolder(MinorType.INT, intValue);
+  }
+
+  public ConstantHolder toBigInt() {
+    long longValue;
+    switch (type) {
+      case INT:
+        longValue = (Integer) value;
+        break;
+      case BIGINT:
+        return this;
+      case VARCHAR:
+        try {
+          longValue = Long.parseLong((String) value);
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.BIGINT);
+        }
+        break;
+      default:
+        throw conversionError(MinorType.BIGINT);
+    }
+    return new ConstantHolder(MinorType.BIGINT, longValue);
+  }
+
+  public ConstantHolder toTimestamp(String tz) {
+    long longValue;
+    switch (type) {
+      case TIMESTAMP:
+        return this;
+      case INT:
+        longValue = (Integer) value;
+        break;
+      case BIGINT:
+        longValue = (Long) value;
+        break;
+      case VARCHAR: {
+        DateTimeFormatter format = ISODateTimeFormat.dateTimeNoMillis();
+        if (tz != null) {
+          format = format.withZone(DateTimeZone.forID(tz));
+        }
+        try {
+          longValue = format.parseDateTime((String) value).getMillis();
+        } catch (Exception e) {
+          throw conversionError(MinorType.TIMESTAMP);
+        }
+        break;
+      }
+      default:
+        throw conversionError(MinorType.TIMESTAMP);
+    }
+    return new ConstantHolder(MinorType.TIMESTAMP, longValue);
+  }
+
+  public ConstantHolder toVarChar() {
+    if (type == MinorType.VARCHAR) {
+      return this;
+    } else {
+      return new ConstantHolder(MinorType.VARCHAR, value.toString());
+    }
+  }
+
+  public RuntimeException conversionError(MinorType toType) {
+    return new IllegalStateException(String.format(
+        "Cannot convert a constant %s of type %s to type %s",
+        value.toString(), type.name(), toType.name()));
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder("Constant")
+      .field("type", type.name())
+      .field("value", value)
+      .toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/DisjunctionFilterSpec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/DisjunctionFilterSpec.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.store.base.PlanStringBuilder;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class DisjunctionFilterSpec {
+  public final String column;
+  public final MinorType type;
+  public final Object[] values;
+
+  public DisjunctionFilterSpec(String column, MinorType type,
+      Object[] values) {
+    this.column = column;
+    this.type = type;
+    this.values = values;
+  }
+
+  public DisjunctionFilterSpec(List<RelOp> orTerms) {
+    Preconditions.checkArgument(orTerms != null & orTerms.size() > 1);
+    RelOp first = orTerms.get(0);
+    column = first.colName;
+    type = first.value.type;
+    values = new Object[orTerms.size()];
+    for (int i = 0; i < orTerms.size(); i++) {
+      values[i] = orTerms.get(i).value.value;
+    }
+  }
+
+  public List<List<RelOp>> distributeOverCnf(List<RelOp> cnfTerms) {
+
+    // Distribute the (single) OR clause over the AND clauses
+    // (a AND b AND (x OR y)) --> ((a AND b AND x), (a AND b AND y))
+
+    List<List<RelOp>> dnfTerms = new ArrayList<>();
+    for (int i = 0; i < values.length; i++) {
+      dnfTerms.add(distributeTerm(cnfTerms, i));
+    }
+    return dnfTerms;
+  }
+
+  public RelOp toRelOp(int orIndex) {
+    return new RelOp(RelOp.Op.EQ, column,
+        new ConstantHolder(type, values[orIndex]));
+  }
+
+  public List<RelOp> distributeTerm(List<RelOp> andFilters, int orIndex) {
+    List<RelOp> filters = new ArrayList<>();
+    if (andFilters != null) {
+      filters.addAll(andFilters);
+    }
+    filters.add(toRelOp(orIndex));
+    return filters;
+  }
+
+  public static List<RelOp> distribute(List<RelOp> andFilters,
+      DisjunctionFilterSpec orFilters, int orIndex) {
+    Preconditions.checkArgument(orIndex == 0 || (orFilters != null && orIndex < orFilters.values.length));
+    return orFilters == null ? andFilters :
+      orFilters.distributeTerm(andFilters, orIndex);
+  }
+
+  /**
+   * Compute the selectivity of this DNF (OR) clause. Drill assumes
+   * the selectivity of = is 0.15. An OR is a series of equal statements,
+   * so selectivity is n * 0.15. However, limit total selectivity to
+   * 0.9 (that is, if there are more than 6 clauses in the DNF, assume
+   * at least some reduction.)
+   *
+   * @return the estimated selectivity of this DNF clause
+   */
+  public double selectivity() {
+    if (values.length == 0) {
+      return 1.0;
+    } else {
+      return Math.min(0.9,  0.15 * values.length);
+    }
+  }
+
+  @Override
+  public String toString() {
+    PlanStringBuilder builder = new PlanStringBuilder(this);
+    builder.field("column", column);
+    builder.field("type", type);
+    List<String> strValues = Arrays.stream(values).map(v -> v.toString()).collect(Collectors.toList());
+    builder.unquotedField("values",
+        "[" + String.join(", ", strValues) + "]");
+    return builder.toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import java.util.List;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.exec.physical.base.GroupScan;
+
+/**
+ * Call-back (listener) implementation for a push-down filter.
+ * Abstracts away the common work; plugins implement this class
+ * to do work specific to the plugin.
+ * <p>
+ * Supports two kinds of filter push down:
+ * <dl>
+ * <dt>Conjunctive Normal Form (CNF)</dt>
+ * <dd>A series of expressions joined by an AND: the scan should
+ * produce only rows that satisfy all the conditions.</dd>
+ * <dt>Disjunctive Normal Form (DNF)</dt>
+ * <dd>A series of alternative values for a single column, essentially
+ * a set of expressions joined by OR. The scan spits into multiple
+ * scans, each scanning one of the partitions (or regions or
+ * queries) identified by the case. This is an implementation of the
+ * SQL <tt>IN</tt> clause.</dd>
+ * <dl>
+ * <p>
+ * In both cases, the conditions are in the form of a
+ * {@link RelOp} in which one side refers to a column in the scan
+ * and the other is a constant expression. The "driver" will ensure
+ * the rel op is of the correct form; this class ensures that the
+ * column is valid for the scan and the type of the value matches the
+ * column type (or can be converted.)
+ * <p>
+ * The DNF form further ensures that all rel ops refer to the same
+ * column, and that only the equality operator appears in the
+ * terms.
+ */
+
+public interface FilterPushDownListener {
+
+  /**
+   * Prefix to display in filter rules
+   */
+  String prefix();
+
+  /**
+   * Broad check to see if the scan is of the correct type for this
+   * listener. Generally implemented as: <code><pre>
+   * public boolean isTargetScan(ScanPrel scan) {
+   *   return scan.getGroupScan() instanceof MyGroupScan;
+   * }
+   * </pre></code>
+   */
+  boolean isTargetScan(GroupScan groupScan);
+
+  /**
+   * Check if the filter rule should be applied to the target group scan.
+   * Calcite will run this rule multiple times during planning, but the
+   * transform only needs to occur once.
+   * Allows the group scan to mark in its own way whether the rule has
+   * been applied.
+   *
+   * @param scan the scan node
+   * @return true if filter push-down should be applied
+   */
+
+  boolean needsApplication(GroupScan groupScan);
+
+  /**
+   * Determine if the given relational operator (which is already in the form
+   * <tt>&lt;col name> &lt;relop> &lt;const></tt>, qualifies for push down for
+   * this scan.
+   * <p>
+   * If so, return an equivalent RelOp with the value normalized to what
+   * the plugin needs. The returned value may be the same as the original
+   * one if the value is already normalized.
+   *
+   * @param scan the scan element. Use <tt>scan.getGroupScan()</tt> to get the
+   * group scan
+   * @param relOp the description of the relational operator expression
+   * @return a normalized RelOp if this relop can be transformed into a filter
+   * push-down, <tt>null</tt> if not and thus the relop should remain in
+   * the Drill plan
+   */
+
+  RelOp accept(GroupScan groupScan, RelOp relOp);
+
+  /**
+   * Transform a normalized DNF term into a new scan. Normalized form is:
+   * <br><code><pre>
+   * (a AND b AND (x OR y))</pre></code><br>
+   * In which each <code>OR</code> term represents a scan partition. It
+   * is up to the code here to determine if the scan partition can be handled,
+   * corresponds to a storage partition, or can be done as a separate
+   * scan (as for a JDBC or REST plugin, say.)
+   * <p>
+   * Each term is accompanied by the Calcite expression from which it was
+   * derived. The caller is responsible for determining which expressions,
+   * if any, to leave in the query by returning a list AND'ed (CNF) terms
+   * to leave in the query. Those terms can be the ones passed in, or
+   * new terms to handle special needs.
+   *
+   * @param scan the scan node
+   * @param rexNode the Calcite OR node from which the list of relops was
+   * derived
+   * @param dnfTerms the list of OR conditions. All refer to the same column,
+   * and all are equality operators; only the values differ
+   * @return a pair of elements: a new scan (that represents the pushed filters),
+   * and the original or new expression to appear in the WHERE clause
+   * joined by AND with any non-candidate expressions. One or the other must
+   * be non-null. Or, return null if the filter condition can't be handled
+   * and the query should remain unchanged.
+   */
+
+  Pair<GroupScan, List<RexNode>> transform(GroupScan groupScan,
+      List<Pair<RexNode, RelOp>> andTerms, Pair<RexNode, DisjunctionFilterSpec> orTerm);
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
@@ -43,7 +43,6 @@ import org.apache.drill.exec.planner.logical.DrillScanRel;
 import org.apache.drill.exec.planner.logical.RelOptHelper;
 import org.apache.drill.exec.planner.physical.FilterPrel;
 import org.apache.drill.exec.planner.physical.PrelUtil;
-import org.apache.drill.exec.planner.physical.ScanPrel;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -189,6 +188,11 @@ public class FilterPushDownStrategy {
 
     Pair<GroupScan, List<RexNode>> translated =
         listener.transform(scan.getGroupScan(), filterTerms.left, filterTerms.right);
+
+    // Listener abandoned effort. (Allows a stub early in development.)
+    if (translated == null) {
+      return;
+    }
 
     // Listener rejected the DNF terms
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.logical.DrillFilterRel;
+import org.apache.drill.exec.planner.logical.DrillOptiq;
+import org.apache.drill.exec.planner.logical.DrillParseContext;
+import org.apache.drill.exec.planner.logical.DrillProjectRel;
+import org.apache.drill.exec.planner.logical.DrillScanRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+import org.apache.drill.exec.planner.physical.FilterPrel;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.planner.physical.ScanPrel;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+
+/**
+ * Generalized filter push-down strategy which performs all the tree-walking
+ * and tree restructuring work, allowing a "listener" to do the work needed
+ * for a particular scan.
+ * <p>
+ * General usage in a storage plugin: <code><pre>
+ * public Set<StoragePluginOptimizerRule> getPhysicalOptimizerRules(
+ *        OptimizerRulesContext optimizerRulesContext) {
+ *   return FilterPushDownStrategy.rulesFor(optimizerRulesContext,
+ *      new MyPushDownListener(...));
+ * }
+ * </pre></code>
+ */
+
+public class FilterPushDownStrategy {
+
+  private static final Collection<String> BANNED_OPERATORS =
+      Lists.newArrayList("flatten");
+
+  /**
+   * Base rule that passes target information to the push-down strategy
+   */
+
+  private static abstract class AbstractFilterPushDownRule extends StoragePluginOptimizerRule {
+
+    protected final FilterPushDownStrategy strategy;
+
+    public AbstractFilterPushDownRule(RelOptRuleOperand operand, String description,
+        FilterPushDownStrategy strategy) {
+      super(operand, description);
+      this.strategy = strategy;
+    }
+  }
+
+  /**
+   * Calcite rule for FILTER --> PROJECT --> SCAN
+   */
+
+  private static class ProjectAndFilterRule extends AbstractFilterPushDownRule {
+
+    private ProjectAndFilterRule(FilterPushDownStrategy strategy) {
+      super(RelOptHelper.some(FilterPrel.class, RelOptHelper.some(DrillProjectRel.class, RelOptHelper.any(DrillScanRel.class))),
+            strategy.namePrefix() + "PushDownFilter:Filter_On_Project",
+            strategy);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      if (!super.matches(call)) {
+        return false;
+      }
+      DrillScanRel scan = call.rel(2);
+      return strategy.isTargetScan(scan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      DrillFilterRel filterRel = call.rel(0);
+      DrillProjectRel projectRel = call.rel(1);
+      DrillScanRel scanRel = call.rel(2);
+      strategy.onMatch(call, filterRel, projectRel, scanRel);
+    }
+  }
+
+  /**
+   * Calcite rule for FILTER --> SCAN
+   */
+
+  private static class FilterWithoutProjectRule extends AbstractFilterPushDownRule {
+
+    private FilterWithoutProjectRule(FilterPushDownStrategy strategy) {
+      super(RelOptHelper.some(DrillFilterRel.class, RelOptHelper.any(DrillScanRel.class)),
+            strategy.namePrefix() + "PushDownFilter:Filter_On_Scan",
+            strategy);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      if (!super.matches(call)) {
+        return false;
+      }
+      DrillScanRel scan = call.rel(1);
+      return strategy.isTargetScan(scan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      DrillFilterRel filterRel = call.rel(0);
+      DrillScanRel scanRel = call.rel(1);
+      strategy.onMatch(call, filterRel, null, scanRel);
+    }
+  }
+
+  private final FilterPushDownListener listener;
+
+  public FilterPushDownStrategy(FilterPushDownListener listener) {
+    this.listener = listener;
+  }
+
+  public Set<StoragePluginOptimizerRule> rules() {
+    return ImmutableSet.of(
+        new ProjectAndFilterRule(this),
+        new FilterWithoutProjectRule(this));
+  }
+
+  public static Set<StoragePluginOptimizerRule> rulesFor(
+      OptimizerRulesContext optimizerContext, FilterPushDownListener listener) {
+    return new FilterPushDownStrategy(listener).rules();
+  }
+
+  private String namePrefix() { return listener.prefix(); }
+
+  private boolean isTargetScan(DrillScanRel scan) {
+    return listener.isTargetScan(scan.getGroupScan());
+  }
+
+  public void onMatch(RelOptRuleCall call, DrillFilterRel filter, DrillProjectRel project, DrillScanRel scan) {
+
+    // Skip if rule has already been applied.
+
+    if (!listener.needsApplication(scan.getGroupScan())) {
+      return;
+    }
+
+    // Predicates which cannot be converted to a filter predicate
+
+    List<RexNode> nonConvertedPreds = new ArrayList<>();
+
+    List<Pair<RexNode, List<RelOp>>> cnfTerms =
+        sortPredicates(nonConvertedPreds, call, filter, project, scan);
+    if (cnfTerms == null) {
+      return;
+    }
+    Pair<List<Pair<RexNode, RelOp>>, Pair<RexNode, DisjunctionFilterSpec>> filterTerms =
+        convertToFilterSpec(cnfTerms);
+    if (filterTerms == null) {
+      return;
+    }
+
+    Pair<GroupScan, List<RexNode>> translated =
+        listener.transform(scan.getGroupScan(), filterTerms.left, filterTerms.right);
+
+    // Listener rejected the DNF terms
+
+    GroupScan newGroupScan = translated.left;
+    if (newGroupScan == null) {
+      return;
+    }
+
+    // Gather unqualified and rewritten predicates
+
+    List<RexNode> remainingPreds = new ArrayList<>();
+    remainingPreds.addAll(nonConvertedPreds);
+    if (translated.right != null) {
+      remainingPreds.addAll(translated.right);
+    }
+
+    // Replace the child with the new filter on top of the child/scan
+
+    call.transformTo(
+        rebuildTree(scan, newGroupScan, filter, project, remainingPreds));
+  }
+
+  private List<Pair<RexNode, List<RelOp>>> sortPredicates(
+      List<RexNode> nonConvertedPreds, RelOptRuleCall call, DrillFilterRel filter,
+      DrillProjectRel project, DrillScanRel scan) {
+
+    // Get the filter expression
+
+    RexNode condition;
+    if (project == null) {
+      condition = filter.getCondition();
+    } else {
+      // get the filter as if it were below the projection.
+      condition = RelOptUtil.pushPastProject(filter.getCondition(), project);
+    }
+
+    // Skip if no expression or expression is trivial.
+    // This seems to never happen because Calcite optimizes away
+    // any expression of the form WHERE true, 1 = 1 or 0 = 1.
+
+    if (condition == null || condition.isAlwaysTrue() || condition.isAlwaysFalse()) {
+      return null;
+    }
+
+    // Get a conjunctions of the filter condition. For each conjunction, if it refers
+    // to ITEM or FLATTEN expression then it cannot be pushed down. Otherwise, it's
+    // qualified to be pushed down.
+
+    List<RexNode> filterPreds = RelOptUtil.conjunctions(
+        RexUtil.toCnf(filter.getCluster().getRexBuilder(), condition));
+
+    DrillParseContext parseContext = new DrillParseContext(PrelUtil.getPlannerSettings(call.getPlanner()));
+    List<Pair<RexNode, List<RelOp>>> cnfTerms = new ArrayList<>();
+    for (RexNode pred : filterPreds) {
+      List<RelOp> relOps = identifyCandidate(parseContext, scan, pred);
+      if (relOps == null) {
+        nonConvertedPreds.add(pred);
+      } else {
+        cnfTerms.add(Pair.of(pred, relOps));
+      }
+    }
+    return cnfTerms.isEmpty() ? null : cnfTerms;
+  }
+
+  public List<RelOp> identifyCandidate(DrillParseContext parseContext, DrillScanRel scan, RexNode pred) {
+    if (DrillRelOptUtil.findOperators(pred, Collections.emptyList(), BANNED_OPERATORS) != null) {
+      return null;
+    }
+
+    // Extract an AND term, which may be an OR expression.
+
+    LogicalExpression drillPredicate = DrillOptiq.toDrill(parseContext, scan, pred);
+    List<RelOp> relOps = drillPredicate.accept(FilterPushDownUtils.REL_OP_EXTRACTOR, null);
+    if (relOps == null || relOps.isEmpty()) {
+      return null;
+    }
+
+    // Check if each term can be pushed down, and, if so, return a new RelOp
+    // with the value normalized.
+
+    List<RelOp> normalized = new ArrayList<>();
+    for (RelOp relOp : relOps) {
+      RelOp rewritten = listener.accept(scan.getGroupScan(), relOp);
+
+      // Must discard the entire OR clause if any part is rejected
+
+      if (rewritten == null) {
+        return null;
+      }
+      normalized.add(rewritten);
+    }
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  /**
+   * Parse the allowed filter forms:<br><code><pre>
+   * x AND y
+   * a OR b
+   * x AND y AND (a OR b)</pre></code>
+   * <p>
+   * The last form is equivalent to a partitioned scan:<br><code><pre>
+   * (x AND y AND a) OR
+   * (x AND y AND b)</pre></code>
+   * <p>
+   * Input is in the first form, output is in the second.
+   */
+
+  private Pair<List<Pair<RexNode, RelOp>>, Pair<RexNode, DisjunctionFilterSpec>>
+      convertToFilterSpec(List<Pair<RexNode, List<RelOp>>> cnfTerms) {
+
+    // If no qualified predicates, nothing to do.
+
+    if (cnfTerms.isEmpty()) {
+      return null;
+    }
+
+    // Any OR clauses?
+
+    Pair<RexNode, List<RelOp>> orTerm = null;
+    List<Pair<RexNode, RelOp>> andTerms = new ArrayList<>();
+    for (Pair<RexNode, List<RelOp>> cnfTerm : cnfTerms) {
+      List<RelOp> relOps = cnfTerm.right;
+      if (relOps.size() == 1) {
+        andTerms.add(Pair.of(cnfTerm.left, relOps.get(0)));
+      } else if (orTerm == null) {
+        orTerm = cnfTerm;
+      } else {
+
+        // Can't handle (w OR x) AND (y OR z)
+        return null;
+      }
+    }
+
+    if (orTerm == null) {
+
+      // No OR, all are simple CNF terms
+      // ((x), (y)) --> ((x, y))
+
+      return Pair.of(andTerms, null);
+    }
+
+    // If an OR clause, all must be on the same column, all
+    // must be equality and all must be of the same type.
+
+    List<RelOp> orRelops = orTerm.right;
+    assert orRelops.size() > 1; // Sanity check
+
+    // All OR terms must be equality
+
+    for (RelOp relOp : orRelops) {
+      if (relOp.op != RelOp.Op.EQ) {
+        return null;
+      }
+    }
+
+    // All must be for the same column and of the same type.
+
+    RelOp first = orRelops.get(0);
+    String colName = first.colName;
+    MinorType valueType = first.value.type;
+    for (int i = 1; i < orRelops.size(); i++) {
+      RelOp orRelop = orRelops.get(i);
+      if (!colName.equals(orRelop.colName)) {
+        return null;
+      }
+
+      // The following should not happen if the listener is well-behaved:
+      // converted all values for a column to a single type. But if the listener
+      // is lazy, and did not do so, we reject the OR expression here.
+
+      if (orRelop.value.type != valueType) {
+        return null;
+      }
+    }
+
+    // Convert to a disjunction filter
+
+    Pair<RexNode, DisjunctionFilterSpec> disjunction =
+        Pair.of(orTerm.left, new DisjunctionFilterSpec(orRelops));
+    return Pair.of(andTerms, disjunction);
+  }
+
+  private RelNode rebuildTree(DrillScanRel oldScan, GroupScan newGroupScan, DrillFilterRel filter,
+      DrillProjectRel project, List<RexNode> remainingPreds) {
+
+    // Rebuild the subtree with transformed nodes.
+
+    // Scan: new if available, else existing.
+
+    RelNode newNode;
+    if (newGroupScan == null) {
+      newNode = oldScan;
+    } else {
+      newNode = new DrillScanRel(oldScan.getCluster(), oldScan.getTraitSet(), oldScan.getTable(),
+          newGroupScan, oldScan.getRowType(), oldScan.getColumns());
+    }
+
+    // Copy project, if exists
+
+    if (project != null) {
+      newNode = project.copy(project.getTraitSet(), Collections.singletonList(newNode));
+    }
+
+    // Add filter, if any predicates remain.
+
+    if (!remainingPreds.isEmpty()) {
+
+      // If some of the predicates weren't used in the filter, creates new filter with them
+      // on top of current scan. Excludes the case when all predicates weren't used in the filter.
+      // FILTER(a, b, c) --> SCAN becomes FILTER(a, d) --> SCAN
+
+      newNode = filter.copy(filter.getTraitSet(), newNode,
+          RexUtil.composeConjunction(
+              filter.getCluster().getRexBuilder(),
+              remainingPreds,
+              true));
+    }
+
+    return newNode;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
@@ -32,7 +32,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.types.TypeProtos.MinorType;
-import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
 import org.apache.drill.exec.planner.logical.DrillFilterRel;
@@ -79,7 +78,7 @@ public class FilterPushDownStrategy {
   }
 
   /**
-   * Calcite rule for FILTER --> PROJECT --> SCAN
+   * Custom rule passed to Calcite for FILTER --> PROJECT --> SCAN
    */
   private static class ProjectAndFilterRule extends AbstractFilterPushDownRule {
 
@@ -108,7 +107,7 @@ public class FilterPushDownStrategy {
   }
 
   /**
-   * Calcite rule for FILTER --> SCAN
+   * Custom rule passed to Calcite to handle FILTER --> SCAN
    */
   private static class FilterWithoutProjectRule extends AbstractFilterPushDownRule {
 
@@ -148,7 +147,7 @@ public class FilterPushDownStrategy {
   }
 
   public static Set<StoragePluginOptimizerRule> rulesFor(
-      OptimizerRulesContext optimizerContext, FilterPushDownListener listener) {
+      FilterPushDownListener listener) {
     return new FilterPushDownStrategy(listener).rules();
   }
 
@@ -286,7 +285,7 @@ public class FilterPushDownStrategy {
    * @param cnfTerms List of (Calcite node, Relop) pairs that give the
    * CNF terms. More than one RelOp can occur for each Calcite Rex node.
    * @return a pair of CNF and DNF parts, each with their corresponding
-   * Calcite nodes, ready to pass to the {@link FilterPushDownListener.}
+   * Calcite nodes, ready to pass to the {@link FilterPushDownListener}.
    */
   private Pair<List<Pair<RexNode, RelOp>>, Pair<RexNode, DisjunctionFilterSpec>>
       convertToFilterSpec(List<Pair<RexNode, List<RelOp>>> cnfTerms) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownUtils.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.drill.common.expression.BooleanOperator;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
+import org.apache.drill.common.expression.ValueExpressions.IntExpression;
+import org.apache.drill.common.expression.ValueExpressions.LongExpression;
+import org.apache.drill.common.expression.ValueExpressions.QuotedString;
+import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+
+public class FilterPushDownUtils {
+
+  /**
+   * Extracted selected constants from an argument. Finds literals, omits
+   * expressions, columns and so on.
+   */
+
+  private static class ConstantExtractor extends AbstractExprVisitor<ConstantHolder, Void, RuntimeException> {
+
+    @Override
+    public ConstantHolder visitIntConstant(IntExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.INT, expr.getInt());
+    }
+
+    @Override
+    public ConstantHolder visitLongConstant(LongExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.BIGINT, expr.getLong());
+    }
+
+    @Override
+    public ConstantHolder visitBooleanConstant(BooleanExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.BIT, expr.getBoolean());
+    }
+
+    @Override
+    public ConstantHolder visitQuotedStringConstant(QuotedString expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.VARCHAR, expr.getString());
+    }
+
+    @Override
+    public ConstantHolder visitUnknown(LogicalExpression e, Void valueArg) throws RuntimeException {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a column name argument, or null if the argument is not a column, or is
+   * a complex column (a[10], a.b).
+   */
+
+  private static class ColRefExtractor extends AbstractExprVisitor<String, Void, RuntimeException> {
+
+    @Override
+    public String visitSchemaPath(SchemaPath path, Void value) throws RuntimeException {
+
+      // Can't handle names such as a.b or a[10]
+
+      if (! path.isLeaf()) {
+        return null;
+      }
+
+      // Can only handle columns known to the scan
+
+      return path.getRootSegmentPath();
+    }
+
+    @Override
+    public String visitUnknown(LogicalExpression e, Void valueArg) throws RuntimeException {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a relational operator of the pattern<br>
+   * <tt>&lt;col> &lt;relop> &lt;const></tt> or<br>
+   * <tt>&lt;col> &lt;relop></tt>.
+   */
+
+  private static class RelOpExtractor extends AbstractExprVisitor<List<RelOp>, Void, RuntimeException> {
+
+    @Override
+    public List<RelOp> visitBooleanOperator(BooleanOperator op, Void value) throws RuntimeException {
+      switch (op.getName()) {
+      case BooleanOperator.OR_FN:
+        break;
+      case BooleanOperator.AND_FN:
+        assert false : "Should not get here, the CNF conversion should have handled AND";
+      default:
+        return null;
+      }
+
+      // OR is allowed only when the equivalent of IN:
+      // a IN('x', 'y') is equivalent to a = 'x' OR a = 'y'
+      // a IN('x', 'y', 'z') is equivalent to a = 'z' OR (a = 'y' OR a = 'z')
+
+      List<RelOp> left = op.args.get(0).accept(this, null);
+      if (left == null) {
+        return null;
+      }
+      List<RelOp> right = op.args.get(1).accept(this, null);
+      if (right == null) {
+        return null;
+      }
+      List<RelOp> scans = new ArrayList<>();
+      scans.addAll(left);
+      scans.addAll(right);
+      return scans;
+    }
+
+
+    @Override
+    public List<RelOp> visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
+
+      RelOp.Op op;
+      switch(call.getName()) {
+      case FunctionCall.EQ_FN:
+        op = RelOp.Op.EQ;
+        break;
+      case FunctionCall.NE_FN:
+        op = RelOp.Op.NE;
+        break;
+      case FunctionCall.LT_FN:
+        op = RelOp.Op.LT;
+        break;
+      case FunctionCall.LE_FN:
+        op = RelOp.Op.LE;
+        break;
+      case FunctionCall.GT_FN:
+        op = RelOp.Op.GT;
+        break;
+      case FunctionCall.GE_FN:
+        op = RelOp.Op.GE;
+        break;
+      case FunctionCall.IS_NULL:
+        op = RelOp.Op.IS_NULL;
+        break;
+      case FunctionCall.IS_NOT_NULL:
+        op = RelOp.Op.IS_NOT_NULL;
+        break;
+      default:
+        return null;
+      }
+
+      RelOp relOp;
+      if (op.argCount() == 1) {
+        relOp = checkCol(op, call);
+      } else {
+        relOp = checkColOpConst(op, call);
+        if (relOp == null) {
+          relOp = checkConstOpCol(op, call);
+        }
+      }
+      return relOp == null ? null : Collections.singletonList(relOp);
+    }
+
+    /**
+     * Check just the one argument for a unary operator:
+     * IS NULL, IS NOT NULL.
+     */
+
+    private RelOp checkCol(RelOp.Op op, FunctionCall call) {
+      String colName = call.args.get(0).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      return new RelOp(op, colName, null);
+    }
+
+    /**
+     * Extracts a relational operator of the "normal" form of:<br>
+     * <tt>&lt;col> &lt;relop> &lt;const>.
+     */
+
+    private RelOp checkColOpConst(RelOp.Op op, FunctionCall call) {
+      String colName = call.args.get(0).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      ConstantHolder constArg = call.args.get(1).accept(CONSTANT_EXTRACTOR, null);
+      if (constArg == null) {
+        return null;
+      }
+
+      return new RelOp(op, colName, constArg);
+    }
+
+    /**
+     * Extracts a relational operator of the "reversed" form of:<br>
+     * <tt>&lt;const> &lt;relop> &lt;col>. (Unfortunately, Calcite
+     * does not normalize predicates.) Reverses the sense of the
+     * relational operator to put the predicate into normalized
+     * form.
+     */
+
+    private RelOp checkConstOpCol(RelOp.Op op, FunctionCall call) {
+      ConstantHolder constArg = call.args.get(0).accept(CONSTANT_EXTRACTOR, null);
+      if (constArg == null) {
+        return null;
+      }
+
+      String colName = call.args.get(1).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      return new RelOp(op.invert(), colName, constArg);
+    }
+
+    @Override
+    public List<RelOp> visitUnknown(LogicalExpression e, Void value) throws RuntimeException {
+      // Catches OR clauses among other things
+      return null;
+    }
+  }
+
+  private static final ConstantExtractor CONSTANT_EXTRACTOR = new ConstantExtractor();
+
+  private static final ColRefExtractor COL_REF_EXTRACTOR = new ColRefExtractor();
+
+  public static final RelOpExtractor REL_OP_EXTRACTOR = new RelOpExtractor();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterSpec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterSpec.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base.filter;
+
+import java.util.List;
+
+import org.apache.drill.exec.store.base.PlanStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value=Include.NON_EMPTY, content=Include.NON_NULL)
+@JsonPropertyOrder({"andTerms", "orTerms"})
+public class FilterSpec {
+
+  private final List<RelOp> andTerms;
+  private final DisjunctionFilterSpec orTerms;
+
+  @JsonCreator
+  public FilterSpec(
+      @JsonProperty("andTerms") List<RelOp> andFilters,
+      @JsonProperty("orTerms") DisjunctionFilterSpec orFilters) {
+    this.andTerms = andFilters == null || andFilters.isEmpty() ? null : andFilters;
+    this.orTerms = orFilters == null || orFilters.values.length == 0 ? null : orFilters;
+  }
+
+  public static FilterSpec build(List<RelOp> andFilters, DisjunctionFilterSpec orFilters) {
+    FilterSpec spec = new FilterSpec(andFilters, orFilters);
+    return spec.isEmpty() ? null : spec;
+  }
+
+  @JsonProperty("andTerms")
+  public List<RelOp> andTerms() { return andTerms; }
+
+  @JsonProperty("orTerms")
+  public DisjunctionFilterSpec orTerms() { return orTerms; }
+
+  /**
+   * The number of partitions in the sense of scan "segments" given
+   * by an OR clause. (May not correspond to HDFS file partitions.)
+   *
+   * @return the number of logical partitions, which is the number
+   * of OR clause terms (or 1 if no OR terms exist)
+   */
+
+  public int partitionCount() {
+    return orTerms == null ? 1 : orTerms.values.length;
+  }
+
+  public static int parititonCount(FilterSpec filters) {
+    return filters == null ? 1 : filters.partitionCount();
+  }
+
+  public List<RelOp> distribute(int orTerm) {
+    return DisjunctionFilterSpec.distribute(andTerms, orTerms, orTerm);
+  }
+
+  /**
+   * Compute selectivity of a CNF form of equality conditions. Without stats,
+   * Drill assumes a selectivity of 0.15 for each equality, then multiplies
+   * the selectivity of multiple columns. Place a lower limit of 0.001 on
+   * the result, assuming the user wants to return some rows.
+   *
+   * @param andTerms list of AND filters (in CNF form), or null if no
+   * filters apply to a scan
+   * @return selectivity of the filters
+   */
+
+  public double cnfSelectivity() {
+    if (andTerms == null || andTerms.isEmpty()) {
+      return 1.0;
+    }
+    double selectivity = 1.0;
+    for (RelOp relOp : andTerms) {
+      selectivity *= relOp.op.selectivity();
+    }
+    return Math.max(0.001, selectivity);
+  }
+
+  /**
+   * Compute the combined selectivity of a set of AND (CNF) and OR
+   * (DNF) filters. We assume the DNF returns a subset of rows, which
+   * the CNF terms further reduce. Selectivity will be at least
+   * 0.001, which assumes the user wants to return some rows.
+   *
+   * @param andTerms and filters for the scan, or null if none
+   * @param orTerms or filters for the scan, or null if none
+   * @return combined selectivity
+   */
+
+  public double selectivity() {
+    double selectivity = cnfSelectivity();
+    if (orTerms != null) {
+      selectivity = Math.max(0.001, selectivity * orTerms.selectivity());
+    }
+    return selectivity;
+  }
+
+  /**
+   * Drill scan stats want a row count, the selectivity is a means to
+   * that end. Apply the selectivity of a set of filters to the given
+   * row count to produce a reduced row count.
+   *
+   * @param andTerms and filters for the scan, or null if none
+   * @param orTerms or filters for the scan, or null if none
+   * @param rowCount original estimated row count before filtering
+   * @return adjusted estimated row count after filtering
+   */
+
+  public static int applySelectivity(FilterSpec filterSpec, int rowCount) {
+    return filterSpec == null ? rowCount : filterSpec.applySelectivity(rowCount);
+  }
+
+  public int applySelectivity(int rowCount) {
+    return (int) Math.round(rowCount * selectivity());
+  }
+
+  @JsonIgnore
+  public boolean isEmpty() {
+    return (andTerms == null || andTerms.isEmpty()) &&
+           (orTerms == null || orTerms.values.length == 0);
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+      .field("andFilters", andTerms)
+      .field("orFilters", orTerms)
+      .toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
@@ -1,0 +1,156 @@
+package org.apache.drill.exec.store.base.filter;
+
+import org.apache.drill.exec.store.base.PlanStringBuilder;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Semanticized form of a Calcite relational operator. Abstracts
+ * out the Drill implementation details to capture just the
+ * column name, operator and value. Supports only expressions
+ * of the form:<br>
+ * <code>&lt;column> &lt;relop> &lt;const></code><br>
+ * Where the column is a simple name (not an array or map reference),
+ * the relop is one of a defined set, and the constant is one
+ * of the defined Drill types.
+ * <p>
+ * (The driver will convert expressions of the form:<br>
+ * <code>&lt;const></code> &lt;relop> <code>&lt;column></code><br>
+ * into the normalized form represented here.
+ */
+
+@JsonInclude(Include.NON_NULL)
+@JsonPropertyOrder({"op", "colName", "value"})
+public class RelOp {
+
+  public enum Op {
+    EQ, NE, LT, LE, GT, GE, IS_NULL, IS_NOT_NULL;
+
+    /**
+     * Return the result of flipping the sides of an
+     * expression:</br>
+     * a op b &rarr; b op.invert() a
+     */
+    public RelOp.Op invert() {
+      switch(this) {
+      case LT:
+        return GT;
+      case LE:
+        return GE;
+      case GT:
+        return LT;
+      case GE:
+        return LE;
+      default:
+        return this;
+      }
+    }
+
+    public int argCount() {
+      switch (this) {
+      case IS_NULL:
+      case IS_NOT_NULL:
+        return 1;
+      default:
+        return 2;
+      }
+    }
+
+    /**
+     * Poor-man's guess at selectivity of each operator.
+     * Should match Calcite's built-in defaults (which are
+     * hard to find.)
+     *
+     * TODO: Double check against Drill defaults.
+     * @return crude estimate of operator selectivity
+     */
+
+    public double selectivity() {
+      switch (this) {
+      case EQ:
+        return 0.15;
+      case GE:
+      case GT:
+      case LE:
+      case LT:
+        return 0.45;
+      case IS_NOT_NULL:
+      case IS_NULL:
+        return 0.5;
+      case NE:
+        return 0.85;
+      default:
+        return 0.5;
+      }
+    }
+  }
+
+  @JsonProperty("op")
+  public final RelOp.Op op;
+  @JsonProperty("colName")
+  public final String colName;
+  @JsonProperty("value")
+  public final ConstantHolder value;
+
+  @JsonCreator
+  public RelOp(
+      @JsonProperty("op") RelOp.Op op,
+      @JsonProperty("colName") String colName,
+      @JsonProperty("value") ConstantHolder value) {
+    Preconditions.checkArgument(op.argCount() == 1 || value != null);
+    this.op = op;
+    this.colName = colName;
+    this.value = value;
+  }
+
+  /**
+   * Rewrite the RelOp with a normalized value.
+   *
+   * @param from the original RelOp
+   * @param value the new value with a different type and matching
+   * value
+   */
+
+  public RelOp(RelOp from, ConstantHolder value) {
+    Preconditions.checkArgument(from.op.argCount() == 2);
+    this.op = from.op;
+    this.colName = from.colName;
+    this.value = value;
+  }
+
+  /**
+   * Return a new RelOp with the normalized value. Will be the same relop
+   * if the normalized value is the same as the unnormalized value.
+   */
+
+  public RelOp normalize(ConstantHolder normalizedValue) {
+    if (value == normalizedValue) {
+      return this;
+    }
+    return new RelOp(this, normalizedValue);
+  }
+
+  public RelOp rewrite(String newName, ConstantHolder newValue) {
+    if (value == newValue && colName.equals(newName)) {
+      return this;
+    }
+    return new RelOp(op, newName, newValue);
+  }
+
+  @Override
+  public String toString() {
+    PlanStringBuilder builder = new PlanStringBuilder(this)
+      .field("op", op.name())
+      .field("colName", colName);
+    if (value != null) {
+      builder.field("type", value.type.name())
+             .field("value", value.value);
+    }
+    return builder.toString();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
@@ -31,82 +31,18 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * out the Drill implementation details to capture just the
  * column name, operator and value. Supports only expressions
  * of the form:<br>
- * <code>&lt;column> &lt;relop> &lt;const></code><br>
+ * {@code <column> <relop> <const>}<br>
  * Where the column is a simple name (not an array or map reference),
  * the relop is one of a defined set, and the constant is one
  * of the defined Drill types.
  * <p>
  * (The driver will convert expressions of the form:<br>
- * <code>&lt;const></code> &lt;relop> <code>&lt;column></code><br>
+ * {@code <const> <relop> <column>}<br>
  * into the normalized form represented here.
  */
-
 @JsonInclude(Include.NON_NULL)
 @JsonPropertyOrder({"op", "colName", "value"})
 public class RelOp {
-
-  public enum Op {
-    EQ, NE, LT, LE, GT, GE, IS_NULL, IS_NOT_NULL;
-
-    /**
-     * Return the result of flipping the sides of an
-     * expression:</br>
-     * a op b &rarr; b op.invert() a
-     */
-    public RelOp.Op invert() {
-      switch(this) {
-      case LT:
-        return GT;
-      case LE:
-        return GE;
-      case GT:
-        return LT;
-      case GE:
-        return LE;
-      default:
-        return this;
-      }
-    }
-
-    public int argCount() {
-      switch (this) {
-      case IS_NULL:
-      case IS_NOT_NULL:
-        return 1;
-      default:
-        return 2;
-      }
-    }
-
-    /**
-     * Poor-man's guess at selectivity of each operator.
-     * Should match Calcite's built-in defaults (which are
-     * hard to find.)
-     *
-     * TODO: Double check against Drill defaults.
-     * @return crude estimate of operator selectivity
-     */
-
-    public double selectivity() {
-      switch (this) {
-      case EQ:
-        return 0.15;
-      case GE:
-      case GT:
-      case LE:
-      case LT:
-        return 0.45;
-      case IS_NOT_NULL:
-      case IS_NULL:
-        return 0.5;
-      case NE:
-        return 0.85;
-      default:
-        return 0.5;
-      }
-    }
-  }
-
   @JsonProperty("op")
   public final RelOp.Op op;
   @JsonProperty("colName")
@@ -132,7 +68,6 @@ public class RelOp {
    * @param value the new value with a different type and matching
    * value
    */
-
   public RelOp(RelOp from, ConstantHolder value) {
     Preconditions.checkArgument(from.op.argCount() == 2);
     this.op = from.op;
@@ -141,10 +76,11 @@ public class RelOp {
   }
 
   /**
-   * Return a new RelOp with the normalized value. Will be the same relop
+   * Rewrite a relop using the given normalized value.
+   *
+   * @return a new RelOp with the normalized value. Will be the same relop
    * if the normalized value is the same as the unnormalized value.
    */
-
   public RelOp normalize(ConstantHolder normalizedValue) {
     if (value == normalizedValue) {
       return this;
@@ -169,5 +105,83 @@ public class RelOp {
              .field("value", value.value);
     }
     return builder.toString();
+  }
+
+  /**
+   * Fixed set of Drill relational operators, using well-defined
+   * names. Distilled from the more general string function names
+   * used in the query plan tree.
+   */
+  public enum Op {
+    EQ, NE, LT, LE, GT, GE, IS_NULL, IS_NOT_NULL;
+
+    /**
+     * Return the result of flipping the sides of an
+     * expression:</br>
+     * {@code a op b} &rarr; {@code b op.invert() a}
+     *
+     * @return a new relop resulting from flipping the sides
+     * of the expression, or this relop if the operation
+     * is symmetric.
+     */
+    public RelOp.Op invert() {
+      switch(this) {
+        case LT:
+          return GT;
+        case LE:
+          return GE;
+        case GT:
+          return LT;
+        case GE:
+          return LE;
+        default:
+          return this;
+      }
+    }
+
+    /**
+     * Returns the number of arguments for the relop.
+     * @return 1 for IS (NOT) NULL, 2 otherwise
+     */
+    public int argCount() {
+      switch (this) {
+        case IS_NULL:
+        case IS_NOT_NULL:
+          return 1;
+        default:
+          return 2;
+      }
+    }
+
+    /**
+     * Poor-man's guess at selectivity of each operator.
+     * Should match Calcite's built-in defaults. The Calcite estimates
+     * are not great, but we need to match them.
+     * <p>
+     * If a query has access to metadata, then each predicates should
+     * have a computed selectivity based on that metadata. This
+     * mechanism should be extended to include that selecvity as a field,
+     * and pass it back from this method.
+     *
+     * @return crude estimate of operator selectivity
+     * @see {@code package org.apache.calcite.rel.metadata.RelMdUtil}
+     */
+    public double selectivity() {
+      switch (this) {
+        case EQ:
+          return 0.15;
+        case GE:
+        case GT:
+        case LE:
+        case LT:
+        case NE: // Very bad estimate!
+          return 0.5;
+        case IS_NOT_NULL:
+        case IS_NULL:
+          return 0.9;
+        default:
+          return 0.25;
+      }
+    }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.drill.exec.store.base.filter;
 
 import org.apache.drill.exec.store.base.PlanStringBuilder;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
@@ -1,0 +1,31 @@
+/**
+ * Provides a standard, reusable framework for implementing filter push-down
+ * for storage plugins. Handles the work of parsing a Drill physical plan
+ * (using Calcite rules) to extract candidate predicates, converting those
+ * to a normalized form, and calling a listener to check if the predicates
+ * are eligible for push-down, then to implement the push-down.
+ * <p>
+ * Some plugins may which to remove the pushed conditions. That way, Drill
+ * does not do work that the plugin has already done. In the ideal case,
+ * Drill can omit a filter operator entirely.
+ * <p>
+ * In other cases, the plugin might only make a "best effort", and wishes
+ * to allow Drill to still apply the filter conditions as a final check.
+ * <p>
+ * The listener can implement both forms (or other variations) by
+ * choosing which predicates to leave in the filter.
+ *
+ * <h4>Serialization</h4>
+ *
+ * A plugin can simply serialize the {@link RelOp} conditions as part
+ * of the sub scan, allowing the run-time scan operator to implement the
+ * push down. (This works well for sources such as JDBC or REST.) In
+ * other cases (such as Parquet), the terms can be used at plan time
+ * (to prune partition directories). The <code>RelOp</code> class
+ * is designed for serialization when the plugin chooses to include
+ * it in the sub scan.
+ *
+ * @See {@link DummyStoragePlugin} for an example of how to use this
+ * mechanism. This plugin is the "test mule" for this package.
+ */
+package org.apache.drill.exec.store.base.filter;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
@@ -22,7 +22,7 @@
  * to a normalized form, and calling a listener to check if the predicates
  * are eligible for push-down, then to implement the push-down.
  * <p>
- * Some plugins may which to remove the pushed conditions. That way, Drill
+ * Some plugins may wish to remove the pushed conditions. That way, Drill
  * does not do work that the plugin has already done. In the ideal case,
  * Drill can omit a filter operator entirely.
  * <p>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/package-info.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides a standard, reusable framework for implementing filter push-down
  * for storage plugins. Handles the work of parsing a Drill physical plan

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
@@ -10,7 +10,7 @@
  * <li>The storage plugin class,</li>
  * <li>The schema factory for the plugin (which says which schemas
  * or tables are available),<.li>
- * <li>The batch reader to read the data for the plugin.<.li>
+ * <li>The batch reader to read the data for the plugin.</li>
  * </ul>
  *
  * Super classes require a number of standard methods to make

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * Provides a set of base classes for creating a storage plugin.
+ * Handles the "boilerplate" which is otherwise implemented via
+ * copy-and-paste.
+ * <p>
+ * The simplest possible plugin will use many of the base
+ * classes as-is, and will implement:
+ * <ul>
+ * <li>The storage plugin configuration (needed to identify the plugin),</li>
+ * <li>The storage plugin class,</li>
+ * <li>The schema factory for the plugin (which says which schemas
+ * or tables are available),<.li>
+ * <li>The batch reader to read the data for the plugin.<.li>
+ * </ul>
+ *
+ * Super classes require a number of standard methods to make
+ * copies, present configuration and so on. As much as possible,
+ * this class handles those details. For example, the
+ * {@link StoragePluginOptions} class holds many of the options
+ * that otherwise require one-line method implementations.
+ * The framework automatically makes copies of scan objects
+ * to avoid other standard methods.
+ * <p>
+ * As a plugin gets more complex, it can create its own
+ * group and sub scans, add filter push down, and so on.
+ *
+ * @see {@link DummyStoragePlugin} for an example how this
+ * framework is used. The Dummy plugin is the "test mule"
+ * for this framework.
+ */
+
+package org.apache.drill.exec.store.base;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides a set of base classes for creating a storage plugin.
  * Handles the "boilerplate" which is otherwise implemented via

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/package-info.java
@@ -27,23 +27,222 @@
  * <li>The storage plugin class,</li>
  * <li>The schema factory for the plugin (which says which schemas
  * or tables are available),<.li>
+ * <li>A scan spec which transfers schema information from the schema
+ * factory to the group scan.</li>
+ * <li>The GroupScan class to describe the scan during planning.</li>
+ * <li>The SubScan class to carry information from the planner to the
+ * execution engine, serialized as JSON.</li>
  * <li>The batch reader to read the data for the plugin.</li>
  * </ul>
  *
  * Super classes require a number of standard methods to make
  * copies, present configuration and so on. As much as possible,
- * this class handles those details. For example, the
+ * the classes here handle those details. For example, the
  * {@link StoragePluginOptions} class holds many of the options
  * that otherwise require one-line method implementations.
  * The framework automatically makes copies of scan objects
  * to avoid other standard methods.
- * <p>
- * As a plugin gets more complex, it can create its own
- * group and sub scans, add filter push down, and so on.
  *
- * @see {@link DummyStoragePlugin} for an example how this
+ * <h4>Life Cycle</h4>
+ *
+ * Drill uses Calcite for planning. Calcite is a bit complex: it applies a series
+ * of rules to transform the query, then chooses the lowest cost among the
+ * available transforms. As a result, the group scan object is continually
+ * created and recreated. The following is a rough outline of these events.
+ *
+ * <h4>The Scan Specification</h4>
+ *
+ * The storage plugin provides a
+ * {@link org.apache.drill.exec.store.SchemaFactory SchemaFactory}
+ * which provides a
+ * {@link org.apache.drill.exec.store.SchemaConfig SchemaConfig}
+ * which represents the set of (logical) tables available
+ * from the plugin.
+ * <p>
+ * Calcite offers table names to the schema. If the table is valid, the schema
+ * creates a scan spec instance to describe the schema, table and other
+ * information unique to the plugin. The schema then creates a group scan using
+ * from the scan spec.
+ * <p>
+ * Calcite uses the schema to look up a table and obtain a scan spec.
+ * The scan spec is then serialized to JSON and passed back to the plugin
+ * to be deserialized and to create a group scan for the scan spec. The
+ * {@link BaseStoragePlugin} and {@link BaseScanFactory}
+ * classes (try to) hide the details.
+ *
+ * Drill has the idea of a scan specification. The scan
+ * spec transfers information from the schema table lookup to the group scan.
+ * Each plugin defines its own scan spec; there is no base class. At the
+ * least, include the table definition (whatever that means for the plugin.)
+ * The scan spec must be Jackson serializable.
+ * <p>
+ * Some plugins use the scan spec directly in the group scan (store it as
+ * a field), others do not. Choose the simplest design for your needs.
+ * <p>
+ * Your subclass should include other query-specific data needed at both plan
+ * and run time such as file locations, partition information, filter push-downs
+ * and so on.
+ *
+ * <h5>Column Resolution</h5>
+ *
+ * Calcite makes multiple attempts to refine the set of columns from the scan.
+ * If we have the following query:<br>
+ * <code><pre>
+ * SELECT a AS x, b FROM myTable</pre></code><br>
+ * Then Calcite will offer the following set of columns as planning proceeds:
+ *
+ * <ol>
+ * <li>['**'] (The default starter set.)</li>
+ * <li>['**', 'a', 'b', 'x'] (alias not yet resolved.)</li>
+ * <li>['a', 'b'] (aliases resolved)</li>
+ * </ol>
+ *
+ * Each time the column set changes, Calcite makes a copy of the group scan by
+ * calling {@link AbstractGroupScan#clone(List<SchemaPath>)}.
+ * <p>
+ * Since Calcite is cost-based, it is important that the cost of the scan
+ * decrease after columns are pushed down. This can be done by reducing
+ * the disk I/O cost or reducing the CPU factor from 1.0 to, say, 0.75.
+ * See {@link DummyGroupScan} for an example.
+ *
+ * <h5>Intermediate Copies</h5>
+ *
+ * At multiple points during logical planning, Calcite will create
+ * a simple copy of the group scan by invoking
+ * {@link GroupScan#getNewWithChildren(List<PhysicalOperator>)}. Scans never
+ * have children, so this method should just make a copy.
+ *
+ * <h4>Filter Push-Down</h5>
+ *
+ * If a plugin allows filter push-down, the plugin must add logical planning
+ * rules to implement the push down. The rules rewrite the group scan with
+ * the push-downs included (and optionally remove the filters from the
+ * query.) See {@link FilterPushDownStrategy} for details.
+ *
+ * <h5>Node Assignment</h5>
+ *
+ * Drill calls {@link GroupScan#getMaxParallelizationWidth()} to
+ * determine how much it
+ * can parallelize the scan. If this method returns 1, Drill assumes that this
+ * is a single-threaded scan. If the return is 2 or greater, Drill will create
+ * a parallelized scan. This base class assumes a single-threaded scan.
+ * Override {@link GroupScan#getMinParallelizationWidth()} and
+ * {@link GroupScan#getMaxParallelizationWidth()} to enable parallelism.
+ * <p>
+ * Drill then calls {@link GroupScan#applyAssignments(List)} to
+ * declare the actual number of minor fragments (offered as Drillbit endpoints.)
+ * Since most non-file scans don't care about node affinity, they can simply use
+ * the {@link GroupScan#endpointCount} variable to determine the number of minor
+ * fragments which Drill will create.
+ * <p>
+ * Drill then calls {@link GroupScan#getSpecificScan(int)}. The number of minor fragments
+ * is the same as the number of endpoints offered above, which is determined by
+ * the min/max parallelization width and Drill configuration.
+ * <p>
+ * Your group scan may create a set of scan "segments". For example, to read
+ * a distributed database, there might be one segment per database server node.
+ * The physical planning process maps the segments into minor fragments.
+ * Ideally there will be one segment per minor fragment, but there may be
+ * multiple if Drill can offer fewer endpoints than requested. Thus, each
+ * specific scan might host multiple segments. Each plugin determines what
+ * that means for the target engine. At runtime, each segment translates to
+ * a distinct batch reader.
+ *
+ * <h4>The Storage Plugin</h4>
+ *
+ * Group scans are ephemeral and serialized. They should hold only data that
+ * describes the scan. Group scans <i>should not</i> hold metadata about the
+ * underlying system because of the complexity of recreating that data on each
+ * of the many copies that occur.
+ * <p>
+ * Instead, the implementation should cache metadata in the storage plugin. Each
+ * storage plugin instance exists for the duration of a single query: either at
+ * plan time or (if requested) at runtime (one instance per minor fragment.) A
+ * good practice is:
+ * <ul>
+ * <li>The group scan asks the storage plugin for metadata as needed to process
+ * each group scan operation.</li>
+ * <li>The storage plugin retrieves the metadata from the external system and
+ * caches it; returning the cached copies on subsequent requests.</li>
+ * <li>The sub scan (execution description) should avoid asking for metadata to
+ * avoid caching metadata in each of the many execution minor fragments.</li>
+ * <li>Cached information is lost once planning completes for a query. If
+ * additional caching is needed, the storage plugin can implement a shared cache
+ * (with proper concurrency controls) which is shared across multiple plugin
+ * instances. (Note, however, than planning is also distributed; each query may
+ * be planned on a different Drillbit (Foreman), so even a shared cache will
+ * hold as many copies as there are Drillbits (one copy per Drillbit.)</li>
+ * </ul>
+ * <p>
+ * The storage plugin is the only part of the data for a query that persists
+ * across the entire planning session. Group scans are created and deleted.
+ * Although some of these are done via copies (and so could preserve data), the
+ * <tt>getPhysicalScan()</tt> step is not a copy and discards all data except
+ * that in the scan spec. Note, however, that if a query contains a join or
+ * a union, then the query will contain multiple group scans (one per table)
+ * but a single storage plugin instance.
+ *
+ * <h4>Costs</h4>
+ *
+ * Calcite is a cost-based optimizer. This means it uses the cost associated
+ * with a group scan instance to pick which of several options to use.
+ * <p>
+ * You must provide a scan cost estimate in terms of rows, data and CPU. For
+ * some systems (such as Hive), these numbers are available. For others (such as
+ * local files), the data size may be available, from which we can estimate a
+ * row count by assuming some reasonable average row width. In other cases (such
+ * as REST), we may not have any good estimate at all.
+ * <p>
+ * In these cases, it helps to know how Drill uses the cost estimates. The scan
+ * must occur, so there is no decision about whether to use the scan or not. But,
+ * Drill has to decide which scan to put on which side of a join (the so-called
+ * "build" and "probe" sides.) Further, Drill needs to know if the table is
+ * small enough to "broadcast" the contents to all nodes.
+ * <p>
+ * So, at the least, the estimate must identify "small" vs. "large" tables. If
+ * the scan is known to be small enough to broadcast (because it is for, say, a
+ * small lookup list), then provide a small row and data estimate, say 100 rows
+ * and 1K.
+ * <p>
+ * If, however, the data size is potentially large, then provide a large
+ * estimate (10K rows, 100M data, say) to force Drill to not consider broadcast,
+ * and to avoid putting the table on the build side of a join unless some other
+ * table is even larger.
+ * <p>
+ * Logical planning will include projection (column) push-down and optionally
+ * filter push-down. Each of these <i>must</i> reduce scan cost so that
+ * Calcite decides that doing them improves query performance.
+ *
+ * <h4>Projection Push-Down</h4>
+ *
+ * This base class assumes that the scan supports projection push-down. You
+ * get this "for free" if you use the EVF-based scan framework (that is,
+ * the result set loader and associated classes.) You are, however,
+ * responsible for updating costs based on projection push-down.
+ *
+ * <h4>EXPLAIN PLAN</h4>
+ *
+ * The group scan appears in the output of the <tt>EXPLAIN PLAN FOR</tt>
+ * command. Drill calls the
+ * {@link org.apache.drill.exec.physical.base.GroupScan#toString() GroupScan.toString()}
+ * method to obtain the string. The
+ * format of the string should follow Drill's conventions. The easiest way to to
+ * that is to instead override {@link BaseGroupScan#buildPlanString(PlanStringBuilder)} and
+ * add your custom fields to those already included from this base class.
+ * <p>
+ * If your fields have structure, ensure that the <tt>toString()</tt> method of
+ * those classes also uses {@link PlanStringBuilder}, or create the encoding
+ * yourself in your own <tt>buildPlanString</tt> method. Test by calling the
+ * method or by examining the output of an <tt>EXPLAIN</tt>.
+ * <p>
+ * Include only the logical planning fields. That is, include only the
+ * fields that also appear in the JSON serialized form of the group scan.
+ *
+ * @see {@link org.apache.drill.exec.store.base.DummyStoragePlugin DummyStoragePlugin}
+ * for an example how this
  * framework is used. The Dummy plugin is the "test mule"
  * for this framework.
  */
-
 package org.apache.drill.exec.store.base;
+
+import java.util.List;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyBatchReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyBatchReader.java
@@ -1,5 +1,3 @@
-package org.apache.drill.exec.store.base;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,6 +15,8 @@ package org.apache.drill.exec.store.base;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.drill.exec.store.base;
+
 import java.util.List;
 
 import org.apache.drill.common.expression.SchemaPath;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyBatchReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyBatchReader.java
@@ -1,0 +1,83 @@
+package org.apache.drill.exec.store.base;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.store.base.filter.RelOp;
+
+public class DummyBatchReader implements ManagedReader<SchemaNegotiator> {
+
+  @SuppressWarnings("unused")
+  private final DummyStoragePluginConfig config;
+  @SuppressWarnings("unused")
+  private final List<SchemaPath> columns;
+
+  // Filters are not actually used; just carried along for testing
+  @SuppressWarnings("unused")
+  private final List<RelOp> filters;
+  private ResultSetLoader rsLoader;
+
+  public DummyBatchReader(DummyStoragePluginConfig config,
+      List<SchemaPath> columns, List<RelOp> filters) {
+    this.config = config;
+    this.columns = columns;
+    this.filters = filters;
+  }
+
+  @Override
+  public boolean open(SchemaNegotiator negotiator) {
+    TupleMetadata schema = new SchemaBuilder()
+          .add("a", MinorType.VARCHAR)
+          .add("b", MinorType.VARCHAR)
+          .add("c", MinorType.VARCHAR)
+          .build();
+    negotiator.setTableSchema(schema, true);
+    rsLoader = negotiator.build();
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    if (rsLoader.batchCount() > 0) {
+      return false;
+    }
+    RowSetLoader writer = rsLoader.writer();
+    int rowCount = 3;
+    int colCount = writer.tupleSchema().size();
+    for (int i = 0; i < rowCount; i++) {
+      writer.start();
+      for (int j = 0; j < colCount; j++) {
+        writer.scalar(j).setString("Row " + (i + 1) + ", Col " + (j + 1));
+      }
+      writer.save();
+    }
+    return true;
+  }
+
+  @Override
+  public void close() { }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyFilterPushDownListener.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyFilterPushDownListener.java
@@ -43,7 +43,7 @@ public class DummyFilterPushDownListener implements FilterPushDownListener {
 
   public static Set<StoragePluginOptimizerRule> rulesFor(
       OptimizerRulesContext optimizerRulesContext, DummyStoragePluginConfig config) {
-    return FilterPushDownStrategy.rulesFor(optimizerRulesContext,
+    return FilterPushDownStrategy.rulesFor(
         new DummyFilterPushDownListener(config));
   }
 
@@ -113,7 +113,9 @@ public class DummyFilterPushDownListener implements FilterPushDownListener {
     if (config.keepFilters()) {
       exprs = new ArrayList<>();
       if (andTerms != null) {
-        exprs.addAll(andTerms.stream().map(t -> t.left).collect(Collectors.toList()));
+        exprs.addAll(andTerms.stream()
+            .map(t -> t.left)
+            .collect(Collectors.toList()));
       }
       if (orTerm != null) {
         exprs.add(orTerm.left);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyFilterPushDownListener.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyFilterPushDownListener.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.base.filter.DisjunctionFilterSpec;
+import org.apache.drill.exec.store.base.filter.FilterPushDownListener;
+import org.apache.drill.exec.store.base.filter.FilterPushDownStrategy;
+import org.apache.drill.exec.store.base.filter.FilterSpec;
+import org.apache.drill.exec.store.base.filter.RelOp;
+
+public class DummyFilterPushDownListener implements FilterPushDownListener {
+
+  private final DummyStoragePluginConfig config;
+
+  public DummyFilterPushDownListener(DummyStoragePluginConfig config) {
+    this.config = config;
+  }
+
+  public static Set<StoragePluginOptimizerRule> rulesFor(
+      OptimizerRulesContext optimizerRulesContext, DummyStoragePluginConfig config) {
+    return FilterPushDownStrategy.rulesFor(optimizerRulesContext,
+        new DummyFilterPushDownListener(config));
+  }
+
+  @Override
+  public String prefix() { return "Dummy"; }
+
+  @Override
+  public boolean isTargetScan(GroupScan groupScan) {
+    return groupScan instanceof DummyGroupScan;
+  }
+
+  @Override
+  public boolean needsApplication(GroupScan groupScan) {
+    DummyGroupScan dummyScan = (DummyGroupScan) groupScan;
+    return !dummyScan.hasFilters();
+  }
+
+  @Override
+  public RelOp accept(GroupScan groupScan, RelOp relOp) {
+
+    // Determine if filter applies to this scan
+
+    DummyGroupScan dummyScan = (DummyGroupScan) groupScan;
+    return dummyScan.acceptFilter(relOp);
+  }
+
+  @Override
+  public Pair<GroupScan, List<RexNode>> transform(GroupScan groupScan,
+      List<Pair<RexNode, RelOp>> andTerms, Pair<RexNode, DisjunctionFilterSpec> orTerm) {
+    List<RelOp> andExprs;
+    if (andTerms == null || andTerms.isEmpty()) {
+      andExprs = null;
+    } else {
+      andExprs = andTerms.stream().map(t -> t.right).collect(Collectors.toList());
+    }
+    DisjunctionFilterSpec orExprs;
+    if (orTerm == null) {
+      orExprs = null;
+    } else {
+      orExprs = orTerm.right;
+    }
+    FilterSpec filters = FilterSpec.build(andExprs, orExprs);
+    DummyGroupScan dummyScan = (DummyGroupScan) groupScan;
+    GroupScan newScan = new DummyGroupScan(dummyScan, filters);
+
+    List<RexNode> exprs;
+    if (config.keepFilters()) {
+      exprs = new ArrayList<>();
+      if (andTerms != null) {
+        exprs.addAll(andTerms.stream().map(t -> t.left).collect(Collectors.toList()));
+      }
+      if (orTerm != null) {
+        exprs.add(orTerm.left);
+      }
+    } else {
+      exprs = null;
+    }
+    return Pair.of(newScan, exprs);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyGroupScan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyGroupScan.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.base.ScanStats;
+import org.apache.drill.exec.physical.base.ScanStats.GroupScanProperty;
+import org.apache.drill.exec.physical.base.SubScan;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.base.filter.FilterSpec;
+import org.apache.drill.exec.store.base.filter.RelOp;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("dummy-scan")
+@JsonPropertyOrder({"userName", "scanSpec", "columns",
+                    "filters", "cost", "config"})
+@JsonInclude(value=Include.NON_EMPTY, content=Include.NON_NULL)
+public class DummyGroupScan extends BaseGroupScan {
+
+  private final DummyScanSpec scanSpec;
+  private final FilterSpec filters;
+
+  public DummyGroupScan(DummyStoragePlugin storagePlugin, String userName,
+      DummyScanSpec scanSpec) {
+    super(storagePlugin, userName, null);
+    this.scanSpec = scanSpec;
+    filters = null;
+  }
+
+  public DummyGroupScan(DummyGroupScan from, List<SchemaPath> columns) {
+    super(from.storagePlugin, from.getUserName(), columns);
+    this.scanSpec = from.scanSpec;
+    this.filters = from.filters;
+  }
+
+  @JsonCreator
+  public DummyGroupScan(
+      @JsonProperty("config") DummyStoragePluginConfig config,
+      @JsonProperty("userName") String userName,
+      @JsonProperty("scanSpec") DummyScanSpec scanSpec,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JsonProperty("filters") FilterSpec filters,
+      @JacksonInject StoragePluginRegistry engineRegistry) {
+    super(config, userName, columns, engineRegistry);
+    this.scanSpec = scanSpec;
+    this.filters = filters;
+  }
+
+  public DummyGroupScan(DummyGroupScan from, FilterSpec filters) {
+    super(from);
+    this.scanSpec = from.scanSpec;
+    this.filters = filters;
+  }
+
+  @JsonProperty("scanSpec")
+  public DummyScanSpec scanSpec() { return scanSpec; }
+
+  @JsonProperty("filters")
+  public FilterSpec andFilters() { return filters; }
+
+  public boolean hasFilters() {
+    return filters != null && ! filters.isEmpty();
+  }
+
+  private static final List<String> FILTER_COLS = ImmutableList.of("a", "b", "id");
+
+  public RelOp acceptFilter(RelOp relOp) {
+
+    // Pretend that "id" is a special integer column. Can handle
+    // equality only.
+
+    if (relOp.colName.contentEquals("id")) {
+
+      // To allow easier testing, require exact type match: no
+      // attempt at type conversion here.
+
+      if (relOp.op != RelOp.Op.EQ || relOp.value.type != MinorType.INT) {
+        return null;
+      }
+      return relOp;
+    }
+
+    // All other columns apply only if projected
+
+    if (!FILTER_COLS.contains(relOp.colName)) {
+      return null;
+    }
+
+    // Only supports a few operators so we can verify that the
+    // others are left in the WHERE clause.
+    // Neither are really implemented. Less-than lets us check
+    // inverting operations for the const op col case.
+
+    switch (relOp.op) {
+    case EQ:
+    case LT:
+    case LE:
+
+      // Convert to target type (pretend all columns are VARCHAR)
+
+      return relOp.normalize(relOp.value.toVarChar());
+    case IS_NULL:
+    case IS_NOT_NULL:
+      return relOp;
+    default:
+      return null;
+    }
+  }
+
+//  private boolean hasColumn(String colName) {
+//    for (SchemaPath col : scanSpec.columns()) {
+//      if (col.isLeaf() && col.getRootSegmentPath().contentEquals(colName)) {
+//        return true;
+//      }
+//    }
+//    return false;
+//  }
+
+  @Override
+  public ScanStats computeScanStats() {
+
+    // No good estimates at all, just make up something.
+
+    int estRowCount = 10_000;
+
+    // If filter push down, assume this reduces data size.
+    // Need to get Calcite to choose this version rather
+    // than the un-filtered version.
+
+    estRowCount = FilterSpec.applySelectivity(filters, estRowCount);
+
+    // Assume no disk I/O. So we have to explain costs by reducing
+    // CPU.
+
+    double cpuRatio = 1.0;
+
+    // If columns provided, then assume this saves data transfer
+
+    if (getColumns() != BaseGroupScan.ALL_COLUMNS) {
+      cpuRatio = 0.75;
+    }
+
+    // Would like to reduce network costs, but not easy to do here since Drill
+    // scans assume we read from disk, not network.
+
+    return new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, estRowCount, cpuRatio, 0);
+  }
+
+  @Override
+  @JsonIgnore
+  public int getMinParallelizationWidth() {
+    return FilterSpec.parititonCount(filters);
+  }
+
+  @Override
+  @JsonIgnore
+  public int getMaxParallelizationWidth() {
+    return FilterSpec.parititonCount(filters);
+  }
+
+  @Override
+  public SubScan getSpecificScan(int minorFragmentId) {
+    Preconditions.checkArgument(minorFragmentId < endpointCount);
+    if (!hasFilters()) {
+      Preconditions.checkState(minorFragmentId == 0);
+      return new DummySubScan(this, null);
+    }
+    int orCount = filters.partitionCount();
+    int sliceSize = orCount / endpointCount;
+    List<List<RelOp>> segmentFilters = new ArrayList<>();
+    int start = minorFragmentId * sliceSize;
+    int end = Math.min(start + sliceSize, orCount);
+    for (int i = start; i < end; i++) {
+      segmentFilters.add(filters.distribute(i));
+    }
+    return new DummySubScan(this, segmentFilters);
+  }
+
+  @Override
+  public void buildPlanString(PlanStringBuilder builder) {
+    super.buildPlanString(builder);
+    builder.field("scanSpec", scanSpec);
+    builder.field("filters", filters);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyScanSpec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyScanSpec.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.drill.exec.store.base;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyScanSpec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyScanSpec.java
@@ -1,0 +1,39 @@
+package org.apache.drill.exec.store.base;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("dummy-scan-spec")
+@JsonInclude(Include.NON_NULL)
+public class DummyScanSpec  {
+
+  protected final String schemaName;
+  protected final String tableName;
+
+  @JsonCreator
+  public DummyScanSpec(
+      @JsonProperty("schemaName") String schemaName,
+      @JsonProperty("tableName") String tableName) {
+    this.schemaName = schemaName;
+    this.tableName = tableName;
+  }
+
+  @JsonProperty("schemaName")
+  public String schemaName() { return schemaName; }
+
+  @JsonProperty("tableName")
+  public String tableName() { return tableName; }
+
+  @Override
+  public String toString() {
+    PlanStringBuilder builder = new PlanStringBuilder(this);
+    if (schemaName != null && !schemaName.equals(BaseStoragePlugin.DEFAULT_SCHEMA_NAME)) {
+      builder.field("schema", schemaName);
+    }
+    builder.field("table", tableName);
+    return builder.toString();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySchemaFactory.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySchemaFactory.java
@@ -34,6 +34,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 public class DummySchemaFactory extends AbstractSchemaFactory {
 
   public static final String MY_TABLE = "myTable";
+  public static final String ALL_TYPES_TABLE = "allTypes";
 
   private final DummyStoragePlugin plugin;
 
@@ -62,7 +63,7 @@ public class DummySchemaFactory extends AbstractSchemaFactory {
       if (table != null) {
         return table;
       }
-      if (MY_TABLE.contentEquals(name)) {
+      if (getTableNames().contains(name)) {
         DummyScanSpec scanSpec = new DummyScanSpec(BaseStoragePlugin.DEFAULT_SCHEMA_NAME, name);
         return registerTable(name,
             new DynamicDrillTable(plugin, plugin.getName(), scanSpec));
@@ -77,7 +78,7 @@ public class DummySchemaFactory extends AbstractSchemaFactory {
 
     @Override
     public Set<String> getTableNames() {
-      return Sets.newHashSet(MY_TABLE);
+      return Sets.newHashSet(MY_TABLE, ALL_TYPES_TABLE);
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySchemaFactory.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySchemaFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.drill.exec.planner.logical.DynamicDrillTable;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.exec.store.AbstractSchemaFactory;
+import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+
+public class DummySchemaFactory extends AbstractSchemaFactory {
+
+  public static final String MY_TABLE = "myTable";
+
+  private final DummyStoragePlugin plugin;
+
+  public DummySchemaFactory(DummyStoragePlugin plugin) {
+    super(plugin.getName());
+    this.plugin = plugin;
+  }
+
+  @Override
+  public void registerSchemas(SchemaConfig schemaConfig, SchemaPlus parent)
+      throws IOException {
+    parent.add(getName(), new DefaultSchema(getName()));
+  }
+
+  class DefaultSchema extends AbstractSchema {
+
+    private final Map<String, DynamicDrillTable> activeTables = new HashMap<>();
+
+    DefaultSchema(String name) {
+      super(Collections.emptyList(), name);
+    }
+
+    @Override
+    public Table getTable(String name) {
+      DynamicDrillTable table = activeTables.get(name);
+      if (table != null) {
+        return table;
+      }
+      if (MY_TABLE.contentEquals(name)) {
+        DummyScanSpec scanSpec = new DummyScanSpec(BaseStoragePlugin.DEFAULT_SCHEMA_NAME, name);
+        return registerTable(name,
+            new DynamicDrillTable(plugin, plugin.getName(), scanSpec));
+      }
+      return null; // Unknown table
+    }
+
+    private DynamicDrillTable registerTable(String name, DynamicDrillTable table) {
+      activeTables.put(name, table);
+      return table;
+    }
+
+    @Override
+    public Set<String> getTableNames() {
+      return Sets.newHashSet(MY_TABLE);
+    }
+
+    @Override
+    public String getTypeName() {
+      return DummyStoragePluginConfig.NAME;
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
@@ -47,7 +47,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
  * "Test mule" for the base storage plugin and the filter push down
  * framework.
  */
-
 public class DummyStoragePlugin
   extends BaseStoragePlugin<DummyStoragePluginConfig> {
 
@@ -103,6 +102,19 @@ public class DummyStoragePlugin
     return options;
   }
 
+  /**
+   * Add a Calcite rule to implement filter push-down. This plugin uses
+   * filters to define a set of "shards" to scan. Thus, the filters
+   * will influence the number of minor fragments. That can be done
+   * only if the filter push-down is done at logical planning time.
+   * Many other plugins, which do no use filters to determine the
+   * number of minor fragments, do filter push-down during physical
+   * planning.
+   *
+   * It turns out Drill has three different way to to logical planning.
+   * To avoid listing those phases here, the {@link FilterPushDownUtils}
+   * provides a convenience method to check all of them.
+   */
   @Override
   public Set<? extends StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
 
@@ -118,6 +130,16 @@ public class DummyStoragePlugin
     return ImmutableSet.of();
   }
 
+  /**
+   * Example reader factory which creates the readers for the scan. A {@code SubScan}
+   * corresponds to a minor fragment, which includes one or more actual scans. (There
+   * will be more than one scan if the plugin asks for more minor fragments than
+   * Drill can provide.) This factory creates each of the scans one by one.
+   * <p>
+   * Since this is a dummy reader, the actual scan is rather lame; real plugins
+   * would do actual work with information passed from the {@code SubScan} and
+   * plugin configuration.
+   */
   private static class DummyReaderFactory implements ReaderFactory {
 
     private final DummyStoragePluginConfig config;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
@@ -76,6 +76,7 @@ public class DummyStoragePlugin
       storagePlugin.initFramework(builder, subScan);
       ReaderFactory readerFactory = new DummyReaderFactory(storagePlugin.config(), subScan);
       builder.setReaderFactory(readerFactory);
+      builder.setNullType(Types.optional(MinorType.VARCHAR));
       builder.setContext(
         new ChildErrorContext(builder.errorContext()) {
           @Override
@@ -96,8 +97,6 @@ public class DummyStoragePlugin
   private static StoragePluginOptions buildOptions(DummyStoragePluginConfig config) {
     StoragePluginOptions options = new StoragePluginOptions();
     options.supportsRead = true;
-    options.supportsProjectPushDown = config.enableProjectPushDown();
-    options.nullType = Types.optional(MinorType.VARCHAR);
     options.scanSpecType = new TypeReference<DummyScanSpec>() { };
     options.scanFactory = new DummyScanFactory();
     return options;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
@@ -37,6 +37,7 @@ import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.SessionOptionManager;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.base.filter.FilterPushDownUtils;
 import org.apache.drill.exec.store.base.filter.RelOp;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 
@@ -108,9 +109,10 @@ public class DummyStoragePlugin
     // Push-down planning is done at the logical phase so it can
     // influence parallelization in the physical phase. Note that many
     // existing plugins perform filter push-down at the physical
-    // phase.
+    // phase, which also works fine if push-down is independent of
+    // parallelization.
 
-    if (phase.isFilterPushDownPhase() && config.enableFilterPushDown()) {
+    if (FilterPushDownUtils.isFilterPushDownPhase(phase) && config.enableFilterPushDown()) {
       return DummyFilterPushDownListener.rulesFor(optimizerContext, config);
     }
     return ImmutableSet.of();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePlugin.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.metastore.MetadataProviderManager;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.framework.ManagedScanFramework.ScanFrameworkBuilder;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.planner.PlannerPhase;
+import org.apache.drill.exec.server.DrillbitContext;
+import org.apache.drill.exec.server.options.OptionManager;
+import org.apache.drill.exec.server.options.SessionOptionManager;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.base.filter.RelOp;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+/**
+ * "Test mule" for the base storage plugin and the filter push down
+ * framework.
+ */
+
+public class DummyStoragePlugin
+  extends BaseStoragePlugin<DummyStoragePluginConfig> {
+
+  private static class DummyScanFactory extends
+        BaseScanFactory<DummyStoragePlugin, DummyScanSpec, DummyGroupScan, DummySubScan> {
+
+    @Override
+    public DummyGroupScan newGroupScan(DummyStoragePlugin storagePlugin,
+        String userName, DummyScanSpec scanSpec,
+        SessionOptionManager sessionOptions,
+        MetadataProviderManager metadataProviderManager) {
+
+      // Force user name to "dummy" so golden and actual test files are stable
+      return new DummyGroupScan(storagePlugin, "dummy", scanSpec);
+    }
+
+    @Override
+    public DummyGroupScan groupWithColumns(DummyGroupScan group,
+        List<SchemaPath> columns) {
+      return new DummyGroupScan(group, columns);
+    }
+
+    @Override
+    public ScanFrameworkBuilder scanBuilder(DummyStoragePlugin storagePlugin,
+        OptionManager options, DummySubScan subScan) {
+      ScanFrameworkBuilder builder = new ScanFrameworkBuilder();
+      storagePlugin.initFramework(builder, subScan);
+      ReaderFactory readerFactory = new DummyReaderFactory(storagePlugin.config(), subScan);
+      builder.setReaderFactory(readerFactory);
+      builder.setContext(
+        new ChildErrorContext(builder.errorContext()) {
+          @Override
+          public void addContext(UserException.Builder builder) {
+            builder.addContext("Table:", subScan.scanSpec().tableName());
+          }
+        });
+      return builder;
+    }
+  }
+
+  public DummyStoragePlugin(DummyStoragePluginConfig config,
+      DrillbitContext context, String name) {
+    super(context, config, name, buildOptions(config));
+    schemaFactory = new DummySchemaFactory(this);
+  }
+
+  private static StoragePluginOptions buildOptions(DummyStoragePluginConfig config) {
+    StoragePluginOptions options = new StoragePluginOptions();
+    options.supportsRead = true;
+    options.supportsProjectPushDown = config.enableProjectPushDown();
+    options.nullType = Types.optional(MinorType.VARCHAR);
+    options.scanSpecType = new TypeReference<DummyScanSpec>() { };
+    options.scanFactory = new DummyScanFactory();
+    return options;
+  }
+
+  @Override
+  public Set<? extends StoragePluginOptimizerRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
+
+    // Push-down planning is done at the logical phase so it can
+    // influence parallelization in the physical phase. Note that many
+    // existing plugins perform filter push-down at the physical
+    // phase.
+
+    if (phase.isFilterPushDownPhase() && config.enableFilterPushDown()) {
+      return DummyFilterPushDownListener.rulesFor(optimizerContext, config);
+    }
+    return ImmutableSet.of();
+  }
+
+  private static class DummyReaderFactory implements ReaderFactory {
+
+    private final DummyStoragePluginConfig config;
+    private final DummySubScan subScan;
+    private final int readerCount;
+    private int readerIndex;
+
+    public DummyReaderFactory(DummyStoragePluginConfig config, DummySubScan subScan) {
+      this.config = config;
+      this.subScan = subScan;
+      List<List<RelOp>> filters = subScan.filters();
+      readerCount = filters == null || filters.isEmpty() ? 1 : filters.size();
+    }
+
+    @Override
+    public void bind(ManagedScanFramework framework) { }
+
+    @Override
+    public ManagedReader<? extends SchemaNegotiator> next() {
+      if (readerIndex >= readerCount) {
+        return null;
+      }
+      List<RelOp> filters;
+      if (subScan.filters() == null) {
+        filters = null;
+      } else {
+        filters = subScan.filters().get(readerIndex);
+      }
+      readerIndex++;
+      return new DummyBatchReader(config, subScan.columns(), filters);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePluginConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePluginConfig.java
@@ -54,7 +54,6 @@ public class DummyStoragePluginConfig extends StoragePluginConfig {
    * the plan, or remove them (because they are done (simulated)
    * in the reader.
    */
-
   private final boolean keepFilters;
 
   public DummyStoragePluginConfig(
@@ -77,6 +76,11 @@ public class DummyStoragePluginConfig extends StoragePluginConfig {
   public boolean keepFilters() { return keepFilters; }
 
   @Override
+  public int hashCode() {
+    return Objects.hashCode(enableProjectPushDown, enableFilterPushDown, keepFilters);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (o == this) {
       return true;
@@ -88,11 +92,6 @@ public class DummyStoragePluginConfig extends StoragePluginConfig {
     return enableProjectPushDown == other.enableProjectPushDown &&
            enableFilterPushDown == other.enableFilterPushDown &&
            keepFilters == other.keepFilters;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(enableProjectPushDown, enableFilterPushDown, keepFilters);
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePluginConfig.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummyStoragePluginConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.shaded.guava.com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Options for the "test mule" storage plugin. The options
+ * control how the plugin behaves for testing. A real plugin
+ * would simply implement project push down, and, if filter push-down
+ * is needed, would implement one of the strategies described
+ * here.
+ */
+
+@JsonTypeName(DummyStoragePluginConfig.NAME)
+@JsonPropertyOrder({"enableProjectPushDown", "enableFilterPushDown",
+  "keepFilters", "enable"})
+public class DummyStoragePluginConfig extends StoragePluginConfig {
+
+  public static final String NAME = "dummy";
+
+  /**
+   * Whether to enable or disable project push down.
+   */
+  private final boolean enableProjectPushDown;
+
+  /**
+   * Whether to enable or disable filter push down.
+   */
+  private final boolean enableFilterPushDown;
+
+  /**
+   * When doing filter push-down, whether to keep the filters in
+   * the plan, or remove them (because they are done (simulated)
+   * in the reader.
+   */
+
+  private final boolean keepFilters;
+
+  public DummyStoragePluginConfig(
+      @JsonProperty("enableProjectPushDown") boolean enableProjectPushDown,
+      @JsonProperty("enableFilterPushDown") boolean enableFilterPushDown,
+      @JsonProperty("keepFilters") boolean keepFilters) {
+    this.enableProjectPushDown = enableProjectPushDown;
+    this.enableFilterPushDown = enableFilterPushDown;
+    this.keepFilters = keepFilters;
+    setEnabled(true);
+  }
+
+  @JsonProperty("enableProjectPushDown")
+  public boolean enableProjectPushDown() { return enableProjectPushDown; }
+
+  @JsonProperty("enableFilterPushDown")
+  public boolean enableFilterPushDown() { return enableFilterPushDown; }
+
+  @JsonProperty("keepFilters")
+  public boolean keepFilters() { return keepFilters; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(o instanceof DummyStoragePluginConfig)) {
+      return false;
+    }
+    DummyStoragePluginConfig other = (DummyStoragePluginConfig) o;
+    return enableProjectPushDown == other.enableProjectPushDown &&
+           enableFilterPushDown == other.enableFilterPushDown &&
+           keepFilters == other.keepFilters;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(enableProjectPushDown, enableFilterPushDown, keepFilters);
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder(this)
+        .field("enableProjectPushDown", enableProjectPushDown)
+        .field("enableFilterPushDown", enableFilterPushDown)
+        .field("keepFilters", keepFilters)
+        .toString();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySubScan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/DummySubScan.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.logical.StoragePluginConfig;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.exec.store.base.filter.RelOp;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Dummy sub scan that simply passes along the group scan
+ * information. A real scan operator definition would likely translate the
+ * group scan information into the form needed by the
+ * underlying storage system.
+ * <p>
+ * For testing, we use a list of filters as a proxy for scans
+ * of the underlying system. Each filter is a list of filter
+ * conditions to be applied. (The dummy scan does not actually
+ * do anything with these, other than holding them for use in
+ * verifying plans.)
+ */
+
+@JsonTypeName("dummy-sub-scan")
+@JsonPropertyOrder({"userName", "scanSpec", "columns",
+                    "andFilters", "orFilters", "config"})
+@JsonInclude(Include.NON_NULL)
+public class DummySubScan extends BaseSubScan {
+
+  private final DummyScanSpec scanSpec;
+  private final List<List<RelOp>> filters;
+
+  @JsonCreator
+  public DummySubScan(
+      @JsonProperty("userName") String userName,
+      @JsonProperty("config") StoragePluginConfig config,
+      @JsonProperty("scanSpec") DummyScanSpec scanSpec,
+      @JsonProperty("columns") List<SchemaPath> columns,
+      @JsonProperty("filters") List<List<RelOp>> filters,
+      @JacksonInject StoragePluginRegistry engineRegistry) {
+    super(userName, config, columns, engineRegistry);
+    this.scanSpec = scanSpec;
+    this.filters = filters;
+ }
+
+  public DummySubScan(DummyGroupScan groupScan, List<List<RelOp>> filters) {
+    super(groupScan);
+    this.scanSpec = groupScan.scanSpec();
+    this.filters = filters;
+  }
+
+  @JsonProperty("scanSpec")
+  public DummyScanSpec scanSpec() { return scanSpec; }
+
+  @JsonProperty("filters")
+  public List<List<RelOp>> filters() { return filters; }
+
+  @Override
+  public void buildPlanString(PlanStringBuilder builder) {
+    super.buildPlanString(builder);
+    builder.field("scanSpec", scanSpec);
+    builder.field("filters", filters);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/PlanVerifier.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/PlanVerifier.java
@@ -45,7 +45,7 @@ import org.apache.drill.test.ClientFixture;
  * copy the plan to the golden file and run again.
  * <p>
  * If comparison fails, you can optionally ask the verifier to write the
- * output to {@code /tmp} so you can compare the golden and actual
+ * output to {@code /tmp/drill/test} so you can compare the golden and actual
  * outputs using your favorite diff tool to understand changes. If the changes
  * are expected, use that same IDE to copy changes from the actual
  * to the golden file.
@@ -64,15 +64,19 @@ public class PlanVerifier {
 
   private final String basePath;
 
-  /**
-   * Persist test results. Turn this on if you have failing tests.
-   ( Then, you can diff the actual and golden results in your favorite
-   * tool or IDE.
-   */
-  public boolean saveResults;
+  private boolean saveResults;
 
   public PlanVerifier(String goldenFileDir) {
     this.basePath = goldenFileDir;
+  }
+
+  /**
+   * Persist test results. Turn this on if you have failing tests.
+   * Then, you can diff the actual and golden results in your favorite
+   * tool or IDE.
+   */
+  public void saveResults(boolean flag) {
+    saveResults = flag;
   }
 
   protected void verifyPlan(ClientFixture client, String sql, String expectedFile) throws Exception {
@@ -139,7 +143,7 @@ public class PlanVerifier {
         if (aLine == null) {
           fail("Missing actual lines");
         }
-        assertEquals(eLine, aLine, "Line: " + lineNo);
+        assertEquals("Line: " + lineNo, eLine, aLine);
       }
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/PlanVerifier.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/PlanVerifier.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URL;
+
+import org.apache.drill.test.ClientFixture;
+
+/**
+ * Verifier for execution plans. A handy tool to ensure that the
+ * planner produces the expected plan given some set of conditions.
+ * <p>
+ * The test works by comparing the actual {@code EXPLAIN} output
+ * to a "golden" file with the expected ("golden") plan.
+ * <p>
+ * To create a test, just write it and let it fail due to a missing file.
+ * The output will go to the console. Inspect it. If it looks good,
+ * copy the plan to the golden file and run again.
+ * <p>
+ * If comparison fails, you can optionally ask the verifier to write the
+ * output to {@code /tmp} so you can compare the golden and actual
+ * outputs using your favorite diff tool to understand changes. If the changes
+ * are expected, use that same IDE to copy changes from the actual
+ * to the golden file.
+ * <p>
+ * The JSON properties of the serialized classes are all controlled
+ * to have a fixed order to ensure that files compare across test
+ * runs. If you see spurious failures do to changed JSON order, consider
+ * adding a {@code @JsonPropertyOrder} tag to enforce a consistent order.
+ * <p>
+ * A fancier version of this class would use a regex or other mechanism
+ * to say "ignore differences in this bit of the plan." For example, when
+ * using systems with metadata, the exact values might bounce around
+ * some.
+ */
+public class PlanVerifier {
+
+  private final String basePath;
+
+  /**
+   * Persist test results. Turn this on if you have failing tests.
+   ( Then, you can diff the actual and golden results in your favorite
+   * tool or IDE.
+   */
+  public boolean saveResults;
+
+  public PlanVerifier(String goldenFileDir) {
+    this.basePath = goldenFileDir;
+  }
+
+  protected void verifyPlan(ClientFixture client, String sql, String expectedFile) throws Exception {
+    String plan = client.queryBuilder().sql(sql).explainJson();
+    verify(plan, expectedFile);
+  }
+
+  protected void verify(String actual, String relativePath) {
+    URL url = getClass().getResource(basePath + relativePath);
+    if (url == null) {
+
+      // We' re about to fail. Before we do, dump the plan to output
+      // so you can inspect the output, verify it is what you want,
+      // and copy it into a golden file. Then, the next run will
+      // pass. So, output goes to the console only if the test will
+      // fail because the golden output file is missing.
+      System.out.println(actual);
+    }
+    assertNotNull("Golden file is missing: " + relativePath, url);
+    File resource = new File(url.getPath());
+    try {
+      verify(actual, resource);
+    } catch (AssertionError e) {
+
+      // If a test fails, it is handy to persist the results.
+      // Done only when requested.
+      if (saveResults) {
+        System.out.println(actual);
+        File dest = new File("/tmp/drill/test", basePath);
+        File destFile = new File(dest, relativePath);
+        dest.mkdirs();
+        try (PrintWriter out = new PrintWriter(destFile)) {
+          out.println(actual);
+        } catch (FileNotFoundException e1) {
+          fail("Cannnot save actual results to " + destFile.getAbsolutePath());
+        }
+      }
+      throw e;
+    }
+  }
+
+  protected void verify(String actual, File resource) {
+    try (Reader expected = new FileReader(resource)) {
+      verify(new StringReader(actual), expected);
+    } catch (FileNotFoundException e) {
+      fail("Missing resource file: " + resource.getAbsolutePath());
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  private void verify(Reader actualReader, Reader expectedReader) throws IOException {
+    try (BufferedReader actual = new BufferedReader(actualReader);
+         BufferedReader expected = new BufferedReader(expectedReader);) {
+      for (int lineNo = 1; ;lineNo++ ) {
+        String aLine = actual.readLine();
+        String eLine = expected.readLine();
+        if (aLine == null && eLine == null) {
+          break;
+        }
+        if (eLine == null) {
+          fail("Too many actual lines");
+        }
+        if (aLine == null) {
+          fail("Missing actual lines");
+        }
+        assertEquals(eLine, aLine, "Line: " + lineNo);
+      }
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestFilterPushDown.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URL;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests for the Filter push-down helper classes as part of the
+ * "Base" storage plugin to be used for add-on plugins. Uses a
+ * "test mule" ("Dummy") plug-in which goes through the paces of
+ * planning push down, but then glosses over the details at run time.
+ * The focus here are plans: the tests plan a query then compare the
+ * actual plan against and expected ("golden") plan.
+ * <p>
+ * If comparison fails, the tests print the actual plan to the console.
+ * Use this, when adding new tests, to create the initial "golden" file.
+ * Also, on failures, actual output is written to
+ * <code>/tmp/drill/store/base</code>. You can use your IDE to compare
+ * the actual and golden files to understand changes. If the changes
+ * are expected, use that same IDE to copy changes from the actual
+ * to the golden file.
+ * <p>
+ * The JSON properties of the serialized classes are all controlled
+ * to have a fixed order to ensure that files compare across test
+ * runs.
+ */
+public class TestFilterPushDown extends ClusterTest {
+
+  private static final String BASE_SQL = "SELECT a, b FROM dummy.myTable";
+  private static final String BASE_WHERE = BASE_SQL +  " WHERE ";
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher);
+    startCluster(builder);
+
+    StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
+    DummyStoragePluginConfig config =
+        new DummyStoragePluginConfig(true, true, false);
+    pluginRegistry.createOrUpdate("dummy", config, true);
+  }
+
+  //-------------------------------------------------
+  // Unsupported filter push-down cases
+
+  // No predicates
+
+  @Test
+  public void testNoPushDown() throws Exception
+  {
+    verifyPlan(BASE_SQL, "noPushDown.json");
+  }
+
+  // Predicate mismatch on type (id should be INT, dummy does
+  // not try to convert)
+
+  @Test
+  public void testTypeMismatch() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "id = 'foo'", "typeMismatch.json");
+  }
+
+  // Unsupported relop type (dummy supports limited set)
+
+  @Test
+  public void testUnsupportedOp() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a <> 'foo'", "unsupportedOp.json");
+  }
+
+  // Column reference rather than constant
+
+  @Test
+  public void testNonConst() throws Exception
+  {
+   verifyPlan(BASE_WHERE + "a = b", "nonConstPred.json");
+  }
+
+  // Unknown column (dummy only knows columns a and b)
+
+  @Test
+  public void testUnsupportedCol() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "c = 'foo'", "unsupportedColPred.json");
+  }
+
+  // Not simple col = const
+
+  @Test
+  public void testComplexPred() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "id + 10 = 20", "complexPred.json");
+  }
+
+  // Complex schema paths
+
+  @Test
+  public void testComplexCols() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a[10] = 'foo' AND myTable.b.c = 'bar'", "complexCols.json");
+  }
+
+  // OR, can't push
+
+  @Test
+  public void testGenericOr() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar' OR id = 10", "or.json");
+  }
+
+  // Listener rejects one of the expressions within an OR,
+  // must reject the entire OR clause. (Dummy rejects >.)
+
+  @Test
+  public void testRejectOneOrExpr() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar' OR a > 'foo'", "rejectOneOrExpr.json");
+  }
+
+  // Or clause expressions accepted, but whole of OR is rejected
+  // because it is not all = operators. (Dummy accepts <.)
+
+  @Test
+  public void testNonEqOr() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar' OR a < 'foo'", "nonEqOr.json");
+  }
+
+  @Test
+  public void testDoubleOr() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "(a = 'x' OR a = 'y') AND (a = 'a' OR a = 'b')", "doubleOr.json");
+  }
+
+  //-------------------------------------------------
+  // Supported filter push-down cases
+
+  // Single matching predicate
+
+  @Test
+  public void testSingleCol() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar'", "singleCol.json");
+  }
+
+    // Two matching predicates, one is implicit (not in project list)
+
+  @Test
+  public void testTwoCols() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar' AND id = 10", "twoCols.json");
+  }
+
+  // Pushed and unpushed conditions
+
+  @Test
+  public void testMixedPreds() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 'bar' AND id = 10 AND c > 20", "mixedPreds.json");
+  }
+
+  // Reversed predicate
+
+  @Test
+  public void testReversed() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "'bar' > a", "reversed.json");
+  }
+
+  // Join, same project list from both scans. (Calcite does filter push down
+  // only once into a scan node shared by both scans.)
+
+  @Test
+  @Ignore("DRILL-7457")
+  public void testSimpleJoin() throws Exception
+  {
+    String sql =
+        "SELECT t1.a, t1.b, t2.b FROM dummy.myTable t1, dummy.myTable t2 WHERE t1.a = t2.a AND t1.a = 'bar'";
+    verifyPlan(sql, "join1.json");
+  }
+
+  // Similar case, but different project lists. So, two scan nodes and two
+  // sets of filter push downs. (Difference is: t2.b --> t2.c)
+
+  @Test
+  @Ignore("DRILL-7457")
+  public void testComplexJoin() throws Exception
+  {
+    String sql =
+        "SELECT t1.a, t1.b, t2.c FROM dummy.myTable t1, dummy.myTable t2 WHERE t1.a = t2.a AND t1.a = 'bar'";
+    verifyPlan(sql, "join2.json");
+  }
+
+  // IS NULL and IS NOT NULL. Has only one argument.
+
+  @Test
+  public void testIsNull() throws Exception
+  {
+    String sql = "SELECT a, b FROM dummy.myTable WHERE a IS NULL AND b IS NOT NULL";
+    verifyPlan(sql, "isNull.json");
+  }
+
+  // BETWEEN. Calcite rewrites a BETWEEN x AND y into
+  // a >= x AND a <= y.
+  // Since the dummy plug-in only handles <=, the => is left in the query.
+
+  @Test
+  public void testBetween() throws Exception
+  {
+    String sql = "SELECT a, b FROM dummy.myTable WHERE a BETWEEN 'bar' AND 'foo'";
+    verifyPlan(sql, "between.json");
+  }
+
+  // IN clause, handled as a = 'bar' OR a = 'foo'.
+  // Presumption is that this turns into multiple scans
+
+  @Test
+  public void testIn() throws Exception
+  {
+    String sql = "SELECT a, b FROM dummy.myTable WHERE a IN('bar', 'foo')";
+    verifyPlan(sql, "in.json");
+  }
+
+  // Equivalent to the above
+
+  @Test
+  public void testInLikeOr() throws Exception
+  {
+    String sql = "SELECT a, b FROM dummy.myTable WHERE a = 'bar' OR a = 'foo'";
+    verifyPlan(sql, "in.json");
+  }
+
+  // Test constant value conversion: Dummy will convert a to VARCHAR
+
+  @Test
+  public void testTypeConversion() throws Exception
+  {
+    verifyPlan(BASE_WHERE + "a = 10", "typeConversion.json");
+  }
+
+  public String basePath = "/store/base/";
+  public boolean saveResults = true;
+
+  protected void verifyPlan(String sql, String expectedFile) throws Exception {
+    String plan = client.queryBuilder().sql(sql).explainJson();
+    verify(plan, expectedFile);
+  }
+
+  protected void verify(String actual, String relativePath) {
+    URL url = getClass().getResource(basePath + relativePath);
+    if (url == null) {
+      System.out.println(actual);
+    }
+    assertNotNull("Golden file is missing: " + relativePath, url);
+    File resource = new File(url.getPath());
+    try {
+      verify(actual, resource);
+    } catch (AssertionError e) {
+      if (saveResults) {
+        System.out.println(actual);
+        File dest = new File("/tmp/drill", basePath);
+        File destFile = new File(dest, relativePath);
+        dest.mkdirs();
+        try (PrintWriter out = new PrintWriter(destFile)) {
+          out.println(actual);
+        } catch (FileNotFoundException e1) {
+          // Warn user, but don't fail test
+          System.err.print("Cannnot save actual results to ");
+          System.err.println(destFile.getAbsolutePath());
+        }
+      }
+      throw e;
+    }
+  }
+
+  protected void verify(String actual, File resource) {
+    try (Reader expected = new FileReader(resource)) {
+      verify(new StringReader(actual), expected);
+    } catch (FileNotFoundException e) {
+      fail("Missing resource file: " + resource.getAbsolutePath());
+    } catch (IOException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  private void verify(Reader actualReader, Reader expectedReader) throws IOException {
+    BufferedReader actual = new BufferedReader(actualReader);
+    BufferedReader expected = new BufferedReader(expectedReader);
+    for (;;) {
+      String aLine = actual.readLine();
+      String eLine = expected.readLine();
+      if (aLine == null && eLine == null) {
+        break;
+      }
+      if (eLine == null) {
+        fail("Too many actual lines");
+      }
+      if (aLine == null) {
+        fail("Missing actual lines");
+      }
+      assertEquals(eLine, aLine);
+    }
+  }
+}
+

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestFilterPushDown.java
@@ -31,7 +31,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
 
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestProjectPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestProjectPushDown.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.base;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.store.StoragePluginRegistry;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestProjectPushDown extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder(dirTestWatcher);
+    startCluster(builder);
+
+    StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
+    DummyStoragePluginConfig config1 =
+        new DummyStoragePluginConfig(true, false, true);
+    pluginRegistry.createOrUpdate("pushOn", config1, true);
+
+    DummyStoragePluginConfig config2 =
+        new DummyStoragePluginConfig(false, false, true);
+    pluginRegistry.createOrUpdate("pushOff", config2, true);
+  }
+
+  @Test
+  public void testPushDownEnabled() throws Exception {
+    String plan = client.queryBuilder().sql("SELECT a, b, c from pushOn.myTable").explainJson();
+    // DRILL-7451: should be 0
+    assertEquals(1, StringUtils.countMatches(plan, "\"pop\" : \"project\""));
+  }
+
+  @Test
+  public void testPushDownDisabled() throws Exception {
+    String plan = client.queryBuilder().sql("SELECT a, b, c from pushOff.myTable").explainJson();
+    // DRILL-7451: should be 1
+    assertEquals(2, StringUtils.countMatches(plan, "\"pop\" : \"project\""));
+  }
+
+  @Test
+  public void testDummyReader() throws Exception {
+    RowSet results = client.queryBuilder().sql("SELECT a, b, c from pushOn.myTable").rowSet();
+    assertEquals(3, results.rowCount());
+    results.clear();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestProjectPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/base/TestProjectPushDown.java
@@ -37,30 +37,19 @@ public class TestProjectPushDown extends ClusterTest {
     StoragePluginRegistry pluginRegistry = cluster.drillbit().getContext().getStorage();
     DummyStoragePluginConfig config1 =
         new DummyStoragePluginConfig(true, false, true);
-    pluginRegistry.createOrUpdate("pushOn", config1, true);
-
-    DummyStoragePluginConfig config2 =
-        new DummyStoragePluginConfig(false, false, true);
-    pluginRegistry.createOrUpdate("pushOff", config2, true);
+    pluginRegistry.createOrUpdate("dummy", config1, true);
   }
 
   @Test
   public void testPushDownEnabled() throws Exception {
-    String plan = client.queryBuilder().sql("SELECT a, b, c from pushOn.myTable").explainJson();
+    String plan = client.queryBuilder().sql("SELECT a, b, c from dummy.myTable").explainJson();
     // DRILL-7451: should be 0
     assertEquals(1, StringUtils.countMatches(plan, "\"pop\" : \"project\""));
   }
 
   @Test
-  public void testPushDownDisabled() throws Exception {
-    String plan = client.queryBuilder().sql("SELECT a, b, c from pushOff.myTable").explainJson();
-    // DRILL-7451: should be 1
-    assertEquals(2, StringUtils.countMatches(plan, "\"pop\" : \"project\""));
-  }
-
-  @Test
   public void testDummyReader() throws Exception {
-    RowSet results = client.queryBuilder().sql("SELECT a, b, c from pushOn.myTable").rowSet();
+    RowSet results = client.queryBuilder().sql("SELECT a, b, c from dummy.myTable").rowSet();
     assertEquals(3, results.rowCount());
     results.clear();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import org.apache.drill.common.config.DrillProperties;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.logical.FormatPluginConfig;
+import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ZookeeperHelper;
 import org.apache.drill.exec.client.DrillClient;
@@ -477,6 +478,17 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
       StoragePluginRegistryImpl registry = (StoragePluginRegistryImpl) drillbit.getContext().getStorage();
       StoragePlugin plugin = pluginFactory.apply(drillbit.getContext());
       registry.addPluginToPersistentStoreIfAbsent(plugin.getName(), plugin.getConfig(), plugin);
+    }
+  }
+
+  public void defineStoragePlugin(String name, StoragePluginConfig config) {
+    try {
+      for (Drillbit drillbit : drillbits()) {
+        StoragePluginRegistryImpl registry = (StoragePluginRegistryImpl) drillbit.getContext().getStorage();
+        registry.createOrUpdate(name, config, true);
+      }
+    } catch (ExecutionSetupException e) {
+      throw new IllegalStateException("Plugin definition failed", e);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -62,6 +62,7 @@ import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.store.PartitionExplorer;
+import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.work.filter.RuntimeFilterWritable;
@@ -344,6 +345,10 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     @Override
     public void requestMemory(RecordBatch requestor) {
       // Does nothing in a mock fragment.
+    }
+
+    public StoragePluginRegistry getStorageRegistry() {
+      return null;
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -700,6 +700,19 @@ public class QueryBuilder {
 
   /**
    * Submits explain plan statement
+   * and creates plan matcher instance based on return query plan
+   * in JSON format.
+   *
+   * @return plan matcher
+   * @throws Exception if the query fails
+   */
+  public PlanMatcher jsonPlanMatcher() throws Exception {
+    String plan = explainText();
+    return new PlanMatcher(plan);
+  }
+
+  /**
+   * Submits explain plan statement
    * and creates plan matcher instance based on return query plan with all attributes.
    *
    * @return plan matcher
@@ -839,9 +852,9 @@ public class QueryBuilder {
      *  <code>planMatcher.exclude("usedMetadataSummaryFile = true")</code></li>
      * </ul>
      *
-     *  Calling <code>planMatcher.match()</code> method would check that given patterns are present
-     *  or absent in the given plan. Method execution will fail with {@link AssertionError}
-     *  only if expected pattern was not matched or unexpected pattern was matched.
+     * Calling <code>planMatcher.match()</code> method would check that given patterns are present
+     * or absent in the given plan. Method execution will fail with {@link AssertionError}
+     * only if expected pattern was not matched or unexpected pattern was matched.
      */
     public void match() {
       included.forEach(pattern -> match(pattern, true));

--- a/exec/java-exec/src/test/resources/store/base/allTypes.json
+++ b/exec/java-exec/src/test/resources/store/base/allTypes.json
@@ -1,0 +1,207 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 6,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "allTypes"
+    },
+    "columns" : [ "`**`", "`v`", "`b`", "`i`", "`l`", "`de`", "`da`", "`ti`", "`ts`", "`iy`", "`ids`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "EQ",
+        "colName" : "v",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "varchar"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "i",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "10"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "l",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "5000000000"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "de",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "123.45"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "da",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "1203724800000"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "ti",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "44614000"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "ts",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "1203769414456"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "iy",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "12"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "ids",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "<1, 37230000>"
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 5,
+    "exprs" : [ {
+      "ref" : "`T0¦¦**`",
+      "expr" : "`**`"
+    }, {
+      "ref" : "`v`",
+      "expr" : "`v`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`i`",
+      "expr" : "`i`"
+    }, {
+      "ref" : "`l`",
+      "expr" : "`l`"
+    }, {
+      "ref" : "`de`",
+      "expr" : "`de`"
+    }, {
+      "ref" : "`da`",
+      "expr" : "`da`"
+    }, {
+      "ref" : "`ti`",
+      "expr" : "`ti`"
+    }, {
+      "ref" : "`ts`",
+      "expr" : "`ts`"
+    }, {
+      "ref" : "`iy`",
+      "expr" : "`iy`"
+    }, {
+      "ref" : "`ids`",
+      "expr" : "`ids`"
+    } ],
+    "child" : 6,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10.0
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 4,
+    "child" : 5,
+    "expr" : "`b`",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2.5
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 3,
+    "child" : 4,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2.5
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 2,
+    "exprs" : [ {
+      "ref" : "`T0¦¦**`",
+      "expr" : "`T0¦¦**`"
+    } ],
+    "child" : 3,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2.5
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`**`",
+      "expr" : "`T0¦¦**`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2.5
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2.5
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/between.json
+++ b/exec/java-exec/src/test/resources/store/base/between.json
@@ -1,0 +1,94 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "LE",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "foo"
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 4500.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "greater_than_or_equal_to(`a`, 'bar') ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2250.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2250.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2250.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2250.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/between.json
+++ b/exec/java-exec/src/test/resources/store/base/between.json
@@ -32,7 +32,7 @@
     },
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 4500.0
+      "outputRowCount" : 5000.0
     },
     "config" : {
       "type" : "dummy",
@@ -50,7 +50,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2250.0
+      "outputRowCount" : 2500.0
     }
   }, {
     "pop" : "selection-vector-remover",
@@ -60,7 +60,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2250.0
+      "outputRowCount" : 2500.0
     }
   }, {
     "pop" : "project",
@@ -78,7 +78,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2250.0
+      "outputRowCount" : 2500.0
     }
   }, {
     "pop" : "screen",
@@ -88,7 +88,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2250.0
+      "outputRowCount" : 2500.0
     }
   } ]
 }

--- a/exec/java-exec/src/test/resources/store/base/complexCols.json
+++ b/exec/java-exec/src/test/resources/store/base/complexCols.json
@@ -1,0 +1,108 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 5,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`", "`a`[10]", "`b`.`c`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 4,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`ITEM`",
+      "expr" : "`a`[10]"
+    }, {
+      "ref" : "`ITEM3`",
+      "expr" : "`b`.`c`"
+    } ],
+    "child" : 5,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "booleanAnd(equal(`ITEM`, 'foo') , equal(`ITEM3`, 'bar') ) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/complexPred.json
+++ b/exec/java-exec/src/test/resources/store/base/complexPred.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`id`", "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "equal(add(`id`, 10) , 20) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/doubleOr.json
+++ b/exec/java-exec/src/test/resources/store/base/doubleOr.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "booleanAnd(booleanOr(equal(`a`, 'x') , equal(`a`, 'y') ) , booleanOr(equal(`a`, 'a') , equal(`a`, 'b') ) ) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 625.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 625.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 625.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 625.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/in.json
+++ b/exec/java-exec/src/test/resources/store/base/in.json
@@ -1,0 +1,80 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 65537,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "orTerms" : {
+        "column" : "a",
+        "type" : "VARCHAR",
+        "values" : [ "bar", "foo" ]
+      }
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 3000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "union-exchange",
+    "@id" : 2,
+    "child" : 65537,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 3000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 3000.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 3000.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/isNull.json
+++ b/exec/java-exec/src/test/resources/store/base/isNull.json
@@ -1,0 +1,72 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "IS_NULL",
+        "colName" : "a"
+      }, {
+        "op" : "IS_NOT_NULL",
+        "colName" : "b"
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/isNull.json
+++ b/exec/java-exec/src/test/resources/store/base/isNull.json
@@ -31,7 +31,7 @@
     },
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2500.0
+      "outputRowCount" : 8100.0
     },
     "config" : {
       "type" : "dummy",
@@ -56,7 +56,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2500.0
+      "outputRowCount" : 8100.0
     }
   }, {
     "pop" : "screen",
@@ -66,7 +66,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 2500.0
+      "outputRowCount" : 8100.0
     }
   } ]
 }

--- a/exec/java-exec/src/test/resources/store/base/join1.json
+++ b/exec/java-exec/src/test/resources/store/base/join1.json
@@ -1,0 +1,159 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 5,
+    "userName" : "dummy",
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    },
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable",
+      "columns" : [ "`a`", "`b`" ],
+      "filters" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "config" : {
+      "type" : "dummy",
+      "enabled" : true,
+      "supportProjectPushDown" : true,
+      "filterPushDownStyle" : "REMOVE"
+    }
+  }, {
+    "pop" : "dummy-scan",
+    "@id" : 6,
+    "userName" : "dummy",
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    },
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable",
+      "columns" : [ "`a`", "`b`" ],
+      "filters" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "config" : {
+      "type" : "dummy",
+      "enabled" : true,
+      "supportProjectPushDown" : true,
+      "filterPushDownStyle" : "REMOVE"
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 4,
+    "exprs" : [ {
+      "ref" : "`a0`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b0`",
+      "expr" : "`b`"
+    } ],
+    "child" : 6,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "hash-join",
+    "@id" : 3,
+    "left" : 4,
+    "right" : 5,
+    "conditions" : [ {
+      "relationship" : "EQUALS",
+      "left" : "`a0`",
+      "right" : "`a`"
+    } ],
+    "joinType" : "INNER",
+    "semiJoin" : false,
+    "isRowKeyJoin" : false,
+    "joinControl" : 0,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 88000.0,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 2,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`b0`",
+      "expr" : "`b0`"
+    } ],
+    "child" : 3,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`b0`",
+      "expr" : "`b0`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/join2.json
+++ b/exec/java-exec/src/test/resources/store/base/join2.json
@@ -1,0 +1,159 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 5,
+    "userName" : "dummy",
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    },
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable",
+      "columns" : [ "`a`", "`b`" ],
+      "filters" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "config" : {
+      "type" : "dummy",
+      "enabled" : true,
+      "supportProjectPushDown" : true,
+      "filterPushDownStyle" : "REMOVE"
+    }
+  }, {
+    "pop" : "dummy-scan",
+    "@id" : 6,
+    "userName" : "dummy",
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    },
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable",
+      "columns" : [ "`a`", "`c`" ],
+      "filters" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "config" : {
+      "type" : "dummy",
+      "enabled" : true,
+      "supportProjectPushDown" : true,
+      "filterPushDownStyle" : "REMOVE"
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 4,
+    "exprs" : [ {
+      "ref" : "`a0`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`c`",
+      "expr" : "`c`"
+    } ],
+    "child" : 6,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "hash-join",
+    "@id" : 3,
+    "left" : 4,
+    "right" : 5,
+    "conditions" : [ {
+      "relationship" : "EQUALS",
+      "left" : "`a0`",
+      "right" : "`a`"
+    } ],
+    "joinType" : "INNER",
+    "semiJoin" : false,
+    "isRowKeyJoin" : false,
+    "joinControl" : 0,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 88000.0,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 2,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`c`",
+      "expr" : "`c`"
+    } ],
+    "child" : 3,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    }, {
+      "ref" : "`c`",
+      "expr" : "`c`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/mixedPreds.json
+++ b/exec/java-exec/src/test/resources/store/base/mixedPreds.json
@@ -1,0 +1,101 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`id`", "`c`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "id",
+        "value" : {
+          "type" : "INT",
+          "value" : 10
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "greater_than(`c`, 20) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 112.5
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 112.5
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 112.5
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 112.5
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/noPushDown.json
+++ b/exec/java-exec/src/test/resources/store/base/noPushDown.json
@@ -1,0 +1,63 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/nonConstPred.json
+++ b/exec/java-exec/src/test/resources/store/base/nonConstPred.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "equal(`a`, `b`) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/nonEqOr.json
+++ b/exec/java-exec/src/test/resources/store/base/nonEqOr.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "booleanOr(equal(`a`, 'bar') , less_than(`a`, 'foo') ) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/or.json
+++ b/exec/java-exec/src/test/resources/store/base/or.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`id`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "booleanOr(equal(`a`, 'bar') , equal(`id`, 10) ) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/rejectOneOrExpr.json
+++ b/exec/java-exec/src/test/resources/store/base/rejectOneOrExpr.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "booleanOr(equal(`a`, 'bar') , greater_than(`a`, 'foo') ) ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 2500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/reversed.json
+++ b/exec/java-exec/src/test/resources/store/base/reversed.json
@@ -32,7 +32,7 @@
     },
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 4500.0
+      "outputRowCount" : 5000.0
     },
     "config" : {
       "type" : "dummy",
@@ -57,7 +57,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 4500.0
+      "outputRowCount" : 5000.0
     }
   }, {
     "pop" : "screen",
@@ -67,7 +67,7 @@
     "maxAllocation" : 10000000000,
     "cost" : {
       "memoryCost" : 1.6777216E7,
-      "outputRowCount" : 4500.0
+      "outputRowCount" : 5000.0
     }
   } ]
 }

--- a/exec/java-exec/src/test/resources/store/base/reversed.json
+++ b/exec/java-exec/src/test/resources/store/base/reversed.json
@@ -1,0 +1,73 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "LT",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 4500.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 4500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 4500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/singleCol.json
+++ b/exec/java-exec/src/test/resources/store/base/singleCol.json
@@ -1,0 +1,73 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/twoCols.json
+++ b/exec/java-exec/src/test/resources/store/base/twoCols.json
@@ -1,0 +1,80 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "bar"
+        }
+      }, {
+        "op" : "EQ",
+        "colName" : "id",
+        "value" : {
+          "type" : "INT",
+          "value" : 10
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : false,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 225.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/typeConversion.json
+++ b/exec/java-exec/src/test/resources/store/base/typeConversion.json
@@ -1,0 +1,73 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 2,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "filters" : {
+      "andTerms" : [ {
+        "op" : "EQ",
+        "colName" : "a",
+        "value" : {
+          "type" : "VARCHAR",
+          "value" : "10"
+        }
+      } ]
+    },
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/typeMismatch.json
+++ b/exec/java-exec/src/test/resources/store/base/typeMismatch.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`id`", "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "equal(`id`, 'foo') ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/unsupportedColPred.json
+++ b/exec/java-exec/src/test/resources/store/base/unsupportedColPred.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`c`", "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "equal(`c`, 'foo') ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 1500.0
+    }
+  } ]
+}

--- a/exec/java-exec/src/test/resources/store/base/unsupportedOp.json
+++ b/exec/java-exec/src/test/resources/store/base/unsupportedOp.json
@@ -1,0 +1,84 @@
+{
+  "head" : {
+    "version" : 1,
+    "generator" : {
+      "type" : "ExplainHandler",
+      "info" : ""
+    },
+    "type" : "APACHE_DRILL_PHYSICAL",
+    "options" : [ ],
+    "queue" : 0,
+    "hasResourcePlan" : false,
+    "resultMode" : "EXEC"
+  },
+  "graph" : [ {
+    "pop" : "dummy-scan",
+    "@id" : 4,
+    "userName" : "dummy",
+    "scanSpec" : {
+      "schemaName" : "default",
+      "tableName" : "myTable"
+    },
+    "columns" : [ "`a`", "`b`" ],
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 10000.0
+    },
+    "config" : {
+      "type" : "dummy",
+      "enableProjectPushDown" : true,
+      "enableFilterPushDown" : true,
+      "keepFilters" : false,
+      "enabled" : true
+    }
+  }, {
+    "pop" : "filter",
+    "@id" : 3,
+    "child" : 4,
+    "expr" : "not_equal(`a`, 'foo') ",
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "selection-vector-remover",
+    "@id" : 2,
+    "child" : 3,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "project",
+    "@id" : 1,
+    "exprs" : [ {
+      "ref" : "`a`",
+      "expr" : "`a`"
+    }, {
+      "ref" : "`b`",
+      "expr" : "`b`"
+    } ],
+    "child" : 2,
+    "outputProj" : true,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  }, {
+    "pop" : "screen",
+    "@id" : 0,
+    "child" : 1,
+    "initialAllocation" : 1000000,
+    "maxAllocation" : 10000000000,
+    "cost" : {
+      "memoryCost" : 1.6777216E7,
+      "outputRowCount" : 5000.0
+    }
+  } ]
+}

--- a/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
@@ -24,20 +24,23 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.Types;
 
-public class BooleanOperator extends FunctionCall{
+public class BooleanOperator extends FunctionCall {
+
+  public static final String OR_FN = "booleanOr";
+  public static final String AND_FN = "booleanAnd";
 
   public BooleanOperator(String name, List<LogicalExpression> args, ExpressionPosition pos) {
     super(name, args, pos);
   }
 
   @Override
-  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E{
+  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
     return visitor.visitBooleanOperator(this, value);
   }
 
   @Override
   public MajorType getMajorType() {
-    // If any of argumgnet of a boolean "and"/"or" is nullable, the result is nullable bit.
+    // If any of argument of a boolean "and"/"or" is nullable, the result is nullable bit.
     // Otherwise, it's non-nullable bit.
     for (LogicalExpression e : args) {
       if (e.getMajorType().getMode() == DataMode.OPTIONAL) {
@@ -45,7 +48,6 @@ public class BooleanOperator extends FunctionCall{
       }
     }
     return Types.REQUIRED_BIT;
-
   }
 
   @Override
@@ -61,5 +63,4 @@ public class BooleanOperator extends FunctionCall{
 
     return cost / i;
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/FunctionCall.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FunctionCall.java
@@ -22,11 +22,21 @@ import java.util.List;
 
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos.MajorType;
-
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class FunctionCall extends LogicalExpressionBase implements Iterable<LogicalExpression> {
+
+  public static final String EQ_FN = "equal";
+  public static final String GT_FN = "greater_than";
+  public static final String NE_FN = "not_equal";
+  public static final String GE_FN = "greater_than_or_equal_to";
+  public static final String LT_FN = "less_than";
+  public static final String LE_FN = "less_than_or_equal_to";
+  public static final String LIKE_FN = "like";
+  public static final String IS_NULL = "isnull";
+  public static final String IS_NOT_NULL = "isnotnull";
+
   private final String name;
   public final ImmutableList<LogicalExpression> args;
   private final ExpressionPosition pos;
@@ -56,7 +66,7 @@ public class FunctionCall extends LogicalExpressionBase implements Iterable<Logi
   }
 
   @Override
-  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E{
+  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
     return visitor.visitFunctionCall(this, value);
   }
 
@@ -77,5 +87,4 @@ public class FunctionCall extends LogicalExpressionBase implements Iterable<Logi
     return "FunctionCall [func=" + name + ", args="
         + (args != null ? args.subList(0, Math.min(args.size(), maxLen)) : null) + ", pos=" + pos + "]";
   }
-
 }


### PR DESCRIPTION
Drill has an increasing number of storage plugins.
It turns out, many have the same boilerplate code
copy and pasted into each new plugin. This patch
provides a generic framework to allow easier creation
of storage plugins by abstracting out the
boilerplate.

Many storage plugins provide filter push-down,
again by copying a large amount of boilerplate
code from earlier plugins. This patch provides a
generic filter push-down framework that abstracts out
the common Drill/Calcite work, allowing the plugin
to implement just the functionality unique to that
plugin.

A "dummy" plugin shows how to use both frameworks and
acts as a "test mule" for the filter push-down framework.

Jira - [DRILL-7458](https://issues.apache.org/jira/browse/DRILL-7458).