### PR TITLE
DRILL-7482: Fix missing artifact and overlapping classes warnings in Drill build

### DIFF
--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -92,6 +92,8 @@
           <artifactSet>
             <includes>
               <include>org.apache.hive:hive-exec</include>
+              <!-- Provides custom version of parquet-hadoop-bundle instead of the shaded one
+                to be able to use version with some critical fixes like PARQUET-363 -->
               <include>org.apache.parquet:parquet-hadoop-bundle</include>
               <include>commons-codec:commons-codec</include>
               <include>com.fasterxml.jackson.core:jackson-databind</include>
@@ -154,7 +156,8 @@
                 <!-- This exclusion can be removed once hive-exec uses parquet-hadoop-bundle 1.8.2 or higher.
                  It can be so, for example, after upgrading Hive to 3.0. To check if it's safe to remove the exclusion
                  you can use TestHiveStorage.readFromAlteredPartitionedTableWithEmptyGroupType() test case. -->
-                <exclude>org/apache/parquet/schema/*</exclude>
+                <exclude>org/apache/parquet/**</exclude>
+                <exclude>shaded/parquet/org/**</exclude>
               </excludes>
             </filter>
           </filters>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -343,6 +343,9 @@
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
               <exclude>io.netty:netty-tcnative:jar:*</exclude>
               <exclude>com.fasterxml.woodstox:woodstox-core:jar:*</exclude>
+              <exclude>com.google.code.findbugs:jsr305:*</exclude>
+              <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
+              <exclude>fr.bmartel:pcapngdecoder:*</exclude>
               <exclude>dnsjava:dnsjava:jar:*</exclude>
             </excludes>
           </artifactSet>
@@ -506,6 +509,8 @@
              <artifact>org.apache.calcite.avatica:*</artifact>
              <excludes>
                <exclude>META-INF/services/java.sql.Driver</exclude>
+               <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
+               <exclude>org/slf4j/**</exclude>
              </excludes>
            </filter>
          </filters>
@@ -670,6 +675,9 @@
                     <exclude>commons-io:commons-io</exclude>
                     <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
                     <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
+                    <exclude>com.google.code.findbugs:jsr305:*</exclude>
+                    <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
+                    <exclude>fr.bmartel:pcapngdecoder:*</exclude>
                   </excludes>
                 </artifactSet>
                 <relocations>
@@ -817,6 +825,8 @@
                     <artifact>org.apache.calcite.avatica:*</artifact>
                     <excludes>
                       <exclude>META-INF/services/java.sql.Driver</exclude>
+                      <!-- Excludes shaded slf4j to avoid conflicts when they are put into the fat jar -->
+                      <exclude>org/slf4j/**</exclude>
                     </excludes>
                   </filter>
                 </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <protobuf.version>3.6.1</protobuf.version>
     <codemodel.version>2.6</codemodel.version>
     <joda.version>2.10.5</joda.version>
+    <javax.el.version>3.0.0</javax.el.version>
   </properties>
 
   <scm>
@@ -1817,6 +1818,16 @@
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${joda.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.el</groupId>
+        <artifactId>javax.el-api</artifactId>
+        <version>${javax.el.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>${javax.el.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Jira - [DRILL-7482](https://issues.apache.org/jira/browse/DRILL-7482)

- Added `javax.el` into dependency management block with specifying the version to avoid searching SNAPSHOT versions since some dependencies specify their version range.
- Excluded `com.google.code.findbugs:jsr305` from `jdbc-all` jar since all required annotations are present in `com.google.code.findbugs:annotations` jar.
- Excluded `org.slf4j`classes shaded in `org.apache.calcite.avatica` jar from `jdbc-all`.
- Completely excluded `parquet-hadoop-bundle` shaded  in `hive-exec` to use the version provided by Drill in `drill-hive-exec-shaded`.