### PR TITLE
DRILL-7496: Update Dockerfile to publish release images under Apache Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please read [Environment.md](docs/dev/Environment.md) for setting up and running
 Please see the [Apache Drill Website](http://drill.apache.org/) or the [Apache Drill Documentation](http://drill.apache.org/docs/) for more information including:
 
  * Remote Execution Installation Instructions
+ * [Running Drill on Docker instructions](https://drill.apache.org/docs/running-drill-on-docker/)
  * Information about how to submit logical and distributed physical plans
  * More example queries and sample data
  * Find out ways to be involved or discuss Drill

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -702,7 +702,7 @@
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>dockerfile-maven-plugin</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.13</version>
             <executions>
               <execution>
                 <id>docker-image</id>

--- a/docs/dev/Docker.md
+++ b/docs/dev/Docker.md
@@ -6,71 +6,75 @@
   * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
   * [Maven 3.3.3 or greater](https://maven.apache.org/download.cgi)
   * [Docker CE](https://store.docker.com/search?type=edition&offering=community)
-  
+
    If you are using an older Mac or PC, additionally configure [docker-machine](https://docs.docker.com/machine/overview/#what-is-docker-machine) on your system
+
+## Drill Dockerfiles info
+
+   Drill has two Dockerfiles:
+   - Dockerfile placed in the project root is used for Automated Builds in DockerHub. It builds Drill when building Docker images.
+   - Dockerfile placed in the distribution directory may be used during developing the project. It requires a pre-built Drill.
 
 ## Checkout
 ```
-git clone https://github.com/apache/drill.git
+$ git clone https://github.com/apache/drill.git
 ```
+
 ## Build Drill
 ```
 $ cd drill
 $ mvn clean install
 ```   
+
 ## Build Docker Image
+   To build a Docker image tagged with the current project version using dockerfile maven plugin using pre-built Drill, the following command may be used:
 ```
-$ cd distribution
-$ mvn dockerfile:build -Pdocker
+$ mvn dockerfile:build -Pdocker -pl distribution
 ```
 ## Push Docker Image
-   
-   By default, the docker image built above is configured to be pushed to [Drill Docker Hub](https://hub.docker.com/r/drill/apache-drill/) to create official Drill Docker images.
-```   
-$ cd distribution
-$ mvn dockerfile:push -Pdocker
-```    
-  You can configure the repository in pom.xml to point to any private or public container registry, or specify it in your mvn command.
-```  
-$ cd distribution
-$ mvn dockerfile:push -Pdocker -Pdocker.repository=<my_repo>
+   By default, the docker image built above is configured to be pushed to [Drill Docker Hub](https://hub.docker.com/r/apache/drill/).
+   **Please do not push images manually since it should be done using automated builds in DockerHub.**
+```
+$ mvn dockerfile:push -Pdocker -pl distribution
+```
+  You can configure the repository in `pom.xml` to point to any private or public container registry, or specify it in your mvn command.
+```
+$ mvn dockerfile:push -Pdocker -Ddocker.repository=<my_repo> -pl distribution
 ```
 ## Run Docker Container
-   
+
    Running the Docker container should start Drill in embedded mode and connect to Sqlline. 
-```    
-$ docker run -i --name drill-1.14.0 -p 8047:8047 -t drill/apache-drill:1.14.0 /bin/bash
-Jun 29, 2018 3:28:21 AM org.glassfish.jersey.server.ApplicationHandler initialize
-INFO: Initiating Jersey application, version Jersey: 2.8 2014-04-29 01:25:26...
-apache drill 1.14.0 
-"json ain't no thang"
-0: jdbc:drill:zk=local> select version from sys.version;
-+------------+
-|  version   |
-+------------+
-| 1.14.0     |
-+------------+
-1 row selected (0.28 seconds)
-```  
+```
+$ docker run --rm -i --name drill-1.17.0 -p 8047:8047 -t apache/drill:1.17.0 /bin/bash
+Apache Drill 1.17.0
+"JSON ain't no thang."
+apache drill> select version from sys.version;
++---------+
+| version |
++---------+
+| 1.17.0  |
++---------+
+1 row selected (1.65 seconds)
+```
 
    You can also run the container in detached mode and connect to sqlline using drill-localhost. 
-```    
-$ docker run -i --name drill-1.14.0 -p 8047:8047 --detach -t drill/apache-drill:1.14.0 /bin/bash
+```
+$ docker run -i --name drill-1.17.0 -p 8047:8047 --detach -t apache/drill:1.17.0 /bin/bash
 <displays container ID>
 
-$ docker exec -it drill-1.14.0 bash
+$ docker exec -it drill-1.17.0 bash
 <connects to container>
 
 $ /opt/drill/bin/drill-localhost
-apache drill 1.14.0 
-"json ain't no thang"
-0: jdbc:drill:drillbit=localhost> select version from sys.version;
-+------------+
-|  version   |
-+------------+
-| 1.14.0     |
-+------------+
-1 row selected (0.28 seconds)
+Apache Drill 1.17.0
+"JSON ain't no thang."
+apache drill> select version from sys.version;
++---------+
+| version |
++---------+
+| 1.17.0  |
++---------+
+1 row selected (1.65 seconds)
 ```
 
 ## Querying Data
@@ -87,10 +91,14 @@ apache drill 1.14.0
 ```
 
    To query files outside of the container, you can configure [docker volumes](https://docs.docker.com/storage/volumes/#start-a-service-with-volumes)
-   
+
 ## Drill Web UI
 
    Drill web UI can be accessed using http://localhost:8047 once the Drill docker container is up and running. On Windows, you may need to specify the IP address of your system instead of 'localhost'.
+
+## Automated Builds in DockerHub
+
+   Autobuild triggers a new build to [Drill Docker Hub](https://hub.docker.com/repository/docker/apache/drill) with every git push to Apache master repository or when new tags are added. It uses Dockerfile from project root directory which builds Drill when building docker image.
 
 ## More information 
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <directMemoryMb>4096</directMemoryMb>
     <rat.skip>true</rat.skip>
     <license.skip>true</license.skip>
-    <docker.repository>drill/apache-drill</docker.repository>
+    <docker.repository>apache/drill</docker.repository>
     <antlr.version>4.7.2</antlr.version>
     <lowestMavenVersion>3.3.3</lowestMavenVersion>
     <commons.net.version>3.6</commons.net.version>


### PR DESCRIPTION
- Updated Dockerfile to attach project sources and build Drill when building docker images, so now it may be used for automatic triggering Docker build job, here is an example for my fork: https://hub.docker.com/repository/registry-1.docker.io/vvysotskyi/drill-docker-test/builds/53c17631-a09d-43b9-8436-c8b11d935733
- Used multistage build to exclude maven cached repositories from the target image to reduce image size.
- Updated docs to be consistent with current changes.

Jira - [DRILL-7496](https://issues.apache.org/jira/browse/DRILL-7496).