### PR TITLE
DRILL-7615: UNION ALL query returns the wrong result for the decimal value

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/join/JoinUtils.java
@@ -159,7 +159,7 @@ public class JoinUtils {
     // or both of them are decimal
     if (TypeCastRules.isNumericType(input1) && TypeCastRules.isNumericType(input2)
         && ((!Types.isDecimalType(input1) && !Types.isDecimalType(input2))
-          || Types.isDecimalType(input1) && Types.isDecimalType(input2))) {
+          || Types.areDecimalTypes(input1, input2))) {
       return true;
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestVarlenDecimal.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestVarlenDecimal.java
@@ -18,8 +18,14 @@
 package org.apache.drill.exec.store.parquet;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.drill.categories.ParquetTest;
 import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.test.ClusterFixture;
@@ -33,6 +39,8 @@ import org.junit.experimental.categories.Category;
 
 import java.math.BigDecimal;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 
 @Category({ParquetTest.class, UnlikelyTest.class})
 public class TestVarlenDecimal extends ClusterTest {
@@ -168,6 +176,15 @@ public class TestVarlenDecimal extends ClusterTest {
           .baselineValues(new BigDecimal("1000.000"))
           .baselineValues(new BigDecimal("596.000"))
           .baselineValues(new BigDecimal("999999999999999.000"))
+          .go();
+
+      List<Pair<SchemaPath, TypeProtos.MajorType>> expectedSchema = Collections.singletonList(Pair.of(
+          SchemaPath.getSimplePath("d"),
+          Types.withPrecisionAndScale(MinorType.VARDECIMAL, DataMode.REQUIRED, 18, 3)));
+
+      testBuilder()
+          .sqlQuery(query)
+          .schemaBaseLine(expectedSchema)
           .go();
     } finally {
       run("drop table if exists dfs.tmp.t");

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
@@ -451,16 +451,6 @@ public class MaterializedField {
     return toString(true);
   }
 
-  /**
-   * Return true if two fields have identical MinorType and Mode.
-   * @param that
-   * @return
-   */
-  public boolean hasSameTypeAndMode(MaterializedField that) {
-    return (getType().getMinorType() == that.getType().getMinorType())
-        && (getType().getMode() == that.getType().getMode());
-  }
-
   private String toString(Collection<?> collection, int maxLen) {
     final StringBuilder builder = new StringBuilder();
     int i = 0;


### PR DESCRIPTION
# [DRILL-7615](https://issues.apache.org/jira/browse/DRILL-7615): UNION ALL query returns the wrong result for the decimal value

## Description
Added checks for union operator to create casts for the case when both input columns have a decimal type, but its scale differs. Enhanced calculation of resulting scale and precision for the decimal data type.

## Documentation
NA

## Testing
Added unit tests to check the fix, ran full tests suite.
