### PR TITLE
DRILL-7507: Convert fragment interrupts to exceptions

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -213,13 +213,34 @@ public interface FragmentContext extends UdfUtilities, AutoCloseable {
 
   interface ExecutorState {
     /**
-     * Tells individual operations whether they should continue. In some cases, an external event (typically cancellation)
-     * will mean that the fragment should prematurely exit execution. Long running operations should check this every so
-     * often so that Drill is responsive to cancellation operations.
+     * Tells individual operations whether they should continue. In some cases,
+     * an external event (typically cancellation) will mean that the fragment
+     * should prematurely exit execution. Long running operations should check
+     * this every so often so that Drill is responsive to cancellation
+     * operations.
      *
-     * @return False if the action should terminate immediately, true if everything is okay.
+     * @return False if the action should terminate immediately, true if
+     *         everything is okay.
      */
     boolean shouldContinue();
+
+    /**
+     * Check if an operation should continue. In some cases,
+     * an external event (typically cancellation) will mean that the fragment
+     * should prematurely exit execution. Long running operations should check
+     * this every so often so that Drill is responsive to cancellation
+     * operations.
+     * <p>
+     * Throws QueryCancelledException if the query (fragment) should stop.
+     * The fragment executor interprets this as an exception it, itself,
+     * requested, and will call the operator's close() method to release
+     * resources. Operators should not catch and handle this exception,
+     * and should only call this method when the operator holds no
+     * transient resources (such as local variables.)
+     *
+     * @throws QueryCancelledException if the query (fragment) should stop.
+     */
+    void checkContinue();
 
     /**
      * Inform the executor if a exception occurs and fragment should be failed.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryCancelledException.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/QueryCancelledException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ops;
+
+/**
+ * Indicates that an external source has cancelled the query.
+ * Thrown by the operator that detects the cancellation. Bubbles
+ * up the operator tree like other exceptions. However, this one
+ * tells the fragment executor that the exception is one that
+ * the fragment executor itself initiated and so should not
+ * be reported as an error.
+ */
+@SuppressWarnings("serial")
+public class QueryCancelledException extends RuntimeException {
+
+  // No need for messages; this exception is silently ignored.
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
@@ -32,9 +32,11 @@ import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class BaseRootExec implements RootExec {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseRootExec.class);
+  private static final Logger logger = LoggerFactory.getLogger(BaseRootExec.class);
 
   public static final String ENABLE_BATCH_DUMP_CONFIG = "drill.exec.debug.dump_batches";
   protected OperatorStats stats;
@@ -85,11 +87,8 @@ public abstract class BaseRootExec implements RootExec {
 
   @Override
   public final boolean next() {
-    // Stats should have been initialized
     assert stats != null;
-    if (!fragmentContext.getExecutorState().shouldContinue()) {
-      return false;
-    }
+    fragmentContext.getExecutorState().checkContinue();
     try {
       stats.startProcessing();
       return innerNext();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordbatch.java
@@ -47,12 +47,12 @@ public class SpilledRecordbatch implements CloseableRecordBatch {
   private VectorContainer container;
   private InputStream spillStream;
   private int spilledBatches;
-  private FragmentContext context;
-  private BatchSchema schema;
-  private SpillSet spillSet;
-  private String spillFile;
+  private final FragmentContext context;
+  private final BatchSchema schema;
+  private final SpillSet spillSet;
+  private final String spillFile;
   VectorAccessibleSerializable vas;
-  private IterOutcome initialOutcome;
+  private final IterOutcome initialOutcome;
   // Represents last outcome of next(). If an Exception is thrown
   // during the method's execution a value IterOutcome.STOP will be assigned.
   private IterOutcome lastOutcome;
@@ -134,10 +134,7 @@ public class SpilledRecordbatch implements CloseableRecordBatch {
   @Override
   public IterOutcome next() {
 
-    if (!context.getExecutorState().shouldContinue()) {
-      lastOutcome = IterOutcome.STOP;
-      return lastOutcome;
-    }
+    context.getExecutorState().checkContinue();
 
     if ( spilledBatches <= 0 ) { // no more batches to read in this partition
       this.close();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.LockSupport;
 
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.OperatorStats;
+import org.apache.drill.exec.ops.QueryCancelledException;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.testing.ControlsInjector;
 import org.apache.drill.exec.testing.ControlsInjectorFactory;
@@ -51,7 +52,7 @@ public final class PartitionerDecorator {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PartitionerDecorator.class);
   private static final ControlsInjector injector = ControlsInjectorFactory.getInjector(PartitionerDecorator.class);
 
-  private List<Partitioner> partitioners;
+  private final List<Partitioner> partitioners;
   private final OperatorStats stats;
   private final ExecutorService executor;
   private final FragmentContext context;
@@ -155,6 +156,7 @@ public final class PartitionerDecorator {
         testCountDownLatch.countDown();
       } catch (InterruptedException e) {
         logger.warn("fragment thread interrupted", e);
+        throw new QueryCancelledException();
       } catch (RejectedExecutionException e) {
         logger.warn("Failed to execute partitioner tasks. Execution service down?", e);
         executionException = new ExecutionException(e);
@@ -309,7 +311,7 @@ public final class PartitionerDecorator {
 
     private final GeneralExecuteIface iface;
     private final Partitioner partitioner;
-    private CountDownLatchInjection testCountDownLatch;
+    private final CountDownLatchInjection testCountDownLatch;
 
     private volatile ExecutionException exception;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unorderedreceiver/UnorderedReceiverBatch.java
@@ -188,9 +188,7 @@ public class UnorderedReceiverBatch implements CloseableRecordBatch {
       if (batch == null) {
         lastOutcome = IterOutcome.NONE;
         batchLoader.zero();
-        if (!context.getExecutorState().shouldContinue()) {
-          lastOutcome = IterOutcome.STOP;
-        }
+        context.getExecutorState().checkContinue();
         return lastOutcome;
       }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/ExternalSortBatch.java
@@ -423,11 +423,8 @@ public class ExternalSortBatch extends AbstractRecordBatch<ExternalSort> {
       // No records to sort
       sortState = SortState.DONE;
       return NONE;
-    } else if (!context.getExecutorState().shouldContinue()) {
-      // Interrupted
-      sortState = SortState.DONE;
-      return STOP;
     } else {
+      checkContinue();
 
       // There is some data to be returned downstream.
       // We have to prepare output container

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/xsort/MSortTemplate.java
@@ -150,9 +150,7 @@ public abstract class MSortTemplate implements MSorter, IndexedSortable {
       int totalCount = vector4.getTotalCount();
 
       // check if we're cancelled/failed recently
-      if (!context.getExecutorState().shouldContinue()) {
-        return;
-      }
+      context.getExecutorState().checkContinue();
 
       int outIndex = 0;
       Queue<Integer> newRunStarts = Queues.newLinkedBlockingQueue();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/SimpleRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/SimpleRootExec.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.drill.common.DeferredException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ops.FragmentContext;
+import org.apache.drill.exec.ops.QueryCancelledException;
 import org.apache.drill.exec.ops.RootFragmentContext;
 import org.apache.drill.exec.physical.impl.ScreenCreator.ScreenRoot;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
@@ -74,6 +75,12 @@ public class SimpleRootExec implements RootExec, Iterable<ValueVector> {
       return ex.getException();
     }
 
+    @Override
+    public void checkContinue() {
+      if (!shouldContinue()) {
+        throw new QueryCancelledException();
+      }
+    }
   }
 
   public RootFragmentContext getContext() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
@@ -57,7 +57,7 @@ import org.junit.experimental.categories.Category;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 
 @Category(OperatorTest.class)
 public class TestUnnestWithLateralCorrectness extends SubOperatorTest {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -464,27 +464,22 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
     }
   }
 
-  public static class MockExecutorState implements FragmentContext.ExecutorState
-  {
+  public static class MockExecutorState
+      implements FragmentContext.ExecutorState {
     @Override
-    public boolean shouldContinue() {
-      return true;
-    }
+    public boolean shouldContinue() { return true; }
 
     @Override
-    public void fail(Throwable t) {
-
-    }
+    public void fail(Throwable t) { }
 
     @Override
-    public boolean isFailed() {
-      return false;
-    }
+    public boolean isFailed() { return false; }
 
     @Override
-    public Throwable getFailureCause() {
-      return null;
-    }
+    public Throwable getFailureCause() { return null; }
+
+    @Override
+    public void checkContinue() { }
   }
 
   public OperatorContext newOperatorContext(PhysicalOperator popConfig) {


### PR DESCRIPTION
Modifies fragment interrupt handling to throw a specialized exception, rather than relying on the complex and cumbersome STOP iterator status.

## Description

PR #1948 (DRILL-7506) explains how Drill's execution engine has two error reporting systems. The execution engine has a mechanism to tell operators that the fragment has been cancelled. Today that system uses the `STOP`-based error system. This PR converts the cancellation mechanism to use the exception-based system.

Basically, an operator periodically checks if the fragment should terminate. Rather than return a `STOP` status, the fragment now throws a specialized exception. This check logic is encapsulated in a new `checkContinue()` method.

The fragment executor catches the exception, notices it is the special cancellation exception that it, itself, requested, and proceeds to shut down the fragment as if it completed with a `STOP` status (or with a runtime exception.)

## Tests

Reran all unit tests, including `TestDrillbitResiliance` which checks for query cancellations.