### PR TITLE
DRILL-7497: Fix warnings when starting Drill on Windows using Java 11

### DIFF
--- a/distribution/src/main/resources/sqlline.bat
+++ b/distribution/src/main/resources/sqlline.bat
@@ -198,14 +198,15 @@ if "%JAVA_HOME%" == "" (set JAVA_CMD=%JAVA_EXE%)
 set ERROR_CODE=0
 
 rem Check that java is newer than 1.8
-"%JAVA_CMD%" -version 2>&1 | findstr "1.8" > nul  2>&1
+"%JAVA_CMD%" -version 2>&1 | findstr "1.8" > nul 2>&1
 if errorlevel 1 (
   rem allow reflective access on Java 9+
-  set DRILL_SHELL_JAVA_OPTS=%DRILL_SHELL_JAVA_OPTS% --add-opens java.base/java.lang=ALL-UNNAMED
-  set DRILL_SHELL_JAVA_OPTS=%DRILL_SHELL_JAVA_OPTS% --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-  set DRILL_SHELL_JAVA_OPTS=%DRILL_SHELL_JAVA_OPTS% --add-opens java.base/java.nio=ALL-UNNAMED
-  set DRILL_SHELL_JAVA_OPTS=%DRILL_SHELL_JAVA_OPTS% --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED
-  set DRILL_SHELL_JAVA_OPTS=%DRILL_SHELL_JAVA_OPTS% --illegal-access=permit
+  set DRILL_SHELL_JAVA_OPTS=!DRILL_SHELL_JAVA_OPTS! ^
+    --add-opens java.base/java.lang=ALL-UNNAMED ^
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED ^
+    --add-opens java.base/java.nio=ALL-UNNAMED ^
+    --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED ^
+    --illegal-access=permit
 )
 
 set SQLLINE_CALL=sqlline.SqlLine -ac org.apache.drill.exec.client.DrillSqlLineApplication


### PR DESCRIPTION
Jira - [DRILL-7497](https://issues.apache.org/jira/browse/DRILL-7497).

`%DRILL_SHELL_JAVA_OPTS%` is expanded when if block is parsed, so as a result, every next line of the if block will override the value set in the previous one.
Replaced it with a single assignment.