### PR TITLE
DRILL-7487: Removes the unused OUT_OF_MEMORY iterator status

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -36,6 +36,7 @@ import org.apache.drill.exec.ops.QueryContext.SqlStatementType;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.proto.ExecProtos;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.testing.ExecutionControls;
 import org.apache.drill.exec.work.filter.RuntimeFilterWritable;
@@ -200,6 +201,15 @@ public interface FragmentContext extends UdfUtilities, AutoCloseable {
    * @return Metastore registry
    */
   MetastoreRegistry getMetastoreRegistry();
+
+  /**
+   * An operator is experiencing memory pressure. Asks the fragment
+   * executor to poll all operators to release an optional memory
+   * (such as by spilling.) The request is advisory. The caller should
+   * again try to allocate memory, and if the second request fails,
+   * throw an <code>OutOfMemoryException</code>.
+   */
+  void requestMemory(RecordBatch requestor);
 
   interface ExecutorState {
     /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContextImpl.java
@@ -54,6 +54,7 @@ import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.rpc.RpcException;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.rpc.UserClientConnection;
@@ -74,36 +75,46 @@ import org.apache.drill.exec.work.filter.RuntimeFilterWritable;
 import org.apache.drill.metastore.MetastoreRegistry;
 import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * <p>
- *   This is the core Context which implements all the Context interfaces:
+ * This is the core Context which implements all the Context interfaces:
  *
- *   <ul>
- *     <li>{@link FragmentContext}: A context provided to non-exchange operators.</li>
- *     <li>{@link ExchangeFragmentContext}: A context provided to exchange operators.</li>
- *     <li>{@link RootFragmentContext}: A context provided to fragment roots.</li>
- *     <li>{@link ExecutorFragmentContext}: A context used by the Drillbit.</li>
- *   </ul>
+ * <ul>
+ * <li>{@link FragmentContext}: A context provided to non-exchange
+ * operators.</li>
+ * <li>{@link ExchangeFragmentContext}: A context provided to exchange
+ * operators.</li>
+ * <li>{@link RootFragmentContext}: A context provided to fragment roots.</li>
+ * <li>{@link ExecutorFragmentContext}: A context used by the Drillbit.</li>
+ * </ul>
  *
- *   The interfaces above expose resources to varying degrees. They are ordered from most restrictive ({@link FragmentContext})
- *   to least restrictive ({@link ExecutorFragmentContext}).
+ * The interfaces above expose resources to varying degrees. They are ordered
+ * from most restrictive ({@link FragmentContext}) to least restrictive
+ * ({@link ExecutorFragmentContext}).
  * </p>
  * <p>
- *   Since {@link FragmentContextImpl} implements all of the interfaces listed above, the facade pattern is used in order
- *   to cast a {@link FragmentContextImpl} object to the desired interface where-ever it is needed. The facade pattern
- *   is powerful since it allows us to easily create minimal context objects to be used in unit tests. Without
- *   the use of interfaces and the facade pattern we would have to create a complete {@link FragmentContextImpl} object
- *   to unit test any part of the code that depends on a context.
+ * Since {@link FragmentContextImpl} implements all of the interfaces listed
+ * above, the facade pattern is used in order to cast a
+ * {@link FragmentContextImpl} object to the desired interface where-ever it is
+ * needed. The facade pattern is powerful since it allows us to easily create
+ * minimal context objects to be used in unit tests. Without the use of
+ * interfaces and the facade pattern we would have to create a complete
+ * {@link FragmentContextImpl} object to unit test any part of the code that
+ * depends on a context.
  * </p>
  * <p>
- *  <b>General guideline:</b> Use the most narrow interface for the task. For example, "internal" operators don't need visibility to the networking functionality.
- *  Using the narrow interface allows unit testing without using mocking libraries. Often, the surrounding structure already has exposed the most narrow interface. If there are
- *  opportunities to clean up older code, we can do so as needed to make testing easier.
+ * <b>General guideline:</b> Use the most narrow interface for the task. For
+ * example, "internal" operators don't need visibility to the networking
+ * functionality. Using the narrow interface allows unit testing without using
+ * mocking libraries. Often, the surrounding structure already has exposed the
+ * most narrow interface. If there are opportunities to clean up older code, we
+ * can do so as needed to make testing easier.
  * </p>
  */
 public class FragmentContextImpl extends BaseFragmentContext implements ExecutorFragmentContext {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentContextImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(FragmentContextImpl.class);
 
   private final Map<DrillbitEndpoint, AccountingDataTunnel> tunnels = new HashMap<>();
   private final List<OperatorContextImpl> contexts = new LinkedList<>();
@@ -120,8 +131,8 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   private final BufferManager bufferManager;
   private ExecutorState executorState;
   private final ExecutionControls executionControls;
-  private boolean enableRuntimeFilter;
-  private boolean enableRFWaiting;
+  private final boolean enableRuntimeFilter;
+  private final boolean enableRFWaiting;
   private Lock lock4RF;
   private Condition condition4RF;
 
@@ -145,8 +156,8 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   private final AccountingUserConnection accountingUserConnection;
   /** Stores constants and their holders by type */
   private final Map<String, Map<MinorType, ValueHolder>> constantValueHolderCache;
-  private Map<Long, RuntimeFilterWritable> rfIdentifier2RFW = new ConcurrentHashMap<>();
-  private Map<Long, Boolean> rfIdentifier2fetched = new ConcurrentHashMap<>();
+  private final Map<Long, RuntimeFilterWritable> rfIdentifier2RFW = new ConcurrentHashMap<>();
+  private final Map<Long, Boolean> rfIdentifier2fetched = new ConcurrentHashMap<>();
 
   /**
    * Create a FragmentContext instance for non-root fragment.
@@ -624,5 +635,16 @@ public class FragmentContextImpl extends BaseFragmentContext implements Executor
   @Override
   public MetastoreRegistry getMetastoreRegistry() {
     return context.getMetastoreRegistry();
+  }
+
+  @Override
+  public void requestMemory(RecordBatch requestor) {
+    // Does not actually do anything yet. Should ask the fragment
+    // executor to talk the tree, except for the given batch,
+    // and request the operator free up memory. Then, if the
+    // requestor is above its allocator limit, increase that
+    // limit. Since this operation is purely optional, we leave
+    // it as a stub for now. (No operator ever actually used the
+    // old OUT_OF_MEMORY iterator status that this method replaces.)
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
@@ -83,8 +83,6 @@ public class ScreenCreator implements RootCreator<Screen> {
       IterOutcome outcome = next(incoming);
       logger.trace("Screen Outcome {}", outcome);
       switch (outcome) {
-      case OUT_OF_MEMORY:
-        throw new OutOfMemoryException();
       case STOP:
         return false;
       case NONE:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/SingleSenderCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/SingleSenderCreator.java
@@ -49,10 +49,10 @@ public class SingleSenderCreator implements RootCreator<SingleSender>{
 
     private final FragmentHandle oppositeHandle;
 
-    private RecordBatch incoming;
+    private final RecordBatch incoming;
     private AccountingDataTunnel tunnel;
-    private FragmentHandle handle;
-    private int recMajor;
+    private final FragmentHandle handle;
+    private final int recMajor;
     private volatile boolean ok = true;
     private volatile boolean done = false;
 
@@ -95,10 +95,7 @@ public class SingleSenderCreator implements RootCreator<SingleSender>{
         incoming.kill(true);
         out = IterOutcome.NONE;
       }
-//      logger.debug("Outcome of sender next {}", out);
       switch (out) {
-      case OUT_OF_MEMORY:
-        throw new OutOfMemoryException();
       case STOP:
       case NONE:
         // if we didn't do anything yet, send an empty schema.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/StatisticsWriterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/StatisticsWriterRecordBatch.java
@@ -96,7 +96,6 @@ public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
         upstream = next(incoming);
 
         switch(upstream) {
-          case OUT_OF_MEMORY:
           case STOP:
             return upstream;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
@@ -94,7 +94,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   private BatchSchema schema;
   private boolean schemaChanged = false;
   private PriorityQueue priorityQueue;
-  private TopN config;
+  private final TopN config;
   private SelectionVector4 sv4;
   private long countSincePurge;
   private int batchCount;
@@ -155,9 +155,6 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
         return;
       case STOP:
         state = BatchState.STOP;
-        return;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
         return;
       case NONE:
         state = BatchState.DONE;
@@ -221,7 +218,6 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
           break outer;
         case NOT_YET:
           throw new UnsupportedOperationException();
-        case OUT_OF_MEMORY:
         case STOP:
           return lastKnownOutcome;
         case OK_NEW_SCHEMA:
@@ -663,7 +659,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   }
 
   public static class SimpleSV4RecordBatch extends SimpleRecordBatch {
-    private SelectionVector4 sv4;
+    private final SelectionVector4 sv4;
 
     public SimpleSV4RecordBatch(VectorContainer container, SelectionVector4 sv4, FragmentContext context) {
       super(container, context);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
@@ -90,7 +90,6 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
         upstream = next(incoming);
 
         switch(upstream) {
-          case OUT_OF_MEMORY:
           case STOP:
             return upstream;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
@@ -99,7 +99,7 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
   private boolean firstBatch = true;
 
   // This map saves the mapping between outgoing column and incoming column.
-  private Map<String, String> columnMapping;
+  private final Map<String, String> columnMapping;
   private final HashAggMemoryManager hashAggMemoryManager;
 
   private final GeneratorMapping UPDATE_AGGR_INSIDE =
@@ -251,9 +251,6 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
       case NONE:
         state = BatchState.DONE;
         container.buildSchema(SelectionVectorMode.NONE);
-        return;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
         return;
       case STOP:
         state = BatchState.STOP;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggTemplate.java
@@ -649,7 +649,6 @@ public abstract class HashAggTemplate implements HashAggregator {
       }
       // Handle various results from getting the next batch
       switch (outcome) {
-        case OUT_OF_MEMORY:
         case NOT_YET:
           return AggOutcome.RETURN_OUTCOME;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggBatch.java
@@ -172,9 +172,6 @@ public class StreamingAggBatch extends AbstractRecordBatch<StreamingAggregate> {
         state = BatchState.DONE;
         container.buildSchema(SelectionVectorMode.NONE);
         return;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
-        return;
       case STOP:
         state = BatchState.STOP;
         return;
@@ -242,7 +239,6 @@ public class StreamingAggBatch extends AbstractRecordBatch<StreamingAggregate> {
             return IterOutcome.OK;
           }
           // else fall thru
-        case OUT_OF_MEMORY:
         case NOT_YET:
         case STOP:
           return lastKnownOutcome;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggTemplate.java
@@ -136,9 +136,6 @@ public abstract class StreamingAggTemplate implements StreamingAggregator {
                     currentIndex = this.getVectorIndex(underlyingIndex);
                     break outer;
                   }
-                case OUT_OF_MEMORY:
-                  outcome = out;
-                  return AggOutcome.RETURN_OUTCOME;
                 case EMIT:
                   outerOutcome = EMIT;
                   if (incoming.getRecordCount() == 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/broadcastsender/BroadcastSenderRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/broadcastsender/BroadcastSenderRootExec.java
@@ -95,8 +95,6 @@ public class BroadcastSenderRootExec extends BaseRootExec {
     RecordBatch.IterOutcome out = next(incoming);
     logger.debug("Outcome of sender next {}", out);
     switch(out){
-      case OUT_OF_MEMORY:
-        throw new OutOfMemoryException();
       case STOP:
       case NONE:
         for (int i = 0; i < tunnels.length; ++i) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -453,10 +453,7 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
 
     isEmpty.setValue(outcome == IterOutcome.NONE); // If we received NONE there is no data.
 
-    if (outcome == IterOutcome.OUT_OF_MEMORY) {
-      // We reached a termination state
-      state = BatchState.OUT_OF_MEMORY;
-    } else if (outcome == IterOutcome.STOP) {
+    if (outcome == IterOutcome.STOP) {
       // We reached a termination state
       state = BatchState.STOP;
     } else {
@@ -561,11 +558,6 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
 
           if (leftUpstream == IterOutcome.STOP || rightUpstream == IterOutcome.STOP) {
             state = BatchState.STOP;
-            return leftUpstream;
-          }
-
-          if (leftUpstream == IterOutcome.OUT_OF_MEMORY || rightUpstream == IterOutcome.OUT_OF_MEMORY) {
-            state = BatchState.OUT_OF_MEMORY;
             return leftUpstream;
           }
         }
@@ -1009,7 +1001,6 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
     boolean moreData = true;
     while (moreData) {
       switch (rightUpstream) {
-      case OUT_OF_MEMORY:
       case NONE:
       case NOT_YET:
       case STOP:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/LateralJoinBatch.java
@@ -53,7 +53,6 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK_NEW_SCHEMA;
-import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OUT_OF_MEMORY;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.STOP;
 
 /**
@@ -413,7 +412,7 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
   }
 
   private boolean isTerminalOutcome(IterOutcome outcome) {
-    return (outcome == STOP || outcome == OUT_OF_MEMORY || outcome == NONE);
+    return (outcome == STOP || outcome == NONE);
   }
 
   /**
@@ -477,7 +476,6 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
             leftJoinIndex = 0;
           }
           break;
-        case OUT_OF_MEMORY:
         case NONE:
         case STOP:
           // Not using =0 since if outgoing container is empty then no point returning anything
@@ -547,7 +545,6 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
           rightJoinIndex = (right.getRecordCount() > 0) ? 0 : -1;
           needNewRightBatch = false;
           break;
-        case OUT_OF_MEMORY:
         case NONE:
         case STOP:
           needNewRightBatch = false;
@@ -924,9 +921,6 @@ public class LateralJoinBatch extends AbstractBinaryRecordBatch<LateralJoinPOP> 
       case STOP:
       case EMIT:
         state = BatchState.STOP;
-        return false;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
         return false;
       case NONE:
       case NOT_YET:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/NestedLoopJoinBatch.java
@@ -177,8 +177,6 @@ public class NestedLoopJoinBatch extends AbstractBinaryRecordBatch<NestedLoopJoi
               batchMemoryManager.getRecordBatchSizer(RIGHT_INDEX), getRecordBatchStatsContext());
             addBatchToHyperContainer(right);
             break;
-          case OUT_OF_MEMORY:
-            return IterOutcome.OUT_OF_MEMORY;
           case NONE:
           case STOP:
             //TODO we got a STOP, shouldn't we stop immediately ?

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/RowKeyJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/RowKeyJoinBatch.java
@@ -52,7 +52,7 @@ public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implemen
   private IterOutcome rightUpstream = IterOutcome.NONE;
   private final List<TransferPair> transfers = Lists.newArrayList();
   private int recordCount = 0;
-  private SchemaChangeCallBack callBack = new SchemaChangeCallBack();
+  private final SchemaChangeCallBack callBack = new SchemaChangeCallBack();
   private RowKeyJoinState rkJoinState = RowKeyJoinState.INITIAL;
 
   public RowKeyJoinBatch(RowKeyJoinPOP config, FragmentContext context, RecordBatch left, RecordBatch right)
@@ -100,11 +100,6 @@ public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implemen
 
     leftUpstream = next(left);
 
-    if (leftUpstream == IterOutcome.OUT_OF_MEMORY || rightUpstream == IterOutcome.OUT_OF_MEMORY) {
-      state = BatchState.OUT_OF_MEMORY;
-      return;
-    }
-
     for (final VectorWrapper<?> v : left) {
       final TransferPair pair = v.getValueVector().makeTransferPair(
           container.addOrGet(v.getField(), callBack));
@@ -143,7 +138,6 @@ public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implemen
 
       switch(rightUpstream) {
       case NONE:
-      case OUT_OF_MEMORY:
       case STOP:
         rkJoinState = RowKeyJoinState.DONE;
         state = BatchState.DONE;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
@@ -41,7 +41,7 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
 public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
   private static final Logger logger = LoggerFactory.getLogger(LimitRecordBatch.class);
 
-  private SelectionVector2 outgoingSv;
+  private final SelectionVector2 outgoingSv;
   private SelectionVector2 incomingSv;
 
   // Start offset of the records
@@ -64,9 +64,6 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
       incoming.kill(true);
 
       IterOutcome upStream = next(incoming);
-      if (upStream == IterOutcome.OUT_OF_MEMORY) {
-        return upStream;
-      }
 
       while (upStream == IterOutcome.OK || upStream == IterOutcome.OK_NEW_SCHEMA) {
         // Clear the memory for the incoming batch
@@ -78,9 +75,6 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
           incomingSv.clear();
         }
         upStream = next(incoming);
-        if (upStream == IterOutcome.OUT_OF_MEMORY) {
-          return upStream;
-        }
       }
       // If EMIT that means leaf operator is UNNEST, in this case refresh the limit states and return EMIT.
       if (upStream == EMIT) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
@@ -159,7 +159,6 @@ public class MetadataControllerBatch extends AbstractBinaryRecordBatch<MetadataC
           // all incoming data was processed when returned OK_NEW_SCHEMA
           finishedLeft = !firstLeft;
           break outer;
-        case OUT_OF_MEMORY:
         case NOT_YET:
         case STOP:
           return outcome;
@@ -210,7 +209,6 @@ public class MetadataControllerBatch extends AbstractBinaryRecordBatch<MetadataC
           // all incoming data was processed
           finishedRight = true;
           break outer;
-        case OUT_OF_MEMORY:
         case NOT_YET:
         case STOP:
           return outcome;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
@@ -124,7 +124,6 @@ public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHand
         assert !firstBatch : "First batch should be OK_NEW_SCHEMA";
         doWorkInternal();
         // fall thru
-      case OUT_OF_MEMORY:
       case NOT_YET:
       case STOP:
         return outcome;
@@ -413,6 +412,7 @@ public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHand
     container.setEmpty();
   }
 
+  @Override
   protected boolean setupNewSchema() {
     setupSchemaFromContainer(incoming.getContainer());
     return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
@@ -61,11 +61,11 @@ import com.sun.codemodel.JType;
 
 public class PartitionSenderRootExec extends BaseRootExec {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PartitionSenderRootExec.class);
-  private RecordBatch incoming;
-  private HashPartitionSender operator;
+  private final RecordBatch incoming;
+  private final HashPartitionSender operator;
   private PartitionerDecorator partitioner;
 
-  private ExchangeFragmentContext context;
+  private final ExchangeFragmentContext context;
   private final int outGoingBatchCount;
   private final HashPartitionSender popConfig;
   private final double cost;
@@ -74,14 +74,14 @@ public class PartitionSenderRootExec extends BaseRootExec {
   private final AtomicInteger remaingReceiverCount;
   private boolean done = false;
   private boolean first = true;
-  private boolean closeIncoming;
+  private final boolean closeIncoming;
 
   long minReceiverRecordCount = Long.MAX_VALUE;
   long maxReceiverRecordCount = Long.MIN_VALUE;
   protected final int numberPartitions;
   protected final int actualPartitions;
 
-  private IntArrayList terminations = new IntArrayList();
+  private final IntArrayList terminations = new IntArrayList();
 
   public enum Metric implements MetricDef {
     BATCHES_SENT,
@@ -174,9 +174,6 @@ public class PartitionSenderRootExec extends BaseRootExec {
           context.getExecutorState().fail(e.getCause());
         }
         return false;
-
-      case OUT_OF_MEMORY:
-        throw new OutOfMemoryException();
 
       case STOP:
         if (partitioner != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/producer/ProducerConsumerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/producer/ProducerConsumerBatch.java
@@ -133,9 +133,6 @@ public class ProducerConsumerBatch extends AbstractRecordBatch<ProducerConsumer>
             case NONE:
               stop = true;
               break outer;
-            case OUT_OF_MEMORY:
-              queue.putFirst(RecordBatchDataWrapper.outOfMemory());
-              return;
             case STOP:
               queue.putFirst(RecordBatchDataWrapper.failed());
               return;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectRecordBatch.java
@@ -173,10 +173,7 @@ public class ProjectRecordBatch extends AbstractSingleRecordBatch<Project> {
 
           next = next(incoming);
           setLastKnownOutcome(next);
-          if (next == IterOutcome.OUT_OF_MEMORY) {
-            outOfMemory = true;
-            return next;
-          } else if (next == IterOutcome.NONE) {
+          if (next == IterOutcome.NONE) {
             // since this is first batch and we already got a NONE, need to set up the schema
             doAlloc(0);
             setValueCount(0);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
@@ -105,7 +105,6 @@ public class SortBatch extends AbstractRecordBatch<Sort> {
           break outer;
         case NOT_YET:
           throw new UnsupportedOperationException();
-        case OUT_OF_MEMORY:
         case STOP:
           return upstream;
         case OK_NEW_SCHEMA:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/statistics/StatisticsMergeBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/statistics/StatisticsMergeBatch.java
@@ -346,7 +346,6 @@ public class StatisticsMergeBatch extends AbstractSingleRecordBatch<StatisticsMe
         switch (outcome) {
           case NONE:
             break outer;
-          case OUT_OF_MEMORY:
           case NOT_YET:
           case STOP:
             return outcome;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -129,7 +129,6 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
 
         switch (upstream) {
         case NONE:
-        case OUT_OF_MEMORY:
         case STOP:
           return upstream;
         case OK_NEW_SCHEMA:
@@ -391,7 +390,6 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
               batchMemoryManager.getRecordBatchSizer(topStatus.inputIndex),
               getRecordBatchStatsContext());
             return Pair.of(outcome, topStatus);
-          case OUT_OF_MEMORY:
           case STOP:
             batchStatusStack.pop();
             return Pair.of(outcome, topStatus);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -195,8 +195,10 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
       }
 
       if (context.getAllocator().isOverLimit()) {
-        lastOutcome = IterOutcome.OUT_OF_MEMORY;
-        return lastOutcome;
+        context.requestMemory(this);
+        if (context.getAllocator().isOverLimit()) {
+          throw new OutOfMemoryException("Allocator over limit");
+        }
       }
 
       RecordBatchDef rbd = batch.getHeader().getDef();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unpivot/UnpivotMapsRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unpivot/UnpivotMapsRecordBatch.java
@@ -112,7 +112,6 @@ public class UnpivotMapsRecordBatch extends AbstractSingleRecordBatch<UnpivotMap
     // Process according to upstream outcome
     switch (upStream) {
       case NONE:
-      case OUT_OF_MEMORY:
       case NOT_YET:
       case STOP:
         return upStream;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/IteratorValidatorBatchIterator.java
@@ -278,10 +278,9 @@ public class IteratorValidatorBatchIterator implements CloseableRecordBatch {
           validationState = ValidationState.TERMINAL;
           break;
         case NOT_YET:
-        case OUT_OF_MEMORY:
-          // NOT_YET and OUT_OF_MEMORY are allowed at any time, except if
+          // NOT_YET is allowed at any time, except if
           // terminated (checked above).
-          // NOT_YET and OUT_OF_MEMORY OK don't change high-level state.
+          // NOT_YET doesn't change high-level state.
           break;
         default:
           throw new AssertionError(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFrameRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFrameRecordBatch.java
@@ -116,7 +116,6 @@ public class WindowFrameRecordBatch extends AbstractRecordBatch<WindowPOP> {
         case NONE:
           noMoreBatches = true;
           break;
-        case OUT_OF_MEMORY:
         case NOT_YET:
         case STOP:
           cleanup();
@@ -236,9 +235,6 @@ public class WindowFrameRecordBatch extends AbstractRecordBatch<WindowPOP> {
       return;
     case STOP:
       state = BatchState.STOP;
-      return;
-    case OUT_OF_MEMORY:
-      state = BatchState.OUT_OF_MEMORY;
       return;
     default:
       break;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
@@ -119,7 +119,7 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
   private boolean first = true;
   private int targetRecordCount;
   private final String fileName;
-  private Set<Path> currSpillDirs = Sets.newTreeSet();
+  private final Set<Path> currSpillDirs = Sets.newTreeSet();
   private int firstSpillBatchCount = 0;
   private int peakNumBatches = -1;
 
@@ -279,9 +279,6 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       case STOP:
         state = BatchState.STOP;
         break;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
-        break;
       case NONE:
         state = BatchState.DONE;
         break;
@@ -434,19 +431,6 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
             if (!success) {
               rbd.clear();
             }
-          }
-          break;
-        case OUT_OF_MEMORY:
-          logger.debug("received OUT_OF_MEMORY, trying to spill");
-          if (batchesSinceLastSpill > 2) {
-            final BatchGroup merged = mergeAndSpill(batchGroups);
-            if (merged != null) {
-              spilledBatchGroups.add(merged);
-              batchesSinceLastSpill = 0;
-            }
-          } else {
-            logger.debug("not enough batches to spill, sending OUT_OF_MEMORY downstream");
-            return IterOutcome.OUT_OF_MEMORY;
           }
           break;
         default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/managed/ExternalSortBatch.java
@@ -288,9 +288,6 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       case STOP:
         state = BatchState.STOP;
         break;
-      case OUT_OF_MEMORY:
-        state = BatchState.OUT_OF_MEMORY;
-        break;
       case NONE:
         state = BatchState.DONE;
         break;
@@ -426,19 +423,6 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       // needed.
 
       sortImpl.addBatch(incoming);
-      break;
-    case OUT_OF_MEMORY:
-
-      // Note: it is highly doubtful that this code actually works. It
-      // requires that the upstream batches got to a safe place to run
-      // out of memory and that no work was in-flight and thus abandoned.
-      // Consider removing this case once resource management is in place.
-
-      logger.error("received OUT_OF_MEMORY, trying to spill");
-      if (! sortImpl.forceSpill()) {
-        throw UserException.memoryError("Received OUT_OF_MEMORY, but not enough batches to spill")
-          .build(logger);
-      }
       break;
     default:
       throw new IllegalStateException("Unexpected iter outcome: " + lastKnownOutcome);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractBinaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractBinaryRecordBatch.java
@@ -79,11 +79,6 @@ public abstract class AbstractBinaryRecordBatch<T extends PhysicalOperator> exte
       return false;
     }
 
-    if (leftOutcome == IterOutcome.OUT_OF_MEMORY || rightOutcome == IterOutcome.OUT_OF_MEMORY) {
-      state = BatchState.OUT_OF_MEMORY;
-      return false;
-    }
-
     if (checkForEarlyFinish(leftOutcome, rightOutcome)) {
       state = BatchState.DONE;
       return false;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.record;
 import java.util.Iterator;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.exception.OutOfMemoryException;
@@ -91,8 +90,6 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     NOT_FIRST,
     /** The query most likely failed, we need to propagate STOP to the root. */
     STOP,
-    /** Out of Memory while building the Schema...Ouch! */
-    OUT_OF_MEMORY,
     /** All work is done, no more data to be sent. */
     DONE
   }
@@ -165,11 +162,6 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
             case DONE:
               lastOutcome = IterOutcome.NONE;
               break;
-            case OUT_OF_MEMORY:
-              // because we don't support schema changes, it is safe to fail the query right away
-              context.getExecutorState().fail(UserException.memoryError()
-                .build(logger));
-              // FALL-THROUGH
             case STOP:
               lastOutcome = IterOutcome.STOP;
               break;
@@ -253,7 +245,9 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
 
   @Override
   public VectorContainer getOutgoingContainer() {
-    throw new UnsupportedOperationException(String.format(" You should not call getOutgoingContainer() for class %s", this.getClass().getCanonicalName()));
+    throw new UnsupportedOperationException(String.format(
+        "You should not call getOutgoingContainer() for class %s",
+        getClass().getCanonicalName()));
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> extends AbstractRecordBatch<T> {
   private static final Logger logger = LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
-  protected boolean outOfMemory;
   protected SchemaChangeCallBack callBack = new SchemaChangeCallBack();
   private IterOutcome lastKnownOutcome;
 
@@ -90,8 +89,6 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
           container.buildSchema(SelectionVectorMode.NONE);
         }
         return upstream;
-      case OUT_OF_MEMORY:
-        return upstream;
       case OK_NEW_SCHEMA:
         if (state == BatchState.FIRST) {
           state = BatchState.NOT_FIRST;
@@ -120,11 +117,6 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
         // But if upstream is IterOutcome.OK_NEW_SCHEMA, we should return that
         if (out != IterOutcome.OK) {
           upstream = out;
-        }
-
-        if (outOfMemory) {
-          outOfMemory = false;
-          return IterOutcome.OUT_OF_MEMORY;
         }
 
         // Check if schema has changed

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -80,8 +80,8 @@ public interface RecordBatch extends VectorAccessible {
    *   </li>
    * </ol>
    * <p>
-   *   In addition to that basic sequence, {@link #NOT_YET} and
-   *   {@link #OUT_OF_MEMORY} values can appear anywhere in the subsequence
+   *   In addition to that basic sequence, {@link #NOT_YET}
+   *   values can appear anywhere in the subsequence
    *   before the terminal value ({@code NONE} or {@code STOP}).
    * </p>
    * <p>
@@ -94,10 +94,10 @@ public interface RecordBatch extends VectorAccessible {
    *   (The normal-completion return sequence is matched by the following
    *   regular-expression-style grammar:
    *   <pre>
-   *     ( ( NOT_YET | OUT_OF_MEMORY )*  OK_NEW_SCHEMA
-   *       ( NOT_YET | OUT_OF_MEMORY )*  OK )*
+   *     ( NOT_YET*  OK_NEW_SCHEMA
+   *       NOT_YET*  OK )*
    *     )+
-   *     ( NOT_YET | OUT_OF_+MEMORY )*  NONE
+   *     NOT_YET*  NONE
    *   </pre>
    *   )
    * </p>
@@ -194,19 +194,9 @@ public interface RecordBatch extends VectorAccessible {
      */
     NOT_YET(false),
 
-    /**
-     * Out of memory (not fatal).
-     * <p>
-     *   The call to {@link #next()},
-     *   including upstream operators, was unable to allocate memory
-     *   and did not read any records,
-     *   and the batch will have more results to return (at least completion or
-     *     abnormal termination ({@code NONE} or {@code STOP})).
-     *   The caller should release memory if it can (including by returning
-     *     {@code OUT_OF_MEMORY} to its caller) and call {@code next()} again.
-     * </p>
-     */
-    OUT_OF_MEMORY(true),
+    // Note: the former OUT_OF_MEMORY state was never really used.
+    // It is now handled by calling FragmentContext.requestMemory()
+    // at the point that the operator realizes it is short on memory.
 
     /**
      * Emit record to produce output batches.
@@ -233,7 +223,7 @@ public interface RecordBatch extends VectorAccessible {
      */
     EMIT(false);
 
-    private boolean error;
+    private final boolean error;
 
     IterOutcome(boolean error) {
       this.error = error;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatch.java
@@ -60,7 +60,7 @@ public interface RecordBatch extends VectorAccessible {
    *   </li>
    * </ul>
    * <p>
-   *  <strong>Details</strong>:
+   *  <h4>Details</h4>
    * </p>
    * <p>
    *   For normal completion, the basic sequence of return values from calls to
@@ -91,16 +91,20 @@ public interface RecordBatch extends VectorAccessible {
    *   and that does not contain {@code NONE}, and ends with {@code STOP}.
    * </p>
    * <p>
-   *   (The normal-completion return sequence is matched by the following
+   *   The normal-completion return sequence is matched by the following
    *   regular-expression-style grammar:
    *   <pre>
    *     ( NOT_YET*  OK_NEW_SCHEMA
    *       NOT_YET*  OK )*
    *     )+
-   *     NOT_YET*  NONE
-   *   </pre>
-   *   )
+   *     NOT_YET*    NONE</pre>
    * </p>
+   * <h4>Obsolete Outcomes</h4>
+   *
+   * The former <tt>OUT_OF_MEMORY</tt> state was never really used.
+   * It is now handled by calling
+   * {@link FragmentContext#requestMemory()}
+   * at the point that the operator realizes it is short on memory.
    */
   enum IterOutcome {
     /**
@@ -193,10 +197,6 @@ public interface RecordBatch extends VectorAccessible {
      * </p>
      */
     NOT_YET(false),
-
-    // Note: the former OUT_OF_MEMORY state was never really used.
-    // It is now handled by calling FragmentContext.requestMemory()
-    // at the point that the operator realizes it is short on memory.
 
     /**
      * Emit record to produce output batches.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordIterator.java
@@ -240,8 +240,6 @@ public class RecordIterator implements VectorAccessible {
             rbd.clear();
           }
           break;
-        case OUT_OF_MEMORY:
-          return lastOutcome;
         case NOT_YET:
         default:
           throw new UnsupportedOperationException("Unsupported outcome received " + lastOutcome);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -256,7 +256,6 @@ public class MockRecordBatch implements CloseableRecordBatch {
         return currentOutcome;
       case NONE:
       case STOP:
-      case OUT_OF_MEMORY:
         isDone = true;
       case NOT_YET:
         container.setRecordCount(0);
@@ -328,7 +327,6 @@ public class MockRecordBatch implements CloseableRecordBatch {
 
     public Builder terminateWithError(IterOutcome errorOutcome) {
       Preconditions.checkArgument(errorOutcome != IterOutcome.STOP);
-      Preconditions.checkArgument(errorOutcome != IterOutcome.OUT_OF_MEMORY);
 
       iterOutcomes.add(errorOutcome);
       return this;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestLateralJoinCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/join/TestLateralJoinCorrectness.java
@@ -55,7 +55,6 @@ import static org.junit.Assert.assertTrue;
 
 @Category(OperatorTest.class)
 public class TestLateralJoinCorrectness extends SubOperatorTest {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestNestedNotYet.class);
 
   // Operator Context for mock batch
   private static OperatorContext operatorContext;
@@ -155,8 +154,7 @@ public class TestLateralJoinCorrectness extends SubOperatorTest {
    * @return
    */
   private boolean isTerminal(RecordBatch.IterOutcome outcome) {
-    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP)
-      || (outcome == RecordBatch.IterOutcome.OUT_OF_MEMORY);
+    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP);
   }
 
   /**
@@ -1358,98 +1356,6 @@ public class TestLateralJoinCorrectness extends SubOperatorTest {
       rightMockBatch.close();
       leftRowSet2.clear();
       nonEmptyRightRowSet2.clear();
-    }
-  }
-
-  @Test
-  public void testHandlingOOMFromLeft() throws Exception {
-    // Get the left container with dummy data for Lateral Join
-    leftContainer.add(nonEmptyLeftRowSet.container());
-
-    // Get the left IterOutcomes for Lateral Join
-    leftOutcomes.add(RecordBatch.IterOutcome.OK_NEW_SCHEMA);
-    leftOutcomes.add(RecordBatch.IterOutcome.OUT_OF_MEMORY);
-
-    // Create Left MockRecordBatch
-    final CloseableRecordBatch leftMockBatch = new MockRecordBatch(fixture.getFragmentContext(), operatorContext,
-      leftContainer, leftOutcomes, leftContainer.get(0).getSchema());
-
-    // Get the right container with dummy data
-    rightContainer.add(emptyRightRowSet.container());
-    rightContainer.add(nonEmptyRightRowSet.container());
-
-    rightOutcomes.add(RecordBatch.IterOutcome.OK_NEW_SCHEMA);
-    rightOutcomes.add(RecordBatch.IterOutcome.EMIT);
-
-    final CloseableRecordBatch rightMockBatch = new MockRecordBatch(fixture.getFragmentContext(), operatorContext,
-      rightContainer, rightOutcomes, rightContainer.get(0).getSchema());
-
-    final LateralJoinBatch ljBatch = new LateralJoinBatch(ljPopConfig, fixture.getFragmentContext(),
-      leftMockBatch, rightMockBatch);
-
-    try {
-      int totalRecordCount = 0;
-      assertTrue(RecordBatch.IterOutcome.OK_NEW_SCHEMA == ljBatch.next());
-
-      // 1st output batch
-      assertTrue(RecordBatch.IterOutcome.OK == ljBatch.next());
-      totalRecordCount += ljBatch.getRecordCount();
-
-      // 2nd output batch
-      assertTrue(RecordBatch.IterOutcome.OUT_OF_MEMORY == ljBatch.next());
-
-      // Compare the total records generated in 2 output batches with expected count.
-      assertTrue(totalRecordCount ==
-        (nonEmptyLeftRowSet.rowCount() * nonEmptyRightRowSet.rowCount()));
-    } catch (AssertionError | Exception error) {
-      fail();
-    } finally {
-      // Close all the resources for this test case
-      ljBatch.close();
-      leftMockBatch.close();
-      rightMockBatch.close();
-    }
-  }
-
-  @Test
-  public void testHandlingOOMFromRight() throws Exception {
-    // Get the left container with dummy data for Lateral Join
-    leftContainer.add(nonEmptyLeftRowSet.container());
-
-    // Get the left IterOutcomes for Lateral Join
-    leftOutcomes.add(RecordBatch.IterOutcome.OK_NEW_SCHEMA);
-    leftOutcomes.add(RecordBatch.IterOutcome.OK);
-
-    // Create Left MockRecordBatch
-    final CloseableRecordBatch leftMockBatch = new MockRecordBatch(fixture.getFragmentContext(), operatorContext,
-      leftContainer, leftOutcomes, leftContainer.get(0).getSchema());
-
-    // Get the right container with dummy data
-    rightContainer.add(emptyRightRowSet.container());
-    rightContainer.add(nonEmptyRightRowSet.container());
-
-    rightOutcomes.add(RecordBatch.IterOutcome.OK_NEW_SCHEMA);
-    rightOutcomes.add(RecordBatch.IterOutcome.OUT_OF_MEMORY);
-
-    final CloseableRecordBatch rightMockBatch = new MockRecordBatch(fixture.getFragmentContext(), operatorContext,
-      rightContainer, rightOutcomes, rightContainer.get(0).getSchema());
-
-    final LateralJoinBatch ljBatch = new LateralJoinBatch(ljPopConfig, fixture.getFragmentContext(),
-      leftMockBatch, rightMockBatch);
-
-    try {
-      // int totalRecordCount = 0;
-      assertTrue(RecordBatch.IterOutcome.OK_NEW_SCHEMA == ljBatch.next());
-
-      // 2nd output batch
-      assertTrue(RecordBatch.IterOutcome.OUT_OF_MEMORY == ljBatch.next());
-    } catch (AssertionError | Exception error) {
-      fail();
-    } finally {
-      // Close all the resources for this test case
-      ljBatch.close();
-      leftMockBatch.close();
-      rightMockBatch.close();
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/MockLateralJoinBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/MockLateralJoinBatch.java
@@ -45,7 +45,7 @@ import java.util.List;
  */
 public class MockLateralJoinBatch implements LateralContract, CloseableRecordBatch {
 
-  private RecordBatch incoming;
+  private final RecordBatch incoming;
 
   private int recordIndex = 0;
   private RecordBatch unnest;
@@ -57,7 +57,7 @@ public class MockLateralJoinBatch implements LateralContract, CloseableRecordBat
   private final FragmentContext context;
   private  final OperatorContext oContext;
 
-  private List<ValueVector> resultList = new ArrayList<>();
+  private final List<ValueVector> resultList = new ArrayList<>();
 
   public MockLateralJoinBatch(FragmentContext context, OperatorContext oContext, RecordBatch incoming) {
     this.context = context;
@@ -98,6 +98,7 @@ public class MockLateralJoinBatch implements LateralContract, CloseableRecordBat
     return unnest;
   }
 
+  @Override
   public IterOutcome next() {
 
     IterOutcome currentOutcome = incoming.next();
@@ -139,7 +140,6 @@ public class MockLateralJoinBatch implements LateralContract, CloseableRecordBat
         return currentOutcome;
       case NONE:
       case STOP:
-      case OUT_OF_MEMORY:
         isDone = true;
         return currentOutcome;
       case NOT_YET:

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestCorrectness.java
@@ -75,10 +75,10 @@ import static org.junit.Assert.assertTrue;
   public void testUnnestFixedWidthColumn() {
 
     Object[][] data = {
-        { (Object) new int[] {1, 2},
-          (Object) new int[] {3, 4, 5}},
-        { (Object) new int[] {6, 7, 8, 9},
-          (Object) new int[] {10, 11, 12, 13, 14}}
+        { new int[] {1, 2},
+          new int[] {3, 4, 5}},
+        { new int[] {6, 7, 8, 9},
+          new int[] {10, 11, 12, 13, 14}}
     };
 
     // Create input schema
@@ -107,10 +107,10 @@ import static org.junit.Assert.assertTrue;
   public void testUnnestVarWidthColumn() {
 
     Object[][] data = {
-        { (Object) new String[] {"", "zero"},
-          (Object) new String[] {"one", "two", "three"}},
-        { (Object) new String[] {"four", "five", "six", "seven"},
-          (Object) new String[] {"eight", "nine", "ten", "eleven", "twelve"}}
+        { new String[] {"", "zero"},
+          new String[] {"one", "two", "three"}},
+        { new String[] {"four", "five", "six", "seven"},
+          new String[] {"eight", "nine", "ten", "eleven", "twelve"}}
     };
 
     // Create input schema
@@ -162,11 +162,11 @@ import static org.junit.Assert.assertTrue;
   public void testUnnestEmptyList() {
 
     Object[][] data = {
-        { (Object) new String[] {},
-          (Object) new String[] {}
+        { new String[] {},
+          new String[] {}
         },
-        { (Object) new String[] {},
-          (Object) new String[] {}
+        { new String[] {},
+          new String[] {}
         }
     };
 
@@ -197,14 +197,14 @@ import static org.junit.Assert.assertTrue;
     // unnest column itself has changed
     Object[][] data = {
         {
-            (Object) new String[] {"0", "1"},
-            (Object) new String[] {"2", "3", "4"}
+            new String[] {"0", "1"},
+            new String[] {"2", "3", "4"}
         },
         {
-            (Object) new String[] {"5", "6" },
+            new String[] {"5", "6" },
         },
         {
-            (Object) new String[] {"9"}
+            new String[] {"9"}
         }
     };
 
@@ -240,14 +240,14 @@ import static org.junit.Assert.assertTrue;
   public void testUnnestSchemaChange() {
     Object[][] data = {
         {
-            (Object) new String[] {"0", "1"},
-            (Object) new String[] {"2", "3", "4"}
+            new String[] {"0", "1"},
+            new String[] {"2", "3", "4"}
         },
         {
-            (Object) new String[] {"5", "6" },
+            new String[] {"5", "6" },
         },
         {
-            (Object) new int[] {9}
+            new int[] {9}
         }
     };
 
@@ -463,10 +463,10 @@ import static org.junit.Assert.assertTrue;
   public void testUnnestNonArrayColumn() {
 
     Object[][] data = {
-        { (Object) new Integer (1),
-            (Object) new Integer (3)},
-        { (Object) new Integer (6),
-            (Object) new Integer (10)}
+        { new Integer (1),
+            new Integer (3)},
+        { new Integer (6),
+            new Integer (10)}
     };
 
     // Create input schema
@@ -584,7 +584,7 @@ import static org.junit.Assert.assertTrue;
         for (int j = 0; j < valueCount; j++) {
 
           if (vv instanceof MapVector) {
-            if (!compareMapBaseline((Object) baseline[i][j], vv.getAccessor().getObject(j))) {
+            if (!compareMapBaseline(baseline[i][j], vv.getAccessor().getObject(j))) {
               fail("Test failed in validating unnest(Map) output. Value mismatch");
             }
           } else if (vv instanceof VarCharVector) {
@@ -606,7 +606,7 @@ import static org.junit.Assert.assertTrue;
 
       }
 
-      assertTrue(((MockLateralJoinBatch) lateralJoinBatch).isCompleted());
+      assertTrue(lateralJoinBatch.isCompleted());
 
     } catch (UserException e) {
       throw e; // Valid exception
@@ -716,8 +716,7 @@ import static org.junit.Assert.assertTrue;
   }
 
   private boolean isTerminal(RecordBatch.IterOutcome outcome) {
-    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP) || (outcome
-        == RecordBatch.IterOutcome.OUT_OF_MEMORY);
+    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP);
   }
 
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
@@ -84,10 +84,10 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   public void testUnnestFixedWidthColumn() {
 
     Object[][] data = {
-        { (Object) new int[] {1, 2},
-          (Object) new int[] {3, 4, 5}},
-        { (Object) new int[] {6, 7, 8, 9},
-          (Object) new int[] {10, 11, 12, 13, 14}}
+        { new int[] {1, 2},
+          new int[] {3, 4, 5}},
+        { new int[] {6, 7, 8, 9},
+          new int[] {10, 11, 12, 13, 14}}
     };
 
     // Create input schema
@@ -119,10 +119,10 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   public void testUnnestVarWidthColumn() {
 
     Object[][] data = {
-        { (Object) new String[] {"", "zero"},
-          (Object) new String[] {"one", "two", "three"}},
-        { (Object) new String[] {"four", "five", "six", "seven"},
-          (Object) new String[] {"eight", "nine", "ten", "eleven", "twelve"}}
+        { new String[] {"", "zero"},
+          new String[] {"one", "two", "three"}},
+        { new String[] {"four", "five", "six", "seven"},
+          new String[] {"eight", "nine", "ten", "eleven", "twelve"}}
     };
 
     // Create input schema
@@ -174,11 +174,11 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   public void testUnnestEmptyList() {
 
     Object[][] data = {
-        { (Object) new String[] {},
-          (Object) new String[] {}
+        { new String[] {},
+          new String[] {}
         },
-        { (Object) new String[] {},
-          (Object) new String[] {}
+        { new String[] {},
+          new String[] {}
         }
     };
 
@@ -208,14 +208,14 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     // unnest column itself has changed
     Object[][] data = {
         {
-            (Object) new String[] {"0", "1"},
-            (Object) new String[] {"2", "3", "4"}
+            new String[] {"0", "1"},
+            new String[] {"2", "3", "4"}
         },
         {
-            (Object) new String[] {"5", "6" },
+            new String[] {"5", "6" },
         },
         {
-            (Object) new String[] {"9"}
+            new String[] {"9"}
         }
     };
 
@@ -253,14 +253,14 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   public void testUnnestSchemaChange() {
     Object[][] data = {
         {
-            (Object) new String[] {"0", "1"},
-            (Object) new String[] {"2", "3", "4"}
+            new String[] {"0", "1"},
+            new String[] {"2", "3", "4"}
         },
         {
-            (Object) new String[] {"5", "6" },
+            new String[] {"5", "6" },
         },
         {
-            (Object) new int[] {9}
+            new int[] {9}
         }
     };
 
@@ -502,10 +502,10 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   public void testUnnestNonArrayColumn() {
 
     Object[][] data = {
-        { (Object) new Integer (1),
-            (Object) new Integer (3)},
-        { (Object) new Integer (6),
-            (Object) new Integer (10)}
+        { new Integer (1),
+            new Integer (3)},
+        { new Integer (6),
+            new Integer (10)}
     };
 
     // Create input schema
@@ -668,7 +668,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
               if (!baseline[batchIndex][vectorIndex][valueIndex].equals(val)) {
                 fail("Test failed in validating unnest output. Value mismatch. Baseline value[" + vectorIndex + "][" + valueIndex
                     + "]" + ": "
-                    + ((Object[])baseline[batchIndex][vectorIndex])[valueIndex] + "   VV.getObject(valueIndex): " + val);
+                    + baseline[batchIndex][vectorIndex][valueIndex] + "   VV.getObject(valueIndex): " + val);
               }
             }
           }
@@ -824,8 +824,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
   }
 
   private boolean isTerminal(RecordBatch.IterOutcome outcome) {
-    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP) || (outcome
-        == RecordBatch.IterOutcome.OUT_OF_MEMORY);
+    return (outcome == RecordBatch.IterOutcome.NONE || outcome == RecordBatch.IterOutcome.STOP);
   }
 
 
@@ -985,7 +984,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
               if (!baseline[batchIndex][vectorIndex][valueIndex].equals(val)) {
                 fail("Test failed in validating unnest output. Value mismatch. Baseline value[" + vectorIndex + "][" + valueIndex
                     + "]" + ": "
-                    + ((Object[])baseline[batchIndex][vectorIndex])[valueIndex] + "   VV.getObject(valueIndex): " + val);
+                    + baseline[batchIndex][vectorIndex][valueIndex] + "   VV.getObject(valueIndex): " + val);
               }
             }
           }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -54,6 +54,7 @@ import org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory;
 import org.apache.drill.exec.proto.ExecProtos;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
+import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -171,8 +172,8 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     private final List<OperatorContext> contexts = Lists.newLinkedList();
 
 
-    private ExecutorState executorState = new OperatorFixture.MockExecutorState();
-    private ExecutionControls controls;
+    private final ExecutorState executorState = new OperatorFixture.MockExecutorState();
+    private final ExecutionControls controls;
 
     public MockFragmentContext(final DrillConfig config,
                                final OptionManager options,
@@ -338,6 +339,11 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     @Override
     public MetastoreRegistry getMetastoreRegistry() {
       return null;
+    }
+
+    @Override
+    public void requestMemory(RecordBatch requestor) {
+      // Does nothing in a mock fragment.
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
@@ -129,7 +129,7 @@ public class PhysicalOpUnitTestBase extends ExecTest {
 
   protected static class BatchIterator implements Iterable<VectorAccessible> {
 
-    private RecordBatch operator;
+    private final RecordBatch operator;
     public BatchIterator(RecordBatch operator) {
       this.operator = operator;
     }
@@ -148,8 +148,6 @@ public class PhysicalOpUnitTestBase extends ExecTest {
           if (lastResultOutcome == RecordBatch.IterOutcome.NONE
             || lastResultOutcome == RecordBatch.IterOutcome.STOP) {
             return false;
-          } else if (lastResultOutcome == RecordBatch.IterOutcome.OUT_OF_MEMORY) {
-            throw new RuntimeException("Operator ran out of memory");
           } else {
             return true;
           }


### PR DESCRIPTION
Drill has long supported the `OUT_OF_MEMORY` iterator status. The idea is that an operator can realize it has encountered memory pressure and ask its downstream operator to free up some memory. However, an inspection of the code shows that the status is actually sent in only one place (`UnorderedReceiverBatch`), and then only in response to the operator hitting its allocator limit (which no other batch can do anything about.)

This PR removes the `OUT_OF_MEMORY` status and all uses. All operators tried to handle the status, but no operator (except the one above) actually sent it.

Adds a stub implementation for an OOM strategy (borrowed from Presto) that might actually work.

See JIRA ticket for full explanation.

Tests: Ran all exec tests to verify the revised code builds and runs.