### PR TITLE
DRILL-7582: Moved Drillbits REST API communication to the back end layer

### DIFF
--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -37,6 +37,17 @@
       <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerb-client</artifactId>
       <version>${kerby.version}</version>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -212,6 +212,7 @@ public final class ExecConstants {
   public static final String HTTP_JETTY_SERVER_SELECTORS = "drill.exec.http.jetty.server.selectors";
   public static final String HTTP_JETTY_SERVER_HANDLERS = "drill.exec.http.jetty.server.handlers";
   public static final String HTTP_ENABLE_SSL = "drill.exec.http.ssl_enabled";
+  public static final String HTTP_CLIENT_TIMEOUT = "drill.exec.http.client.timeout";
   public static final String HTTP_CORS_ENABLED = "drill.exec.http.cors.enabled";
   public static final String HTTP_CORS_ALLOWED_ORIGINS = "drill.exec.http.cors.allowedOrigins";
   public static final String HTTP_CORS_ALLOWED_METHODS = "drill.exec.http.cors.allowedMethods";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -17,15 +17,18 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -53,6 +56,7 @@ import org.apache.drill.exec.work.foreman.rm.DynamicResourceManager;
 import org.apache.drill.exec.work.foreman.rm.QueryQueue;
 import org.apache.drill.exec.work.foreman.rm.ResourceManager;
 import org.apache.drill.exec.work.foreman.rm.ThrottledResourceManager;
+import org.apache.http.client.methods.HttpPost;
 import org.glassfish.jersey.server.mvc.Viewable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -72,6 +76,8 @@ public class DrillRoot {
   SecurityContext sc;
   @Inject
   Drillbit drillbit;
+  @Inject
+  HttpServletRequest request;
 
   @GET
   @Produces(MediaType.TEXT_HTML)
@@ -130,6 +136,15 @@ public class DrillRoot {
   public Response shutdownDrillbit() throws Exception {
     String resp = "Graceful Shutdown request is triggered";
     return shutdown(resp);
+  }
+
+  @POST
+  @Path("/gracefulShutdown/{hostname}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed(ADMIN_ROLE)
+  public String shutdownDrillbitByName(@PathParam("hostname") String hostname) throws Exception {
+    URL shutdownURL = WebUtils.getDrillbitURL(work, request, hostname, "/gracefulShutdown");
+    return WebUtils.doHTTPRequest(new HttpPost(shutdownURL.toURI()), work.getContext().getConfig());
   }
 
   @POST

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StatusResources.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -32,6 +33,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -51,6 +53,7 @@ import org.apache.drill.exec.server.options.SystemOptionManager;
 import org.apache.drill.exec.server.rest.DrillRestServer.UserAuthEnabled;
 import org.apache.drill.exec.server.rest.auth.DrillUserPrincipal;
 import org.apache.drill.exec.work.WorkManager;
+import org.apache.http.client.methods.HttpGet;
 import org.glassfish.jersey.server.mvc.Viewable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -64,6 +67,7 @@ public class StatusResources {
   public static final String REST_API_SUFFIX = ".json";
   public static final String PATH_STATUS_JSON = "/status" + REST_API_SUFFIX;
   public static final String PATH_STATUS = "/status";
+  public static final String PATH_METRICS = PATH_STATUS + "/metrics";
   public static final String PATH_OPTIONS_JSON = "/options" + REST_API_SUFFIX;
   public static final String PATH_INTERNAL_OPTIONS_JSON = "/internal_options" + REST_API_SUFFIX;
   public static final String PATH_OPTIONS = "/options";
@@ -95,6 +99,14 @@ public class StatusResources {
   @Produces(MediaType.TEXT_HTML)
   public Viewable getStatus() {
     return ViewableWithPermissions.create(authEnabled.get(), "/rest/status.ftl", sc, getStatusJSON());
+  }
+
+  @GET
+  @Path(StatusResources.PATH_METRICS + "/{hostname}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getMetrics(@PathParam("hostname") String hostname) throws Exception {
+    URL metricsURL = WebUtils.getDrillbitURL(work, request, hostname, StatusResources.PATH_METRICS);
+    return WebUtils.doHTTPRequest(new HttpGet(metricsURL.toURI()), work.getContext().getConfig());
   }
 
   private List<OptionWrapper> getSystemOptionsJSONHelper(boolean internal)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUtils.java
@@ -17,12 +17,33 @@
  */
 package org.apache.drill.exec.server.rest;
 
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
+import org.apache.drill.exec.work.WorkManager;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.http.ssl.SSLContexts;
+
+import javax.net.ssl.SSLContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.stream.Collectors;
 
 public class WebUtils {
+
+  private static CloseableHttpAsyncClient httpClient;
 
   /**
    * Retrieves the CSRF protection token from the HTTP request.
@@ -47,5 +68,90 @@ public class WebUtils {
     byte[] buffer = new byte[32];
     new SecureRandom().nextBytes(buffer);
     return Base64.getUrlEncoder().withoutPadding().encodeToString(buffer);
+  }
+
+  /**
+   * Build an URL of a remote Drillbit endpoint.
+   *
+   * @param work {@link WorkManager} instance needed to retrieve the Drillbit address.
+   * @param request {@link HttpServletRequest} instance needed to set the URL schema.
+   * @param hostname hostname of the Drillbit.
+   * @param path relative path to the endpoint.
+   * @return remote Drillbit endpoint URL.
+   * @throws RuntimeException if there is no Drillbit at the given hostname.
+   */
+  static URL getDrillbitURL(WorkManager work, HttpServletRequest request, String hostname, String path) {
+    int drillbitPort = work.getContext().getAvailableBits().stream()
+        .filter(db -> db.getAddress().equals(hostname))
+        .findAny()
+        .map(DrillbitEndpoint::getHttpPort)
+        .orElseThrow(() -> new RuntimeException("No such drillbit: " + hostname));
+    try {
+      return new URL(request.getScheme(), hostname, drillbitPort, path);
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Should never occur", e);
+    }
+  }
+
+  /**
+   * Send an HTTP request and return response body as String.
+   *
+   * @param httpRequest {@link org.apache.http.client.methods.HttpGet} or {@link org.apache.http.client.methods.HttpPost} instance representing an HTTP request.
+   * @param drillConfig {@link DrillConfig} instance needed to setup HTTP Client.
+   * @return String response body.
+   * @throws Exception if unable to create HTTP client or in case of HTTP timeout.
+   */
+  static String doHTTPRequest(HttpRequestBase httpRequest, DrillConfig drillConfig) throws Exception {
+    CloseableHttpAsyncClient httpClient = getHttpClient(drillConfig);
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+        httpClient.execute(httpRequest, null)
+            .get()
+            .getEntity()
+            .getContent()))) {
+      return reader.lines().collect(Collectors.joining("\n"));
+    }
+  }
+
+  /**
+   * Get singleton instance of an HTTP Client.
+   *
+   * @param drillConfig {@link DrillConfig} instance needed to retrieve Drill SSL parameters.
+   * @return HTTP Client instance.
+   * @throws Exception if unable to create an HTTP Client.
+   */
+  private static CloseableHttpAsyncClient getHttpClient(DrillConfig drillConfig) throws Exception {
+    CloseableHttpAsyncClient localHttpClient = httpClient;
+    if (localHttpClient == null) {
+      synchronized (WebUtils.class) {
+        localHttpClient = httpClient;
+        if (httpClient == null) {
+          localHttpClient = createHttpClient(drillConfig);
+          localHttpClient.start();
+          httpClient = localHttpClient;
+        }
+      }
+    }
+    return localHttpClient;
+  }
+
+  private static CloseableHttpAsyncClient createHttpClient(DrillConfig drillConfig) throws Exception {
+    HttpAsyncClientBuilder clientBuilder = HttpAsyncClients.custom();
+    if (drillConfig.getBoolean(ExecConstants.HTTP_ENABLE_SSL)) {
+      SSLContext sslContext = SSLContexts.custom()
+          .loadTrustMaterial(new TrustSelfSignedStrategy())
+          .build();
+      SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(
+          sslContext,
+          new String[]{drillConfig.getString(ExecConstants.SSL_PROTOCOL)},
+          null,
+          SSLIOSessionStrategy.getDefaultHostnameVerifier()
+      );
+      clientBuilder.setSSLStrategy(sessionStrategy);
+    }
+    RequestConfig requestConfig = RequestConfig.custom()
+        .setConnectTimeout(drillConfig.getInt(ExecConstants.HTTP_CLIENT_TIMEOUT))
+        .build();
+    clientBuilder.setDefaultRequestConfig(requestConfig);
+    return clientBuilder.build();
   }
 }

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -131,6 +131,9 @@ drill.exec: {
   },
   http: {
     enabled: true,
+    client: {
+      timeout: 5000
+    },
     ssl_enabled: false,
     porthunt: false,
     port: 8047,


### PR DESCRIPTION
# [DRILL-7582](https://issues.apache.org/jira/browse/DRILL-7582): Moved Drillbits REST API communication to the back end layer

## Description

There is a list of Drillbits on the Web UI index page and some statistics, such as Heap Memory Usage, Direct Memory Usage, CPU Usage, Avg Sys Load, Uptime.
Retrieving these stats is implemented by javascript REST API calls from client side. This causes the following problems:
- Requires all Drillbit hostnames to be be added to client hosts as they are used in the URLs.
- Won't work with SSL/TLS enabled.
- Won't work if the Drill cluster is running in isolated environment such as Kubernetes.
- Won't work if Drill is running in docker and the Web port is remapped (e.g. -p 80:8047)

Now all these HTTP requests are sent by [org.apache.http.impl.nio.client.CloseableHttpAsyncClient](http://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/CloseableHttpAsyncClient.html) in back end.

## Documentation
Statistics should be displayed in all cases.

## Testing
Tested manually with SSL enabled/disabled as well as authentication.
Unit / Functional tests were passed.