### PR TITLE
DRILL-7622: Compilation error when using HLL / TDigest with group by

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
@@ -159,7 +159,7 @@ class DrillAggFuncHolder extends DrillFuncHolder {
     for (int i = 0; i < getWorkspaceVars().length; i++) {
       if (getWorkspaceVars()[i].isInject()) {
         workspaceJVars[i] = g.declareClassField("work", g.getModel()._ref(getWorkspaceVars()[i].getType()));
-        g.getBlock(BlockType.SETUP).assign(workspaceJVars[i], g.getMappingSet().getIncoming().invoke("getContext").invoke("getManagedBuffer"));
+        assignInjectableValue(g, workspaceJVars[i], getWorkspaceVars()[i]);
       } else {
         Preconditions.checkState(Types.isFixedWidthType(getWorkspaceVars()[i].getMajorType()), String.format("Workspace variable '%s' in aggregation function '%s' is not allowed to " +
             "have variable length type.", getWorkspaceVars()[i].getName(), getRegisteredNames()[0]));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestAggregateFunctions.java
@@ -1224,4 +1224,19 @@ public class TestAggregateFunctions extends ClusterTest {
       client.resetSession(PlannerSettings.STREAMAGG.getOptionName());
     }
   }
+
+  @Test
+  public void testInjectVariablesHashAgg() throws Exception {
+    try {
+      client.alterSession(PlannerSettings.STREAMAGG.getOptionName(), false);
+      testBuilder()
+          .sqlQuery("select tdigest(p.col_int) from " +
+              "cp.`parquet/alltypes_required.parquet` p group by p.col_flt")
+          .unOrdered()
+          .expectsNumRecords(4)
+          .go();
+    } finally {
+      client.resetSession(PlannerSettings.STREAMAGG.getOptionName());
+    }
+  }
 }


### PR DESCRIPTION
# [DRILL-7622](https://issues.apache.org/jira/browse/DRILL-7622): DRILL-7622: Compilation error when using HLL / TDigest with group by

## Description
Fixes code generation for workspace variables injected from OperationContext

## Testing
Appropriate unit test added (TestBugFixes#testDRILL7622)
