### PR TITLE
DRILL-7589: Set temporary tests folder for UDF_DIRECTORY_LOCAL, fix allocators closing in BloomFilterTest, fix permissions issue for TestGracefulShutdown tests

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/TestDynamicUDFSupport.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/udf/dynamic/TestDynamicUDFSupport.java
@@ -78,7 +78,6 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
 
   private static final String DEFAULT_JAR_NAME = "drill-custom-lower";
   private static URI fsUri;
-  private static File udfDir;
   private static File jarsDir;
   private static File buildDirectory;
   private static JarBuilder jarBuilder;
@@ -103,9 +102,10 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
 
   @Before
   public void setupNewDrillbit() throws Exception {
-    udfDir = dirTestWatcher.makeSubDir(Paths.get("udf"));
+    File udfLocalDir = new File(dirTestWatcher.getUdfDir(), "local");
     Properties overrideProps = new Properties();
-    overrideProps.setProperty(ExecConstants.UDF_DIRECTORY_ROOT, udfDir.getAbsolutePath());
+    overrideProps.setProperty(ExecConstants.UDF_DIRECTORY_ROOT, dirTestWatcher.getUdfDir().getAbsolutePath());
+    overrideProps.setProperty(ExecConstants.UDF_DIRECTORY_LOCAL, udfLocalDir.getAbsolutePath());
     overrideProps.setProperty(ExecConstants.UDF_DIRECTORY_FS, FileSystem.DEFAULT_FS);
     updateTestCluster(1, DrillConfig.create(overrideProps));
 
@@ -115,7 +115,6 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
   @After
   public void cleanup() throws Exception {
     closeClient();
-    FileUtils.cleanDirectory(udfDir);
     dirTestWatcher.clear();
   }
 
@@ -957,7 +956,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
     return spy;
   }
 
-  private class SimpleQueryRunner implements Runnable {
+  private static class SimpleQueryRunner implements Runnable {
 
     private final String query;
 
@@ -975,7 +974,7 @@ public class TestDynamicUDFSupport extends BaseTestQuery {
     }
   }
 
-  private class TestBuilderRunner implements Runnable {
+  private static class TestBuilderRunner implements Runnable {
 
     private final TestBuilder testBuilder;
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/work/filter/BloomFilterTest.java
@@ -17,18 +17,16 @@
  */
 package org.apache.drill.exec.work.filter;
 
-import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
-import org.apache.drill.common.scanner.ClassPathScanner;
 import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.util.function.CheckedFunction;
+import org.apache.drill.exec.exception.ClassTransformationException;
+import org.apache.drill.exec.exception.SchemaChangeException;
 import org.apache.drill.exec.expr.ValueVectorReadExpression;
-import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.fn.impl.ValueVectorHashHelper;
-import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.FragmentContext;
-import org.apache.drill.exec.ops.FragmentContextImpl;
-import org.apache.drill.exec.proto.BitControl;
+import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TypedFieldId;
@@ -36,26 +34,23 @@ import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
 import org.apache.drill.exec.record.WritableBatch;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.selection.SelectionVector2;
 import org.apache.drill.exec.record.selection.SelectionVector4;
-import org.apache.drill.exec.server.Drillbit;
-import org.apache.drill.exec.server.DrillbitContext;
-import org.apache.drill.exec.server.RemoteServiceSet;
-import org.apache.drill.exec.vector.VarCharVector;
-import org.apache.drill.test.BaseTest;
+import org.apache.drill.test.SubOperatorTest;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 import java.util.Iterator;
 
-public class BloomFilterTest extends BaseTest {
-  public static DrillConfig c = DrillConfig.create();
+public class BloomFilterTest extends SubOperatorTest {
 
-  class TestRecordBatch implements RecordBatch {
+  private static class TestRecordBatch implements RecordBatch {
     private final VectorContainer container;
 
     public TestRecordBatch(VectorContainer container) {
       this.container = container;
-
     }
 
     @Override
@@ -85,7 +80,6 @@ public class BloomFilterTest extends BaseTest {
 
     @Override
     public void kill(boolean sendUpstream) {
-
     }
 
     @Override
@@ -133,214 +127,110 @@ public class BloomFilterTest extends BaseTest {
     }
   }
 
-
   @Test
   public void testNotExist() throws Exception {
-    Drillbit bit = new Drillbit(c, RemoteServiceSet.getLocalServiceSet(), ClassPathScanner.fromPrescan(c));
-    bit.run();
-    DrillbitContext bitContext = bit.getContext();
-    FunctionImplementationRegistry registry = bitContext.getFunctionImplementationRegistry();
-    FragmentContextImpl context = new FragmentContextImpl(bitContext, BitControl.PlanFragment.getDefaultInstance(), null, registry);
-    BufferAllocator bufferAllocator = bitContext.getAllocator();
-    //create RecordBatch
-    VarCharVector vector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    vector.allocateNew();
-    int valueCount = 3;
-    VarCharVector.Mutator mutator = vector.getMutator();
-    mutator.setSafe(0, "a".getBytes());
-    mutator.setSafe(1, "b".getBytes());
-    mutator.setSafe(2, "c".getBytes());
-    mutator.setValueCount(valueCount);
-    VectorContainer vectorContainer = new VectorContainer();
-    TypedFieldId fieldId = vectorContainer.add(vector);
-    RecordBatch recordBatch = new TestRecordBatch(vectorContainer);
-    //construct hash64
-    ValueVectorReadExpression exp = new ValueVectorReadExpression(fieldId);
-    LogicalExpression[] expressions = new LogicalExpression[1];
-    expressions[0] = exp;
-    TypedFieldId[] fieldIds = new TypedFieldId[1];
-    fieldIds[0] = fieldId;
-    ValueVectorHashHelper valueVectorHashHelper = new ValueVectorHashHelper(recordBatch, context);
-    ValueVectorHashHelper.Hash64 hash64 = valueVectorHashHelper.getHash64(expressions, fieldIds);
+    RowSet.SingleRowSet probeRowSet = fixture.rowSetBuilder(getTestSchema())
+        .addRow("f")
+        .build();
 
-    //construct BloomFilter
-    int numBytes = BloomFilter.optimalNumOfBytes(3, 0.03);
-
-    BloomFilter bloomFilter = new BloomFilter(numBytes, bufferAllocator);
-    for (int i = 0; i < valueCount; i++) {
-      long hashCode = hash64.hash64Code(i, 0, 0);
-      bloomFilter.insert(hashCode);
-    }
-
-    //-----------------create probe side RecordBatch---------------------
-    VarCharVector probeVector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    probeVector.allocateNew();
-    int probeValueCount = 1;
-    VarCharVector.Mutator mutator1 = probeVector.getMutator();
-    mutator1.setSafe(0, "f".getBytes());
-    mutator1.setValueCount(probeValueCount);
-    VectorContainer probeVectorContainer = new VectorContainer();
-    TypedFieldId probeFieldId = probeVectorContainer.add(probeVector);
-    RecordBatch probeRecordBatch = new TestRecordBatch(probeVectorContainer);
-    ValueVectorReadExpression probExp = new ValueVectorReadExpression(probeFieldId);
-    LogicalExpression[] probExpressions = new LogicalExpression[1];
-    probExpressions[0] = probExp;
-    TypedFieldId[] probeFieldIds = new TypedFieldId[1];
-    probeFieldIds[0] = probeFieldId;
-    ValueVectorHashHelper probeValueVectorHashHelper = new ValueVectorHashHelper(probeRecordBatch, context);
-    ValueVectorHashHelper.Hash64 probeHash64 = probeValueVectorHashHelper.getHash64(probExpressions, probeFieldIds);
-    long hashCode = probeHash64.hash64Code(0, 0, 0);
-    boolean contain = bloomFilter.find(hashCode);
-    Assert.assertFalse(contain);
-    bloomFilter.getContent().close();
-    vectorContainer.clear();
-    probeVectorContainer.clear();
-    context.close();
-    bitContext.close();
-    bit.close();
+    checkBloomFilterResult(probeRowSet, BloomFilterTest::getSimpleBloomFilter, false);
   }
-
 
   @Test
   public void testExist() throws Exception {
+    RowSet.SingleRowSet probeRowSet = fixture.rowSetBuilder(getTestSchema())
+        .addRow("a")
+        .build();
 
-    Drillbit bit = new Drillbit(c, RemoteServiceSet.getLocalServiceSet(), ClassPathScanner.fromPrescan(c));
-    bit.run();
-    DrillbitContext bitContext = bit.getContext();
-    FunctionImplementationRegistry registry = bitContext.getFunctionImplementationRegistry();
-    FragmentContextImpl context = new FragmentContextImpl(bitContext, BitControl.PlanFragment.getDefaultInstance(), null, registry);
-    BufferAllocator bufferAllocator = bitContext.getAllocator();
-    //create RecordBatch
-    VarCharVector vector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    vector.allocateNew();
-    int valueCount = 3;
-    VarCharVector.Mutator mutator = vector.getMutator();
-    mutator.setSafe(0, "a".getBytes());
-    mutator.setSafe(1, "b".getBytes());
-    mutator.setSafe(2, "c".getBytes());
-    mutator.setValueCount(valueCount);
-    VectorContainer vectorContainer = new VectorContainer();
-    TypedFieldId fieldId = vectorContainer.add(vector);
-    RecordBatch recordBatch = new TestRecordBatch(vectorContainer);
-    //construct hash64
-    ValueVectorReadExpression exp = new ValueVectorReadExpression(fieldId);
-    LogicalExpression[] expressions = new LogicalExpression[1];
-    expressions[0] = exp;
-    TypedFieldId[] fieldIds = new TypedFieldId[1];
-    fieldIds[0] = fieldId;
-    ValueVectorHashHelper valueVectorHashHelper = new ValueVectorHashHelper(recordBatch, context);
-    ValueVectorHashHelper.Hash64 hash64 = valueVectorHashHelper.getHash64(expressions, fieldIds);
-
-    //construct BloomFilter
-    int numBytes = BloomFilter.optimalNumOfBytes(3, 0.03);
-
-    BloomFilter bloomFilter = new BloomFilter(numBytes, bufferAllocator);
-    for (int i = 0; i < valueCount; i++) {
-      long hashCode = hash64.hash64Code(i, 0, 0);
-      bloomFilter.insert(hashCode);
-    }
-
-    //-----------------create probe side RecordBatch---------------------
-    VarCharVector probeVector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    probeVector.allocateNew();
-    int probeValueCount = 1;
-    VarCharVector.Mutator mutator1 = probeVector.getMutator();
-    mutator1.setSafe(0, "a".getBytes());
-    mutator1.setValueCount(probeValueCount);
-    VectorContainer probeVectorContainer = new VectorContainer();
-    TypedFieldId probeFieldId = probeVectorContainer.add(probeVector);
-    RecordBatch probeRecordBatch = new TestRecordBatch(probeVectorContainer);
-    ValueVectorReadExpression probExp = new ValueVectorReadExpression(probeFieldId);
-    LogicalExpression[] probExpressions = new LogicalExpression[1];
-    probExpressions[0] = probExp;
-    TypedFieldId[] probeFieldIds = new TypedFieldId[1];
-    probeFieldIds[0] = probeFieldId;
-    ValueVectorHashHelper probeValueVectorHashHelper = new ValueVectorHashHelper(probeRecordBatch, context);
-    ValueVectorHashHelper.Hash64 probeHash64 = probeValueVectorHashHelper.getHash64(probExpressions, probeFieldIds);
-    long hashCode = probeHash64.hash64Code(0, 0, 0);
-    boolean contain = bloomFilter.find(hashCode);
-    Assert.assertTrue(contain);
-    bloomFilter.getContent().close();
-    vectorContainer.clear();
-    probeVectorContainer.clear();
-    context.close();
-    bitContext.close();
-    bit.close();
+    checkBloomFilterResult(probeRowSet, BloomFilterTest::getSimpleBloomFilter, true);
   }
-
 
   @Test
   public void testMerged() throws Exception {
+    RowSet.SingleRowSet probeRowSet = fixture.rowSetBuilder(getTestSchema())
+        .addRow("a")
+        .build();
 
-    Drillbit bit = new Drillbit(c, RemoteServiceSet.getLocalServiceSet(), ClassPathScanner.fromPrescan(c));
-    bit.run();
-    DrillbitContext bitContext = bit.getContext();
-    FunctionImplementationRegistry registry = bitContext.getFunctionImplementationRegistry();
-    FragmentContextImpl context = new FragmentContextImpl(bitContext, BitControl.PlanFragment.getDefaultInstance(), null, registry);
-    BufferAllocator bufferAllocator = bitContext.getAllocator();
-    //create RecordBatch
-    VarCharVector vector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    vector.allocateNew();
-    int valueCount = 3;
-    VarCharVector.Mutator mutator = vector.getMutator();
-    mutator.setSafe(0, "a".getBytes());
-    mutator.setSafe(1, "b".getBytes());
-    mutator.setSafe(2, "c".getBytes());
-    mutator.setValueCount(valueCount);
-    VectorContainer vectorContainer = new VectorContainer();
-    TypedFieldId fieldId = vectorContainer.add(vector);
-    RecordBatch recordBatch = new TestRecordBatch(vectorContainer);
-    //construct hash64
-    ValueVectorReadExpression exp = new ValueVectorReadExpression(fieldId);
-    LogicalExpression[] expressions = new LogicalExpression[1];
-    expressions[0] = exp;
-    TypedFieldId[] fieldIds = new TypedFieldId[1];
-    fieldIds[0] = fieldId;
-    ValueVectorHashHelper valueVectorHashHelper = new ValueVectorHashHelper(recordBatch, context);
-    ValueVectorHashHelper.Hash64 hash64 = valueVectorHashHelper.getHash64(expressions, fieldIds);
+    checkBloomFilterResult(probeRowSet, this::getDisjunctionBloomFilter, true);
+  }
 
-    //construct BloomFilter
+  private BloomFilter getDisjunctionBloomFilter(ValueVectorHashHelper.Hash64 hash64) throws SchemaChangeException {
     int numBytes = BloomFilter.optimalNumOfBytes(3, 0.03);
-
-    BloomFilter bloomFilter = new BloomFilter(numBytes, bufferAllocator);
+    BloomFilter bloomFilter = new BloomFilter(numBytes, fixture.allocator());
+    int valueCount = 3;
     for (int i = 0; i < valueCount; i++) {
       long hashCode = hash64.hash64Code(i, 0, 0);
       bloomFilter.insert(hashCode);
     }
 
-    BloomFilter bloomFilter1 = new BloomFilter(numBytes, bufferAllocator);
+    BloomFilter disjunctionBloomFilter = getSimpleBloomFilter(hash64);
+    disjunctionBloomFilter.or(bloomFilter);
+
+    bloomFilter.getContent().close();
+
+    return disjunctionBloomFilter;
+  }
+
+  private static BloomFilter getSimpleBloomFilter(ValueVectorHashHelper.Hash64 hash64) throws SchemaChangeException {
+    int numBytes = BloomFilter.optimalNumOfBytes(3, 0.03);
+
+    BloomFilter bloomFilter = new BloomFilter(numBytes, fixture.allocator());
+
+    int valueCount = 3;
     for (int i = 0; i < valueCount; i++) {
       long hashCode = hash64.hash64Code(i, 0, 0);
-      bloomFilter1.insert(hashCode);
+      bloomFilter.insert(hashCode);
     }
+    return bloomFilter;
+  }
 
-    bloomFilter.or(bloomFilter1);
+  private void checkBloomFilterResult(RowSet.SingleRowSet probeRowSet,
+      CheckedFunction<ValueVectorHashHelper.Hash64, BloomFilter, SchemaChangeException> bloomFilterProvider,
+      boolean matches) throws ClassTransformationException, IOException, SchemaChangeException {
+    try (FragmentContext context = fixture.getFragmentContext()) {
+      // create build side batch
+      RowSet.SingleRowSet batchRowSet = fixture.rowSetBuilder(getTestSchema())
+          .addRow("a")
+          .addRow("b")
+          .addRow("c")
+          .build();
 
-    //-----------------create probe side RecordBatch---------------------
-    VarCharVector probeVector = new VarCharVector(SchemaBuilder.columnSchema("a", TypeProtos.MinorType.VARCHAR, TypeProtos.DataMode.REQUIRED), bufferAllocator);
-    probeVector.allocateNew();
-    int probeValueCount = 1;
-    VarCharVector.Mutator mutator1 = probeVector.getMutator();
-    mutator1.setSafe(0, "a".getBytes());
-    mutator1.setValueCount(probeValueCount);
-    VectorContainer probeVectorContainer = new VectorContainer();
-    TypedFieldId probeFieldId = probeVectorContainer.add(probeVector);
-    RecordBatch probeRecordBatch = new TestRecordBatch(probeVectorContainer);
+      // create build side Hash64
+      ValueVectorHashHelper.Hash64 hash64 = getHash64(context, batchRowSet);
+
+      // construct BloomFilter
+      BloomFilter bloomFilter = bloomFilterProvider.apply(hash64);
+
+      // create probe side Hash64
+      ValueVectorHashHelper.Hash64 probeHash64 = getHash64(context, probeRowSet);
+
+      long hashCode = probeHash64.hash64Code(0, 0, 0);
+
+      Assert.assertEquals(matches, bloomFilter.find(hashCode));
+
+      bloomFilter.getContent().close();
+      batchRowSet.clear();
+      probeRowSet.clear();
+    }
+  }
+
+  private static TupleMetadata getTestSchema() {
+    return new SchemaBuilder()
+        .add("a", TypeProtos.MinorType.VARCHAR)
+        .build();
+  }
+
+  private static ValueVectorHashHelper.Hash64 getHash64(FragmentContext context,
+      RowSet.SingleRowSet probeRowSet) throws ClassTransformationException, IOException, SchemaChangeException {
+
+    RecordBatch probeRecordBatch = new TestRecordBatch(probeRowSet.container());
+    TypedFieldId probeFieldId = probeRecordBatch.getValueVectorId(SchemaPath.getSimplePath("a"));
     ValueVectorReadExpression probExp = new ValueVectorReadExpression(probeFieldId);
     LogicalExpression[] probExpressions = new LogicalExpression[1];
     probExpressions[0] = probExp;
     TypedFieldId[] probeFieldIds = new TypedFieldId[1];
     probeFieldIds[0] = probeFieldId;
     ValueVectorHashHelper probeValueVectorHashHelper = new ValueVectorHashHelper(probeRecordBatch, context);
-    ValueVectorHashHelper.Hash64 probeHash64 = probeValueVectorHashHelper.getHash64(probExpressions, probeFieldIds);
-    long hashCode = probeHash64.hash64Code(0, 0, 0);
-    boolean contain = bloomFilter.find(hashCode);
-    Assert.assertTrue(contain);
-    bloomFilter.getContent().close();
-    vectorContainer.clear();
-    probeVectorContainer.clear();
-    context.close();
-    bitContext.close();
-    bit.close();
+    return probeValueVectorHashHelper.getHash64(probExpressions, probeFieldIds);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/BaseDirTestWatcher.java
@@ -73,6 +73,7 @@ public class BaseDirTestWatcher extends DirTestWatcher {
   private File dfsTestTmpParentDir;
   private File dfsTestTmpDir;
   private File rootDir;
+  private File udfDir;
 
   /**
    * Creates a {@link BaseDirTestWatcher} which does not delete it's temp directories at the end of tests.
@@ -103,6 +104,7 @@ public class BaseDirTestWatcher extends DirTestWatcher {
     tmpDir = makeSubDir(Paths.get("tmp"));
     storeDir = makeSubDir(Paths.get("store"));
     dfsTestTmpParentDir = makeSubDir(Paths.get("dfsTestTmp"));
+    udfDir = makeSubDir(Paths.get("udf"));
 
     newDfsTestTmpDir();
   }
@@ -118,6 +120,7 @@ public class BaseDirTestWatcher extends DirTestWatcher {
       FileUtils.cleanDirectory(tmpDir);
       FileUtils.cleanDirectory(storeDir);
       FileUtils.cleanDirectory(dfsTestTmpDir);
+      FileUtils.cleanDirectory(udfDir);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -165,6 +168,14 @@ public class BaseDirTestWatcher extends DirTestWatcher {
 
   public File getSpillDir() {
     return spillDir;
+  }
+
+  /**
+   * Gets the temp directory that should be used as base directory for dynamic UDFs.
+   * @return The temp directory that should be used as base directory for dynamic UDFs.
+   */
+  public File getUdfDir() {
+    return udfDir;
   }
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -584,6 +584,7 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
     Properties props = new Properties();
     props.putAll(ClusterFixture.TEST_CONFIGURATIONS);
     props.setProperty(ExecConstants.DRILL_TMP_DIR, dirTestWatcher.getTmpDir().getAbsolutePath());
+    props.setProperty(ExecConstants.UDF_DIRECTORY_ROOT, dirTestWatcher.getUdfDir().getAbsolutePath());
     props.setProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH, dirTestWatcher.getStoreDir().getAbsolutePath());
 
     builder.configBuilder.configProps(props);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -127,6 +127,7 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
         configBuilder.put(ExecConstants.SYS_STORE_PROVIDER_LOCAL_PATH, dirTestWatcher.getStoreDir().getAbsolutePath());
         configBuilder.put(ExecConstants.SPILL_DIRS, Lists.newArrayList(dirTestWatcher.getSpillDir().getAbsolutePath()));
         configBuilder.put(ExecConstants.HASHJOIN_SPILL_DIRS, Lists.newArrayList(dirTestWatcher.getSpillDir().getAbsolutePath()));
+        configBuilder.put(ExecConstants.UDF_DIRECTORY_ROOT, dirTestWatcher.getUdfDir().getAbsolutePath());
       }
     }
 


### PR DESCRIPTION
# [DRILL-7589](https://issues.apache.org/jira/browse/DRILL-7589): Set temporary tests folder for UDF_DIRECTORY_LOCAL, fix allocators closing in BloomFilterTest, fix permissions issue for TestGracefulShutdown tests

## Description

Initially, `UDF_DIRECTORY_LOCAL` had default value for tests and was set to `/tmp/drill/udf/udf/local`. Changed its value to refer to the test directory. Hope it will help to fix CI failures.

Fixed the following errors for `TestGracefulShutdown` tests (it was only logged, but tests pass.
```
Unable to store data for the path [file:/var/log/drill/profiles/21b7ceae-680b-91ab-3cd2-24f6d5d53a7d.sys.drill]: Mkdirs failed to create file:/var/log/drill/profiles (exists=false, cwd=file:/home/runner/work/drill/drill/exec/java-exec)
```

Fixed closing allocators for `BloomFilterTest` tests, the following error was logged, after tests from this class are finished:
```
java.lang.IllegalStateException: Allocator[ROOT] closed with outstanding buffers allocated (1).
```

## Documentation
NA

## Testing
Checked several times on GitHub Actions Jobs on the forked repo.
