### PR TITLE
DRILL-7505: PCAP Plugin Fails on IPv6 Packets

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/Packet.java
@@ -513,12 +513,14 @@ public class Packet implements Comparable<Packet> {
         case PacketConstants.AUTHENTICATION_V6:
         case PacketConstants.ENCAPSULATING_SECURITY_V6:
         case PacketConstants.MOBILITY_EXTENSION_V6:
+        case PacketConstants.HOST_IDENTITY_PROTOCOL:
+        case PacketConstants.SHIM6_PROTOCOL:
           nextHeader = getByte(raw, ipOffset + headerLength);
           headerLength += (getByte(raw, ipOffset + headerLength) + 1) * 8;
           break;
         default:
           //noinspection ConstantConditions
-          Preconditions.checkState(false, "Unknown V6 extension or protocol: ", nextHeader);
+          logger.warn("Unknown V6 extension or protocol: {}", nextHeader);
           return getByte(raw, ipOffset + headerLength);
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/PacketConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/decoder/PacketConstants.java
@@ -41,6 +41,9 @@ public final class PacketConstants {
   public static final int AUTHENTICATION_V6 = 51;
   public static final int ENCAPSULATING_SECURITY_V6 = 50;
   public static final int MOBILITY_EXTENSION_V6 = 135;
+  public static final int HOST_IDENTITY_PROTOCOL = 139;
+  public static final int SHIM6_PROTOCOL = 140;
+
   public static final int NO_NEXT_HEADER = 59;
   public static final int UDP_HEADER_LENGTH = 8;
   public static final int VER_IHL_OFFSET = 14;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/decoder/PacketDecoder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/decoder/PacketDecoder.java
@@ -54,7 +54,7 @@ public class PacketDecoder extends Packet {
   protected int processIpV6Packet() {
     try {
       return super.processIpV6Packet();
-    } catch (IllegalStateException ise) {
+    } catch (IllegalStateException | ArrayIndexOutOfBoundsException e) {
       return -1;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/pcap/TestPcapDecoder.java
@@ -211,7 +211,6 @@ public class TestPcapDecoder extends BaseTestQuery {
     logger.info("\n\n\n");
   }
 
-
   /**
    * Creates an ephemeral file of about a GB in size
    *


### PR DESCRIPTION
In its current implementation, the PCAP parser fails with an exception if it encounters a protocol it does not have in its enumerated list. 
This is not an acceptable strategy in that there are many protocols out there and having Drill crash when it encounters an unknown protocol is not helpful or useful.  This minor PR makes the PCAP plugin more fault tolerant.

I tested this on proprietary PCAP files which are too large to include.  Existing unit tests are unaffected.

Jira: [Drill-7505](https://issues.apache.org/jira/browse/DRILL-7505)