### PR TITLE
DRILL-7586: drill-hive-exec-shaded contains commons-lang3 version 3.1

### DIFF
--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -148,6 +148,14 @@
               <pattern>com.google.protobuf.</pattern>
               <shadedPattern>hive.com.google.protobuf.</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>org.apache.commons.lang.</pattern>
+              <shadedPattern>hive.org.apache.commons.lang.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.lang3.</pattern>
+              <shadedPattern>hive.org.apache.commons.lang3.</shadedPattern>
+            </relocation>
           </relocations>
           <filters>
             <filter>


### PR DESCRIPTION
# [DRILL-7586](https://issues.apache.org/jira/browse/DRILL-7586): drill-hive-exec-shaded contains commons-lang3 version 3.1

## Description
Fix moves commons-lang3 classes shaded in drill-hive-exec-shaded

## Testing
The custom plugin stopped throwing a java error.lang.NoSuchMethodError: org.apache.commons.lang3.StringUtils.prependIfMissing (this method is not available in commons-lang3 3.1)
