### PR TITLE
DRILL-7619: Fixed link to the metrics endpoint

### DIFF
--- a/exec/java-exec/src/main/resources/rest/index.ftl
+++ b/exec/java-exec/src/main/resources/rest/index.ftl
@@ -475,7 +475,7 @@
 
       //Update memory
       function updateMetricsHtml(drillbit, isCurrent, idx) {
-        let drillbitURL = isCurrent ? "/status/metrics" : "/status/" + drillbit + "/metrics";
+        let drillbitURL = isCurrent ? "/status/metrics" : "/status/metrics/" + drillbit;
         let result = $.ajax({
           type: 'GET',
           url: drillbitURL,


### PR DESCRIPTION
# [DRILL-7619](https://issues.apache.org/jira/browse/DRILL-7619): Fixed link to the metrics endpoint

## Description

Fixed link to the metrics endpoint

## Documentation
n/a

## Testing
Tested manually on the Web UI
