### PR TITLE
DRILL-7628: Fix Mongo tests broken after the fix for DRILL-7547

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -31,7 +31,7 @@
   <name>contrib/mongo-storage-plugin</name>
 
   <properties>
-     <mongo.TestSuite>**/MongoTestSuit.class</mongo.TestSuite>
+     <mongo.TestSuite>**/MongoTestSuite.class</mongo.TestSuite>
   </properties>
 
   <dependencies>

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/DrillMongoConstants.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/DrillMongoConstants.java
@@ -19,33 +19,39 @@ package org.apache.drill.exec.store.mongo;
 
 public interface DrillMongoConstants {
 
-  public static final String SYS_STORE_PROVIDER_MONGO_URL = "drill.exec.sys.store.provider.mongo.url";
+  String SYS_STORE_PROVIDER_MONGO_URL = "drill.exec.sys.store.provider.mongo.url";
 
-  public static final String ID = "_id";
+  String ID = "_id";
 
-  public static final String SHARDS = "shards";
+  String SHARDS = "shards";
 
-  public static final String NS = "ns";
+  String NS = "ns";
 
-  public static final String SHARD = "shard";
+  String SHARD = "shard";
 
-  public static final String HOST = "host";
+  String HOST = "host";
 
-  public static final String CHUNKS = "chunks";
+  String CHUNKS = "chunks";
 
-  public static final String SIZE = "size";
+  String SIZE = "size";
 
-  public static final String COUNT = "count";
+  String COUNT = "count";
 
-  public static final String CONFIG = "config";
+  String CONFIG = "config";
 
-  public static final String MIN = "min";
+  String MIN = "min";
 
-  public static final String MAX = "max";
+  String MAX = "max";
 
-  public static final String PARTITIONED = "partitioned";
+  String PARTITIONED = "partitioned";
 
-  public static final String PRIMARY = "primary";
+  String PRIMARY = "primary";
 
-  public static final String DATABASES = "databases";
+  String DATABASES = "databases";
+
+  String STORE_CONFIG_PREFIX = "drill.exec.store.";
+
+  String USERNAME_CONFIG_SUFFIX = ".username";
+
+  String PASSWORD_CONFIG_SUFFIX = ".password";
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -35,6 +35,7 @@ public interface MongoTestConstants {
   int MONGOS_PORT = 27017;
 
   String EMPLOYEE_DB = "employee";
+  String AUTHENTICATION_DB = "admin";
   String DONUTS_DB = "donuts";
 
   String DONUTS_COLLECTION = "donuts";

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoStoragePluginUsesCredentialsStore.java
@@ -18,17 +18,20 @@
 package org.apache.drill.exec.store.mongo;
 
 import com.mongodb.MongoCredential;
+import org.apache.drill.categories.MongoStorageTest;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.test.BaseTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestMongoStoragePluginUsesCredentialsStore {
+@Category({MongoStorageTest.class})
+public class TestMongoStoragePluginUsesCredentialsStore extends BaseTest {
 
-  private void test(String expectedUserName, String expectedPassword, String connection, String name) throws IOException, ExecutionSetupException {
+  private void test(String expectedUserName, String expectedPassword, String connection, String name) throws ExecutionSetupException {
     MongoStoragePlugin plugin = new MongoStoragePlugin(new MongoStoragePluginConfig(
       connection), null, name);
     List<MongoCredential> creds = plugin.getClient().getCredentialsList();


### PR DESCRIPTION
# [DRILL-7628](https://issues.apache.org/jira/browse/DRILL-7628): Fix Mongo tests broken after the fix for DRILL-7547

## Description
Fixed test suite name in pom file, since all mongo tests were skipped during tests run because of this issue. Made changes to create mongo user for tests using a conf file. Added missed `TestMongoStoragePluginUsesCredentialsStore` to the test suite.

## Documentation
NA

## Testing
Ran all tests.
