### PR TITLE
DRILL-7494: Unable to connect to Drill using JDBC driver when using custom authenticator

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
@@ -454,8 +454,8 @@ public class UserClient
       Thread.currentThread().setContextClassLoader(oldThreadCtxtCL);
 
       startSaslHandshake(connectionHandler, saslProperties, ugi, factory, RpcType.SASL_MESSAGE);
-    } catch (final IOException e) {
-      logger.error("Failed while doing setup for starting SASL handshake for connection", connection.getName());
+    } catch (IOException e) {
+      logger.error("Failed while doing setup for starting SASL handshake for connection {}", connection.getName());
       final Exception ex = new RpcException(String.format("Failed to initiate authentication for connection %s",
         connection.getName()), e);
       connectionHandler.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -342,7 +342,6 @@
               <exclude>commons-beanutils:commons-beanutils-core:jar:*</exclude>
               <exclude>commons-beanutils:commons-beanutils:jar:*</exclude>
               <exclude>io.netty:netty-tcnative:jar:*</exclude>
-              <exclude>com.fasterxml.woodstox:woodstox-core:jar:*</exclude>
               <exclude>com.google.code.findbugs:jsr305:*</exclude>
               <exclude>com.esri.geometry:esri-geometry-api:*</exclude>
               <exclude>fr.bmartel:pcapngdecoder:*</exclude>
@@ -409,7 +408,7 @@
             <relocation><pattern>org.apache.xpath.</pattern><shadedPattern>oadd.org.apache.xpath.</shadedPattern></relocation>
             <relocation><pattern>org.apache.zookeeper.</pattern><shadedPattern>oadd.org.apache.zookeeper.</shadedPattern></relocation>
             <relocation><pattern>org.apache.hadoop.</pattern><shadedPattern>oadd.org.apache.hadoop.</shadedPattern></relocation>
-            <relocation><pattern>com.fasterxml.woodstox.</pattern><shadedPattern>oadd.com.fasterxml.woodstox.</shadedPattern></relocation>
+            <relocation><pattern>com.ctc.wstx.</pattern><shadedPattern>oadd.com.ctc.wstx.</shadedPattern></relocation>
           </relocations>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/Driver.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/Driver.java
@@ -21,9 +21,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
+import org.apache.drill.common.util.GuavaPatcher;
+import org.apache.drill.common.util.ProtobufPatcher;
 import org.apache.drill.jdbc.impl.DriverImpl;
 
 
@@ -42,6 +43,8 @@ public class Driver implements java.sql.Driver {
   // DriverManager access it:
 
   static {
+    ProtobufPatcher.patch();
+    GuavaPatcher.patch();
     // Upon loading of class, register an instance with DriverManager.
     try {
       DriverManager.registerDriver(new Driver());
@@ -100,7 +103,7 @@ public class Driver implements java.sql.Driver {
   }
 
   @Override
-  public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+  public java.util.logging.Logger getParentLogger() {
     return impl.getParentLogger();
   }
 

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/ConnectionMultiListener.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/ConnectionMultiListener.java
@@ -77,7 +77,7 @@ public class ConnectionMultiListener<T extends EnumLite, CC extends ClientConnec
   private class ConnectionHandler implements GenericFutureListener<ChannelFuture> {
 
     @Override
-    public void operationComplete(ChannelFuture future) throws Exception {
+    public void operationComplete(ChannelFuture future) {
       boolean isInterrupted = false;
 
       // We want to wait for at least 120 secs when interrupts occur. Establishing a connection fails/succeeds quickly,
@@ -131,7 +131,7 @@ public class ConnectionMultiListener<T extends EnumLite, CC extends ClientConnec
 
   private class SSLConnectionHandler implements GenericFutureListener<Future<Channel>> {
     @Override
-    public void operationComplete(Future<Channel> future) throws Exception {
+    public void operationComplete(Future<Channel> future) {
       // send the handshake
       parent.send(handshakeSendHandler, handshakeValue, true);
     }
@@ -165,9 +165,9 @@ public class ConnectionMultiListener<T extends EnumLite, CC extends ClientConnec
       } catch (NonTransientRpcException ex) {
         logger.error("Failure while validating client and server sasl compatibility", ex);
         connectionListener.connectionFailed(RpcConnectionHandler.FailureType.AUTHENTICATION, ex);
-      } catch (Exception ex) {
-        logger.error("Failure while validating handshake", ex);
-        connectionListener.connectionFailed(RpcConnectionHandler.FailureType.HANDSHAKE_VALIDATION, ex);
+      } catch (Throwable t) {
+        logger.error("Failure while validating handshake", t);
+        connectionListener.connectionFailed(RpcConnectionHandler.FailureType.HANDSHAKE_VALIDATION, t);
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <zookeeper.version>3.4.12</zookeeper.version>
     <mapr.release.version>6.1.0-mapr</mapr.release.version>
     <ojai.version>3.0-mapr-1808</ojai.version>
-    <kerby.version>1.0.0-RC2</kerby.version>
+    <kerby.version>1.0.0</kerby.version>
     <findbugs.version>3.0.0</findbugs.version>
     <netty.tcnative.classifier />
     <commons.io.version>2.4</commons.io.version>


### PR DESCRIPTION
- Removed excluding `com.fasterxml.woodstox:woodstox-core` since it is used in Hadoop classes, for example in the `Configuration` class.
-  Fixed relocation pattern for `com.fasterxml.woodstox:woodstox-core` classes, since there wasn't package `com.fasterxml.woodstox`.
- Replaced catching `Exception` with catching `Throwable` in `ConnectionMultiListener` since, for some cases, error may be thrown, for example, `NoClassDefFoundError` so it should be reported to the client correctly instead of hanging as it was before.
- Added code to patch Guava for JDBC driver since Hadoop uses some methods from the new version absent in 1.19.
- Added code to use the same class loader, which was used for loading patcher classes, for finding classes to patch instead of using system class loader since some clients use separate class loaders for loading and registering drivers.

Jira - [DRILL-7494](https://issues.apache.org/jira/browse/DRILL-7494).