### PR TITLE
DRILL-7562: Support HTTP Basic authentication for REST API calls

### DIFF
--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -103,8 +103,8 @@ drill.exec: {
     },
     auth: {
         # Http Auth mechanisms to configure. If not provided but user.auth is enabled
-        # then default value is FORM.
-        mechanisms: ["FORM", "SPNEGO"],
+        # then default value is ["FORM"].
+        mechanisms: ["BASIC", "FORM", "SPNEGO"],
         # Spnego principal to be used by WebServer when Spnego authentication is enabled.
         spnego.principal: "HTTP://<localhost>"
         # Location to keytab file for above spnego principal

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpConstraintSecurityHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpConstraintSecurityHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.server.rest.auth;
 
+import org.apache.drill.exec.rpc.security.plain.PlainFactory;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.server.DrillbitContext;
@@ -38,24 +39,33 @@ import static org.apache.drill.exec.server.rest.auth.DrillUserPrincipal.AUTHENTI
  **/
 public abstract class DrillHttpConstraintSecurityHandler extends ConstraintSecurityHandler {
 
-    @Override
-    public void doStart() throws Exception {
-        super.doStart();
+  @Override
+  public void doStart() throws Exception {
+    super.doStart();
+  }
+
+  @Override
+  public void doStop() throws Exception {
+    super.doStop();
+  }
+
+  public abstract void doSetup(DrillbitContext dbContext) throws DrillException;
+
+  public void setup(LoginAuthenticator authenticator, LoginService loginService) {
+    final Set<String> knownRoles = ImmutableSet.of(AUTHENTICATED_ROLE, ADMIN_ROLE);
+    setConstraintMappings(Collections.<ConstraintMapping>emptyList(), knownRoles);
+    setAuthenticator(authenticator);
+    setLoginService(loginService);
+  }
+
+  protected void requireAuthProvider(DrillbitContext dbContext, String name) throws DrillException {
+    // Check if PAMAuthenticator is available or not which is required for FORM authentication
+    if (!dbContext.getAuthProvider().containsFactory(PlainFactory.SIMPLE_NAME)) {
+      throw new DrillException(String.format("%1$s auth mechanism was configured but %2$s mechanism is not enabled to provide an " +
+        "authenticator. Please configure user authentication with %2$s mechanism and authenticator to use " +
+        "%1$s authentication", getImplName(), name));
     }
+  }
 
-    @Override
-    public void doStop() throws Exception {
-        super.doStop();
-    }
-
-    public abstract void doSetup(DrillbitContext dbContext) throws DrillException;
-
-    public void setup(LoginAuthenticator authenticator, LoginService loginService) {
-      final Set<String> knownRoles = ImmutableSet.of(AUTHENTICATED_ROLE, ADMIN_ROLE);
-      setConstraintMappings(Collections.<ConstraintMapping>emptyList(), knownRoles);
-      setAuthenticator(authenticator);
-      setLoginService(loginService);
-    }
-
-    public abstract String getImplName();
+  public abstract String getImplName();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpSecurityHandlerProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpSecurityHandlerProvider.java
@@ -27,6 +27,7 @@ import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.rpc.security.AuthStringUtil;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.rest.WebServerConstants;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.authentication.SessionAuthentication;
 import org.eclipse.jetty.server.Handler;
@@ -139,10 +140,14 @@ public class DrillHttpSecurityHandlerProvider extends ConstraintSecurityHandler 
       if (isSpnegoEnabled() && (!isFormEnabled() || uri.equals(WebServerConstants.SPENGO_LOGIN_RESOURCE_PATH))) {
         securityHandler = securityHandlers.get(Constraint.__SPNEGO_AUTH);
         securityHandler.handle(target, baseRequest, request, response);
+      } else if(isBasicEnabled() && request.getHeader(HttpHeader.AUTHORIZATION.asString()) != null) {
+        securityHandler = securityHandlers.get(Constraint.__BASIC_AUTH);
+        securityHandler.handle(target, baseRequest, request, response);
       } else if (isFormEnabled()) {
         securityHandler = securityHandlers.get(Constraint.__FORM_AUTH);
         securityHandler.handle(target, baseRequest, request, response);
       }
+
     }
     // If user has logged in, use the corresponding handler to handle the request
     else {
@@ -173,6 +178,10 @@ public class DrillHttpSecurityHandlerProvider extends ConstraintSecurityHandler 
 
   public boolean isFormEnabled() {
     return securityHandlers.containsKey(Constraint.__FORM_AUTH);
+  }
+
+  public boolean isBasicEnabled() {
+    return securityHandlers.containsKey(Constraint.__BASIC_AUTH);
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/HttpBasicAuthSecurityHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/HttpBasicAuthSecurityHandler.java
@@ -20,14 +20,16 @@ package org.apache.drill.exec.server.rest.auth;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.rpc.security.plain.PlainFactory;
 import org.apache.drill.exec.server.DrillbitContext;
-import org.apache.drill.exec.server.rest.WebServerConstants;
-import org.eclipse.jetty.security.authentication.FormAuthenticator;
+import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.util.security.Constraint;
 
-public class FormSecurityHandler extends DrillHttpConstraintSecurityHandler {
+/**
+ * Implement HTTP Basic authentication for REST API access
+ */
+public class HttpBasicAuthSecurityHandler extends DrillHttpConstraintSecurityHandler {
   @Override
   public String getImplName() {
-    return Constraint.__FORM_AUTH;
+    return Constraint.__BASIC_AUTH;
   }
 
   @Override
@@ -35,8 +37,7 @@ public class FormSecurityHandler extends DrillHttpConstraintSecurityHandler {
 
     requireAuthProvider(dbContext, PlainFactory.SIMPLE_NAME);
 
-    setup(new FormAuthenticator(WebServerConstants.FORM_LOGIN_RESOURCE_PATH,
-      WebServerConstants.FORM_LOGIN_RESOURCE_PATH, true), new DrillRestLoginService(dbContext));
+    setup(new BasicAuthenticator(), new DrillRestLoginService(dbContext));
   }
 
 }


### PR DESCRIPTION
This can greatly simplify the development of HTTP clients, as well as
use from the command line using curl/wget, since you don't have to
deal with storing the session cookie.

# [DRILL-7562](https://issues.apache.org/jira/browse/DRILL-7562): Support HTTP Basic authentication for REST API calls

## Description

Implement support for Basic authentication.  This allows an HTTP client to supply the login credentials in the same request as the query.  For clients that do not wish to keep track of cookies, this saves an HTTP round-trip per query.

This is useful for access via the command-line, but also for client libraries where storing the cookie is a nuisance.

## Documentation

----------

# Authenticating REST API requests

## Basic authentication

Basic authentication refers to the standard HTTP authentication method of the same name.  Most HTTP clients and tools provide a simple way to do Basic authentication.

Basic authentication is enabled or disabled using `drill-override.conf`.  Add the string `"BASIC"` to `http.auth.mechanisms`.  Note that if the field is not currently set, it defaults to having `"FORM"` in it, so you probably want to include `"FORM"` if you set this field, so that Web UI users can still log in.

Example:

```
http: {
    enabled: true,
    auth: {
        # Http Auth mechanisms to configure. If not provided but user.auth is enabled
        # then default value is ["FORM"].
        mechanisms: ["BASIC", "FORM"]
    }
}
```

To authenticate requests using Basic authentication, send the appropriate `Authorization` header with each request using your HTTP client's options:

    curl -kv \
           -u drilluser:drillpassword  \
           -X POST \
           -H "Content-Type: application/json" \
           -d '{"queryType":"SQL", "query": "select * from sys.version"}' \
           http://localhost:8047/query.json

## Form based authentication

Form-based authentication is enabled or disabled using `drill-override.conf`.  Add the string `"FORM"` to `http.auth.mechanisms` if it is set.  If `http.auth.mechanisms` is not set, `"FORM"` is enabled by default.

Example:

```
http: {
    enabled: true,
    auth: {
        # Http Auth mechanisms to configure. If not provided but user.auth is enabled
        # then default value is ["FORM"].
        mechanisms: ["BASIC", "FORM"]
    }
}
```

To authenticate requests using form-based authentication, you must use an HTTP client that saves cookies between requests.  Simulate a form submission to the same URL used in the Web UI / Console (`/j_security_check`)

    curl -X POST \
        -H "Content-Type: application/x-www-form-urlencoded" \
        -k -c cookies.txt -s \
        -d "j_username=drilluser" \
        -d "j_password=drillpassword" \
        http://localhost:8047/j_security_check


In subsequent requests, use the cookie returned from that request:

    curl -kv \
           -b cookies.txt  \
           -X POST \
           -H "Content-Type: application/json" \
           -d '{"queryType":"SQL", "query": "select * from sys.version"}' \
           http://localhost:8047/query.json


---------

## Testing

I tested it using `curl -u user:pass "localhost:8049/storage.json"`.  When the feature was active, the request would succeed.  If not, the server returned a redirect to the login page.

Assistance in writing a unit test would be appreciated, I didn't see one for the current login system to base this off and I didn't want to spend a ton of time trying to figure out how to write a test for this one.

