### PR TITLE
DRILL-7471: DESCRIBE TABLE command fails with ClassCastException when Metastore is enabled

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeColumnUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/AnalyzeColumnUtils.java
@@ -21,6 +21,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.metastore.statistics.BaseStatisticsKind;
 import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
+import org.apache.drill.metastore.statistics.ExactStatisticsConstants;
 import org.apache.drill.metastore.statistics.StatisticsKind;
 import org.apache.drill.metastore.statistics.TableStatisticsKind;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
@@ -30,19 +31,19 @@ import java.util.Map;
 public class AnalyzeColumnUtils {
   private static final String COLUMN_SEPARATOR = "$";
 
-  public static final Map<StatisticsKind, SqlKind> COLUMN_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind, SqlKind>builder()
+  public static final Map<StatisticsKind<?>, SqlKind> COLUMN_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind<?>, SqlKind>builder()
       .put(ColumnStatisticsKind.MAX_VALUE, SqlKind.MAX)
       .put(ColumnStatisticsKind.MIN_VALUE, SqlKind.MIN)
-      .put(ColumnStatisticsKind.NON_NULL_COUNT, SqlKind.COUNT)
+      .put(ColumnStatisticsKind.NON_NULL_VALUES_COUNT, SqlKind.COUNT)
       .put(TableStatisticsKind.ROW_COUNT, SqlKind.COUNT)
       .build();
 
-  public static final Map<StatisticsKind, TypeProtos.MinorType> COLUMN_STATISTICS_TYPES = ImmutableMap.<StatisticsKind, TypeProtos.MinorType>builder()
-      .put(ColumnStatisticsKind.NON_NULL_COUNT, TypeProtos.MinorType.BIGINT)
+  public static final Map<StatisticsKind<?>, TypeProtos.MinorType> COLUMN_STATISTICS_TYPES = ImmutableMap.<StatisticsKind<?>, TypeProtos.MinorType>builder()
+      .put(ColumnStatisticsKind.NON_NULL_VALUES_COUNT, TypeProtos.MinorType.BIGINT)
       .put(TableStatisticsKind.ROW_COUNT, TypeProtos.MinorType.BIGINT)
       .build();
 
-  public static final Map<StatisticsKind, SqlKind> META_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind, SqlKind>builder()
+  public static final Map<StatisticsKind<?>, SqlKind> META_STATISTICS_FUNCTIONS = ImmutableMap.<StatisticsKind<?>, SqlKind>builder()
       .put(TableStatisticsKind.ROW_COUNT, SqlKind.COUNT)
       .build();
 
@@ -65,21 +66,21 @@ public class AnalyzeColumnUtils {
    * @param fullName the source of {@link StatisticsKind} to obtain
    * @return {@link StatisticsKind} instance
    */
-  public static StatisticsKind getStatisticsKind(String fullName) {
+  public static StatisticsKind<?> getStatisticsKind(String fullName) {
     String statisticsIdentifier = fullName.split("\\" + COLUMN_SEPARATOR)[1];
     switch (statisticsIdentifier) {
-      case "minValue":
+      case ExactStatisticsConstants.MIN_VALUE:
         return ColumnStatisticsKind.MIN_VALUE;
-      case "maxValue":
+      case ExactStatisticsConstants.MAX_VALUE:
         return ColumnStatisticsKind.MAX_VALUE;
-      case "nullsCount":
+      case ExactStatisticsConstants.NULLS_COUNT:
         return ColumnStatisticsKind.NULLS_COUNT;
-      case "nonnullrowcount":
-        return ColumnStatisticsKind.NON_NULL_COUNT;
-      case "rowCount":
+      case ExactStatisticsConstants.NON_NULL_VALUES_COUNT:
+        return ColumnStatisticsKind.NON_NULL_VALUES_COUNT;
+      case ExactStatisticsConstants.ROW_COUNT:
         return TableStatisticsKind.ROW_COUNT;
     }
-    return new BaseStatisticsKind(statisticsIdentifier, false);
+    return new BaseStatisticsKind<>(statisticsIdentifier, false);
   }
 
   /**
@@ -93,7 +94,7 @@ public class AnalyzeColumnUtils {
    * @param statisticsKind statistics kind
    * @return analyze-specific field name which includes actual column name and statistics kind information
    */
-  public static String getColumnStatisticsFieldName(String columnName, StatisticsKind statisticsKind) {
+  public static String getColumnStatisticsFieldName(String columnName, StatisticsKind<?> statisticsKind) {
     return String.format("column%1$s%2$s%1$s%3$s", COLUMN_SEPARATOR, statisticsKind.getName(), columnName);
   }
 
@@ -105,7 +106,7 @@ public class AnalyzeColumnUtils {
    * @param statisticsKind statistics kind
    * @return analyze-specific field name for metadata statistics
    */
-  public static String getMetadataStatisticsFieldName(StatisticsKind statisticsKind) {
+  public static String getMetadataStatisticsFieldName(StatisticsKind<?> statisticsKind) {
     return String.format("metadata%s%s", COLUMN_SEPARATOR, statisticsKind.getName());
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataControllerContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/MetadataControllerContext.java
@@ -44,6 +44,7 @@ public class MetadataControllerContext {
   private final List<MetadataInfo> metadataToHandle;
   private final List<MetadataInfo> metadataToRemove;
   private final MetadataType analyzeMetadataLevel;
+  private final boolean multiValueSegments;
 
   private MetadataControllerContext(MetadataControllerContextBuilder builder) {
     this.tableInfo = builder.tableInfo;
@@ -54,6 +55,7 @@ public class MetadataControllerContext {
     this.metadataToHandle = builder.metadataToHandle;
     this.metadataToRemove = builder.metadataToRemove;
     this.analyzeMetadataLevel = builder.analyzeMetadataLevel;
+    this.multiValueSegments = builder.multiValueSegments;
   }
 
   @JsonProperty
@@ -96,6 +98,18 @@ public class MetadataControllerContext {
     return analyzeMetadataLevel;
   }
 
+  /**
+   * Specifies whether metadata controller should create segments with multiple partition values.
+   * For example, Hive partitions contain multiple partition values within the same segment.
+   *
+   * @return {@code true} if metadata controller should create segments with multiple partition values,
+   * {@code false} otherwise
+   */
+  @JsonProperty
+  public boolean multiValueSegments() {
+    return multiValueSegments;
+  }
+
   @Override
   public String toString() {
     return new StringJoiner(",\n", MetadataControllerContext.class.getSimpleName() + "[", "]")
@@ -123,6 +137,7 @@ public class MetadataControllerContext {
     private List<MetadataInfo> metadataToHandle;
     private List<MetadataInfo> metadataToRemove;
     private MetadataType analyzeMetadataLevel;
+    private boolean multiValueSegments;
 
     public MetadataControllerContextBuilder tableInfo(TableInfo tableInfo) {
       this.tableInfo = tableInfo;
@@ -161,6 +176,11 @@ public class MetadataControllerContext {
 
     public MetadataControllerContextBuilder analyzeMetadataLevel(MetadataType metadataType) {
       this.analyzeMetadataLevel = metadataType;
+      return this;
+    }
+
+    public MetadataControllerContextBuilder multiValueSegments(boolean multiValueSegments) {
+      this.multiValueSegments = multiValueSegments;
       return this;
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
@@ -263,7 +263,7 @@ public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHand
     baseMetadata.getColumnsStatistics().entrySet().stream()
         .sorted(Comparator.comparing(e -> e.getKey().getRootSegmentPath()))
         .forEach(entry -> {
-          for (StatisticsKind statisticsKind : AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet()) {
+          for (StatisticsKind<?> statisticsKind : AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet()) {
             MinorType type = AnalyzeColumnUtils.COLUMN_STATISTICS_TYPES.get(statisticsKind);
             type = type != null ? type : entry.getValue().getComparatorType();
             schemaBuilder.addNullable(
@@ -272,7 +272,7 @@ public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHand
           }
         });
 
-    for (StatisticsKind statisticsKind : AnalyzeColumnUtils.META_STATISTICS_FUNCTIONS.keySet()) {
+    for (StatisticsKind<?> statisticsKind : AnalyzeColumnUtils.META_STATISTICS_FUNCTIONS.keySet()) {
       schemaBuilder.addNullable(
           AnalyzeColumnUtils.getMetadataStatisticsFieldName(statisticsKind),
           AnalyzeColumnUtils.COLUMN_STATISTICS_TYPES.get(statisticsKind));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertMetadataAggregateToDirectScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ConvertMetadataAggregateToDirectScanRule.java
@@ -201,16 +201,16 @@ public class ConvertMetadataAggregateToDirectScanRule extends RelOptRule {
 
       // populates record list with row group column metadata
       for (SchemaPath schemaPath : interestingColumns) {
-        ColumnStatistics columnStatistics = rowGroupMetadata.getColumnsStatistics().get(schemaPath);
+        ColumnStatistics<?> columnStatistics = rowGroupMetadata.getColumnsStatistics().get(schemaPath);
         if (IsPredicate.isNullOrEmpty(columnStatistics)) {
           logger.debug("Statistics for {} column wasn't found within {} row group.", schemaPath, path);
           return null;
         }
-        for (StatisticsKind statisticsKind : AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet()) {
+        for (StatisticsKind<?> statisticsKind : AnalyzeColumnUtils.COLUMN_STATISTICS_FUNCTIONS.keySet()) {
           Object statsValue;
           if (statisticsKind.getName().equalsIgnoreCase(TableStatisticsKind.ROW_COUNT.getName())) {
             statsValue = TableStatisticsKind.ROW_COUNT.getValue(rowGroupMetadata);
-          } else if (statisticsKind.getName().equalsIgnoreCase(ColumnStatisticsKind.NON_NULL_COUNT.getName())) {
+          } else if (statisticsKind.getName().equalsIgnoreCase(ColumnStatisticsKind.NON_NULL_VALUES_COUNT.getName())) {
             statsValue = TableStatisticsKind.ROW_COUNT.getValue(rowGroupMetadata) - ColumnStatisticsKind.NULLS_COUNT.getFrom(columnStatistics);
           } else {
             statsValue = columnStatistics.get(statisticsKind);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.ischema;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode.Type;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
@@ -45,6 +46,8 @@ public class InfoSchemaFilter {
     return exprRoot;
   }
 
+  // include type-info to be able to deserialize subclasses correctly
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
   public static class ExprNode {
     @JsonProperty
     public Type type;
@@ -68,7 +71,8 @@ public class InfoSchemaFilter {
     public List<ExprNode> args;
 
     @JsonCreator
-    public FunctionExprNode(String function, List<ExprNode> args) {
+    public FunctionExprNode(@JsonProperty("function") String function,
+        @JsonProperty("args") List<ExprNode> args) {
       super(Type.FUNCTION);
       this.function = function;
       this.args = args;
@@ -90,7 +94,7 @@ public class InfoSchemaFilter {
     public String field;
 
     @JsonCreator
-    public FieldExprNode(String field) {
+    public FieldExprNode(@JsonProperty("field") String field) {
       super(Type.FIELD);
       this.field = field;
     }
@@ -106,7 +110,7 @@ public class InfoSchemaFilter {
     public String value;
 
     @JsonCreator
-    public ConstantExprNode(String value) {
+    public ConstantExprNode(@JsonProperty("value") String value) {
       super(Type.CONSTANT);
       this.value = value;
     }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/ColumnStatisticsKind.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/ColumnStatisticsKind.java
@@ -92,7 +92,25 @@ public class ColumnStatisticsKind<T> extends BaseStatisticsKind<T> implements Co
       };
 
   /**
-   * Column statistics kind which represents number of non-null values for the specific column.
+   * Column statistics kind which represents exact number of non-null values for the specific column.
+   */
+  public static final ColumnStatisticsKind<Long> NON_NULL_VALUES_COUNT =
+      new ColumnStatisticsKind<Long>(ExactStatisticsConstants.NON_NULL_VALUES_COUNT, true) {
+        @Override
+        public Long mergeStatistics(List<? extends ColumnStatistics> statisticsList) {
+          long nonNullRowCount = 0;
+          for (ColumnStatistics<?> statistics : statisticsList) {
+            Long nnRowCount = statistics.get(this);
+            if (nnRowCount != null) {
+              nonNullRowCount += nnRowCount;
+            }
+          }
+          return nonNullRowCount;
+        }
+      };
+
+  /**
+   * Column statistics kind which represents estimated number of non-null values for the specific column.
    */
   public static final ColumnStatisticsKind<Double> NON_NULL_COUNT =
       new ColumnStatisticsKind<Double>(Statistic.NNROWCOUNT, false) {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/ExactStatisticsConstants.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/statistics/ExactStatisticsConstants.java
@@ -22,6 +22,7 @@ public interface ExactStatisticsConstants {
   String MAX_VALUE = "maxValue";
   String ROW_COUNT = "rowCount";
   String NULLS_COUNT = "nullsCount";
+  String NON_NULL_VALUES_COUNT = "nonNullValuesCount";
 
   String START = "start";
   String LENGTH = "length";


### PR DESCRIPTION
Please refer to [DRILL-7471](https://issues.apache.org/jira/browse/DRILL-7471) for details.