### PR TITLE
DRILL-7518: Support INT_64 for nullable INT64 in Parquet

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReaderFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/columnreaders/ColumnReaderFactory.java
@@ -315,7 +315,9 @@ public class ColumnReaderFactory {
               return new NullableFixedByteAlignedReaders.NullableDictionaryTimeStampReader(parentReader, columnDescriptor, columnChunkMetaData, fixedLength, (NullableTimeStampVector)valueVec, schemaElement);
             // DRILL-6670: handle TIMESTAMP_MICROS as INT64 with no logical type
             case TIMESTAMP_MICROS:
-              return new NullableFixedByteAlignedReaders.NullableDictionaryBigIntReader(parentReader, columnDescriptor, columnChunkMetaData, fixedLength, (NullableBigIntVector)valueVec, schemaElement);
+            case INT_64:
+              return new NullableFixedByteAlignedReaders.NullableDictionaryBigIntReader(parentReader,
+                columnDescriptor, columnChunkMetaData, fixedLength, (NullableBigIntVector) valueVec, schemaElement);
             default:
               throw new ExecutionSetupException("Unsupported nullable converted type " + convertedType + " for primitive type INT64");
           }


### PR DESCRIPTION
Jira - [DRILL-7518](https://issues.apache.org/jira/browse/DRILL-7518).

Sadly no file to reproduce the issue was attached. It's hard to generate such file using Jira code since such converted types are deprecated. Apparently, `pyspark` generates such files but did not try to generate file with it.

Anyway, checked all supported converted types for int 32 and 64 according to documentation (https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) and made sure all of them are supported for non-nullable and nullable readers. So far only one was missing.
