### PR TITLE
DRILL-7469: Disable doclint for maven-javadoc-plugin

### DIFF
--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -343,6 +343,7 @@
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
               <exclude>io.netty:netty-tcnative:jar:*</exclude>
               <exclude>com.fasterxml.woodstox:woodstox-core:jar:*</exclude>
+              <exclude>dnsjava:dnsjava:jar:*</exclude>
             </excludes>
           </artifactSet>
           <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -929,6 +929,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.1.1</version>
+          <configuration>
+            <doclint>none</doclint>
+          </configuration>
         </plugin>
 
         <!--Note: apache-21.pom has the latest versions of apache-rat-plugin, maven-dependency-plugin and


### PR DESCRIPTION
Jira - [DRILL-7469](https://issues.apache.org/jira/browse/DRILL-7469).