### PR TITLE
DRILL-7587: Fix ValuesPrule distribution trait type

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrule.java
@@ -27,7 +27,7 @@ import org.apache.drill.exec.planner.logical.RelOptHelper;
 public class MetadataControllerPrule extends Prule {
   public static final MetadataControllerPrule INSTANCE = new MetadataControllerPrule();
 
-  public MetadataControllerPrule() {
+  private MetadataControllerPrule() {
     super(RelOptHelper.some(MetadataControllerRel.class, DrillRel.DRILL_LOGICAL,
         RelOptHelper.any(RelNode.class)), "MetadataControllerPrule");
   }
@@ -41,6 +41,8 @@ public class MetadataControllerPrule extends Prule {
     RelNode convertedLeft = convert(left, traits);
     RelNode convertedRight = convert(right, traits);
     call.transformTo(new MetadataControllerPrel(relNode.getCluster(),
-        relNode.getTraitSet().plus(Prel.DRILL_PHYSICAL), convertedLeft, convertedRight, relNode.getContext()));
+      // force singleton execution since this is the final step for metadata collection which collects all results into one
+      relNode.getTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON),
+      convertedLeft, convertedRight, relNode.getContext()));
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ValuesPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ValuesPrule.java
@@ -17,25 +17,25 @@
  */
 package org.apache.drill.exec.planner.physical;
 
-import org.apache.calcite.plan.RelOptRule;
-import org.apache.drill.exec.planner.logical.DrillRelFactories;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.drill.exec.planner.logical.DrillRel;
 import org.apache.drill.exec.planner.logical.DrillValuesRel;
 import org.apache.drill.exec.planner.logical.RelOptHelper;
-import org.apache.calcite.plan.RelOptRuleCall;
 
-public class ValuesPrule extends RelOptRule {
+public class ValuesPrule extends Prule {
 
   public static final ValuesPrule INSTANCE = new ValuesPrule();
 
   private ValuesPrule() {
-    super(RelOptHelper.any(DrillValuesRel.class), DrillRelFactories.LOGICAL_BUILDER, "Prel.ValuesPrule");
+    super(RelOptHelper.any(DrillValuesRel.class, DrillRel.DRILL_LOGICAL), "Prel.ValuesPrule");
   }
 
   @Override
   public void onMatch(final RelOptRuleCall call) {
-    final DrillValuesRel rel = call.rel(0);
+    DrillValuesRel rel = call.rel(0);
     call.transformTo(new ValuesPrel(rel.getCluster(), rel.getRowType(), rel.getTuples(),
-        rel.getTraitSet().plus(Prel.DRILL_PHYSICAL), rel.getContent()));
+      // force singleton execution since values rel contains all results and they cannot be split
+      rel.getTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON),
+      rel.getContent()));
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestValues.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestValues.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.sql;
+
+import org.apache.drill.categories.SqlTest;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(SqlTest.class)
+public class TestValues extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+  }
+
+  @Test
+  public void testSingle() throws Exception {
+    assertEquals("A", queryBuilder().sql("values('A')").singletonString());
+  }
+
+  @Test
+  public void testNamed() throws Exception {
+    testBuilder()
+      .sqlQuery("select col from (values('A'), ('B')) t(col)")
+      .unOrdered()
+      .baselineColumns("col")
+      .baselineValues("A")
+      .baselineValues("B")
+      .go();
+  }
+
+  @Test
+  public void testDistribution() throws Exception {
+    try {
+      client.alterSession(ExecConstants.SLICE_TARGET, 1);
+      testBuilder()
+        .sqlQuery("select id, name from (values(1, 'A'), (2, 'B')) t(id, name)")
+        .unOrdered()
+        .baselineColumns("id", "name")
+        .baselineValues(1L, "A")
+        .baselineValues(2L, "B")
+        .go();
+    } finally {
+      client.resetSession(ExecConstants.SLICE_TARGET);
+    }
+  }
+}


### PR DESCRIPTION
[DRILL-7587](https://issues.apache.org/jira/browse/DRILL-7587): Fix ValuesPrule distribution trait type

## Description

Incorrect result was retuning due to absence of singleton distribution trait which forces to run such type of queries only in one fragment.

## Documentation
NA

## Testing
Add unit tests and run full test suit, including Functional and Advanced tests.