### PR TITLE
DRILL-7575: Fix typo in class name of FormSecurityHandler

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/FormSecurityHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/FormSecurityHandler.java
@@ -24,9 +24,7 @@ import org.apache.drill.exec.server.rest.WebServerConstants;
 import org.eclipse.jetty.security.authentication.FormAuthenticator;
 import org.eclipse.jetty.util.security.Constraint;
 
-public class FormSecurityHanlder extends DrillHttpConstraintSecurityHandler {
-  //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FormSecurityHanlder.class);
-
+public class FormSecurityHandler extends DrillHttpConstraintSecurityHandler {
   @Override
   public String getImplName() {
     return Constraint.__FORM_AUTH;


### PR DESCRIPTION
[DRILL-7575](https://issues.apache.org/jira/browse/DRILL-7575): FormSecurityHandler class name is spelled incorrectly

Just a little fix to the name of this class.  It isn't referenced anywhere by name, so only the class file itself had to be changed.
