### PR TITLE
Clean up a bit, add example for s3 storage of query profiles

### DIFF
--- a/_docs/configure-drill/configuration-options/040-persistent-configuration-storage.md
+++ b/_docs/configure-drill/configuration-options/040-persistent-configuration-storage.md
@@ -18,32 +18,25 @@ modes:
 
 ## Configuring ZooKeeper PStore
 
-Drill uses ZooKeeper to
-store persistent configuration data. The ZooKeeper PStore provider stores all
-of the persistent configuration data in ZooKeeper except for query profile
-data. The ZooKeeper PStore provider offloads query profile data to the Drill log directory on Drill nodes. 
+Drill uses ZooKeeper to store persistent configuration data. The ZooKeeper PStore provider stores all of the persistent configuration data in ZooKeeper except for query profile data. By default, Drill stores query profile data to the Drill log directory on Drill nodes. 
 
-You need to configure the ZooKeeper PStore to use the Drill Web UI when running multiple Drillbits. 
+If you are running multiple drillbits, it is likely that the log folder is not shared between them. In this case each drillbit will only have access to profiles for the queries where it was the foreman. To make query profiles visible globally, configure drill to use a shared location for query profiles by setting the `drill.exec.sys.store.provider.zk.blobroot` in `drill-override.conf`.
 
-### Why Configure the ZooKeeper PStore
+**Examples**
 
-When you run multiple DrillBits, configure a specific location for ZooKeeper to offload the query profile data instead of accepting the default temporary location. All Drillbits in the cluster cannot access the temporary location. Consequently, when you do not configure a location on the distributed file system, queries sent to some Drillbits do not appear in the Completed section of the Drill Web UI. Also, some Running links that you click to get information about running queries are broken links.
-
-### How to Configure the ZooKeeper PStore
-
-To configure the ZooKeeper PStore, set the `sys.store.provider.zk.blobroot` property in the `drill.exec`
-block in `<drill_installation_directory>/conf/drill-override.conf` on each
-Drill node and then restart the Drillbit service.
-
-**Example**
+Store query profiles on HDFS:
 
 	drill.exec: {
-	 cluster-id: "my_cluster_com-drillbits",
-	 zk.connect: "<zkhostname>:<port>",
-	 sys.store.provider.zk.blobroot: "hdfs:///apps/drill/pstore/"
+	  sys.store.provider.zk.blobroot: "hdfs:///apps/drill/pstore/"
 	}
 
-[Restart the Drillbit]({{site.baseurl}}/docs/starting-drill-in-distributed-mode/).
+Store query profiles on Amazon S3:
+
+	drill.exec: {
+	  sys.store.provider.zk.blobroot: "s3a://drill-query-profiles"
+	}
+
+Changes will take effect when you [Restart the Drillbit]({{site.baseurl}}/docs/starting-drill-in-distributed-mode/).
 
 ## Configuring HBase for Persistent Configuration Storage
 
@@ -64,6 +57,6 @@ override.conf.`
 	    }
 	  },  
 
-##Storing Query Profiles in Memory
-As of Drill 1.11, Drill can store query profiles in memory instead of writing them to disk. For sub-second queries, writing the query profile to disk is expensive due to the interactions with the file system. You can enable the `drill.exec.profiles.store.inmemory` option in the drill-override.conf file if you want Drill to store the profiles for sub-second queries in memory instead of writing the profiles to disk. When you enable this option, Drill stores the profiles in memory for as long as the drillbit runs. When the drillbit restarts, the profiles no longer exist. You can set the maximum number of most recent profiles to retain in memory through the `drill.exec.profiles.store.capacity` option. See [Start-Up Options]({{site.baseurl}}/docs/start-up-options/) for more information. You must [restart the drillbit]({{site.baseurl}}/docs/starting-drill-in-distributed-mode/) after you enable the `drill.exec.profiles.store.inmemory` option. 
+## Storing Query Profiles in Memory
 
+As of Drill 1.11, Drill can store query profiles in memory instead of writing them to disk. For sub-second queries, writing the query profile to disk is expensive due to the interactions with the file system. You can enable the `drill.exec.profiles.store.inmemory` option in the drill-override.conf file if you want Drill to store the profiles for sub-second queries in memory instead of writing the profiles to disk. When you enable this option, Drill stores the profiles in memory for as long as the drillbit runs. When the drillbit restarts, the profiles no longer exist. You can set the maximum number of most recent profiles to retain in memory through the `drill.exec.profiles.store.capacity` option. See [Start-Up Options]({{site.baseurl}}/docs/start-up-options/) for more information. You must [restart the drillbit]({{site.baseurl}}/docs/starting-drill-in-distributed-mode/) after you enable the `drill.exec.profiles.store.inmemory` option. 


### PR DESCRIPTION
Try to improve PStore configuration docs to be a bit less confusing (to me at least), and also add an example showing how you could store the query profiles on Amazon S3 (which would have been useful information to me)
