### PR TITLE
DRILL-7576: Fail fast for operator errors

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
@@ -17,11 +17,7 @@
  */
 package org.apache.drill.common.exceptions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class DrillRuntimeException extends RuntimeException {
-  private static final Logger logger = LoggerFactory.getLogger(DrillRuntimeException.class);
   private static final long serialVersionUID = -3796081521525479249L;
 
   public DrillRuntimeException() {

--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillRuntimeException.java
@@ -17,8 +17,11 @@
  */
 package org.apache.drill.common.exceptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DrillRuntimeException extends RuntimeException {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRuntimeException.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillRuntimeException.class);
   private static final long serialVersionUID = -3796081521525479249L;
 
   public DrillRuntimeException() {

--- a/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/TestSimpleJson.java
+++ b/contrib/format-maprdb/src/test/java/com/mapr/drill/maprdb/tests/json/TestSimpleJson.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 
 import org.apache.drill.PlanTestBase;
 import org.apache.drill.SingleRowListener;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.exec.record.RecordBatchLoader;
 import org.apache.drill.exec.rpc.user.QueryDataBatch;
@@ -53,6 +52,7 @@ public class TestSimpleJson extends BaseJsonTest {
 
   private static boolean tableCreated = false;
   private static String tablePath;
+  @Override
   protected String getTablePath() {
     return tablePath;
   }
@@ -148,16 +148,12 @@ public class TestSimpleJson extends BaseJsonTest {
     SingleRowListener listener = new SingleRowListener() {
       @Override
       protected void rowArrived(QueryDataBatch result) {
-        try {
-          final RecordBatchLoader loader = new RecordBatchLoader(getAllocator());
-          loader.load(result.getHeader().getDef(), result.getData());
-          StringBuilder sb = new StringBuilder();
-          VectorUtil.appendVectorAccessibleContent(loader, sb, "|", false);
-          loader.clear();
-          queryResult.set("result", sb.toString());
-        } catch (SchemaChangeException e) {
-          queryResult.set("error", "true");
-        }
+        final RecordBatchLoader loader = new RecordBatchLoader(getAllocator());
+        loader.load(result.getHeader().getDef(), result.getData());
+        StringBuilder sb = new StringBuilder();
+        VectorUtil.appendVectorAccessibleContent(loader, sb, "|", false);
+        loader.clear();
+        queryResult.set("result", sb.toString());
       }
     };
     testWithListener(QueryType.SQL, sql, listener);

--- a/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriterImpl.java
+++ b/exec/java-exec/src/main/codegen/templates/StatisticsRecordWriterImpl.java
@@ -83,21 +83,16 @@ public class StatisticsRecordWriterImpl {
     }
   }
 
-  private void initFieldWriters() throws IOException {
+  private void initFieldWriters() {
     fieldConverters = Lists.newArrayList();
-    try {
-      int fieldId = 0;
-      for (VectorWrapper w : batch) {
-        if (w.getField().getName().equalsIgnoreCase(WriterPrel.PARTITION_COMPARATOR_FIELD)) {
-          continue;
-        }
-        FieldReader reader = w.getValueVector().getReader();
-        FieldConverter converter = getConverter(recordWriter, fieldId++, w.getField().getName(), reader);
-        fieldConverters.add(converter);
+    int fieldId = 0;
+    for (VectorWrapper<?> w : batch) {
+      if (w.getField().getName().equalsIgnoreCase(WriterPrel.PARTITION_COMPARATOR_FIELD)) {
+        continue;
       }
-    } catch(Exception e) {
-      logger.error("Failed to create FieldWriter.", e);
-      throw new IOException("Failed to initialize FieldWriters.", e);
+      FieldReader reader = w.getValueVector().getReader();
+      FieldConverter converter = getConverter(recordWriter, fieldId++, w.getField().getName(), reader);
+      fieldConverters.add(converter);
     }
   }
 
@@ -114,10 +109,13 @@ public class StatisticsRecordWriterImpl {
           return recordWriter.getNewNullable${minor.class}Converter(fieldId, fieldName, reader);
         case REPEATED:
           return recordWriter.getNewRepeated${minor.class}Converter(fieldId, fieldName, reader);
+        default:
+          throw new UnsupportedOperationException();
       }
       </#list>
       </#list>
+      default:
+        throw new UnsupportedOperationException();
     }
-    throw new UnsupportedOperationException();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/LoggingResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/LoggingResultsListener.java
@@ -24,7 +24,6 @@ import org.apache.drill.common.DrillAutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.client.QuerySubmitter.Format;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.proto.UserBitShared.QueryData;
@@ -76,13 +75,9 @@ public class LoggingResultsListener implements UserResultsListener {
     try {
       if (data != null) {
         count.addAndGet(header.getRowCount());
-        try {
-          loader.load(header.getDef(), data);
-          // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
-          // SchemaChangeException, so check/clean catch clause below.
-        } catch (SchemaChangeException e) {
-          submissionFailed(UserException.systemError(e).build(logger));
-        }
+        // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
+        // SchemaChangeException.
+        loader.load(header.getDef(), data);
 
         try {
           switch(format) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperatorUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperatorUtil.java
@@ -47,7 +47,6 @@ public class PhysicalOperatorUtil {
 
   /**
    * Helper method to create a list of {@code MinorFragmentEndpoint} instances from a
-   * Helper method to create a list of MinorFragmentEndpoint instances from a
    * given endpoint assignment list.
    *
    * @param endpoints

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperatorUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperatorUtil.java
@@ -47,6 +47,7 @@ public class PhysicalOperatorUtil {
 
   /**
    * Helper method to create a list of {@code MinorFragmentEndpoint} instances from a
+   * Helper method to create a list of MinorFragmentEndpoint instances from a
    * given endpoint assignment list.
    *
    * @param endpoints

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnorderedReceiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnorderedReceiver.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("unordered-receiver")
 public class UnorderedReceiver extends AbstractReceiver{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnorderedReceiver.class);
 
   @JsonCreator
   public UnorderedReceiver(@JsonProperty("sender-major-fragment") int oppositeMajorFragmentId,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
@@ -204,7 +204,7 @@ public abstract class BaseRootExec implements RootExec {
     for (int i = dag.size() - 1; i >= 0; i--) {
       T leaf = dag.get(i);
       String opName = leaf.getClass().getName();
-      for(StackTraceElement element : trace) {
+      for (StackTraceElement element : trace) {
         String frameName = element.getClassName();
         if (frameName.contentEquals(opName)) {
           return leaf;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/BaseRootExec.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.drill.common.DeferredException;
@@ -126,7 +125,7 @@ public abstract class BaseRootExec implements RootExec {
   }
 
   @Override
-  public void dumpBatches() {
+  public void dumpBatches(Throwable t) {
     if (operators == null) {
       return;
     }
@@ -134,22 +133,18 @@ public abstract class BaseRootExec implements RootExec {
       return;
     }
 
-    final int numberOfBatchesToDump = 2;
+    CloseableRecordBatch leafMost = findLeaf(operators, t);
+    if (leafMost == null) {
+      // Don't know which batch failed.
+      return;
+    }
+    int batchPosn = operators.indexOf(leafMost);
+    final int numberOfBatchesToDump = Math.min(batchPosn + 1, 2);
     logger.error("Batch dump started: dumping last {} failed batches", numberOfBatchesToDump);
     // As batches are stored in a 'flat' List there is a need to filter out the failed batch
     // and a few of its parent (actual number of batches is set by a constant defined above)
-    List<CloseableRecordBatch> failedBatchStack = new LinkedList<>();
-    for (int i = operators.size() - 1; i >= 0; i--) {
-      CloseableRecordBatch batch = operators.get(i);
-      if (batch.hasFailed()) {
-        failedBatchStack.add(0, batch);
-        if (failedBatchStack.size() == numberOfBatchesToDump) {
-          break;
-        }
-      }
-    }
-    for (CloseableRecordBatch batch : failedBatchStack) {
-      batch.dump();
+    for (int i = 0; i < numberOfBatchesToDump; i++) {
+      operators.get(batchPosn--).dump();
     }
     logger.error("Batch dump completed.");
   }
@@ -183,5 +178,39 @@ public abstract class BaseRootExec implements RootExec {
         fragmentContext.getExecutorState().fail(e);
       }
     }
+  }
+
+  /**
+   * Given a list of operators and a stack trace, walks the stack trace and
+   * the operator list to find the leaf-most operator, which is the one
+   * that was active when the exception was thrown. Handle the cases in
+   * which no operator was active, each operator had multiple methods on
+   * the stack, or the exception was thrown in some class called by
+   * the operator.
+   * <p>
+   * Not all operators leave a mark in the trace. In particular if a the
+   * call stack is only through base-class methods, then we have no way to
+   * know the actual class during the call. This is OK because the leaf
+   * methods are just pass-through operations, they are unlikely to fail.
+   *
+   * @param <T> the type of the operator. Parameterized to allow easier
+   * testing
+   * @param dag the list of operators from root-most to leaf-most
+   * @param e the exception thrown somewhere in the operator tree
+   * @return the leaf-most operator, if any
+   */
+  public static <T> T findLeaf(List<T> dag, Throwable e) {
+    StackTraceElement[] trace = e.getStackTrace();
+    for (int i = dag.size() - 1; i >= 0; i--) {
+      T leaf = dag.get(i);
+      String opName = leaf.getClass().getName();
+      for(StackTraceElement element : trace) {
+        String frameName = element.getClassName();
+        if (frameName.contentEquals(opName)) {
+          return leaf;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ImplCreator.java
@@ -107,8 +107,9 @@ public class ImplCreator {
     return null;
   }
 
-  /** Create RootExec and its children (RecordBatches) for given FragmentRoot */
-
+  /**
+   * Create RootExec and its children (RecordBatches) for given FragmentRoot
+   */
   @SuppressWarnings("unchecked")
   private RootExec getRootExec(final FragmentRoot root, final ExecutorFragmentContext context) throws ExecutionSetupException {
     final List<RecordBatch> childRecordBatches = getChildren(root, context);
@@ -132,8 +133,9 @@ public class ImplCreator {
     }
   }
 
-
-  /** Create a RecordBatch and its children for given PhysicalOperator */
+  /**
+   * Create a RecordBatch and its children for given PhysicalOperator
+   */
   @VisibleForTesting
   public RecordBatch getRecordBatch(final PhysicalOperator op, final ExecutorFragmentContext context) throws ExecutionSetupException {
     Preconditions.checkNotNull(op);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/RootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/RootExec.java
@@ -52,6 +52,9 @@ public interface RootExec extends AutoCloseable {
   /**
    * Dump failed batches' state preceded by its parent's state to logs. Invoked
    * when there is a failure during fragment execution.
+   *
+   * @param t the exception thrown by an operator and which therefore
+   * records, in its stack trace, which operators were active on the stack
    */
   void dumpBatches(Throwable t);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/RootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/RootExec.java
@@ -20,34 +20,38 @@ package org.apache.drill.exec.physical.impl;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
 
 /**
- * <h2>Functionality</h2>
- * <p>
- *   A FragmentRoot is a node which is the last processing node in a query plan. FragmentTerminals include Exchange
- *   output nodes and storage nodes.  They are there driving force behind the completion of a query.
+ * Node which is the last processing node in a query plan. FragmentTerminals
+ * include Exchange output nodes and storage nodes. They are there driving force
+ * behind the completion of a query.
  * </p>
- * <h2>Assumptions</h2>
- * <p>
- *   All implementations of {@link RootExec} assume that all their methods are called by the same thread.
- * </p>
+ * Assumes that all implementations of {@link RootExec} assume that all their
+ * methods are called by the same thread.
  */
 public interface RootExec extends AutoCloseable {
+
   /**
    * Do the next batch of work.
-   * @return Whether or not additional batches of work are necessary. False means that this fragment is done.
+   *
+   * @return Whether or not additional batches of work are necessary. False
+   *         means that this fragment is done.
    */
   boolean next();
 
   /**
-   * Inform sender that receiving fragment is finished and doesn't need any more data. This can be called multiple
-   * times (once for each downstream receiver). If all receivers are finished then a subsequent call to {@link #next()}
-   * will return false.
-   * @param handle The handle pointing to the downstream receiver that does not need anymore data.
+   * Inform sender that receiving fragment is finished and doesn't need any more
+   * data. This can be called multiple times (once for each downstream
+   * receiver). If all receivers are finished then a subsequent call to
+   * {@link #next()} will return false.
+   *
+   * @param handle
+   *          The handle pointing to the downstream receiver that does not need
+   *          anymore data.
    */
   void receivingFragmentFinished(FragmentHandle handle);
 
   /**
-   * Dump failed batches' state preceded by its parent's state to logs. Invoked when there is a
-   * failure during fragment execution.
+   * Dump failed batches' state preceded by its parent's state to logs. Invoked
+   * when there is a failure during fragment execution.
    */
-  void dumpBatches();
+  void dumpBatches(Throwable t);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -219,15 +220,8 @@ public class ScanBatch implements CloseableRecordBatch {
   }
 
   private void closeCurrentReader() {
-    try {
-      if (currentReader != null) {
-        currentReader.close();
-      }
-    } catch (Exception e) {
-      logger.warn("Failure on closing reader: {}", e.getMessage());
-    } finally {
-      currentReader = null;
-    }
+    AutoCloseables.closeSilently(currentReader);
+    currentReader = null;
   }
 
   private IterOutcome internalNext() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScanBatch.java
@@ -40,6 +40,7 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.record.TypedFieldId;
+import org.apache.drill.exec.record.VectorAccessibleUtilities;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
@@ -202,7 +203,7 @@ public class ScanBatch implements CloseableRecordBatch {
    * @return whether we could continue iteration
    * @throws Exception
    */
-  private boolean shouldContinueAfterNoRecords() throws Exception {
+  private boolean shouldContinueAfterNoRecords() {
     logger.trace("scan got 0 record.");
     if (isRepeatableScan) {
       if (!currentReader.hasNext()) {
@@ -212,13 +213,24 @@ public class ScanBatch implements CloseableRecordBatch {
       }
       return true;
     } else { // Regular scan
-      currentReader.close();
-      currentReader = null;
+      closeCurrentReader();
       return true; // In regular case, we always continue the iteration, if no more reader, we will break out at the head of loop
     }
   }
 
-  private IterOutcome internalNext() throws Exception {
+  private void closeCurrentReader() {
+    try {
+      if (currentReader != null) {
+        currentReader.close();
+      }
+    } catch (Exception e) {
+      logger.warn("Failure on closing reader: {}", e.getMessage());
+    } finally {
+      currentReader = null;
+    }
+  }
+
+  private IterOutcome internalNext() {
     while (true) {
       if (currentReader == null && !getNextReaderIfHas()) {
         logger.trace("currentReader is null");
@@ -281,18 +293,6 @@ public class ScanBatch implements CloseableRecordBatch {
       clearFieldVectorMap();
       lastOutcome = IterOutcome.STOP;
       throw UserException.memoryError(ex).build(logger);
-    } catch (ExecutionSetupException e) {
-      if (currentReader != null) {
-        try {
-          currentReader.close();
-        } catch (final Exception e2) {
-          logger.error("Close failed for reader " + currentReaderClassName, e2);
-        }
-      }
-      lastOutcome = IterOutcome.STOP;
-      throw UserException.internalError(e)
-          .addContext("Setup failed for", currentReaderClassName)
-          .build(logger);
     } catch (UserException ex) {
       lastOutcome = IterOutcome.STOP;
       throw ex;
@@ -309,15 +309,11 @@ public class ScanBatch implements CloseableRecordBatch {
   }
 
   private void clearFieldVectorMap() {
-    for (final ValueVector v : mutator.fieldVectorMap().values()) {
-      v.clear();
-    }
-    for (final ValueVector v : mutator.implicitFieldVectorMap.values()) {
-      v.clear();
-    }
+    VectorAccessibleUtilities.clear(mutator.fieldVectorMap().values());
+    VectorAccessibleUtilities.clear(mutator.implicitFieldVectorMap.values());
   }
 
-  private boolean getNextReaderIfHas() throws ExecutionSetupException {
+  private boolean getNextReaderIfHas() {
     if (!readers.hasNext()) {
       return false;
     }
@@ -326,8 +322,15 @@ public class ScanBatch implements CloseableRecordBatch {
       readers.remove();
     }
     implicitValues = implicitColumns.hasNext() ? implicitColumns.next() : null;
-    currentReader.setup(oContext, mutator);
     currentReaderClassName = currentReader.getClass().getSimpleName();
+    try {
+      currentReader.setup(oContext, mutator);
+    } catch (ExecutionSetupException e) {
+      closeCurrentReader();
+      throw UserException.executionError(e)
+          .addContext("Failed to setup reader", currentReaderClassName)
+          .build(logger);
+    }
     return true;
   }
 
@@ -405,7 +408,6 @@ public class ScanBatch implements CloseableRecordBatch {
     return fqn;
   }
 
-
   /**
    * Row set mutator implementation provided to record readers created by
    * this scan batch. Made visible so that tests can create this mutator
@@ -414,7 +416,6 @@ public class ScanBatch implements CloseableRecordBatch {
    * in turn, the only use of the generated vector readers in the vector
    * package.)
    */
-
   @VisibleForTesting
   public static class Mutator implements OutputMutator {
     /** Flag keeping track whether top-level schema has changed since last inquiry (via #isNewSchema}).
@@ -589,9 +590,7 @@ public class ScanBatch implements CloseableRecordBatch {
   public void close() throws Exception {
     container.clear();
     mutator.clear();
-    if (currentReader != null) {
-      currentReader.close();
-    }
+    closeCurrentReader();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/ScreenCreator.java
@@ -123,7 +123,7 @@ public class ScreenCreator implements RootCreator<Screen> {
 
           return true;
         default:
-          throw new UnsupportedOperationException();
+          throw new UnsupportedOperationException(outcome.name());
       }
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/StatisticsWriterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/StatisticsWriterRecordBatch.java
@@ -19,6 +19,7 @@
 package org.apache.drill.exec.physical.impl;
 
 
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
@@ -36,18 +37,19 @@ import org.apache.drill.exec.store.StatisticsRecordWriterImpl;
 import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.BigIntVector;
 import org.apache.drill.exec.vector.VarCharVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
-
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StatisticsWriterRecordBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(StatisticsWriterRecordBatch.class);
 
   private StatisticsRecordWriterImpl statsRecordWriterImpl;
   private StatisticsRecordWriter recordWriter;
-  private long counter = 0;
+  private long counter;
   private final RecordBatch incoming;
-  private boolean processed = false;
+  private boolean processed;
   private final String fragmentUniqueId;
   private BatchSchema schema;
 
@@ -91,41 +93,47 @@ public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
     }
     // process the complete upstream in one next() call
     IterOutcome upstream;
-    try {
-      do {
-        upstream = next(incoming);
+    do {
+      upstream = next(incoming);
 
-        switch(upstream) {
-          case STOP:
-            return upstream;
+      switch(upstream) {
+        case STOP:
+          return upstream;
 
-          case NOT_YET:
-          case NONE:
-            break;
+        case NOT_YET:
+        case NONE:
+          break;
 
-          case OK_NEW_SCHEMA:
-            setupNewSchema();
-            // $FALL-THROUGH$
-          case OK:
+        case OK_NEW_SCHEMA:
+          setupNewSchema();
+          // $FALL-THROUGH$
+        case OK:
+          try {
             counter += statsRecordWriterImpl.writeStatistics(incoming.getRecordCount());
-            logger.debug("Total records written so far: {}", counter);
+          } catch (IOException e) {
+            // TODO: Better handled inside the write() method.
+            throw UserException.dataWriteError(e)
+              .addContext("Failure when writing the record count")
+              .build(logger);
+          }
+          logger.debug("Total records written so far: {}", counter);
 
-            for(final VectorWrapper<?> v : incoming) {
-              v.getValueVector().clear();
-            }
-            break;
+          for(final VectorWrapper<?> v : incoming) {
+            v.getValueVector().clear();
+          }
+          break;
 
-          default:
-            throw new UnsupportedOperationException();
-        }
-      } while(upstream != IterOutcome.NONE);
-      // Flush blocking writers now
+        default:
+          throw new UnsupportedOperationException();
+      }
+    } while(upstream != IterOutcome.NONE);
+    // Flush blocking writers now
+    try {
       statsRecordWriterImpl.flushBlockingWriter();
-    } catch(IOException ex) {
-      logger.error("Failure during query", ex);
-      kill(false);
-      context.getExecutorState().fail(ex);
-      return IterOutcome.STOP;
+    } catch (IOException ex) {
+      throw UserException.executionError(ex)
+        .addContext("Failure when flushing the block writer")
+        .build(logger);
     }
 
     addOutputContainerData();
@@ -154,11 +162,18 @@ public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
     container.setRecordCount(1);
   }
 
-  protected void setupNewSchema() throws IOException {
+  protected void setupNewSchema() {
     try {
       // update the schema in RecordWriter
       stats.startSetup();
-      recordWriter.updateSchema(incoming);
+      try {
+        recordWriter.updateSchema(incoming);
+      } catch (IOException e) {
+        // TODO: This is better handled inside updateSchema()
+        throw UserException.dataWriteError(e)
+          .addContext("Failure updating the statistics record writer schema")
+          .build(logger);
+      }
       // Create two vectors for:
       //   1. Fragment unique id.
       //   2. Summary: currently contains number of records written.
@@ -175,12 +190,21 @@ public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
       stats.stopSetup();
     }
 
-    statsRecordWriterImpl = new StatisticsRecordWriterImpl(incoming, recordWriter);
+    try {
+      statsRecordWriterImpl = new StatisticsRecordWriterImpl(incoming, recordWriter);
+    } catch (IOException e) {
+      throw UserException.dataWriteError(e)
+            .addContext("Failure when creating the statistics record writer")
+            .build(logger);
+    }
     container.buildSchema(BatchSchema.SelectionVectorMode.NONE);
     schema = container.getSchema();
   }
 
-  /** Clean up needs to be performed before closing writer. Partially written data will be removed. */
+  /**
+   * Clean up needs to be performed before closing writer. Partially written
+   * data will be removed.
+   */
   private void closeWriter() {
     if (recordWriter == null) {
       return;
@@ -209,5 +233,4 @@ public class StatisticsWriterRecordBatch extends AbstractRecordBatch<Writer> {
     closeWriter();
     super.close();
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/PriorityQueueTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/PriorityQueueTemplate.java
@@ -42,6 +42,14 @@ import org.slf4j.LoggerFactory;
 public abstract class PriorityQueueTemplate implements PriorityQueue {
   private static final Logger logger = LoggerFactory.getLogger(PriorityQueueTemplate.class);
 
+  /**
+   * The estimated maximum queue size used with allocating the SV4
+   * for the queue. If the queue is larger, then a) we should probably
+   * be using a sort instead of top N, and b) the code will automatically
+   * grow the SV4 as needed up to the max supported size.
+   */
+  public static final int EST_MAX_QUEUE_SIZE = 4000;
+
   // This holds the min heap of the record indexes. Heapify condition is based on actual record though. Only records
   // meeting the heap condition have their indexes in this heap. Actual record are stored inside the hyperBatch. Since
   // hyperBatch contains ValueVectors from all the incoming batches, the indexes here consider both BatchNumber and
@@ -143,7 +151,7 @@ public abstract class PriorityQueueTemplate implements PriorityQueue {
   public void generate() {
     Stopwatch watch = Stopwatch.createStarted();
     final DrillBuf drillBuf = allocator.buffer(4 * queueSize);
-    finalSv4 = new SelectionVector4(drillBuf, queueSize, 4000);
+    finalSv4 = new SelectionVector4(drillBuf, queueSize, EST_MAX_QUEUE_SIZE);
     for (int i = queueSize - 1; i >= 0; i--) {
       finalSv4.set(i, pop());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/TopN/TopNBatch.java
@@ -17,13 +17,13 @@
  */
 package org.apache.drill.exec.physical.impl.TopN;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.drill.common.DrillAutoCloseables;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -31,7 +31,6 @@ import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.compile.CodeCompiler;
 import org.apache.drill.exec.compile.sig.MappingSet;
-import org.apache.drill.exec.exception.ClassTransformationException;
 import org.apache.drill.exec.exception.OutOfMemoryException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.ClassGenerator;
@@ -79,12 +78,14 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK_NEW_SCHEMA;
 
 /**
- * Operator Batch which implements the TopN functionality. It is more efficient than (sort + limit) since unlike sort
- * it doesn't have to store all the input data to sort it first and then apply limit on the sorted data. Instead
- * internally it maintains a priority queue backed by a heap with the size being same as limit value.
+ * Operator Batch which implements the TopN functionality. It is more efficient
+ * than (sort + limit) since unlike sort it doesn't have to store all the input
+ * data to sort it first and then apply limit on the sorted data. Instead
+ * internally it maintains a priority queue backed by a heap with the size being
+ * same as limit value.
  */
 public class TopNBatch extends AbstractRecordBatch<TopN> {
-  static final Logger logger = LoggerFactory.getLogger(TopNBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(TopNBatch.class);
 
   private final MappingSet mainMapping = createMainMappingSet();
   private final MappingSet leftMapping = createLeftMappingSet();
@@ -139,7 +140,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   }
 
   @Override
-  public void buildSchema() throws SchemaChangeException {
+  public void buildSchema() {
     IterOutcome outcome = next(incoming);
     switch (outcome) {
       case OK:
@@ -184,157 +185,157 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
     // Reset the TopN state for next iteration
     resetTopNState();
 
-    try {
-      boolean incomingHasSv2 = false;
-      switch (incoming.getSchema().getSelectionVectorMode()) {
-        case NONE: {
-          break;
-        }
-        case TWO_BYTE: {
-          incomingHasSv2 = true;
-          break;
-        }
-        case FOUR_BYTE: {
-          throw new SchemaChangeException("TopN doesn't support incoming with SV4 mode");
-        }
-        default:
-          throw new UnsupportedOperationException("Unsupported SV mode detected in TopN incoming batch");
+    boolean incomingHasSv2 = false;
+    switch (incoming.getSchema().getSelectionVectorMode()) {
+      case NONE: {
+        break;
       }
-
-      outer: while (true) {
-        Stopwatch watch = Stopwatch.createStarted();
-        if (first) {
-          lastKnownOutcome = IterOutcome.OK_NEW_SCHEMA;
-          // Create the SV4 object upfront to be used for both empty and non-empty incoming batches at EMIT boundary
-          sv4 = new SelectionVector4(context.getAllocator(), 0);
-          first = false;
-        } else {
-          lastKnownOutcome = next(incoming);
-        }
-        if (lastKnownOutcome == OK && schema == null) {
-          lastKnownOutcome = IterOutcome.OK_NEW_SCHEMA;
-          container.clear();
-        }
-        logger.debug("Took {} us to get next", watch.elapsed(TimeUnit.MICROSECONDS));
-        switch (lastKnownOutcome) {
-        case NONE:
-          break outer;
-        case NOT_YET:
-          throw new UnsupportedOperationException();
-        case STOP:
-          return lastKnownOutcome;
-        case OK_NEW_SCHEMA:
-          // only change in the case that the schema truly changes.  Artificial schema changes are ignored.
-          // schema change handling in case when EMIT is also seen is same as without EMIT. i.e. only if union type
-          // is enabled it will be handled.
-          container.clear();
-          firstBatchForSchema = true;
-          if (!incoming.getSchema().equals(schema)) {
-            if (schema != null) {
-              if (!unionTypeEnabled) {
-                throw new UnsupportedOperationException(String.format("TopN currently doesn't support changing " +
-                  "schemas with union type disabled. Please try enabling union type: %s and re-execute the query",
-                  ExecConstants.ENABLE_UNION_TYPE_KEY));
-              } else {
-                this.schema = SchemaUtil.mergeSchemas(this.schema, incoming.getSchema());
-                purgeAndResetPriorityQueue();
-                this.schemaChanged = true;
-              }
-            } else {
-              this.schema = incoming.getSchema();
-            }
-          }
-          // fall through.
-        case OK:
-        case EMIT:
-          if (incoming.getRecordCount() == 0) {
-            for (VectorWrapper<?> w : incoming) {
-              w.clear();
-            }
-            // Release memory for incoming SV2 vector
-            if (incomingHasSv2) {
-              incoming.getSelectionVector2().clear();
-            }
-            break;
-          }
-          countSincePurge += incoming.getRecordCount();
-          batchCount++;
-          RecordBatchData batch;
-          if (schemaChanged) {
-            batch = new RecordBatchData(SchemaUtil.coerceContainer(incoming, this.schema, oContext), oContext.getAllocator());
-          } else {
-            batch = new RecordBatchData(incoming, oContext.getAllocator());
-          }
-          boolean success = false;
-          try {
-            if (priorityQueue == null) {
-              priorityQueue = createNewPriorityQueue(new ExpandableHyperContainer(batch.getContainer()), config.getLimit());
-            } else if (!priorityQueue.isInitialized()) {
-              // means priority queue is cleaned up after producing output for first record boundary. We should
-              // initialize it for next record boundary
-              priorityQueue.init(config.getLimit(), oContext.getAllocator(),
-                schema.getSelectionVectorMode() == SelectionVectorMode.TWO_BYTE);
-            }
-            priorityQueue.add(batch);
-            // Based on static threshold of number of batches, perform purge operation to release the memory for
-            // RecordBatches which are of no use or doesn't fall under TopN category
-            if (countSincePurge > config.getLimit() && batchCount > batchPurgeThreshold) {
-              purge();
-              countSincePurge = 0;
-              batchCount = 0;
-            }
-            success = true;
-          } finally {
-            if (!success) {
-              batch.clear();
-            }
-          }
-          break;
-        default:
-          throw new UnsupportedOperationException();
-        }
-
-        // If the last seen outcome is EMIT then break the loop. We do it here since we want to process the batch
-        // with records and EMIT outcome in above case statements
-        if (lastKnownOutcome == EMIT) {
-          break;
-        }
+      case TWO_BYTE: {
+        incomingHasSv2 = true;
+        break;
       }
-
-      // PriorityQueue can be null here if first batch is received with OK_NEW_SCHEMA and is empty and second next()
-      // call returned NONE or EMIT.
-      // PriorityQueue can be uninitialized here if only empty batch is received between 2 EMIT outcome.
-      if (schema == null || (priorityQueue == null || !priorityQueue.isInitialized())) {
-        // builder may be null at this point if the first incoming batch is empty
-        return handleEmptyBatches(lastKnownOutcome);
+      case FOUR_BYTE: {
+        throw UserException.internalError(null)
+          .message("TopN doesn't support incoming with SV4 mode")
+          .build(logger);
       }
-
-      priorityQueue.generate();
-      prepareOutputContainer(priorityQueue.getHyperBatch(), priorityQueue.getFinalSv4());
-
-      // With EMIT outcome control will come here multiple times whereas without EMIT outcome control will only come
-      // here once. In EMIT outcome case if there is schema change in any iteration then that will be handled by
-      // lastKnownOutcome.
-      return getFinalOutcome();
-    } catch(SchemaChangeException | ClassTransformationException | IOException ex) {
-      kill(false);
-      logger.error("Failure during query", ex);
-      context.getExecutorState().fail(ex);
-      return IterOutcome.STOP;
+      default:
+        throw new UnsupportedOperationException("Unsupported SV mode detected in TopN incoming batch");
     }
+
+    outer: while (true) {
+      Stopwatch watch = Stopwatch.createStarted();
+      if (first) {
+        lastKnownOutcome = IterOutcome.OK_NEW_SCHEMA;
+        // Create the SV4 object upfront to be used for both empty and non-empty incoming batches at EMIT boundary
+        sv4 = new SelectionVector4(context.getAllocator(), 0);
+        first = false;
+      } else {
+        lastKnownOutcome = next(incoming);
+      }
+      if (lastKnownOutcome == OK && schema == null) {
+        lastKnownOutcome = IterOutcome.OK_NEW_SCHEMA;
+        container.clear();
+      }
+      logger.debug("Took {} us to get next", watch.elapsed(TimeUnit.MICROSECONDS));
+      switch (lastKnownOutcome) {
+      case NONE:
+        break outer;
+      case NOT_YET:
+        throw new UnsupportedOperationException();
+      case STOP:
+        return lastKnownOutcome;
+      case OK_NEW_SCHEMA:
+        // only change in the case that the schema truly changes.  Artificial schema changes are ignored.
+        // schema change handling in case when EMIT is also seen is same as without EMIT. i.e. only if union type
+        // is enabled it will be handled.
+        container.clear();
+        firstBatchForSchema = true;
+        if (!incoming.getSchema().equals(schema)) {
+          if (schema != null) {
+            if (!unionTypeEnabled) {
+              throw new UnsupportedOperationException(String.format("TopN currently doesn't support changing " +
+                "schemas with union type disabled. Please try enabling union type: %s and re-execute the query",
+                ExecConstants.ENABLE_UNION_TYPE_KEY));
+            } else {
+              schema = SchemaUtil.mergeSchemas(this.schema, incoming.getSchema());
+              purgeAndResetPriorityQueue();
+              schemaChanged = true;
+            }
+          } else {
+            schema = incoming.getSchema();
+          }
+        }
+        // fall through.
+      case OK:
+      case EMIT:
+        if (incoming.getRecordCount() == 0) {
+          for (VectorWrapper<?> w : incoming) {
+            w.clear();
+          }
+          // Release memory for incoming SV2 vector
+          if (incomingHasSv2) {
+            incoming.getSelectionVector2().clear();
+          }
+          break;
+        }
+        countSincePurge += incoming.getRecordCount();
+        batchCount++;
+        RecordBatchData batch;
+        if (schemaChanged) {
+          batch = new RecordBatchData(SchemaUtil.coerceContainer(incoming, this.schema, oContext), oContext.getAllocator());
+        } else {
+          batch = new RecordBatchData(incoming, oContext.getAllocator());
+        }
+        boolean success = false;
+        try {
+          if (priorityQueue == null) {
+            priorityQueue = createNewPriorityQueue(new ExpandableHyperContainer(batch.getContainer()), config.getLimit());
+          } else if (!priorityQueue.isInitialized()) {
+            // means priority queue is cleaned up after producing output for first record boundary. We should
+            // initialize it for next record boundary
+            priorityQueue.init(config.getLimit(), oContext.getAllocator(),
+              schema.getSelectionVectorMode() == SelectionVectorMode.TWO_BYTE);
+          }
+          priorityQueue.add(batch);
+          // Based on static threshold of number of batches, perform purge operation to release the memory for
+          // RecordBatches which are of no use or doesn't fall under TopN category
+          if (countSincePurge > config.getLimit() && batchCount > batchPurgeThreshold) {
+            purge();
+            countSincePurge = 0;
+            batchCount = 0;
+          }
+          success = true;
+        } catch (SchemaChangeException e) {
+          throw schemaChangeException(e, logger);
+        } finally {
+          if (!success) {
+            batch.clear();
+          }
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException();
+      }
+
+      // If the last seen outcome is EMIT then break the loop. We do it here since we want to process the batch
+      // with records and EMIT outcome in above case statements
+      if (lastKnownOutcome == EMIT) {
+        break;
+      }
+    }
+
+    // PriorityQueue can be null here if first batch is received with OK_NEW_SCHEMA and is empty and second next()
+    // call returned NONE or EMIT.
+    // PriorityQueue can be uninitialized here if only empty batch is received between 2 EMIT outcome.
+    if (schema == null || (priorityQueue == null || !priorityQueue.isInitialized())) {
+      // builder may be null at this point if the first incoming batch is empty
+      return handleEmptyBatches(lastKnownOutcome);
+    }
+
+    priorityQueue.generate();
+    prepareOutputContainer(priorityQueue.getHyperBatch(), priorityQueue.getFinalSv4());
+
+    // With EMIT outcome control will come here multiple times whereas without EMIT outcome control will only come
+    // here once. In EMIT outcome case if there is schema change in any iteration then that will be handled by
+    // lastKnownOutcome.
+    return getFinalOutcome();
   }
 
   /**
-   * When PriorityQueue is built up then it stores the list of limit number of record indexes (in heapSv4) which falls
-   * under TopN category. But it also stores all the incoming RecordBatches with all records inside a HyperContainer
-   * (hyperBatch). When a certain threshold of batches are reached then this method is called which copies the limit
-   * number of records whose indexes are stored in heapSv4 out of HyperBatch to a new VectorContainer and releases
-   * all other records and their batches. Later this new VectorContainer is stored inside the HyperBatch and it's
-   * corresponding indexes are stored in the heapSv4 vector. This is done to avoid holding up lot's of Record Batches
-   * which can create OutOfMemory condition.
-   * @throws SchemaChangeException
+   * When PriorityQueue is built up then it stores the list of limit number of
+   * record indexes (in heapSv4) which falls under TopN category. But it also
+   * stores all the incoming RecordBatches with all records inside a
+   * HyperContainer (hyperBatch). When a certain threshold of batches are
+   * reached then this method is called which copies the limit number of records
+   * whose indexes are stored in heapSv4 out of HyperBatch to a new
+   * VectorContainer and releases all other records and their batches. Later
+   * this new VectorContainer is stored inside the HyperBatch and it's
+   * corresponding indexes are stored in the heapSv4 vector. This is done to
+   * avoid holding up lot's of Record Batches which can create OutOfMemory
+   * condition.
    */
-  private void purge() throws SchemaChangeException {
+  private void purge() {
     Stopwatch watch = Stopwatch.createStarted();
     VectorContainer c = priorityQueue.getHyperBatch();
 
@@ -362,7 +363,11 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
       // HyperContainer backing the priority queue out of it
       VectorContainer newQueue = new VectorContainer();
       builder.build(newQueue);
-      priorityQueue.resetQueue(newQueue, builder.getSv4().createNewWrapperCurrent());
+      try {
+        priorityQueue.resetQueue(newQueue, builder.getSv4().createNewWrapperCurrent());
+      } catch (SchemaChangeException e) {
+        throw schemaChangeException(e, logger);
+      }
       builder.getSv4().clear();
     } finally {
       DrillAutoCloseables.closeNoChecked(builder);
@@ -370,8 +375,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
     logger.debug("Took {} us to purge", watch.elapsed(TimeUnit.MICROSECONDS));
   }
 
-  private PriorityQueue createNewPriorityQueue(VectorAccessible batch, int limit)
-    throws SchemaChangeException, ClassTransformationException, IOException {
+  private PriorityQueue createNewPriorityQueue(VectorAccessible batch, int limit) {
     return createNewPriorityQueue(
       mainMapping, leftMapping, rightMapping, config.getOrderings(), batch, unionTypeEnabled,
       codegenDump, limit, oContext.getAllocator(), schema.getSelectionVectorMode(), context);
@@ -392,8 +396,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   public static PriorityQueue createNewPriorityQueue(
     MappingSet mainMapping, MappingSet leftMapping, MappingSet rightMapping,
     List<Ordering> orderings, VectorAccessible batch, boolean unionTypeEnabled, boolean codegenDump,
-    int limit, BufferAllocator allocator, SelectionVectorMode mode, FragmentContext context)
-          throws ClassTransformationException, IOException, SchemaChangeException {
+    int limit, BufferAllocator allocator, SelectionVectorMode mode, FragmentContext context) {
     OptionSet optionSet = context.getOptions();
     FunctionLookupContext functionLookupContext = context.getFunctionRegistry();
     CodeGenerator<PriorityQueue> cg = CodeGenerator.get(PriorityQueue.TEMPLATE_DEFINITION, optionSet);
@@ -407,11 +410,8 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
     for (Ordering od : orderings) {
       // first, we rewrite the evaluation stack for each side of the comparison.
       ErrorCollector collector = new ErrorCollectorImpl();
-      final LogicalExpression expr = ExpressionTreeMaterializer.materialize(od.getExpr(),
-          batch, collector, functionLookupContext, unionTypeEnabled);
-      if (collector.hasErrors()) {
-        throw new SchemaChangeException("Failure while materializing expression. " + collector.toErrorString());
-      }
+      final LogicalExpression expr = ExpressionTreeMaterializer.materialize(od.getExpr(), batch, collector, functionLookupContext, unionTypeEnabled);
+      collector.reportErrors(logger);
       g.setMappingSet(leftMapping);
       HoldingContainer left = g.addExpr(expr, ClassGenerator.BlkCreateMode.FALSE);
       g.setMappingSet(rightMapping);
@@ -436,7 +436,11 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
     g.getEvalBlock()._return(JExpr.lit(0));
 
     PriorityQueue q = context.getImplementationClass(cg);
-    q.init(limit, allocator, mode == BatchSchema.SelectionVectorMode.TWO_BYTE);
+    try {
+      q.init(limit, allocator, mode == BatchSchema.SelectionVectorMode.TWO_BYTE);
+    } catch (SchemaChangeException e) {
+      throw TopNBatch.schemaChangeException(e, "Top N", logger);
+    }
     return q;
   }
 
@@ -445,9 +449,8 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
    * 1. Purge existing batches
    * 2. Promote newly created container for new schema.
    * 3. Recreate priority queue and reset with coerced container.
-   * @throws SchemaChangeException
    */
-  public void purgeAndResetPriorityQueue() throws SchemaChangeException, ClassTransformationException, IOException {
+  public void purgeAndResetPriorityQueue() {
     final Stopwatch watch = Stopwatch.createStarted();
     final VectorContainer c = priorityQueue.getHyperBatch();
     final VectorContainer newContainer = new VectorContainer(oContext);
@@ -465,7 +468,11 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
       newSchemaContainer.buildSchema(SelectionVectorMode.FOUR_BYTE);
       priorityQueue.cleanup();
       priorityQueue = createNewPriorityQueue(newSchemaContainer, config.getLimit());
-      priorityQueue.resetQueue(newSchemaContainer, builder.getSv4().createNewWrapperCurrent());
+      try {
+        priorityQueue.resetQueue(newSchemaContainer, builder.getSv4().createNewWrapperCurrent());
+      } catch (SchemaChangeException e) {
+        throw schemaChangeException(e, logger);
+      }
     } finally {
       builder.clear();
       builder.close();
@@ -484,7 +491,8 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
   }
 
   /**
-   * Resets TopNBatch state to process next incoming batches independent of already seen incoming batches.
+   * Resets TopNBatch state to process next incoming batches independent of
+   * already seen incoming batches.
    */
   private void resetTopNState() {
     lastKnownOutcome = OK;
@@ -548,8 +556,7 @@ public class TopNBatch extends AbstractRecordBatch<TopN> {
    * @param batchBuilder - Builder to build hyper vectors batches
    * @throws SchemaChangeException
    */
-  private void copyToPurge(VectorContainer newContainer, SortRecordBatchBuilder batchBuilder)
-    throws SchemaChangeException {
+  private void copyToPurge(VectorContainer newContainer, SortRecordBatchBuilder batchBuilder) {
     final VectorContainer c = priorityQueue.getHyperBatch();
     final SelectionVector4 queueSv4 = priorityQueue.getSv4();
     final SimpleSV4RecordBatch newBatch = new SimpleSV4RecordBatch(newContainer, null, context);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl;
 
 import java.io.IOException;
 
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -37,16 +38,18 @@ import org.apache.drill.exec.store.RecordWriter;
 import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.BigIntVector;
 import org.apache.drill.exec.vector.VarCharVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/* Write the RecordBatch to the given RecordWriter. */
+/** Write the RecordBatch to the given RecordWriter. */
 public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WriterRecordBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(WriterRecordBatch.class);
 
   private EventBasedRecordWriter eventBasedRecordWriter;
   private RecordWriter recordWriter;
-  private long counter = 0;
+  private long counter;
   private final RecordBatch incoming;
-  private boolean processed = false;
+  private boolean processed;
   private final String fragmentUniqueId;
   private BatchSchema schema;
 
@@ -77,7 +80,6 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
   @Override
   public IterOutcome innerNext() {
     if (processed) {
-//      cleanup();
       // if the upstream record batch is already processed and next() is called by
       // downstream then return NONE to indicate completion
       return IterOutcome.NONE;
@@ -85,46 +87,46 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
 
     // process the complete upstream in one next() call
     IterOutcome upstream;
-    try {
-      do {
-        upstream = next(incoming);
+    do {
+      upstream = next(incoming);
 
-        switch(upstream) {
-          case STOP:
-            return upstream;
+      switch(upstream) {
+        case STOP:
+          return upstream;
 
-          case NOT_YET:
+        case NOT_YET:
+          break;
+        case NONE:
+          if (schema != null) {
+            // Schema is for the output batch schema which is setup in setupNewSchema(). Since the output
+            // schema is fixed ((Fragment(VARCHAR), Number of records written (BIGINT)) we should set it
+            // up even with 0 records for it to be reported back to the client.
             break;
-          case NONE:
-            if (schema != null) {
-              // Schema is for the output batch schema which is setup in setupNewSchema(). Since the output
-              // schema is fixed ((Fragment(VARCHAR), Number of records written (BIGINT)) we should set it
-              // up even with 0 records for it to be reported back to the client.
-              break;
-            }
+          }
 
-          case OK_NEW_SCHEMA:
-            setupNewSchema();
-            // $FALL-THROUGH$
-          case OK:
+        case OK_NEW_SCHEMA:
+          setupNewSchema();
+          // $FALL-THROUGH$
+        case OK:
+          try {
             counter += eventBasedRecordWriter.write(incoming.getRecordCount());
-            logger.debug("Total records written so far: {}", counter);
+          } catch (IOException e) {
+            // TODO: Better handled inside the write() method.
+            throw UserException.dataWriteError(e)
+              .addContext("Failure when writing the record count")
+              .build(logger);
+          }
+          logger.debug("Total records written so far: {}", counter);
 
-            for(final VectorWrapper<?> v : incoming) {
-              v.getValueVector().clear();
-            }
-            break;
+          for(final VectorWrapper<?> v : incoming) {
+            v.getValueVector().clear();
+          }
+          break;
 
-          default:
-            throw new UnsupportedOperationException();
-        }
-      } while(upstream != IterOutcome.NONE);
-    } catch(IOException ex) {
-      logger.error("Failure during query", ex);
-      kill(false);
-      context.getExecutorState().fail(ex);
-      return IterOutcome.STOP;
-    }
+        default:
+          throw new UnsupportedOperationException();
+      }
+    } while(upstream != IterOutcome.NONE);
 
     addOutputContainerData();
     processed = true;
@@ -152,11 +154,18 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
     container.setRecordCount(1);
   }
 
-  protected void setupNewSchema() throws IOException {
+  protected void setupNewSchema() {
     try {
       // update the schema in RecordWriter
       stats.startSetup();
-      recordWriter.updateSchema(incoming);
+      try {
+        recordWriter.updateSchema(incoming);
+      } catch (IOException e) {
+        // TODO: This is better handled inside updateSchema()
+        throw UserException.dataWriteError(e)
+          .addContext("Failure updating the statistics record writer schema")
+          .build(logger);
+      }
       // Create two vectors for:
       //   1. Fragment unique id.
       //   2. Summary: currently contains number of records written.
@@ -173,7 +182,13 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
       stats.stopSetup();
     }
 
-    eventBasedRecordWriter = new EventBasedRecordWriter(incoming, recordWriter);
+    try {
+      eventBasedRecordWriter = new EventBasedRecordWriter(incoming, recordWriter);
+    } catch (IOException e) {
+      throw UserException.dataWriteError(e)
+          .addContext("Failed to create the event record writer")
+          .build(logger);
+    }
     container.buildSchema(SelectionVectorMode.NONE);
     schema = container.getSchema();
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/WriterRecordBatch.java
@@ -53,12 +53,14 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
   private final String fragmentUniqueId;
   private BatchSchema schema;
 
-  public WriterRecordBatch(Writer writer, RecordBatch incoming, FragmentContext context, RecordWriter recordWriter) throws OutOfMemoryException {
+  public WriterRecordBatch(Writer writer, RecordBatch incoming, FragmentContext context,
+      RecordWriter recordWriter) throws OutOfMemoryException {
     super(writer, context, false);
     this.incoming = incoming;
 
     final FragmentHandle handle = context.getHandle();
-    fragmentUniqueId = String.format("%d_%d", handle.getMajorFragmentId(), handle.getMinorFragmentId());
+    fragmentUniqueId = String.format(
+        "%d_%d", handle.getMajorFragmentId(), handle.getMinorFragmentId());
     this.recordWriter = recordWriter;
   }
 
@@ -111,9 +113,8 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
           try {
             counter += eventBasedRecordWriter.write(incoming.getRecordCount());
           } catch (IOException e) {
-            // TODO: Better handled inside the write() method.
             throw UserException.dataWriteError(e)
-              .addContext("Failure when writing the record count")
+              .addContext("Failure when writing the batch")
               .build(logger);
           }
           logger.debug("Total records written so far: {}", counter);
@@ -161,9 +162,8 @@ public class WriterRecordBatch extends AbstractRecordBatch<Writer> {
       try {
         recordWriter.updateSchema(incoming);
       } catch (IOException e) {
-        // TODO: This is better handled inside updateSchema()
         throw UserException.dataWriteError(e)
-          .addContext("Failure updating the statistics record writer schema")
+          .addContext("Failure updating record writer schema")
           .build(logger);
       }
       // Create two vectors for:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
@@ -340,16 +340,12 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
       }
 
     case UPDATE_AGGREGATOR:
-      context.getExecutorState().fail(UserException.unsupportedError()
+      throw UserException.unsupportedError()
           .message(SchemaChangeException.schemaChanged(
               "Hash aggregate does not support schema change",
               incomingSchema,
               incoming.getSchema()).getMessage())
-          .build(logger));
-      close();
-      killIncoming(false);
-      firstBatch = false;
-      return IterOutcome.STOP;
+          .build(logger);
     default:
       throw new IllegalStateException(String.format("Unknown state %s.", out));
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/SpilledRecordBatch.java
@@ -39,10 +39,9 @@ import java.io.InputStream;
 import java.util.Iterator;
 
 /**
- * A class to replace "incoming" - instead scanning a spilled partition file
+ * Replaces "incoming" - instead scanning a spilled partition file
  */
 public class SpilledRecordBatch implements CloseableRecordBatch {
-
   private static final Logger logger = LoggerFactory.getLogger(SpilledRecordBatch.class);
 
   private VectorContainer container;
@@ -137,13 +136,13 @@ public class SpilledRecordBatch implements CloseableRecordBatch {
 
     context.getExecutorState().checkContinue();
 
-    if ( spilledBatches <= 0 ) { // no more batches to read in this partition
+    if (spilledBatches <= 0) { // no more batches to read in this partition
       this.close();
       lastOutcome = IterOutcome.NONE;
       return lastOutcome;
     }
 
-    if ( spillStream == null ) {
+    if (spillStream == null) {
       lastOutcome = IterOutcome.STOP;
       throw new IllegalStateException("Spill stream was null");
     }
@@ -153,7 +152,7 @@ public class SpilledRecordBatch implements CloseableRecordBatch {
     }
 
     try {
-      if ( container.getNumberOfColumns() > 0 ) { // container already initialized
+      if (container.getNumberOfColumns() > 0) { // container already initialized
         // Pass our container to the reader because other classes (e.g. HashAggBatch, HashTable)
         // may have a reference to this container (as an "incoming")
         vas.readFromStreamWithContainer(container, spillStream);
@@ -163,11 +162,12 @@ public class SpilledRecordBatch implements CloseableRecordBatch {
         container = vas.get();
       }
     } catch (IOException e) {
-      lastOutcome = IterOutcome.STOP;
-      throw UserException.dataReadError(e).addContext("Failed reading from a spill file").build(logger);
+      throw UserException.dataReadError(e)
+          .addContext("Failed reading from a spill file")
+          .build(logger);
     } catch (Exception e) {
-      lastOutcome = IterOutcome.STOP;
-      throw e;
+      // TODO: Catch the error closer to the cause and create a better error message.
+      throw UserException.executionError(e).build(logger);
     }
 
     spilledBatches--; // one less batch to read
@@ -206,7 +206,7 @@ public class SpilledRecordBatch implements CloseableRecordBatch {
       spillSet.delete(spillFile);
     }
     catch (IOException e) {
-      /* ignore */
+      // ignore
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/StreamingAggBatch.java
@@ -21,7 +21,6 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.OK_NEW_SCHEMA;
-import static org.apache.drill.exec.record.RecordBatch.IterOutcome.STOP;
 
 import java.util.List;
 
@@ -357,13 +356,10 @@ public class StreamingAggBatch extends AbstractRecordBatch<StreamingAggregate> {
           lastKnownOutcome = EMIT;
           return OK_NEW_SCHEMA;
         } else {
-          context.getExecutorState().fail(UserException.unsupportedError().message(SchemaChangeException
-              .schemaChanged("Streaming aggregate does not support schema changes", incomingSchema,
-                  incoming.getSchema()).getMessage()).build(logger));
-          close();
-          killIncoming(false);
-          lastKnownOutcome = STOP;
-          return IterOutcome.STOP;
+          throw UserException.schemaChangeError(SchemaChangeException.schemaChanged(
+                  "Streaming aggregate does not support schema changes", incomingSchema,
+                  incoming.getSchema()))
+              .build(logger);
         }
       default:
         throw new IllegalStateException(String.format("Unknown state %s.", aggOutcome));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/FilterRecordBatch.java
@@ -132,8 +132,9 @@ public class FilterRecordBatch extends AbstractSingleRecordBatch<Filter> {
     if (container.isSchemaChanged()) {
       container.buildSchema(SelectionVectorMode.TWO_BYTE);
       return true;
+    } else {
+      return false;
     }
-    return false;
   }
 
   protected Filterer generateSV4Filterer() throws SchemaChangeException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterBatchCreator.java
@@ -27,11 +27,11 @@ import org.apache.drill.exec.record.RecordBatch;
 
 import java.util.List;
 
-public class RuntimeFilterBatchCreator implements BatchCreator<RuntimeFilterPOP>{
+public class RuntimeFilterBatchCreator implements BatchCreator<RuntimeFilterPOP> {
   @Override
   public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
-                   RuntimeFilterPOP config, List<RecordBatch> children)
-                       throws ExecutionSetupException {
+                                       RuntimeFilterPOP config, List<RecordBatch> children)
+                                       throws ExecutionSetupException {
     Preconditions.checkArgument(children.size() == 1);
     return new RuntimeFilterRecordBatch(config, children.iterator().next(), context);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterBatchCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterBatchCreator.java
@@ -29,7 +29,9 @@ import java.util.List;
 
 public class RuntimeFilterBatchCreator implements BatchCreator<RuntimeFilterPOP>{
   @Override
-  public CloseableRecordBatch getBatch(ExecutorFragmentContext context, RuntimeFilterPOP config, List<RecordBatch> children) throws ExecutionSetupException {
+  public CloseableRecordBatch getBatch(ExecutorFragmentContext context,
+                   RuntimeFilterPOP config, List<RecordBatch> children)
+                       throws ExecutionSetupException {
     Preconditions.checkArgument(children.size() == 1);
     return new RuntimeFilterRecordBatch(config, children.iterator().next(), context);
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterRecordBatch.java
@@ -208,8 +208,6 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
    * incoming batch records and creates an SV2 to store indexes which passes the
    * filter condition. In case when RuntimeFilter is not available it just pass
    * through all the records from incoming batch to downstream.
-   *
-   * @throws SchemaChangeException
    */
   private void applyRuntimeFilter() {
     if (originalRecordCount <= 0) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/RuntimeFilterRecordBatch.java
@@ -75,7 +75,8 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
   private final long maxWaitingTime;
   private final long rfIdentifier;
 
-  public RuntimeFilterRecordBatch(RuntimeFilterPOP pop, RecordBatch incoming, FragmentContext context) throws OutOfMemoryException {
+  public RuntimeFilterRecordBatch(RuntimeFilterPOP pop, RecordBatch incoming,
+      FragmentContext context) throws OutOfMemoryException {
     super(pop, context, incoming);
     enableRFWaiting = context.getOptions().getBoolean(ExecConstants.HASHJOIN_RUNTIME_FILTER_WAITING_ENABLE_KEY);
     maxWaitingTime = context.getOptions().getLong(ExecConstants.HASHJOIN_RUNTIME_FILTER_MAX_WAITING_TIME_KEY);
@@ -106,11 +107,7 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
   protected IterOutcome doWork() {
     originalRecordCount = incoming.getRecordCount();
     sv2.setBatchActualRecordCount(originalRecordCount);
-    try {
-      applyRuntimeFilter();
-    } catch (SchemaChangeException e) {
-      throw new UnsupportedOperationException(e);
-    }
+    applyRuntimeFilter();
     container.transferIn(incoming.getContainer());
     container.setRecordCount(originalRecordCount);
     updateStats();
@@ -129,7 +126,7 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     if (sv2 != null) {
       sv2.clear();
     }
@@ -168,8 +165,9 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
   }
 
   /**
-   * Takes care of setting up HashHelper if RuntimeFilter is received and the HashHelper is not already setup. For each
-   * schema change hash64 should be reset and this method needs to be called again.
+   * Takes care of setting up HashHelper if RuntimeFilter is received and the
+   * HashHelper is not already setup. For each schema change hash64 should be
+   * reset and this method needs to be called again.
    */
   private void setupHashHelper() {
     current = context.getRuntimeFilter(rfIdentifier);
@@ -196,7 +194,9 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
           ValueVectorReadExpression toHashFieldExp = new ValueVectorReadExpression(typedFieldId);
           hashFieldExps.add(toHashFieldExp);
         }
-        hash64 = hashHelper.getHash64(hashFieldExps.toArray(new LogicalExpression[hashFieldExps.size()]), typedFieldIds.toArray(new TypedFieldId[typedFieldIds.size()]));
+        hash64 = hashHelper.getHash64(hashFieldExps.toArray(
+            new LogicalExpression[hashFieldExps.size()]),
+            typedFieldIds.toArray(new TypedFieldId[typedFieldIds.size()]));
       } catch (Exception e) {
         throw UserException.internalError(e).build(logger);
       }
@@ -204,12 +204,14 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
   }
 
   /**
-   * If RuntimeFilter is available then applies the filter condition on the incoming batch records and creates an SV2
-   * to store indexes which passes the filter condition. In case when RuntimeFilter is not available it just pass
+   * If RuntimeFilter is available then applies the filter condition on the
+   * incoming batch records and creates an SV2 to store indexes which passes the
+   * filter condition. In case when RuntimeFilter is not available it just pass
    * through all the records from incoming batch to downstream.
+   *
    * @throws SchemaChangeException
    */
-  private void applyRuntimeFilter() throws SchemaChangeException {
+  private void applyRuntimeFilter() {
     if (originalRecordCount <= 0) {
       sv2.setRecordCount(0);
       return;
@@ -238,7 +240,12 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
       String fieldName = toFilterFields.get(0);
       int fieldId = field2id.get(fieldName);
       for (int rowIndex = 0; rowIndex < originalRecordCount; rowIndex++) {
-        long hash = hash64.hash64Code(rowIndex, 0, fieldId);
+        long hash;
+        try {
+          hash = hash64.hash64Code(rowIndex, 0, fieldId);
+        } catch (SchemaChangeException e) {
+          throw new UnsupportedOperationException(e);
+        }
         boolean contain = bloomFilter.find(hash);
         if (contain) {
           sv2.setIndex(svIndex, rowIndex);
@@ -251,7 +258,11 @@ public class RuntimeFilterRecordBatch extends AbstractSingleRecordBatch<RuntimeF
       for (int i = 0; i < toFilterFields.size(); i++) {
         BloomFilter bloomFilter = bloomFilters.get(i);
         String fieldName = toFilterFields.get(i);
-        computeBitSet(field2id.get(fieldName), bloomFilter, bitSet);
+        try {
+          computeBitSet(field2id.get(fieldName), bloomFilter, bitSet);
+        } catch (SchemaChangeException e) {
+          throw new UnsupportedOperationException(e);
+        }
       }
       for (int i = 0; i < originalRecordCount; i++) {
         boolean contain = bitSet.get(i);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/HashJoinBatch.java
@@ -96,7 +96,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class implements the runtime execution for the Hash-Join operator
+ * Implements the runtime execution for the Hash-Join operator
  * supporting INNER, LEFT OUTER, RIGHT OUTER, and FULL OUTER joins
  * <p>
  * This implementation splits the incoming Build side rows into multiple
@@ -125,7 +125,6 @@ import org.slf4j.LoggerFactory;
  * greater) is a waste, indicating that the number of partitions chosen was too
  * small.
  */
-
 public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implements RowKeyJoin {
   private static final Logger logger = LoggerFactory.getLogger(HashJoinBatch.class);
 
@@ -687,12 +686,13 @@ public class HashJoinBatch extends AbstractBinaryRecordBatch<HashJoinPOP> implem
    * @param isLeft is it the left or right
    */
   private void killAndDrainUpstream(RecordBatch batch, IterOutcome upstream, boolean isLeft) {
-      batch.kill(true);
-      while (upstream == IterOutcome.OK_NEW_SCHEMA || upstream == IterOutcome.OK) {
-        VectorAccessibleUtilities.clear(batch);
-        upstream = next( isLeft ? HashJoinHelper.LEFT_INPUT : HashJoinHelper.RIGHT_INPUT, batch);
-      }
+    batch.kill(true);
+    while (upstream == IterOutcome.OK_NEW_SCHEMA || upstream == IterOutcome.OK) {
+      VectorAccessibleUtilities.clear(batch);
+      upstream = next( isLeft ? HashJoinHelper.LEFT_INPUT : HashJoinHelper.RIGHT_INPUT, batch);
+    }
   }
+
   private void killAndDrainLeftUpstream() { killAndDrainUpstream(probeBatch, leftUpstream, true); }
   private void killAndDrainRightUpstream() { killAndDrainUpstream(buildBatch, rightUpstream, false); }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/MergeJoinBatch.java
@@ -27,6 +27,7 @@ import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -200,8 +201,10 @@ public class MergeJoinBatch extends AbstractBinaryRecordBatch<MergeJoinPOP> {
         case FAILURE:
           status.left.clearInflightBatches();
           status.right.clearInflightBatches();
-          kill(false);
-          return IterOutcome.STOP;
+          // Should handle at the source of the error to provide a better error message.
+          throw UserException.executionError(null)
+              .message("Merge failed")
+              .build(logger);
         case WAITING:
           return IterOutcome.NOT_YET;
         default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/RowKeyJoinBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/RowKeyJoinBatch.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.RowKeyJoinPOP;
 import org.apache.drill.exec.record.AbstractRecordBatch;
@@ -36,10 +35,11 @@ import org.apache.drill.exec.vector.ValueVector;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implements RowKeyJoin {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RowKeyJoinBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(RowKeyJoinBatch.class);
 
   // primary table side record batch
   private final RecordBatch left;
@@ -51,7 +51,7 @@ public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implemen
   private IterOutcome leftUpstream = IterOutcome.NONE;
   private IterOutcome rightUpstream = IterOutcome.NONE;
   private final List<TransferPair> transfers = Lists.newArrayList();
-  private int recordCount = 0;
+  private int recordCount;
   private final SchemaChangeCallBack callBack = new SchemaChangeCallBack();
   private RowKeyJoinState rkJoinState = RowKeyJoinState.INITIAL;
 
@@ -82,7 +82,7 @@ public class RowKeyJoinBatch extends AbstractRecordBatch<RowKeyJoinPOP> implemen
   }
 
   @Override
-  protected void buildSchema() throws SchemaChangeException {
+  protected void buildSchema() {
     container.clear();
 
     rightUpstream = next(right);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/LimitRecordBatch.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.Limit;
 import org.apache.drill.exec.record.AbstractSingleRecordBatch;
@@ -114,7 +113,7 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     container.clear();
     transfers.clear();
 
@@ -139,9 +138,9 @@ public class LimitRecordBatch extends AbstractSingleRecordBatch<Limit> {
     if (container.isSchemaChanged()) {
       container.buildSchema(BatchSchema.SelectionVectorMode.TWO_BYTE);
       return true;
+    } else {
+     return false;
     }
-
-    return false;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/limit/PartitionLimitRecordBatch.java
@@ -22,7 +22,6 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.EMIT;
 import java.util.List;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.PartitionLimit;
 import org.apache.drill.exec.record.AbstractSingleRecordBatch;
@@ -84,7 +83,7 @@ public class PartitionLimitRecordBatch extends AbstractSingleRecordBatch<Partiti
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     container.clear();
     transfers.clear();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataHandlerBatch.java
@@ -72,8 +72,8 @@ import static org.apache.drill.exec.record.RecordBatch.IterOutcome.NONE;
 import static org.apache.drill.exec.record.RecordBatch.IterOutcome.STOP;
 
 /**
- * Operator responsible for handling metadata returned by incoming aggregate operators and fetching
- * required metadata form the Metastore.
+ * Responsible for handling metadata returned by incoming aggregate operators
+ * and fetching required metadata form the Metastore.
  */
 public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHandlerPOP> {
   private static final Logger logger = LoggerFactory.getLogger(MetadataHandlerBatch.class);
@@ -128,11 +128,7 @@ public class MetadataHandlerBatch extends AbstractSingleRecordBatch<MetadataHand
       case STOP:
         return outcome;
       default:
-        context.getExecutorState()
-            .fail(new UnsupportedOperationException("Unsupported upstream state " + outcome));
-        close();
-        killIncoming(false);
-        return IterOutcome.STOP;
+        throw new UnsupportedOperationException("Unsupported upstream state " + outcome);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/orderedpartitioner/OrderedPartitionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/orderedpartitioner/OrderedPartitionRecordBatch.java
@@ -208,9 +208,7 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       try {
         sorter.setup(context, sv4, sortedSamples);
       } catch (SchemaChangeException e) {
-        throw UserException.schemaChangeError(e)
-          .addContext("Failure when setting up the sorter for the ordered partitioner")
-          .build(logger);
+        throw schemaChangeException(e, logger);
       }
       sorter.sort(sv4, sortedSamples);
 
@@ -357,9 +355,7 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       try {
         sorter.setup(context, newSv4, allSamplesContainer);
       } catch (SchemaChangeException e) {
-        throw UserException.schemaChangeError(e)
-            .addContext("Unexpected schema change in Ordered Partitioner")
-            .build(logger);
+        throw schemaChangeException(e, logger);
       }
       sorter.sort(newSv4, allSamplesContainer);
 
@@ -440,9 +436,7 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       sampleCopier.setupCopier(context, sv4, incoming, outgoing);
       return sampleCopier;
     } catch (SchemaChangeException e) {
-      throw UserException.schemaChangeError(e)
-          .addContext("Unexpected schema change in the Ordered Partitioner")
-          .build(logger);
+      throw schemaChangeException(e, logger);
     }
   }
 
@@ -544,7 +538,6 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
    * in the partition table
    *
    * @param batch
-   * @throws SchemaChangeException
    */
   protected void setupNewSchema(VectorAccessible batch) {
     container.clear();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/orderedpartitioner/OrderedPartitionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/orderedpartitioner/OrderedPartitionRecordBatch.java
@@ -23,6 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.FieldReference;
@@ -50,7 +51,6 @@ import org.apache.drill.exec.expr.ValueVectorReadExpression;
 import org.apache.drill.exec.expr.ValueVectorWriteExpression;
 import org.apache.drill.exec.expr.fn.FunctionGenerationHelper;
 import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.ops.QueryCancelledException;
 import org.apache.drill.exec.physical.config.OrderedPartitionSender;
 import org.apache.drill.exec.physical.impl.sort.SortBatch;
 import org.apache.drill.exec.physical.impl.sort.SortRecordBatchBuilder;
@@ -87,6 +87,8 @@ import com.sun.codemodel.JExpr;
  * value is determined by where each record falls in the partition table. This
  * column is used by PartitionSenderRootExec to determine which bucket to assign
  * each record to.
+ * <p>
+ * This code is not used.
  */
 public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPartitionSender> {
   static final Logger logger = LoggerFactory.getLogger(OrderedPartitionRecordBatch.class);
@@ -206,7 +208,9 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       try {
         sorter.setup(context, sv4, sortedSamples);
       } catch (SchemaChangeException e) {
-        throw schemaChangeException(e, logger);
+        throw UserException.schemaChangeError(e)
+          .addContext("Failure when setting up the sorter for the ordered partitioner")
+          .build(logger);
       }
       sorter.sort(sv4, sortedSamples);
 
@@ -267,7 +271,7 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       try {
         Thread.sleep(timeout);
       } catch (final InterruptedException e) {
-        throw new QueryCancelledException();
+        checkContinue();
       }
     }
   }
@@ -281,13 +285,9 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
    * table, and attempts to push the partition table to the distributed cache.
    * Whichever table gets pushed first becomes the table used by all fragments
    * for partitioning.
-   *
-   * @return True is successful. False if failed.
    */
-  private boolean getPartitionVectors() {
-    if (!saveSamples()) {
-      return false;
-    }
+  private void getPartitionVectors() {
+    saveSamples();
 
     CachedVectorContainer finalTable = null;
 
@@ -328,7 +328,6 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
     for (VectorWrapper<?> w : finalTable.get()) {
       partitionVectors.add(w.getValueVector());
     }
-    return true;
   }
 
   private void buildTable() {
@@ -358,7 +357,9 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       try {
         sorter.setup(context, newSv4, allSamplesContainer);
       } catch (SchemaChangeException e) {
-        throw schemaChangeException(e, logger);
+        throw UserException.schemaChangeError(e)
+            .addContext("Unexpected schema change in Ordered Partitioner")
+            .build(logger);
       }
       sorter.sort(newSv4, allSamplesContainer);
 
@@ -398,17 +399,12 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
   }
 
   /**
-   * Creates a copier that does a project for every Nth record from a VectorContainer incoming into VectorContainer
-   * outgoing. Each Ordering in orderings generates a column, and evaluation of the expression associated with each
-   * Ordering determines the value of each column. These records will later be sorted based on the values in each
-   * column, in the same order as the orderings.
-   *
-   * @param sv4
-   * @param incoming
-   * @param outgoing
-   * @param orderings
-   * @return
-   * @throws SchemaChangeException
+   * Creates a copier that does a project for every Nth record from a
+   * VectorContainer incoming into VectorContainer outgoing. Each Ordering in
+   * orderings generates a column, and evaluation of the expression associated
+   * with each Ordering determines the value of each column. These records will
+   * later be sorted based on the values in each column, in the same order as
+   * the orderings.
    */
   private SampleCopier getCopier(SelectionVector4 sv4, VectorContainer incoming, VectorContainer outgoing,
       List<Ordering> orderings, List<ValueVector> localAllocationVectors) {
@@ -444,7 +440,9 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
       sampleCopier.setupCopier(context, sv4, incoming, outgoing);
       return sampleCopier;
     } catch (SchemaChangeException e) {
-      throw schemaChangeException(e, logger);
+      throw UserException.schemaChangeError(e)
+          .addContext("Unexpected schema change in the Ordered Partitioner")
+          .build(logger);
     }
   }
 
@@ -606,7 +604,9 @@ public class OrderedPartitionRecordBatch extends AbstractRecordBatch<OrderedPart
     try {
       projector.setup(context, batch, this, transfers, partitionVectors, partitions, popConfig.getRef());
     } catch (SchemaChangeException e) {
-      throw schemaChangeException(e, logger);
+      throw UserException.schemaChangeError(e)
+        .addContext("Unexpected schema change in the Ordered Partitioner")
+        .build(logger);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionSenderRootExec.java
@@ -47,8 +47,8 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.CloseableRecordBatch;
 import org.apache.drill.exec.record.FragmentWritableBatch;
 import org.apache.drill.exec.record.RecordBatch;
+import org.apache.drill.exec.record.VectorAccessibleUtilities;
 import org.apache.drill.exec.record.RecordBatch.IterOutcome;
-import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.vector.CopyUtil;
 
@@ -211,9 +211,7 @@ public class PartitionSenderRootExec extends BaseRootExec {
           incoming.kill(false);
           return false;
         }
-        for (VectorWrapper<?> v : incoming) {
-          v.clear();
-        }
+        VectorAccessibleUtilities.clear(incoming);
         return true;
       case NOT_YET:
       default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/partitionsender/PartitionerDecorator.java
@@ -39,17 +39,19 @@ import org.apache.drill.exec.testing.CountDownLatchInjection;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.util.concurrent.MoreExecutors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Decorator class to hide multiple Partitioner existence from the caller
- * since this class involves multithreaded processing of incoming batches
- * as well as flushing it needs special handling of OperatorStats - stats
- * since stats are not suitable for use in multithreaded environment
- * The algorithm to figure out processing versus wait time is based on following formula:
- * totalWaitTime = totalAllPartitionersProcessingTime - max(sum(processingTime) by partitioner)
+ * Decorator class to hide multiple Partitioner existence from the caller since
+ * this class involves multithreaded processing of incoming batches as well as
+ * flushing it needs special handling of OperatorStats - stats since stats are
+ * not suitable for use in multithreaded environment The algorithm to figure out
+ * processing versus wait time is based on following formula: totalWaitTime =
+ * totalAllPartitionersProcessingTime - max(sum(processingTime) by partitioner)
  */
 public final class PartitionerDecorator {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PartitionerDecorator.class);
+  private static final Logger logger = LoggerFactory.getLogger(PartitionerDecorator.class);
   private static final ControlsInjector injector = ControlsInjectorFactory.getInjector(PartitionerDecorator.class);
 
   private final List<Partitioner> partitioners;
@@ -394,7 +396,7 @@ public final class PartitionerDecorator {
     }
 
     public ExecutionException getException() {
-      return this.exception;
+      return exception;
     }
 
     public OperatorStats getStats() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/protocol/OperatorRecordBatch.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
  * batches. The <tt>TransferPair</tt> abstraction fails if different
  * vectors appear across batches.
  */
-
 public class OperatorRecordBatch implements CloseableRecordBatch {
   static final Logger logger = LoggerFactory.getLogger(OperatorRecordBatch.class);
 
@@ -149,10 +148,6 @@ public class OperatorRecordBatch implements CloseableRecordBatch {
       driver.operatorContext().getStats().startProcessing();
       lastOutcome = driver.next();
       return lastOutcome;
-    } catch (Exception e) {
-      // mark batch as failed
-      lastOutcome = IterOutcome.STOP;
-      throw e;
     } finally {
       driver.operatorContext().getStats().stopProcessing();
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/rangepartitioner/RangePartitionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/rangepartitioner/RangePartitionRecordBatch.java
@@ -107,7 +107,7 @@ public class RangePartitionRecordBatch extends AbstractSingleRecordBatch<RangePa
    * @return True if the new schema differs from old schema, False otherwise
    */
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     container.clear();
 
     for (VectorWrapper<?> vw : incoming) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.physical.impl.sort;
 
 import java.util.List;
 
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -138,7 +139,9 @@ public class SortBatch extends AbstractRecordBatch<Sort> {
     try {
       sorter.setup(context, getSelectionVector4(), this.container);
     } catch (SchemaChangeException e) {
-      throw schemaChangeException(e, logger);
+      throw UserException.schemaChangeError(e)
+          .addContext("Unexpected schema change in in-memory Sort operator")
+          .build(logger);
     }
     sorter.sort(getSelectionVector4(), this.container);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortBatch.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.physical.impl.sort;
 
 import java.util.List;
 
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -139,9 +138,7 @@ public class SortBatch extends AbstractRecordBatch<Sort> {
     try {
       sorter.setup(context, getSelectionVector4(), this.container);
     } catch (SchemaChangeException e) {
-      throw UserException.schemaChangeError(e)
-          .addContext("Unexpected schema change in in-memory Sort operator")
-          .build(logger);
+      throw schemaChangeException(e, logger);
     }
     sorter.sort(getSelectionVector4(), this.container);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/sort/SortRecordBatchBuilder.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.AllocationReservation;
 import org.apache.drill.exec.memory.BaseAllocator;
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.record.AbstractRecordBatch;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.record.MaterializedField;
@@ -158,11 +157,7 @@ public class SortRecordBatchBuilder implements AutoCloseable {
     if (svBuffer == null) {
       throw new OutOfMemoryError("Failed to allocate direct memory for SV4 vector in SortRecordBatchBuilder.");
     }
-    try {
-      sv4 = new SelectionVector4(svBuffer, recordCount, ValueVector.MAX_ROW_COUNT);
-    } catch (SchemaChangeException e) {
-      throw AbstractRecordBatch.schemaChangeException(e, "Sort", logger);
-    }
+    sv4 = new SelectionVector4(svBuffer, recordCount, ValueVector.MAX_ROW_COUNT);
     BatchSchema schema = batches.keySet().iterator().next();
     List<RecordBatchData> data = batches.get(schema);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/RemovingRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/svremover/RemovingRecordBatch.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.physical.impl.svremover;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.SelectionVectorRemover;
 import org.apache.drill.exec.record.AbstractSingleRecordBatch;
@@ -45,7 +44,7 @@ public class RemovingRecordBatch extends AbstractSingleRecordBatch<SelectionVect
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     // Don't clear off container just because an OK_NEW_SCHEMA was received from
     // upstream. For cases when there is just
     // change in container type but no actual schema change, RemovingRecordBatch

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -25,6 +25,7 @@ import java.util.Stack;
 
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -241,7 +242,9 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
     try {
       unionall.setup(context, inputBatch, this, transfers);
     } catch (SchemaChangeException e) {
-      throw schemaChangeException(e, logger);
+      throw UserException.schemaChangeError(e)
+          .addContext("Unexpected schema change in Union operator")
+          .build(logger);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -25,7 +25,6 @@ import java.util.Stack;
 
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -242,9 +241,7 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
     try {
       unionall.setup(context, inputBatch, this, transfers);
     } catch (SchemaChangeException e) {
-      throw UserException.schemaChangeError(e)
-          .addContext("Unexpected schema change in Union operator")
-          .build(logger);
+      throw schemaChangeException(e, logger);
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
@@ -348,9 +348,7 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
     try {
       unnest.setup(context, incoming, this, transfers);
     } catch (SchemaChangeException e) {
-      throw UserException.schemaChangeError(e)
-        .addContext("Unexpected schema change in Unnest operator")
-        .build(logger);
+      throw schemaChangeException(e, logger);
     }
     setUnnestVector();
     return transferPair;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unnest/UnnestRecordBatch.java
@@ -194,11 +194,6 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
         stats.batchReceived(0, incoming.getRecordCount(), true);
         memoryManager.update();
         hasRemainder = incoming.getRecordCount() > 0;
-      } catch (SchemaChangeException ex) {
-        kill(false);
-        logger.error("Failure during query", ex);
-        context.getExecutorState().fail(ex);
-        return IterOutcome.STOP;
       } finally {
         stats.stopSetup();
       }
@@ -209,32 +204,25 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
       container.zeroVectors();
       // Check if schema has changed
       if (lateral.getRecordIndex() == 0) {
-        try {
-          boolean hasNewSchema = schemaChanged();
-          stats.batchReceived(0, incoming.getRecordCount(), hasNewSchema);
-          if (hasNewSchema) {
-            setupNewSchema();
-            hasRemainder = true;
-            memoryManager.update();
-            return OK_NEW_SCHEMA;
-          } else { // Unnest field schema didn't changed but new left empty/nonempty batch might come with OK_NEW_SCHEMA
-            // This means even though there is no schema change for unnest field the reference of unnest field
-            // ValueVector must have changed hence we should just refresh the transfer pairs and keep output vector
-            // same as before. In case when new left batch is received with SchemaChange but was empty Lateral will
-            // not call next on unnest and will change it's left outcome to OK. Whereas for non-empty batch next will
-            // be called on unnest by Lateral. Hence UNNEST cannot rely on lateral current outcome to setup transfer
-            // pair. It should do for each new left incoming batch.
-            resetUnnestTransferPair();
-            container.zeroVectors();
-          } // else
-          unnest.resetGroupIndex();
+        boolean hasNewSchema = schemaChanged();
+        stats.batchReceived(0, incoming.getRecordCount(), hasNewSchema);
+        if (hasNewSchema) {
+          setupNewSchema();
+          hasRemainder = true;
           memoryManager.update();
-        } catch (SchemaChangeException ex) {
-          kill(false);
-          logger.error("Failure during query", ex);
-          context.getExecutorState().fail(ex);
-          return IterOutcome.STOP;
-        }
+          return OK_NEW_SCHEMA;
+        } else { // Unnest field schema didn't changed but new left empty/nonempty batch might come with OK_NEW_SCHEMA
+          // This means even though there is no schema change for unnest field the reference of unnest field
+          // ValueVector must have changed hence we should just refresh the transfer pairs and keep output vector
+          // same as before. In case when new left batch is received with SchemaChange but was empty Lateral will
+          // not call next on unnest and will change it's left outcome to OK. Whereas for non-empty batch next will
+          // be called on unnest by Lateral. Hence UNNEST cannot rely on lateral current outcome to setup transfer
+          // pair. It should do for each new left incoming batch.
+          resetUnnestTransferPair();
+          container.zeroVectors();
+        } // else
+        unnest.resetGroupIndex();
+        memoryManager.update();
       }
       return doWork();
     }
@@ -350,20 +338,26 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
     return tp;
   }
 
-  private TransferPair resetUnnestTransferPair() throws SchemaChangeException {
+  private TransferPair resetUnnestTransferPair() {
     List<TransferPair> transfers = Lists.newArrayList();
     FieldReference fieldReference = new FieldReference(popConfig.getColumn());
     TransferPair transferPair = getUnnestFieldTransferPair(fieldReference);
     transfers.add(transferPair);
     logger.debug("Added transfer for unnest expression.");
     unnest.close();
-    unnest.setup(context, incoming, this, transfers);
+    try {
+      unnest.setup(context, incoming, this, transfers);
+    } catch (SchemaChangeException e) {
+      throw UserException.schemaChangeError(e)
+        .addContext("Unexpected schema change in Unnest operator")
+        .build(logger);
+    }
     setUnnestVector();
     return transferPair;
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     Preconditions.checkNotNull(lateral);
     container.clear();
     MaterializedField rowIdField = MaterializedField.create(rowIdColumnName, Types.required(TypeProtos
@@ -380,13 +374,13 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
   }
 
   /**
-   * Compares the schema of the unnest column in the current incoming with the schema of
-   * the unnest column in the previous incoming.
-   * Also saves the schema for comparison in future iterations
+   * Compares the schema of the unnest column in the current incoming with the
+   * schema of the unnest column in the previous incoming. Also saves the schema
+   * for comparison in future iterations
    *
    * @return true if the schema has changed, false otherwise
    */
-  private boolean schemaChanged() throws SchemaChangeException {
+  private boolean schemaChanged() {
     unnestTypedFieldId = checkAndGetUnnestFieldId();
     MaterializedField thisField = incoming.getSchema().getColumn(unnestTypedFieldId.getFieldIds()[0]);
     MaterializedField prevField = unnestFieldMetadata;
@@ -430,12 +424,14 @@ public class UnnestRecordBatch extends AbstractTableFunctionRecordBatch<UnnestPO
       memoryManager.getAvgOutputRowWidth(), memoryManager.getTotalOutputRecords());
   }
 
-  private TypedFieldId checkAndGetUnnestFieldId() throws SchemaChangeException {
+  private TypedFieldId checkAndGetUnnestFieldId() {
     TypedFieldId fieldId = incoming.getValueVectorId(popConfig.getColumn());
     if (fieldId == null) {
-      throw new SchemaChangeException(String.format("Unnest column %s not found inside the incoming record batch. " +
-          "This may happen if a wrong Unnest column name is used in the query. Please rerun query after fixing that.",
-        popConfig.getColumn()));
+      throw UserException.schemaChangeError(null)
+          .message(String.format("Unnest column %s not found inside the incoming record batch. " +
+              "This may happen if a wrong Unnest column name is used in the query. Please rerun query after fixing that.",
+              popConfig.getColumn()))
+          .build(logger);
     }
 
     return fieldId;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unpivot/UnpivotMapsRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/unpivot/UnpivotMapsRecordBatch.java
@@ -23,7 +23,6 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.TypeHelper;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.config.UnpivotMaps;
@@ -116,38 +115,19 @@ public class UnpivotMapsRecordBatch extends AbstractSingleRecordBatch<UnpivotMap
       case STOP:
         return upStream;
       case OK_NEW_SCHEMA:
-        if (first) {
-          first = false;
-        }
-        try {
-          if (!setupNewSchema()) {
-            upStream = IterOutcome.OK;
-          } else {
-            return upStream;
-          }
-        } catch (SchemaChangeException ex) {
-          kill(false);
-          logger.error("Failure during query", ex);
-          context.getExecutorState().fail(ex);
-          return IterOutcome.STOP;
-        }
-        //fall through
+        first = false;
+        setupNewSchema();
+        return upStream;
+
       case OK:
         assert first == false : "First batch should be OK_NEW_SCHEMA";
-        try {
-          container.zeroVectors();
-          IterOutcome out = doWork();
-          // Preserve OK_NEW_SCHEMA unless doWork() runs into an issue
-          if (out != IterOutcome.OK) {
-            upStream = out;
-          }
-        } catch (Exception ex) {
-          kill(false);
-          logger.error("Failure during query", ex);
-          context.getExecutorState().fail(ex);
-          return IterOutcome.STOP;
+        container.zeroVectors();
+        IterOutcome out = doWork();
+        // Preserve OK_NEW_SCHEMA unless doWork() runs into an issue
+        if (out != IterOutcome.OK) {
+          upStream = out;
         }
-       return upStream;
+        return upStream;
       default:
         throw new UnsupportedOperationException("Unsupported upstream state " + upStream);
     }
@@ -269,7 +249,7 @@ public class UnpivotMapsRecordBatch extends AbstractSingleRecordBatch<UnpivotMap
   }
 
   @Override
-  protected boolean setupNewSchema() throws SchemaChangeException {
+  protected boolean setupNewSchema() {
     container.clear();
     buildKeyList();
     buildOutputContainer();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/FrameSupportTemplate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/FrameSupportTemplate.java
@@ -21,6 +21,7 @@ import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.config.WindowPOP;
+import org.apache.drill.exec.record.AbstractRecordBatch;
 import org.apache.drill.exec.record.VectorAccessible;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
@@ -34,9 +35,10 @@ import java.util.List;
 
 
 /**
- * WindowFramer implementation that supports the FRAME clause.
- * <br>According to the SQL specification, FIRST_VALUE, LAST_VALUE and all aggregate functions support the FRAME clause.
- * This class will handle such functions even if the FRAME clause is not present.
+ * WindowFramer implementation that supports the FRAME clause. <br>
+ * According to the SQL specification, FIRST_VALUE, LAST_VALUE and all aggregate
+ * functions support the FRAME clause. This class will handle such functions
+ * even if the FRAME clause is not present.
  */
 public abstract class FrameSupportTemplate implements WindowFramer {
 
@@ -90,7 +92,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
    * processes all rows of the first batch.
    */
   @Override
-  public void doWork() throws DrillException {
+  public void doWork() throws SchemaChangeException {
     int currentRow = 0;
 
     this.current = batches.get(0);
@@ -144,7 +146,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
    * @return index of next unprocessed row
    * @throws DrillException if it can't write into the container
    */
-  private int processPartition(final int currentRow) throws DrillException {
+  private int processPartition(final int currentRow) throws SchemaChangeException {
     logger.trace("{} rows remaining to process, currentRow: {}, outputCount: {}", remainingRows, currentRow, outputCount);
 
     setupWriteFirstValue(internal, container);
@@ -156,7 +158,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
     }
   }
 
-  private int processROWS(int row) throws DrillException {
+  private int processROWS(int row) throws SchemaChangeException {
     //TODO (DRILL-4413) we only need to call these once per batch
     setupEvaluatePeer(current, container);
     setupReadLastValue(current, container);
@@ -175,7 +177,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
     return row;
   }
 
-  private int processRANGE(int row) throws DrillException {
+  private int processRANGE(int row) throws SchemaChangeException {
     while (row < outputCount && !isPartitionDone()) {
       if (remainingPeers == 0) {
         // because all peer rows share the same frame, we only need to compute and aggregate the frame once
@@ -199,8 +201,10 @@ public abstract class FrameSupportTemplate implements WindowFramer {
   }
 
   /**
-   * updates partition's length after computing the number of rows for the current the partition starting at the specified
-   * row of the first batch. If !requiresFullPartition, this method will only count the rows in the current batch
+   * Updates partition's length after computing the number of rows for the
+   * current the partition starting at the specified row of the first batch. If
+   * !requiresFullPartition, this method will only count the rows in the current
+   * batch
    */
   private void updatePartitionSize(final int start) {
     logger.trace("compute partition size starting from {} on {} batches", start, batches.size());
@@ -245,12 +249,11 @@ public abstract class FrameSupportTemplate implements WindowFramer {
   }
 
   /**
-   * aggregates all peer rows of current row
+   * Aggregates all peer rows of current row
    * @param start starting row of the current frame
    * @return num peer rows for current row
-   * @throws SchemaChangeException
    */
-  private long aggregatePeers(final int start) throws SchemaChangeException {
+  private long aggregatePeers(final int start) {
     logger.trace("aggregating rows starting from {}", start);
 
     final boolean unboundedFollowing = popConfig.getEnd().isUnbounded();
@@ -260,7 +263,11 @@ public abstract class FrameSupportTemplate implements WindowFramer {
     // a single frame can include rows from multiple batches
     // start processing first batch and, if necessary, move to next batches
     for (WindowDataBatch batch : batches) {
-      setupEvaluatePeer(batch, container);
+      try {
+        setupEvaluatePeer(batch, container);
+      } catch (SchemaChangeException e) {
+        throw AbstractRecordBatch.schemaChangeException(e, "Window", logger);
+      }
       final int recordCount = batch.getRecordCount();
 
       // for every remaining row in the partition, count it if it's a peer row
@@ -281,7 +288,11 @@ public abstract class FrameSupportTemplate implements WindowFramer {
       }
     }
 
-    setupReadLastValue(last, container);
+    try {
+      setupReadLastValue(last, container);
+    } catch (SchemaChangeException e) {
+      throw AbstractRecordBatch.schemaChangeException(e, "Window", logger);
+    }
 
     return length;
   }
@@ -354,6 +365,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
    * @param b2 batch for second row
    * @return true if the rows are in the same partition
    */
+  @Override
   public abstract boolean isSamePartition(@Named("b1Index") int b1Index, @Named("b1") VectorAccessible b1,
                                           @Named("b2Index") int b2Index, @Named("b2") VectorAccessible b2);
 
@@ -366,6 +378,7 @@ public abstract class FrameSupportTemplate implements WindowFramer {
    * @param b2 batch for second row
    * @return true if the rows are in the same partition
    */
+  @Override
   public abstract boolean isPeer(@Named("b1Index") int b1Index, @Named("b1") VectorAccessible b1,
                                  @Named("b2Index") int b2Index, @Named("b2") VectorAccessible b2);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/window/WindowFramer.java
@@ -40,9 +40,10 @@ public interface WindowFramer {
 
   /**
    * process the inner batch and write the aggregated values in the container
+   * @throws SchemaChangeException
    * @throws DrillException
    */
-  void doWork() throws DrillException;
+  void doWork() throws SchemaChangeException;
 
   /**
    * @return number rows processed in last batch

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractRecordBatch.java
@@ -19,7 +19,6 @@ package org.apache.drill.exec.record;
 
 import java.util.Iterator;
 
-import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.ExecConstants;
@@ -178,12 +177,6 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
           break;
       }
       return lastOutcome;
-    } catch (SchemaChangeException e) {
-      lastOutcome = IterOutcome.STOP;
-      throw new DrillRuntimeException(e);
-    } catch (Exception e) {
-      lastOutcome = IterOutcome.STOP;
-      throw e;
     } finally {
       stats.stopProcessing();
     }
@@ -200,8 +193,7 @@ public abstract class AbstractRecordBatch<T extends PhysicalOperator> implements
     }
   }
 
-  protected void buildSchema() throws SchemaChangeException {
-  }
+  protected void buildSchema() { }
 
   @Override
   public void kill(boolean sendUpstream) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractTableFunctionRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractTableFunctionRecordBatch.java
@@ -24,16 +24,19 @@ import org.apache.drill.exec.physical.base.LateralContract;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 
 /**
- * Implements AbstractUnaryRecodBatch for operators that do not have an incoming record batch available at creation
- * time; the input is typically set up a few steps after creation. Table functions and operators like Unnest that
- * require input before they can produce output fall into this category.
- * Table functions can be associated with a Lateral operator in which case they simultaneously operate on the
- * same row as the Lateral operator. In this case the LateralContract member is not null and the table function uses the
- * lateral contract to keep in sync with the Lateral operator.
+ * Implements AbstractUnaryRecodBatch for operators that do not have an incoming
+ * record batch available at creation time; the input is typically set up a few
+ * steps after creation. Table functions and operators like Unnest that require
+ * input before they can produce output fall into this category. Table functions
+ * can be associated with a Lateral operator in which case they simultaneously
+ * operate on the same row as the Lateral operator. In this case the
+ * LateralContract member is not null and the table function uses the lateral
+ * contract to keep in sync with the Lateral operator.
+ *
  * @param <T>
  */
 public abstract class AbstractTableFunctionRecordBatch<T extends PhysicalOperator> extends
-    AbstractUnaryRecordBatch<T> implements TableFunctionContract{
+    AbstractUnaryRecordBatch<T> implements TableFunctionContract {
 
   protected RecordBatch incoming;
   protected LateralContract lateral;
@@ -48,12 +51,14 @@ public abstract class AbstractTableFunctionRecordBatch<T extends PhysicalOperato
     return incoming;
   }
 
+  @Override
   public void setIncoming(RecordBatch incoming) {
     Preconditions.checkArgument(this.incoming == null, "Incoming is already set. setIncoming cannot be called "
         + "multiple times.");
     this.incoming = incoming;
   }
 
+  @Override
   public void setIncoming(LateralContract incoming) {
     setIncoming(incoming.getIncoming());
     lateral = incoming;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractUnaryRecordBatch.java
@@ -18,16 +18,13 @@
 package org.apache.drill.exec.record;
 
 import org.apache.drill.exec.exception.OutOfMemoryException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * The base class for operators that have a single input. The concrete implementations provide the
+ * Base class for operators that have a single input. The concrete implementations provide the
  * input by implementing the getIncoming() method
  * Known implementations:  AbstractSingleRecordBatch and AbstractTableFunctionRecordBatch.
  * @see org.apache.drill.exec.record.AbstractRecordBatch
@@ -36,7 +33,6 @@ import org.slf4j.LoggerFactory;
  * @param <T>
  */
 public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> extends AbstractRecordBatch<T> {
-  private static final Logger logger = LoggerFactory.getLogger(new Object() {}.getClass().getEnclosingClass());
 
   protected SchemaChangeCallBack callBack = new SchemaChangeCallBack();
   private IterOutcome lastKnownOutcome;
@@ -98,11 +94,6 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
           if (!setupNewSchema()) {
             upstream = IterOutcome.OK;
           }
-        } catch (SchemaChangeException ex) {
-          kill(false);
-          logger.error("Failure during query", ex);
-          context.getExecutorState().fail(ex);
-          return IterOutcome.STOP;
         } finally {
           stats.stopSetup();
         }
@@ -130,7 +121,7 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
     }
   }
 
-  protected abstract boolean setupNewSchema() throws SchemaChangeException;
+  protected abstract boolean setupNewSchema();
   protected abstract IterOutcome doWork();
 
   /**
@@ -150,7 +141,7 @@ public abstract class AbstractUnaryRecordBatch<T extends PhysicalOperator> exten
    */
   protected IterOutcome handleNullInput() {
     container.buildSchema(SelectionVectorMode.NONE);
-    container.setRecordCount(0);
+    container.setEmpty();
     return IterOutcome.NONE;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/RecordBatchLoader.java
@@ -75,7 +75,8 @@ public class RecordBatchLoader implements VectorAccessible, Iterable<VectorWrapp
    * @throws SchemaChangeException
    *   TODO:  Clean:  DRILL-2933  load(...) never actually throws SchemaChangeException.
    */
-  public boolean load(RecordBatchDef def, DrillBuf buf) throws SchemaChangeException {
+  @SuppressWarnings("resource")
+  public boolean load(RecordBatchDef def, DrillBuf buf) {
     if (logger.isTraceEnabled()) {
       logger.trace("Loading record batch with def {} and data {}", def, buf);
       logger.trace("Load, ThreadID: {}\n{}", Thread.currentThread().getId(), new StackTrace());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/SimpleRecordBatch.java
@@ -31,8 +31,8 @@ public class SimpleRecordBatch implements RecordBatch {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleRecordBatch.class);
 
-  private VectorContainer container;
-  private FragmentContext context;
+  private final VectorContainer container;
+  private final FragmentContext context;
 
   public SimpleRecordBatch(VectorContainer container, FragmentContext context) {
     this.container = container;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorAccessibleUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/VectorAccessibleUtilities.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.record;
 
 import org.apache.drill.exec.vector.AllocationHelper;
+import org.apache.drill.exec.vector.ValueVector;
 
 /**
  * VectorAccessible is an interface. Yet, several operations are done
@@ -34,6 +35,12 @@ public class VectorAccessibleUtilities {
   public static void clear(VectorAccessible va) {
     for (final VectorWrapper<?> w : va) {
       w.clear();
+    }
+  }
+
+  public static void clear(Iterable<ValueVector> iter) {
+    for (final ValueVector v : iter) {
+      v.clear();
     }
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StatisticsRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StatisticsRecordWriter.java
@@ -15,24 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-<@pp.dropOutputFile />
-<@pp.changeOutputFile name="org/apache/drill/exec/store/StatisticsRecordWriter.java" />
-<#include "/@includes/license.ftl" />
-
 package org.apache.drill.exec.store;
 
 import org.apache.drill.exec.record.VectorAccessible;
-import org.apache.drill.exec.store.EventBasedRecordWriter.FieldConverter;
-import org.apache.drill.exec.vector.complex.reader.FieldReader;
 
 import java.io.IOException;
 import java.util.Map;
 
-/*
- * This class is generated using freemarker and the ${.template_name} template.
- */
-
-/** StatisticsRecordWriter interface. */
 public interface StatisticsRecordWriter extends StatisticsRecordCollector {
 
   /**
@@ -41,14 +30,14 @@ public interface StatisticsRecordWriter extends StatisticsRecordCollector {
    * @param writerOptions Contains key, value pair of settings.
    * @throws IOException
    */
-  void init(Map<String, String> writerOptions) throws IOException;
+  void init(Map<String, String> writerOptions);
 
   /**
    * Update the schema in RecordWriter. Called at least once before starting writing the records.
    * @param batch
    * @throws IOException
    */
-  void updateSchema(VectorAccessible batch) throws IOException;
+  void updateSchema(VectorAccessible batch);
 
   /**
    * Check if the writer should start a new partition, and if so, start a new partition
@@ -66,6 +55,6 @@ public interface StatisticsRecordWriter extends StatisticsRecordCollector {
    * @throws IOException
    */
   void flushBlockingWriter() throws IOException;
-  void abort() throws IOException;
-  void cleanup() throws IOException;
+  void abort();
+  void cleanup();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonRecordWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JsonRecordWriter.java
@@ -48,10 +48,8 @@ public class JsonRecordWriter extends JSONOutputRecordWriter implements RecordWr
 
   private Path cleanUpLocation;
   private String location;
-  private boolean append;
   private String prefix;
 
-  private String fieldDelimiter;
   private String extension;
   private boolean useExtendedOutput;
 
@@ -62,10 +60,7 @@ public class JsonRecordWriter extends JSONOutputRecordWriter implements RecordWr
   private final JsonFactory factory = new JsonFactory();
   private final StorageStrategy storageStrategy;
 
-  // Record write status
-  private boolean fRecordStarted = false; // true once the startRecord() is called until endRecord() is called
-
-  private Configuration fsConf;
+  private final Configuration fsConf;
 
   public JsonRecordWriter(StorageStrategy storageStrategy, Configuration fsConf) {
     this.storageStrategy = storageStrategy == null ? StorageStrategy.DEFAULT : storageStrategy;
@@ -76,7 +71,6 @@ public class JsonRecordWriter extends JSONOutputRecordWriter implements RecordWr
   public void init(Map<String, String> writerOptions) throws IOException {
     this.location = writerOptions.get("location");
     this.prefix = writerOptions.get("prefix");
-    this.fieldDelimiter = writerOptions.get("separator");
     this.extension = writerOptions.get("extension");
     this.useExtendedOutput = Boolean.parseBoolean(writerOptions.get("extended"));
     this.skipNullFields = Boolean.parseBoolean(writerOptions.get("skipnulls"));
@@ -244,13 +238,11 @@ public class JsonRecordWriter extends JSONOutputRecordWriter implements RecordWr
   @Override
   public void startRecord() throws IOException {
     gen.writeStartObject();
-    fRecordStarted = true;
   }
 
   @Override
   public void endRecord() throws IOException {
     gen.writeEndObject();
-    fRecordStarted = false;
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/MockRecordBatch.java
@@ -126,7 +126,7 @@ public class MockRecordBatch implements CloseableRecordBatch {
   @Override
   public void close() {
     container.clear();
-    container.setRecordCount(0);
+    container.setEmpty();
     currentContainerIndex = 0;
     currentOutcomeIndex = 0;
     if (sv2 != null) {
@@ -291,8 +291,7 @@ public class MockRecordBatch implements CloseableRecordBatch {
   }
 
   @Override
-  public void dump() {
-  }
+  public void dump() { }
 
   public static class Builder {
     private final List<RowSet> rowSets = new ArrayList<>();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/SimpleRootExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/SimpleRootExec.java
@@ -113,8 +113,8 @@ public class SimpleRootExec implements RootExec, Iterable<ValueVector> {
   }
 
   @Override
-  public void dumpBatches() {
-    screenRoot.dumpBatches();
+  public void dumpBatches(Throwable t) {
+    screenRoot.dumpBatches(t);
   }
 
   @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStackAnalyzer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStackAnalyzer.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Test the function which finds the leaf-most operator within
+ * an exception call stack. Does the tests using dummy classes
+ * (which is why the stack analyzer function is parameterized.)
+ */
+public class TestStackAnalyzer {
+
+  private static class OperA {
+    public void throwNow() {
+      throw new RuntimeException();
+    }
+
+    public void throwIndirect() {
+      throwNow();
+    }
+
+    public void throwViaB(OperB b) {
+      b.throwIndirect();
+    }
+
+    public void throwAfterB(OperB b) {
+      new RandomC().throwAfterB(b);
+    }
+  }
+
+  private static class OperB {
+    public void throwNow() {
+      throw new RuntimeException();
+    }
+
+    public void throwIndirect() {
+      throwNow();
+    }
+
+    public void throwAfterB() {
+      new RandomC().throwNow();
+    }
+  }
+
+  private static class RandomC {
+    public void throwNow() {
+      throw new RuntimeException();
+    }
+
+    public void throwAfterB(OperB b) {
+      b.throwAfterB();
+    }
+  }
+
+  @Test
+  public void testEmptyStack() {
+    try {
+      throw new RuntimeException();
+    } catch (RuntimeException e) {
+      assertNull(BaseRootExec.findLeaf(Collections.emptyList(), e));
+    }
+  }
+
+  @Test
+  public void testOneLevel() {
+    OperA a = new OperA();
+    try {
+      a.throwNow();
+    } catch (RuntimeException e) {
+      List<Object> ops = Collections.singletonList(a);
+      assertSame(a, BaseRootExec.findLeaf(ops, e));
+    }
+  }
+
+  @Test
+  public void testOneLevelTwoDeep() {
+    OperA a = new OperA();
+    try {
+      a.throwIndirect();
+    } catch (RuntimeException e) {
+      List<Object> ops = Collections.singletonList(a);
+      assertSame(a, BaseRootExec.findLeaf(ops, e));
+    }
+  }
+
+  @Test
+  public void testTwoLevels() {
+    OperA a = new OperA();
+    OperB b = new OperB();
+    try {
+      a.throwViaB(b);
+    } catch (RuntimeException e) {
+      List<Object> ops = Arrays.asList(a, b);
+      assertSame(b, BaseRootExec.findLeaf(ops, e));
+    }
+  }
+
+  @Test
+  public void testTwoLevelsWithExtra() {
+    OperA a = new OperA();
+    OperB b = new OperB();
+    try {
+      a.throwAfterB(b);
+    } catch (RuntimeException e) {
+      List<Object> ops = Arrays.asList(a, b);
+      assertSame(b, BaseRootExec.findLeaf(ops, e));
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/partitionsender/TestPartitionSender.java
@@ -140,7 +140,7 @@ public class TestPartitionSender extends PlanTestBase {
     final SelectionVector4 sv = Mockito.mock(SelectionVector4.class, "SelectionVector4");
     Mockito.when(sv.getCount()).thenReturn(100);
     Mockito.when(sv.getTotalCount()).thenReturn(100);
-    for (int i = 0; i < 100; i++ ) {
+    for (int i = 0; i < 100; i++) {
       Mockito.when(sv.get(i)).thenReturn(i);
     }
 
@@ -165,8 +165,8 @@ public class TestPartitionSender extends PlanTestBase {
 
     // get HashToRandomExchange physical operator
     HashToRandomExchange hashToRandomExchange = null;
-    for ( PhysicalOperator operator : operators) {
-      if ( operator instanceof HashToRandomExchange) {
+    for (PhysicalOperator operator : operators) {
+      if (operator instanceof HashToRandomExchange) {
         hashToRandomExchange = (HashToRandomExchange) operator;
         break;
       }
@@ -241,7 +241,7 @@ public class TestPartitionSender extends PlanTestBase {
         final int actualThreads = DRILLBITS_COUNT > expectedThreadsCount ? expectedThreadsCount : DRILLBITS_COUNT;
         assertEquals("Number of partitioners", actualThreads, partitioners.size());
 
-        for ( int i = 0; i < mfEndPoints.size(); i++) {
+        for (int i = 0; i < mfEndPoints.size(); i++) {
           assertNotNull("PartitionOutgoingBatch", partDecor.getOutgoingBatches(i));
         }
 
@@ -249,10 +249,11 @@ public class TestPartitionSender extends PlanTestBase {
         boolean isFirst = true;
         int prevBatchCountSize = 0;
         int batchCountSize = 0;
-        for (Partitioner part : partitioners ) {
+        for (Partitioner part : partitioners) {
+          @SuppressWarnings("unchecked")
           final List<PartitionOutgoingBatch> outBatch = (List<PartitionOutgoingBatch>) part.getOutgoingBatches();
           batchCountSize = outBatch.size();
-          if ( !isFirst ) {
+          if (!isFirst) {
             assertTrue(Math.abs(batchCountSize - prevBatchCountSize) <= 1);
           } else {
             isFirst = false;
@@ -266,7 +267,7 @@ public class TestPartitionSender extends PlanTestBase {
         } finally {
           partionSenderRootExec.getStats().stopProcessing();
         }
-        if ( actualThreads == 1 ) {
+        if (actualThreads == 1) {
           assertEquals("With single thread parent and child waitNanos should match", partitioners.get(0).getStats().getWaitNanos(), partionSenderRootExec.getStats().getWaitNanos());
         }
 
@@ -274,11 +275,12 @@ public class TestPartitionSender extends PlanTestBase {
         partitioners = partDecor.getPartitioners();
         isFirst = true;
         // since we have fake Nullvector distribution is skewed
-        for (Partitioner part : partitioners ) {
+        for (Partitioner part : partitioners) {
+          @SuppressWarnings("unchecked")
           final List<PartitionOutgoingBatch> outBatches = (List<PartitionOutgoingBatch>) part.getOutgoingBatches();
-          for (PartitionOutgoingBatch partOutBatch : outBatches ) {
+          for (PartitionOutgoingBatch partOutBatch : outBatches) {
             final int recordCount = ((VectorAccessible) partOutBatch).getRecordCount();
-            if ( isFirst ) {
+            if (isFirst) {
               assertEquals("RecordCount", 100, recordCount);
               isFirst = false;
             } else {
@@ -296,8 +298,8 @@ public class TestPartitionSender extends PlanTestBase {
           final OperatorProfile.Builder oPBuilder = OperatorProfile.newBuilder();
           partionSenderRootExec.getStats().addAllMetrics(oPBuilder);
           final List<MetricValue> metrics = oPBuilder.getMetricList();
-          for ( MetricValue metric : metrics) {
-            if ( Metric.BYTES_SENT.metricId() == metric.getMetricId() ) {
+          for (MetricValue metric : metrics) {
+            if (Metric.BYTES_SENT.metricId() == metric.getMetricId()) {
               assertEquals("Should add metricValue irrespective of exception", 5*actualThreads, metric.getLongValue());
             }
             if (Metric.SENDING_THREADS_COUNT.metricId() == metric.getMetricId()) {
@@ -327,7 +329,7 @@ public class TestPartitionSender extends PlanTestBase {
     int numberPartitions;
     int k = 0;
     final Random rand = new Random();
-    while ( k < 1000 ) {
+    while (k < 1000) {
       outGoingBatchCount = rand.nextInt(1000)+1;
       numberPartitions = rand.nextInt(32)+1;
       final int actualPartitions = outGoingBatchCount > numberPartitions ? numberPartitions : outGoingBatchCount;
@@ -339,11 +341,11 @@ public class TestPartitionSender extends PlanTestBase {
       for (int i = 0; i < actualPartitions; i++) {
         startIndex = endIndex;
         endIndex = startIndex + divisor;
-        if ( i < longTail ) {
+        if (i < longTail) {
           endIndex++;
         }
       }
-      assertTrue("endIndex can not be > outGoingBatchCount", endIndex == outGoingBatchCount );
+      assertTrue("endIndex can not be > outGoingBatchCount", endIndex == outGoingBatchCount);
       k++;
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/unnest/TestUnnestWithLateralCorrectness.java
@@ -62,13 +62,11 @@ import static org.junit.Assert.fail;
 @Category(OperatorTest.class)
 public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
 
-
   // Operator Context for mock batch
   public static OperatorContext operatorContext;
 
   public static PhysicalOperator mockPopConfig;
   public static LateralJoinPOP ljPopConfig;
-
 
   @BeforeClass public static void setUpBeforeClass() throws Exception {
     mockPopConfig = new MockStorePOP(null);
@@ -112,7 +110,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   @Test
@@ -146,7 +143,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   @Test
@@ -167,7 +163,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   @Test
@@ -198,7 +193,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   @Test
@@ -246,7 +240,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   @Test
@@ -295,7 +288,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
 
   private void testUnnestBatchSizing(int inputBatchSize, int limitOutputBatchSize,
@@ -437,7 +429,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } finally {
       fixture.getFragmentContext().getOptions().setLocalOption(ExecConstants.OUTPUT_BATCH_SIZE, outputBatchSize);
     }
-
   }
 
   @Test
@@ -495,7 +486,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } finally {
       fixture.getFragmentContext().getOptions().setLocalOption(ExecConstants.OUTPUT_BATCH_SIZE, outputBatchSize);
     }
-
   }
 
   @Test
@@ -528,9 +518,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
-
 
   // test unnest for various input conditions without invoking kill
   private <T> void testUnnest(
@@ -559,7 +547,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     ArrayList<RowSet.SingleRowSet> rowSets = new ArrayList<>();
     int rowNumber = 0;
     int batchNum = 0;
-    for ( Object[] recordBatch : data) {
+    for (Object[] recordBatch : data) {
       RowSetBuilder rowSetBuilder = fixture.rowSetBuilder(incomingSchemas[batchNum]);
       for ( Object rowData : recordBatch) {
         rowSetBuilder.addRow(++rowNumber, rowData);
@@ -604,28 +592,29 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
 
     // Simulate the pipeline by calling next on the incoming
 
-    // results is an array ot batches, each batch being an array of output vectors.
+    // results is an array of batches, each batch being an array of output vectors.
     List<List<ValueVector> > resultList = new ArrayList<>();
     List<List<ValueVector> > results = null;
     int batchesProcessed = 0;
     try{
-    try {
-      while (!isTerminal(lateralJoinBatch.next())) {
-        if (lateralJoinBatch.getRecordCount() > 0) {
-          addBatchToResults(resultList, lateralJoinBatch);
+      try {
+        while (!isTerminal(lateralJoinBatch.next())) {
+          if (lateralJoinBatch.getRecordCount() > 0) {
+            addBatchToResults(resultList, lateralJoinBatch);
+          }
+          batchesProcessed++;
+          if (batchesProcessed == execKill) {
+            // Errors are reported by throwing an exception.
+            // Simulate by skipping out of the loop
+            break;
+          }
+          // else nothing to do
         }
-        batchesProcessed++;
-        if (batchesProcessed == execKill) {
-          lateralJoinBatch.getContext().getExecutorState().fail(new DrillException("Testing failure of execution."));
-          lateralJoinBatch.kill(true);
-        }
-        // else nothing to do
+      } catch (UserException e) {
+        throw e;
+      } catch (Exception e) {
+        fail(e.getMessage());
       }
-    } catch (UserException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new Exception ("Test failed to execute lateralJoinBatch.next() because: " + e.getMessage());
-    }
 
       // Check results against baseline
       results = resultList;
@@ -633,7 +622,7 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
       int batchIndex = 0;
       int vectorIndex = 0;
       //int valueIndex = 0;
-      for ( List<ValueVector> batch: results) {
+      for (List<ValueVector> batch: results) {
         int vectorCount= batch.size();
         int expectedVectorCount = (excludeUnnestColumn) ? 0 : 1;
         expectedVectorCount += baseline[batchIndex].length;
@@ -698,7 +687,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
         rowSet.clear();
       }
     }
-
   }
 
   /**
@@ -849,8 +837,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
    * @param <T>
    * @throws Exception
    */
-
-
   private <T> void testNestedUnnest( TupleMetadata[] incomingSchemas,
       RecordBatch.IterOutcome[] iterOutcomes,
       int execKill, // number of batches after which to kill the execution (!)
@@ -1016,7 +1002,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
         rowSet.clear();
       }
     }
-
   }
 
   @Test
@@ -1037,8 +1022,6 @@ public class TestUnnestWithLateralCorrectness extends SubOperatorTest {
     } catch (Exception e) {
       fail("Failed due to exception: " + e.getMessage());
     }
-
   }
-
 }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/TestDrillbitResilience.java
@@ -47,7 +47,6 @@ import org.apache.drill.exec.ZookeeperHelper;
 import org.apache.drill.exec.ZookeeperTestUtil;
 import org.apache.drill.exec.client.DrillClient;
 import org.apache.drill.exec.exception.DrillbitStartupException;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.memory.RootAllocatorFactory;
 import org.apache.drill.exec.physical.impl.ScreenCreator;
@@ -249,13 +248,9 @@ public class TestDrillbitResilience extends DrillTest {
           public void rowArrived(final QueryDataBatch queryResultBatch) {
             // load the single record
             final QueryData queryData = queryResultBatch.getHeader();
-            try {
-              loader.load(queryData.getDef(), queryResultBatch.getData());
-              // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
-              // SchemaChangeException, so check/clean catch clause below.
-            } catch (final SchemaChangeException e) {
-              fail(e.toString());
-            }
+            // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
+            // SchemaChangeException.
+            loader.load(queryData.getDef(), queryResultBatch.getData());
             assertEquals(1, loader.getRecordCount());
 
             // there should only be one column

--- a/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/DrillTestWrapper.java
@@ -63,11 +63,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An object to encapsulate the options for a Drill unit test, as well as the execution methods to perform the tests and
- * validation of results.
- *
- * To construct an instance easily, look at the TestBuilder class. From an implementation of
- * the BaseTestQuery class, and instance of the builder is accessible through the testBuilder() method.
+ * Encapsulates the options for a Drill unit test, as well as the execution
+ * methods to perform the tests and validation of results.
+ * <p>
+ * To construct an instance easily, look at the TestBuilder class. From an
+ * implementation of the BaseTestQuery class, and instance of the builder is
+ * accessible through the testBuilder() method.
  */
 public class DrillTestWrapper {
 
@@ -98,39 +99,39 @@ public class DrillTestWrapper {
   // one case where the setup for the baseline is driven by the test query results, and this is implicit type enforcement
   // for the baseline data. In this case there needs to be a call back into the TestBuilder once we know the type information
   // from the test query.
-  private TestBuilder testBuilder;
+  private final TestBuilder testBuilder;
   /**
    * Test query to run. Type of object depends on the {@link #queryType}
    */
-  private Object query;
+  private final Object query;
   // The type of query provided
-  private UserBitShared.QueryType queryType;
+  private final UserBitShared.QueryType queryType;
   // The type of query provided for the baseline
-  private UserBitShared.QueryType baselineQueryType;
+  private final UserBitShared.QueryType baselineQueryType;
   // should ordering be enforced in the baseline check
-  private boolean ordered;
-  private TestServices services;
+  private final boolean ordered;
+  private final TestServices services;
   // queries to run before the baseline or test queries, can be used to set options
-  private String baselineOptionSettingQueries;
-  private String testOptionSettingQueries;
+  private final String baselineOptionSettingQueries;
+  private final String testOptionSettingQueries;
   // allow approximate equality tests for number types
-  private boolean approximateEquality;
+  private final boolean approximateEquality;
   // tolerance for approximate equality tests defined as |Expected - Actual|/|Expected| <= Tolerance
-  private double tolerance;
+  private final double tolerance;
   // two different methods are available for comparing ordered results, the default reads all of the records
   // into giant lists of objects, like one giant on-heap batch of 'vectors'
   // this flag enables the other approach which iterates through a hyper batch for the test query results and baseline
   // while this does work faster and use less memory, it can be harder to debug as all of the elements are not in a
   // single list
-  private boolean highPerformanceComparison;
+  private final boolean highPerformanceComparison;
   // if the baseline is a single option test writers can provide the baseline values and columns
   // without creating a file, these are provided to the builder in the baselineValues() and baselineColumns() methods
   // and translated into a map in the builder
-  private String[] baselineColumns;
-  private List<Map<String, Object>> baselineRecords;
+  private final String[] baselineColumns;
+  private final List<Map<String, Object>> baselineRecords;
 
-  private int expectedNumBatches;
-  private int expectedNumRecords;
+  private final int expectedNumBatches;
+  private final int expectedNumRecords;
 
   public DrillTestWrapper(TestBuilder testBuilder, TestServices services, Object query, QueryType queryType,
       String baselineOptionSettingQueries, String testOptionSettingQueries,
@@ -312,11 +313,7 @@ public class DrillTestWrapper {
           }
           batchLoader.clear();
           QueryDataBatch batch = dataBatches.get(index);
-          try {
-            batchLoader.load(batch.getHeader().getDef(), batch.getData());
-          } catch (SchemaChangeException e) {
-            throw new RuntimeException(e);
-          }
+          batchLoader.load(batch.getHeader().getDef(), batch.getData());
           return batchLoader;
         }
 
@@ -421,6 +418,7 @@ public class DrillTestWrapper {
           case FOUR_BYTE:
             sv4 = loader.getSelectionVector4();
             break;
+          default:
         }
         if (sv4 != null) {
           for (int j = 0; j < sv4.getCount(); j++) {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryBuilder.java
@@ -67,21 +67,18 @@ import static org.junit.Assert.assertEquals;
  * Builder for a Drill query. Provides all types of query formats,
  * and a variety of ways to run the query.
  */
-
 public class QueryBuilder {
 
   /**
    * Listener used to retrieve the query summary (only) asynchronously
    * using a {@link QuerySummaryFuture}.
    */
-
   public static class SummaryOnlyQueryEventListener implements UserResultsListener {
 
     /**
      * The future to be notified. Created here and returned by the
      * query builder.
      */
-
     private final QuerySummaryFuture future;
     private QueryId queryId;
     private int recordCount;
@@ -374,28 +371,24 @@ public class QueryBuilder {
     // Unload the batch and convert to a row set.
 
     RecordBatchLoader loader = new RecordBatchLoader(client.allocator());
-    try {
-      loader.load(resultBatch.getHeader().getDef(), resultBatch.getData());
-      resultBatch.release();
-      VectorContainer container = loader.getContainer();
-      container.setRecordCount(loader.getRecordCount());
+    loader.load(resultBatch.getHeader().getDef(), resultBatch.getData());
+    resultBatch.release();
+    VectorContainer container = loader.getContainer();
+    container.setRecordCount(loader.getRecordCount());
 
-      // Null results? Drill will return a single batch with no rows
-      // and no columns even if the scan (or other) operator returns
-      // no batches at all. For ease of testing, simply map this null
-      // result set to a null output row set that says "nothing at all
-      // was returned." Note that this is different than an empty result
-      // set which has a schema, but no rows.
+    // Null results? Drill will return a single batch with no rows
+    // and no columns even if the scan (or other) operator returns
+    // no batches at all. For ease of testing, simply map this null
+    // result set to a null output row set that says "nothing at all
+    // was returned." Note that this is different than an empty result
+    // set which has a schema, but no rows.
 
-      if (container.getRecordCount() == 0 && container.getNumberOfColumns() == 0) {
-        container.clear();
-        return null;
-      }
-
-      return DirectRowSet.fromContainer(container);
-    } catch (SchemaChangeException e) {
-      throw new IllegalStateException(e);
+    if (container.getRecordCount() == 0 && container.getNumberOfColumns() == 0) {
+      container.clear();
+      return null;
     }
+
+    return DirectRowSet.fromContainer(container);
   }
 
   public QueryRowSetIterator rowSetIterator() {

--- a/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/QueryRowSetIterator.java
@@ -19,7 +19,6 @@ package org.apache.drill.test;
 
 import java.util.Iterator;
 
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.physical.rowSet.DirectRowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetFormatter;
@@ -87,16 +86,12 @@ public class QueryRowSetIterator implements Iterator<DirectRowSet>, Iterable<Dir
     // Unload the batch and convert to a row set.
 
     final RecordBatchLoader loader = new RecordBatchLoader(allocator);
-    try {
-      loader.load(batch.getHeader().getDef(), batch.getData());
-      batch.release();
-      batch = null;
-      VectorContainer container = loader.getContainer();
-      container.setRecordCount(loader.getRecordCount());
-      return DirectRowSet.fromContainer(container);
-    } catch (SchemaChangeException e) {
-      throw new IllegalStateException(e);
-    }
+    loader.load(batch.getHeader().getDef(), batch.getData());
+    batch.release();
+    batch = null;
+    VectorContainer container = loader.getContainer();
+    container.setRecordCount(loader.getRecordCount());
+    return DirectRowSet.fromContainer(container);
   }
 
   public void printAll() {

--- a/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
+++ b/exec/jdbc/src/main/java/org/apache/drill/jdbc/impl/DrillCursor.java
@@ -40,7 +40,6 @@ import org.apache.calcite.avatica.util.Cursor;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.client.DrillClient;
-import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
 import org.apache.drill.exec.proto.UserBitShared.QueryType;
@@ -88,13 +87,13 @@ public class DrillCursor implements Cursor {
     // that the _query_ has _terminated_ (not necessarily _completing_
     // normally), while some uses imply that it's some other state of the
     // ResultListener.  Some uses seem redundant.)
-    volatile boolean completed = false;
+    volatile boolean completed;
 
     /** Whether throttling of incoming data is active. */
-    private final AtomicBoolean throttled = new AtomicBoolean( false );
+    private final AtomicBoolean throttled = new AtomicBoolean(false);
     private volatile ConnectionThrottle throttle;
 
-    private volatile boolean closed = false;
+    private volatile boolean closed;
 
     private final CountDownLatch firstMessageReceived = new CountDownLatch(1);
 
@@ -102,7 +101,7 @@ public class DrillCursor implements Cursor {
         Queues.newLinkedBlockingDeque();
 
     private final DrillCursor parent;
-    Stopwatch elapsedTimer = null;
+    Stopwatch elapsedTimer;
 
     /**
      * ...
@@ -111,11 +110,11 @@ public class DrillCursor implements Cursor {
      * @param batchQueueThrottlingThreshold
      *        queue size threshold for throttling server
      */
-    ResultsListener(DrillCursor parent, int batchQueueThrottlingThreshold ) {
+    ResultsListener(DrillCursor parent, int batchQueueThrottlingThreshold) {
       this.parent = parent;
       instanceId = nextInstanceId++;
       this.batchQueueThrottlingThreshold = batchQueueThrottlingThreshold;
-      logger.debug( "[#{}] Query listener created.", instanceId );
+      logger.debug("[#{}] Query listener created.", instanceId);
     }
 
     /**
@@ -123,9 +122,9 @@ public class DrillCursor implements Cursor {
      * @param  throttle  the "throttlable" object to throttle
      * @return  true if actually started (wasn't throttling already)
      */
-    private boolean startThrottlingIfNot( ConnectionThrottle throttle ) {
-      final boolean started = throttled.compareAndSet( false, true );
-      if ( started ) {
+    private boolean startThrottlingIfNot(ConnectionThrottle throttle) {
+      final boolean started = throttled.compareAndSet(false, true);
+      if (started) {
         this.throttle = throttle;
         throttle.setAutoRead(false);
       }
@@ -137,8 +136,8 @@ public class DrillCursor implements Cursor {
      * @return  true if actually stopped (was throttling)
      */
     private boolean stopThrottlingIfSo() {
-      final boolean stopped = throttled.compareAndSet( true, false );
-      if ( stopped ) {
+      final boolean stopped = throttled.compareAndSet(true, false);
+      if (stopped) {
         throttle.setAutoRead(true);
         throttle = null;
       }
@@ -147,10 +146,10 @@ public class DrillCursor implements Cursor {
 
     public void awaitFirstMessage() throws InterruptedException, SQLTimeoutException {
       //Check if a non-zero timeout has been set
-      if ( parent.timeoutInMilliseconds > 0 ) {
+      if (parent.timeoutInMilliseconds > 0) {
         //Identifying remaining in milliseconds to maintain a granularity close to integer value of timeout
         long timeToTimeout = parent.timeoutInMilliseconds - parent.elapsedTimer.elapsed(TimeUnit.MILLISECONDS);
-        if ( timeToTimeout <= 0 || !firstMessageReceived.await(timeToTimeout, TimeUnit.MILLISECONDS)) {
+        if (timeToTimeout <= 0 || !firstMessageReceived.await(timeToTimeout, TimeUnit.MILLISECONDS)) {
             throw new SqlTimeoutException(TimeUnit.MILLISECONDS.toSeconds(parent.timeoutInMilliseconds));
         }
       } else {
@@ -164,25 +163,25 @@ public class DrillCursor implements Cursor {
 
     @Override
     public void queryIdArrived(QueryId queryId) {
-      logger.debug( "[#{}] Received query ID: {}.",
-                    instanceId, QueryIdHelper.getQueryId( queryId ) );
+      logger.debug("[#{}] Received query ID: {}.",
+                    instanceId, QueryIdHelper.getQueryId(queryId));
       this.queryId = queryId;
     }
 
     @Override
     public void submissionFailed(UserException ex) {
-      logger.debug( "Received query failure:", instanceId, ex );
+      logger.debug("Received query failure:", instanceId, ex);
       this.executionFailureException = ex;
       completed = true;
       close();
-      logger.info( "[#{}] Query failed: ", instanceId, ex );
+      logger.info("[#{}] Query failed: ", instanceId, ex);
     }
 
     @Override
     public void dataArrived(QueryDataBatch result, ConnectionThrottle throttle) {
       lastReceivedBatchNumber++;
-      logger.debug( "[#{}] Received query data batch #{}: {}.",
-                    instanceId, lastReceivedBatchNumber, result );
+      logger.debug("[#{}] Received query data batch #{}: {}.",
+                    instanceId, lastReceivedBatchNumber, result);
 
       // If we're in a closed state, just release the message.
       if (closed) {
@@ -197,10 +196,10 @@ public class DrillCursor implements Cursor {
       batchQueue.add(result);
 
       // Throttle server if queue size has exceed threshold.
-      if (batchQueue.size() > batchQueueThrottlingThreshold ) {
-        if ( startThrottlingIfNot( throttle ) ) {
-          logger.debug( "[#{}] Throttling started at queue size {}.",
-                        instanceId, batchQueue.size() );
+      if (batchQueue.size() > batchQueueThrottlingThreshold) {
+        if (startThrottlingIfNot(throttle)) {
+          logger.debug("[#{}] Throttling started at queue size {}.",
+                        instanceId, batchQueue.size());
         }
       }
 
@@ -209,7 +208,7 @@ public class DrillCursor implements Cursor {
 
     @Override
     public void queryCompleted(QueryState state) {
-      logger.debug( "[#{}] Received query completion: {}.", instanceId, state );
+      logger.debug("[#{}] Received query completion: {}.", instanceId, state);
       releaseIfFirst();
       completed = true;
     }
@@ -217,7 +216,6 @@ public class DrillCursor implements Cursor {
     QueryId getQueryId() {
       return queryId;
     }
-
 
     /**
      * Gets the next batch of query results from the queue.
@@ -230,8 +228,8 @@ public class DrillCursor implements Cursor {
     QueryDataBatch getNext() throws UserException, InterruptedException, SQLTimeoutException {
       while (true) {
         if (executionFailureException != null) {
-          logger.debug( "[#{}] Dequeued query failure exception: {}.",
-                        instanceId, executionFailureException );
+          logger.debug("[#{}] Dequeued query failure exception: {}.",
+                        instanceId, executionFailureException);
           throw executionFailureException;
         }
         if (completed && batchQueue.isEmpty()) {
@@ -240,23 +238,23 @@ public class DrillCursor implements Cursor {
           QueryDataBatch qdb = batchQueue.poll(50, TimeUnit.MILLISECONDS);
           if (qdb != null) {
             lastDequeuedBatchNumber++;
-            logger.debug( "[#{}] Dequeued query data batch #{}: {}.",
-                          instanceId, lastDequeuedBatchNumber, qdb );
+            logger.debug("[#{}] Dequeued query data batch #{}: {}.",
+                          instanceId, lastDequeuedBatchNumber, qdb);
 
             // Unthrottle server if queue size has dropped enough below threshold:
-            if ( batchQueue.size() < batchQueueThrottlingThreshold / 2
+            if (batchQueue.size() < batchQueueThrottlingThreshold / 2
                  || batchQueue.size() == 0  // (in case threshold < 2)
-                 ) {
-              if ( stopThrottlingIfSo() ) {
-                logger.debug( "[#{}] Throttling stopped at queue size {}.",
-                              instanceId, batchQueue.size() );
+                ) {
+              if (stopThrottlingIfSo()) {
+                logger.debug("[#{}] Throttling stopped at queue size {}.",
+                              instanceId, batchQueue.size());
               }
             }
             return qdb;
           }
 
           // Check and throw SQLTimeoutException
-          if ( parent.timeoutInMilliseconds > 0 && parent.elapsedTimer.elapsed(TimeUnit.MILLISECONDS) >= parent.timeoutInMilliseconds ) {
+          if (parent.timeoutInMilliseconds > 0 && parent.elapsedTimer.elapsed(TimeUnit.MILLISECONDS) >= parent.timeoutInMilliseconds) {
             throw new SqlTimeoutException(TimeUnit.MILLISECONDS.toSeconds(parent.timeoutInMilliseconds));
           }
         }
@@ -264,11 +262,11 @@ public class DrillCursor implements Cursor {
     }
 
     void close() {
-      logger.debug( "[#{}] Query listener closing.", instanceId );
+      logger.debug("[#{}] Query listener closing.", instanceId);
       closed = true;
-      if ( stopThrottlingIfSo() ) {
-        logger.debug( "[#{}] Throttling stopped at close() (at queue size {}).",
-                      instanceId, batchQueue.size() );
+      if (stopThrottlingIfSo()) {
+        logger.debug("[#{}] Throttling stopped at close() (at queue size {}).",
+                      instanceId, batchQueue.size());
       }
       while (!batchQueue.isEmpty()) {
         // Don't bother with query timeout, we're closing the cursor
@@ -283,10 +281,9 @@ public class DrillCursor implements Cursor {
       firstMessageReceived.countDown(); // TODO:  Why not call releaseIfFirst as used elsewhere?
       completed = true;
     }
-
   }
 
-  private static final Logger logger = getLogger( DrillCursor.class );
+  private static final Logger logger = getLogger(DrillCursor.class);
 
   /** JDBC-specified string for unknown catalog, schema, and table names. */
   private static final String UNKNOWN_NAME_STRING = "";
@@ -310,10 +307,10 @@ public class DrillCursor implements Cursor {
   private DrillColumnMetaDataList columnMetaDataList;
 
   /** Whether loadInitialSchema() has been called. */
-  private boolean initialSchemaLoaded = false;
+  private boolean initialSchemaLoaded;
 
   /** Whether after first batch.  (Re skipping spurious empty batches.) */
-  private boolean afterFirstBatch = false;
+  private boolean afterFirstBatch;
 
   /**
    * Whether the next call to {@code this.}{@link #next()} should just return
@@ -329,10 +326,10 @@ public class DrillCursor implements Cursor {
    *   and schema before {@code Statement.execute...(...)} even returns.)
    * </p>
    */
-  private boolean returnTrueForNextCallToNext = false;
+  private boolean returnTrueForNextCallToNext;
 
   /** Whether cursor is after the end of the sequence of records/rows. */
-  private boolean afterLastRow = false;
+  private boolean afterLastRow;
 
   private int currentRowNumber = -1;
   /** Zero-based offset of current record in record batch.
@@ -340,7 +337,7 @@ public class DrillCursor implements Cursor {
   private int currentRecordNumber = -1;
 
   //Track timeout period
-  private long timeoutInMilliseconds = 0L;
+  private long timeoutInMilliseconds;
   private Stopwatch elapsedTimer;
 
   /**
@@ -357,7 +354,7 @@ public class DrillCursor implements Cursor {
     DrillClient client = connection.getClient();
     final int batchQueueThrottlingThreshold =
         client.getConfig().getInt(
-            ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD );
+            ExecConstants.JDBC_BATCH_QUEUE_THROTTLING_THRESHOLD);
     resultsListener = new ResultsListener(this, batchQueueThrottlingThreshold);
     currentBatchHolder = new RecordBatchLoader(client.getAllocator());
 
@@ -429,10 +426,10 @@ public class DrillCursor implements Cursor {
     final List<Class<?>> getObjectClasses = new ArrayList<>();
     // (Can't use modern for loop because, for some incompletely clear reason,
     // DrillAccessorList blocks iterator() (throwing exception).)
-    for ( int ax = 0; ax < accessors.size(); ax++ ) {
+    for (int ax = 0; ax < accessors.size(); ax++) {
       final AvaticaDrillSqlAccessor accessor =
-          accessors.get( ax );
-      getObjectClasses.add( accessor.getObjectClass() );
+          accessors.get(ax);
+      getObjectClasses.add(accessor.getObjectClass());
     }
 
     // Update metadata for result set.
@@ -441,7 +438,7 @@ public class DrillCursor implements Cursor {
         UNKNOWN_NAME_STRING,  // schema name
         UNKNOWN_NAME_STRING,  // table name
         schema,
-        getObjectClasses );
+        getObjectClasses);
 
     if (changeListener != null) {
       changeListener.schemaChanged(schema);
@@ -478,7 +475,7 @@ public class DrillCursor implements Cursor {
           while (qrb != null
               && (qrb.getHeader().getRowCount() == 0 && qrb.getData() == null)) {
             // Empty message--dispose of and try to get another.
-            logger.warn( "Spurious batch read: {}", qrb );
+            logger.warn("Spurious batch read: {}", qrb);
 
             qrb.release();
 
@@ -528,29 +525,22 @@ public class DrillCursor implements Cursor {
           return true;
         }
       }
-      catch ( UserException e ) {
+      catch (UserException e) {
         // A normally expected case--for any server-side error (e.g., syntax
         // error in SQL statement).
         // Construct SQLException with message text from the UserException.
         // TODO:  Map UserException error type to SQLException subclass (once
-        // error type is accessible, of course. :-( )
-        throw new SQLException( e.getMessage(), e );
+        // error type is accessible, of course. :-()
+        throw new SQLException(e.getMessage(), e);
       }
-      catch ( InterruptedException e ) {
+      catch (InterruptedException e) {
         // Not normally expected--Drill doesn't interrupt in this area (right?)--
         // but JDBC client certainly could.
-        throw new SQLException( "Interrupted.", e );
+        throw new SQLException("Interrupted.", e);
       }
-      catch ( SchemaChangeException e ) {
-        // TODO:  Clean:  DRILL-2933:  RecordBatchLoader.load(...) no longer
-        // throws SchemaChangeException, so check/clean catch clause.
-        throw new SQLException(
-            "Unexpected SchemaChangeException from RecordBatchLoader.load(...)" );
+      catch (RuntimeException e) {
+        throw new SQLException("Unexpected RuntimeException: " + e.toString(), e);
       }
-      catch ( RuntimeException e ) {
-        throw new SQLException( "Unexpected RuntimeException: " + e.toString(), e );
-      }
-
     }
   }
 
@@ -562,9 +552,9 @@ public class DrillCursor implements Cursor {
    * <p>
    */
   void loadInitialSchema() throws SQLException {
-    if ( initialSchemaLoaded ) {
+    if (initialSchemaLoaded) {
       throw new IllegalStateException(
-          "loadInitialSchema() called a second time" );
+          "loadInitialSchema() called a second time");
     }
 
     assert ! afterLastRow : "afterLastRow already true in loadInitialSchema()";
@@ -593,7 +583,7 @@ public class DrillCursor implements Cursor {
 
     try {
       resultsListener.awaitFirstMessage();
-    } catch ( InterruptedException e ) {
+    } catch (InterruptedException e) {
       // Preserve evidence that the interruption occurred so that code higher up
       // on the call stack can learn of the interruption and respond to it if it
       // wants to.
@@ -601,7 +591,7 @@ public class DrillCursor implements Cursor {
 
       // Not normally expected--Drill doesn't interrupt in this area (right?)--
       // but JDBC client certainly could.
-      throw new SQLException("Interrupted", e );
+      throw new SQLException("Interrupted", e);
     }
 
     returnTrueForNextCallToNext = true;
@@ -620,17 +610,17 @@ public class DrillCursor implements Cursor {
    */
   @Override
   public boolean next() throws SQLException {
-    if ( ! initialSchemaLoaded ) {
+    if (! initialSchemaLoaded) {
       throw new IllegalStateException(
-          "next() called but loadInitialSchema() was not called" );
+          "next() called but loadInitialSchema() was not called");
     }
     assert afterFirstBatch : "afterFirstBatch still false in next()";
 
-    if ( afterLastRow ) {
+    if (afterLastRow) {
       // We're already after end of rows/records--just report that after end.
       return false;
     }
-    else if ( returnTrueForNextCallToNext ) {
+    else if (returnTrueForNextCallToNext) {
       ++currentRowNumber;
       // We have a deferred "not after end" to report--reset and report that.
       returnTrueForNextCallToNext = false;
@@ -666,5 +656,4 @@ public class DrillCursor implements Cursor {
   public Stopwatch getElapsedTimer() {
     return elapsedTimer;
   }
-
 }


### PR DESCRIPTION
Converts operators to fail with a UserException rather than using
the STOP iterator status. The result is clearer error messages
and simpler code.

## Description

Drill has long had two ways to indicate operator failures:

* By throwing an unchecked exception, preferably `UserException`.
* By setting the failed status on the operator and returning the `STOP` iterator status.

Since the exception mechanism has been stable for several years, there is little reason to use the complex mechanism involved with the `STOP` status. Rather than write code to propagate `STOP` up the stack, we just let Java unwind the stack for us.

This PR converts all places where we returned `STOP` status to instead throw an exception. It also cleans up some lingering places where lower-level calls threw generic exceptions to higher-level code. This PR catches the error as close as possible to the source of the error to allow clearer, more focused error messages.

One consequence of using exceptions to report errors is that there is no longer any code to set the "failed" status for an operator. Mostly this doesn't matter; no code (except `STOP` handling) uses that status. Except in one place: the handy utility which dumps two batches on operator failure. That code relied on the failure status. Since most errors didn't set the status, the batch dump code did not actually work well.

Instead of having each operator catch the exception and mark itself failed. this PR uses a more general solution. It compares the stack trace in the exception with the list of operators to determine the leaf-most operator. This must be the operator which failed. This operator, and its parent, are not those dumped by the batch dump code.

## Documentation

This code is internal to Drill and is not user-visible.

## Testing

Added a new test for the stack trace analyzer. Reran all unit tests and adjusted those that needed changes.
