### PR TITLE
DRILL-7632: Improve user exception formatting

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionContext.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserExceptionContext.java
@@ -67,7 +67,7 @@ class UserExceptionContext {
    * @param value context value
    */
   void add(String context, String value) {
-    add(context + " " + value);
+    add(deColon(context) + ": " + value);
   }
 
   /**
@@ -76,7 +76,7 @@ class UserExceptionContext {
    * @param value context value
    */
   void add(String context, long value) {
-    add(context + " " + value);
+    add(deColon(context) + ": " + value);
   }
 
   /**
@@ -85,7 +85,16 @@ class UserExceptionContext {
    * @param value context value
    */
   void add(String context, double value) {
-    add(context + " " + value);
+    add(deColon(context) + ": " + value);
+  }
+
+  private String deColon(String context) {
+    context = context.trim();
+    if (context.endsWith(":")) {
+      return context.substring(0, context.length() - 1);
+    } else {
+      return context;
+    }
   }
 
   /**
@@ -102,7 +111,7 @@ class UserExceptionContext {
    * @param value context value
    */
   void push(String context, String value) {
-    push(context + " " + value);
+    push(deColon(context) + ": " + value);
   }
 
   /**
@@ -111,7 +120,7 @@ class UserExceptionContext {
    * @param value context value
    */
   void push(String context, long value) {
-    push(context + " " + value);
+    push(deColon(context) + ": " + value);
   }
 
   /**
@@ -120,7 +129,7 @@ class UserExceptionContext {
    * @param value context value
    */
   void push(String context, double value) {
-    push(context + " " + value);
+    push(deColon(context) + ": " + value);
   }
 
   String getErrorId() {


### PR DESCRIPTION
# [DRILL-7632](https://issues.apache.org/jira/browse/DRILL-7632): Improve user exception formatting

## Description

Modifies user exception to insert a colon between the "context" title and value. Old style:
```
My Context value
```
Revised:
```
My Context: value
```

Some code already added their own colons. So, the fix removes any existing colon before adding its own.

## Documentation

If the documentation shows exception output, and those exceptions contain context, then the format of that exception will change and such examples should be updated.

## Testing

Reran the full unit tests.
