### PR TITLE
DRILL-7561: Document REST API authentication

### DIFF
--- a/_docs/developer-information/rest-api/010-rest-api-introduction.md
+++ b/_docs/developer-information/rest-api/010-rest-api-introduction.md
@@ -487,7 +487,7 @@ If drill has authentication enabled, you will have to supply credentials when yo
 
 ### Basic authentication
 
-Apache Drill versions 1.18 and higher support HTTP's "Basic" authentication system, sendind the username & password in the `Authorization` header, encoded to base64 and joined using `:`.
+Apache Drill versions 1.18 and higher support HTTP's "Basic" authentication system, sending the username & password in the `Authorization` header, encoded to base64 and joined using `:`.
 
 Basic authentication support is controlled using `drill-override.conf`.  Add the string `"BASIC"` to `http.auth.mechanisms`.  Note that if the field is not currently set, it defaults to having `"FORM"` in it, so you probably want to include `"FORM"` if you set this field, so that Web UI users can still use the login form.
 


### PR DESCRIPTION
# [DRILL-7561](https://issues.apache.org/jira/browse/DRILL-7561): Document authentication for REST API

## Description

Add documentation for current and near-future REST API authentication / authorization mechanism.  This didn't seem to be clearly documented before - the documentation mostly seemed to assume the drill server did not require and authentication.

Documents features added in https://github.com/apache/drill/pull/1972 so that should be merged first.

