### PR TITLE
DRILL-7544: Upgrade Iceberg version to support Parquet 1.11.0

### DIFF
--- a/metastore/iceberg-metastore/README.md
+++ b/metastore/iceberg-metastore/README.md
@@ -183,8 +183,8 @@ expiration process is launched.
 Iceberg table generates metadata for each modification operation:
 snapshot, manifest file, table metadata file. Also when performing delete operation,
 previously stored data files are not deleted. These files with the time
-can occupy lots of space. `ExpirationHandler` allows to expire outdated metadata and
-data files after configured time period (`drill.metastore.iceberg.expiration.period`).
-If expiration period is not indicated, zero or negative, expiration won't be performed.
-`ExpirationHandler` is called after each modification operation, it checks if expiration period
-has elapsed and submits expiration process in a separate thread.
+can occupy lots of space. Two table properties `write.metadata.delete-after-commit.enabled`
+and `write.metadata.previous-versions-max` control expiration process.
+Metadata files will be expired automatically if `write.metadata.delete-after-commit.enabled` 
+is enabled. Snapshots and data files will be expired using `ExpirationHandler` 
+after each commit operation based on the same table properties values.

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -31,7 +31,7 @@
   <name>metastore/Drill Iceberg Metastore</name>
 
   <properties>
-    <iceberg.version>0.7.0-incubating</iceberg.version>
+    <iceberg.version>2d75130</iceberg.version>
     <caffeine.version>2.7.0</caffeine.version>
   </properties>
 
@@ -47,27 +47,27 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
       <artifactId>iceberg-parquet</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
       <artifactId>iceberg-data</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
       <artifactId>iceberg-core</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
       <artifactId>iceberg-common</artifactId>
       <version>${iceberg.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.iceberg</groupId>
+      <groupId>com.github.apache.incubator-iceberg</groupId>
       <artifactId>iceberg-api</artifactId>
       <version>${iceberg.version}</version>
     </dependency>

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/IcebergMetastore.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/IcebergMetastore.java
@@ -25,7 +25,6 @@ import org.apache.drill.metastore.components.views.Views;
 import org.apache.drill.metastore.iceberg.components.tables.IcebergTables;
 import org.apache.drill.metastore.iceberg.config.IcebergConfigConstants;
 import org.apache.drill.metastore.iceberg.exceptions.IcebergMetastoreException;
-import org.apache.drill.metastore.iceberg.operate.ExpirationHandler;
 import org.apache.drill.metastore.iceberg.schema.IcebergTableSchema;
 import org.apache.drill.shaded.guava.com.google.common.collect.MapDifference;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
@@ -59,7 +58,6 @@ public class IcebergMetastore implements Metastore {
   private final org.apache.iceberg.Tables tables;
   private final String baseLocation;
   private final Map<String, String> commonProperties;
-  private final ExpirationHandler expirationHandler;
 
   /**
    * Table properties for each Iceberg table should be updated only once,
@@ -77,7 +75,6 @@ public class IcebergMetastore implements Metastore {
     this.tables = new HadoopTables(new Configuration(configuration));
     this.baseLocation = baseLocation(new Configuration(configuration));
     this.commonProperties = properties(IcebergConfigConstants.COMPONENTS_COMMON_PROPERTIES);
-    this.expirationHandler = new ExpirationHandler(config, new Configuration(configuration));
   }
 
   @Override
@@ -85,7 +82,7 @@ public class IcebergMetastore implements Metastore {
     Table table = loadTable(IcebergConfigConstants.COMPONENTS_TABLES_LOCATION,
       IcebergConfigConstants.COMPONENTS_TABLES_PROPERTIES,
       IcebergTables.SCHEMA, Tables.class);
-    return new IcebergTables(table, expirationHandler);
+    return new IcebergTables(table);
   }
 
   @Override
@@ -273,6 +270,5 @@ public class IcebergMetastore implements Metastore {
 
   @Override
   public void close() {
-    expirationHandler.close();
   }
 }

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
@@ -58,9 +58,9 @@ public class IcebergTables implements Tables, MetastoreContext<TableMetadataUnit
   private final Table table;
   private final ExpirationHandler expirationHandler;
 
-  public IcebergTables(Table table, ExpirationHandler expirationHandler) {
+  public IcebergTables(Table table) {
     this.table = table;
-    this.expirationHandler = expirationHandler;
+    this.expirationHandler = new ExpirationHandler(table);
   }
 
   public MetastoreContext<TableMetadataUnit> context() {

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/config/IcebergConfigConstants.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/config/IcebergConfigConstants.java
@@ -52,11 +52,6 @@ public interface IcebergConfigConstants {
   String RELATIVE_PATH = LOCATION_NAMESPACE + "relative_path";
 
   /**
-   * Defines config which provides expiration period value.
-   */
-  String EXPIRATION_PERIOD = BASE + "expiration.period";
-
-  /**
    * Drill Iceberg Metastore components configuration properties namespace.
    */
   String COMPONENTS = BASE + "components.";

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/ExpirationHandler.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/ExpirationHandler.java
@@ -17,33 +17,15 @@
  */
 package org.apache.drill.metastore.iceberg.operate;
 
-import com.typesafe.config.ConfigValue;
-import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.metastore.iceberg.config.IcebergConfigConstants;
-import org.apache.drill.metastore.iceberg.exceptions.IcebergMetastoreException;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Iceberg table generates metadata for each modification operation:
@@ -51,226 +33,55 @@ import java.util.regex.Pattern;
  * previously stored data files are not deleted. These files with the time
  * can occupy lots of space.
  * <p/>
- * Expiration handler expires outdated metadata and data files after configured expiration period.
- * Expiration period is set in the Iceberg Metastore config {@link IcebergConfigConstants#EXPIRATION_PERIOD}.
- * Units should correspond to {@link ChronoUnit} values that do not have estimated duration
- * (millis, seconds, minutes, hours, days).
- * If expiration period is not set, zero or negative, expiration process will not be executed.
- * <p/>
- * Expiration process is launched using executor service which allows to execute only one thread at a time,
- * idle thread is not kept in the core pool since it is assumed that expiration process won't be launched to often.
- * <p/>
- * During Drillbit shutdown, if there are expiration tasks in the queue, they will be discarded in order to
- * unblock Drillbit shutdown process.
+ * Table metadata in Iceberg is expired automatically
+ * if {@link TableProperties#METADATA_DELETE_AFTER_COMMIT_ENABLED} set to true.
+ * Number of metadata files to be retained is configured using {@link TableProperties#METADATA_PREVIOUS_VERSIONS_MAX}.
+ * Snapshots and data expiration should be called manually to align with metadata expiration process,
+ * the same table properties are used to determine if expiration is needed and which number
+ * of snapshots should be retained.
  */
-public class ExpirationHandler implements AutoCloseable {
+public class ExpirationHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(ExpirationHandler.class);
 
-  private static final Pattern METADATA_VERSION_PATTERN = Pattern.compile("^v([0-9]+)\\..*");
+  private final Table table;
+  private final boolean shouldExpire;
+  private final int retainNumber;
 
-  // contains Iceberg table location and its last expiration time
-  private final Map<String, Long> expirationStatus = new ConcurrentHashMap<>();
-  private final Configuration configuration;
-  private final long expirationPeriod;
-  private volatile ExecutorService executorService;
+  public ExpirationHandler(Table table) {
+    this.table = table;
 
-  public ExpirationHandler(DrillConfig config, Configuration configuration) {
-    this.configuration = configuration;
-    this.expirationPeriod = expirationPeriod(config);
-    logger.debug("Drill Iceberg Metastore expiration period: {}", expirationPeriod);
+    Map<String, String> properties = table.properties();
+    this.shouldExpire = PropertyUtil.propertyAsBoolean(properties,
+      TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED,
+      TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT);
+    this.retainNumber = PropertyUtil.propertyAsInt(properties,
+      TableProperties.METADATA_PREVIOUS_VERSIONS_MAX,
+      TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT);
   }
 
   /**
-   * Checks if expiration process needs to be performed for the given Iceberg table
-   * by comparing stored last expiration time.
-   * If difference between last expiration time and current time is more or equal to
-   * expiration period, launches expiration process.
-   * If expiration period is zero or negative, no expiration process will be launched.
-   *
-   * @param table Iceberg table instance
-   * @return true if expiration process was launched, false otherwise
+   * Expires snapshots and related data if needed
+   * based on the given table properties values.
    */
-  public boolean expire(Table table) {
-    if (expirationPeriod <= 0) {
-      return false;
-    }
-
-    long current = System.currentTimeMillis();
-    Long last = expirationStatus.putIfAbsent(table.location(), current);
-
-    if (last != null && current - last >= expirationPeriod) {
-      expirationStatus.put(table.location(), current);
-
-      ExecutorService executorService = executorService();
-      executorService.submit(() -> {
-        logger.debug("Expiring Iceberg table [{}] metadata", table.location());
-        table.expireSnapshots()
-          .expireOlderThan(current)
-          .commit();
-        // TODO: Replace with table metadata expiration through Iceberg API
-        //       when https://github.com/apache/incubator-iceberg/issues/181 is resolved
-        //       table.expireTableMetadata().expireOlderThan(current).commit();
-        expireTableMetadata(table);
-      });
-      return true;
-    }
-    return false;
-  }
-
-  public long expirationPeriod() {
-    return expirationPeriod;
-  }
-
-  @Override
-  public void close() {
-    if (executorService != null) {
-      // unlike shutdown(), shutdownNow() discards all queued waiting tasks
-      // this is done in order to unblock Drillbit shutdown
-      executorService.shutdownNow();
+  public void expire() {
+    if (shouldExpire) {
+      table.expireSnapshots()
+        .expireOlderThan(System.currentTimeMillis())
+        .retainLast(retainNumber)
+        .commit();
     }
   }
 
-  private long expirationPeriod(DrillConfig config) {
-    if (config.hasPath(IcebergConfigConstants.EXPIRATION_PERIOD)) {
-      Duration duration = config.getConfig(IcebergConfigConstants.EXPIRATION_PERIOD).entrySet().stream()
-        .map(this::duration)
-        .reduce(Duration.ZERO, Duration::plus);
-      return duration.toMillis();
-    }
-    return 0;
-  }
-
-  private Duration duration(Map.Entry<String, ConfigValue> entry) {
-    String amountText = String.valueOf(entry.getValue().unwrapped());
-    String unitText = entry.getKey().toUpperCase();
+  /**
+   * Expires snapshots and related data and ignores possible exceptions.
+   */
+  public void expireQuietly() {
     try {
-      long amount = Long.parseLong(amountText);
-      ChronoUnit unit = ChronoUnit.valueOf(unitText);
-      return Duration.of(amount, unit);
-    } catch (NumberFormatException e) {
-      throw new IcebergMetastoreException(String.format("Error when parsing expiration period config. " +
-        "Unable to convert [%s] into long", amountText), e);
-    } catch (IllegalArgumentException e) {
-      throw new IcebergMetastoreException(String.format("Error when parsing expiration period config. " +
-        "Unable to convert [%s] into [%s]", unitText, ChronoUnit.class.getCanonicalName()), e);
-    }
-  }
-
-  /**
-   * Initializes executor service instance using DCL.
-   * Created thread executor instance allows to execute only one thread at a time
-   * but unlike single thread executor does not keep this thread in the pool.
-   * Custom thread factory is used to define Iceberg Metastore specific thread names.
-   *
-   * @return executor service instance
-   */
-  private ExecutorService executorService() {
-    if (executorService == null) {
-      synchronized (this) {
-        if (executorService == null) {
-          this.executorService = new ThreadPoolExecutor(0, 1, 0L,
-            TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), new IcebergThreadFactory());
-        }
-      }
-    }
-    return executorService;
-  }
-
-  /**
-   * Expires outdated Iceberg table metadata files.
-   * Reads current Iceberg table metadata version from version-hint.text file
-   * and deletes all metadata files that end with ".metadata.json" and have
-   * version less than current.
-   * <p/>
-   * Should be replaced with
-   * <code>table.expireTableMetadata().expireOlderThan(current).commit();</code>
-   * when <a href="https://github.com/apache/incubator-iceberg/issues/181">Issue#181</a>
-   * is resolved.
-   *
-   * @param table Iceberg table instance
-   */
-  private void expireTableMetadata(Table table) {
-    try {
-      String location = table.location();
-      Path metadata = new Path(location, "metadata");
-      FileSystem fs = metadata.getFileSystem(configuration);
-      for (FileStatus fileStatus : listExpiredMetadataFiles(fs, metadata)) {
-        if (fs.delete(fileStatus.getPath(), false)) {
-          logger.debug("Deleted Iceberg table [{}] metadata file [{}]", table.location(), fileStatus.getPath());
-        }
-      }
-    } catch (NumberFormatException | IOException e) {
-      logger.warn("Unable to expire Iceberg table [{}] metadata files", table.location(), e);
-    }
-  }
-
-  /**
-   * Reads current Iceberg table metadata version from version-hint.text file
-   * and returns all metadata files that end with ".metadata.json" and have
-   * version less than current.
-   *
-   * @param fs file system
-   * @param metadata pth to Iceberg metadata
-   * @return metadata files with version less than current
-   * @throws IOException in case of error listing file statuses
-   */
-  private FileStatus[] listExpiredMetadataFiles(FileSystem fs, Path metadata) throws IOException {
-    int currentVersion = currentVersion(fs, metadata);
-    return fs.listStatus(metadata, path -> {
-      if (path.getName().endsWith(".metadata.json")) {
-        int version = parseVersion(path);
-        return version != -1 && currentVersion > version;
-      }
-      return false;
-    });
-  }
-
-  /**
-   * Reads current table metadata version from version-hint.text file.
-   *
-   * @param fs file system
-   * @param metadata table metadata path
-   * @return current table metadata version
-   * @throws IOException if unable to read current table metadata version
-   */
-  private int currentVersion(FileSystem fs, Path metadata) throws IOException {
-    Path versionHintFile = new Path(metadata, "version-hint.text");
-    try (BufferedReader in = new BufferedReader(new InputStreamReader(fs.open(versionHintFile)))) {
-      return Integer.parseInt(in.readLine().replace("\n", ""));
-    }
-  }
-
-  /**
-   * Extracts metadata version from table metadata file name.
-   * Example: v1.metadata.json -> 1, v15.metadata.json -> 15
-   *
-   * @param path table metadata file path
-   * @return metadata version
-   */
-  private int parseVersion(Path path) {
-    Matcher matcher = METADATA_VERSION_PATTERN.matcher(path.getName());
-    if (matcher.find() && matcher.groupCount() == 1) {
-      return Integer.parseInt(matcher.group(1));
-    }
-    throw new NumberFormatException("Unable to parse version for path " + path);
-  }
-
-  /**
-   * Wraps default thread factory and adds Iceberg Metastore prefix to the original thread name.
-   * Is used to uniquely identify Iceberg metastore threads.
-   * Example: drill-iceberg-metastore-pool-1-thread-1
-   */
-  private static class IcebergThreadFactory implements ThreadFactory {
-
-    private static final String THREAD_PREFIX = "drill-iceberg-metastore-";
-    private final ThreadFactory delegate = Executors.defaultThreadFactory();
-
-    @Override
-    public Thread newThread(Runnable runnable) {
-      Thread thread = delegate.newThread(runnable);
-      thread.setName(THREAD_PREFIX + thread.getName());
-      return thread;
+      expire();
+    } catch (ValidationException | CommitFailedException e) {
+      logger.warn("Unable to expire snapshots: {}", e.getMessage());
+      logger.debug("Error when expiring snapshots", e);
     }
   }
 }

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergModify.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergModify.java
@@ -80,7 +80,8 @@ public class IcebergModify<T> implements Modify<T> {
     operations.forEach(op -> op.add(transaction));
     transaction.commitTransaction();
 
-    // check if Iceberg table metadata needs to be expired after each modification operation
-    context.expirationHandler().expire(context.table());
+    // expiration process should not intervene with data modification operations
+    // if expiration fails, will attempt to expire the next time
+    context.expirationHandler().expireQuietly();
   }
 }

--- a/metastore/iceberg-metastore/src/main/resources/drill-metastore-module.conf
+++ b/metastore/iceberg-metastore/src/main/resources/drill-metastore-module.conf
@@ -34,18 +34,14 @@ drill.metastore.iceberg: {
     relative_path: ${drill.exec.zk.root}"/metastore/iceberg"
   }
 
-  // Specifies time period after which outdated Iceberg table metadata will be expired,
-  // unit names must correspond to java.time.temporal.ChronoUnit enum values
-  // that do not have estimated duration (millis, seconds, minutes, hours, days).
-  // Example: hours: 10, minutes: 20
-  expiration.period: {
-    days: 5
-  }
-
   components: {
         // Common properties for all Iceberg tables from org.apache.iceberg.TableProperties can be specified
        common.properties: {
-          write.metadata.compression-codec: "none"
+         write.metadata.compression-codec: "none",
+         // Enables metadata expiration to avoid consuming space with historical data
+         // In Drill the same table properties apply to the snapshots expiration process as well
+         write.metadata.delete-after-commit.enabled: true
+         write.metadata.previous-versions-max: 2,
        },
 
     tables: {


### PR DESCRIPTION
[DRILL-7544](https://issues.apache.org/jira/browse/DRILL-7544): Upgrade Iceberg version to support Parquet 1.11.0

## Description
1. Upgraded Iceberg to the commit that supports Parquet 1.11.0.
2. Removed workaround in ExpirationHandler and used built-in logic from Iceberg library.
3. Updated description about expiration logic in README.md.

## Documentation
No documentation updates are required.

## Testing
Updated some of unit tests and ran all tests.
