### PR TITLE
DRILL-7476: Set lastSet on TransferPair copies

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DrillClient.java
@@ -112,8 +112,8 @@ public class DrillClient implements Closeable, ConnectionThrottle {
   private volatile ClusterCoordinator clusterCoordinator;
   private volatile boolean connected = false;
   private final BufferAllocator allocator;
-  private int reconnectTimes;
-  private int reconnectDelay;
+  private final int reconnectTimes;
+  private final int reconnectDelay;
   private boolean supportComplexTypes;
   private final boolean ownsZkConnection;
   private final boolean ownsAllocator;
@@ -862,7 +862,7 @@ public class DrillClient implements Closeable, ConnectionThrottle {
 
     @Override
     public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
-      logger.debug("Result arrived:  Result: {}", result );
+      logger.debug("Result arrived:  Result: {}", result);
       results.add(result);
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
@@ -41,7 +41,7 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
 public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
   private static final Logger logger = LoggerFactory.getLogger(LimitRecordBatch.class);
 
-  private SelectionVector2 outgoingSv;
+  private final SelectionVector2 outgoingSv;
   private SelectionVector2 incomingSv;
 
   // Start offset of the records
@@ -234,7 +234,8 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
     outgoingSv.setRecordCount(svIndex);
     outgoingSv.setBatchActualRecordCount(inputRecordCount);
     // Actual number of values in the container; not the number in
-    // the SV.
+    // the SV. Set record count, not value count. Value count is
+    // carried over from input vectors.
     container.setRecordCount(inputRecordCount);
     // Update the start offset
     recordStartOffset = 0;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -206,7 +206,7 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
       stats.addLongStat(Metric.BYTES_RECEIVED, batch.getByteCount());
 
       batch.release();
-      if(schemaChanged) {
+      if (schemaChanged) {
         this.schema = batchLoader.getSchema();
         stats.batchReceived(0, rbd.getRecordCount(), true);
         lastOutcome = IterOutcome.OK_NEW_SCHEMA;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/FragmentWritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/FragmentWritableBatch.java
@@ -23,25 +23,36 @@ import org.apache.drill.exec.proto.BitData.FragmentRecordBatch;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.RecordBatchDef;
 
-public class FragmentWritableBatch{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentWritableBatch.class);
+public class FragmentWritableBatch {
 
   private static RecordBatchDef EMPTY_DEF = RecordBatchDef.newBuilder().setRecordCount(0).build();
 
   private final ByteBuf[] buffers;
   private final FragmentRecordBatch header;
 
-  public FragmentWritableBatch(final boolean isLast, final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId, final int receiveMajorFragmentId, final int receiveMinorFragmentId, final WritableBatch batch){
-    this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId, new int[]{receiveMinorFragmentId}, batch.getDef(), batch.getBuffers());
+  public FragmentWritableBatch(boolean isLast, QueryId queryId,
+      int sendMajorFragmentId, int sendMinorFragmentId,
+      int receiveMajorFragmentId, int receiveMinorFragmentId,
+      WritableBatch batch){
+    this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId,
+        new int[]{receiveMinorFragmentId}, batch.getDef(), batch.getBuffers());
   }
 
-  public FragmentWritableBatch(final boolean isLast, final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId, final int receiveMajorFragmentId, final int[] receiveMinorFragmentIds, final WritableBatch batch){
-    this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId, receiveMinorFragmentIds, batch.getDef(), batch.getBuffers());
+  public FragmentWritableBatch(boolean isLast, QueryId queryId,
+      int sendMajorFragmentId, int sendMinorFragmentId,
+      int receiveMajorFragmentId, int[] receiveMinorFragmentIds,
+      WritableBatch batch){
+    this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId,
+        receiveMajorFragmentId, receiveMinorFragmentIds, batch.getDef(),
+        batch.getBuffers());
   }
 
-  private FragmentWritableBatch(final boolean isLast, final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId, final int receiveMajorFragmentId, final int[] receiveMinorFragmentId, final RecordBatchDef def, final ByteBuf... buffers){
+  private FragmentWritableBatch(boolean isLast, QueryId queryId,
+      int sendMajorFragmentId, int sendMinorFragmentId,
+      int receiveMajorFragmentId, int[] receiveMinorFragmentId,
+      RecordBatchDef def, ByteBuf... buffers){
     this.buffers = buffers;
-    final FragmentRecordBatch.Builder builder = FragmentRecordBatch.newBuilder()
+    FragmentRecordBatch.Builder builder = FragmentRecordBatch.newBuilder()
         .setIsLastBatch(isLast)
         .setDef(def)
         .setQueryId(queryId)
@@ -49,39 +60,50 @@ public class FragmentWritableBatch{
         .setSendingMajorFragmentId(sendMajorFragmentId)
         .setSendingMinorFragmentId(sendMinorFragmentId);
 
-    for(final int i : receiveMinorFragmentId){
+    for(int i : receiveMinorFragmentId){
       builder.addReceivingMinorFragmentId(i);
     }
 
     this.header = builder.build();
   }
 
-
-  public static FragmentWritableBatch getEmptyLast(final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId, final int receiveMajorFragmentId, final int receiveMinorFragmentId){
-    return getEmptyLast(queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId, new int[]{receiveMinorFragmentId});
+  public static FragmentWritableBatch getEmptyLast(QueryId queryId,
+      int sendMajorFragmentId, int sendMinorFragmentId,
+      int receiveMajorFragmentId, int receiveMinorFragmentId){
+    return getEmptyLast(queryId, sendMajorFragmentId, sendMinorFragmentId,
+        receiveMajorFragmentId, new int[]{receiveMinorFragmentId});
   }
 
-  public static FragmentWritableBatch getEmptyLast(final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId, final int receiveMajorFragmentId, final int[] receiveMinorFragmentIds){
-    return new FragmentWritableBatch(true, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId, receiveMinorFragmentIds, EMPTY_DEF);
+  public static FragmentWritableBatch getEmptyLast(QueryId queryId,
+      int sendMajorFragmentId, int sendMinorFragmentId,
+      int receiveMajorFragmentId, int[] receiveMinorFragmentIds){
+    return new FragmentWritableBatch(true, queryId, sendMajorFragmentId,
+        sendMinorFragmentId, receiveMajorFragmentId, receiveMinorFragmentIds,
+        EMPTY_DEF);
   }
 
-
-  public static FragmentWritableBatch getEmptyLastWithSchema(final QueryId queryId, final int sendMajorFragmentId, final int sendMinorFragmentId,
-                                                             final int receiveMajorFragmentId, final int receiveMinorFragmentId, final BatchSchema schema){
-    return getEmptyBatchWithSchema(true, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId,
+  public static FragmentWritableBatch getEmptyLastWithSchema(
+      QueryId queryId, int sendMajorFragmentId,
+      int sendMinorFragmentId, int receiveMajorFragmentId,
+      int receiveMinorFragmentId, BatchSchema schema){
+    return getEmptyBatchWithSchema(true, queryId, sendMajorFragmentId,
+        sendMinorFragmentId, receiveMajorFragmentId,
         receiveMinorFragmentId, schema);
   }
 
-  public static FragmentWritableBatch getEmptyBatchWithSchema(final boolean isLast, final QueryId queryId, final int sendMajorFragmentId,
-      final int sendMinorFragmentId, final int receiveMajorFragmentId, final int receiveMinorFragmentId, final BatchSchema schema){
+  public static FragmentWritableBatch getEmptyBatchWithSchema(
+      boolean isLast, QueryId queryId, int sendMajorFragmentId,
+      int sendMinorFragmentId, int receiveMajorFragmentId,
+      int receiveMinorFragmentId, BatchSchema schema){
 
-    final RecordBatchDef.Builder def = RecordBatchDef.newBuilder();
+    RecordBatchDef.Builder def = RecordBatchDef.newBuilder();
     if (schema != null) {
-      for (final MaterializedField field : schema) {
+      for (MaterializedField field : schema) {
         def.addField(field.getSerializedField());
       }
     }
-    return new FragmentWritableBatch(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId,
+    return new FragmentWritableBatch(isLast, queryId, sendMajorFragmentId,
+        sendMinorFragmentId, receiveMajorFragmentId,
         new int[] { receiveMinorFragmentId }, def.build());
   }
 
@@ -91,7 +113,7 @@ public class FragmentWritableBatch{
 
   public long getByteCount() {
     long n = 0;
-    for (final ByteBuf buf : buffers) {
+    for (ByteBuf buf : buffers) {
       n += buf.readableBytes();
     }
     return n;
@@ -99,11 +121,5 @@ public class FragmentWritableBatch{
 
   public FragmentRecordBatch getHeader() {
     return header;
-
   }
-
-
-
-
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/FragmentWritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/FragmentWritableBatch.java
@@ -33,7 +33,7 @@ public class FragmentWritableBatch {
   public FragmentWritableBatch(boolean isLast, QueryId queryId,
       int sendMajorFragmentId, int sendMinorFragmentId,
       int receiveMajorFragmentId, int receiveMinorFragmentId,
-      WritableBatch batch){
+      WritableBatch batch) {
     this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId, receiveMajorFragmentId,
         new int[]{receiveMinorFragmentId}, batch.getDef(), batch.getBuffers());
   }
@@ -41,7 +41,7 @@ public class FragmentWritableBatch {
   public FragmentWritableBatch(boolean isLast, QueryId queryId,
       int sendMajorFragmentId, int sendMinorFragmentId,
       int receiveMajorFragmentId, int[] receiveMinorFragmentIds,
-      WritableBatch batch){
+      WritableBatch batch) {
     this(isLast, queryId, sendMajorFragmentId, sendMinorFragmentId,
         receiveMajorFragmentId, receiveMinorFragmentIds, batch.getDef(),
         batch.getBuffers());
@@ -50,7 +50,7 @@ public class FragmentWritableBatch {
   private FragmentWritableBatch(boolean isLast, QueryId queryId,
       int sendMajorFragmentId, int sendMinorFragmentId,
       int receiveMajorFragmentId, int[] receiveMinorFragmentId,
-      RecordBatchDef def, ByteBuf... buffers){
+      RecordBatchDef def, ByteBuf... buffers) {
     this.buffers = buffers;
     FragmentRecordBatch.Builder builder = FragmentRecordBatch.newBuilder()
         .setIsLastBatch(isLast)
@@ -60,8 +60,8 @@ public class FragmentWritableBatch {
         .setSendingMajorFragmentId(sendMajorFragmentId)
         .setSendingMinorFragmentId(sendMinorFragmentId);
 
-    for(int i : receiveMinorFragmentId){
-      builder.addReceivingMinorFragmentId(i);
+    for (int fragmentId : receiveMinorFragmentId) {
+      builder.addReceivingMinorFragmentId(fragmentId);
     }
 
     this.header = builder.build();
@@ -69,14 +69,14 @@ public class FragmentWritableBatch {
 
   public static FragmentWritableBatch getEmptyLast(QueryId queryId,
       int sendMajorFragmentId, int sendMinorFragmentId,
-      int receiveMajorFragmentId, int receiveMinorFragmentId){
+      int receiveMajorFragmentId, int receiveMinorFragmentId) {
     return getEmptyLast(queryId, sendMajorFragmentId, sendMinorFragmentId,
         receiveMajorFragmentId, new int[]{receiveMinorFragmentId});
   }
 
   public static FragmentWritableBatch getEmptyLast(QueryId queryId,
       int sendMajorFragmentId, int sendMinorFragmentId,
-      int receiveMajorFragmentId, int[] receiveMinorFragmentIds){
+      int receiveMajorFragmentId, int[] receiveMinorFragmentIds) {
     return new FragmentWritableBatch(true, queryId, sendMajorFragmentId,
         sendMinorFragmentId, receiveMajorFragmentId, receiveMinorFragmentIds,
         EMPTY_DEF);
@@ -85,7 +85,7 @@ public class FragmentWritableBatch {
   public static FragmentWritableBatch getEmptyLastWithSchema(
       QueryId queryId, int sendMajorFragmentId,
       int sendMinorFragmentId, int receiveMajorFragmentId,
-      int receiveMinorFragmentId, BatchSchema schema){
+      int receiveMinorFragmentId, BatchSchema schema) {
     return getEmptyBatchWithSchema(true, queryId, sendMajorFragmentId,
         sendMinorFragmentId, receiveMajorFragmentId,
         receiveMinorFragmentId, schema);
@@ -94,7 +94,7 @@ public class FragmentWritableBatch {
   public static FragmentWritableBatch getEmptyBatchWithSchema(
       boolean isLast, QueryId queryId, int sendMajorFragmentId,
       int sendMinorFragmentId, int receiveMajorFragmentId,
-      int receiveMinorFragmentId, BatchSchema schema){
+      int receiveMinorFragmentId, BatchSchema schema) {
 
     RecordBatchDef.Builder def = RecordBatchDef.newBuilder();
     if (schema != null) {
@@ -107,7 +107,7 @@ public class FragmentWritableBatch {
         new int[] { receiveMinorFragmentId }, def.build());
   }
 
-  public ByteBuf[] getBuffers(){
+  public ByteBuf[] getBuffers() {
     return buffers;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
@@ -163,8 +163,11 @@ public class WritableBatch implements AutoCloseable {
       vv.clear();
     }
 
-    RecordBatchDef batchDef = RecordBatchDef.newBuilder().addAllField(metadata).setRecordCount(recordCount)
-        .setCarriesTwoByteSelectionVector(isSV2).build();
+    RecordBatchDef batchDef = RecordBatchDef.newBuilder()
+        .addAllField(metadata)
+        .setRecordCount(recordCount)
+        .setCarriesTwoByteSelectionVector(isSV2)
+        .build();
     WritableBatch b = new WritableBatch(batchDef, buffers);
     return b;
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -86,7 +86,7 @@ public class QueryBuilder {
     private QueryId queryId;
     private int recordCount;
     private int batchCount;
-    private long startTime;
+    private final long startTime;
 
     public SummaryOnlyQueryEventListener(QuerySummaryFuture future) {
       this.future = future;
@@ -132,7 +132,7 @@ public class QueryBuilder {
      * launched the query.
      */
 
-    private CountDownLatch lock = new CountDownLatch(1);
+    private final CountDownLatch lock = new CountDownLatch(1);
     private QuerySummary summary;
 
     /**
@@ -373,7 +373,7 @@ public class QueryBuilder {
 
     // Unload the batch and convert to a row set.
 
-    final RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
+    RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
     try {
       loader.load(resultBatch.getHeader().getDef(), resultBatch.getData());
       resultBatch.release();
@@ -760,18 +760,18 @@ public class QueryBuilder {
    */
   private String queryPlan(String columnName) throws Exception {
     Preconditions.checkArgument(queryType == QueryType.SQL, "Can only explain an SQL query.");
-    final List<QueryDataBatch> results = results();
-    final RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
-    final StringBuilder builder = new StringBuilder();
+    List<QueryDataBatch> results = results();
+    RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
+    StringBuilder builder = new StringBuilder();
 
-    for (final QueryDataBatch b : results) {
+    for (QueryDataBatch b : results) {
       if (!b.hasData()) {
         continue;
       }
 
       loader.load(b.getHeader().getDef(), b.getData());
 
-      final VectorWrapper<?> vw;
+      VectorWrapper<?> vw;
       try {
           vw = loader.getValueAccessorById(
               NullableVarCharVector.class,
@@ -780,9 +780,9 @@ public class QueryBuilder {
         throw new IllegalStateException("Looks like you did not provide an explain plan query, please add EXPLAIN PLAN FOR to the beginning of your query.");
       }
 
-      final ValueVector vv = vw.getValueVector();
+      ValueVector vv = vw.getValueVector();
       for (int i = 0; i < vv.getAccessor().getValueCount(); i++) {
-        final Object o = vv.getAccessor().getObject(i);
+        Object o = vv.getAccessor().getObject(i);
         builder.append(o);
       }
       loader.clear();

--- a/exec/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/exec/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -299,6 +299,15 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     int bitsLength = bitsField.getBufferLength();
     SerializedField valuesField = metadata.getChild(1);
     values.load(valuesField, buffer.slice(bitsLength, capacity - bitsLength));
+    <#if type.major == "VarLen">
+
+    // Though a loaded vector should be read only,
+    // it can have its values set such as when copying
+    // with transfer pairs. Since lastSet is used when
+    // setting values, it must be set on vector load.
+
+    mutator.lastSet = accessor.getValueCount() - 1;
+    </#if>
   }
 
   @Override


### PR DESCRIPTION
Variable-width nullable vectors maintain a "lastSet" field in the mutator. This field is used in "fill empties" logic when setting the vector's value count. This is true even if the vector is read-only, or has been transferred from another (read-only) vector. LastSet must be set to the row count or the code will helpfully overwrite existing offsets with 0.

Added batch validation code to catch this problem should it happen again.

Includes minor code cleanup in files visited during debugging.