### PR TITLE
DRILL-7604: Allow session options to be set in HTTP queries

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/RestServerTest.java
@@ -28,13 +28,26 @@ import org.apache.drill.exec.work.WorkManager;
 import org.apache.drill.exec.work.foreman.Foreman;
 import org.apache.drill.test.ClusterTest;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class RestServerTest extends ClusterTest {
   protected QueryWrapper.QueryResult runQuery(String sql) throws Exception {
-    return runQuery(new QueryWrapper(sql, "SQL", null, null, null));
+    return runQuery(new QueryWrapper(sql, "SQL", null, null, null, null));
   }
 
   protected QueryWrapper.QueryResult runQueryWithUsername(String sql, String userName) throws Exception {
-    return runQuery(new QueryWrapper(sql, "SQL", null, userName, null));
+    return runQuery(new QueryWrapper(sql, "SQL", null, userName, null, null));
+  }
+
+  protected QueryWrapper.QueryResult runQueryWithOptions(String sql, Map<String, Object> options) throws Exception {
+    return runQuery(new QueryWrapper(sql, "SQL", null, null, null, options));
+  }
+
+  protected QueryWrapper.QueryResult runQueryWithOption(String sql, String name, Object value) throws Exception {
+    Map<String, Object> options = new HashMap<>();
+    options.put(name, value);
+    return runQueryWithOptions(sql, options);
   }
 
   protected QueryWrapper.QueryResult runQuery(QueryWrapper q) throws Exception {
@@ -51,7 +64,6 @@ public class RestServerTest extends ClusterTest {
     WebUserConnection connection = new WebUserConnection.AnonWebUserConnection(webSessionResources);
     return q.run(cluster.drillbit().getManager(), connection);
   }
-
 
   protected UserBitShared.QueryProfile getQueryProfile(QueryWrapper.QueryResult result) {
     String queryId = result.getQueryId();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapper.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapper.java
@@ -23,6 +23,11 @@ import org.apache.drill.test.ClusterFixture;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.apache.drill.exec.ExecConstants.ENABLE_VERBOSE_ERRORS_KEY;
+import static org.apache.drill.exec.ExecConstants.OUTPUT_FORMAT_OPTION;
+import static org.apache.drill.exec.ExecConstants.PARQUET_FLAT_BATCH_MEMORY_SIZE_VALIDATOR;
+import static org.apache.drill.exec.ExecConstants.QUERY_MAX_ROWS;
+import static org.apache.drill.exec.ExecConstants.TEXT_ESTIMATED_ROW_SIZE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -48,9 +53,121 @@ public class TestQueryWrapper extends RestServerTest {
   }
 
   @Test
+  public void testSpecifyOutputFormatAsParquet() throws Exception {
+    QueryWrapper.QueryResult result = runQueryWithOption(
+      "CREATE TABLE dfs.tmp.schemata_parquet AS SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA",
+      OUTPUT_FORMAT_OPTION,
+      "parquet");
+    assertEquals("COMPLETED", result.queryState);
+    assertEquals(2, result.columns.size());
+    assertEquals(2, result.metadata.size());
+    assertEquals(1, result.rows.size());
+    assertEquals("0_0", result.rows.get(0).get("Fragment"));
+    assertNotEquals("0", result.rows.get(0).get("Number of records written"));
+    QueryWrapper.QueryResult result2 = runQuery("SHOW FILES IN dfs.tmp.schemata_parquet");
+    assertEquals("0_0_0.parquet", result2.rows.get(0).get("name"));
+  }
+
+  @Test
+  public void testSpecifyOutputFormatAsJson() throws Exception {
+    QueryWrapper.QueryResult result = runQueryWithOption(
+      "CREATE TABLE dfs.tmp.schemata_json AS SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA",
+      OUTPUT_FORMAT_OPTION,
+      "json");
+    assertEquals("COMPLETED", result.queryState);
+    assertEquals(2, result.columns.size());
+    assertEquals(2, result.metadata.size());
+    assertEquals(1, result.rows.size());
+    assertEquals("0_0", result.rows.get(0).get("Fragment"));
+    assertNotEquals("0", result.rows.get(0).get("Number of records written"));
+    QueryWrapper.QueryResult result2 = runQuery("SHOW FILES IN dfs.tmp.schemata_json");
+    assertEquals("0_0_0.json", result2.rows.get(0).get("name"));
+  }
+
+  @Test
+  public void testInvalidOptionName() throws Exception {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", "xxx", "s");
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("The option 'xxx' does not exist."));
+    }
+  }
+
+  @Test
+  public void testBooleanOptionGivenAsString() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", ENABLE_VERBOSE_ERRORS_KEY, "not a boolean");
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected boolean value"));
+    }
+  }
+
+  @Test
+  public void testBooleanOptionGivenAsNumber() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", ENABLE_VERBOSE_ERRORS_KEY, Long.valueOf(7));
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected boolean value"));
+    }
+  }
+
+  @Test
+  public void testStringOptionGivenAsBoolean() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", OUTPUT_FORMAT_OPTION, Boolean.TRUE);
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected string value"));
+    }
+  }
+
+  @Test
+  public void testStringOptionGivenAsNumber() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", OUTPUT_FORMAT_OPTION, Long.valueOf(7));
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected string value"));
+    }
+  }
+
+  @Test
+  public void testDoubleOptionGivenAsString() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", TEXT_ESTIMATED_ROW_SIZE.getOptionName(), "3.14");
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected number value"));
+    }
+  }
+
+  @Test
+  public void testLongOptionGivenAsString() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", QUERY_MAX_ROWS, "3.14");
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Expected number value"));
+    }
+  }
+
+  @Test
+  public void testInternalOptionGiven() {
+    try {
+      runQueryWithOption("SHOW SCHEMAS", PARQUET_FLAT_BATCH_MEMORY_SIZE_VALIDATOR.getOptionName(), "3.14");
+      fail("Expected exception to be thrown");
+    } catch (Exception e) {
+      assertThat(e.getMessage(), containsString("Internal option 'store.parquet.flat.batch.memory_size' cannot be set with query"));
+    }
+  }
+
+  @Test
   public void testImpersonationDisabled() throws Exception {
     try {
-      QueryWrapper q = new QueryWrapper("SHOW SCHEMAS", "SQL", null, "alfred", null);
+      QueryWrapper q = new QueryWrapper("SHOW SCHEMAS", "SQL", null, "alfred", null, null);
       runQuery(q);
       fail("Should have thrown exception");
     } catch (UserException e) {
@@ -60,7 +177,7 @@ public class TestQueryWrapper extends RestServerTest {
 
   @Test
   public void testSpecifyDefaultSchema() throws Exception {
-    QueryWrapper.QueryResult result = runQuery(new QueryWrapper("SHOW FILES", "SQL", null, null, "dfs.tmp"));
+    QueryWrapper.QueryResult result = runQuery(new QueryWrapper("SHOW FILES", "SQL", null, null, "dfs.tmp", null));
     // SHOW FILES will fail if default schema is not provided
     assertEquals("COMPLETED", result.queryState);
   }


### PR DESCRIPTION
# [DRILL-7604](https://issues.apache.org/jira/browse/DRILL-7604): Allow session options to be set in HTTP queries

## Description

Normally session options must be set using the `SET` command.  However,
this command does not work for HTTP clients (REST API and Web UI)
because it doesn't keep a session between requests.

This changes it so that a request can contain the options you might want
to set using the `SET` command.  It also updates the Web UI to include a
widget to select the `store.format` option so users can specify the file
format that will be used be `CREATE TABLE AS`.  Additional options could
be added later if desired without much difficulty.

## Documentation

### POST /query.json

Submit a query and return results.

**Parameters**

* `queryType`--SQL, PHYSICAL, or LOGICAL are valid types. Use only "SQL". Other types are for internal use only.  
* `query`--A SQL query that runs in Drill.  
* `autoLimit`--Limits the number of rows returned from the result set. (Drill 1.16+)
* `options`--Object containing session options that you could have set using the SET command.  Note that numeric & boolean
  options should be provided as a number or boolean, not as a string.  A common iuse case would be to set `"store.format":"json"`
  to specify that `CREATE TABLE AS` should output in JSON format.

## Testing

I added a JUnit test.  I also did some manual testing.

(Please describe how this PR has been tested.)