### PR TITLE
DRILL-7514: Update Apache POI to Latest Version

### DIFF
--- a/contrib/format-excel/pom.xml
+++ b/contrib/format-excel/pom.xml
@@ -31,7 +31,7 @@
   <name>contrib/format-excel</name>
 
   <properties>
-    <poi.version>4.1.1</poi.version>
+    <poi.version>4.1.2</poi.version>
   </properties>
   <dependencies>
     <dependency>

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -38,6 +38,7 @@ import org.apache.poi.ss.usermodel.CellValue;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
@@ -270,15 +271,10 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
    * @return The number of actual columns
    */
   private int getColumnCount() {
-    int columnCount;
+    int rowNumber = readerConfig.headerRow > 0 ? sheet.getFirstRowNum() : 0;
+    XSSFRow sheetRow = sheet.getRow(rowNumber);
 
-    if (readerConfig.headerRow >= 0) {
-      columnCount = sheet.getRow(sheet.getFirstRowNum()).getPhysicalNumberOfCells();
-    } else {
-      // Case for when the user defines the headerRow as -1 IE:  When there isn't a headerRow.
-      columnCount = sheet.getRow(0).getPhysicalNumberOfCells();
-    }
-    return columnCount;
+    return sheetRow != null ? sheetRow.getPhysicalNumberOfCells() : 0;
   }
 
   @Override

--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>nl.basjes.parse.useragent</groupId>
       <artifactId>yauaa</artifactId>
-      <version>5.11</version>
+      <version>5.13</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
# [DRILL-7514](https://issues.apache.org/jira/browse/DRILL-7514): Update Apache POI to Latest Version

## Description

Drill's Excel Format Plugin uses Apache POI to parse Excel files. While this reader is effective in that it parses formulae and data types, it uses memory inefficiently and will struggle to read very large Excel files.  
The latest version of POI addresses some of the memory issues and hopefully Drill will be able to query larger Excel files without running out of memory.

This PR updates Drill to use the latest version of Apache POI and also updates the User Agent Parser to a more recent version. 

There was a minor change to the POI's behavior with respect to empty sheets, so I had to enclose a line in a `try/catch` block.  

## Documentation
No user visible changes.

## Testing
All relevant unit tests run and passed.
