### PR TITLE
DRILL-7548: Updating Environment.md to Skip Tests

### DIFF
--- a/docs/dev/Environment.md
+++ b/docs/dev/Environment.md
@@ -22,7 +22,7 @@ Currently, the Apache Drill build process is known to work on Linux, Windows and
 ## Build
 
     cd drill
-    mvn clean install
+    mvn clean install -DskipTests
 
 ## Explode tarball in installation directory
    


### PR DESCRIPTION
Updating the instructions for setting up the development environment. Developers are now instructed to skip running tests as part of initial setup.

JIRA: https://issues.apache.org/jira/browse/DRILL-7548