### PR TITLE
DRILL-7617: Disabled plugins not showing in Web UI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -128,7 +128,7 @@ public class StorageResources {
         .map(plugin -> new StoragePluginModel(plugin, request))
         .collect(Collectors.toList());
     // Creating an empty model with CSRF token, if there are no storage plugins
-    if (model.size() == 0) {
+    if (model.isEmpty()) {
       model.add(new StoragePluginModel(null, request));
     }
     return ViewableWithPermissions.create(authEnabled.get(), "/rest/storage/list.ftl", sc, model);
@@ -315,7 +315,6 @@ public class StorageResources {
     public String getResult() {
       return result;
     }
-
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistry.java
@@ -61,10 +61,10 @@ public interface StoragePluginRegistry extends Iterable<Map.Entry<String, Storag
   StoragePlugin getPlugin(StoragePluginConfig config) throws ExecutionSetupException;
 
   /**
-   * Retrieve a plugin configuration by name.
-   *
-   * @param name
-   * @return
+   * Retrieve a stored configuration by name. Returns only defined
+   * plugins (not system plugins). Returns both enabled and disabled
+   * plugins. Use this to obtain a plugin for editing (rather than
+   * for planning or executing a query.)
    */
   StoragePluginConfig getConfig(String name);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -338,12 +338,9 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
    */
   private boolean loadEnabledPlugins() {
     Iterator<Entry<String, StoragePluginConfig>> allPlugins = pluginStore.load();
-    if (!allPlugins.hasNext()) {
-      // Nothing found, this is (likely) a new install and should be
-      // initialized
-      return false;
-    }
+    int count = 0;
     while (allPlugins.hasNext()) {
+      count++;
       Entry<String, StoragePluginConfig> plugin = allPlugins.next();
       String name = plugin.getKey();
       StoragePluginConfig config = plugin.getValue();
@@ -358,8 +355,8 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
         pluginStore.put(name, config);
       }
     }
-    // Found at least one entry, so this is an existing registry.
-    return true;
+    // If found at least one entry then this is an existing registry.
+    return count > 0;
   }
 
   @Override
@@ -429,8 +426,11 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
 
   @Override
   public StoragePluginConfig getConfig(String name) {
-    PluginHandle entry = getEntry(name);
-    return entry == null ? null : entry.config();
+    PluginHandle plugin = pluginCache.get(name);
+    if (plugin != null) {
+      return plugin.isIntrinsic() ? null : plugin.config();
+    }
+    return pluginStore.get(name);
   }
 
   // Gets a plugin with the named configuration

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/TestPluginRegistry.java
@@ -66,6 +66,8 @@ public class TestPluginRegistry extends BasePluginRegistryTest {
       // Bootstrap file loaded.
       assertNotNull(registry.getPlugin(StoragePluginTestUtils.CP_PLUGIN_NAME)); // Normal
       assertNotNull(registry.getPlugin("sys")); // System
+      assertNull(registry.getConfig("sys")); // Not editable
+
       assertNull(registry.getPlugin("bogus"));
 
       // Enabled plugins
@@ -78,6 +80,8 @@ public class TestPluginRegistry extends BasePluginRegistryTest {
       configMap = registry.storedConfigs();
       assertTrue(configMap.containsKey(StoragePluginTestUtils.CP_PLUGIN_NAME));
       assertTrue(configMap.containsKey("s3")); // Disabled, but still appears
+      assertNotNull(configMap.get("s3"));
+      assertSame(registry.getConfig("s3"), configMap.get("s3"));
       assertFalse(configMap.containsKey("sys"));
       int bootstrapCount = configMap.size();
 


### PR DESCRIPTION
# [DRILL-7617](https://issues.apache.org/jira/browse/DRILL-7617): Disabled plugins not showing in Web UI

## Description

Fixes a misunderstanding in prior PR: `StoragePluginRegistry.`getConfigs()` should return both enabled and disabled configs. This contrasts with other `get` methods which return only enabled plugins.

## Testing

Added additional unit tests to verify behavior. Ran the full Drill to reproduce the scenario in the Jira ticket. Web UI now works as expected.