### PR TITLE
DRILL-6332: Allow to provide two-component Kerberos principals

### DIFF
--- a/common/src/main/java/org/apache/drill/common/KerberosUtil.java
+++ b/common/src/main/java/org/apache/drill/common/KerberosUtil.java
@@ -38,29 +38,38 @@ public final class KerberosUtil {
    * Returns principal of format primary/instance@REALM.
    *
    * @param primary non-null primary component
-   * @param instance non-null instance component
+   * @param instance non-null instance component, can be empty string
    * @param realm non-null realm component
-   * @return principal of format primary/instance@REALM
+   * @return principal of format primary/instance@REALM or primary@REALM
    */
   public static String getPrincipalFromParts(final String primary, final String instance, final String realm) {
-    return checkNotNull(primary) + "/" +
-        checkNotNull(instance) + "@" +
-        checkNotNull(realm);
+    checkNotNull(primary);
+    checkNotNull(realm);
+
+    return primary +
+        ((instance != "") ? "/" + instance : "")
+        + "@" + realm;
   }
 
   /**
-   * Expects principal of the format primary/instance@REALM.
+   * Expects principal of the format primary/instance@REALM or primary@REALM.
    *
    * @param principal principal
    * @return components
    */
   public static String[] splitPrincipalIntoParts(final String principal) {
     final String[] components = principal.split("[/@]");
-    checkState(components.length == 3);
+    checkState(components.length < 4);
+    checkState(components.length > 1);
     checkNotNull(components[0]);
     checkNotNull(components[1]);
-    checkNotNull(components[2]);
-    return components;
+
+    if (components.length == 2) {
+      return new String[] { components[0], "", components[1] };
+    } else {
+      checkNotNull(components[2]);
+      return components;
+    }
   }
 
   public static String canonicalizeInstanceName(String instanceName, final String canonicalName) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -135,10 +135,11 @@ public class BootStrapContext implements AutoCloseable {
         final String parts[] = KerberosUtil.splitPrincipalIntoParts(principal);
         if (parts.length != 3) {
           throw new DrillbitStartupException(
-              String.format("Invalid %s, Drill service principal must be of format: primary/instance@REALM",
-                ExecConstants.SERVICE_PRINCIPAL));
+            String.format("Invalid %s, Drill service principal must be of format 'primary/instance@REALM' or 'primary@REALM'",
+              ExecConstants.SERVICE_PRINCIPAL));
         }
-        parts[1] = KerberosUtil.canonicalizeInstanceName(parts[1], hostName);
+
+        parts[1] = (parts[1] == "") ? "" : KerberosUtil.canonicalizeInstanceName(parts[1], hostName);
 
         final String canonicalizedPrincipal = KerberosUtil.getPrincipalFromParts(parts[0], parts[1], parts[2]);
         final String keytab = config.getString(ExecConstants.SERVICE_KEYTAB_LOCATION);


### PR DESCRIPTION
Currently drill only allows for three-component kerberos principals `primary/instance@REALM`
I had the requirement to deal with two-part principals `primary@REALM` and thus made these little changes to the principal checks. This enables drill to deal with two- and three-part principals.

Behaviour: The principal splitting function will return an empty string for `instance` if only a two-component principal is given.