### PR TITLE
DRILL-7584: Fix method name spelling

### DIFF
--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePluginConfig.java
@@ -65,7 +65,7 @@ public class MongoStoragePluginConfig extends StoragePluginConfig {
   }
 
   @JsonIgnore
-  public MongoCredential getMongoCrendials() {
+  public MongoCredential getMongoCredentials() {
     return clientURI.getCredentials();
   }
 


### PR DESCRIPTION
# [DRILL-7584](https://issues.apache.org/jira/browse/DRILL-7584): Misspelled method name in MongoStoragePluginConfig (getMongoCrendials)

## Description

I noticed this method name was not spelled correctly, so here's a little fix.