### PR TITLE
DRILL-7477: Allow passing table function parameters into ANALYZE statement

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillTable.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.logical;
 
 import java.io.IOException;
 
+import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
@@ -168,9 +169,9 @@ public abstract class DrillTable implements Table {
   }
 
   public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable table) {
-    return new DrillScanRel(context.getCluster(),
-        context.getCluster().traitSetOf(DrillRel.DRILL_LOGICAL),
-        table);
+    // returns non-drill table scan to allow directory-based partition pruning
+    // before table group scan is created
+    return EnumerableTableScan.create(context.getCluster(), table);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.planner.sql;
 
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -328,4 +329,16 @@ public class SchemaUtilites {
     return schema;
   }
 
+  /**
+   * Returns schema path which corresponds to the specified table identifier.
+   * If table identifier contains only table name, empty list will be returned.
+   *
+   * @param tableIdentifier table identifier
+   * @return schema path which corresponds to the specified table identifier
+   */
+  public static List<String> getSchemaPath(SqlIdentifier tableIdentifier) {
+    return tableIdentifier.isSimple()
+        ? Collections.emptyList()
+        : tableIdentifier.names.subList(0, tableIdentifier.names.size() - 1);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/AnalyzeTableHandler.java
@@ -70,12 +70,12 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
 
     verifyNoUnsupportedFunctions(sqlAnalyzeTable);
 
-    SqlIdentifier tableIdentifier = sqlAnalyzeTable.getTableIdentifier();
+    SqlNode tableRef = sqlAnalyzeTable.getTableRef();
     SqlSelect scanSql = new SqlSelect(
         SqlParserPos.ZERO,              /* position */
         SqlNodeList.EMPTY,              /* keyword list */
         getColumnList(sqlAnalyzeTable), /* select list */
-        tableIdentifier,                /* from */
+        tableRef,                       /* from */
         null,                           /* where */
         null,                           /* group by */
         null,                           /* having */
@@ -85,13 +85,14 @@ public class AnalyzeTableHandler extends DefaultSqlHandler {
         null                            /* fetch */
     );
 
-    final ConvertedRelNode convertedRelNode = validateAndConvert(rewrite(scanSql));
-    final RelDataType validatedRowType = convertedRelNode.getValidatedRowType();
+    ConvertedRelNode convertedRelNode = validateAndConvert(rewrite(scanSql));
+    RelDataType validatedRowType = convertedRelNode.getValidatedRowType();
 
-    final RelNode relScan = convertedRelNode.getConvertedNode();
-    final String tableName = sqlAnalyzeTable.getName();
-    final AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
-        config.getConverter().getDefaultSchema(), sqlAnalyzeTable.getSchemaPath());
+    RelNode relScan = convertedRelNode.getConvertedNode();
+    DrillTableInfo drillTableInfo = DrillTableInfo.getTableInfoHolder(sqlAnalyzeTable.getTableRef(), config);
+    String tableName = drillTableInfo.tableName();
+    AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+        config.getConverter().getDefaultSchema(), drillTableInfo.schemaPath());
     Table table = SqlHandlerUtil.getTableFromSchema(drillSchema, tableName);
 
     if (table == null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DrillTableInfo.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.planner.sql.handlers;
+
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlUserDefinedTableMacro;
+import org.apache.calcite.util.Util;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.planner.logical.DrillTable;
+import org.apache.drill.exec.planner.logical.DrillTranslatableTable;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.store.AbstractSchema;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Holder class for {@link DrillTable}, {@code tableName} and table {@code schemaPath} obtained from
+ * {@code SqlNode tableRef}.
+ */
+public class DrillTableInfo {
+  private static final Logger logger = LoggerFactory.getLogger(DrillTableInfo.class);
+
+  private final DrillTable drillTable;
+  private final String tableName;
+  private final List<String> schemaPath;
+
+  private DrillTableInfo(DrillTable drillTable, List<String> schemaPath, String tableName) {
+    this.drillTable = drillTable;
+    this.tableName = tableName;
+    this.schemaPath = schemaPath;
+  }
+
+  public DrillTable drillTable() {
+    return drillTable;
+  }
+
+  public String tableName() {
+    return tableName;
+  }
+
+  public List<String> schemaPath() {
+    return schemaPath;
+  }
+
+  /**
+   * Returns {@link DrillTableInfo} instance which holds {@link DrillTable}, {@code drillTable},
+   * {@code schemaPath} corresponding to specified {@code tableRef}.
+   *
+   * @param tableRef table ref
+   * @param config   handler config
+   * @return {@link DrillTableInfo} instance
+   */
+  public static DrillTableInfo getTableInfoHolder(SqlNode tableRef, SqlHandlerConfig config) {
+    switch (tableRef.getKind()) {
+      case COLLECTION_TABLE: {
+        SqlCall call = (SqlCall) config.getConverter().validate(tableRef);
+        assert call.getOperandList().size() == 1;
+        SqlOperator operator = ((SqlCall) call.operand(0)).getOperator();
+        assert operator instanceof SqlUserDefinedTableMacro;
+        SqlUserDefinedTableMacro tableMacro = (SqlUserDefinedTableMacro) operator;
+        SqlIdentifier tableIdentifier = tableMacro.getSqlIdentifier();
+
+        AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+            config.getConverter().getDefaultSchema(), SchemaUtilites.getSchemaPath(tableIdentifier));
+
+        TranslatableTable translatableTable = tableMacro.getTable(config.getConverter().getTypeFactory(), prepareTableMacroOperands(call.operand(0)));
+        DrillTable table = ((DrillTranslatableTable) translatableTable).getDrillTable();
+        return new DrillTableInfo(table, drillSchema.getSchemaPath(), Util.last(tableIdentifier.names));
+      }
+      case IDENTIFIER: {
+        SqlIdentifier tableIdentifier = (SqlIdentifier) tableRef;
+        AbstractSchema drillSchema = SchemaUtilites.resolveToDrillSchema(
+            config.getConverter().getDefaultSchema(), SchemaUtilites.getSchemaPath(tableIdentifier));
+        String tableName = Util.last(tableIdentifier.names);
+        DrillTable table = getDrillTable(drillSchema, tableName);
+        return new DrillTableInfo(table, drillSchema.getSchemaPath(), tableName);
+      }
+      default:
+        throw new UnsupportedOperationException("Unsupported table ref kind: " + tableRef.getKind());
+    }
+  }
+
+  /**
+   * Returns list with operands for table function, obtained from specified call in the order
+   * suitable to be used in table function and default values for absent arguments.
+   * For example, for the following call:
+   * <pre>
+   *   `dfs`.`corrupted_dates`(`type` => 'parquet', `autoCorrectCorruptDates` => FALSE, `enableStringsSignedMinMax` => FALSE)
+   * </pre>
+   * will be returned the following list:
+   * <pre>
+   *   ['parquet', FALSE, FALSE, DEFAULT]
+   * </pre>
+   * whose elements correspond to the following parameters:
+   * <pre>
+   *   [type, autoCorrectCorruptDates, enableStringsSignedMinMax, schema]
+   * </pre>
+   *
+   * @param call sql call whose arguments should be prepared
+   * @return list with operands for table function
+   */
+  private static List<SqlNode> prepareTableMacroOperands(SqlCall call) {
+    Function<String, SqlNode> convertOperand = paramName -> call.getOperandList().stream()
+        .map(sqlNode -> (SqlCall) sqlNode)
+        .filter(sqlCall -> ((SqlIdentifier) sqlCall.operand(1)).getSimple().equals(paramName))
+        .peek(sqlCall -> Preconditions.checkState(sqlCall.getKind() == SqlKind.ARGUMENT_ASSIGNMENT))
+        .findFirst()
+        .map(sqlCall -> (SqlNode) sqlCall.operand(0))
+        .orElse(SqlStdOperatorTable.DEFAULT.createCall(SqlParserPos.ZERO));
+
+    SqlFunction operator = (SqlFunction) call.getOperator();
+
+    return operator.getParamNames().stream()
+        .map(convertOperand)
+        .collect(Collectors.toList());
+  }
+
+  private static DrillTable getDrillTable(AbstractSchema drillSchema, String tableName) {
+    Table tableFromSchema = SqlHandlerUtil.getTableFromSchema(drillSchema, tableName);
+
+    if (tableFromSchema == null) {
+      throw UserException.validationError()
+          .message("No table with given name [%s] exists in schema [%s]", tableName, drillSchema.getFullSchemaName())
+          .build(logger);
+    }
+
+    switch (tableFromSchema.getJdbcTableType()) {
+      case TABLE:
+        if (tableFromSchema instanceof DrillTable) {
+          return (DrillTable) tableFromSchema;
+        } else {
+          throw UserException.validationError()
+              .message("ANALYZE does not support [%s] table kind", tableFromSchema.getClass().getSimpleName())
+              .build(logger);
+        }
+      default:
+        throw UserException.validationError()
+            .message("ANALYZE does not support [%s] object type", tableFromSchema.getJdbcTableType())
+            .build(logger);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateTable.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
@@ -35,7 +36,6 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerUtil;
 import org.apache.drill.exec.util.Pointer;
@@ -131,11 +131,7 @@ public class SqlCreateTable extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (tblName.isSimple()) {
-      return ImmutableList.of();
-    }
-
-    return tblName.names.subList(0, tblName.names.size() - 1);
+    return SchemaUtilites.getSchemaPath(tblName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateView.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlCreateView.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.planner.sql.parser;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -106,11 +106,7 @@ public class SqlCreateView extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (viewName.isSimple()) {
-      return ImmutableList.of();
-    }
-
-    return viewName.names.subList(0, viewName.names.size()-1);
+    return SchemaUtilites.getSchemaPath(viewName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTable.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.DropTableHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
@@ -87,11 +88,7 @@ public class SqlDropTable extends DrillSqlCall {
   }
 
   public List<String> getSchema() {
-    if (tableName.isSimple()) {
-      return ImmutableList.of();
-    }
-
-    return tableName.names.subList(0, tableName.names.size()-1);
+    return SchemaUtilites.getSchemaPath(tableName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropTableMetadata.java
@@ -27,13 +27,13 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Util;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.MetastoreDropTableMetadataHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 import org.apache.drill.exec.util.Pointer;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class SqlDropTableMetadata extends DrillSqlCall {
@@ -94,11 +94,7 @@ public class SqlDropTableMetadata extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (tableName.isSimple()) {
-      return Collections.emptyList();
-    }
-
-    return tableName.names.subList(0, tableName.names.size() - 1);
+    return SchemaUtilites.getSchemaPath(tableName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropView.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlDropView.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.planner.sql.parser;
 
 import java.util.List;
 
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 import org.apache.drill.exec.planner.sql.handlers.ViewHandler.DropView;
@@ -87,11 +88,7 @@ public class SqlDropView extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (viewName.isSimple()) {
-      return ImmutableList.of();
-    }
-
-    return viewName.names.subList(0, viewName.names.size()-1);
+    return SchemaUtilites.getSchemaPath(viewName);
   }
 
   public String getName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlRefreshMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlRefreshMetadata.java
@@ -29,11 +29,11 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.RefreshMetadataHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
@@ -82,7 +82,7 @@ public class SqlRefreshMetadata extends DrillSqlCall {
       writer.keyword("COLUMNS");
       if (fieldList == null) {
         writer.keyword("NONE");
-      } else if (fieldList != null && fieldList.size() > 0) {
+      } else if (fieldList.size() > 0) {
         writer.keyword("(");
         fieldList.get(0).unparse(writer, leftPrec, rightPrec);
         for (int i = 1; i < fieldList.size(); i++) {
@@ -104,11 +104,7 @@ public class SqlRefreshMetadata extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (tblName.isSimple()) {
-      return ImmutableList.of();
-    }
-
-    return tblName.names.subList(0, tblName.names.size() - 1);
+    return SchemaUtilites.getSchemaPath(tblName);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/parser/SqlSchema.java
@@ -30,13 +30,13 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.drill.common.util.DrillStringUtils;
+import org.apache.drill.exec.planner.sql.SchemaUtilites;
 import org.apache.drill.exec.planner.sql.handlers.AbstractSqlHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerConfig;
 import org.apache.drill.exec.planner.sql.handlers.SchemaHandler;
 import org.apache.drill.exec.planner.sql.handlers.SqlHandlerUtil;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,10 +79,7 @@ public abstract class SqlSchema extends DrillSqlCall {
   }
 
   public List<String> getSchemaPath() {
-    if (hasTable()) {
-      return table.isSimple() ? Collections.emptyList() : table.names.subList(0, table.names.size() - 1);
-    }
-    return null;
+    return hasTable() ? SchemaUtilites.getSchemaPath(table) : null;
   }
 
   public String getTableName() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchema.java
@@ -261,6 +261,8 @@ public abstract class AbstractSchema implements Schema, SchemaPartitionExplorer,
       Table table = getTable(name);
       if (table instanceof DrillTable) {
         return applyFunctionParameters((DrillTable) table, parameters, arguments);
+      } else if (table == null) {
+        return null;
       }
       throw new DrillRuntimeException(String.format("Table [%s] is not of Drill table instance. " +
         "Given instance is of [%s].", name, table.getClass().getName()));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestAnalyze.java
@@ -110,7 +110,7 @@ public class TestAnalyze extends ClusterTest {
       client.alterSession(ExecConstants.OUTPUT_FORMAT_OPTION, "parquet");
       client.alterSession(ExecConstants.DETERMINISTIC_SAMPLING, true);
       run("CREATE TABLE dfs.tmp.employee_basic3 AS SELECT * from cp.`employee.json`");
-      run("ANALYZE TABLE dfs.tmp.employee_basic3 COMPUTE STATISTICS (employee_id, birth_date) SAMPLE 55 PERCENT");
+      run("ANALYZE TABLE table(dfs.tmp.employee_basic3 (type => 'parquet')) COMPUTE STATISTICS (employee_id, birth_date) SAMPLE 55 PERCENT");
 
       testBuilder()
           .sqlQuery("SELECT tbl.`columns`.`column` as `column`, tbl.`columns`.rowcount is not null as has_rowcount,"


### PR DESCRIPTION
# [DRILL-7477](https://issues.apache.org/jira/browse/DRILL-7477): Allow passing table function parameters into ANALYZE statement

## Description

Updated `parserImpls.ftl` to allow using table function in `ANALYZE` statement, updated corresponding table handlers.
Added changes to `WorkspaceSchema` to use `MetadataProviderManager` for table functions.
Updated `DrillTable` to return `EnumerableTableScan` instead of `DrillScanRel` during SQL to rel conversion to postpone group scan creation and fix dirs pruning when table function is used.

## Documentation
Additional docs to the Drill Web Site will be added in the scope of #1986.

This PR allows the following syntax:
```
ANALYZE TABLE table(dfs.`table_name` (type => 'parquet', autoCorrectCorruptDates => false, enableStringsSignedMinMax=>false, schema=>'inline=(mykey int, col_notexist varchar)')) REFRESH METADATA;
```
instead of using regular table function.

## Testing
Added tests to verify that table function is used when executing `ANALYZE`. Added test to verify that dirs pruning is done when table function is used.
