### PR TITLE
DRILL-7627: Update MySql version for JdbcStoragePlugin tests and cache ~/.embedmysql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
               ${{ runner.os }}-maven-
+      # Caches MySQL directory used for JDBC storage plugin tests
+      - name: Cache MySQL
+        uses: actions/cache@v1
+        with:
+          path: ~/.embedmysql
+          key: ${{ runner.os }}-mysql
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:

--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -31,7 +31,9 @@
   <name>contrib/jdbc-storage-plugin</name>
 
   <properties>
-    <mysql.connector.version>8.0.13</mysql.connector.version>
+    <mysql.connector.version>8.0.19</mysql.connector.version>
+    <wix-embedded-mysql.version>4.6.1</wix-embedded-mysql.version>
+    <h2.version>1.4.200</h2.version>
   </properties>
 
   <dependencies>
@@ -69,13 +71,13 @@
     <dependency>
       <groupId>com.wix</groupId>
       <artifactId>wix-embedded-mysql</artifactId>
-      <version>4.2.0</version>
+      <version>${wix-embedded-mysql.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.197</version>
+      <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * JDBC storage plugin tests against MySQL.
- * Note: it requires libaio.so library in the system
+ * Note: it requires libaio1.so library on Linux
  */
 @Category(JdbcStorageTest.class)
 public class TestJdbcPluginWithMySQLIT extends ClusterTest {
@@ -53,7 +53,7 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
     String mysqlDBName = "drill_mysql_test";
     int mysqlPort = QueryTestUtil.getFreePortNumber(2215, 300);
 
-    MysqldConfig config = MysqldConfig.aMysqldConfig(Version.v5_6_21)
+    MysqldConfig config = MysqldConfig.aMysqldConfig(Version.v5_7_27)
         .withPort(mysqlPort)
         .withUser("mysqlUser", "mysqlPass")
         .withTimeZone(DateTimeZone.UTC.toTimeZone())


### PR DESCRIPTION
# [DRILL-7627](https://issues.apache.org/jira/browse/DRILL-7627): Update MySql version for JdbcStoragePlugin tests and cache ~/.embedmysql

## Description
Update MySql version 5.7.27 for JdbcStoragePlugin tests and cache ~/.embedmysql during GitHub Actions CI run.

## Documentation
NA

## Testing
Ran all tests.
