### PR TITLE
DRILL-7483: Add support for 12 and 13 java versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,147 +25,44 @@ jobs:
     working_directory: ~/drill
 
     steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - m2-{{ checksum "pom.xml" }}
-        - m2- # used if checksum fails
-    - run:
-        name: Update maven version
-        # TODO: Could be removed, once Machine Executor image is updated https://github.com/circleci/image-builder/issues/140
-        # and the possibility of specifying Maven version is added https://github.com/circleci/image-builder/issues/143
-        command:
-          curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-    - run:
-        name: Update packages list
-        command:
-          sudo apt-get update
-    - run:
-        name: Install libaio1.so library for MySQL integration tests
-        command:
-          sudo apt-get install libaio1 libaio-dev
-    - run:
-        name: Drill project build
-        # TODO: 2. Optimizing Maven Builds on CircleCI - https://circleci.com/blog/optimizing-maven-builds-on-circleci/
-        # TODO: 3. Resolving memory issues without "SlowTest" and "UnlikelyTest" excludedGroups in the build
-        command: >
-          mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
-          -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/test-results/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/test-results
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: m2-{{ checksum "pom.xml" }}
-  build_jdk9:
-    machine:
-      enabled: true
-      image: circleci/classic:latest
-    parallelism: 1
-
-    working_directory: ~/drill
-
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - m2-{{ checksum "pom.xml" }}
-        - m2- # used if checksum fails
-    - run:
-        name: Update packages list
-        command:
-          sudo apt-get update
-    - run:
-        name: Install java 9
-        command:
-          sudo apt-get -y install openjdk-9-jdk
-    - run:
-        name: Set default java 9
-        command:
-          sudo update-java-alternatives --set java-1.9.0-openjdk-amd64
-    - run:
-        name: Update maven version
-        command:
-          curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-    - run:
-        name: Install libaio1.so library for MySQL integration tests
-        command:
-          sudo apt-get install libaio1 libaio-dev
-    - run:
-        name: Drill project build
-        command: >
-          mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
-          -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/test-results/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/test-results
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: m2-{{ checksum "pom.xml" }}
-
-  build_jdk10:
-    machine:
-      enabled: true
-      image: circleci/classic:latest
-    parallelism: 1
-
-    working_directory: ~/drill
-
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - m2-{{ checksum "pom.xml" }}
-        - m2- # used if checksum fails
-    - run:
-        name: Update packages list
-        command:
-          sudo apt-get update
-    - run:
-        name: Install java 10
-        command:
-          sudo apt-get -y install openjdk-10-jdk
-    - run:
-        name: Set default java 10
-        command:
-          sudo update-java-alternatives --set java-1.10.0-openjdk-amd64
-    - run:
-        name: Update maven version
-        command:
-          curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-    - run:
-        name: Install libaio1.so library for MySQL integration tests
-        command:
-          sudo apt-get install libaio1 libaio-dev
-    - run:
-        name: Drill project build
-        command: >
-          mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
-          -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/test-results/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/test-results
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: m2-{{ checksum "pom.xml" }}
+      - checkout
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2- # used if checksum fails
+      - run:
+          name: Update maven version
+          # TODO: Could be removed, once Machine Executor image is updated https://github.com/circleci/image-builder/issues/140
+          # and the possibility of specifying Maven version is added https://github.com/circleci/image-builder/issues/143
+          command:
+            curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.3
+      - run:
+          name: Update packages list
+          command:
+            sudo apt-get update
+      - run:
+          name: Install libaio1.so library for MySQL integration tests
+          command:
+            sudo apt-get install libaio1 libaio-dev
+      - run:
+          name: Drill project build
+          # TODO: 2. Optimizing Maven Builds on CircleCI - https://circleci.com/blog/optimizing-maven-builds-on-circleci/
+          # TODO: 3. Resolving memory issues without "SlowTest" and "UnlikelyTest" excludedGroups in the build
+          command: >
+            mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
+            -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: m2-{{ checksum "pom.xml" }}
 
   build_jdk11:
     machine:
@@ -176,56 +73,158 @@ jobs:
     working_directory: ~/drill
 
     steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - m2-{{ checksum "pom.xml" }}
-        - m2- # used if checksum fails
-    - run:
-        name: Update packages list
-        command:
-          sudo apt-get update
-    - run:
-        name: Install java 11
-        command:
-          sudo apt-get -y install openjdk-11-jdk
-    - run:
-        name: Set default java 11
-        command:
-          sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
-    - run:
-        name: Update maven version
-        command:
-          curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.0
-    - run:
-        name: Install libaio1.so library for MySQL integration tests
-        command:
-          sudo apt-get install libaio1 libaio-dev
-    - run:
-        name: Drill project build
-        # Set forkCount to 1 since tests use more memory and memory limitations for CircleCI is reached
-        # for default value of forkCount.
-        command: >
-          mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608 -DforkCount=1
-          -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/test-results/junit/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-        when: always
-    - store_test_results:
-        path: ~/test-results
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: m2-{{ checksum "pom.xml" }}
+      - checkout
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2- # used if checksum fails
+      - run:
+          name: Update packages list
+          command:
+            sudo apt-get update
+      - run:
+          name: Install java 11
+          command:
+            sudo apt-get -y install openjdk-11-jdk
+      - run:
+          name: Set default java 11
+          command:
+            sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
+      - run:
+          name: Update maven version
+          command:
+            curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.3
+      - run:
+          name: Install libaio1.so library for MySQL integration tests
+          command:
+            sudo apt-get install libaio1 libaio-dev
+      - run:
+          name: Drill project build
+          command: >
+            mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
+            -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: m2-{{ checksum "pom.xml" }}
+
+  build_jdk12:
+    machine:
+      enabled: true
+      image: circleci/classic:latest
+    parallelism: 1
+
+    working_directory: ~/drill
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2- # used if checksum fails
+      - run:
+          name: Update packages list
+          command:
+            sudo apt-get update
+      - run:
+          name: Install java 12
+          command:
+            sudo apt-get -y install openjdk-12-jdk
+      - run:
+          name: Set default java 12
+          command:
+            sudo update-java-alternatives --set java-1.12.0-openjdk-amd64
+      - run:
+          name: Update maven version
+          command:
+            curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.3
+      - run:
+          name: Install libaio1.so library for MySQL integration tests
+          command:
+            sudo apt-get install libaio1 libaio-dev
+      - run:
+          name: Drill project build
+          command: >
+            mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
+            -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: m2-{{ checksum "pom.xml" }}
+
+  build_jdk13:
+    machine:
+      enabled: true
+      image: circleci/classic:latest
+    parallelism: 1
+
+    working_directory: ~/drill
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2- # used if checksum fails
+      - run:
+          name: Update packages list
+          command:
+            sudo apt-get update
+      - run:
+          name: Install java 13
+          command:
+            sudo apt-get -y install openjdk-13-jdk
+      - run:
+          name: Set default java 13
+          command:
+            sudo update-java-alternatives --set java-1.13.0-openjdk-amd64
+      - run:
+          name: Update maven version
+          command:
+            curl -fsSL https://git.io/vpDIf | bash -s -- 3.6.3
+      - run:
+          name: Install libaio1.so library for MySQL integration tests
+          command:
+            sudo apt-get install libaio1 libaio-dev
+      - run:
+          name: Drill project build
+          command: >
+            mvn install -Drat.skip=false -Dlicense.skip=false -DmemoryMb=2560 -DdirectMemoryMb=4608
+            -DexcludedGroups="org.apache.drill.categories.SlowTest,org.apache.drill.categories.UnlikelyTest" --batch-mode
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: m2-{{ checksum "pom.xml" }}
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-    - build_jdk8
-    - build_jdk9
-    - build_jdk10
-    - build_jdk11
+      - build_jdk8
+      - build_jdk11
+      - build_jdk12
+      - build_jdk13

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveClusterTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveClusterTest.java
@@ -20,8 +20,6 @@ package org.apache.drill.exec.hive;
 import org.apache.drill.test.ClusterTest;
 import org.junit.BeforeClass;
 
-import static org.junit.Assume.assumeTrue;
-
 /**
  * Base class for Hive cluster tests.
  */
@@ -29,6 +27,6 @@ public class HiveClusterTest extends ClusterTest {
 
   @BeforeClass
   public static void checkJavaVersion() {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
+    HiveTestUtilities.assumeJavaVersion();
   }
 }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveClusterTest.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveClusterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.hive;
+
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Base class for Hive cluster tests.
+ */
+public class HiveClusterTest extends ClusterTest {
+
+  @BeforeClass
+  public static void checkJavaVersion() {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
+  }
+}

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
@@ -65,7 +65,7 @@ public class HiveTestBase extends PlanTestBase {
 
   @BeforeClass
   public static void setUp() {
-    HiveClusterTest.checkJavaVersion();
+    HiveTestUtilities.assumeJavaVersion();
     HIVE_TEST_FIXTURE.getPluginManager().addHivePluginTo(bits);
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
@@ -28,8 +28,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.Description;
 
-import static org.junit.Assume.assumeTrue;
-
 /**
  * Base class for Hive test. Takes care of generating and adding Hive test plugin before tests and deleting the
  * plugin after tests.
@@ -67,7 +65,7 @@ public class HiveTestBase extends PlanTestBase {
 
   @BeforeClass
   public static void setUp() {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
+    HiveClusterTest.checkJavaVersion();
     HIVE_TEST_FIXTURE.getPluginManager().addHivePluginTo(bits);
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestBase.java
@@ -28,6 +28,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.Description;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Base class for Hive test. Takes care of generating and adding Hive test plugin before tests and deleting the
  * plugin after tests.
@@ -37,30 +39,35 @@ public class HiveTestBase extends PlanTestBase {
   public static final HiveTestFixture HIVE_TEST_FIXTURE;
 
   static {
-    // generate hive data common for all test classes using own dirWatcher
-    BaseDirTestWatcher generalDirWatcher = new BaseDirTestWatcher() {
-      {
+    if (HiveTestUtilities.supportedJavaVersion()) {
+      // generate hive data common for all test classes using own dirWatcher
+      BaseDirTestWatcher generalDirWatcher = new BaseDirTestWatcher() {
+        {
         /*
            Below protected method invoked to create directory DirWatcher.dir with path like:
            ./target/org.apache.drill.exec.hive.HiveTestBase123e4567-e89b-12d3-a456-556642440000.
            Then subdirectory with name 'root' will be used to hold metastore_db and other data shared between
            all derivatives of the class. Note that UUID suffix is necessary to avoid conflicts between forked JVMs.
         */
-        starting(Description.createSuiteDescription(HiveTestBase.class.getName().concat(UUID.randomUUID().toString())));
-      }
-    };
-    File baseDir = generalDirWatcher.getRootDir();
-    HIVE_TEST_FIXTURE = HiveTestFixture.builder(baseDir).build();
-    HiveTestDataGenerator dataGenerator = new HiveTestDataGenerator(generalDirWatcher, baseDir,
-        HIVE_TEST_FIXTURE.getWarehouseDir());
-    HIVE_TEST_FIXTURE.getDriverManager().runWithinSession(dataGenerator::generateData);
+          starting(Description.createSuiteDescription(HiveTestBase.class.getName().concat(UUID.randomUUID().toString())));
+        }
+      };
+      File baseDir = generalDirWatcher.getRootDir();
+      HIVE_TEST_FIXTURE = HiveTestFixture.builder(baseDir).build();
+      HiveTestDataGenerator dataGenerator = new HiveTestDataGenerator(generalDirWatcher, baseDir,
+          HIVE_TEST_FIXTURE.getWarehouseDir());
+      HIVE_TEST_FIXTURE.getDriverManager().runWithinSession(dataGenerator::generateData);
 
-    // set hook for clearing watcher's dir on JVM shutdown
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(generalDirWatcher.getDir())));
+      // set hook for clearing watcher's dir on JVM shutdown
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteQuietly(generalDirWatcher.getDir())));
+    } else {
+      HIVE_TEST_FIXTURE = null;
+    }
   }
 
   @BeforeClass
   public static void setUp() {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     HIVE_TEST_FIXTURE.getPluginManager().addHivePluginTo(bits);
   }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
@@ -128,4 +128,13 @@ public class HiveTestUtilities {
     assertThat(plan, containsString("HiveDrillNativeParquetScan"));
   }
 
+  /**
+   * Current Hive version doesn't support JDK 9+.
+   * Checks whether used supported for Hive Java version.
+   *
+   * @return {@code true} if used supported for Hive Java version, {@code false} otherwise
+   */
+  public static boolean supportedJavaVersion() {
+    return System.getProperty("java.version").startsWith("1.8");
+  }
 }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
@@ -30,9 +30,12 @@ import org.apache.drill.test.TestTools;
 import org.apache.hadoop.hive.ql.CommandNeedRetryException;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
+import org.junit.AssumptionViolatedException;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 public class HiveTestUtilities {
 
@@ -136,5 +139,15 @@ public class HiveTestUtilities {
    */
   public static boolean supportedJavaVersion() {
     return System.getProperty("java.version").startsWith("1.8");
+  }
+
+  /**
+   * Checks if current version is supported by Hive.
+   *
+   * @throws AssumptionViolatedException if current version is not supported by Hive,
+   * so unit tests may be skipped.
+   */
+  public static void assumeJavaVersion() throws AssumptionViolatedException {
+    assumeThat("Skipping tests since Hive supports only JDK 8.", System.getProperty("java.version"), startsWith("1.8"));
   }
 }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestUtilities.java
@@ -130,9 +130,9 @@ public class HiveTestUtilities {
 
   /**
    * Current Hive version doesn't support JDK 9+.
-   * Checks whether used supported for Hive Java version.
+   * Checks if current version is supported by Hive.
    *
-   * @return {@code true} if used supported for Hive Java version, {@code false} otherwise
+   * @return {@code true} if current version is supported by Hive, {@code false} otherwise
    */
   public static boolean supportedJavaVersion() {
     return System.getProperty("java.version").startsWith("1.8");

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveArrays.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveArrays.java
@@ -48,6 +48,7 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.listOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestHiveArrays extends ClusterTest {
@@ -59,6 +60,7 @@ public class TestHiveArrays extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveArrays.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveArrays.java
@@ -28,12 +28,12 @@ import java.util.stream.Stream;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.hive.HiveTestFixture;
 import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.exec.util.Text;
 import org.apache.drill.test.ClusterFixture;
-import org.apache.drill.test.ClusterTest;
 import org.apache.drill.test.TestBuilder;
 import org.apache.hadoop.hive.ql.Driver;
 import org.junit.AfterClass;
@@ -48,10 +48,9 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.listOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
-public class TestHiveArrays extends ClusterTest {
+public class TestHiveArrays extends HiveClusterTest {
 
   private static HiveTestFixture hiveTestFixture;
 
@@ -60,7 +59,6 @@ public class TestHiveArrays extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();
@@ -69,7 +67,7 @@ public class TestHiveArrays extends ClusterTest {
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     if (hiveTestFixture != null) {
       hiveTestFixture.getPluginManager().removeHivePluginFrom(cluster.drillbit());
     }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveMaps.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveMaps.java
@@ -24,11 +24,11 @@ import java.nio.file.Paths;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.hive.HiveTestFixture;
 import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.test.ClusterFixture;
-import org.apache.drill.test.ClusterTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -43,16 +43,14 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
-public class TestHiveMaps extends ClusterTest {
+public class TestHiveMaps extends HiveClusterTest {
 
   private static HiveTestFixture hiveTestFixture;
 
   @BeforeClass
   public static void setUp() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveMaps.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveMaps.java
@@ -43,6 +43,7 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestHiveMaps extends ClusterTest {
@@ -51,6 +52,7 @@ public class TestHiveMaps extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();
@@ -59,7 +61,7 @@ public class TestHiveMaps extends ClusterTest {
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     if (hiveTestFixture != null) {
       hiveTestFixture.getPluginManager().removeHivePluginFrom(cluster.drillbit());
     }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
@@ -42,6 +42,7 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestHiveStructs extends ClusterTest {
@@ -80,6 +81,7 @@ public class TestHiveStructs extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();
@@ -88,7 +90,7 @@ public class TestHiveStructs extends ClusterTest {
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     if (hiveTestFixture != null) {
       hiveTestFixture.getPluginManager().removeHivePluginFrom(cluster.drillbit());
     }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
@@ -23,13 +23,13 @@ import java.nio.file.Paths;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.hive.HiveTestFixture;
 import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.util.JsonStringHashMap;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.exec.util.Text;
 import org.apache.drill.test.ClusterFixture;
-import org.apache.drill.test.ClusterTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -42,10 +42,9 @@ import static org.apache.drill.exec.expr.fn.impl.DateUtility.parseLocalDate;
 import static org.apache.drill.exec.hive.HiveTestUtilities.assertNativeScanUsed;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
-public class TestHiveStructs extends ClusterTest {
+public class TestHiveStructs extends HiveClusterTest {
 
   private static final JsonStringHashMap<String, Object> STR_N0_ROW_1 = mapOf(
       "f_int", -3000, "f_string", new Text("AbbBBa"), "f_varchar", new Text("-c54g"), "f_char", new Text("Th"),
@@ -81,7 +80,6 @@ public class TestHiveStructs extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true));
     hiveTestFixture = HiveTestFixture.builder(dirTestWatcher).build();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveUnions.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveUnions.java
@@ -37,6 +37,7 @@ import org.junit.experimental.categories.Category;
 import static org.apache.drill.test.TestBuilder.listOf;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestHiveUnions extends ClusterTest {
@@ -45,6 +46,7 @@ public class TestHiveUnions extends ClusterTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true)
     );
@@ -54,7 +56,7 @@ public class TestHiveUnions extends ClusterTest {
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     if (hiveTestFixture != null) {
       hiveTestFixture.getPluginManager().removeHivePluginFrom(cluster.drillbit());
     }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveUnions.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveUnions.java
@@ -24,10 +24,10 @@ import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.expr.fn.impl.DateUtility;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.hive.HiveTestFixture;
 import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.test.ClusterFixture;
-import org.apache.drill.test.ClusterTest;
 import org.apache.hadoop.hive.ql.Driver;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -37,16 +37,14 @@ import org.junit.experimental.categories.Category;
 import static org.apache.drill.test.TestBuilder.listOf;
 import static org.apache.drill.test.TestBuilder.mapOf;
 import static org.apache.drill.test.TestBuilder.mapOfObject;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
-public class TestHiveUnions extends ClusterTest {
+public class TestHiveUnions extends HiveClusterTest {
 
   private static HiveTestFixture hiveTestFixture;
 
   @BeforeClass
   public static void setUp() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startCluster(ClusterFixture.builder(dirTestWatcher)
         .sessionOption(ExecConstants.HIVE_OPTIMIZE_PARQUET_SCAN_WITH_NATIVE_READER, true)
     );

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.calcite.schema.Schema.TableType;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.impersonation.BaseTestImpersonation;
 import org.apache.drill.exec.store.hive.HiveStoragePluginConfig;
 import org.apache.drill.test.TestBuilder;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.shims.ShimLoader;
+import org.junit.BeforeClass;
 
 import static org.apache.drill.exec.hive.HiveTestUtilities.createDirWithPosixPermissions;
 import static org.apache.drill.exec.hive.HiveTestUtilities.executeQuery;
@@ -61,6 +63,11 @@ public class BaseTestHiveImpersonation extends BaseTestImpersonation {
   protected static final String partitionStudentDef = "CREATE TABLE %s.%s" +
       "(rownum INT, name STRING, gpa FLOAT, studentnum BIGINT) " +
       "partitioned by (age INT) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' STORED AS TEXTFILE";
+
+  @BeforeClass
+  public static void setUp() {
+    HiveClusterTest.checkJavaVersion();
+  }
 
   protected static void prepHiveConfAndData() throws Exception {
     hiveConf = new HiveConf();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/BaseTestHiveImpersonation.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.calcite.schema.Schema.TableType;
-import org.apache.drill.exec.hive.HiveClusterTest;
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.impersonation.BaseTestImpersonation;
 import org.apache.drill.exec.store.hive.HiveStoragePluginConfig;
 import org.apache.drill.test.TestBuilder;
@@ -66,7 +66,7 @@ public class BaseTestHiveImpersonation extends BaseTestImpersonation {
 
   @BeforeClass
   public static void setUp() {
-    HiveClusterTest.checkJavaVersion();
+    HiveTestUtilities.assumeJavaVersion();
   }
 
   protected static void prepHiveConfAndData() throws Exception {

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.impersonation.hive;
 
-import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.categories.HiveStorageTest;
@@ -49,7 +48,6 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestSqlStdBasedAuthorization extends BaseTestHiveImpersonation {
@@ -80,7 +78,6 @@ public class TestSqlStdBasedAuthorization extends BaseTestHiveImpersonation {
 
   @BeforeClass
   public static void setup() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startMiniDfsCluster(TestSqlStdBasedAuthorization.class.getSimpleName());
     prepHiveConfAndData();
     setSqlStdBasedAuthorizationInHiveConf();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestSqlStdBasedAuthorization.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.impersonation.hive;
 
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.categories.HiveStorageTest;
@@ -48,6 +49,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestSqlStdBasedAuthorization extends BaseTestHiveImpersonation {
@@ -78,6 +80,7 @@ public class TestSqlStdBasedAuthorization extends BaseTestHiveImpersonation {
 
   @BeforeClass
   public static void setup() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startMiniDfsCluster(TestSqlStdBasedAuthorization.class.getSimpleName());
     prepHiveConfAndData();
     setSqlStdBasedAuthorizationInHiveConf();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.hadoop.fs.Path;
@@ -54,7 +53,6 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREAT
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation {
@@ -168,7 +166,6 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
 
   @BeforeClass
   public static void setup() throws Exception {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startMiniDfsCluster(TestStorageBasedHiveAuthorization.class.getName());
     prepHiveConfAndData();
     setStorabaseBasedAuthorizationInHiveConf();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/impersonation/hive/TestStorageBasedHiveAuthorization.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.calcite.schema.Schema.TableType;
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.hadoop.fs.Path;
@@ -53,6 +54,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_AUTO_CREAT
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_SCHEMA_VERIFICATION;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation {
@@ -166,6 +168,7 @@ public class TestStorageBasedHiveAuthorization extends BaseTestHiveImpersonation
 
   @BeforeClass
   public static void setup() throws Exception {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     startMiniDfsCluster(TestStorageBasedHiveAuthorization.class.getName());
     prepHiveConfAndData();
     setStorabaseBasedAuthorizationInHiveConf();

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.hive.HiveTestUtilities;
+import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.sql.TestBaseViewSupport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,14 +30,13 @@ import org.junit.experimental.categories.Category;
 
 import static org.apache.drill.exec.hive.HiveTestBase.HIVE_TEST_FIXTURE;
 import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_TMP_SCHEMA;
-import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestViewSupportOnHiveTables extends TestBaseViewSupport {
 
   @BeforeClass
   public static void setUp() {
-    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
+    HiveClusterTest.checkJavaVersion();
     Objects.requireNonNull(HIVE_TEST_FIXTURE, "Failed to configure Hive storage plugin, " +
         "because HiveTestBase.HIVE_TEST_FIXTURE isn't initialized!")
         .getPluginManager().addHivePluginTo(bits);

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.sql.TestBaseViewSupport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,19 +30,21 @@ import org.junit.experimental.categories.Category;
 
 import static org.apache.drill.exec.hive.HiveTestBase.HIVE_TEST_FIXTURE;
 import static org.apache.drill.exec.util.StoragePluginTestUtils.DFS_TMP_SCHEMA;
+import static org.junit.Assume.assumeTrue;
 
 @Category({SlowTest.class, HiveStorageTest.class})
 public class TestViewSupportOnHiveTables extends TestBaseViewSupport {
 
   @BeforeClass
-  public static void setUp() throws Exception {
+  public static void setUp() {
+    assumeTrue("Skipping tests since Hive supports only JDK 8.", HiveTestUtilities.supportedJavaVersion());
     Objects.requireNonNull(HIVE_TEST_FIXTURE, "Failed to configure Hive storage plugin, " +
         "because HiveTestBase.HIVE_TEST_FIXTURE isn't initialized!")
         .getPluginManager().addHivePluginTo(bits);
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     if (HIVE_TEST_FIXTURE != null) {
       HIVE_TEST_FIXTURE.getPluginManager().removeHivePluginFrom(bits);
     }

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/sql/hive/TestViewSupportOnHiveTables.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
-import org.apache.drill.exec.hive.HiveClusterTest;
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.exec.sql.TestBaseViewSupport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,7 +36,7 @@ public class TestViewSupportOnHiveTables extends TestBaseViewSupport {
 
   @BeforeClass
   public static void setUp() {
-    HiveClusterTest.checkJavaVersion();
+    HiveTestUtilities.assumeJavaVersion();
     Objects.requireNonNull(HIVE_TEST_FIXTURE, "Failed to configure Hive storage plugin, " +
         "because HiveTestBase.HIVE_TEST_FIXTURE isn't initialized!")
         .getPluginManager().addHivePluginTo(bits);

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>2.0.3</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggregateHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataAggregateHelper.java
@@ -182,7 +182,8 @@ public class MetadataAggregateHelper {
   private void addLastModifiedCall() {
     String lastModifiedColumn = columnNamesOptions.lastModifiedTime();
     LogicalExpression lastModifiedTime;
-    if (createNewAggregations()) {
+    // it is enough to call any_value(`lmt`) for file metadata level or more specific metadata
+    if (context.metadataLevel().includes(MetadataType.FILE)) {
       lastModifiedTime = new FunctionCall("any_value",
           Collections.singletonList(
               FieldReference.getWithQuotedRef(lastModifiedColumn)),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -173,6 +173,10 @@ public class BatchValidator {
   }
 
   public static boolean validate(RecordBatch batch) {
+    // This is a handy place to trace batches as they flow up
+    // the DAG. Works best for single-threaded runs with few records.
+    // System.out.println(batch.getClass().getSimpleName());
+    // RowSetFormatter.print(batch);
     ErrorReporter reporter = errorReporter(batch);
     int rowCount = batch.getRecordCount();
     int valueCount = rowCount;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/validate/BatchValidator.java
@@ -174,7 +174,7 @@ public class BatchValidator {
 
   public static boolean validate(RecordBatch batch) {
     // This is a handy place to trace batches as they flow up
-    // the DAG. Works best for single-threaded runs with few records.
+    // the DAG. Works best for single-threaded runs with a few records.
     // System.out.println(batch.getClass().getSimpleName());
     // RowSetFormatter.print(batch);
     ErrorReporter reporter = errorReporter(batch);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/spnego/TestDrillSpnegoAuthenticator.java
@@ -133,7 +133,6 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
   /**
    * Test to verify response when request is sent for {@link WebServerConstants#SPENGO_LOGIN_RESOURCE_PATH} from
    * unauthenticated session. Expectation is client will receive response with Negotiate header.
-   * @throws Exception
    */
   @Test
   public void testNewSessionReqForSpnegoLogin() throws Exception {
@@ -154,7 +153,6 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
   /**
    * Test to verify response when request is sent for {@link WebServerConstants#SPENGO_LOGIN_RESOURCE_PATH} from
    * authenticated session. Expectation is server will find the authenticated UserIdentity.
-   * @throws Exception
    */
   @Test
   public void testAuthClientRequestForSpnegoLoginResource() throws Exception {
@@ -179,7 +177,6 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
    * Test to verify response when request is sent for any other resource other than
    * {@link WebServerConstants#SPENGO_LOGIN_RESOURCE_PATH} from authenticated session. Expectation is server will
    * find the authenticated UserIdentity and will not perform the authentication again for new resource.
-   * @throws Exception
    */
   @Test
   public void testAuthClientRequestForOtherPage() throws Exception {
@@ -203,8 +200,7 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
   /**
    * Test to verify that when request is sent for {@link WebServerConstants#LOGOUT_RESOURCE_PATH} then the UserIdentity
    * will be removed from the session and returned authentication will be null from
-   * {@link DrillSpnegoAuthenticator#validateRequest(ServletRequest, ServletResponse, boolean)}
-   * @throws Exception
+   * {@link DrillSpnegoAuthenticator#validateRequest(javax.servlet.ServletRequest, javax.servlet.ServletResponse, boolean)}
    */
   @Test
   public void testAuthClientRequestForLogOut() throws Exception {
@@ -228,7 +224,6 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
   /**
    * Test to verify authentication fails when client sends invalid SPNEGO token for the
    * {@link WebServerConstants#SPENGO_LOGIN_RESOURCE_PATH} resource.
-   * @throws Exception
    */
   @Test
   public void testSpnegoLoginInvalidToken() throws Exception {
@@ -242,28 +237,25 @@ public class TestDrillSpnegoAuthenticator extends BaseTest {
         spnegoHelper.clientKeytab.getAbsoluteFile());
 
     // Generate a SPNEGO token for the peer SERVER_PRINCIPAL from this CLIENT_PRINCIPAL
-    final String token = Subject.doAs(clientSubject, new PrivilegedExceptionAction<String>() {
-      @Override
-      public String run() throws Exception {
+    final String token = Subject.doAs(clientSubject, (PrivilegedExceptionAction<String>) () -> {
 
-        final GSSManager gssManager = GSSManager.getInstance();
-        GSSContext gssContext = null;
-        try {
-          final Oid oid = GSSUtil.GSS_SPNEGO_MECH_OID;
-          final GSSName serviceName = gssManager.createName(spnegoHelper.SERVER_PRINCIPAL, GSSName.NT_USER_NAME, oid);
+      final GSSManager gssManager = GSSManager.getInstance();
+      GSSContext gssContext = null;
+      try {
+        final Oid oid = GSSUtil.GSS_SPNEGO_MECH_OID;
+        final GSSName serviceName = gssManager.createName(spnegoHelper.SERVER_PRINCIPAL, GSSName.NT_USER_NAME, oid);
 
-          gssContext = gssManager.createContext(serviceName, oid, null, GSSContext.DEFAULT_LIFETIME);
-          gssContext.requestCredDeleg(true);
-          gssContext.requestMutualAuth(true);
+        gssContext = gssManager.createContext(serviceName, oid, null, GSSContext.DEFAULT_LIFETIME);
+        gssContext.requestCredDeleg(true);
+        gssContext.requestMutualAuth(true);
 
-          byte[] outToken = new byte[0];
-          outToken = gssContext.initSecContext(outToken, 0, outToken.length);
-          return Base64.encodeBase64String(outToken);
+        byte[] outToken = new byte[0];
+        outToken = gssContext.initSecContext(outToken, 0, outToken.length);
+        return Base64.encodeBase64String(outToken);
 
-        } finally {
-          if (gssContext != null) {
-            gssContext.dispose();
-          }
+      } finally {
+        if (gssContext != null) {
+          gssContext.dispose();
         }
       }
     });

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchemaWithMetastore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchemaWithMetastore.java
@@ -395,7 +395,10 @@ public class TestInfoSchemaWithMetastore extends ClusterTest {
   }
 
   private ZonedDateTime currentUtcTime() {
-    ZonedDateTime currentTime = ZonedDateTime.of(LocalDateTime.now(), ZoneId.systemDefault());
+    // Java 9 and later returns LocalDateTime with nanoseconds precision,
+    // but Java 8 returns LocalDateTime with milliseconds precision
+    // and metastore stores last modified time in milliseconds
+    ZonedDateTime currentTime = ZonedDateTime.of(LocalDateTime.now().withNano(0), ZoneId.systemDefault());
     return currentTime.withZoneSameInstant(ZoneId.of("UTC"));
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
@@ -528,7 +528,8 @@ public class TestMetastoreCommands extends ClusterTest {
             .basicRequests()
             .tableMetadata(tableInfo);
 
-        assertEquals(expectedTableMetadata, actualTableMetadata);
+        assertEquals(String.format("Table metadata mismatch for [%s] metadata level", analyzeLevel),
+            expectedTableMetadata, actualTableMetadata);
       } finally {
         run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
       }

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -136,15 +136,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.codemodel</groupId>
-      <artifactId>codemodel</artifactId>
-      <version>${codemodel.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.openhft</groupId>
-      <artifactId>compiler</artifactId>
-      <version>2.3.4</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
@@ -298,8 +298,9 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
   /**
    * Helper class for constructing field type signature string.
-   *
+   * <p>
    * Example of usage:
+   * <p>
    * Desired type: {@code List<Map<String, List<Integer>>>}
    * <pre><code>
    *         String signature = FieldSignatureBuilder.builder()
@@ -321,7 +322,6 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
    *           .endType()
    *           .buildSignature();
    * </code></pre>
-   *
    */
   private static class FieldSignatureBuilder {
     private final SignatureVisitor signatureVisitor = new SignatureWriter();

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
@@ -17,35 +17,27 @@
  */
 package org.apache.drill.metastore.iceberg.schema;
 
-import com.sun.codemodel.CodeWriter;
-import com.sun.codemodel.JAnnotationArrayMember;
-import com.sun.codemodel.JAnnotationUse;
-import com.sun.codemodel.JClass;
-import com.sun.codemodel.JClassAlreadyExistsException;
-import com.sun.codemodel.JCodeModel;
-import com.sun.codemodel.JDefinedClass;
-import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JMod;
-import com.sun.codemodel.JPackage;
-import net.openhft.compiler.CompilerUtils;
 import org.apache.drill.metastore.MetastoreFieldDefinition;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
 import org.apache.drill.metastore.iceberg.exceptions.IcebergMetastoreException;
-import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.signature.SignatureWriter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.V1_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -53,40 +45,36 @@ import static org.junit.Assert.assertNull;
 public class TestIcebergTableSchema extends IcebergBaseTest {
 
   @Test
-  public void testAllTypes() throws Exception {
+  public void testAllTypes() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "AllTypes") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JFieldVar stringField = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "stringField");
+      void addFields(ClassWriter classWriter) {
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
         annotate(stringField);
 
-        JFieldVar intField = jDefinedClass.field(DEFAULT_FIELD_MODE, int.class, "intField");
+        FieldVisitor intField = addField(classWriter, Opcodes.ACC_PRIVATE, "intField", int.class);
         annotate(intField);
 
-        JFieldVar integerField = jDefinedClass.field(DEFAULT_FIELD_MODE, Integer.class, "integerField");
+        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
         annotate(integerField);
 
-        JFieldVar longField = jDefinedClass.field(DEFAULT_FIELD_MODE, Long.class, "longField");
+        FieldVisitor longField = addField(classWriter, Opcodes.ACC_PRIVATE, "longField", Long.class);
         annotate(longField);
 
-        JFieldVar floatField = jDefinedClass.field(DEFAULT_FIELD_MODE, Float.class, "floatField");
+        FieldVisitor floatField = addField(classWriter, Opcodes.ACC_PRIVATE, "floatField", Float.class);
         annotate(floatField);
 
-        JFieldVar doubleField = jDefinedClass.field(DEFAULT_FIELD_MODE, Double.class, "doubleField");
+        FieldVisitor doubleField = addField(classWriter, Opcodes.ACC_PRIVATE, "doubleField", Double.class);
         annotate(doubleField);
 
-        JFieldVar booleanField = jDefinedClass.field(DEFAULT_FIELD_MODE, Boolean.class, "booleanField");
+        FieldVisitor booleanField = addField(classWriter, Opcodes.ACC_PRIVATE, "booleanField", Boolean.class);
         annotate(booleanField);
 
-        JCodeModel jCodeModel = jDefinedClass.owner();
-
-        JClass listRef = jCodeModel.ref(List.class).narrow(String.class);
-        JFieldVar listField = jDefinedClass.field(DEFAULT_FIELD_MODE, listRef, "listField");
+        FieldVisitor listField = addField(classWriter, Opcodes.ACC_PRIVATE, "listField", List.class, String.class);
         annotate(listField);
 
-        JClass mapRef = jCodeModel.ref(Map.class).narrow(String.class, Float.class);
-        JFieldVar mapField = jDefinedClass.field(DEFAULT_FIELD_MODE, mapRef, "mapField");
+        FieldVisitor mapField = addField(classWriter, Opcodes.ACC_PRIVATE, "mapField", Map.class, String.class, Float.class);
         annotate(mapField);
       }
 
@@ -114,15 +102,15 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
   }
 
   @Test
-  public void testIgnoreUnannotatedFields() throws Exception {
+  public void testIgnoreUnannotatedFields() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "IgnoreUnannotatedFields") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JFieldVar stringField = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "stringField");
+      void addFields(ClassWriter classWriter) {
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
         annotate(stringField);
 
-        jDefinedClass.field(DEFAULT_FIELD_MODE, Integer.class, "integerField");
+        addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
       }
     }.generate();
 
@@ -132,16 +120,28 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
   }
 
   @Test
-  public void testNestedComplexType() throws Exception {
+  public void testNestedComplexType() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "NestedComplexType") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JCodeModel jCodeModel = jDefinedClass.owner();
+      void addFields(ClassWriter classWriter) {
+        String descriptor = Type.getType(List.class).getDescriptor();
 
-        JClass nestedListRef = jCodeModel.ref(List.class).narrow(String.class);
-        JClass listRef = jCodeModel.ref(List.class).narrow(nestedListRef);
-        JFieldVar listField = jDefinedClass.field(DEFAULT_FIELD_MODE, listRef, "listField");
+        String signature = FieldSignatureBuilder.builder()
+            .declareType(List.class)
+            .startGeneric()
+                .declareType(List.class)
+                .startGeneric()
+                    .declareType(String.class)
+                    .endType()
+                .endGeneric()
+                .endType()
+            .endGeneric()
+            .endType()
+            .buildSignature();
+
+        FieldVisitor listField =
+            classWriter.visitField(Opcodes.ACC_PRIVATE, "stringField", descriptor, signature, null);
         annotate(listField);
       }
     }.generate();
@@ -152,12 +152,12 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
   }
 
   @Test
-  public void testUnpartitionedPartitionSpec() throws Exception {
+  public void testUnpartitionedPartitionSpec() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "UnpartitionedPartitionSpec") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JFieldVar stringField = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "stringField");
+      void addFields(ClassWriter classWriter) {
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
         annotate(stringField);
       }
     }.generate();
@@ -169,24 +169,24 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
   }
 
   @Test
-  public void testPartitionedPartitionSpec() throws Exception {
+  public void testPartitionedPartitionSpec() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "PartitionedPartitionSpec") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JFieldVar partKey1 = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "partKey1");
+      void addFields(ClassWriter classWriter) {
+        FieldVisitor partKey1 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey1", String.class);
         annotate(partKey1);
 
-        JFieldVar partKey2 = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "partKey2");
+        FieldVisitor partKey2 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey2", String.class);
         annotate(partKey2);
 
-        JFieldVar partKey3 = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "partKey3");
+        FieldVisitor partKey3 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey3", String.class);
         annotate(partKey3);
 
-        JFieldVar integerField = jDefinedClass.field(DEFAULT_FIELD_MODE, Integer.class, "integerField");
+        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
         annotate(integerField);
 
-        JFieldVar booleanField = jDefinedClass.field(DEFAULT_FIELD_MODE, Boolean.class, "booleanField");
+        FieldVisitor booleanField = addField(classWriter, Opcodes.ACC_PRIVATE, "booleanField", Boolean.class);
         annotate(booleanField);
       }
     }.generate();
@@ -216,15 +216,15 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
   }
 
   @Test
-  public void testUnMatchingPartitionSpec() throws Exception {
+  public void testUnMatchingPartitionSpec() {
     Class<?> clazz = new ClassGenerator(getClass().getSimpleName() + "UnMatchingPartitionSpec") {
 
       @Override
-      void addFields(JDefinedClass jDefinedClass) {
-        JFieldVar partKey1 = jDefinedClass.field(DEFAULT_FIELD_MODE, String.class, "partKey1");
+      void addFields(ClassWriter classWriter) {
+        FieldVisitor partKey1 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey1", String.class);
         annotate(partKey1);
 
-        JFieldVar integerField = jDefinedClass.field(DEFAULT_FIELD_MODE, Integer.class, "integerField");
+        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
         annotate(integerField);
       }
     }.generate();
@@ -238,9 +238,7 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
    * Generates and loads class at the runtime with specified fields.
    * Fields may or may not be annotated.
    */
-  private abstract class ClassGenerator {
-
-    final int DEFAULT_FIELD_MODE = JMod.PRIVATE;
+  private static abstract class ClassGenerator {
 
     private final String name;
 
@@ -248,53 +246,112 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
       this.name = name;
     }
 
-    Class<?> generate() throws JClassAlreadyExistsException, IOException, ClassNotFoundException {
-      JCodeModel jCodeModel = prepareModel();
-      ByteArrayStreamCodeWriter codeWriter = new ByteArrayStreamCodeWriter();
-      jCodeModel.build(codeWriter);
+    Class<?> generate() {
+      ClassWriter classWriter = generateClass();
 
-      String sourceCode = codeWriter.sourceCode();
-      return CompilerUtils.CACHED_COMPILER.loadFromJava(name, sourceCode);
+      byte[] bytes = classWriter.toByteArray();
+      return new ClassLoader() {
+        public Class<?> injectClass(String name, byte[] classBytes) {
+          return defineClass(name, classBytes, 0, classBytes.length);
+        }
+      }.injectClass(name, bytes);
     }
 
-    private JCodeModel prepareModel() throws JClassAlreadyExistsException {
-      JCodeModel jCodeModel = new JCodeModel();
-      JPackage jPackage = jCodeModel._package("");
-      JDefinedClass jDefinedClass = jPackage._class(name);
-      addFields(jDefinedClass);
-      return jCodeModel;
-    }
+    public FieldVisitor addField(ClassWriter classWriter, int access, String fieldName, Class<?> clazz, Class<?>... genericTypes) {
+      String descriptor = Type.getType(clazz).getDescriptor();
 
-    void annotate(JFieldVar field) {
-      annotate(field, MetadataType.ALL);
-    }
+      String signature = null;
 
-    void annotate(JFieldVar field, MetadataType... scopes) {
-      JAnnotationUse annotate = field.annotate(MetastoreFieldDefinition.class);
-      assert scopes.length != 0;
-      JAnnotationArrayMember scopesParam = annotate.paramArray("scopes");
-      Stream.of(scopes).forEach(scopesParam::param);
-    }
-
-    abstract void addFields(JDefinedClass jDefinedClass);
-
-    private class ByteArrayStreamCodeWriter extends CodeWriter {
-
-      private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-      @Override
-      public OutputStream openBinary(JPackage pkg, String fileName) {
-        return outputStream;
+      if (genericTypes.length > 0) {
+        FieldSignatureBuilder fieldSignatureBuilder = FieldSignatureBuilder.builder()
+            .declareType(clazz)
+            .startGeneric();
+        for (Class<?> genericType : genericTypes) {
+          fieldSignatureBuilder
+              .declareType(genericType)
+              .endType();
+        }
+        signature = fieldSignatureBuilder
+            .endGeneric()
+            .endType()
+            .buildSignature();
       }
 
-      @Override
-      public void close() {
-        // no need to close byte array stream
-      }
+      return classWriter.visitField(access, fieldName, descriptor, signature, null);
+    }
 
-      String sourceCode() {
-        return new String(outputStream.toByteArray());
-      }
+    void annotate(FieldVisitor field) {
+      field.visitAnnotation(Type.getType(MetastoreFieldDefinition.class).getDescriptor(), true);
+    }
+
+    private ClassWriter generateClass() {
+      ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+      classWriter.visit(V1_8, ACC_PUBLIC, name, null, Type.getInternalName(Object.class), null);
+      addFields(classWriter);
+      classWriter.visitEnd();
+
+      return classWriter;
+    }
+
+    abstract void addFields(ClassWriter classWriter);
+  }
+
+  /**
+   * Helper class for constructing field type signature string.
+   *
+   * Example of usage:
+   * Desired type: {@code List<Map<String, List<Integer>>>}
+   * <pre><code>
+   *         String signature = FieldSignatureBuilder.builder()
+   *           .declareType(List.class)
+   *           .startGeneric()
+   *               .declareType(Map.class)
+   *               .startGeneric()
+   *                   .declareType(String.class)
+   *                   .endType()
+   *                   .declareType(List.class)
+   *                   .startGeneric()
+   *                       .declareType(Integer.class)
+   *                       .endType()
+   *                   .endGeneric()
+   *                   .endType()
+   *               .endGeneric()
+   *               .endType()
+   *           .endGeneric()
+   *           .endType()
+   *           .buildSignature();
+   * </code></pre>
+   *
+   */
+  private static class FieldSignatureBuilder {
+    private final SignatureVisitor signatureVisitor = new SignatureWriter();
+
+    public FieldSignatureBuilder declareType(Class<?> clazz) {
+      signatureVisitor.visitClassType(Type.getInternalName(clazz));
+      return this;
+    }
+
+    public FieldSignatureBuilder startGeneric() {
+      signatureVisitor.visitTypeArgument('=');
+      return this;
+    }
+
+    public FieldSignatureBuilder endGeneric() {
+      signatureVisitor.visitSuperclass();
+      return this;
+    }
+
+    public FieldSignatureBuilder endType() {
+      signatureVisitor.visitEnd();
+      return this;
+    }
+
+    public String buildSignature() {
+      return signatureVisitor.toString();
+    }
+
+    public static FieldSignatureBuilder builder() {
+      return new FieldSignatureBuilder();
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,14 @@
     <hbase.version>2.2.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>
-    <javassist.version>3.25.0-GA</javassist.version>
+    <javassist.version>3.26.0-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.9.0</avro.version>
     <metrics.version>4.0.2</metrics.version>
     <jetty.version>9.3.25.v20180904</jetty.version>
     <jersey.version>2.25.1</jersey.version>
-    <asm.version>7.0</asm.version>
+    <asm.version>7.2</asm.version>
     <excludedGroups />
     <memoryMb>4096</memoryMb>
     <directMemoryMb>4096</directMemoryMb>
@@ -108,6 +108,7 @@
     <protobuf.version>3.6.1</protobuf.version>
     <codemodel.version>2.6</codemodel.version>
     <joda.version>2.10.5</joda.version>
+    <surefire.version>3.0.0-M4</surefire.version>
   </properties>
 
   <scm>
@@ -552,7 +553,7 @@
                   <version>[{$lowestMavenVersion},4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.8,12)</version>
+                  <version>[1.8,14)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -759,7 +760,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>${surefire.version}</version>
           <executions>
             <execution>
               <id>default-test</id>
@@ -773,7 +774,7 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>3.0.0-M3</version>
+              <version>${surefire.version}</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -914,6 +915,14 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <!-- Specifies asm version which supports JDK 12+ -->
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -82,7 +82,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6.0</version>
         <configuration>
           <goalPrefix>drill-fmpp</goalPrefix>
         </configuration>
@@ -102,6 +102,14 @@
             <phase>process-classes</phase>
           </execution>
          </executions>
+        <!-- Specifies asm version which supports JDK 9+ -->
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
+          </dependency>
+        </dependencies>
        </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Updated ASM (made required changes in code), javassist and maven-surefire-plugin versions to the versions which support JDK 13
- Updated CircleCI configs to run tests for  JDK 8, 11, 12 and 13
- Disabled Hive tests for JDK 9+ since current version doesn't support newer java versions
- Fixed small metastore issue connected with calculating last modified time when performed analyze for table level
- Updated TestIcebergTableSchema test to generate required classes using ASM since `net.openhft:compiler` doesn't support JDK 12+ (due to new restrictions added in https://bugs.openjdk.java.net/browse/JDK-8210522)

Jira - [DRILL-7483](https://issues.apache.org/jira/browse/DRILL-7483)