### PR TITLE
DRILL-7603: Allow default schema to be set for HTTP queries

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryResources.java
@@ -96,10 +96,12 @@ public class QueryResources {
   public Viewable submitQuery(@FormParam("query") String query,
                               @FormParam("queryType") String queryType,
                               @FormParam("autoLimit") String autoLimit,
-                              @FormParam("userName") String userName) throws Exception {
+                              @FormParam("userName") String userName,
+                              @FormParam("defaultSchema") String defaultSchema) throws Exception {
     try {
+      // Apply options from the form fields, if provided
       final String trimmedQueryString = CharMatcher.is(';').trimTrailingFrom(query.trim());
-      final QueryResult result = submitQueryJSON(new QueryWrapper(trimmedQueryString, queryType, autoLimit, userName));
+      final QueryResult result = submitQueryJSON(new QueryWrapper(trimmedQueryString, queryType, autoLimit, userName, defaultSchema));
       List<Integer> rowsPerPageValues = work.getContext().getConfig().getIntList(ExecConstants.HTTP_WEB_CLIENT_RESULTSET_ROWS_PER_PAGE_VALUES);
       Collections.sort(rowsPerPageValues);
       final String rowsPerPageValuesAsStr = Joiner.on(",").join(rowsPerPageValues);

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -82,6 +82,8 @@
       Submit
     </button>
     <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
+    <label> Default Schema <input type="text" size="10" name="defaultSchema" id="defaultSchema"> </label>
+    <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names, and for SHOW FILES and SHOW TABLES" style="cursor:pointer"></span>
     <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
   </form>
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -30,11 +30,11 @@ import org.apache.drill.test.ClusterTest;
 
 public class RestServerTest extends ClusterTest {
   protected QueryWrapper.QueryResult runQuery(String sql) throws Exception {
-    return runQuery(new QueryWrapper(sql, "SQL", null, null));
+    return runQuery(new QueryWrapper(sql, "SQL", null, null, null));
   }
 
   protected QueryWrapper.QueryResult runQueryWithUsername(String sql, String userName) throws Exception {
-    return runQuery(new QueryWrapper(sql, "SQL", null, userName));
+    return runQuery(new QueryWrapper(sql, "SQL", null, userName, null));
   }
 
   protected QueryWrapper.QueryResult runQuery(QueryWrapper q) throws Exception {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapper.java
@@ -50,11 +50,19 @@ public class TestQueryWrapper extends RestServerTest {
   @Test
   public void testImpersonationDisabled() throws Exception {
     try {
-      QueryWrapper q = new QueryWrapper("SHOW SCHEMAS", "SQL", null, "alfred");
+      QueryWrapper q = new QueryWrapper("SHOW SCHEMAS", "SQL", null, "alfred", null);
       runQuery(q);
       fail("Should have thrown exception");
     } catch (UserException e) {
       assertThat(e.getMessage(), containsString("User impersonation is not enabled"));
     }
   }
+
+  @Test
+  public void testSpecifyDefaultSchema() throws Exception {
+    QueryWrapper.QueryResult result = runQuery(new QueryWrapper("SHOW FILES", "SQL", null, null, "dfs.tmp"));
+    // SHOW FILES will fail if default schema is not provided
+    assertEquals("COMPLETED", result.queryState);
+  }
+
 }


### PR DESCRIPTION
# [DRILL-7603](https://issues.apache.org/jira/browse/DRILL-7603): Allow default schema to be set for HTTP queries

## Description

This allows REST API requests and Web UI requests to specify a default
schema.  Otherwise this is not possible for HTTP clients because the
"USE" command requires a session, which HTTP clients do not have.

## Documentation

### POST /query.json

Submit a query and return results.

**Parameters**

* `queryType`--SQL, PHYSICAL, or LOGICAL are valid types. Use only "SQL". Other types are for internal use only.  
* `query`--A SQL query that runs in Drill.  
* `autoLimit`--Limits the number of rows returned from the result set. (Drill 1.16+)
* `defaultSchema`--Specify the default schema for the request, as if the `USE` command was run before the query

## Screenshot

![image](https://user-images.githubusercontent.com/327833/75385306-5b657000-5894-11ea-8ff7-d0f2150d043a.png)

## Testing

I added a JUnit test, and also did a bit of manual testing.

e.g.

     curl -d '{"query":"SHOW FILES","defaultSchema":"dfs.tmp","queryType":"SQL"}' -H 'Content-Type: application/json' -H 'User-Name: test' localhost:8047/query.json
