### PR TITLE
DRILL-7623: Link error is displayed at the log content page on Web UI

### DIFF
--- a/exec/java-exec/src/main/resources/ace.mode-sql.template.js
+++ b/exec/java-exec/src/main/resources/ace.mode-sql.template.js
@@ -15,17 +15,18 @@ var SqlHighlightRules = function() {
     //Covered: https://drill.apache.org/docs/supported-sql-commands/
     var keywords = (
         "select|insert|update|delete|from|where|and|or|group|by|order|limit|offset|having|as|case|" +
-        "when|else|end|type|left|right|join|on|outer|desc|asc|union|create|table|key|if|lateral|apply|unnest|" +
+        "when|else|end|type|left|right|cross|join|on|outer|desc|asc|union|create|table|key|if|lateral|apply|unnest|" +
         "not|default|null|inner|database|drop|" +
         "flatten|kvgen|columns|" +
         "set|reset|alter|session|system|" +
         "temporary|function|using|jar|between|distinct|" +
         "partition|view|schema|files|" +
         "explain|plan|with|without|implementation|" +
-        "show|describe|use"
+        "show|describe|use|" +
+        "analyze|refresh|metadata|none|level|compute|estimate|statistics|sample|percent|exists"
     );
     //Confirmed to be UnSupported as of Drill-1.12.0
-    /* cross|natural|primary|foreign|references|grant */
+    /* natural|primary|foreign|references|grant */
 
     var builtinConstants = (
         "true|false"

--- a/exec/java-exec/src/main/resources/rest/generic.ftl
+++ b/exec/java-exec/src/main/resources/rest/generic.ftl
@@ -35,7 +35,7 @@
 
       <link href="/static/css/bootstrap.min.css" rel="stylesheet">
 
-      <script type="text/javascript" language="javascript" src="../static/js/jquery-3.2.1.min.js"></script>
+      <script type="text/javascript" language="javascript" src="/static/js/jquery-3.2.1.min.js"></script>
       <script src="/static/js/bootstrap.min.js"></script>
 
       <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/exec/java-exec/src/main/resources/rest/query/result.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/result.ftl
@@ -19,8 +19,8 @@
 -->
 <#include "*/generic.ftl">
 <#macro page_head>
-    <script type="text/javascript" language="javascript"  src="../static/js/jquery.dataTables-1.10.0.min.js"> </script>
-    <script type="text/javascript" language="javascript" src="../static/js/dataTables.colVis-1.1.0.min.js"></script>
+    <script type="text/javascript" language="javascript"  src="/static/js/jquery.dataTables-1.10.0.min.js"> </script>
+    <script type="text/javascript" language="javascript" src="/static/js/dataTables.colVis-1.1.0.min.js"></script>
     <link href="/static/css/dataTables.colVis-1.1.0.min.css" rel="stylesheet">
     <link href="/static/css/dataTables.jqueryui.css" rel="stylesheet">
     <link href="/static/css/jquery-ui-1.10.3.min.css" rel="stylesheet">


### PR DESCRIPTION
# [DRILL-7623](https://issues.apache.org/jira/browse/DRILL-7623): Link error is displayed at the log content page on Web UI

## Description
Updated links to `jquery` to use an absolute path and revised code for similar issues.
Added metastore-related keywords to be highlighted when printing queries.

## Documentation
NA

## Testing
Checked manually.
