### PR TITLE
DRILL-7634: Rollup of code cleanup changes

### DIFF
--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillConfigurationException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillConfigurationException.java
@@ -17,10 +17,10 @@
  */
 package org.apache.drill.common.exceptions;
 
+@SuppressWarnings("serial")
 public class DrillConfigurationException extends DrillException {
-  public DrillConfigurationException() {
-    super();
-  }
+
+  public DrillConfigurationException() { }
 
   public DrillConfigurationException(String message, Throwable cause, boolean enableSuppression,
       boolean writableStackTrace) {
@@ -38,6 +38,4 @@ public class DrillConfigurationException extends DrillException {
   public DrillConfigurationException(Throwable cause) {
     super(cause);
   }
-
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillConfigurationException.class);
 }

--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillError.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillError.java
@@ -17,12 +17,10 @@
  */
 package org.apache.drill.common.exceptions;
 
+@SuppressWarnings("serial")
 public class DrillError extends Error {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillError.class);
 
-  public DrillError() {
-    super();
-  }
+  public DrillError() { }
 
   public DrillError(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
@@ -39,6 +37,4 @@ public class DrillError extends Error {
   public DrillError(Throwable cause) {
     super(cause);
   }
-
-
 }

--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillIOException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillIOException.java
@@ -19,12 +19,10 @@ package org.apache.drill.common.exceptions;
 
 import java.io.IOException;
 
+@SuppressWarnings("serial")
 public class DrillIOException extends IOException{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillIOException.class);
 
-  public DrillIOException() {
-    super();
-  }
+  public DrillIOException() { }
 
   public DrillIOException(String message, Throwable cause) {
     super(message, cause);
@@ -37,6 +35,4 @@ public class DrillIOException extends IOException{
   public DrillIOException(Throwable cause) {
     super(cause);
   }
-
-
 }

--- a/common/src/main/java/org/apache/drill/common/exceptions/RetryAfterSpillException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/RetryAfterSpillException.java
@@ -18,9 +18,10 @@
 package org.apache.drill.common.exceptions;
 
 /**
- *  A special exception to be caught by caller, who is supposed to free memory by spilling and try again
- *
+ * Special exception to be caught by caller, who is supposed to free memory by
+ * spilling and try again
  */
+@SuppressWarnings("serial")
 public class RetryAfterSpillException extends Exception {
 
 }

--- a/common/src/main/java/org/apache/drill/common/exceptions/UserRemoteException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/UserRemoteException.java
@@ -22,9 +22,11 @@ import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 import static org.apache.drill.common.util.DrillExceptionUtil.getThrowable;
 
 /**
- * Wraps a DrillPBError object so we don't need to rebuilt it multiple times when sending it to the client. It also
- * gives access to the original exception className and message.
+ * Wraps a DrillPBError object so we don't need to rebuilt it multiple times
+ * when sending it to the client. It also gives access to the original exception
+ * className and message.
  */
+@SuppressWarnings("serial")
 public class UserRemoteException extends UserException {
 
   private final DrillPBError error;

--- a/common/src/main/java/org/apache/drill/common/types/Types.java
+++ b/common/src/main/java/org/apache/drill/common/types/Types.java
@@ -844,7 +844,6 @@ public class Types {
    * @return true if the two types have the same minor type, mode,
    * precision and scale
    */
-
   public static boolean isSameType(MajorType type1, MajorType type2) {
     return isSameTypeAndMode(type1, type2) &&
            type1.getScale() == type2.getScale() &&
@@ -870,7 +869,6 @@ public class Types {
    * But, unset fields are equivalent to 0. Can't use the protobuf-provided
    * isEquals() which treats set and unset fields as different.
    */
-
   public static boolean isEquivalent(MajorType type1, MajorType type2) {
 
     if (!isSameType(type1, type2)) {
@@ -878,7 +876,6 @@ public class Types {
     }
 
     // Subtypes are only for unions and are seldom used.
-
     if (type1.getMinorType() != MinorType.UNION) {
       return true;
     }
@@ -896,7 +893,6 @@ public class Types {
     }
 
     // Now it gets slow because subtype lists are not ordered.
-
     final List<MinorType> copy1 = new ArrayList<>(subtypes1);
     final List<MinorType> copy2 = new ArrayList<>(subtypes2);
     Collections.sort(copy1);
@@ -913,7 +909,6 @@ public class Types {
    * @return string key to use for this type in a union vector type
    * map
    */
-
   public static String typeKey(MinorType type) {
     return type.name().toLowerCase();
   }

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBFilterBuilder.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/MapRDBFilterBuilder.java
@@ -18,7 +18,9 @@
 package org.apache.drill.exec.store.mapr.db.binary;
 
 import java.util.Arrays;
+import java.util.List;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -39,7 +41,6 @@ import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void, RuntimeException> implements DrillHBaseConstants {
 
@@ -59,7 +60,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
   public HBaseScanSpec parseTree() {
     HBaseScanSpec parsedSpec = le.accept(this, null);
     if (parsedSpec != null) {
-      parsedSpec = mergeScanSpecs("booleanAnd", this.groupScan.getHBaseScanSpec(), parsedSpec);
+      parsedSpec = mergeScanSpecs(FunctionNames.AND, this.groupScan.getHBaseScanSpec(), parsedSpec);
       /*
        * If RowFilter is THE filter attached to the scan specification,
        * remove it since its effect is also achieved through startRow and stopRow.
@@ -93,7 +94,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
   public HBaseScanSpec visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
     HBaseScanSpec nodeScanSpec = null;
     String functionName = call.getName();
-    ImmutableList<LogicalExpression> args = call.args;
+    List<LogicalExpression> args = call.args();
 
     if (MaprDBCompareFunctionsProcessor.isCompareFunction(functionName)) {
       /*
@@ -111,8 +112,8 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
       }
     } else {
       switch (functionName) {
-      case "booleanAnd":
-      case "booleanOr":
+      case FunctionNames.AND:
+      case FunctionNames.OR:
         HBaseScanSpec firstScanSpec = args.get(0).accept(this, null);
         for (int i = 1; i < args.size(); ++i) {
           HBaseScanSpec nextScanSpec = args.get(i).accept(this, null);
@@ -120,7 +121,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
             nodeScanSpec = mergeScanSpecs(functionName, firstScanSpec, nextScanSpec);
           } else {
             allExpressionsConverted = false;
-            if ("booleanAnd".equals(functionName)) {
+            if (FunctionNames.AND.equals(functionName)) {
               nodeScanSpec = firstScanSpec == null ? nextScanSpec : firstScanSpec;
             }
           }
@@ -143,12 +144,12 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
     byte[] stopRow = HConstants.EMPTY_END_ROW;
 
     switch (functionName) {
-    case "booleanAnd":
+    case FunctionNames.AND:
       newFilter = HBaseUtils.andFilterAtIndex(leftScanSpec.getFilter(), -1, rightScanSpec.getFilter()); //HBaseUtils.LAST_FILTER
       startRow = HBaseUtils.maxOfStartRows(leftScanSpec.getStartRow(), rightScanSpec.getStartRow());
       stopRow = HBaseUtils.minOfStopRows(leftScanSpec.getStopRow(), rightScanSpec.getStopRow());
       break;
-    case "booleanOr":
+    case FunctionNames.OR:
       newFilter = HBaseUtils.orFilterAtIndex(leftScanSpec.getFilter(), -1, rightScanSpec.getFilter()); //HBaseUtils.LAST_FILTER
       startRow = HBaseUtils.minOfStartRows(leftScanSpec.getStartRow(), rightScanSpec.getStartRow());
       stopRow = HBaseUtils.maxOfStopRows(leftScanSpec.getStopRow(), rightScanSpec.getStopRow());
@@ -184,7 +185,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
     byte[] startRow = HConstants.EMPTY_START_ROW;
     byte[] stopRow = HConstants.EMPTY_END_ROW;
     switch (functionName) {
-    case "equal":
+    case FunctionNames.EQ:
       compareOp = CompareOp.EQUAL;
       if (isRowKey) {
         startRow = fieldValue;
@@ -193,10 +194,10 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
         compareOp = CompareOp.EQUAL;
       }
       break;
-    case "not_equal":
+    case FunctionNames.NE:
       compareOp = CompareOp.NOT_EQUAL;
       break;
-    case "greater_than_or_equal_to":
+    case FunctionNames.GE:
       if (sortOrderAscending) {
         compareOp = CompareOp.GREATER_OR_EQUAL;
         if (isRowKey) {
@@ -210,7 +211,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
         }
       }
       break;
-    case "greater_than":
+    case FunctionNames.GT:
       if (sortOrderAscending) {
         compareOp = CompareOp.GREATER;
         if (isRowKey) {
@@ -224,7 +225,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
         }
       }
       break;
-    case "less_than_or_equal_to":
+    case FunctionNames.LE:
       if (sortOrderAscending) {
         compareOp = CompareOp.LESS_OR_EQUAL;
         if (isRowKey) {
@@ -238,7 +239,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
         }
       }
       break;
-    case "less_than":
+    case FunctionNames.LT:
       if (sortOrderAscending) {
         compareOp = CompareOp.LESS;
         if (isRowKey) {
@@ -252,7 +253,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
         }
       }
       break;
-    case "isnull":
+    case FunctionNames.IS_NULL:
     case "isNull":
     case "is null":
       if (isRowKey) {
@@ -262,7 +263,7 @@ public class MapRDBFilterBuilder extends AbstractExprVisitor<HBaseScanSpec, Void
       compareOp = CompareOp.EQUAL;
       comparator = new NullComparator();
       break;
-    case "isnotnull":
+    case FunctionNames.IS_NOT_NULL:
     case "isNotNull":
     case "is not null":
       if (isRowKey) {

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/CompareFunctionsProcessor.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/CompareFunctionsProcessor.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.mapr.db.json;
 
 import static com.mapr.db.rowcol.DBValueBuilderImpl.KeyValueBuilder;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
@@ -111,8 +112,8 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
 
   private static CompareFunctionsProcessor processWithEvaluator(FunctionCall call, CompareFunctionsProcessor evaluator) {
     String functionName = call.getName();
-    LogicalExpression nameArg = call.args.get(0);
-    LogicalExpression valueArg = call.args.size() >= 2 ? call.args.get(1) : null;
+    LogicalExpression nameArg = call.arg(0);
+    LogicalExpression valueArg = call.argCount() >= 2 ? call.arg(1) : null;
 
     if (VALUE_EXPRESSION_CLASSES.contains(nameArg.getClass())) {
       LogicalExpression swapArg = valueArg;
@@ -258,20 +259,20 @@ class CompareFunctionsProcessor extends AbstractExprVisitor<Boolean, LogicalExpr
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     COMPARE_FUNCTIONS_TRANSPOSE_MAP = builder
      // unary functions
-        .put("isnotnull", "isnotnull")
+        .put(FunctionNames.IS_NOT_NULL, FunctionNames.IS_NOT_NULL)
         .put("isNotNull", "isNotNull")
         .put("is not null", "is not null")
-        .put("isnull", "isnull")
+        .put(FunctionNames.IS_NULL, FunctionNames.IS_NULL)
         .put("isNull", "isNull")
         .put("is null", "is null")
         // binary functions
         .put("like", "like")
-        .put("equal", "equal")
-        .put("not_equal", "not_equal")
-        .put("greater_than_or_equal_to", "less_than_or_equal_to")
-        .put("greater_than", "less_than")
-        .put("less_than_or_equal_to", "greater_than_or_equal_to")
-        .put("less_than", "greater_than")
+        .put(FunctionNames.EQ, FunctionNames.EQ)
+        .put(FunctionNames.NE, FunctionNames.NE)
+        .put(FunctionNames.GE, FunctionNames.LE)
+        .put(FunctionNames.GT, FunctionNames.LT)
+        .put(FunctionNames.LE, FunctionNames.GE)
+        .put(FunctionNames.LT, FunctionNames.GT)
         .build();
   }
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonConditionBuilder.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonConditionBuilder.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.store.mapr.db.json;
 
+import java.util.List;
+
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -27,7 +30,6 @@ import org.ojai.Value;
 import org.ojai.store.QueryCondition;
 import org.ojai.store.QueryCondition.Op;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import com.mapr.db.impl.MapRDBImpl;
 
 public class JsonConditionBuilder extends AbstractExprVisitor<JsonScanSpec, Void, RuntimeException> implements DrillHBaseConstants {
@@ -47,7 +49,7 @@ public class JsonConditionBuilder extends AbstractExprVisitor<JsonScanSpec, Void
   public JsonScanSpec parseTree() {
     JsonScanSpec parsedSpec = le.accept(this, null);
     if (parsedSpec != null) {
-      parsedSpec.mergeScanSpec("booleanAnd", this.groupScan.getScanSpec());
+      parsedSpec.mergeScanSpec(FunctionNames.AND, this.groupScan.getScanSpec());
     }
     return parsedSpec;
   }
@@ -81,7 +83,7 @@ public class JsonConditionBuilder extends AbstractExprVisitor<JsonScanSpec, Void
   public JsonScanSpec visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
     JsonScanSpec nodeScanSpec = null;
     String functionName = call.getName();
-    ImmutableList<LogicalExpression> args = call.args;
+    List<LogicalExpression> args = call.args();
 
     if (CompareFunctionsProcessor.isCompareFunction(functionName)) {
       CompareFunctionsProcessor processor;
@@ -95,34 +97,34 @@ public class JsonConditionBuilder extends AbstractExprVisitor<JsonScanSpec, Void
       }
     } else {
       switch(functionName) {
-      case "booleanAnd":
-      case "booleanOr":
-        nodeScanSpec = args.get(0).accept(this, null);
-        for (int i = 1; i < args.size(); ++i) {
-          JsonScanSpec nextScanSpec = args.get(i).accept(this, null);
-          if (nodeScanSpec != null && nextScanSpec != null) {
-            nodeScanSpec.mergeScanSpec(functionName, nextScanSpec);
-          } else {
-            allExpressionsConverted = false;
-            if ("booleanAnd".equals(functionName)) {
-              nodeScanSpec = nodeScanSpec == null ? nextScanSpec : nodeScanSpec;
+        case FunctionNames.AND:
+        case FunctionNames.OR:
+          nodeScanSpec = args.get(0).accept(this, null);
+          for (int i = 1; i < args.size(); ++i) {
+            JsonScanSpec nextScanSpec = args.get(i).accept(this, null);
+            if (nodeScanSpec != null && nextScanSpec != null) {
+              nodeScanSpec.mergeScanSpec(functionName, nextScanSpec);
+            } else {
+              allExpressionsConverted = false;
+              if (FunctionNames.AND.equals(functionName)) {
+                nodeScanSpec = nodeScanSpec == null ? nextScanSpec : nodeScanSpec;
+              }
             }
           }
-        }
-        break;
+          break;
 
-      case "ojai_sizeof":
-      case "ojai_typeof":
-      case "ojai_nottypeof":
-      case "ojai_matches":
-      case "ojai_notmatches":
-      case "ojai_condition": {
-        final OjaiFunctionsProcessor processor = OjaiFunctionsProcessor.process(call);
-        if (processor != null) {
-                return new JsonScanSpec(groupScan.getTableName(), groupScan.getIndexDesc(),
-                                processor.getCondition());
+        case "ojai_sizeof":
+        case "ojai_typeof":
+        case "ojai_nottypeof":
+        case "ojai_matches":
+        case "ojai_notmatches":
+        case "ojai_condition": {
+          final OjaiFunctionsProcessor processor = OjaiFunctionsProcessor.process(call);
+          if (processor != null) {
+                  return new JsonScanSpec(groupScan.getTableName(), groupScan.getIndexDesc(),
+                                  processor.getCondition());
+          }
         }
-      }
       }
     }
 
@@ -191,61 +193,61 @@ public class JsonConditionBuilder extends AbstractExprVisitor<JsonScanSpec, Void
 
     QueryCondition cond = null;
     switch (functionName) {
-    case "equal":
+    case FunctionNames.EQ:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.EQUAL, fieldValue);
       break;
 
-    case "not_equal":
+    case FunctionNames.NE:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.NOT_EQUAL, fieldValue);
       break;
 
-    case "less_than":
+    case FunctionNames.LT:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.LESS, fieldValue);
       break;
 
-    case "less_than_or_equal_to":
+    case FunctionNames.LE:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.LESS_OR_EQUAL, fieldValue);
       break;
 
-    case "greater_than":
+    case FunctionNames.GT:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.GREATER, fieldValue);
       break;
 
-    case "greater_than_or_equal_to":
+    case FunctionNames.GE:
       cond = MapRDBImpl.newCondition();
       setIsCondition(cond, fieldPath, Op.GREATER_OR_EQUAL, fieldValue);
       break;
 
-    case "isnull":
+    case FunctionNames.IS_NULL:
       // 'field is null' should be transformed to 'field not exists OR typeof(field) = NULL'
       QueryCondition orCond = MapRDBImpl.newCondition().or();
       cond = orCond.notExists(fieldPath).typeOf(fieldPath, Value.Type.NULL).close();
       break;
 
-    case "isnotnull":
+    case FunctionNames.IS_NOT_NULL:
       // 'field is not null should be transformed to 'field exists AND typeof(field) != NULL'
       QueryCondition andCond = MapRDBImpl.newCondition().and();
       cond = andCond.exists(fieldPath).notTypeOf(fieldPath, Value.Type.NULL).close();
       break;
 
-    case "istrue":
+    case FunctionNames.IS_TRUE:
       cond = MapRDBImpl.newCondition().is(fieldPath, Op.EQUAL, true);
       break;
 
-    case "isnotfalse":
+    case FunctionNames.IS_NOT_FALSE:
       cond = MapRDBImpl.newCondition().is(fieldPath, Op.NOT_EQUAL, false);
       break;
 
-    case "isfalse":
+    case FunctionNames.IS_FALSE:
       cond = MapRDBImpl.newCondition().is(fieldPath, Op.EQUAL, false);
       break;
 
-    case "isnottrue":
+    case FunctionNames.IS_NOT_TRUE:
       cond = MapRDBImpl.newCondition().is(fieldPath, Op.NOT_EQUAL, true);
       break;
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonScanSpec.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonScanSpec.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.mapr.db.json;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HConstants;
 import org.ojai.store.QueryCondition;
@@ -119,10 +120,10 @@ public class JsonScanSpec {
     if (this.condition != null && scanSpec.getCondition() != null) {
       QueryCondition newCond = MapRDBImpl.newCondition();
       switch (functionName) {
-      case "booleanAnd":
+      case FunctionNames.AND:
         newCond.and();
         break;
-      case "booleanOr":
+      case FunctionNames.OR:
         newCond.or();
         break;
       default:
@@ -148,5 +149,4 @@ public class JsonScanSpec {
         + fidInfo
         + "]";
   }
-
 }

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/OjaiFunctionsProcessor.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/OjaiFunctionsProcessor.java
@@ -169,7 +169,6 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
     case "ojai_matches":
     case "ojai_notmatches": {
       // ojai_[not]matches(field, <regex>);
-      //final SchemaPath schemaPath = getSchemaPathArg(call.arg(0));
       final String regex = getStringArg(call.arg(1));
       if (functionName.equals("ojai_matches")) {
         queryCond = MapRDBImpl.newCondition()
@@ -184,8 +183,7 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
 
     case "ojai_condition": {
       // ojai_condition(field, <serialized-condition>);
-      //final SchemaPath schemaPath = getSchemaPathArg(call.arg(0));
-      final String condString = getStringArg(call.arg(1));
+       final String condString = getStringArg(call.arg(1));
       final byte[] condBytes = Base64.decodeBase64(condString);
       final ByteBuffer condBuffer = ByteBuffer.wrap(condBytes);
       queryCond = ConditionImpl.parseFrom(condBuffer);

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/OjaiFunctionsProcessor.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/OjaiFunctionsProcessor.java
@@ -139,12 +139,12 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
   @Override
   public Void visitFunctionCall(FunctionCall call, Void v) throws RuntimeException {
     final String functionName = call.getName();
-    final String fieldName = FieldPathHelper.schemaPath2FieldPath(getSchemaPathArg(call.args.get(0))).asPathString();
+    final String fieldName = FieldPathHelper.schemaPath2FieldPath(getSchemaPathArg(call.arg(0))).asPathString();
     switch(functionName) {
     case "ojai_sizeof": {
       // ojai_sizeof(field, "<rel-op>", <int-value>)
-      final String relOp = getStringArg(call.args.get(1));
-      final long size = getLongArg(call.args.get(2));
+      final String relOp = getStringArg(call.arg(1));
+      final long size = getLongArg(call.arg(2));
       queryCond = MapRDBImpl.newCondition()
           .sizeOf(fieldName, STRING_TO_RELOP.get(relOp), size)
           .build();
@@ -154,7 +154,7 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
     case "ojai_typeof":
     case "ojai_nottypeof": {
       // ojai_[not]typeof(field, <type-code>);
-      final int typeCode = getIntArg(call.args.get(1));
+      final int typeCode = getIntArg(call.arg(1));
       final Value.Type typeValue = Value.Type.valueOf(typeCode);
       queryCond = MapRDBImpl.newCondition();
       if (functionName.equals("ojai_typeof")) {
@@ -169,8 +169,8 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
     case "ojai_matches":
     case "ojai_notmatches": {
       // ojai_[not]matches(field, <regex>);
-      final SchemaPath schemaPath = getSchemaPathArg(call.args.get(0));
-      final String regex = getStringArg(call.args.get(1));
+      //final SchemaPath schemaPath = getSchemaPathArg(call.arg(0));
+      final String regex = getStringArg(call.arg(1));
       if (functionName.equals("ojai_matches")) {
         queryCond = MapRDBImpl.newCondition()
             .matches(fieldName, regex);
@@ -184,8 +184,8 @@ class OjaiFunctionsProcessor extends AbstractExprVisitor<Void, Void, RuntimeExce
 
     case "ojai_condition": {
       // ojai_condition(field, <serialized-condition>);
-      final SchemaPath schemaPath = getSchemaPathArg(call.args.get(0));
-      final String condString = getStringArg(call.args.get(1));
+      //final SchemaPath schemaPath = getSchemaPathArg(call.arg(0));
+      final String condString = getStringArg(call.arg(1));
       final byte[] condBytes = Base64.decodeBase64(condString);
       final ByteBuffer condBuffer = ByteBuffer.wrap(condBytes);
       queryCond = ConditionImpl.parseFrom(condBuffer);

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRegexParser.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseRegexParser.java
@@ -152,12 +152,12 @@ public class HBaseRegexParser {
   }
 
   private static String likeString(FunctionCall call) {
-    return ((QuotedString) call.args.get(1)).value;
+    return ((QuotedString) call.arg(1)).value;
   }
 
   private static Character escapeString(FunctionCall call) {
-    if (call.args.size() > 2) {
-      return ((QuotedString) call.args.get(2)).value.charAt(0);
+    if (call.argCount() > 2) {
+      return ((QuotedString) call.arg(2)).value.charAt(0);
     }
     return null;
   }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFunctionRegistry.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFunctionRegistry.java
@@ -42,18 +42,20 @@ import org.apache.drill.exec.planner.sql.HiveUDFOperator;
 import org.apache.drill.exec.planner.sql.HiveUDFOperatorWithoutInference;
 import org.apache.drill.exec.planner.sql.TypeInferenceUtils;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
+import org.apache.drill.shaded.guava.com.google.common.collect.Multimap;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDF;
 import org.apache.hadoop.hive.ql.udf.UDFType;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBridge;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.shaded.guava.com.google.common.collect.ArrayListMultimap;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
 
 public class HiveFunctionRegistry implements PluggableFunctionRegistry {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HiveFunctionRegistry.class);
+  private static final Logger logger = LoggerFactory.getLogger(HiveFunctionRegistry.class);
 
   /**
    * Map for renaming UDFs. Keys of the map represent UDF names which should be replaced
@@ -65,9 +67,9 @@ public class HiveFunctionRegistry implements PluggableFunctionRegistry {
           OracleSqlOperatorTable.TRANSLATE3.getName().toLowerCase())
       .build();
 
-  private final ArrayListMultimap<String, Class<? extends GenericUDF>> methodsGenericUDF = ArrayListMultimap.create();
-  private final ArrayListMultimap<String, Class<? extends UDF>> methodsUDF = ArrayListMultimap.create();
-  private final HashSet<Class<?>> nonDeterministicUDFs = new HashSet<>();
+  private final Multimap<String, Class<? extends GenericUDF>> methodsGenericUDF = ArrayListMultimap.create();
+  private final Multimap<String, Class<? extends UDF>> methodsUDF = ArrayListMultimap.create();
+  private final Set<Class<?>> nonDeterministicUDFs = new HashSet<>();
 
   /**
    * Scan the classpath for implementation of GenericUDF/UDF interfaces,
@@ -116,7 +118,7 @@ public class HiveFunctionRegistry implements PluggableFunctionRegistry {
     }
   }
 
-  private <I> void register(Class<? extends I> clazz, ArrayListMultimap<String, Class<? extends I>> methods) {
+  private <I> void register(Class<? extends I> clazz, Multimap<String, Class<? extends I>> methods) {
     Description desc = clazz.getAnnotation(Description.class);
     Stream<String> namesStream;
     if (desc != null) {

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFunctionRegistry.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/expr/fn/HiveFunctionRegistry.java
@@ -65,9 +65,9 @@ public class HiveFunctionRegistry implements PluggableFunctionRegistry {
           OracleSqlOperatorTable.TRANSLATE3.getName().toLowerCase())
       .build();
 
-  private ArrayListMultimap<String, Class<? extends GenericUDF>> methodsGenericUDF = ArrayListMultimap.create();
-  private ArrayListMultimap<String, Class<? extends UDF>> methodsUDF = ArrayListMultimap.create();
-  private HashSet<Class<?>> nonDeterministicUDFs = new HashSet<>();
+  private final ArrayListMultimap<String, Class<? extends GenericUDF>> methodsGenericUDF = ArrayListMultimap.create();
+  private final ArrayListMultimap<String, Class<? extends UDF>> methodsUDF = ArrayListMultimap.create();
+  private final HashSet<Class<?>> nonDeterministicUDFs = new HashSet<>();
 
   /**
    * Scan the classpath for implementation of GenericUDF/UDF interfaces,
@@ -168,11 +168,11 @@ public class HiveFunctionRegistry implements PluggableFunctionRegistry {
    */
   private HiveFuncHolder resolveFunction(FunctionCall call, boolean varCharToStringReplacement) {
     HiveFuncHolder holder;
-    MajorType[] argTypes = new MajorType[call.args.size()];
-    ObjectInspector[] argOIs = new ObjectInspector[call.args.size()];
-    for (int i=0; i<call.args.size(); i++) {
+    MajorType[] argTypes = new MajorType[call.argCount()];
+    ObjectInspector[] argOIs = new ObjectInspector[call.argCount()];
+    for (int i=0; i<call.argCount(); i++) {
       try {
-        argTypes[i] = call.args.get(i).getMajorType();
+        argTypes[i] = call.arg(i).getMajorType();
         argOIs[i] = ObjectInspectorHelper.getDrillObjectInspector(argTypes[i].getMode(), argTypes[i].getMinorType(),
             varCharToStringReplacement);
       } catch(Exception e) {

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpec.java
@@ -17,12 +17,14 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import org.apache.drill.common.FunctionNames;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class KafkaPartitionScanSpec {
-  private String topicName;
-  private int partitionId;
+  private final String topicName;
+  private final int partitionId;
   private long startOffset;
   private long endOffset;
 
@@ -55,7 +57,7 @@ public class KafkaPartitionScanSpec {
 
   public void mergeScanSpec(String functionName, KafkaPartitionScanSpec scanSpec) {
     switch (functionName) {
-      case "booleanAnd":
+      case FunctionNames.AND:
         //Reduce the scan range
         if (startOffset < scanSpec.startOffset) {
           startOffset = scanSpec.startOffset;
@@ -65,7 +67,7 @@ public class KafkaPartitionScanSpec {
           endOffset = scanSpec.endOffset;
         }
         break;
-      case "booleanOr":
+      case FunctionNames.OR:
         //Increase the scan range
         if (scanSpec.startOffset < startOffset) {
           startOffset = scanSpec.startOffset;
@@ -94,6 +96,7 @@ public class KafkaPartitionScanSpec {
                + startOffset + ", endOffset=" + endOffset + "]";
   }
 
+  @Override
   public KafkaPartitionScanSpec clone() {
     return new KafkaPartitionScanSpec(topicName, partitionId, startOffset, endOffset);
   }

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpecBuilder.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaPartitionScanSpecBuilder.java
@@ -17,11 +17,11 @@
  */
 package org.apache.drill.exec.store.kafka;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
@@ -83,7 +83,7 @@ public class KafkaPartitionScanSpecBuilder
   @Override
   public List<KafkaPartitionScanSpec> visitBooleanOperator(BooleanOperator op, Void value) {
     Map<TopicPartition, KafkaPartitionScanSpec> specMap = Maps.newHashMap();
-    ImmutableList<LogicalExpression> args = op.args;
+    List<LogicalExpression> args = op.args();
     if (op.getName().equals("booleanOr")) {
 
       for (LogicalExpression expr : args) {
@@ -169,7 +169,7 @@ public class KafkaPartitionScanSpecBuilder
     ImmutableSet<TopicPartition> topicPartitions = fullScanSpec.keySet();
 
     for (TopicPartition partitions : topicPartitions) {
-      timesValMap.put(partitions, functionName.equals("greater_than") ? fieldValue+1 : fieldValue);
+      timesValMap.put(partitions, functionName.equals(FunctionNames.GT) ? fieldValue+1 : fieldValue);
     }
 
     Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestamp = kafkaConsumer.offsetsForTimes(timesValMap);
@@ -202,7 +202,7 @@ public class KafkaPartitionScanSpecBuilder
     */
 
     switch (functionName) {
-      case "equal":
+      case FunctionNames.EQ:
         for (TopicPartition tp : topicPartitions) {
           if (fieldValue < fullScanSpec.get(tp).getStartOffset()) {
             //Offset does not exist
@@ -216,7 +216,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "greater_than_or_equal_to":
+      case FunctionNames.GE:
         for (TopicPartition tp : topicPartitions) {
           //Ensure scan range is between startOffset and endOffset,
           long val = bindOffsetToRange(tp, fieldValue);
@@ -225,7 +225,7 @@ public class KafkaPartitionScanSpecBuilder
                   fullScanSpec.get(tp).getEndOffset()));
         }
         break;
-      case "greater_than":
+      case FunctionNames.GT:
         for (TopicPartition tp : topicPartitions) {
           //Ensure scan range is between startOffset and endOffset,
           long val = bindOffsetToRange(tp, fieldValue + 1);
@@ -234,7 +234,7 @@ public class KafkaPartitionScanSpecBuilder
                   val, fullScanSpec.get(tp).getEndOffset()));
         }
         break;
-      case "less_than_or_equal_to":
+      case FunctionNames.LE:
         for (TopicPartition tp : topicPartitions) {
           //Ensure scan range is between startOffset and endOffset,
           long val = bindOffsetToRange(tp, fieldValue+1);
@@ -244,7 +244,7 @@ public class KafkaPartitionScanSpecBuilder
                   fullScanSpec.get(tp).getStartOffset(), val));
         }
         break;
-      case "less_than":
+      case FunctionNames.LT:
         for (TopicPartition tp : topicPartitions) {
           //Ensure scan range is between startOffset and endOffset,
           long val = bindOffsetToRange(tp, fieldValue);
@@ -263,7 +263,7 @@ public class KafkaPartitionScanSpecBuilder
     ImmutableSet<TopicPartition> topicPartitions = fullScanSpec.keySet();
 
     switch (functionName) {
-      case "equal":
+      case FunctionNames.EQ:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() == fieldValue) {
             scanSpecList.add(
@@ -273,7 +273,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "not_equal":
+      case FunctionNames.NE:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() != fieldValue) {
             scanSpecList.add(
@@ -283,7 +283,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "greater_than_or_equal_to":
+      case FunctionNames.GE:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() >= fieldValue) {
             scanSpecList.add(
@@ -293,7 +293,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "greater_than":
+      case FunctionNames.GT:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() > fieldValue) {
             scanSpecList.add(
@@ -303,7 +303,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "less_than_or_equal_to":
+      case FunctionNames.LE:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() <= fieldValue) {
             scanSpecList.add(
@@ -313,7 +313,7 @@ public class KafkaPartitionScanSpecBuilder
           }
         }
         break;
-      case "less_than":
+      case FunctionNames.LT:
         for (TopicPartition tp : topicPartitions) {
           if (tp.partition() < fieldValue) {
             scanSpecList.add(

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoCompareFunctionProcessor.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoCompareFunctionProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.mongo;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.CastExpression;
 import org.apache.drill.common.expression.ConvertExpression;
 import org.apache.drill.common.expression.FunctionCall;
@@ -40,7 +41,7 @@ public class MongoCompareFunctionProcessor extends
     AbstractExprVisitor<Boolean, LogicalExpression, RuntimeException> {
   private Object value;
   private boolean success;
-  private boolean isEqualityFn;
+  private final boolean isEqualityFn;
   private SchemaPath path;
   private String functionName;
 
@@ -50,8 +51,8 @@ public class MongoCompareFunctionProcessor extends
 
   public static MongoCompareFunctionProcessor process(FunctionCall call) {
     String functionName = call.getName();
-    LogicalExpression nameArg = call.args.get(0);
-    LogicalExpression valueArg = call.args.size() == 2 ? call.args.get(1)
+    LogicalExpression nameArg = call.arg(0);
+    LogicalExpression valueArg = call.argCount() == 2 ? call.arg(1)
         : null;
     MongoCompareFunctionProcessor evaluator = new MongoCompareFunctionProcessor(
         functionName);
@@ -65,7 +66,7 @@ public class MongoCompareFunctionProcessor extends
             .get(functionName);
       }
       evaluator.success = nameArg.accept(evaluator, valueArg);
-    } else if (call.args.get(0) instanceof SchemaPath) {
+    } else if (call.arg(0) instanceof SchemaPath) {
       evaluator.success = true;
       evaluator.path = (SchemaPath) nameArg;
     }
@@ -247,18 +248,19 @@ public class MongoCompareFunctionProcessor extends
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     COMPARE_FUNCTIONS_TRANSPOSE_MAP = builder
         // unary functions
-        .put("isnotnull", "isnotnull")
+        .put(FunctionNames.IS_NOT_NULL, FunctionNames.IS_NOT_NULL)
         .put("isNotNull", "isNotNull")
         .put("is not null", "is not null")
-        .put("isnull", "isnull")
+        .put(FunctionNames.IS_NULL, FunctionNames.IS_NULL)
         .put("isNull", "isNull")
         .put("is null", "is null")
         // binary functions
-        .put("equal", "equal").put("not_equal", "not_equal")
-        .put("greater_than_or_equal_to", "less_than_or_equal_to")
-        .put("greater_than", "less_than")
-        .put("less_than_or_equal_to", "greater_than_or_equal_to")
-        .put("less_than", "greater_than").build();
+        .put(FunctionNames.EQ, FunctionNames.EQ)
+        .put(FunctionNames.NE, FunctionNames.NE)
+        .put(FunctionNames.GE, FunctionNames.LE)
+        .put(FunctionNames.GT, FunctionNames.LT)
+        .put(FunctionNames.LE, FunctionNames.GE)
+        .put(FunctionNames.LT, FunctionNames.GT).build();
   }
 
 }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoFilterBuilder.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoFilterBuilder.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.store.mongo;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -29,8 +30,6 @@ import org.apache.drill.exec.store.mongo.common.MongoCompareOp;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public class MongoFilterBuilder extends
     AbstractExprVisitor<MongoScanSpec, Void, RuntimeException> implements
@@ -50,7 +49,7 @@ public class MongoFilterBuilder extends
   public MongoScanSpec parseTree() {
     MongoScanSpec parsedSpec = le.accept(this, null);
     if (parsedSpec != null) {
-      parsedSpec = mergeScanSpecs("booleanAnd", this.groupScan.getScanSpec(),
+      parsedSpec = mergeScanSpecs(FunctionNames.AND, this.groupScan.getScanSpec(),
           parsedSpec);
     }
     return parsedSpec;
@@ -61,7 +60,7 @@ public class MongoFilterBuilder extends
     Document newFilter = new Document();
 
     switch (functionName) {
-    case "booleanAnd":
+    case FunctionNames.AND:
       if (leftScanSpec.getFilters() != null
           && rightScanSpec.getFilters() != null) {
         newFilter = MongoUtils.andFilterAtIndex(leftScanSpec.getFilters(),
@@ -72,7 +71,7 @@ public class MongoFilterBuilder extends
         newFilter = rightScanSpec.getFilters();
       }
       break;
-    case "booleanOr":
+    case FunctionNames.OR:
       newFilter = MongoUtils.orFilterAtIndex(leftScanSpec.getFilters(),
           rightScanSpec.getFilters());
     }
@@ -93,13 +92,13 @@ public class MongoFilterBuilder extends
 
   @Override
   public MongoScanSpec visitBooleanOperator(BooleanOperator op, Void value) {
-    List<LogicalExpression> args = op.args;
+    List<LogicalExpression> args = op.args();
     MongoScanSpec nodeScanSpec = null;
     String functionName = op.getName();
     for (int i = 0; i < args.size(); ++i) {
       switch (functionName) {
-      case "booleanAnd":
-      case "booleanOr":
+      case FunctionNames.AND:
+      case FunctionNames.OR:
         if (nodeScanSpec == null) {
           nodeScanSpec = args.get(i).accept(this, null);
         } else {
@@ -121,7 +120,7 @@ public class MongoFilterBuilder extends
       throws RuntimeException {
     MongoScanSpec nodeScanSpec = null;
     String functionName = call.getName();
-    ImmutableList<LogicalExpression> args = call.args;
+    List<LogicalExpression> args = call.args();
 
     if (MongoCompareFunctionProcessor.isCompareFunction(functionName)) {
       MongoCompareFunctionProcessor processor = MongoCompareFunctionProcessor
@@ -137,8 +136,8 @@ public class MongoFilterBuilder extends
       }
     } else {
       switch (functionName) {
-      case "booleanAnd":
-      case "booleanOr":
+      case FunctionNames.AND:
+      case FunctionNames.OR:
         MongoScanSpec leftScanSpec = args.get(0).accept(this, null);
         MongoScanSpec rightScanSpec = args.get(1).accept(this, null);
         if (leftScanSpec != null && rightScanSpec != null) {
@@ -146,7 +145,7 @@ public class MongoFilterBuilder extends
               rightScanSpec);
         } else {
           allExpressionsConverted = false;
-          if ("booleanAnd".equals(functionName)) {
+          if (FunctionNames.AND.equals(functionName)) {
             nodeScanSpec = leftScanSpec == null ? rightScanSpec : leftScanSpec;
           }
         }
@@ -168,30 +167,30 @@ public class MongoFilterBuilder extends
     String fieldName = field.getRootSegmentPath();
     MongoCompareOp compareOp = null;
     switch (functionName) {
-    case "equal":
+    case FunctionNames.EQ:
       compareOp = MongoCompareOp.EQUAL;
       break;
-    case "not_equal":
+    case FunctionNames.NE:
       compareOp = MongoCompareOp.NOT_EQUAL;
       break;
-    case "greater_than_or_equal_to":
+    case FunctionNames.GE:
       compareOp = MongoCompareOp.GREATER_OR_EQUAL;
       break;
-    case "greater_than":
+    case FunctionNames.GT:
       compareOp = MongoCompareOp.GREATER;
       break;
-    case "less_than_or_equal_to":
+    case FunctionNames.LE:
       compareOp = MongoCompareOp.LESS_OR_EQUAL;
       break;
-    case "less_than":
+    case FunctionNames.LT:
       compareOp = MongoCompareOp.LESS;
       break;
-    case "isnull":
+    case FunctionNames.IS_NULL:
     case "isNull":
     case "is null":
       compareOp = MongoCompareOp.IFNULL;
       break;
-    case "isnotnull":
+    case FunctionNames.IS_NOT_NULL:
     case "isNotNull":
     case "is not null":
       compareOp = MongoCompareOp.IFNOTNULL;
@@ -215,5 +214,4 @@ public class MongoFilterBuilder extends
     }
     return null;
   }
-
 }

--- a/exec/java-exec/src/main/codegen/templates/ComparisonFunctions.java
+++ b/exec/java-exec/src/main/codegen/templates/ComparisonFunctions.java
@@ -164,6 +164,7 @@
 
 package org.apache.drill.exec.expr.fn.impl;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.NullHandling;
@@ -233,236 +234,225 @@ public class GCompare${leftTypeBase}Vs${rightTypeBase} {
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"less_than", "<"},
+  @FunctionTemplate(names = {FunctionNames.LT, "<"},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class LessThan${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(left.value) || ( Double.isNaN(left.value) && Double.isNaN(right.value))) {
-          out.value=0;
-        } else if (Double.isNaN(right.value) && !Double.isNaN(left.value)) {
-          out.value = 1;
-        } else {
-          out.value = left.value < right.value ? 1 : 0;
-        }
-        <#elseif typeGroup.mode == "varString"
-            || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp == -1 ? 1 : 0;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(left.value) || ( Double.isNaN(left.value) && Double.isNaN(right.value))) {
+        out.value=0;
+      } else if (Double.isNaN(right.value) && !Double.isNaN(left.value)) {
+        out.value = 1;
+      } else {
+        out.value = left.value < right.value ? 1 : 0;
       }
+    <#elseif typeGroup.mode == "varString"
+        || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                     output="cmp" nullCompare=false nullComparesHigh=false />
+      out.value = cmp == -1 ? 1 : 0;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
+    }
   }
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"less_than_or_equal_to", "<="},
+  @FunctionTemplate(names = {FunctionNames.LE, "<="},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class LessThanEq${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(right.value)){
-          out.value = 1;
-        } else if (!Double.isNaN(right.value) && Double.isNaN(left.value)) {
-          out.value = 0;
-        } else {
-          out.value = left.value <= right.value ? 1 : 0;
-        }
-        <#elseif typeGroup.mode == "varString"
-            || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp < 1 ? 1 : 0;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(right.value)){
+        out.value = 1;
+      } else if (!Double.isNaN(right.value) && Double.isNaN(left.value)) {
+        out.value = 0;
+      } else {
+        out.value = left.value <= right.value ? 1 : 0;
+      }
+    <#elseif typeGroup.mode == "varString"
+        || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                     output="cmp" nullCompare=false nullComparesHigh=false />
+      out.value = cmp < 1 ? 1 : 0;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
     }
   }
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"greater_than", ">"},
+  @FunctionTemplate(names = {FunctionNames.GT, ">"},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class GreaterThan${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(right.value) || ( Double.isNaN(left.value) && Double.isNaN(right.value))) {
-          out.value = 0;
-        } else if (Double.isNaN(left.value) && !Double.isNaN(right.value)) {
-          out.value = 1;
-        } else {
-          out.value = left.value > right.value ? 1 : 0;
-        }
-        <#elseif typeGroup.mode == "varString"
-            || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp == 1 ? 1 : 0;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(right.value) || ( Double.isNaN(left.value) && Double.isNaN(right.value))) {
+        out.value = 0;
+      } else if (Double.isNaN(left.value) && !Double.isNaN(right.value)) {
+        out.value = 1;
+      } else {
+        out.value = left.value > right.value ? 1 : 0;
+      }
+    <#elseif typeGroup.mode == "varString"
+        || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                     output="cmp" nullCompare=false nullComparesHigh=false />
+      out.value = cmp == 1 ? 1 : 0;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
     }
   }
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"greater_than_or_equal_to", ">="},
+  @FunctionTemplate(names = {FunctionNames.GE, ">="},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class GreaterThanEq${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(left.value)){
-          out.value=1;
-        } else if (!Double.isNaN(left.value) && Double.isNaN(right.value)) {
-          out.value = 0;
-        } else {
-          out.value = left.value >= right.value ? 1 : 0;
-        }
-
-        <#elseif typeGroup.mode == "varString"
-            || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp > -1 ? 1 : 0;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(left.value)){
+        out.value=1;
+      } else if (!Double.isNaN(left.value) && Double.isNaN(right.value)) {
+        out.value = 0;
+      } else {
+        out.value = left.value >= right.value ? 1 : 0;
       }
+
+    <#elseif typeGroup.mode == "varString"
+        || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                     output="cmp" nullCompare=false nullComparesHigh=false />
+      out.value = cmp > -1 ? 1 : 0;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
+    }
   }
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"equal", "==", "="},
+  @FunctionTemplate(names = {FunctionNames.EQ, "==", "="},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class Equals${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(left.value) && Double.isNaN(right.value)) {
-          out.value = 1;
-        } else {
-          out.value = left.value == right.value ? 1 : 0;
-        }
-        <#elseif typeGroup.mode == "varString" >
-          out.value = org.apache.drill.exec.expr.fn.impl.ByteFunctionHelpers.equal(
-              left.buffer, left.start, left.end, right.buffer, right.start, right.end);
-        <#elseif typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp == 0 ? 1 : 0;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(left.value) && Double.isNaN(right.value)) {
+        out.value = 1;
+      } else {
+        out.value = left.value == right.value ? 1 : 0;
       }
+    <#elseif typeGroup.mode == "varString" >
+      out.value = org.apache.drill.exec.expr.fn.impl.ByteFunctionHelpers.equal(
+          left.buffer, left.start, left.end, right.buffer, right.start, right.end);
+    <#elseif typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                     output="cmp" nullCompare=false nullComparesHigh=false />
+      out.value = cmp == 0 ? 1 : 0;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
+    }
   }
 
   <#-- Comparison function for comparison expression operator (=, &lt;, etc.),
        not for sorting and grouping relational operators. -->
-  @FunctionTemplate(names = {"not_equal", "<>", "!="},
+  @FunctionTemplate(names = {FunctionNames.NE, "<>", "!="},
                     scope = FunctionTemplate.FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class NotEquals${leftTypeBase}Vs${rightTypeBase} implements DrillSimpleFunc {
 
-      @Param ${leftTypeBase}Holder left;
-      @Param ${rightTypeBase}Holder right;
-      @Output BitHolder out;
+    @Param ${leftTypeBase}Holder left;
+    @Param ${rightTypeBase}Holder right;
+    @Output BitHolder out;
 
-      public void setup() {}
+    public void setup() {}
 
-      public void eval() {
+    public void eval() {
 
-        <#if typeGroup.mode == "primitive">
-        // NaN is the biggest possible value, and NaN == NaN
-        if (Double.isNaN(left.value) && Double.isNaN(right.value)) {
-          out.value = 0;
-        } else {
-          out.value = left.value != right.value ? 1 : 0;
-        }
-        <#elseif typeGroup.mode == "varString"
-            || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
-          int cmp;
-          <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
-                         output="cmp" nullCompare=false nullComparesHigh=false />
-          out.value = cmp == 0 ? 0 : 1;
-        <#-- TODO:  Refactor other comparison code to here. -->
-        <#else>
-          ${mode_HAS_BAD_VALUE}
-        </#if>
-
+    <#if typeGroup.mode == "primitive">
+      // NaN is the biggest possible value, and NaN == NaN
+      if (Double.isNaN(left.value) && Double.isNaN(right.value)) {
+        out.value = 0;
+      } else {
+        out.value = left.value != right.value ? 1 : 0;
       }
+    <#elseif typeGroup.mode == "varString"
+          || typeGroup.mode == "intervalNameThis" || typeGroup.mode == "intervalDay" >
+      int cmp;
+      <@compareBlock mode=typeGroup.mode leftType=leftTypeBase rightType=rightTypeBase
+                       output="cmp" nullCompare=false nullComparesHigh=false />
+        out.value = cmp == 0 ? 0 : 1;
+    <#-- TODO:  Refactor other comparison code to here. -->
+    <#else>
+      ${mode_HAS_BAD_VALUE}
+    </#if>
+    }
   }
-
 }
-
-
 </#list> <#-- 2.  Pair of types-->
 </#list>
-
 </#list> <#-- 1. Group -->
-

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/BooleanPredicate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/BooleanPredicate.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.expr;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.ExpressionPosition;
 import org.apache.drill.common.expression.LogicalExpression;
@@ -56,7 +57,7 @@ public abstract class BooleanPredicate<C extends Comparable<C>> extends BooleanO
         RowsMatch resultMatch = RowsMatch.ALL;
         for (LogicalExpression child : this) {
           if (child instanceof FilterPredicate) {
-            switch (((FilterPredicate) child).matches(evaluator)) {
+            switch (((FilterPredicate<C>) child).matches(evaluator)) {
               case NONE:
                 return RowsMatch.NONE;  // No row comply to 1 filter part => can drop RG
               case SOME:
@@ -87,7 +88,7 @@ public abstract class BooleanPredicate<C extends Comparable<C>> extends BooleanO
         RowsMatch resultMatch = RowsMatch.NONE;
         for (LogicalExpression child : this) {
           if (child instanceof FilterPredicate) {
-            switch (((FilterPredicate) child).matches(evaluator)) {
+            switch (((FilterPredicate<C>) child).matches(evaluator)) {
               case ALL:
                 return RowsMatch.ALL;  // One at least is ALL => can drop filter but not RG
               case SOME:
@@ -104,9 +105,9 @@ public abstract class BooleanPredicate<C extends Comparable<C>> extends BooleanO
   public static <C extends Comparable<C>> LogicalExpression createBooleanPredicate(
       String function, String name, List<LogicalExpression> args, ExpressionPosition pos) {
     switch (function) {
-      case "booleanOr":
+      case FunctionNames.OR:
         return BooleanPredicate.<C>createOrPredicate(name, args, pos);
-      case "booleanAnd":
+      case FunctionNames.AND:
         return BooleanPredicate.<C>createAndPredicate(name, args, pos);
       default:
         logger.warn("Unknown Boolean '{}' predicate.", function);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CloneVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/CloneVisitor.java
@@ -57,7 +57,7 @@ public class CloneVisitor extends AbstractExprVisitor<LogicalExpression,Void,Run
   @Override
   public LogicalExpression visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
     List<LogicalExpression> args = Lists.newArrayList();
-    for (LogicalExpression arg : call.args) {
+    for (LogicalExpression arg : call.args()) {
       args.add(arg.accept(this, null));
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ComparisonPredicate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/ComparisonPredicate.java
@@ -17,11 +17,11 @@
  */
 package org.apache.drill.exec.expr;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.LogicalExpressionBase;
 import org.apache.drill.common.expression.visitors.ExprVisitor;
 import org.apache.drill.common.types.TypeProtos;
-import org.apache.drill.exec.expr.fn.FunctionGenerationHelper;
 import org.apache.drill.exec.expr.stat.RowsMatch;
 import org.apache.drill.metastore.statistics.ColumnStatistics;
 import org.apache.drill.metastore.statistics.ColumnStatisticsKind;
@@ -258,17 +258,17 @@ public class ComparisonPredicate<C extends Comparable<C>> extends LogicalExpress
   public static <C extends Comparable<C>> LogicalExpression createComparisonPredicate(
       String function, LogicalExpression left, LogicalExpression right) {
     switch (function) {
-      case FunctionGenerationHelper.EQ:
+      case FunctionNames.EQ:
         return ComparisonPredicate.<C>createEqualPredicate(left, right);
-      case FunctionGenerationHelper.GT:
+      case FunctionNames.GT:
         return ComparisonPredicate.<C>createGTPredicate(left, right);
-      case FunctionGenerationHelper.GE:
+      case FunctionNames.GE:
         return ComparisonPredicate.<C>createGEPredicate(left, right);
-      case FunctionGenerationHelper.LT:
+      case FunctionNames.LT:
         return ComparisonPredicate.<C>createLTPredicate(left, right);
-      case FunctionGenerationHelper.LE:
+      case FunctionNames.LE:
         return ComparisonPredicate.<C>createLEPredicate(left, right);
-      case FunctionGenerationHelper.NE:
+      case FunctionNames.NE:
         return ComparisonPredicate.<C>createNEPredicate(left, right);
       default:
         return null;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/EvaluationVisitor.java
@@ -31,6 +31,7 @@ import java.util.Stack;
 
 import io.netty.buffer.DrillBuf;
 import org.apache.calcite.util.Pair;
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.AnyValueExpression;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.CastExpression;
@@ -250,9 +251,9 @@ public class EvaluationVisitor {
     @Override
     public HoldingContainer visitBooleanOperator(BooleanOperator op,
         ClassGenerator<?> generator) throws RuntimeException {
-      if (op.getName().equals("booleanAnd")) {
+      if (op.getName().equals(FunctionNames.AND)) {
         return visitBooleanAnd(op, generator);
-      } else if(op.getName().equals("booleanOr")) {
+      } else if(op.getName().equals(FunctionNames.OR)) {
         return visitBooleanOr(op, generator);
       } else {
         throw new UnsupportedOperationException(
@@ -1033,8 +1034,8 @@ public class EvaluationVisitor {
       //    null    true     null
       //    null    false    false
       //    null    null     null
-      for (int i = 0; i < op.args.size(); i++) {
-        arg = op.args.get(i).accept(this, generator);
+      for (LogicalExpression expr : op.args()) {
+        arg = expr.accept(this, generator);
 
         JBlock earlyExit = null;
         if (arg.isOptional()) {
@@ -1095,9 +1096,8 @@ public class EvaluationVisitor {
       //    null    true     true
       //    null    false    null
       //    null    null     null
-
-      for (int i = 0; i < op.args.size(); i++) {
-        arg = op.args.get(i).accept(this, generator);
+      for (LogicalExpression expr : op.args()) {
+        arg = expr.accept(this, generator);
 
         JBlock earlyExit = null;
         if (arg.isOptional()) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/StatisticsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/StatisticsProvider.java
@@ -76,8 +76,9 @@ public class StatisticsProvider<T extends Comparable<T>> extends AbstractExprVis
     } else if (typedFieldExpr.getMajorType().equals(Types.OPTIONAL_INT)) {
       // field does not exist.
       return StatisticsProvider.getColumnStatistics(null, null, rowCount, typedFieldExpr.getMajorType().getMinorType());
+    } else {
+      return null;
     }
-    return null;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/DrillAggFuncHolder.java
@@ -47,15 +47,19 @@ class DrillAggFuncHolder extends DrillFuncHolder {
   protected String setup() {
     return meth("setup");
   }
+
   protected String reset() {
     return meth("reset", false);
   }
+
   protected String add() {
     return meth("add");
   }
+
   protected String output() {
     return meth("output");
   }
+
   protected String cleanup() {
     return meth("cleanup", false);
   }
@@ -82,7 +86,7 @@ class DrillAggFuncHolder extends DrillFuncHolder {
       JVar[] workspaceJVars = declareWorkspaceVariables(g);
       generateBody(g, BlockType.SETUP, setup(), null, workspaceJVars, true);
       return workspaceJVars;
-      } else {  //Declare workspace vars and workspace vectors for hash aggregation.
+    } else {  //Declare workspace vars and workspace vectors for hash aggregation.
 
       JVar[] workspaceJVars = declareWorkspaceVectors(g);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionGenerationHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionGenerationHelper.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.ErrorCollector;
 import org.apache.drill.common.expression.ErrorCollectorImpl;
 import org.apache.drill.common.expression.ExpressionPosition;
@@ -36,24 +37,7 @@ import org.apache.drill.exec.expr.ClassGenerator.HoldingContainer;
 import org.apache.drill.exec.expr.ExpressionTreeMaterializer;
 import org.apache.drill.exec.expr.HoldingContainerExpression;
 
-public class FunctionGenerationHelper {
-  public static final String COMPARE_TO_NULLS_HIGH = "compare_to_nulls_high";
-  public static final String COMPARE_TO_NULLS_LOW = "compare_to_nulls_low";
-
-  public static final String EQ = "equal";
-  public static final String NE = "not_equal";
-  public static final String GT = "greater_than";
-  public static final String GE = "greater_than_or_equal_to";
-  public static final String LT = "less_than";
-  public static final String LE = "less_than_or_equal_to";
-
-  public static final String IS_NULL = "isnull";
-  public static final String IS_NOT_NULL = "isnotnull";
-  public static final String IS_TRUE = "istrue";
-  public static final String IS_NOT_TRUE = "isnottrue";
-  public static final String IS_FALSE = "isfalse";
-  public static final String IS_NOT_FALSE = "isnotfalse";
-  public static final String NOT = "not";
+public class FunctionGenerationHelper implements FunctionNames {
 
   /**
    * Finds ordering comparator ("compare_to...") FunctionHolderExpression with
@@ -141,7 +125,7 @@ public class FunctionGenerationHelper {
     List<LogicalExpression> newArgs = Lists.newArrayList();
     newArgs.add(call);
     newArgs.add(new IntExpression(0, ExpressionPosition.UNKNOWN));
-    FunctionCall notEqual = new FunctionCall("not_equal", newArgs, ExpressionPosition.UNKNOWN);
+    FunctionCall notEqual = new FunctionCall(FunctionNames.NE, newArgs, ExpressionPosition.UNKNOWN);
 
     IfExpression.IfCondition ifCondition = new IfCondition(notEqual, call);
     IfExpression ifExpression = IfExpression.newBuilder().setIfCondition(ifCondition).setElse(comparisonFunction).build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/FunctionImplementationRegistry.java
@@ -204,7 +204,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
    */
   private String functionReplacement(FunctionCall functionCall) {
     String funcName = functionCall.getName();
-    if (functionCall.args.size() == 0) {
+    if (functionCall.argCount() == 0) {
       return funcName;
     }
     boolean castEmptyStringToNull = optionManager != null &&
@@ -212,7 +212,7 @@ public class FunctionImplementationRegistry implements FunctionLookupContext, Au
     if (!castEmptyStringToNull) {
       return funcName;
     }
-    MajorType majorType =  functionCall.args.get(0).getMajorType();
+    MajorType majorType =  functionCall.arg(0).getMajorType();
     DataMode dataMode = majorType.getMode();
     MinorType minorType = majorType.getMinorType();
     if (FunctionReplacementUtils.isReplacementNeeded(funcName, minorType)) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/BitFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/BitFunctions.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.expr.fn.impl;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
@@ -34,7 +35,7 @@ import org.apache.drill.exec.expr.holders.IntHolder;
  */
 public class BitFunctions {
 
-  @FunctionTemplate(names = {"booleanOr", "or", "||", "orNoShortCircuit"},
+  @FunctionTemplate(names = {FunctionNames.OR, "or", "||", "orNoShortCircuit"},
                     scope = FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class BitOr implements DrillSimpleFunc {
@@ -43,14 +44,16 @@ public class BitFunctions {
     @Param BitHolder right;
     @Output BitHolder out;
 
+    @Override
     public void setup() {}
 
+    @Override
     public void eval() {
       out.value = left.value | right.value;
     }
   }
 
-  @FunctionTemplate(names = {"booleanAnd", "and", "&&"},
+  @FunctionTemplate(names = {FunctionNames.AND, "and", "&&"},
                     scope = FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class BitAnd implements DrillSimpleFunc {
@@ -59,15 +62,17 @@ public class BitFunctions {
     @Param BitHolder right;
     @Output BitHolder out;
 
+    @Override
     public void setup() {}
 
+    @Override
     public void eval() {
       out.value = left.value & right.value;
     }
   }
 
 
-  @FunctionTemplate(names = {"xor", "^"},
+  @FunctionTemplate(names = {FunctionNames.XOR, "^"},
                     scope = FunctionScope.SIMPLE,
                     nulls = NullHandling.NULL_IF_NULL)
   public static class IntXor implements DrillSimpleFunc {
@@ -76,11 +81,12 @@ public class BitFunctions {
     @Param IntHolder right;
     @Output IntHolder out;
 
+    @Override
     public void setup() {}
 
+    @Override
     public void eval() {
       out.value = left.value ^ right.value;
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/StringFunctions.java
@@ -19,6 +19,8 @@ package org.apache.drill.exec.expr.fn.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DrillBuf;
+
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.exec.expr.DrillSimpleFunc;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate;
 import org.apache.drill.exec.expr.annotations.FunctionTemplate.FunctionScope;
@@ -47,7 +49,7 @@ public class StringFunctions{
    * String Function Implementation.
    */
 
-  @FunctionTemplate(name = "like", scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
+  @FunctionTemplate(name = FunctionNames.LIKE, scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
   public static class Like implements DrillSimpleFunc {
 
     @Param VarCharHolder input;
@@ -69,7 +71,7 @@ public class StringFunctions{
     }
   }
 
-  @FunctionTemplate(name = "like", scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
+  @FunctionTemplate(name = FunctionNames.LIKE, scope = FunctionScope.SIMPLE, nulls = NullHandling.NULL_IF_NULL)
   public static class LikeWithEscape implements DrillSimpleFunc {
 
     @Param VarCharHolder input;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ExecutorFragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/ExecutorFragmentContext.java
@@ -38,7 +38,7 @@ import java.util.Set;
 public interface ExecutorFragmentContext extends RootFragmentContext {
 
   /**
-   * @return The root allocator for the Drillbit.
+   * Returns the root allocator for the Drillbit.
    */
   BufferAllocator getRootAllocator();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractDbGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractDbGroupScan.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.planner.physical.PartitionFunction;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 
 public abstract class AbstractDbGroupScan extends AbstractGroupScan implements DbGroupScan {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractDbGroupScan.class);
 
   private static final String ROW_KEY = "_id";
   private static final SchemaPath ROW_KEY_PATH = SchemaPath.getSimplePath(ROW_KEY);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractDbSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractDbSubScan.java
@@ -25,6 +25,7 @@ public abstract class AbstractDbSubScan extends AbstractSubScan implements DbSub
     super(userName);
   }
 
+  @Override
   public boolean isRestrictedSubScan() {
     return false;
   }
@@ -33,5 +34,4 @@ public abstract class AbstractDbSubScan extends AbstractSubScan implements DbSub
   public void addJoinForRestrictedSubScan(RowKeyJoin batch) {
     throw new UnsupportedOperationException();
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -132,7 +132,8 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
    */
   @Override
   public long getColumnValueCount(SchemaPath column) {
-    throw new UnsupportedOperationException(String.format("%s does not have exact column value count!", this.getClass().getCanonicalName()));
+    throw new UnsupportedOperationException(String.format(
+        "%s does not have exact column value count!", getClass().getCanonicalName()));
   }
 
   @Override
@@ -195,7 +196,8 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
   }
 
   @Override
-  public GroupScan applyFilter(LogicalExpression filterExpr, UdfUtilities udfUtilities, FunctionImplementationRegistry functionImplementationRegistry, OptionManager optionManager) {
+  public GroupScan applyFilter(LogicalExpression filterExpr, UdfUtilities udfUtilities,
+      FunctionImplementationRegistry functionImplementationRegistry, OptionManager optionManager) {
     return null;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScanWithMetadata.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScanWithMetadata.java
@@ -108,7 +108,7 @@ public abstract class AbstractGroupScanWithMetadata<P extends TableMetadataProvi
   protected Set<Path> fileSet;
 
   // whether all files, partitions or row groups of this group scan fully match the filter
-  protected boolean matchAllMetadata = false;
+  protected boolean matchAllMetadata;
 
   protected boolean usedMetastore; // false by default
 
@@ -640,7 +640,7 @@ public abstract class AbstractGroupScanWithMetadata<P extends TableMetadataProvi
   protected abstract static class GroupScanWithMetadataFilterer<B extends GroupScanWithMetadataFilterer<B>> {
     protected final AbstractGroupScanWithMetadata<? extends TableMetadataProvider> source;
 
-    protected boolean matchAllMetadata = false;
+    protected boolean matchAllMetadata;
 
     protected TableMetadata tableMetadata;
     protected List<PartitionMetadata> partitions = Collections.emptyList();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractPhysicalVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractPhysicalVisitor.java
@@ -47,10 +47,9 @@ import org.apache.drill.exec.physical.config.Values;
 import org.apache.drill.exec.physical.config.WindowPOP;
 
 public abstract class AbstractPhysicalVisitor<T, X, E extends Throwable> implements PhysicalVisitor<T, X, E> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractPhysicalVisitor.class);
 
   @Override
-  public T visitExchange(Exchange exchange, X value) throws E{
+  public T visitExchange(Exchange exchange, X value) throws E {
     return visitOp(exchange, value);
   }
 
@@ -65,7 +64,7 @@ public abstract class AbstractPhysicalVisitor<T, X, E extends Throwable> impleme
   }
 
   @Override
-  public T visitFilter(Filter filter, X value) throws E{
+  public T visitFilter(Filter filter, X value) throws E {
     return visitOp(filter, value);
   }
 
@@ -75,17 +74,17 @@ public abstract class AbstractPhysicalVisitor<T, X, E extends Throwable> impleme
   }
 
   @Override
-  public T visitProject(Project project, X value) throws E{
+  public T visitProject(Project project, X value) throws E {
     return visitOp(project, value);
   }
 
   @Override
-  public T visitTrace(Trace trace, X value) throws E{
+  public T visitTrace(Trace trace, X value) throws E {
       return visitOp(trace, value);
   }
 
   @Override
-  public T visitSort(Sort sort, X value) throws E{
+  public T visitSort(Sort sort, X value) throws E {
     return visitOp(sort, value);
   }
 
@@ -130,22 +129,21 @@ public abstract class AbstractPhysicalVisitor<T, X, E extends Throwable> impleme
   }
 
   @Override
-  public T visitGroupScan(GroupScan groupScan, X value) throws E{
+  public T visitGroupScan(GroupScan groupScan, X value) throws E {
     return visitOp(groupScan, value);
   }
 
   @Override
-  public T visitSubScan(SubScan subScan, X value) throws E{
+  public T visitSubScan(SubScan subScan, X value) throws E {
     return visitOp(subScan, value);
   }
 
   @Override
-  public T visitStore(Store store, X value) throws E{
+  public T visitStore(Store store, X value) throws E {
     return visitOp(store, value);
   }
 
-
-  public T visitChildren(PhysicalOperator op, X value) throws E{
+  public T visitChildren(PhysicalOperator op, X value) throws E {
     for (PhysicalOperator child : op) {
       child.accept(this, value);
     }
@@ -233,10 +231,9 @@ public abstract class AbstractPhysicalVisitor<T, X, E extends Throwable> impleme
   }
 
   @Override
-  public T visitOp(PhysicalOperator op, X value) throws E{
+  public T visitOp(PhysicalOperator op, X value) throws E {
     throw new UnsupportedOperationException(String.format(
-        "The PhysicalVisitor of type %s does not currently support visiting the PhysicalOperator type %s.", this
+        "PhysicalVisitor of type %s does not support PhysicalOperator type %s.", this
             .getClass().getCanonicalName(), op.getClass().getCanonicalName()));
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FragmentLeaf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/FragmentLeaf.java
@@ -18,8 +18,8 @@
 package org.apache.drill.exec.physical.base;
 
 /**
- * A Physical Operator that can be the leaf node of one particular execution fragment. Typically includes Receivers and
- * Scans
+ * A Physical Operator that can be the leaf node of one particular execution
+ * fragment. Typically includes Receivers and Scans.
  */
 public interface FragmentLeaf extends PhysicalOperator {
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Leaf.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/Leaf.java
@@ -18,8 +18,10 @@
 package org.apache.drill.exec.physical.base;
 
 /**
- * An operator which specifically is a lowest level leaf node of a query plan across all possible fragments. Currently, the only operator that is a Leaf
- * node are GroupScan nodes. Ultimately this could include use of Cache scans and other types of atypical data production systems.
+ * Operator which specifically is a lowest level leaf node of a query plan
+ * across all possible fragments. Currently, the only operator that is a Leaf
+ * node are GroupScan nodes. Ultimately this could include use of Cache scans
+ * and other types of atypical data production systems.
  */
 public interface Leaf extends FragmentLeaf {
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
@@ -47,9 +47,10 @@ public class ScanStats {
   }
 
   /**
-   * Return if GroupScan knows the exact row count in the result of getSize() call.
-   * By default, group scan does not know the exact row count, before it scans every rows.
-   * Currently, parquet group scan will return the exact row count.
+   * Return whether GroupScan knows the exact row count in the result of getSize()
+   * call. By default, group scan does not know the exact row count, before it
+   * scans every rows. Currently, Parquet group scan will return the exact row
+   * count.
    *
    * @return group scan property
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SingleMergeExchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SingleMergeExchange.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("single-merge-exchange")
 public class SingleMergeExchange extends AbstractExchange {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SingleMergeExchange.class);
 
   private final List<Ordering> orderExpr;
 
@@ -71,7 +70,8 @@ public class SingleMergeExchange extends AbstractExchange {
 
   @Override
   public Receiver getReceiver(int minorFragmentId) {
-    return new MergingReceiverPOP(senderMajorFragmentId, PhysicalOperatorUtil.getIndexOrderedEndpoints(senderLocations), orderExpr, false);
+    return new MergingReceiverPOP(senderMajorFragmentId,
+        PhysicalOperatorUtil.getIndexOrderedEndpoints(senderLocations), orderExpr, false);
   }
 
   @Override
@@ -83,5 +83,4 @@ public class SingleMergeExchange extends AbstractExchange {
   public List<Ordering> getOrderings() {
     return this.orderExpr;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/aggregate/HashAggBatch.java
@@ -445,14 +445,14 @@ public class HashAggBatch extends AbstractRecordBatch<HashAggregate> {
           if (funcName.equals("sum") || funcName.equals("max") || funcName.equals("min")) {
             extraNonNullColumns++;
           }
-          List<LogicalExpression> args = ((FunctionCall) ne.getExpr()).args;
+          List<LogicalExpression> args = ((FunctionCall) ne.getExpr()).args();
           if (!args.isEmpty()) {
             if (args.get(0) instanceof SchemaPath) {
               columnMapping.put(outputField.getName(), ((SchemaPath) args.get(0)).getAsNamePart().getName());
             } else if (args.get(0) instanceof FunctionCall) {
               FunctionCall functionCall = (FunctionCall) args.get(0);
-              if (functionCall.args.get(0) instanceof SchemaPath) {
-                columnMapping.put(outputField.getName(), ((SchemaPath) functionCall.args.get(0)).getAsNamePart().getName());
+              if (functionCall.arg(0) instanceof SchemaPath) {
+                columnMapping.put(outputField.getName(), ((SchemaPath) functionCall.arg(0)).getAsNamePart().getName());
               }
             }
           }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ResolvedMapColumn.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ResolvedMapColumn.java
@@ -55,7 +55,6 @@ public class ResolvedMapColumn extends ResolvedColumn {
     // We may have to create a matching new output
     // map. Determine whether it is a single map or
     // an array.
-
     assert schema.getType().getMinorType() == MinorType.MAP;
     if (schema.getType().getMode() == DataMode.REPEATED) {
       members = new ResolvedMapArray(this);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/BuildFromSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/BuildFromSchema.java
@@ -269,8 +269,7 @@ public class BuildFromSchema {
    */
 
   private ObjectWriter buildRepeatedList(ParentShim parent, ColumnMetadata colSchema) {
-    final ColumnMetadata seed = colSchema.cloneEmpty();
-    final ObjectWriter objWriter = parent.add(seed);
+    final ObjectWriter objWriter = parent.add(colSchema.cloneEmpty());
     final RepeatedListWriter listWriter = (RepeatedListWriter) objWriter.array();
     final ColumnMetadata elements = colSchema.childSchema();
     if (elements != null) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnBuilder.java
@@ -487,7 +487,7 @@ public class ColumnBuilder {
         columnSchema, vector, dummyElement);
 
     // Create the list vector state that tracks the list vector lifecycle.
-    // For a repeated list, we only care about
+
     final RepeatedListVectorState vectorState = new RepeatedListVectorState(
         arrayWriter, vector);
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnState.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ColumnState.java
@@ -289,7 +289,7 @@ public abstract class ColumnState {
         // Remember that we have look-ahead values stashed away in the
         // backup vector.
 
-        state= State.LOOK_AHEAD;
+        state = State.LOOK_AHEAD;
         break;
 
       default:

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/AbstractPartitionDescriptor.java
@@ -25,21 +25,23 @@ import org.apache.drill.exec.store.dfs.MetadataContext;
 import org.apache.hadoop.fs.Path;
 
 /**
- * Abstract base class for file system based partition descriptors and Hive partition descriptors.
- *
+ * Abstract base class for file system based partition descriptors and Hive
+ * partition descriptors.
  */
 public abstract class AbstractPartitionDescriptor implements PartitionDescriptor, Iterable<List<PartitionLocation>> {
 
   /**
-   * A sequence of sublists of partition locations combined into a single super list.
-   * The size of each sublist is at most {@link PartitionDescriptor#PARTITION_BATCH_SIZE}
-   * For example if the size is 3, the complete list could be: {(a, b, c), {d, e, f), (g, h)}
+   * A sequence of sublists of partition locations combined into a single super
+   * list. The size of each sublist is at most
+   * {@link PartitionDescriptor#PARTITION_BATCH_SIZE} For example if the size is
+   * 3, the complete list could be: {(a, b, c), {d, e, f), (g, h)}
    */
   protected List<List<PartitionLocation>> locationSuperList;
+
   /**
-   * Flag to indicate if the sublists of the partition locations has been created
+   * Indicates if the sublists of the partition locations has been created
    */
-  protected boolean sublistsCreated = false;
+  protected boolean sublistsCreated;
 
   /**
    * Create sublists of the partition locations, each sublist of size
@@ -64,11 +66,9 @@ public abstract class AbstractPartitionDescriptor implements PartitionDescriptor
     return false;
   }
 
-
   @Override
   public TableScan createTableScan(List<PartitionLocation> newPartitions, Path cacheFileRoot,
       boolean isAllPruned, MetadataContext metaContext) throws Exception {
     throw new UnsupportedOperationException();
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSFilePartitionLocation.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/DFSFilePartitionLocation.java
@@ -21,7 +21,7 @@ import org.apache.drill.exec.store.ColumnExplorer;
 import org.apache.hadoop.fs.Path;
 
 /**
- * Class defines a single partition in a DFS table.
+ * Defines a single partition in a DFS table.
  */
 public class DFSFilePartitionLocation extends SimplePartitionLocation {
   private final String[] dirs;
@@ -58,6 +58,4 @@ public class DFSFilePartitionLocation extends SimplePartitionLocation {
   public String[] getDirs() {
     return dirs;
   }
-
 }
-

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/FileSystemPartitionDescriptor.java
@@ -33,7 +33,6 @@ import org.apache.drill.shaded.guava.com.google.common.base.Charsets;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
 import org.apache.calcite.adapter.enumerable.EnumerableTableScan;
 import org.apache.calcite.prepare.RelOptTableImpl;
@@ -58,14 +57,16 @@ import org.apache.drill.exec.vector.ValueVector;
 import org.apache.hadoop.fs.Path;
 
 
-// partition descriptor for file system based tables
+/**
+ * Partition descriptor for file system based tables.
+ */
 public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
 
-  static final int MAX_NESTED_SUBDIRS = 10;          // allow up to 10 nested sub-directories
+  static final int MAX_NESTED_SUBDIRS = 10; // allow up to 10 nested sub-directories
 
   private final String partitionLabel;
   private final int partitionLabelLength;
-  private final Map<String, Integer> partitions = Maps.newHashMap();
+  private final Map<String, Integer> partitions = new HashMap<>();
   private final TableScan scanRel;
   private final DrillTable table;
 
@@ -160,14 +161,15 @@ public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
 
     final Path selectionRoot = getBaseTableLocation();
 
-    // map used to map the partition keys (dir0, dir1, ..), to the list of partitions that share the same partition keys.
+    // map used to map the partition keys (dir0, dir1, ..), to the list of partitions
+    // that share the same partition keys.
     // For example,
     //   1990/Q1/1.parquet, 2.parquet
     // would have <1990, Q1> as key, and value as list of partition location for 1.parquet and 2.parquet.
     HashMap<List<String>, List<PartitionLocation>> dirToFileMap = new HashMap<>();
 
-    // Figure out the list of leaf subdirectories. For each leaf subdirectory, find the list of files (DFSFilePartitionLocation)
-    // it contains.
+    // Figure out the list of leaf subdirectories. For each leaf subdirectory, find
+    // the list of files (DFSFilePartitionLocation) it contains.
     for (Path file: fileLocationsAndStatus.getLeft()) {
       DFSFilePartitionLocation dfsFilePartitionLocation = new DFSFilePartitionLocation(MAX_NESTED_SUBDIRS,
           selectionRoot, file, hasDirsOnly);
@@ -267,11 +269,7 @@ public class FileSystemPartitionDescriptor extends AbstractPartitionDescriptor {
   @Override
   public boolean supportsMetadataCachePruning() {
     final Object selection = this.table.getSelection();
-    if (selection instanceof FormatSelection
-        && ((FormatSelection)selection).getSelection().getCacheFileRoot() != null) {
-      return true;
-    }
-    return false;
+    return selection instanceof FormatSelection
+        && ((FormatSelection)selection).getSelection().getCacheFileRoot() != null;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PartitionDescriptor.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Interface used to describe partitions. Currently used by file system based partitions and hive partitions
+ * Interface used to describe partitions. Currently used by file system based
+ * partitions and hive partitions
  */
 public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
 
@@ -71,7 +72,7 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
   int getMaxHierarchyLevel();
 
   /**
-   * Method creates an in memory representation of all the partitions. For each level of partitioning we
+   * Creates an in memory representation of all the partitions. For each level of partitioning we
    * will create a value vector which this method will populate for all the partitions with the values of the
    * partitioning key
    * @param vectors - Array of vectors in the container that need to be populated
@@ -90,7 +91,7 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
   TypeProtos.MajorType getVectorType(SchemaPath column, PlannerSettings plannerSettings);
 
   /**
-   * Methods create a new TableScan rel node, given the lists of new partitions or new files to SCAN.
+   * Create a new TableScan rel node, given the lists of new partitions or new files to SCAN.
    * @param newPartitions
    * @param wasAllPartitionsPruned
    * @throws Exception
@@ -113,5 +114,4 @@ public interface PartitionDescriptor extends Iterable<List<PartitionLocation>> {
   boolean supportsMetadataCachePruning();
 
   Path getBaseTableLocation();
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/PlannerPhase.java
@@ -105,6 +105,7 @@ import java.util.Set;
 public enum PlannerPhase {
 
   LOGICAL_PRUNE_AND_JOIN("Logical Planning (with join and partition pruning)") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           getDrillBasicRules(context),
@@ -116,6 +117,7 @@ public enum PlannerPhase {
   },
 
   WINDOW_REWRITE("Window Function rewrites") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return RuleSets.ofList(
           RuleInstance.CALC_INSTANCE,
@@ -125,6 +127,7 @@ public enum PlannerPhase {
   },
 
   SUBQUERY_REWRITE("Sub-queries rewrites") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return RuleSets.ofList(
           RuleInstance.SUB_QUERY_FILTER_REMOVE_RULE,
@@ -135,6 +138,7 @@ public enum PlannerPhase {
   },
 
   LOGICAL_PRUNE("Logical Planning (with partition pruning)") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           getDrillBasicRules(context),
@@ -145,6 +149,7 @@ public enum PlannerPhase {
   },
 
   JOIN_PLANNING("LOPT Join Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       List<RelOptRule> rules = Lists.newArrayList();
       if (context.getPlannerSettings().isJoinOptimizationEnabled()) {
@@ -160,6 +165,7 @@ public enum PlannerPhase {
   },
 
   ROWKEYJOIN_CONVERSION("Convert Join to RowKeyJoin") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       List<RelOptRule> rules = Lists.newArrayList();
       if (context.getPlannerSettings().isRowKeyJoinConversionEnabled()) {
@@ -173,6 +179,7 @@ public enum PlannerPhase {
   },
 
   SUM_CONVERSION("Convert SUM to $SUM0") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           RuleSets.ofList(
@@ -184,24 +191,28 @@ public enum PlannerPhase {
   },
 
   PARTITION_PRUNING("Partition Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   PHYSICAL_PARTITION_PRUNING("Physical Partition Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getPhysicalPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   DIRECTORY_PRUNING("Directory Prune Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(getDirPruneScanRules(context), getStorageRules(context, plugins, this));
     }
   },
 
   LOGICAL("Logical Planning (no pruning or join).") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           PlannerPhase.getDrillBasicRules(context),
@@ -211,6 +222,7 @@ public enum PlannerPhase {
   },
 
   PHYSICAL("Physical Planning") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.mergedRuleSets(
           PlannerPhase.getPhysicalRules(context),
@@ -220,12 +232,14 @@ public enum PlannerPhase {
   },
 
   PRE_LOGICAL_PLANNING("Planning with Hep planner only for rules, which are failed for Volcano planner") {
+    @Override
     public RuleSet getRules (OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return PlannerPhase.getSetOpTransposeRules();
     }
   },
 
   TRANSITIVE_CLOSURE("Transitive closure") {
+    @Override
     public RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins) {
       return getJoinTransitiveClosureRules();
     }
@@ -239,19 +253,19 @@ public enum PlannerPhase {
 
   public abstract RuleSet getRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins);
 
+  @SuppressWarnings("deprecation")
   private static RuleSet getStorageRules(OptimizerRulesContext context, Collection<StoragePlugin> plugins,
       PlannerPhase phase) {
     final Builder<RelOptRule> rules = ImmutableSet.builder();
-    for(StoragePlugin plugin : plugins){
-      if(plugin instanceof AbstractStoragePlugin){
+    for (StoragePlugin plugin : plugins) {
+      if (plugin instanceof AbstractStoragePlugin) {
         rules.addAll(((AbstractStoragePlugin) plugin).getOptimizerRules(context, phase));
-      }else{
+      } else {
         rules.addAll(plugin.getOptimizerRules(context));
       }
     }
     return RuleSets.ofList(rules.build());
   }
-
 
   static final RelOptRule DRILL_JOIN_TO_MULTIJOIN_RULE =
       new JoinToMultiJoinRule(DrillJoinRel.class, DrillRelFactories.LOGICAL_BUILDER);
@@ -412,9 +426,7 @@ public enum PlannerPhase {
 
     return RuleSets.ofList(pruneRules);
   }
-  /**
-   *
-   */
+
   static RuleSet getIndexRules(OptimizerRulesContext optimizerRulesContext) {
     final PlannerSettings ps = optimizerRulesContext.getPlannerSettings();
     if (!ps.isIndexPlanningEnabled()) {
@@ -480,7 +492,6 @@ public enum PlannerPhase {
         .build();
 
     return RuleSets.ofList(pruneRules);
-
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillRelOptUtil.java
@@ -73,8 +73,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Utility class that is a subset of the RelOptUtil class and is a placeholder for Drill specific
- * static methods that are needed during either logical or physical planning.
+ * Utility class that is a subset of the RelOptUtil class and is a placeholder
+ * for Drill specific static methods that are needed during either logical or
+ * physical planning.
  */
 public abstract class DrillRelOptUtil {
 
@@ -142,10 +143,12 @@ public abstract class DrillRelOptUtil {
     assert fieldNames.size() == fields.size();
     final List<RexNode> refs =
         new AbstractList<RexNode>() {
+          @Override
           public int size() {
             return fields.size();
           }
 
+          @Override
           public RexNode get(int index) {
             return RexInputRef.of(index, fields);
           }
@@ -221,6 +224,7 @@ public abstract class DrillRelOptUtil {
     try {
       RexVisitor<Void> visitor =
           new RexVisitorImpl<Void>(true) {
+            @Override
             public Void visitCall(RexCall call) {
               if (operators.contains(call.getOperator().getName().toLowerCase())) {
                 throw new Util.FoundOne(call); /* throw exception to interrupt tree walk (this is similar to
@@ -229,6 +233,7 @@ public abstract class DrillRelOptUtil {
               return super.visitCall(call);
             }
 
+            @Override
             public Void visitInputRef(RexInputRef inputRef) {
               if (projExprs.size() == 0 ) {
                 return super.visitInputRef(inputRef);
@@ -264,6 +269,7 @@ public abstract class DrillRelOptUtil {
           if (((long) l.getValue2()) == 0) {
             return true;
           }
+        default:
       }
     }
     return false;
@@ -296,6 +302,7 @@ public abstract class DrillRelOptUtil {
     try {
       RexVisitor<Void> visitor =
           new RexVisitorImpl<Void>(true) {
+            @Override
             public Void visitCall(RexCall call) {
               if ("convert_fromjson".equals(call.getOperator().getName().toLowerCase())) {
                 throw new Util.FoundOne(call); /* throw exception to interrupt tree walk (this is similar to
@@ -327,11 +334,13 @@ public abstract class DrillRelOptUtil {
       inputRefList = new ArrayList<>();
     }
 
+    @Override
     public Void visitInputRef(RexInputRef ref) {
       inputRefList.add(ref);
       return null;
     }
 
+    @Override
     public Void visitCall(RexCall call) {
       for (RexNode operand : call.operands) {
         operand.accept(this);
@@ -421,12 +430,12 @@ public abstract class DrillRelOptUtil {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public static boolean isProjectFlatten(RelNode project) {
 
     assert project instanceof Project : "Rel is NOT an instance of project!";
 
     for (RexNode rex : project.getChildExps()) {
-      RexNode newExpr = rex;
       if (rex instanceof RexCall) {
         RexCall function = (RexCall) rex;
         String functionName = function.getOperator().getName();
@@ -684,6 +693,7 @@ public abstract class DrillRelOptUtil {
     try {
       RexVisitor<Void> visitor =
           new RexVisitorImpl<Void>(true) {
+            @Override
             public Void visitCall(RexCall call) {
               if (call.getKind() == SqlKind.AND || call.getKind() == SqlKind.OR) {
                 super.visitCall(call);
@@ -738,6 +748,7 @@ public abstract class DrillRelOptUtil {
     List<RexInputRef> rexRefs = new ArrayList<>();
     RexVisitor<Void> visitor =
             new RexVisitorImpl<Void>(true) {
+              @Override
               public Void visitInputRef(RexInputRef inputRef) {
                 rexRefs.add(inputRef);
                 return super.visitInputRef(inputRef);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillScanRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillScanRelBase.java
@@ -37,7 +37,7 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
  * Base class for logical/physical scan rel implemented in Drill.
  */
 public abstract class DrillScanRelBase extends TableScan implements DrillRelNode {
-  protected GroupScan groupScan;
+  protected final GroupScan groupScan;
   protected final DrillTable drillTable;
 
   public DrillScanRelBase(RelOptCluster cluster,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DistributionAffinity.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/DistributionAffinity.java
@@ -18,8 +18,10 @@
 package org.apache.drill.exec.planner.fragment;
 
 /**
- * Describes an operator's endpoint assignment requirements. Ordering is from no assignment requirement to mandatory
- * assignment requirements. Changes/new addition should keep the order of increasing restrictive assignment requirement.
+ * Describes an operator's endpoint assignment requirements. Ordering is from no
+ * assignment requirement to mandatory assignment requirements. Changes/new
+ * addition should keep the order of increasing restrictive assignment
+ * requirement.
  */
 public enum DistributionAffinity {
   /**
@@ -28,14 +30,15 @@ public enum DistributionAffinity {
   NONE(SoftAffinityFragmentParallelizer.INSTANCE),
 
   /**
-   * Operator has soft distribution affinity to one or more endpoints. Operator performs better when fragments are
-   * assigned to the endpoints with affinity, but not a mandatory requirement.
+   * Operator has soft distribution affinity to one or more endpoints. Operator
+   * performs better when fragments are assigned to the endpoints with affinity,
+   * but not a mandatory requirement.
    */
   SOFT(SoftAffinityFragmentParallelizer.INSTANCE),
 
   /**
-   * Hard distribution affinity to one or more endpoints. Fragments having the operator must be scheduled on the nodes
-   * with affinity.
+   * Hard distribution affinity to one or more endpoints. Fragments having the
+   * operator must be scheduled on the nodes with affinity.
    */
   HARD(HardAffinityFragmentParallelizer.INSTANCE);
 
@@ -53,9 +56,12 @@ public enum DistributionAffinity {
   }
 
   /**
-   * Is the current DistributionAffinity less restrictive than the given DistributionAffinity?
+   * Is the current DistributionAffinity less restrictive than the given
+   * DistributionAffinity?
+   *
    * @param distributionAffinity
-   * @return True if the current DistributionAffinity less restrictive than the given DistributionAffinity. False otherwise.
+   * @return True if the current DistributionAffinity less restrictive than the
+   *         given DistributionAffinity. False otherwise.
    */
   public boolean isLessRestrictiveThan(final DistributionAffinity distributionAffinity) {
     return ordinal() < distributionAffinity.ordinal();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/HardAffinityFragmentParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/HardAffinityFragmentParallelizer.java
@@ -23,6 +23,7 @@ import org.apache.drill.exec.physical.EndpointAffinity;
 import org.apache.drill.exec.physical.PhysicalOperatorSetupException;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,11 +31,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * Implementation of {@link FragmentParallelizer} where fragment requires running on a given set of endpoints. Width
- * per node is depended on the affinity to the endpoint and total width (calculated using costs)
+ * Implementation of {@link FragmentParallelizer} where fragment requires
+ * running on a given set of endpoints. Width per node is depended on the
+ * affinity to the endpoint and total width (calculated using costs).
  */
 public class HardAffinityFragmentParallelizer implements FragmentParallelizer {
-  private static final Logger logger = org.slf4j.LoggerFactory.getLogger(HardAffinityFragmentParallelizer.class);
+  private static final Logger logger = LoggerFactory.getLogger(HardAffinityFragmentParallelizer.class);
 
   public static final HardAffinityFragmentParallelizer INSTANCE = new HardAffinityFragmentParallelizer();
 
@@ -53,7 +55,7 @@ public class HardAffinityFragmentParallelizer implements FragmentParallelizer {
 
     // Go through the affinity map and extract the endpoints that have mandatory assignment requirement
     final Map<DrillbitEndpoint, EndpointAffinity> endpointPool = Maps.newHashMap();
-    for(Entry<DrillbitEndpoint, EndpointAffinity> entry : pInfo.getEndpointAffinityMap().entrySet()) {
+    for (Entry<DrillbitEndpoint, EndpointAffinity> entry : pInfo.getEndpointAffinityMap().entrySet()) {
       if (entry.getValue().isAssignmentRequired()) {
         endpointPool.put(entry.getKey(), entry.getValue());
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/MemoryCalculator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/MemoryCalculator.java
@@ -121,13 +121,13 @@ public class MemoryCalculator extends AbstractOpWrapperVisitor<Void, RuntimeExce
 
   @Override
   public Void visitOp(PhysicalOperator op, Wrapper fragment) {
-    long memoryCost = (int)Math.ceil(op.getCost().getMemoryCost());
+    long memoryCost = (int) Math.ceil(op.getCost().getMemoryCost());
     if (op.isBufferedOperator(queryContext)) {
       // If the operator is a buffered operator then get the memory estimates of the optimizer.
       // The memory estimates of the optimizer are for the whole operator spread across all the
       // minor fragments. Divide this memory estimation by fragment width to get the memory
       // requirement per minor fragment.
-      long memoryCostPerMinorFrag = (int)Math.ceil(memoryCost/fragment.getAssignedEndpoints().size());
+      long memoryCostPerMinorFrag = (int) Math.ceil(memoryCost/fragment.getAssignedEndpoints().size());
       Map<DrillbitEndpoint, Integer> drillbitEndpointMinorFragMap = getMinorFragCountPerDrillbit(fragment);
 
       Map<DrillbitEndpoint,

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/PlanningSet.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/PlanningSet.java
@@ -21,14 +21,15 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PlanningSet implements Iterable<Wrapper> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlanningSet.class);
+  static final Logger logger = LoggerFactory.getLogger(PlanningSet.class);
 
   private final Map<Fragment, Wrapper> fragmentMap = Maps.newHashMap();
-  private int majorFragmentIdIndex = 0;
-
-  private Wrapper rootWrapper = null;
+  private int majorFragmentIdIndex;
+  private Wrapper rootWrapper;
 
   public Wrapper get(Fragment node) {
     Wrapper wrapper = fragmentMap.get(node);
@@ -42,7 +43,8 @@ public class PlanningSet implements Iterable<Wrapper> {
         // assign the upper 16 bits as the major fragment id.
         majorFragmentId = node.getSendingExchange().getChild().getOperatorId() >> 16;
 
-        // if they are not assigned, that means we mostly likely have an externally generated plan.  in this case, come up with a major fragmentid.
+        // if they are not assigned, that means we mostly likely have an externally generated plan.
+        // In this case, come up with a major fragmentid.
         if (majorFragmentId == 0) {
           majorFragmentId = majorFragmentIdIndex;
         }
@@ -84,5 +86,4 @@ public class PlanningSet implements Iterable<Wrapper> {
   public Wrapper getRootWrapper(){
     return rootWrapper;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/QueryParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/QueryParallelizer.java
@@ -28,15 +28,15 @@ import org.apache.drill.exec.work.QueryWorkUnit;
 import java.util.Collection;
 
 /**
- * This class parallelizes the query plan. Once the optimizer finishes its job by producing a
+ * Parallelizes the query plan. Once the optimizer finishes its job by producing a
  * optimized plan, it is the job of this parallelizer to generate a parallel plan out of the
  * optimized physical plan. It does so by using the optimizers estimates for row count etc.
  * There are two kinds of parallelizers as explained below. Currently the difference in
  * both of these parallelizers is only in the memory assignment for the physical operators.
- *
+ * <p>
  * a) Default Parallelizer: It optimistically assumes that the whole cluster is running only the
  *    current query and based on heuristics assigns the optimal memory to the buffered operators.
- *
+ * <p>
  * b) Queue Parallelizer: This parallelizer computes the memory that can be allocated at best based
  *    on the current cluster state(as to how much memory is available) and also the configuration
  *    of the queue that it can run on.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SimpleParallelizer.java
@@ -52,6 +52,8 @@ import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTes
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.work.QueryWorkUnit;
 import org.apache.drill.exec.work.QueryWorkUnit.MinorFragmentDefn;
@@ -59,13 +61,16 @@ import org.apache.drill.exec.work.foreman.ForemanSetupException;
 
 
 /**
- * The simple parallelizer determines the level of parallelization of a plan based on the cost of the underlying
- * operations.  It doesn't take into account system load or other factors.  Based on the cost of the query, the
- * parallelization for each major fragment will be determined.  Once the amount of parallelization is done, assignment
- * is done based on round robin assignment ordered by operator affinity (locality) to available execution Drillbits.
+ * The simple parallelizer determines the level of parallelization of a plan
+ * based on the cost of the underlying operations. It doesn't take into account
+ * system load or other factors. Based on the cost of the query, the
+ * parallelization for each major fragment will be determined. Once the amount
+ * of parallelization is done, assignment is done based on round robin
+ * assignment ordered by operator affinity (locality) to available execution
+ * Drillbits.
  */
 public abstract class SimpleParallelizer implements QueryParallelizer {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleParallelizer.class);
+  static final Logger logger = LoggerFactory.getLogger(SimpleParallelizer.class);
 
   private final long parallelizationThreshold;
   private final int maxWidthPerNode;
@@ -80,7 +85,7 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
     double cpu_load_average = optionManager.getOption(ExecConstants.CPU_LOAD_AVERAGE);
     final long maxWidth = optionManager.getOption(ExecConstants.MAX_WIDTH_PER_NODE);
     // compute the maxwidth
-    this.maxWidthPerNode = ExecConstants.MAX_WIDTH_PER_NODE.computeMaxWidth(cpu_load_average,maxWidth);
+    this.maxWidthPerNode = ExecConstants.MAX_WIDTH_PER_NODE.computeMaxWidth(cpu_load_average, maxWidth);
     this.maxGlobalWidth = optionManager.getOption(ExecConstants.MAX_WIDTH_GLOBAL_KEY).num_val.intValue();
     this.affinityFactor = optionManager.getOption(ExecConstants.AFFINITY_FACTOR_KEY).float_val.intValue();
     this.enableDynamicFC = optionManager.getBoolean(ExecConstants.ENABLE_DYNAMIC_CREDIT_BASED_FC);
@@ -114,19 +119,20 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
   }
 
   public Set<Wrapper> getRootFragments(PlanningSet planningSet) {
-    //The following code gets the root fragment by removing all the dependent fragments on which root fragments depend upon.
-    //This is fine because the later parallelizer code traverses from these root fragments to their respective dependent
-    //fragments.
+    // Gets the root fragment by removing all the dependent fragments on which
+    // root fragments depend upon. This is fine because the later parallelizer
+    // code traverses from these root fragments to their respective dependent
+    // fragments.
     final Set<Wrapper> roots = Sets.newHashSet();
-    for(Wrapper w : planningSet) {
+    for (Wrapper w : planningSet) {
       roots.add(w);
     }
 
-    //roots will be left over with the fragments which are not depended upon by any other fragments.
-    for(Wrapper wrapper : planningSet) {
+    // Roots will be left over with the fragments which are not depended upon by any other fragments.
+    for (Wrapper wrapper : planningSet) {
       final List<Wrapper> fragmentDependencies = wrapper.getFragmentDependencies();
       if (fragmentDependencies != null && fragmentDependencies.size() > 0) {
-        for(Wrapper dependency : fragmentDependencies) {
+        for (Wrapper dependency : fragmentDependencies) {
           if (roots.contains(dependency)) {
             roots.remove(dependency);
           }
@@ -193,7 +199,7 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
    * @param options List of options set by the user.
    * @param foremanNode foreman node for this query plan.
    * @param queryId  Query ID.
-   * @param activeEndpoints currently active endpoins on which this plan will run.
+   * @param activeEndpoints currently active endpoints on which this plan will run.
    * @param rootFragment Root major fragment.
    * @param session session context.
    * @param queryContextInfo query context.
@@ -235,8 +241,6 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
     throw new UnsupportedOperationException("Use children classes");
   }
 
-
-
   // For every fragment, create a Wrapper in PlanningSet.
   @VisibleForTesting
   public void initFragmentWrappers(Fragment rootFragment, PlanningSet planningSet) {
@@ -256,14 +260,15 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
   private void constructFragmentDependencyGraph(Fragment rootFragment, PlanningSet planningSet) {
 
     // Set up dependency of fragments based on the affinity of exchange that separates the fragments.
-    for(Wrapper currentFragment : planningSet) {
+    for (Wrapper currentFragment : planningSet) {
       ExchangeFragmentPair sendingXchgForCurrFrag = currentFragment.getNode().getSendingExchangePair();
       if (sendingXchgForCurrFrag != null) {
         ParallelizationDependency dependency = sendingXchgForCurrFrag.getExchange().getParallelizationDependency();
         Wrapper receivingFragmentWrapper = planningSet.get(sendingXchgForCurrFrag.getNode());
 
-        //Mostly Receivers of the current fragment depend on the sender of the child fragments. However there is a special case
-        //for DeMux Exchanges where the Sender of the current fragment depends on the receiver of the parent fragment.
+        // Mostly Receivers of the current fragment depend on the sender of the child fragments.
+        // However there is a special case for DeMux Exchanges where the Sender of the current
+        // fragment depends on the receiver of the parent fragment.
         if (dependency == ParallelizationDependency.RECEIVER_DEPENDS_ON_SENDER) {
           receivingFragmentWrapper.addFragmentDependency(currentFragment);
         } else if (dependency == ParallelizationDependency.SENDER_DEPENDS_ON_RECEIVER) {
@@ -274,16 +279,15 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
     planningSet.findRootWrapper(rootFragment);
   }
 
-
   /**
-   * Helper method to call operation on each fragment. Traversal calls operation on child fragments before
-   * calling it on the parent fragment.
+   * Call operation on each fragment. Traversal calls operation
+   * on child fragments before calling it on the parent fragment.
    */
   protected void traverse(Wrapper fragmentWrapper, Consumer<Wrapper> operation) throws PhysicalOperatorSetupException {
 
     final List<Wrapper> fragmentDependencies = fragmentWrapper.getFragmentDependencies();
     if (fragmentDependencies != null && fragmentDependencies.size() > 0) {
-      for(Wrapper dependency : fragmentDependencies) {
+      for (Wrapper dependency : fragmentDependencies) {
         traverse(dependency, operation);
       }
     }
@@ -300,8 +304,8 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
 
     MinorFragmentDefn rootFragmentDefn = null;
     FragmentRoot rootOperator = null;
-    // now we generate all the individual plan fragments and associated assignments. Note, we need all endpoints
-    // assigned before we can materialize, so we start a new loop here rather than utilizing the previous one.
+    // Generate all the individual plan fragments and associated assignments. Note, we need all endpoints
+    // assigned before we can materialize.
     for (Wrapper wrapper : planningSet) {
       Fragment node = wrapper.getNode();
       final PhysicalOperator physicalOperatorRoot = node.getRoot();
@@ -312,7 +316,7 @@ public abstract class SimpleParallelizer implements QueryParallelizer {
                 "The root fragment must always have parallelization one. In the current case, the width was set to %d.",
                 wrapper.getWidth()));
       }
-      // a fragment is self driven if it doesn't rely on any other exchanges.
+      // A fragment is self-driven if it doesn't rely on any other exchanges.
       boolean isLeafFragment = node.getReceivingExchangePairs().size() == 0;
       // Create a minorFragment for each major fragment.
       for (int minorFragmentId = 0; minorFragmentId < wrapper.getWidth(); minorFragmentId++) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SoftAffinityFragmentParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/SoftAffinityFragmentParallelizer.java
@@ -34,9 +34,11 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Implementation of {@link FragmentParallelizer} where fragment has zero or more endpoints with affinities. Width
- * per node is depended on the affinity to the endpoint and total width (calculated using costs). Based on various
- * factors endpoints which have no affinity can be assigned to run the fragments.
+ * Implementation of {@link FragmentParallelizer} where fragment has zero or
+ * more endpoints with affinities. Width per node is depended on the affinity to
+ * the endpoint and total width (calculated using costs). Based on various
+ * factors endpoints which have no affinity can be assigned to run the
+ * fragments.
  */
 public class SoftAffinityFragmentParallelizer implements FragmentParallelizer {
   public static final SoftAffinityFragmentParallelizer INSTANCE = new SoftAffinityFragmentParallelizer();
@@ -116,7 +118,7 @@ public class SoftAffinityFragmentParallelizer implements FragmentParallelizer {
 
       // Find the maximum number of slots which should go to endpoints with affinity (See DRILL-825 for details)
       int affinedSlots =
-          Math.max(1, (int) (Math.ceil((double)parameters.getAffinityFactor() * width / activeEndpoints.size()) * sortedAffinityList.size()));
+          Math.max(1, (int) (Math.ceil(parameters.getAffinityFactor() * width / activeEndpoints.size()) * sortedAffinityList.size()));
 
       // Make sure affined slots is at least the number of mandatory nodes
       affinedSlots = Math.max(affinedSlots, numRequiredNodes);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Stats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Stats.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class Stats {
   private final ParallelizationInfoCollector collector = new ParallelizationInfoCollector();
-  private double maxCost = 0.0;
+  private double maxCost;
   private DistributionAffinity distributionAffinity = DistributionAffinity.NONE;
 
   public void addParallelizationInfo(ParallelizationInfo parallelizationInfo) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
@@ -236,8 +236,8 @@ public class Wrapper {
       return result;
     };
 
-    Function<DrillbitEndpoint, NodeResource> cpuPerEndpoint = (
-        endpoint) -> new NodeResource(1, 0);
+    Function<DrillbitEndpoint, NodeResource> cpuPerEndpoint =
+        endpoint -> new NodeResource(1, 0);
 
     nodeResourceMap = endpoints.stream()
         .collect(Collectors.groupingBy(Function.identity(),

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/Wrapper.java
@@ -39,28 +39,30 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
- * A wrapping class that allows us to add additional information to each fragment node for planning purposes.
+ * Wrapper class that allows us to add additional information to each fragment
+ * node for planning purposes.
  */
 public class Wrapper {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Wrapper.class);
 
   private final Fragment node;
   private final int majorFragmentId;
   private int width = -1;
   private final Stats stats;
   private boolean endpointsAssigned;
-  private long initialAllocation = 0;
-  private long maxAllocation = 0;
+  private long initialAllocation;
+  private long maxAllocation;
   // Resources (i.e memory and cpu) are stored per drillbit in this map.
   // A Drillbit can have n number of minor fragments then the NodeResource
   // contains cumulative resources required for all the minor fragments
   // for that major fragment on that Drillbit.
   private Map<DrillbitEndpoint, NodeResource> nodeResourceMap;
 
-  // List of fragments this particular fragment depends on for determining its parallelization and endpoint assignments.
+  // List of fragments this particular fragment depends on for determining its
+  // parallelization and endpoint assignments.
   private final List<Wrapper> fragmentDependencies = Lists.newArrayList();
 
-  // a list of assigned endpoints. Technically, there could repeated endpoints in this list if we'd like to assign the
+  // List of assigned endpoints. Technically, there could repeated endpoints
+  // in this list if we'd like to assign the
   // same fragment multiple times to the same endpoint.
   private final List<DrillbitEndpoint> endpoints = Lists.newLinkedList();
 
@@ -68,7 +70,6 @@ public class Wrapper {
     this.majorFragmentId = majorFragmentId;
     this.node = node;
     this.stats = new Stats();
-    nodeResourceMap = null;
   }
 
   public Stats getStats() {
@@ -113,11 +114,13 @@ public class Wrapper {
     maxAllocation += memory;
   }
 
-  private class AssignEndpointsToScanAndStore extends AbstractPhysicalVisitor<Void, List<DrillbitEndpoint>, PhysicalOperatorSetupException>{
+  private class AssignEndpointsToScanAndStore extends
+      AbstractPhysicalVisitor<Void, List<DrillbitEndpoint>, PhysicalOperatorSetupException> {
 
     @Override
-    public Void visitExchange(Exchange exchange, List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
-      if(exchange == node.getSendingExchange()){
+    public Void visitExchange(Exchange exchange, List<DrillbitEndpoint> value)
+        throws PhysicalOperatorSetupException {
+      if (exchange == node.getSendingExchange()) {
         return visitOp(exchange, value);
       }
       // stop on receiver exchange.
@@ -125,32 +128,36 @@ public class Wrapper {
     }
 
     @Override
-    public Void visitGroupScan(GroupScan groupScan, List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
+    public Void visitGroupScan(GroupScan groupScan,
+        List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
       groupScan.applyAssignments(value);
       return super.visitGroupScan(groupScan, value);
     }
 
     @Override
-    public Void visitSubScan(SubScan subScan, List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
+    public Void visitSubScan(SubScan subScan, List<DrillbitEndpoint> value)
+        throws PhysicalOperatorSetupException {
       // TODO - implement this
       return visitOp(subScan, value);
     }
 
     @Override
-    public Void visitStore(Store store, List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
+    public Void visitStore(Store store, List<DrillbitEndpoint> value)
+        throws PhysicalOperatorSetupException {
       store.applyAssignments(value);
       return super.visitStore(store, value);
     }
 
     @Override
-    public Void visitOp(PhysicalOperator op, List<DrillbitEndpoint> value) throws PhysicalOperatorSetupException {
+    public Void visitOp(PhysicalOperator op, List<DrillbitEndpoint> value)
+        throws PhysicalOperatorSetupException {
       return visitChildren(op, value);
     }
 
   }
 
-  public void assignEndpoints(List<DrillbitEndpoint> assignedEndpoints) throws
-      PhysicalOperatorSetupException {
+  public void assignEndpoints(List<DrillbitEndpoint> assignedEndpoints)
+      throws PhysicalOperatorSetupException {
     Preconditions.checkState(!endpointsAssigned);
     endpointsAssigned = true;
 
@@ -173,7 +180,8 @@ public class Wrapper {
 
   @Override
   public String toString() {
-    return "FragmentWrapper [majorFragmentId=" + majorFragmentId + ", width=" + width + ", stats=" + stats + "]";
+    return "FragmentWrapper [majorFragmentId=" + majorFragmentId + ", width="
+        + width + ", stats=" + stats + "]";
   }
 
   public List<DrillbitEndpoint> getAssignedEndpoints() {
@@ -197,7 +205,9 @@ public class Wrapper {
 
   /**
    * Is the endpoints assignment done for this fragment?
-   * @return True if the endpoints assignment done for this fragment. False otherwise.
+   *
+   * @return True if the endpoints assignment done for this fragment. False
+   *         otherwise.
    */
   public boolean isEndpointsAssignmentDone() {
     return endpointsAssigned;
@@ -205,6 +215,7 @@ public class Wrapper {
 
   /**
    * Get the list of fragements this particular fragment depends on.
+   *
    * @return The list of fragements this particular fragment depends on.
    */
   public List<Wrapper> getFragmentDependencies() {
@@ -212,9 +223,9 @@ public class Wrapper {
   }
 
   /**
-   * Compute the cpu resources required for all the minor fragments of this major fragment.
-   * This information is stored per DrillbitEndpoint. It is assumed that this function is
-   * called only once.
+   * Compute the cpu resources required for all the minor fragments of this
+   * major fragment. This information is stored per DrillbitEndpoint. It is
+   * assumed that this function is called only once.
    */
   public void computeCpuResources() {
     Preconditions.checkArgument(nodeResourceMap == null);
@@ -225,12 +236,12 @@ public class Wrapper {
       return result;
     };
 
-    Function<DrillbitEndpoint, NodeResource> cpuPerEndpoint = (endpoint) -> new NodeResource(1, 0);
+    Function<DrillbitEndpoint, NodeResource> cpuPerEndpoint = (
+        endpoint) -> new NodeResource(1, 0);
 
     nodeResourceMap = endpoints.stream()
-                               .collect(Collectors.groupingBy(Function.identity(),
-                                        Collectors.reducing(NodeResource.create(),
-                                                            cpuPerEndpoint, merge)));
+        .collect(Collectors.groupingBy(Function.identity(),
+            Collectors.reducing(NodeResource.create(), cpuPerEndpoint, merge)));
   }
 
   public Map<DrillbitEndpoint, NodeResource> getResourceMap() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/contrib/SplittingParallelizer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/fragment/contrib/SplittingParallelizer.java
@@ -48,20 +48,21 @@ import org.apache.drill.exec.work.foreman.ForemanSetupException;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * SimpleParallelizerMultiPlans class is an extension to SimpleParallelizer
- * to help with getting PlanFragments for split plan.
- * Split plan is essentially ability to create multiple Physical Operator plans from original Physical Operator plan
- * to be able to run plans separately.
- * Moving functionality specific to splitting the plan to this class
- * allows not to pollute parent class with non-authentic functionality
- *
+ * SimpleParallelizerMultiPlans class is an extension to SimpleParallelizer to
+ * help with getting PlanFragments for split plan. Split plan is essentially
+ * ability to create multiple Physical Operator plans from original Physical
+ * Operator plan to be able to run plans separately. Moving functionality
+ * specific to splitting the plan to this class allows not to pollute parent
+ * class with non-authentic functionality.
  */
 public class SplittingParallelizer extends DefaultQueryParallelizer {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SplittingParallelizer.class);
   private boolean enableDynamicFC;
+  private static final Logger logger = LoggerFactory.getLogger(SplittingParallelizer.class);
 
   public SplittingParallelizer(boolean doMemoryPlanning, QueryContext context) {
     super(doMemoryPlanning, context);
@@ -81,6 +82,7 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
    * @return
    * @throws ExecutionSetupException
    */
+  @Override
   public List<QueryWorkUnit> getSplitFragments(OptionList options, DrillbitEndpoint foremanNode, QueryId queryId,
       Collection<DrillbitEndpoint> activeEndpoints, PhysicalPlanReader reader, Fragment rootFragment,
       UserSession session, QueryContextInformation queryContextInfo) throws ExecutionSetupException {
@@ -118,8 +120,8 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
       PhysicalPlanReader reader, Fragment rootNode, PlanningSet planningSet,
       UserSession session, QueryContextInformation queryContextInfo) throws ExecutionSetupException {
 
-    // now we generate all the individual plan fragments and associated assignments. Note, we need all endpoints
-    // assigned before we can materialize, so we start a new loop here rather than utilizing the previous one.
+    // Generate all the individual plan fragments and associated assignments. Note, we need all endpoints
+    // assigned before we can materialize.
 
     List<QueryWorkUnit> workUnits = Lists.newArrayList();
     int plansCount = 0;
@@ -133,13 +135,13 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
       boolean isLeafFragment = node.getReceivingExchangePairs().size() == 0;
       final PhysicalOperator physicalOperatorRoot = node.getRoot();
       // get all the needed info from leaf fragment
-      if ( (physicalOperatorRoot instanceof Exchange) &&  isLeafFragment) {
+      if ((physicalOperatorRoot instanceof Exchange) &&  isLeafFragment) {
         // need to get info about
         // number of minor fragments
         // assignedEndPoints
         // allocation
         plansCount = wrapper.getWidth();
-        initialAllocation = (wrapper.getInitialAllocation() != 0 ) ? wrapper.getInitialAllocation()/plansCount : 0;
+        initialAllocation = (wrapper.getInitialAllocation() != 0) ? wrapper.getInitialAllocation()/plansCount : 0;
         leafFragEndpoints = new DrillbitEndpoint[plansCount];
         for (int mfId = 0; mfId < plansCount; mfId++) {
           leafFragEndpoints[mfId] = wrapper.getAssignedEndpoint(mfId);
@@ -148,7 +150,7 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
     }
 
     DrillbitEndpoint[] endPoints = leafFragEndpoints;
-    if ( plansCount == 0 ) {
+    if (plansCount == 0) {
       // no exchange, return list of single QueryWorkUnit
       workUnits.add(generateWorkUnit(options, foremanNode, queryId, rootNode, planningSet, session, queryContextInfo));
       return workUnits;
@@ -157,7 +159,7 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
     for (Wrapper wrapper : planningSet) {
       Fragment node = wrapper.getNode();
       final PhysicalOperator physicalOperatorRoot = node.getRoot();
-      if ( physicalOperatorRoot instanceof Exchange ) {
+      if (physicalOperatorRoot instanceof Exchange) {
         // get to 0 MajorFragment
         continue;
       }
@@ -171,11 +173,11 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
       // this fragment is always leaf, as we are removing all the exchanges
       boolean isLeafFragment = true;
 
-      FragmentHandle handle = FragmentHandle //
-          .newBuilder() //
-          .setMajorFragmentId(wrapper.getMajorFragmentId()) //
+      FragmentHandle handle = FragmentHandle
+          .newBuilder()
+          .setMajorFragmentId(wrapper.getMajorFragmentId())
           .setMinorFragmentId(0) // minor fragment ID is going to be always 0, as plan will be split
-          .setQueryId(queryId) //
+          .setQueryId(queryId)
           .build();
 
       // Create a minorFragment for each major fragment.
@@ -197,14 +199,13 @@ public class SplittingParallelizer extends DefaultQueryParallelizer {
         Preconditions.checkArgument(op instanceof FragmentRoot);
         FragmentRoot root = (FragmentRoot) op;
 
-
-        PlanFragment fragment = PlanFragment.newBuilder() //
-            .setForeman(endPoints[minorFragmentId]) //
-            .setHandle(handle) //
-            .setAssignment(endPoints[minorFragmentId]) //
-            .setLeafFragment(isLeafFragment) //
+        PlanFragment fragment = PlanFragment.newBuilder()
+            .setForeman(endPoints[minorFragmentId])
+            .setHandle(handle)
+            .setAssignment(endPoints[minorFragmentId])
+            .setLeafFragment(isLeafFragment)
             .setContext(queryContextInfo)
-            .setMemInitial(initialAllocation)//
+            .setMemInitial(initialAllocation)
             .setMemMax(wrapper.getMaxAllocation()) // TODO - for some reason OOM is using leaf fragment max allocation divided by width
             .setCredentials(session.getCredentials())
             .addAllCollector(CountRequiredFragments.getCollectors(root, enableDynamicFC))

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/PathInExpr.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/PathInExpr.java
@@ -31,14 +31,19 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Class PathInExpr is to recursively analyze a expression trees with a map of indexed expression collected from indexDescriptor,
- * e.g. Map 'cast(a.q as int)' -> '$0' means the expression 'cast(a.q as int)' is named as '$0' in index table.
- *
- * for project expressions: cast(a.q as int), a.q, b + c, PathInExpr will get remainderPath {a.q, b, c}, which is
- * helpful to determine if q query is covering. remainderPathsInFunction will be {a.q}, which will be used to
- * decide if the {a.q} in scan column and project rowtype should be removed or not.
- *
- * This class could be more generic to support any expression, for now it works for only 'cast(schemapath as type)'.
+ * Class PathInExpr is to recursively analyze a expression trees with a map of
+ * indexed expression collected from indexDescriptor, e.g. Map 'cast(a.q as
+ * int)' -> '$0' means the expression 'cast(a.q as int)' is named as '$0' in
+ * index table.
+ * <p>
+ * for project expressions: cast(a.q as int), a.q, b + c, PathInExpr will get
+ * remainderPath {a.q, b, c}, which is helpful to determine if q query is
+ * covering. remainderPathsInFunction will be {a.q}, which will be used to
+ * decide if the {a.q} in scan column and project rowtype should be removed or
+ * not.
+ * <p>
+ * This class could be more generic to support any expression, for now it works
+ * for only 'cast(schemapath as type)'.
  */
 public class PathInExpr extends AbstractExprVisitor<Boolean,Void,RuntimeException> {
 
@@ -46,13 +51,13 @@ public class PathInExpr extends AbstractExprVisitor<Boolean,Void,RuntimeExceptio
   final private Map<LogicalExpression, Set<SchemaPath>> pathsInExpr;
 
   //collection of paths in all functional indexes
-  private Set<SchemaPath> allPaths;
+  private final Set<SchemaPath> allPaths;
 
   //the paths were found out of functional index expressions in query.
-  private Set<LogicalExpression> remainderPaths;
+  private final Set<LogicalExpression> remainderPaths;
 
   //the paths in functional index fields but were found out of index functions expression in query
-  private Set<LogicalExpression> remainderPathsInFunctions;
+  private final Set<LogicalExpression> remainderPathsInFunctions;
 
   //constructor is provided a map of all functional expressions to the paths involved in  the expressions.
   public PathInExpr(Map<LogicalExpression, Set<SchemaPath>> pathsInExpr) {
@@ -88,7 +93,7 @@ public class PathInExpr extends AbstractExprVisitor<Boolean,Void,RuntimeExceptio
     }
 
     boolean bret = true;
-    for (LogicalExpression arg : call.args) {
+    for (LogicalExpression arg : call.args()) {
       bret &= arg.accept(this, null);
       if(bret == false) {
         break;
@@ -109,6 +114,7 @@ public class PathInExpr extends AbstractExprVisitor<Boolean,Void,RuntimeExceptio
     return null;
   }
 
+  @Override
   public Boolean visitCastExpression(CastExpression castExpr, Void value) throws RuntimeException {
     if (preProcess(castExpr)) {
       //when it is true, we know this is exactly the indexed expression, no more deep search

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/generators/AbstractIndexPlanGenerator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/index/generators/AbstractIndexPlanGenerator.java
@@ -23,7 +23,8 @@ import java.util.List;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
@@ -64,7 +65,7 @@ import org.apache.calcite.rex.RexNode;
 
 public abstract class AbstractIndexPlanGenerator extends SubsetTransformer<RelNode, InvalidRelException>{
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractIndexPlanGenerator.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractIndexPlanGenerator.class);
 
   final protected DrillProjectRelBase origProject;
   final protected DrillScanRelBase origScan;
@@ -92,8 +93,8 @@ public abstract class AbstractIndexPlanGenerator extends SubsetTransformer<RelNo
     this.settings = settings;
   }
 
-  //This class provides the utility functions that don't rely on index(one or multiple) or final plan (covering or not),
-  //but those helper functions that focus on serving building index plan (project-filter-indexscan)
+  // Provides the utility functions that don't rely on index(one or multiple) or final plan (covering or not),
+  // but those helper functions that focus on serving building index plan (project-filter-indexscan)
 
   public static int getRowKeyIndex(RelDataType rowType, DrillScanRelBase origScan) {
     List<String> fieldNames = rowType.getFieldNames();
@@ -158,10 +159,11 @@ public abstract class AbstractIndexPlanGenerator extends SubsetTransformer<RelNo
     return convertedRight;
   }
 
+  @Override
   public RelTraitSet newTraitSet(RelTrait... traits) {
     RelTraitSet set = indexContext.getCall().getPlanner().emptyTraitSet();
     for (RelTrait t : traits) {
-      if(t != null) {
+      if (t != null) {
         set = set.plus(t);
       }
     }
@@ -169,10 +171,7 @@ public abstract class AbstractIndexPlanGenerator extends SubsetTransformer<RelNo
   }
 
   protected static boolean toRemoveSort(RelCollation sortCollation, RelCollation inputCollation) {
-    if ( (inputCollation != null) && inputCollation.satisfies(sortCollation)) {
-      return true;
-    }
-    return false;
+    return (inputCollation != null) && inputCollation.satisfies(sortCollation);
   }
 
   public static RelNode getExchange(RelOptCluster cluster, boolean isSingleton, boolean isExchangeRequired,
@@ -240,8 +239,10 @@ public abstract class AbstractIndexPlanGenerator extends SubsetTransformer<RelNo
     return newRel;
   }
 
+  @Override
   public abstract RelNode convertChild(RelNode current, RelNode child) throws InvalidRelException;
 
+  @Override
   public boolean forceConvert(){
     return true;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -67,6 +67,8 @@ import org.apache.calcite.util.NlsString;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.work.ExecErrorConstants;
 
@@ -77,7 +79,7 @@ import static org.apache.drill.exec.planner.physical.PlannerSettings.ENABLE_DECI
  */
 public class DrillOptiq {
   public static final String UNSUPPORTED_REX_NODE_ERROR = "Cannot convert RexNode to equivalent Drill expression. ";
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillOptiq.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillOptiq.class);
 
   /**
    * Converts a tree of {@link RexNode} operators into a scalar expression in Drill syntax using one input.
@@ -110,8 +112,6 @@ public class DrillOptiq {
   }
 
   public static class RexToDrill extends RexVisitorImpl<LogicalExpression> {
-    @SuppressWarnings("unused")
-    private final List<RelNode> inputs;
     private final DrillParseContext context;
     private final List<RelDataTypeField> fieldList;
     private final RelDataType rowType;
@@ -120,7 +120,6 @@ public class DrillOptiq {
     RexToDrill(DrillParseContext context, List<RelNode> inputs) {
       super(true);
       this.context = context;
-      this.inputs = inputs;
       this.fieldList = Lists.newArrayList();
       if (inputs.size() > 0 && inputs.get(0)!=null) {
         this.rowType = inputs.get(0).getRowType();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -120,7 +120,7 @@ public class DrillOptiq {
     RexToDrill(DrillParseContext context, List<RelNode> inputs) {
       super(true);
       this.context = context;
-      this.fieldList = Lists.newArrayList();
+      this.fieldList = new ArrayList<>();
       if (inputs.size() > 0 && inputs.get(0)!=null) {
         this.rowType = inputs.get(0).getRowType();
         this.builder = inputs.get(0).getCluster().getRexBuilder();
@@ -157,7 +157,6 @@ public class DrillOptiq {
       this.context = context;
       this.rowType = rowType;
       this.builder = builder;
-      this.inputs = Lists.newArrayList();
       this.fieldList = rowType.getFieldList();
     }
 
@@ -192,17 +191,18 @@ public class DrillOptiq {
       case POSTFIX:
         logger.debug("Postfix");
         switch(call.getKind()){
-        case IS_NOT_NULL:
-        case IS_NOT_TRUE:
-        case IS_NOT_FALSE:
-        case IS_NULL:
-        case IS_TRUE:
-        case IS_FALSE:
-        case OTHER:
-          return FunctionCallFactory.createExpression(call.getOperator().getName().toLowerCase(),
-              ExpressionPosition.UNKNOWN, call.getOperands().get(0).accept(this));
+          case IS_NOT_NULL:
+          case IS_NOT_TRUE:
+          case IS_NOT_FALSE:
+          case IS_NULL:
+          case IS_TRUE:
+          case IS_FALSE:
+          case OTHER:
+            return FunctionCallFactory.createExpression(call.getOperator().getName().toLowerCase(),
+                ExpressionPosition.UNKNOWN, call.getOperands().get(0).accept(this));
+          default:
+            throw notImplementedException(syntax, call);
         }
-        throw notImplementedException(syntax, call);
       case PREFIX:
         LogicalExpression arg = call.getOperands().get(0).accept(this);
         switch(call.getKind()){
@@ -210,11 +210,12 @@ public class DrillOptiq {
             return FunctionCallFactory.createExpression(call.getOperator().getName().toLowerCase(),
                 ExpressionPosition.UNKNOWN, arg);
           case MINUS_PREFIX:
-            List<LogicalExpression> operands = Lists.newArrayList();
+            List<LogicalExpression> operands = new ArrayList<>();
             operands.add(call.getOperands().get(0).accept(this));
             return FunctionCallFactory.createExpression("u-", operands);
+          default:
+            throw notImplementedException(syntax, call);
         }
-        throw notImplementedException(syntax, call);
       case SPECIAL:
         switch(call.getKind()){
         case CAST:
@@ -234,7 +235,7 @@ public class DrillOptiq {
         case SIMILAR:
           return getDrillFunctionFromOptiqCall(call);
         case CASE:
-          List<LogicalExpression> caseArgs = Lists.newArrayList();
+          List<LogicalExpression> caseArgs = new ArrayList<>();
           for(RexNode r : call.getOperands()){
             caseArgs.add(r.accept(this));
           }
@@ -250,6 +251,8 @@ public class DrillOptiq {
               .setIfCondition(new IfCondition(caseArgs.get(i + 1), caseArgs.get(i))).build();
           }
           return elseExpression;
+
+        default:
         }
 
         if (call.getOperator() == SqlStdOperatorTable.ITEM) {
@@ -409,7 +412,7 @@ public class DrillOptiq {
     }
 
     private LogicalExpression doFunction(RexCall call, String funcName) {
-      List<LogicalExpression> args = Lists.newArrayList();
+      List<LogicalExpression> args = new ArrayList<>();
       for(RexNode r : call.getOperands()){
         args.add(r.accept(this));
       }
@@ -723,12 +726,11 @@ public class DrillOptiq {
         case MILLENNIUM:
           final String functionPostfix = StringUtils.capitalize(timeUnitStr.toLowerCase());
           return FunctionCallFactory.createExpression("date_trunc_" + functionPostfix, args.subList(1, 2));
+        default:
+          throw new UnsupportedOperationException("date_trunc function supports the following time units: " +
+              "YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, WEEK, QUARTER, DECADE, CENTURY, MILLENNIUM");
       }
-
-      throw new UnsupportedOperationException("date_trunc function supports the following time units: " +
-          "YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, WEEK, QUARTER, DECADE, CENTURY, MILLENNIUM");
     }
-
 
     @Override
     public LogicalExpression visitLiteral(RexLiteral literal) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillOptiq.java
@@ -110,6 +110,7 @@ public class DrillOptiq {
   }
 
   public static class RexToDrill extends RexVisitorImpl<LogicalExpression> {
+    @SuppressWarnings("unused")
     private final List<RelNode> inputs;
     private final DrillParseContext context;
     private final List<RelDataTypeField> fieldList;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushLimitToScanRule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillPushLimitToScanRule.java
@@ -18,6 +18,8 @@
 package org.apache.drill.exec.planner.logical;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
@@ -26,7 +28,7 @@ import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.planner.common.DrillRelOptUtil;
 
 public abstract class DrillPushLimitToScanRule extends RelOptRule {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillPushLimitToScanRule.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillPushLimitToScanRule.class);
 
   private DrillPushLimitToScanRule(RelOptRuleOperand operand, String description) {
     super(operand, DrillRelFactories.LOGICAL_BUILDER, description);
@@ -39,7 +41,7 @@ public abstract class DrillPushLimitToScanRule extends RelOptRule {
     public boolean matches(RelOptRuleCall call) {
       DrillLimitRel limitRel = call.rel(0);
       DrillScanRel scanRel = call.rel(1);
-      // For now only applies to Parquet. And pushdown only apply limit but not offset,
+      // For now only applies to Parquet. And pushdown only applies to LIMIT but not OFFSET,
       // so if getFetch() return null no need to run this rule.
       if (scanRel.getGroupScan().supportsLimitPushdown() && (limitRel.getFetch() != null)) {
         return true;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ExprHelper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/ExprHelper.java
@@ -23,12 +23,11 @@ import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
 
 public class ExprHelper {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExprHelper.class);
-
-  private final static String COMPOUND_FAIL_MESSAGE = "The current Optiq based logical plan interpreter does not complicated expressions.  For Order By and Filter";
+  private final static String COMPOUND_FAIL_MESSAGE =
+      "The Calcite-based logical plan interpreter does not handle complicated expressions. For Order By and Filter";
 
   public static String getAggregateFieldName(FunctionCall c) {
-    List<LogicalExpression> exprs = c.args;
+    List<LogicalExpression> exprs = c.args();
     if (exprs.size() != 1) {
       throw new UnsupportedOperationException(COMPOUND_FAIL_MESSAGE);
     }
@@ -39,5 +38,4 @@ public class ExprHelper {
     //if(e instanceof SchemaPath) return ((SchemaPath) e).getPath().toString();
     throw new UnsupportedOperationException(COMPOUND_FAIL_MESSAGE);
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
@@ -27,6 +27,16 @@ import java.util.Objects;
 
 public class DrillDistributionTrait implements RelTrait {
 
+  public enum DistributionType {
+    SINGLETON,
+    HASH_DISTRIBUTED,
+    RANGE_DISTRIBUTED,
+    RANDOM_DISTRIBUTED,
+    ROUND_ROBIN_DISTRIBUTED,
+    BROADCAST_DISTRIBUTED,
+    ANY
+  }
+
   public static DrillDistributionTrait SINGLETON = new DrillDistributionTrait(DistributionType.SINGLETON);
   public static DrillDistributionTrait RANDOM_DISTRIBUTED = new DrillDistributionTrait(DistributionType.RANDOM_DISTRIBUTED);
   public static DrillDistributionTrait ANY = new DrillDistributionTrait(DistributionType.ANY);
@@ -35,7 +45,7 @@ public class DrillDistributionTrait implements RelTrait {
 
   private final DistributionType type;
   private final List<DistributionField> fields;
-  private PartitionFunction partitionFunction = null;
+  private PartitionFunction partitionFunction;
 
   public DrillDistributionTrait(DistributionType type) {
     assert (type == DistributionType.SINGLETON || type == DistributionType.RANDOM_DISTRIBUTED || type == DistributionType.ANY
@@ -97,6 +107,7 @@ public class DrillDistributionTrait implements RelTrait {
     return this.equals(trait);
   }
 
+  @Override
   public RelTraitDef<DrillDistributionTrait> getTraitDef() {
     return DrillDistributionTraitDef.INSTANCE;
   }
@@ -138,16 +149,6 @@ public class DrillDistributionTrait implements RelTrait {
   @Override
   public String toString() {
     return fields == null ? this.type.toString() : this.type.toString() + "(" + fields + ")";
-  }
-
-  public enum DistributionType {
-    SINGLETON,
-    HASH_DISTRIBUTED,
-    RANGE_DISTRIBUTED,
-    RANDOM_DISTRIBUTED,
-    ROUND_ROBIN_DISTRIBUTED,
-    BROADCAST_DISTRIBUTED,
-    ANY
   }
 
   public static class DistributionField {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTrait.java
@@ -27,16 +27,6 @@ import java.util.Objects;
 
 public class DrillDistributionTrait implements RelTrait {
 
-  public enum DistributionType {
-    SINGLETON,
-    HASH_DISTRIBUTED,
-    RANGE_DISTRIBUTED,
-    RANDOM_DISTRIBUTED,
-    ROUND_ROBIN_DISTRIBUTED,
-    BROADCAST_DISTRIBUTED,
-    ANY
-  }
-
   public static DrillDistributionTrait SINGLETON = new DrillDistributionTrait(DistributionType.SINGLETON);
   public static DrillDistributionTrait RANDOM_DISTRIBUTED = new DrillDistributionTrait(DistributionType.RANDOM_DISTRIBUTED);
   public static DrillDistributionTrait ANY = new DrillDistributionTrait(DistributionType.ANY);
@@ -149,6 +139,16 @@ public class DrillDistributionTrait implements RelTrait {
   @Override
   public String toString() {
     return fields == null ? this.type.toString() : this.type.toString() + "(" + fields + ")";
+  }
+
+  public enum DistributionType {
+    SINGLETON,
+    HASH_DISTRIBUTED,
+    RANGE_DISTRIBUTED,
+    RANDOM_DISTRIBUTED,
+    ROUND_ROBIN_DISTRIBUTED,
+    BROADCAST_DISTRIBUTED,
+    ANY
   }
 
   public static class DistributionField {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTraitDef.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/DrillDistributionTraitDef.java
@@ -77,7 +77,7 @@ public class DrillDistributionTraitDef extends RelTraitDef<DrillDistributionTrai
       return null;
     }
 
-    switch(toDist.getType()){
+    switch (toDist.getType()) {
       // UnionExchange, HashToRandomExchange, OrderedPartitionExchange and BroadcastExchange destroy the ordering property,
       // therefore RelCollation is set to default, which is EMPTY.
       case SINGLETON:
@@ -105,5 +105,4 @@ public class DrillDistributionTraitDef extends RelTraitDef<DrillDistributionTrai
         return null;
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ExchangePrel.java
@@ -25,7 +25,7 @@ import org.apache.drill.exec.server.options.OptionManager;
 
 import java.util.Collections;
 
-public abstract class ExchangePrel extends SinglePrel{
+public abstract class ExchangePrel extends SinglePrel {
 
   public ExchangePrel(RelOptCluster cluster, RelTraitSet traits, RelNode child) {
     super(cluster, traits, child);
@@ -38,12 +38,11 @@ public abstract class ExchangePrel extends SinglePrel{
 
   /**
    * The derived classes can override this method to create relevant mux exchanges.
-   * If this method is not overrided the default behaviour is to clone itself.
+   * If this method is not overridden then the default behavior is to clone itself.
    * @param child input to the new muxPrel or new Exchange node.
    * @param options options manager to check if mux is enabled.
    */
   public Prel constructMuxPrel(Prel child, OptionManager options) {
     return (Prel)copy(getTraitSet(), Collections.singletonList(((RelNode)child)));
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashPrelUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/HashPrelUtil.java
@@ -42,6 +42,7 @@ public class HashPrelUtil {
   public static final String HASH_EXPR_NAME = "E_X_P_R_H_A_S_H_F_I_E_L_D";
 
   public static final int DIST_SEED = 1301011; // distribution seed
+
   /**
    * Interface for creating different forms of hash expression types.
    * @param <T>
@@ -63,6 +64,7 @@ public class HashPrelUtil {
       this.rexBuilder = rexBuilder;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public RexNode createCall(String funcName, List<RexNode> inputFields) {
       final DrillSqlOperator op =
@@ -172,11 +174,10 @@ public class HashPrelUtil {
     return createHashExpression(ImmutableList.of(field), seed, HASH_HELPER_LOGICAL_EXPRESSION, hashAsDouble);
   }
 
-
   /**
    * Create a distribution hash expression.
    *
-   * @param fields  Distribution fields
+   * @param fields Distribution fields
    * @param rowType Row type
    * @return distribution hash expression
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPrel.java
@@ -43,14 +43,14 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- *
  * Base class for MergeJoinPrel and HashJoinPrel
- *
  */
 public abstract class JoinPrel extends DrillJoinRelBase implements Prel {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JoinPrel.class);
+  private static final Logger logger = LoggerFactory.getLogger(JoinPrel.class);
 
   protected final boolean isSemiJoin;
   protected JoinUtils.JoinCategory joincategory;
@@ -158,14 +158,16 @@ public abstract class JoinPrel extends DrillJoinRelBase implements Prel {
     }
   }
 
+  @Override
   public boolean isSemiJoin() {
     return isSemiJoin;
   }
 
-  /* A Drill physical rel which is semi join will have output row type with fields from only
-     left side of the join. Calcite's join rel expects to have the output row type from
-     left and right side of the join. This function is overloaded to not throw exceptions for
-     a Drill semi join physical rel.
+  /**
+   * A Drill physical rel which is semi join will have output row type with fields from only
+   * left side of the join. Calcite's join rel expects to have the output row type from
+   * left and right side of the join. This function is overloaded to not throw exceptions for
+   * a Drill semi join physical rel.
    */
   @Override public boolean isValid(Litmus litmus, Context context) {
     if (!this.isSemiJoin && !super.isValid(litmus, context)) {
@@ -186,6 +188,7 @@ public abstract class JoinPrel extends DrillJoinRelBase implements Prel {
       // fields, left fields, and right fields. Very similar to the
       // output row type, except that fields have not yet been made due
       // due to outer joins.
+      @SuppressWarnings("deprecation")
       RexChecker checker =
               new RexChecker(
                       getCluster().getTypeFactory().builder()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/JoinPrel.java
@@ -37,6 +37,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
@@ -188,10 +189,9 @@ public abstract class JoinPrel extends DrillJoinRelBase implements Prel {
       // fields, left fields, and right fields. Very similar to the
       // output row type, except that fields have not yet been made due
       // due to outer joins.
-      @SuppressWarnings("deprecation")
       RexChecker checker =
               new RexChecker(
-                      getCluster().getTypeFactory().builder()
+                  new RelDataTypeFactory.Builder(getCluster().getTypeFactory())
                               .addAll(getSystemFieldList())
                               .addAll(getLeft().getRowType().getFieldList())
                               .addAll(getRight().getRowType().getFieldList())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
@@ -22,6 +22,7 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.BiRel;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.drill.exec.metastore.analyze.MetastoreAnalyzeConstants;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
@@ -85,10 +86,9 @@ public class MetadataControllerPrel extends BiRel implements DrillRelNode, Prel 
     return PrelUtil.iter(getLeft(), getRight());
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   protected RelDataType deriveRowType() {
-    return getCluster().getTypeFactory().builder()
+    return new RelDataTypeFactory.Builder(getCluster().getTypeFactory())
         .add(MetastoreAnalyzeConstants.OK_FIELD_NAME, SqlTypeName.BOOLEAN)
         .add(MetastoreAnalyzeConstants.SUMMARY_FIELD_NAME, SqlTypeName.VARCHAR)
         .build();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/MetadataControllerPrel.java
@@ -85,6 +85,7 @@ public class MetadataControllerPrel extends BiRel implements DrillRelNode, Prel 
     return PrelUtil.iter(getLeft(), getRight());
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   protected RelDataType deriveRowType() {
     return getCluster().getTypeFactory().builder()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/NestedLoopJoinPrule.java
@@ -79,7 +79,6 @@ public class NestedLoopJoinPrule extends JoinPruleBase {
     if (!settings.isNestedLoopJoinEnabled()) {
       return;
     }
-    int[] joinFields = new int[2];
     DrillJoinRel join = (DrillJoinRel) call.rel(0);
     final RelNode left = join.getLeft();
     final RelNode right = join.getRight();
@@ -99,5 +98,4 @@ public class NestedLoopJoinPrule extends JoinPruleBase {
       tracer.warn(e.toString());
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PhysicalPlanCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/PhysicalPlanCreator.java
@@ -38,13 +38,11 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 
 public class PhysicalPlanCreator {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PhysicalPlanCreator.class);
 
   private final Map<Prel, OpId> opIdMap;
-
-  private List<PhysicalOperator> popList;
+  private final List<PhysicalOperator> popList;
   private final QueryContext context;
-  PhysicalPlan plan = null;
+  private PhysicalPlan plan;
 
   public PhysicalPlanCreator(QueryContext context, Map<Prel, OpId> opIdMap) {
     this.context = context;
@@ -88,7 +86,6 @@ public class PhysicalPlanCreator {
     propsBuilder.resultMode(ResultMode.EXEC);
     propsBuilder.generator(PhysicalPlanCreator.class.getName(), "");
 
-
     try {
       // invoke getPhysicalOperator on the root Prel which will recursively invoke it
       // on the descendants and we should have a well-formed physical operator tree
@@ -105,5 +102,4 @@ public class PhysicalPlanCreator {
 
     return plan;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/Prel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/Prel.java
@@ -28,13 +28,14 @@ import org.apache.drill.exec.planner.physical.visitor.PrelVisitor;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 public interface Prel extends DrillRelNode, Iterable<Prel> {
-  org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Prel.class);
 
   Convention DRILL_PHYSICAL = new Convention.Impl("PHYSICAL", Prel.class) {
+    @Override
     public boolean canConvertConvention(Convention toConvention) {
       return true;
     }
 
+    @Override
     public boolean useAbstractConvertersForConversion(RelTraitSet fromTraits,
         RelTraitSet toTraits) {
       return true;
@@ -50,6 +51,7 @@ public interface Prel extends DrillRelNode, Iterable<Prel> {
    * of its child Prel
    */
   SelectionVectorMode[] getSupportedEncodings();
+
   /**
    * A Prel's own SelectionVector mode - i.e whether it generates an SV2, SV4 or None
    */
@@ -66,5 +68,4 @@ public interface Prel extends DrillRelNode, Iterable<Prel> {
     throw new UnsupportedOperationException("Adding Implicit RowID column is not supported for " +
             this.getClass().getSimpleName() + " operator ");
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ScanPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ScanPrule.java
@@ -25,7 +25,7 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTraitSet;
 
-public class ScanPrule extends Prule{
+public class ScanPrule extends Prule {
   public static final RelOptRule INSTANCE = new ScanPrule();
 
   public ScanPrule() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SingleMergeExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SingleMergeExchangePrel.java
@@ -42,7 +42,8 @@ public class SingleMergeExchangePrel extends ExchangePrel {
 
   private final RelCollation collation;
 
-  public SingleMergeExchangePrel(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RelCollation collation) {
+  public SingleMergeExchangePrel(RelOptCluster cluster, RelTraitSet traitSet,
+      RelNode input, RelCollation collation) {
     super(cluster, traitSet, input);
     this.collation = collation;
     assert input.getConvention() == Prel.DRILL_PHYSICAL;
@@ -81,6 +82,7 @@ public class SingleMergeExchangePrel extends ExchangePrel {
     return new SingleMergeExchangePrel(getCluster(), traitSet, sole(inputs), collation);
   }
 
+  @Override
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
     Prel child = (Prel) this.getInput();
 
@@ -131,5 +133,4 @@ public class SingleMergeExchangePrel extends ExchangePrel {
   public SelectionVectorMode getEncoding() {
     return SelectionVectorMode.NONE;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrel.java
@@ -143,6 +143,7 @@ public class SortPrel extends org.apache.calcite.rel.core.Sort implements Ordere
               fieldCollation.direction, fieldCollation.nullDirection));
     }
 
+    @SuppressWarnings("deprecation")
     RelCollation collationTrait = RelCollationImpl.of(relFieldCollations);
     RelTraitSet traits = RelTraitSet.createEmpty()
                                     .replace(this.getTraitSet().getTrait(DrillDistributionTraitDef.INSTANCE))
@@ -166,5 +167,4 @@ public class SortPrel extends org.apache.calcite.rel.core.Sort implements Ordere
   public boolean canBeDropped() {
     return isRemovable;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrule.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SortPrule.java
@@ -38,7 +38,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
  * For Logical Sort, it requires one single data stream as the output.
  *
  */
-public class SortPrule extends Prule{
+public class SortPrule extends Prule {
   public static final RelOptRule INSTANCE = new SortPrule();
 
   private SortPrule() {
@@ -48,7 +48,6 @@ public class SortPrule extends Prule{
   @Override
   public void onMatch(RelOptRuleCall call) {
     final DrillSortRel sort = call.rel(0);
-    final RelNode input = sort.getInput();
 
     // Keep the collation in logical sort. Convert input into a RelNode with 1) this collation, 2) Physical, 3) hash distributed on
 
@@ -59,12 +58,12 @@ public class SortPrule extends Prule{
     SortPrel child = new SortPrel(sort.getCluster(), traits.plus(sort.getCollation()),
             convert(sort.getInput(), traits), sort.getCollation(), false);
 
-    if(isSingleMode(call)){
+    if (isSingleMode(call)) {
       call.transformTo(child);
-    }else{
-      RelNode exch = new SingleMergeExchangePrel(sort.getCluster(), sort.getTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON), child, sort.getCollation());
+    } else {
+      RelNode exch = new SingleMergeExchangePrel(sort.getCluster(), sort.getTraitSet().plus(
+          Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON), child, sort.getCollation());
       call.transformTo(exch);  // transform logical "sort" into "SingleMergeExchange".
-
     }
   }
 
@@ -77,5 +76,4 @@ public class SortPrule extends Prule{
     }
     return distFields;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SubsetTransformer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/SubsetTransformer.java
@@ -18,6 +18,8 @@
 package org.apache.drill.exec.planner.physical;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.plan.RelOptRule;
@@ -29,18 +31,18 @@ import org.apache.calcite.plan.volcano.RelSubset;
 import java.util.Set;
 
 public abstract class SubsetTransformer<T extends RelNode, E extends Exception> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SubsetTransformer.class);
-
-  public abstract RelNode convertChild(T current, RelNode child) throws E;
-
-  public boolean forceConvert() {
-    return false;
-  }
+  private static final Logger logger = LoggerFactory.getLogger(SubsetTransformer.class);
 
   private final RelOptRuleCall call;
 
   public SubsetTransformer(RelOptRuleCall call) {
     this.call = call;
+  }
+
+  public abstract RelNode convertChild(T current, RelNode child) throws E;
+
+  public boolean forceConvert() {
+    return false;
   }
 
   public RelTraitSet newTraitSet(RelTrait... traits) {
@@ -49,7 +51,6 @@ public abstract class SubsetTransformer<T extends RelNode, E extends Exception> 
       set = set.plus(t);
     }
     return set;
-
   }
 
   public boolean go(T n, RelNode candidateSet) throws E {
@@ -105,9 +106,4 @@ public abstract class SubsetTransformer<T extends RelNode, E extends Exception> 
   private boolean isPhysical(RelNode n){
     return n.getTraitSet().getTrait(ConventionTraitDef.INSTANCE).equals(Prel.DRILL_PHYSICAL);
   }
-
-  private boolean isDefaultDist(RelNode n) {
-    return n.getTraitSet().getTrait(DrillDistributionTraitDef.INSTANCE).equals(DrillDistributionTrait.DEFAULT);
-  }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
@@ -140,6 +140,7 @@ public class TopNPrel extends SinglePrel implements OrderedRel,Prel {
               fieldCollation.direction, fieldCollation.nullDirection));
     }
 
+    @SuppressWarnings("deprecation")
     RelCollation collationTrait = RelCollationImpl.of(relFieldCollations);
     RelTraitSet traits = RelTraitSet.createEmpty()
                                     .replace(this.getTraitSet().getTrait(DrillDistributionTraitDef.INSTANCE))

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.apache.calcite.rel.RelCollationImpl;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rex.RexNode;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/TopNPrel.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.calcite.rel.RelCollationImpl;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -140,8 +141,7 @@ public class TopNPrel extends SinglePrel implements OrderedRel,Prel {
               fieldCollation.direction, fieldCollation.nullDirection));
     }
 
-    @SuppressWarnings("deprecation")
-    RelCollation collationTrait = RelCollationImpl.of(relFieldCollations);
+    RelCollation collationTrait = RelCollations.of(relFieldCollations);
     RelTraitSet traits = RelTraitSet.createEmpty()
                                     .replace(this.getTraitSet().getTrait(DrillDistributionTraitDef.INSTANCE))
                                     .replace(collationTrait)

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnionExchangePrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/UnionExchangePrel.java
@@ -70,6 +70,7 @@ public class UnionExchangePrel extends ExchangePrel {
     return new UnionExchangePrel(getCluster(), traitSet, sole(inputs));
   }
 
+  @Override
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator) throws IOException {
     Prel child = (Prel) this.getInput();
 
@@ -87,5 +88,4 @@ public class UnionExchangePrel extends ExchangePrel {
   public SelectionVectorMode getEncoding() {
     return SelectionVectorMode.NONE;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/ExcessiveExchangeIdentifier.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/ExcessiveExchangeIdentifier.java
@@ -37,7 +37,7 @@ import org.apache.drill.exec.planner.physical.UnnestPrel;
 
 public class ExcessiveExchangeIdentifier extends BasePrelVisitor<Prel, ExcessiveExchangeIdentifier.MajorFragmentStat, RuntimeException> {
   private final long targetSliceSize;
-  private LateralJoinPrel topMostLateralJoin = null;
+  private LateralJoinPrel topMostLateralJoin;
 
   public ExcessiveExchangeIdentifier(long targetSliceSize) {
     this.targetSliceSize = targetSliceSize;
@@ -78,11 +78,7 @@ public class ExcessiveExchangeIdentifier extends BasePrelVisitor<Prel, Excessive
       return true;
     }
 
-    if (parentFrag.isRightSideOfLateral()) {
-      return true;
-    }
-
-    return false;
+    return parentFrag.isRightSideOfLateral();
   }
 
   @Override
@@ -147,7 +143,7 @@ public class ExcessiveExchangeIdentifier extends BasePrelVisitor<Prel, Excessive
 
     s.setHashDistribution(prel);
 
-    for(Prel p : prel) {
+    for (Prel p : prel) {
       children.add(p.accept(this, s));
     }
     return (Prel) prel.copy(prel.getTraitSet(), children);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/MemoryEstimationVisitor.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/visitor/MemoryEstimationVisitor.java
@@ -21,11 +21,13 @@ import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.planner.cost.DrillCostBase;
 import org.apache.drill.exec.planner.physical.Prel;
 import org.apache.drill.exec.server.options.OptionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 
 public class MemoryEstimationVisitor extends BasePrelVisitor<Double, Void, RuntimeException> {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MemoryEstimationVisitor.class);
+  private static final Logger logger = LoggerFactory.getLogger(MemoryEstimationVisitor.class);
 
   public static boolean enoughMemory(Prel prel, OptionManager options, int numDrillbits) {
     long allottedMemory = options.getOption(ExecConstants.MAX_QUERY_MEMORY_PER_NODE_KEY).num_val * numDrillbits;
@@ -44,8 +46,7 @@ public class MemoryEstimationVisitor extends BasePrelVisitor<Double, Void, Runti
     return prel.accept(new MemoryEstimationVisitor(), null);
   }
 
-  public MemoryEstimationVisitor() {
-  }
+  public MemoryEstimationVisitor() { }
 
   @Override
   public Double visitPrel(Prel prel, Void value) throws RuntimeException {
@@ -54,6 +55,7 @@ public class MemoryEstimationVisitor extends BasePrelVisitor<Double, Void, Runti
 //    return findCost(prel, mq);
   }
 
+  @SuppressWarnings("unused")
   private double findCost(Prel prel, RelMetadataQuery mq) {
     DrillCostBase cost = (DrillCostBase) mq.getNonCumulativeCost(prel);
     double memory = cost.getMemory();
@@ -63,5 +65,4 @@ public class MemoryEstimationVisitor extends BasePrelVisitor<Double, Void, Runti
     }
     return memory;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/TypeInferenceUtils.java
@@ -21,7 +21,8 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -59,7 +60,7 @@ import java.util.Set;
 
 @SuppressWarnings("WeakerAccess")
 public class TypeInferenceUtils {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeInferenceUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(TypeInferenceUtils.class);
 
   public static final TypeProtos.MajorType UNKNOWN_TYPE = TypeProtos.MajorType.getDefaultInstance();
   private static final ImmutableMap<TypeProtos.MinorType, SqlTypeName> DRILL_TO_CALCITE_TYPE_MAPPING
@@ -351,7 +352,7 @@ public class TypeInferenceUtils {
       final DrillFuncHolder func = resolveDrillFuncHolder(opBinding, functions, functionCall);
 
       final RelDataType returnType = getReturnType(opBinding,
-          func.getReturnType(functionCall.args), func.getNullHandling());
+          func.getReturnType(functionCall.args()), func.getNullHandling());
 
       return returnType.getSqlTypeName() == SqlTypeName.VARBINARY
           ? createCalciteTypeWithNullability(factory, SqlTypeName.ANY, returnType.isNullable())

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/DefaultSqlHandler.java
@@ -180,8 +180,8 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
   }
 
   /**
-   * Rewrite the parse tree. Used before validating the parse tree. Useful if a particular statement needs to converted
-   * into another statement.
+   * Rewrite the parse tree. Used before validating the parse tree. Useful if a
+   * particular statement needs to converted into another statement.
    *
    * @param node sql parse tree to be rewritten
    * @return Rewritten sql parse tree
@@ -312,7 +312,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
   }
 
   /**
-   * A shuttle designed to finalize all RelNodes.
+   * Finalize all RelNodes.
    */
   private static class PrelFinalizer extends RelShuttleImpl {
 
@@ -425,7 +425,8 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
    * @throws RelConversionException
    * @throws SqlUnsupportedException
    */
-  protected Prel convertToPrel(RelNode drel, RelDataType validatedRowType) throws RelConversionException, SqlUnsupportedException {
+  protected Prel convertToPrel(RelNode drel, RelDataType validatedRowType)
+      throws RelConversionException, SqlUnsupportedException {
     Preconditions.checkArgument(drel.getConvention() == DrillRel.DRILL_LOGICAL);
 
     final RelTraitSet traits = drel.getTraitSet().plus(Prel.DRILL_PHYSICAL).plus(DrillDistributionTrait.SINGLETON);
@@ -469,6 +470,8 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
         }
       }
     }
+    // Handy way to visualize the plan while debugging
+    //ExplainHandler.printPlan(phyRelNode, context);
 
     /* The order of the following transformations is important */
 
@@ -530,7 +533,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
 
     /*
      * 3.)
-     * Since our operators work via names rather than indices, we have to make to reorder any
+     * Since our operators work via names rather than indices, we have to reorder any
      * output before we return data to the user as we may have accidentally shuffled things.
      * This adds a trivial project to reorder columns prior to output.
      */
@@ -557,16 +560,14 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
     }
     */
 
-
     /* 6.)
      * if the client does not support complex types (Map, Repeated)
-     * insert a project which which would convert
+     * insert a project which would convert
      */
     if (!context.getSession().isSupportComplexTypes()) {
       logger.debug("Client does not support complex types, add ComplexToJson operator.");
       phyRelNode = ComplexToJsonPrelVisitor.addComplexToJsonPrel(phyRelNode);
     }
-
 
     /* 7.)
      * Insert LocalExchange (mux and/or demux) nodes
@@ -581,14 +582,12 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       phyRelNode = RuntimeFilterVisitor.addRuntimeFilter(phyRelNode, context);
     }
 
-
     /* 9.)
      * Next, we add any required selection vector removers given the supported encodings of each
      * operator. This will ultimately move to a new trait but we're managing here for now to avoid
      * introducing new issues in planning before the next release
      */
     phyRelNode = SelectionVectorPrelVisitor.addSelectionRemoversWhereNecessary(phyRelNode);
-
 
     /* 10.)
      * Finally, Make sure that the no rels are repeats.
@@ -635,6 +634,7 @@ public class DefaultSqlHandler extends AbstractSqlHandler {
       }
       return null;
     }
+
   }
 
   protected Pair<SqlNode, RelDataType> validateNode(SqlNode sqlNode) throws ValidationException, RelConversionException, ForemanSetupException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/ExplainHandler.java
@@ -41,9 +41,12 @@ import org.apache.drill.exec.planner.physical.explain.PrelSequencer;
 import org.apache.drill.exec.planner.sql.DirectPlan;
 import org.apache.drill.exec.util.Pointer;
 import org.apache.drill.exec.work.foreman.ForemanSetupException;
+import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExplainHandler extends DefaultSqlHandler {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExplainHandler.class);
+  private static final Logger logger = LoggerFactory.getLogger(ExplainHandler.class);
 
   private ResultMode mode;
   private SqlExplainLevel level = SqlExplainLevel.ALL_ATTRIBUTES;
@@ -96,23 +99,22 @@ public class ExplainHandler extends DefaultSqlHandler {
     return node.operand(0);
   }
 
-
-  public static class LogicalExplain{
-    public String text;
-    public String json;
+  public static class LogicalExplain {
+    public final String text;
+    public final String json;
 
     public LogicalExplain(RelNode node, SqlExplainLevel level, QueryContext context) {
       this.text = RelOptUtil.toString(node, level);
       DrillImplementor implementor = new DrillImplementor(new DrillParseContext(context.getPlannerSettings()), ResultMode.LOGICAL);
-      implementor.go( (DrillRel) node);
+      implementor.go((DrillRel) node);
       LogicalPlan plan = implementor.getPlan();
       this.json = plan.unparse(context.getLpPersistence());
     }
   }
 
-  public static class PhysicalExplain{
-    public String text;
-    public String json;
+  public static class PhysicalExplain {
+    public final String text;
+    public final String json;
 
     public PhysicalExplain(RelNode node, PhysicalPlan plan, SqlExplainLevel level, QueryContext context) {
       this.text = PrelSequencer.printWithIds((Prel) node, level);
@@ -120,4 +122,15 @@ public class ExplainHandler extends DefaultSqlHandler {
     }
   }
 
+  // Debug-only tool to dump a plan to stdout for inspection
+
+  @VisibleForTesting
+  public static void printPlan(Prel node, QueryContext context) {
+    System.out.println(PrelSequencer.printWithIds(node, SqlExplainLevel.ALL_ATTRIBUTES));
+  }
+
+  @VisibleForTesting
+  public static void printPlan(RelNode node) {
+    System.out.println(RelOptUtil.toString(node, SqlExplainLevel.ALL_ATTRIBUTES));
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/DefaultFunctionResolver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/DefaultFunctionResolver.java
@@ -41,7 +41,7 @@ public class DefaultFunctionResolver implements FunctionResolver {
 
     for (DrillFuncHolder h : methods) {
       final List<TypeProtos.MajorType> argumentTypes = Lists.newArrayList();
-      for (LogicalExpression expression : call.args) {
+      for (LogicalExpression expression : call.args()) {
         argumentTypes.add(expression.getMajorType());
       }
       currcost = TypeCastRules.getCost(argumentTypes, h);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/ExactFunctionResolver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/ExactFunctionResolver.java
@@ -39,7 +39,7 @@ public class ExactFunctionResolver implements FunctionResolver {
     int currCost;
 
     final List<TypeProtos.MajorType> argumentTypes = Lists.newArrayList();
-    for (LogicalExpression expression : call.args) {
+    for (LogicalExpression expression : call.args()) {
       argumentTypes.add(expression.getMajorType());
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FileSystemPlugin.java
@@ -54,9 +54,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Storage engine associated with a Hadoop FileSystem Implementation. Examples include HDFS, MapRFS, QuantacastFileSystem,
- * LocalFileSystem, as well Apache Drill specific CachedFileSystem, ClassPathFileSystem and LocalSyncableFileSystem.
- * Tables are file names, directories and path patterns. This storage engine delegates to FSFormatEngines but shares
+ * A Storage engine associated with a Hadoop FileSystem Implementation. Examples
+ * include HDFS, MapRFS, QuantacastFileSystem, LocalFileSystem, as well Apache
+ * Drill specific CachedFileSystem, ClassPathFileSystem and
+ * LocalSyncableFileSystem. Tables are file names, directories and path
+ * patterns. This storage engine delegates to FSFormatEngines but shares
  * references to the FileSystem configuration and path management.
  */
 public class FileSystemPlugin extends AbstractStoragePlugin {
@@ -118,11 +120,12 @@ public class FileSystemPlugin extends AbstractStoragePlugin {
 
       // if the "default" workspace is not given add one.
       if (noWorkspace || !config.getWorkspaces().containsKey(DEFAULT_WS_NAME)) {
-        factories.add(new WorkspaceSchemaFactory(
-            this, DEFAULT_WS_NAME, name, WorkspaceConfig.DEFAULT, matchers, context.getLpPersistence(), context.getClasspathScan()));
+        factories.add(new WorkspaceSchemaFactory(this, DEFAULT_WS_NAME, name,
+            WorkspaceConfig.DEFAULT, matchers,
+            context.getLpPersistence(), context.getClasspathScan()));
       }
 
-      schemaFactory = new FileSystemSchemaFactory(name, factories);
+      this.schemaFactory = new FileSystemSchemaFactory(name, factories);
     } catch (IOException e) {
       throw new ExecutionSetupException("Failure setting up file system plugin.", e);
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/FormatPlugin.java
@@ -53,21 +53,27 @@ public interface FormatPlugin {
 
   FormatMatcher getMatcher();
 
-  AbstractWriter getWriter(PhysicalOperator child, String location, List<String> partitionColumns) throws IOException;
+  AbstractWriter getWriter(PhysicalOperator child, String location,
+      List<String> partitionColumns) throws IOException;
 
   Set<StoragePluginOptimizerRule> getOptimizerRules();
 
-  AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns) throws IOException;
+  AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns) throws IOException;
 
-  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options) throws IOException {
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns, OptionManager options) throws IOException {
     return getGroupScan(userName, selection, columns);
   }
 
-  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, MetadataProviderManager metadataProviderManager) throws IOException {
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns, MetadataProviderManager metadataProviderManager) throws IOException {
     return getGroupScan(userName, selection, columns);
   }
 
-  default AbstractGroupScan getGroupScan(String userName, FileSelection selection, List<SchemaPath> columns, OptionManager options, MetadataProviderManager metadataProvider) throws IOException {
+  default AbstractGroupScan getGroupScan(String userName, FileSelection selection,
+      List<SchemaPath> columns, OptionManager options,
+      MetadataProviderManager metadataProvider) throws IOException {
     return getGroupScan(userName, selection, columns, metadataProvider);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -119,7 +119,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   }
 
   /**
-   * Builds the readers for the V3 text scan operator.
+   * Builds the readers row-set based scan operator.
    */
   private static class EasyReaderFactory extends FileReaderFactory {
 
@@ -128,7 +128,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
     private final FragmentContext context;
 
     public EasyReaderFactory(EasyFormatPlugin<? extends FormatPluginConfig> plugin,
-        final EasySubScan scan, FragmentContext context) {
+        EasySubScan scan, FragmentContext context) {
       this.plugin = plugin;
       this.scan = scan;
       this.context = context;
@@ -226,7 +226,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * boundaries. If not, the simple format engine will only split on file
    * boundaries.
    *
-   * @return {@code true} if splittable.
+   * @return {@code true} if splitable.
    */
   public boolean isBlockSplittable() { return easyConfig.blockSplittable; }
 
@@ -256,8 +256,8 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
     throw new ExecutionSetupException("Must implement getRecordReader() if using the legacy scanner.");
   }
 
-  protected CloseableRecordBatch getReaderBatch(final FragmentContext context,
-      final EasySubScan scan) throws ExecutionSetupException {
+  protected CloseableRecordBatch getReaderBatch(FragmentContext context,
+      EasySubScan scan) throws ExecutionSetupException {
     if (useEnhancedScan(context.getOptions())) {
       return buildScan(context, scan);
     } else {
@@ -448,9 +448,9 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
     }
   }
 
-  protected ScanStats getScanStats(final PlannerSettings settings, final EasyGroupScan scan) {
+  protected ScanStats getScanStats(PlannerSettings settings, EasyGroupScan scan) {
     long data = 0;
-    for (final CompleteFileWork work : scan.getWorkIterable()) {
+    for (CompleteFileWork work : scan.getWorkIterable()) {
       data += work.getTotalBytes();
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyGroupScan.java
@@ -77,7 +77,7 @@ public class EasyGroupScan extends AbstractFileGroupScan {
   private ListMultimap<Integer, CompleteFileWork> mappings;
   private List<CompleteFileWork> chunks;
   private List<EndpointAffinity> endpointAffinities;
-  private Path selectionRoot;
+  private final Path selectionRoot;
   private TableMetadata tableMetadata;
 
   @JsonCreator
@@ -185,6 +185,7 @@ public class EasyGroupScan extends AbstractFileGroupScan {
     endpointAffinities = AffinityCreator.getAffinityMap(chunks);
   }
 
+  @Override
   public Path getSelectionRoot() {
     return selectionRoot;
   }
@@ -257,13 +258,13 @@ public class EasyGroupScan extends AbstractFileGroupScan {
     for (EndpointAffinity e : affinities) {
       endpoints.add(e.getEndpoint());
     }
-    this.applyAssignments(endpoints);
+    applyAssignments(endpoints);
   }
 
   @Override
   public EasySubScan getSpecificScan(int minorFragmentId) {
     if (mappings == null) {
-      createMappings(this.endpointAffinities);
+      createMappings(endpointAffinities);
     }
     assert minorFragmentId < mappings.size() : String.format(
         "Mappings length [%d] should be longer than minor fragment id [%d] but it isn't.", mappings.size(),
@@ -276,7 +277,7 @@ public class EasyGroupScan extends AbstractFileGroupScan {
 
     EasySubScan subScan = new EasySubScan(getUserName(), convert(filesForMinor), formatPlugin,
         columns, selectionRoot, partitionDepth, getSchema());
-    subScan.setOperatorId(this.getOperatorId());
+    subScan.setOperatorId(getOperatorId());
     return subScan;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilter.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode.Type;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 
@@ -149,7 +151,7 @@ public class InfoSchemaFilter {
 
   private Result evaluateHelperFunction(Map<String, String> recordValues, FunctionExprNode exprNode) {
     switch (exprNode.function) {
-      case "like": {
+      case FunctionNames.LIKE: {
         FieldExprNode col = (FieldExprNode) exprNode.args.get(0);
         ConstantExprNode pattern = (ConstantExprNode) exprNode.args.get(1);
         ConstantExprNode escape = exprNode.args.size() > 2 ? (ConstantExprNode) exprNode.args.get(2) : null;
@@ -166,16 +168,16 @@ public class InfoSchemaFilter {
 
         return Result.INCONCLUSIVE;
       }
-      case "equal":
-      case "not equal":
-      case "notequal":
-      case "not_equal": {
+      case FunctionNames.EQ:
+      case "not equal": // TODO: Is this name correct?
+      case "notequal":  // TODO: Is this name correct?
+      case FunctionNames.NE: {
         FieldExprNode arg0 = (FieldExprNode) exprNode.args.get(0);
         ConstantExprNode arg1 = (ConstantExprNode) exprNode.args.get(1);
 
         final String value = recordValues.get(arg0.field);
         if (value != null) {
-          if (exprNode.function.equals("equal")) {
+          if (exprNode.function.equals(FunctionNames.EQ)) {
             return arg1.value.equals(value) ? Result.TRUE : Result.FALSE;
           } else {
             return arg1.value.equals(value) ? Result.FALSE : Result.TRUE;
@@ -185,7 +187,8 @@ public class InfoSchemaFilter {
         return Result.INCONCLUSIVE;
       }
 
-      case "booleanor": {
+      case FunctionNames.OR:
+      case "booleanor": { // TODO: Is this name correct?
         // If at least one arg returns TRUE, then the OR function value is TRUE
         // If all args return FALSE, then OR function value is FALSE
         // For all other cases, return INCONCLUSIVE
@@ -202,7 +205,8 @@ public class InfoSchemaFilter {
         return result;
       }
 
-      case "booleanand": {
+      case FunctionNames.AND:
+      case "booleanand": { // TODO: Is this name correct?
         // If at least one arg returns FALSE, then the AND function value is FALSE
         // If at least one arg returns INCONCLUSIVE, then the AND function value is INCONCLUSIVE
         // If all args return TRUE, then the AND function value is TRUE

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaFilterBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.ischema;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.expression.BooleanOperator;
 import org.apache.drill.common.expression.CastExpression;
 import org.apache.drill.common.expression.FieldReference;
@@ -30,8 +31,8 @@ import org.apache.drill.exec.store.ischema.InfoSchemaFilter.ExprNode;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.FieldExprNode;
 import org.apache.drill.exec.store.ischema.InfoSchemaFilter.FunctionExprNode;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.drill.exec.store.ischema.InfoSchemaConstants.CATS_COL_CATALOG_NAME;
@@ -73,12 +74,12 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
   public ExprNode visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
     final String funcName = call.getName().toLowerCase();
     switch (funcName) {
-      case "equal":
-      case "not equal":
-      case "notequal":
-      case "not_equal": {
-        final ExprNode col = call.args.get(0).accept(this, value);
-        final ExprNode constant = call.args.get(1).accept(this, value);
+      case FunctionNames.EQ:
+      case "not equal":  // TODO: Is this name correct?
+      case "notequal":   // TODO: Is this name correct?
+      case FunctionNames.NE: {
+        final ExprNode col = call.arg(0).accept(this, value);
+        final ExprNode constant = call.arg(1).accept(this, value);
 
         if (col instanceof FieldExprNode && constant instanceof ConstantExprNode) {
           return new FunctionExprNode(funcName, ImmutableList.of(col, constant));
@@ -86,10 +87,10 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
         break;
       }
 
-      case "like": {
-        final ExprNode col = call.args.get(0).accept(this, value);
-        final ExprNode pattern = call.args.get(1).accept(this, value);
-        final ExprNode escape = call.args.size() > 2 ? call.args.get(2).accept(this, value) : null;
+      case FunctionNames.LIKE: {
+        final ExprNode col = call.arg(0).accept(this, value);
+        final ExprNode pattern = call.arg(1).accept(this, value);
+        final ExprNode escape = call.argCount() > 2 ? call.arg(2).accept(this, value) : null;
 
         if (col instanceof FieldExprNode && pattern instanceof ConstantExprNode &&
             (escape == null || escape instanceof ConstantExprNode)) {
@@ -99,9 +100,10 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
         break;
       }
 
-      case "booleanand": {
-        List<ExprNode> args = Lists.newArrayList();
-        for(LogicalExpression arg : call.args) {
+      case FunctionNames.AND:
+      case "booleanand": {  // TODO: Is this name correct?
+        List<ExprNode> args = new ArrayList<>();
+        for(LogicalExpression arg : call.args()) {
           ExprNode exprNode = arg.accept(this, value);
           if (exprNode instanceof FunctionExprNode) {
             args.add(exprNode);
@@ -114,9 +116,10 @@ public class InfoSchemaFilterBuilder extends AbstractExprVisitor<ExprNode, Void,
         return visitUnknown(call, value);
       }
 
-      case "booleanor": {
-        List<ExprNode> args = Lists.newArrayList();
-        for(LogicalExpression arg : call.args) {
+      case FunctionNames.OR:
+      case "booleanor": {  // TODO: Is this name correct?
+        List<ExprNode> args = new ArrayList<>();
+        for(LogicalExpression arg : call.args()) {
           ExprNode exprNode = arg.accept(this, value);
           if (exprNode instanceof FunctionExprNode) {
             args.add(exprNode);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/FilterEvaluatorUtils.java
@@ -107,12 +107,12 @@ public class FilterEvaluatorUtils {
                                   long rowCount,
                                   TupleMetadata fileMetadata,
                                   Set<SchemaPath> schemaPathsInExpr) {
-    RowsMatch rowsMatch = RowsMatch.SOME;
-    if (parquetPredicate != null) {
-      @SuppressWarnings("rawtypes")
-      StatisticsProvider<T> rangeExprEvaluator = new StatisticsProvider(columnsStatistics, rowCount);
-      rowsMatch = parquetPredicate.matches(rangeExprEvaluator);
+    if (parquetPredicate == null) {
+      return RowsMatch.SOME;
     }
+    @SuppressWarnings("rawtypes")
+    StatisticsProvider<T> rangeExprEvaluator = new StatisticsProvider(columnsStatistics, rowCount);
+    RowsMatch rowsMatch = parquetPredicate.matches(rangeExprEvaluator);
 
     if (rowsMatch == RowsMatch.ALL && isMetaNotApplicable(schemaPathsInExpr, fileMetadata)) {
       rowsMatch = RowsMatch.SOME;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/schedule/AssignmentCreator.java
@@ -36,13 +36,14 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Iterators;
 import org.apache.drill.shaded.guava.com.google.common.collect.ListMultimap;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * The AssignmentCreator is responsible for assigning a set of work units to the available slices.
+ * Responsible for assigning a set of work units to the available slices.
  */
 public class AssignmentCreator<T extends CompleteWork> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AssignmentCreator.class);
-
+  static final Logger logger = LoggerFactory.getLogger(AssignmentCreator.class);
 
   /**
    * Comparator used to sort in order of decreasing affinity
@@ -56,24 +57,24 @@ public class AssignmentCreator<T extends CompleteWork> {
   };
 
   /**
-   * the maximum number of work units to assign to any minor fragment
+   * The maximum number of work units to assign to any minor fragment
    */
   private int maxWork;
 
   /**
    * The units of work to be assigned
    */
-  private List<T> units;
+  private final List<T> units;
 
   /**
    * Mappings
    */
-  private ArrayListMultimap<Integer, T> mappings = ArrayListMultimap.create();
+  private final ArrayListMultimap<Integer, T> mappings = ArrayListMultimap.create();
 
   /**
    * A list of DrillbitEndpoints, where the index in the list corresponds to the minor fragment id
    */
-  private List<DrillbitEndpoint> incomingEndpoints;
+  private final List<DrillbitEndpoint> incomingEndpoints;
 
   private AssignmentCreator(List<DrillbitEndpoint> incomingEndpoints, List<T> units) {
     this.incomingEndpoints = incomingEndpoints;
@@ -106,16 +107,16 @@ public class AssignmentCreator<T extends CompleteWork> {
     LinkedList<WorkEndpointListPair<T>> unassignedWorkList;
     Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators = getEndpointIterators();
 
-    // Assign upto maxCount per node based on locality.
+    // Assign up to maxCount per node based on locality.
     unassignedWorkList = assign(workList, endpointIterators, false);
 
-    // Assign upto minCount per node in a round robin fashion.
+    // Assign up to minCount per node in a round robin fashion.
     assignLeftovers(unassignedWorkList, endpointIterators, true);
 
-    // Assign upto maxCount + leftovers per node based on locality.
+    // Assign up to maxCount + leftovers per node based on locality.
     unassignedWorkList = assign(unassignedWorkList, endpointIterators,  true);
 
-    // Assign upto maxCount + leftovers per node in a round robin fashion.
+    // Assign up to maxCount + leftovers per node in a round robin fashion.
     assignLeftovers(unassignedWorkList, endpointIterators, false);
 
     if (unassignedWorkList.size() != 0) {
@@ -130,7 +131,7 @@ public class AssignmentCreator<T extends CompleteWork> {
    *
    * @param workList the list of work units to assign
    * @param endpointIterators the endpointIterators to assign to
-   * @param assignMaxLeftOvers whether to assign upto maximum including leftovers
+   * @param assignMaxLeftOvers whether to assign up to maximum including leftovers
    * @return a list of unassigned work units
    */
   private LinkedList<WorkEndpointListPair<T>> assign(List<WorkEndpointListPair<T>> workList,
@@ -160,7 +161,7 @@ public class AssignmentCreator<T extends CompleteWork> {
    *
    * @param unassignedWorkList the work units to assign
    * @param endpointIterators the endpointIterators to assign to
-   * @param assignMinimum wheterh to assign the minimum amount
+   * @param assignMinimum whether to assign the minimum amount
    */
   private void assignLeftovers(LinkedList<WorkEndpointListPair<T>> unassignedWorkList,
                                Map<DrillbitEndpoint,FragIteratorWrapper> endpointIterators,
@@ -183,7 +184,6 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @return the list of WorkEndpointListPairs
    */
   private LinkedList<WorkEndpointListPair<T>> getWorkList() {
-    Stopwatch watch = Stopwatch.createStarted();
     LinkedList<WorkEndpointListPair<T>> workList = Lists.newLinkedList();
     for (T work : units) {
       List<Map.Entry<DrillbitEndpoint,Long>> entries = Lists.newArrayList();
@@ -220,7 +220,8 @@ public class AssignmentCreator<T extends CompleteWork> {
   }
 
   /**
-   *  A wrapper class around a work unit and its associated sort list of Endpoints (sorted by affinity in decreasing order)
+   * Wrapper class around a work unit and its associated sort list of Endpoints
+   * (sorted by affinity in decreasing order)
    */
   private static class WorkEndpointListPair<T> {
     T work;
@@ -239,7 +240,6 @@ public class AssignmentCreator<T extends CompleteWork> {
    * @return
    */
   private Map<DrillbitEndpoint,FragIteratorWrapper> getEndpointIterators() {
-    Stopwatch watch = Stopwatch.createStarted();
     Map<DrillbitEndpoint,FragIteratorWrapper> map = Maps.newLinkedHashMap();
     Map<DrillbitEndpoint,List<Integer>> mmap = Maps.newLinkedHashMap();
     for (int i = 0; i < incomingEndpoints.size(); i++) {
@@ -280,7 +280,7 @@ public class AssignmentCreator<T extends CompleteWork> {
   }
 
   /**
-   * A struct that holds a fragment iterator and keeps track of how many units have been assigned, as well as the maximum
+   * Holds a fragment iterator and keeps track of how many units have been assigned, as well as the maximum
    * number of assignment it will accept
    */
   private static class FragIteratorWrapper {
@@ -290,5 +290,4 @@ public class AssignmentCreator<T extends CompleteWork> {
     int minCount;
     Iterator<Integer> iter;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/metadata/MetadataProvider.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.ErrorHelper;
 import org.apache.drill.exec.ops.ViewExpansionContext;
@@ -78,17 +79,19 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.ComparisonChain;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Ordering;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains worker {@link Runnable} classes for providing the metadata and related helper methods.
  */
 public class MetadataProvider {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MetadataProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(MetadataProvider.class);
 
   private static final String IN_FUNCTION = "in";
-  private static final String LIKE_FUNCTION = "like";
-  private static final String AND_FUNCTION = "booleanand";
-  private static final String OR_FUNCTION = "booleanor";
+  // Is this intended? Function name here is lower case of actual name?
+  private static final String AND_FUNCTION = FunctionNames.AND.toLowerCase();
+  private static final String OR_FUNCTION = FunctionNames.OR.toLowerCase();
 
   /**
    * @return Runnable that fetches the catalog metadata for given {@link GetCatalogsReq} and sends response at the end.
@@ -506,7 +509,7 @@ public class MetadataProvider {
       return null;
     }
 
-    return new FunctionExprNode(LIKE_FUNCTION,
+    return new FunctionExprNode(FunctionNames.LIKE,
         likeFilter.hasEscape() ?
             ImmutableList.of(
                 new FieldExprNode(fieldName),

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderMapArray.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderMapArray.java
@@ -204,7 +204,6 @@ public class TestResultSetLoaderMapArray extends SubOperatorTest {
           mapValue(330, strArray("d3.3.1", "d1.2.2"))));
 
     // Verify the batch
-
     RowSet actual = fixture.wrap(rsLoader.harvest());
     SingleRowSet expected = fixture.rowSetBuilder(schema)
         .addRow(10, mapArray(

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestResultSetLoaderRepeatedList.java
@@ -64,7 +64,6 @@ import static org.junit.Assert.assertTrue;
  * actually, since the different "slices" need not have the same length...)
  * Repeated lists appear to be used only by JSON.
  */
-
 @Category(RowSetTests.class)
 public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
@@ -90,7 +89,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     final RowSetLoader writer = rsLoader.writer();
 
     // Sanity check of writer structure
-
     assertEquals(2, writer.size());
     final ObjectWriter listObj = writer.column("list2");
     assertEquals(ObjectType.ARRAY, listObj.type());
@@ -102,7 +100,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     assertEquals(ValueType.STRING, strWriter.valueType());
 
     // Sanity test of schema
-
     final TupleMetadata rowSchema = writer.tupleSchema();
     assertEquals(2, rowSchema.size());
     final ColumnMetadata listSchema = rowSchema.metadata(1);
@@ -118,7 +115,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     assertEquals(DataMode.REPEATED, elementSchema.mode());
 
     // Write values
-
     rsLoader.startBatch();
     writer
         .addRow(1, objArray(strArray("a", "b"), strArray("c", "d")))
@@ -128,7 +124,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
     // Verify the values.
     // (Relies on the row set level repeated list tests having passed.)
-
     final RowSet expected = fixture.rowSetBuilder(schema)
         .addRow(1, objArray(strArray("a", "b"), strArray("c", "d")))
         .addRow(2, objArray(strArray("e"), strArray(), strArray("f", "g", "h")))
@@ -154,15 +149,13 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     final RowSetLoader writer = rsLoader.writer();
 
     // Add columns dynamically
-
     writer.addColumn(schema.metadata(0));
     writer.addColumn(schema.metadata(1).cloneEmpty());
 
     // Yes, this is ugly. The whole repeated array idea is awkward.
     // The only place it is used at present is in JSON where the
-    // awkwardness is mixed in with a logs of JSON complexity.
+    // awkwardness is mixed in with JSON complexity.
     // Consider improving this API in the future.
-
     ((RepeatedListWriter) writer.array(1)).defineElement(schema.metadata(1).childSchema());
 
     do2DTest(schema, rsLoader);
@@ -187,27 +180,22 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     final RowSetLoader writer = rsLoader.writer();
 
     // Add columns dynamically
-
     writer.addColumn(schema.metadata(0));
 
     // Write a row without the array.
-
     rsLoader.startBatch();
     writer.addRow(1);
 
     // Add the repeated list, but without contents.
-
     writer.addColumn(schema.metadata(1).cloneEmpty());
 
     // Sanity check of writer structure
-
     assertEquals(2, writer.size());
     final ObjectWriter listObj = writer.column("list1");
     assertEquals(ObjectType.ARRAY, listObj.type());
     final ArrayWriter listWriter = listObj.array();
 
     // No child defined yet. A dummy child is inserted instead.
-
     assertEquals(MinorType.NULL, listWriter.entry().schema().type());
     assertEquals(ObjectType.ARRAY, listWriter.entryType());
     assertEquals(ObjectType.SCALAR, listWriter.array().entryType());
@@ -215,19 +203,16 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
     // Although we don't know the type of the inner, we can still
     // create null (empty) elements in the outer array.
-
     writer
       .addRow(2, null)
       .addRow(3, objArray())
       .addRow(4, objArray(objArray(), null));
 
     // Define the inner type.
-
     final RepeatedListWriter listWriterImpl = (RepeatedListWriter) listWriter;
     listWriterImpl.defineElement(MaterializedField.create("list1", Types.repeated(MinorType.VARCHAR)));
 
     // Sanity check of completed structure
-
     assertEquals(ObjectType.ARRAY, listWriter.entryType());
     final ArrayWriter innerWriter = listWriter.array();
     assertEquals(ObjectType.SCALAR, innerWriter.entryType());
@@ -235,16 +220,13 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     assertEquals(ValueType.STRING, strWriter.valueType());
 
     // Write values
-
     writer
         .addRow(5, objArray(strArray("a1", "b1"), strArray("c1", "d1")));
 
     // Add the second list, with a complete type
-
     writer.addColumn(schema.metadata(2));
 
     // Sanity check of writer structure
-
     assertEquals(3, writer.size());
     final ObjectWriter list2Obj = writer.column("list2");
     assertEquals(ObjectType.ARRAY, list2Obj.type());
@@ -256,7 +238,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     assertEquals(ValueType.STRING, str2Writer.valueType());
 
     // Write values
-
     writer
         .addRow(6,
             objArray(strArray("a2", "b2"), strArray("c2", "d2")),
@@ -266,7 +247,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
     // Verify the values.
     // (Relies on the row set level repeated list tests having passed.)
-
     final RowSet expected = fixture.rowSetBuilder(schema)
         .addRow(1, objArray(), objArray())
         .addRow(2, objArray(), objArray())
@@ -301,7 +281,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     // Fill the batch with enough data to cause overflow.
     // Data must be large enough to cause overflow before 64K rows
     // Make a bit bigger to overflow early.
-
     final int outerSize = 7;
     final int innerSize = 5;
     final int strLength = ValueVector.MAX_BUFFER_SIZE / ValueVector.MAX_ROW_COUNT / outerSize / innerSize + 20;
@@ -331,25 +310,20 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
     // Number of rows should be driven by vector size.
     // Our row count should include the overflow row
-
     final int expectedCount = ValueVector.MAX_BUFFER_SIZE / (strLength * innerSize * outerSize);
     assertEquals(expectedCount + 1, rowCount);
 
     // Loader's row count should include only "visible" rows
-
     assertEquals(expectedCount, writer.rowCount());
 
     // Total count should include invisible and look-ahead rows.
-
     assertEquals(expectedCount + 1, rsLoader.totalRowCount());
 
     // Result should exclude the overflow row
-
     RowSet result = fixture.wrap(rsLoader.harvest());
     assertEquals(expectedCount, result.rowCount());
 
     // Verify the data.
-
     RowSetReader reader = result.reader();
     ArrayReader outerReader = reader.array(1);
     ArrayReader innerReader = outerReader.array();
@@ -375,7 +349,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
     result.clear();
 
     // Write a few more rows to verify the overflow row.
-
     rsLoader.startBatch();
     for (int i = 0; i < 1000; i++) {
       writer.start();
@@ -424,7 +397,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
   // That test exercises the low-level schema and writer mechanisms.
   // Here we simply ensure that the 3D case continues to work when
   // wrapped in the Result Set Loader
-
   @Test
   public void test3DEarlySchema() {
     final TupleMetadata schema = new SchemaBuilder()
@@ -432,7 +404,6 @@ public class TestResultSetLoaderRepeatedList extends SubOperatorTest {
 
         // Uses a short-hand method to avoid mucking with actual
         // nested lists.
-
         .addArray("cube", MinorType.VARCHAR, 3)
         .buildSchema();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithHeaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithHeaders.java
@@ -406,13 +406,13 @@ public class TestCsvWithHeaders extends BaseCsvTest {
   }
 
   /**
-   * Test partition expansion .
+   * Test partition expansion.
    * <p>
    * This test is tricky because it will return two data batches
    * (preceded by an empty schema batch.) File read order is random
    * so we have to expect the files in either order.
    * <p>
-   * V3, as in V2 before Drill 1.12, puts partition columns after
+   * V3 puts partition columns after
    * data columns (so that data columns don't shift positions if
    * files are nested to another level.)
    */

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -108,7 +108,7 @@ public class TestParquetFilterPushDown extends PlanTestBase {
   };
 
   @Test
-  // Test filter evaluation directly without go through SQL queries.
+  // Test filter evaluation directly without going through SQL queries.
   public void testIntPredicateWithEval() throws Exception {
     // intTbl.parquet has only one int column
     //    intCol : [0, 100].
@@ -150,7 +150,6 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     testParquetRowGroupFilterEval(footer, "intCol = 50 or intCol = 160", RowsMatch.SOME);
 
     //"nonExistCol" does not exist in the table. "AND" with a filter on exist column
-
     testParquetRowGroupFilterEval(footer, "intCol > 100 and nonExistCol = 100", RowsMatch.NONE);
     testParquetRowGroupFilterEval(footer, "intCol > 50 and nonExistCol = 100", RowsMatch.NONE); // since nonExistCol = 100 -> Unknown -> could drop.
     testParquetRowGroupFilterEval(footer, "nonExistCol = 100 and intCol > 50", RowsMatch.NONE); // since nonExistCol = 100 -> Unknown -> could drop.
@@ -162,7 +161,6 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     // is ignored.
 
     //"nonExistCol" does not exist in the table. "OR" with a filter on exist column
-
     testParquetRowGroupFilterEval(footer, "intCol > 100 or nonExistCol = 100", RowsMatch.NONE); // nonExistCol = 100 -> could drop.
     testParquetRowGroupFilterEval(footer, "nonExistCol = 100 or intCol > 100", RowsMatch.NONE); // nonExistCol = 100 -> could drop.
 
@@ -726,6 +724,7 @@ public class TestParquetFilterPushDown extends PlanTestBase {
       runAndCheckResults(client, sql, expectedRows, numPartitions, numPruned);
     }
   }
+
   /**
    * Test runtime pruning
    *
@@ -757,5 +756,4 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     long resultNumPruned = parquestScan0.getMetric(ParquetRecordReader.Metric.ROWGROUPS_PRUNED.ordinal());
     assertEquals(numPruned,resultNumPruned);
   }
-
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/MaterializedField.java
@@ -99,14 +99,14 @@ public class MaterializedField {
    * The type is immutable. But, it contains subtypes, used or lists
    * and unions. To add a subtype, we must create a whole new major type.
    * <p>
-   * It appears that the <tt>MaterializedField</tt> class was also meant
+   * It appears that the {@code MaterializedField} class was also meant
    * to be immutable. But, it holds the children for a map, and contains
    * methods to add children. So, it is not immutable.
    * <p>
    * This method allows evolving a list or union without the need to create
-   * a new <tt>MaterializedField</tt>. Doing so is problematic for nested
+   * a new {@code MaterializedField}. Doing so is problematic for nested
    * maps because the map (or list, or union) holds onto the
-   * <tt>MaterializedField</tt>'s of its children. There is no way for
+   * {@code MaterializedField}'s of its children. There is no way for
    * an inner map to reach out and change the child of its parent.
    * <p>
    * By allowing the non-critical metadata to change, we preserve the
@@ -227,7 +227,7 @@ public class MaterializedField {
    * tricky issue. The rules here:
    * <ul>
    * <li>The other schema is assumed to be non-null (unlike
-   * <tt>equals()</tt>).</li>
+   * {@code equals()}).</li>
    * <li>Names must be identical, ignoring case. (Drill, like SQL, is case
    * insensitive.)
    * <li>Type, mode, precision and scale must be identical.</li>
@@ -235,7 +235,7 @@ public class MaterializedField {
    * "$bits" and "$offsets" vector columns are not compared, as one schema may
    * be an "original" (without these hidden columns) while the other may come
    * from a vector (which has the hidden columns added. The standard
-   * <tt>equals()</tt> comparison does consider hidden columns.</li>
+   * {@code equals()} comparison does consider hidden columns.</li>
    * <li>For maps, the child columns are compared recursively. This version
    * requires that the two sets of columns appear in the same order. (It assumes
    * it is being used in a context where column indexes make sense.) Operators
@@ -274,10 +274,9 @@ public class MaterializedField {
    *
    * @param other
    *          another field
-   * @return <tt>true</tt> if the columns are identical according to the above
-   *         rules, <tt>false</tt> if they differ
+   * @return {@code true} if the columns are identical according to the above
+   *         rules, {@code false} if they differ
    */
-
   public boolean isEquivalent(MaterializedField other) {
     if (! name.equalsIgnoreCase(other.name)) {
       return false;
@@ -286,14 +285,12 @@ public class MaterializedField {
     // Requires full type equality, including fields such as precision and scale.
     // But, unset fields are equivalent to 0. Can't use the protobuf-provided
     // isEquals(), that treats set and unset fields as different.
-
     if (! Types.isEquivalent(type, other.type)) {
       return false;
     }
 
     // Compare children -- but only for maps, not the internal children
     // for Varchar, repeated or nullable types.
-
     if (type.getMinorType() != MinorType.MAP) {
       return true;
     }
@@ -307,7 +304,6 @@ public class MaterializedField {
 
     // Maps are name-based, not position. But, for our
     // purposes, we insist on identical ordering.
-
     final Iterator<MaterializedField> thisIter = children.iterator();
     final Iterator<MaterializedField> otherIter = other.children.iterator();
     while (thisIter.hasNext()) {
@@ -329,7 +325,6 @@ public class MaterializedField {
    * @param other the field to which this one is to be promoted
    * @return true if promotion is possible, false otherwise
    */
-
   public boolean isPromotableTo(MaterializedField other, boolean allowModeChange) {
     if (! name.equalsIgnoreCase(other.name)) {
       return false;
@@ -338,7 +333,6 @@ public class MaterializedField {
     // Requires full type equality, including fields such as precision and scale.
     // But, unset fields are equivalent to 0. Can't use the protobuf-provided
     // isEquals(), that treats set and unset fields as different.
-
     if (type.getMinorType() != other.type.getMinorType()) {
       return false;
     }
@@ -346,7 +340,6 @@ public class MaterializedField {
 
       // Modes differ, but type can be promoted from required to
       // nullable
-
       if (! allowModeChange) {
         return false;
       }
@@ -363,7 +356,6 @@ public class MaterializedField {
 
     // Compare children -- but only for maps, not the internal children
     // for Varchar, repeated or nullable types.
-
     if (type.getMinorType() != MinorType.MAP) {
       return true;
     }
@@ -377,7 +369,6 @@ public class MaterializedField {
 
     // Maps are name-based, not position. But, for our
     // purposes, we insist on identical ordering.
-
     final Iterator<MaterializedField> thisIter = children.iterator();
     final Iterator<MaterializedField> otherIter = other.children.iterator();
     while (thisIter.hasNext()) {
@@ -400,7 +391,6 @@ public class MaterializedField {
    *
    * @return materialized field string representation
    */
-
   public String toString(boolean includeChildren) {
     final int maxLen = 10;
     final StringBuilder builder = new StringBuilder();
@@ -449,6 +439,14 @@ public class MaterializedField {
   @Override
   public String toString() {
     return toString(true);
+  }
+
+  /**
+   * Return true if two fields have identical MinorType and Mode.
+   */
+  public boolean hasSameTypeAndMode(MaterializedField that) {
+    return (getType().getMinorType() == that.getType().getMinorType())
+        && (getType().getMode() == that.getType().getMode());
   }
 
   private String toString(Collection<?> collection, int maxLen) {

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/AbstractColumnMetadata.java
@@ -172,7 +172,6 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
     // TODO: This converts each column to a MaterializedField in
     // order to do the comparison. This is done to avoid duplicating
     // the checks. Consider doing checks here at some point.
-
     return schema().isEquivalent(other.schema());
   }
 
@@ -278,6 +277,10 @@ public abstract class AbstractColumnMetadata extends AbstractPropertied implemen
     if (variantSchema() != null) {
       buf.append(", variant: ")
          .append(variantSchema().toString());
+    }
+    if (childSchema() != null) {
+      buf.append(", child: ")
+         .append(childSchema().toString());
     }
     if (tupleSchema() != null) {
       buf.append(", schema: ")

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/PropertyAccessor.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/PropertyAccessor.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.record.metadata;
 
 /**
- * Helper utilities to get/set typed values within a propertied object
+ * Utilities to get/set typed values within a propertied object
  */
 public class PropertyAccessor {
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractScalarReader.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/reader/AbstractScalarReader.java
@@ -253,7 +253,7 @@ public abstract class AbstractScalarReader implements ScalarReader, ReaderEvents
     case PERIOD:
       return getPeriod().normalizedStandard().toString();
     default:
-      return getObject().toString();
+      return getValue().toString();
     }
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/AbstractTupleWriter.java
@@ -156,7 +156,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
    */
 
   static class MemberWriterIndex implements ColumnWriterIndex {
-    private ColumnWriterIndex baseIndex;
+    private final ColumnWriterIndex baseIndex;
 
     MemberWriterIndex(ColumnWriterIndex baseIndex) {
       this.baseIndex = baseIndex;
@@ -243,15 +243,15 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
   @Override
   public int addColumn(ColumnMetadata column) {
     verifyAddColumn(column.name());
-    final AbstractObjectWriter colWriter = (AbstractObjectWriter) listener.addColumn(this, column);
-    return addColumnWriter(colWriter);
+    return addColumnWriter(
+        (AbstractObjectWriter) listener.addColumn(this, column));
   }
 
   @Override
   public int addColumn(MaterializedField field) {
     verifyAddColumn(field.getName());
-    final AbstractObjectWriter colWriter = (AbstractObjectWriter) listener.addColumn(this, field);
-    return addColumnWriter(colWriter);
+    return addColumnWriter(
+        (AbstractObjectWriter) listener.addColumn(this, field));
   }
 
   private void verifyAddColumn(String colName) {
@@ -262,7 +262,7 @@ public abstract class AbstractTupleWriter implements TupleWriter, WriterEvents {
     if (tupleSchema().column(colName) != null) {
       throw UserException
         .validationError()
-        .message("Duplicate column name: ", colName)
+        .message("Duplicate column name: %s", colName)
         .build(logger);
     }
   }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ObjectArrayWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/ObjectArrayWriter.java
@@ -104,7 +104,6 @@ import org.apache.drill.exec.vector.accessor.writer.AbstractArrayWriter.BaseArra
  * vector can never be in the Behind state, when we have an array of
  * maps then each vector can be in any of the scalar writer states.
  */
-
 public class ObjectArrayWriter extends BaseArrayWriter {
 
   protected ObjectArrayWriter(ColumnMetadata schema,
@@ -123,7 +122,6 @@ public class ObjectArrayWriter extends BaseArrayWriter {
   public void setObject(Object array) {
 
     // Null array = 0-length array
-
     if (array == null) {
       return;
     }

--- a/logical/src/main/java/org/apache/drill/common/FunctionNames.java
+++ b/logical/src/main/java/org/apache/drill/common/FunctionNames.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common;
+
+public interface FunctionNames {
+
+  String NEGATE = "negative";
+  String ADD = "add";
+  String SUBTRACT = "subtract";
+  String MULTIPLY = "multiply";
+  String DIVIDE = "divide";
+  String MODULO = "modulo";
+
+  String NOT = "not";
+  String OR = "booleanOr";
+  String AND = "booleanAnd";
+  String XOR = "xor";
+
+  String COMPARE_TO_NULLS_HIGH = "compare_to_nulls_high";
+  String COMPARE_TO_NULLS_LOW = "compare_to_nulls_low";
+
+  String EQ = "equal";
+  String NE = "not_equal";
+  String GT = "greater_than";
+  String GE = "greater_than_or_equal_to";
+  String LT = "less_than";
+  String LE = "less_than_or_equal_to";
+
+  String IS_NULL = "isnull";
+  String IS_NOT_NULL = "isnotnull";
+  String IS_TRUE = "istrue";
+  String IS_NOT_TRUE = "isnottrue";
+  String IS_FALSE = "isfalse";
+  String IS_NOT_FALSE = "isnotfalse";
+
+  String CONCAT = "concatOperator";
+  String SIMILAR_TO = "similar_to";
+  String LIKE = "like";
+}

--- a/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/BooleanOperator.java
@@ -24,20 +24,20 @@ import org.apache.drill.common.types.TypeProtos.DataMode;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.Types;
 
-public class BooleanOperator extends FunctionCall{
+public class BooleanOperator extends FunctionCall {
 
   public BooleanOperator(String name, List<LogicalExpression> args, ExpressionPosition pos) {
     super(name, args, pos);
   }
 
   @Override
-  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E{
+  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
     return visitor.visitBooleanOperator(this, value);
   }
 
   @Override
   public MajorType getMajorType() {
-    // If any of argumgnet of a boolean "and"/"or" is nullable, the result is nullable bit.
+    // If any of argument of a boolean "and"/"or" is nullable, the result is nullable bit.
     // Otherwise, it's non-nullable bit.
     for (LogicalExpression e : args) {
       if (e.getMajorType().getMode() == DataMode.OPTIONAL) {
@@ -45,7 +45,6 @@ public class BooleanOperator extends FunctionCall{
       }
     }
     return Types.REQUIRED_BIT;
-
   }
 
   @Override
@@ -61,5 +60,4 @@ public class BooleanOperator extends FunctionCall{
 
     return cost / i;
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/ExpressionStringBuilder.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/ExpressionStringBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.drill.common.expression;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.drill.common.expression.IfExpression.IfCondition;
 import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
@@ -43,7 +44,6 @@ import org.joda.time.Period;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 public class ExpressionStringBuilder extends AbstractExprVisitor<Void, StringBuilder, RuntimeException>{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExpressionStringBuilder.class);
 
   static final ExpressionStringBuilder INSTANCE = new ExpressionStringBuilder();
 
@@ -67,7 +67,7 @@ public class ExpressionStringBuilder extends AbstractExprVisitor<Void, StringBui
 
   @Override
   public Void visitFunctionCall(FunctionCall call, StringBuilder sb) throws RuntimeException {
-    ImmutableList<LogicalExpression> args = call.args;
+    List<LogicalExpression> args = call.args();
     sb.append(call.getName());
     sb.append("(");
     for (int i = 0; i < args.size(); i++) {

--- a/logical/src/main/java/org/apache/drill/common/expression/FunctionCall.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FunctionCall.java
@@ -27,8 +27,12 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class FunctionCall extends LogicalExpressionBase implements Iterable<LogicalExpression> {
+
+  // See FunctionNames for a list of well-known built-in functions
+  // often used in filter push-down rules
+
   private final String name;
-  public final ImmutableList<LogicalExpression> args;
+  protected final ImmutableList<LogicalExpression> args;
   private final ExpressionPosition pos;
 
   public FunctionCall(String name, List<LogicalExpression> args, ExpressionPosition pos) {
@@ -46,17 +50,17 @@ public class FunctionCall extends LogicalExpressionBase implements Iterable<Logi
     this.pos = pos;
   }
 
-  public String getName() {
-    return name;
-  }
+  public String getName() { return name; }
 
   @Override
-  public ExpressionPosition getPosition() {
-    return pos;
-  }
+  public ExpressionPosition getPosition() { return pos; }
+
+  public List<LogicalExpression> args() { return args; }
+  public int argCount() { return args.size(); }
+  public LogicalExpression arg(int i) { return args.get(i); }
 
   @Override
-  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E{
+  public <T, V, E extends Exception> T accept(ExprVisitor<T, V, E> visitor, V value) throws E {
     return visitor.visitFunctionCall(this, value);
   }
 
@@ -77,5 +81,4 @@ public class FunctionCall extends LogicalExpressionBase implements Iterable<Logi
     return "FunctionCall [func=" + name + ", args="
         + (args != null ? args.subList(0, Math.min(args.size(), maxLen)) : null) + ", pos=" + pos + "]";
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/FunctionCallFactory.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/FunctionCallFactory.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.drill.common.FunctionNames;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.types.TypeProtos.MajorType;
 
@@ -30,32 +31,32 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 public class FunctionCallFactory {
 
   private static final Map<String, String> OP_TO_FUNC_NAME = ImmutableMap.<String, String>builder()
-      .put("+", "add")
-      .put("-", "subtract")
-      .put("/", "divide")
-      .put("*", "multiply")
-      .put("%", "modulo")
-      .put("^", "xor")
-      .put("||", "concatOperator")
-      .put("or", "booleanOr")
-      .put("and", "booleanAnd")
-      .put(">", "greater_than")
-      .put("<", "less_than")
-      .put("==", "equal")
-      .put("=", "equal")
-      .put("!=", "not_equal")
-      .put("<>", "not_equal")
-      .put(">=", "greater_than_or_equal_to")
-      .put("<=", "less_than_or_equal_to")
-      .put("is null", "isnull")
-      .put("is not null", "isnotnull")
-      .put("is true", "istrue")
-      .put("is not true", "isnottrue")
-      .put("is false", "isfalse")
-      .put("is not false", "isnotfalse")
-      .put("similar to", "similar_to")
-      .put("!", "not")
-      .put("u-", "negative")
+      .put("+",   FunctionNames.ADD)
+      .put("-",   FunctionNames.SUBTRACT)
+      .put("/",   FunctionNames.DIVIDE)
+      .put("*",   FunctionNames.MULTIPLY)
+      .put("%",   FunctionNames.MODULO)
+      .put("^",   FunctionNames.XOR)
+      .put("||",  FunctionNames.CONCAT)
+      .put("or",  FunctionNames.OR)
+      .put("and", FunctionNames.AND)
+      .put(">",   FunctionNames.GT)
+      .put("<",   FunctionNames.LT)
+      .put("==",  FunctionNames.EQ)
+      .put("=",   FunctionNames.EQ)
+      .put("!=",  FunctionNames.NE)
+      .put("<>",  FunctionNames.NE)
+      .put(">=",  FunctionNames.GE)
+      .put("<=",  FunctionNames.LE)
+      .put("is null", FunctionNames.IS_NULL)
+      .put("is not null", FunctionNames.IS_NOT_NULL)
+      .put("is true", FunctionNames.IS_TRUE)
+      .put("is not true", FunctionNames.IS_NOT_TRUE)
+      .put("is false", FunctionNames.IS_FALSE)
+      .put("is not false", FunctionNames.IS_NOT_FALSE)
+      .put("similar to", FunctionNames.SIMILAR_TO)
+      .put("!",   FunctionNames.NOT)
+      .put("u-",  FunctionNames.NEGATE)
       .build();
 
   public static String convertToDrillFunctionName(String op) {
@@ -64,7 +65,7 @@ public class FunctionCallFactory {
 
   public static boolean isBooleanOperator(String funcName) {
     String drillFuncName  = convertToDrillFunctionName(funcName);
-    return drillFuncName.equals("booleanAnd") || drillFuncName.equals("booleanOr");
+    return drillFuncName.equals(FunctionNames.AND) || drillFuncName.equals(FunctionNames.OR);
   }
 
   /*
@@ -132,5 +133,4 @@ public class FunctionCallFactory {
     }
     return first;
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/SchemaPath.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/SchemaPath.java
@@ -156,8 +156,7 @@ public class SchemaPath extends LogicalExpressionBase {
    * @return un-indexed schema path
    */
   public SchemaPath getUnIndexed() {
-    NameSegment nameSegment = getUnIndexedNameSegment(rootSegment, null);
-    return new SchemaPath(nameSegment);
+    return new SchemaPath(getUnIndexedNameSegment(rootSegment, null));
   }
 
   /**

--- a/logical/src/main/java/org/apache/drill/common/expression/TypedFieldExpr.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/TypedFieldExpr.java
@@ -45,16 +45,15 @@ public class TypedFieldExpr extends LogicalExpressionBase {
 
   @Override
   public TypeProtos.MajorType getMajorType() {
-    return this.type;
+    return type;
   }
 
   @Override
   public String toString() {
-    return this.path.getRootSegment().getPath() + "(" + type.getMinorType() + "_" + type.getMode() +")";
+    return path.getRootSegment().getPath() + "(" + type.getMinorType() + "_" + type.getMode() +")";
   }
 
   public SchemaPath getPath() {
-    return this.path;
+    return path;
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/ValueExpressions.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/ValueExpressions.java
@@ -63,12 +63,12 @@ public class ValueExpressions {
   }
 
   public static LogicalExpression getTime(GregorianCalendar time) {
-      int millis = time.get(GregorianCalendar.HOUR_OF_DAY) * 60 * 60 * 1000 +
-                   time.get(GregorianCalendar.MINUTE) * 60 * 1000 +
-                   time.get(GregorianCalendar.SECOND) * 1000 +
-                   time.get(GregorianCalendar.MILLISECOND);
+    int millis = time.get(GregorianCalendar.HOUR_OF_DAY) * 60 * 60 * 1000 +
+                 time.get(GregorianCalendar.MINUTE) * 60 * 1000 +
+                 time.get(GregorianCalendar.SECOND) * 1000 +
+                 time.get(GregorianCalendar.MILLISECOND);
 
-      return new TimeExpression(millis);
+    return new TimeExpression(millis);
   }
 
   public static LogicalExpression getTime(int milliSeconds) {
@@ -98,28 +98,22 @@ public class ValueExpressions {
   public static LogicalExpression getNumericExpression(String sign, String s, ExpressionPosition ep) {
     String numStr = (sign == null) ? s : sign+s;
     try {
-        int a = Integer.parseInt(numStr);
-        return new IntExpression(a, ep);
-    } catch (Exception e) {
+      int a = Integer.parseInt(numStr);
+      return new IntExpression(a, ep);
+    } catch (Exception e) { }
 
-    }
     try {
       long l = Long.parseLong(numStr);
       return new LongExpression(l, ep);
-    } catch (Exception e) {
-
-    }
+    } catch (Exception e) { }
 
     try {
       double d = Double.parseDouble(numStr);
       return new DoubleExpression(d, ep);
-    } catch (Exception e) {
-
-    }
+    } catch (Exception e) { }
 
     throw new IllegalArgumentException(String.format("Unable to parse string %s as integer or floating point number.",
         numStr));
-
   }
 
   public static LogicalExpression getParameterExpression(String name, MajorType type) {
@@ -151,7 +145,6 @@ public class ValueExpressions {
       super(value, pos);
     }
 
-
     @Override
     protected Boolean parseValue(String s) {
       return Boolean.parseBoolean(s);
@@ -170,11 +163,10 @@ public class ValueExpressions {
     public boolean getBoolean() {
       return value;
     }
-
   }
 
   public static class FloatExpression extends LogicalExpressionBase {
-    private float f;
+    private final float f;
 
     private static final MajorType FLOAT_CONSTANT = Types.required(MinorType.FLOAT4);
 
@@ -201,14 +193,13 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class IntExpression extends LogicalExpressionBase {
 
     private static final MajorType INT_CONSTANT = Types.required(MinorType.INT);
 
-    private int i;
+    private final int i;
 
     public IntExpression(int i, ExpressionPosition pos) {
       super(pos);
@@ -233,14 +224,13 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class Decimal9Expression extends LogicalExpressionBase {
 
-    private int decimal;
-    private int scale;
-    private int precision;
+    private final int decimal;
+    private final int scale;
+    private final int precision;
 
     public Decimal9Expression(BigDecimal input, ExpressionPosition pos) {
       super(pos);
@@ -248,7 +238,6 @@ public class ValueExpressions {
       this.precision = input.precision();
       this.decimal = input.setScale(scale, BigDecimal.ROUND_HALF_UP).intValue();
     }
-
 
     public int getIntFromDecimal() {
       return decimal;
@@ -280,9 +269,9 @@ public class ValueExpressions {
 
   public static class Decimal18Expression extends LogicalExpressionBase {
 
-    private long decimal;
-    private int scale;
-    private int precision;
+    private final long decimal;
+    private final int scale;
+    private final int precision;
 
     public Decimal18Expression(BigDecimal input, ExpressionPosition pos) {
       super(pos);
@@ -290,7 +279,6 @@ public class ValueExpressions {
       this.precision = input.precision();
       this.decimal = input.setScale(scale, BigDecimal.ROUND_HALF_UP).longValue();
     }
-
 
     public long getLongFromDecimal() {
       return decimal;
@@ -318,18 +306,16 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class Decimal28Expression extends LogicalExpressionBase {
 
-    private BigDecimal bigDecimal;
+    private final BigDecimal bigDecimal;
 
     public Decimal28Expression(BigDecimal input, ExpressionPosition pos) {
       super(pos);
       this.bigDecimal = input;
     }
-
 
     public BigDecimal getBigDecimal() {
       return bigDecimal;
@@ -349,12 +335,11 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class Decimal38Expression extends LogicalExpressionBase {
 
-    private BigDecimal bigDecimal;
+    private final BigDecimal bigDecimal;
 
     public Decimal38Expression(BigDecimal input, ExpressionPosition pos) {
       super(pos);
@@ -379,7 +364,6 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class VarDecimalExpression extends LogicalExpressionBase {
@@ -422,7 +406,7 @@ public class ValueExpressions {
   }
 
   public static class DoubleExpression extends LogicalExpressionBase {
-    private double d;
+    private final double d;
 
     private static final MajorType DOUBLE_CONSTANT = Types.required(MinorType.FLOAT8);
 
@@ -449,20 +433,19 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class LongExpression extends LogicalExpressionBase {
 
     private static final MajorType LONG_CONSTANT = Types.required(MinorType.BIGINT);
 
-    private long l;
+    private final long l;
 
     public LongExpression(long l) {
       this(l, ExpressionPosition.UNKNOWN);
     }
 
-      public LongExpression(long l, ExpressionPosition pos) {
+    public LongExpression(long l, ExpressionPosition pos) {
       super(pos);
       this.l = l;
     }
@@ -485,21 +468,19 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
-
 
   public static class DateExpression extends LogicalExpressionBase {
 
     private static final MajorType DATE_CONSTANT = Types.required(MinorType.DATE);
 
-    private long dateInMillis;
+    private final long dateInMillis;
 
     public DateExpression(long l) {
       this(l, ExpressionPosition.UNKNOWN);
     }
 
-      public DateExpression(long dateInMillis, ExpressionPosition pos) {
+    public DateExpression(long dateInMillis, ExpressionPosition pos) {
       super(pos);
       this.dateInMillis = dateInMillis;
     }
@@ -522,21 +503,19 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
-
 
   public static class TimeExpression extends LogicalExpressionBase {
 
     private static final MajorType TIME_CONSTANT = Types.required(MinorType.TIME);
 
-    private int timeInMillis;
+    private final int timeInMillis;
 
     public TimeExpression(int timeInMillis) {
       this(timeInMillis, ExpressionPosition.UNKNOWN);
     }
 
-      public TimeExpression(int timeInMillis, ExpressionPosition pos) {
+    public TimeExpression(int timeInMillis, ExpressionPosition pos) {
       super(pos);
       this.timeInMillis = timeInMillis;
     }
@@ -559,20 +538,19 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class TimeStampExpression extends LogicalExpressionBase {
 
     private static final MajorType TIMESTAMP_CONSTANT = Types.required(MinorType.TIMESTAMP);
 
-    private long timeInMillis;
+    private final long timeInMillis;
 
     public TimeStampExpression(long timeInMillis) {
       this(timeInMillis, ExpressionPosition.UNKNOWN);
     }
 
-      public TimeStampExpression(long timeInMillis, ExpressionPosition pos) {
+    public TimeStampExpression(long timeInMillis, ExpressionPosition pos) {
       super(pos);
       this.timeInMillis = timeInMillis;
     }
@@ -595,20 +573,19 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class IntervalYearExpression extends LogicalExpressionBase {
 
     private static final MajorType INTERVALYEAR_CONSTANT = Types.required(MinorType.INTERVALYEAR);
 
-    private int months;
+    private final int months;
 
     public IntervalYearExpression(int months) {
       this(months, ExpressionPosition.UNKNOWN);
     }
 
-      public IntervalYearExpression(int months, ExpressionPosition pos) {
+    public IntervalYearExpression(int months, ExpressionPosition pos) {
       super(pos);
       this.months = months;
     }
@@ -631,7 +608,6 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class IntervalDayExpression extends LogicalExpressionBase {
@@ -639,14 +615,14 @@ public class ValueExpressions {
     private static final MajorType INTERVALDAY_CONSTANT = Types.required(MinorType.INTERVALDAY);
     private static final long MILLIS_IN_DAY = 1000 * 60 * 60 * 24;
 
-    private int days;
-    private int millis;
+    private final int days;
+    private final int millis;
 
     public IntervalDayExpression(long intervalInMillis) {
       this((int) (intervalInMillis / MILLIS_IN_DAY), (int) (intervalInMillis % MILLIS_IN_DAY), ExpressionPosition.UNKNOWN);
     }
 
-      public IntervalDayExpression(int days, int millis, ExpressionPosition pos) {
+    public IntervalDayExpression(int days, int millis, ExpressionPosition pos) {
       super(pos);
       this.days = days;
       this.millis = millis;
@@ -674,7 +650,6 @@ public class ValueExpressions {
     public Iterator<LogicalExpression> iterator() {
       return Collections.emptyIterator();
     }
-
   }
 
   public static class QuotedString extends ValueExpression<String> {
@@ -709,7 +684,7 @@ public class ValueExpressions {
   }
 
   /**
-   * Is used to identify method parameter based on given name and type.
+   * Identifies method parameter based on given name and type.
    */
   public static class ParameterExpression extends LogicalExpressionBase {
 
@@ -741,5 +716,4 @@ public class ValueExpressions {
       return ImmutableList.<LogicalExpression>of().iterator();
     }
   }
-
 }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/AggregateChecker.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/AggregateChecker.java
@@ -87,7 +87,7 @@ public final class AggregateChecker implements ExprVisitor<Boolean, ErrorCollect
 
   @Override
   public Boolean visitBooleanOperator(BooleanOperator op, ErrorCollector errors) {
-    for (LogicalExpression arg : op.args) {
+    for (LogicalExpression arg : op.args()) {
       if (arg.accept(this, errors)) {
         return true;
       }
@@ -133,6 +133,7 @@ public final class AggregateChecker implements ExprVisitor<Boolean, ErrorCollect
   public Boolean visitBooleanConstant(BooleanExpression e, ErrorCollector errors) {
     return false;
   }
+  @Override
   public Boolean visitDecimal9Constant(Decimal9Expression decExpr, ErrorCollector errors) {
     return false;
   }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ConditionalExprOptimizer.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ConditionalExprOptimizer.java
@@ -40,7 +40,7 @@ public class ConditionalExprOptimizer extends AbstractExprVisitor<LogicalExpress
   @Override
   public LogicalExpression visitBooleanOperator(BooleanOperator op, Void value) throws RuntimeException {
     List<LogicalExpression> newArgs = Lists.newArrayList();
-    newArgs.addAll(op.args);
+    newArgs.addAll(op.args());
     Collections.sort(newArgs, costComparator);
 
     return new BooleanOperator(op.getName(), newArgs, op.getPosition());

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ConstantChecker.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ConstantChecker.java
@@ -84,7 +84,7 @@ final class ConstantChecker implements ExprVisitor<Boolean, ErrorCollector, Runt
 
   @Override
   public Boolean visitBooleanOperator(BooleanOperator op, ErrorCollector errors) {
-    for (LogicalExpression e : op.args) {
+    for (LogicalExpression e : op.args()) {
       if (!e.accept(this, errors)) {
         return false;
       }

--- a/logical/src/main/java/org/apache/drill/common/expression/visitors/ExpressionValidator.java
+++ b/logical/src/main/java/org/apache/drill/common/expression/visitors/ExpressionValidator.java
@@ -51,7 +51,6 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 
 public class ExpressionValidator implements ExprVisitor<Void, ErrorCollector, RuntimeException> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExpressionValidator.class);
 
   @Override
   public Void visitFunctionCall(FunctionCall call, ErrorCollector errors) throws RuntimeException {
@@ -77,7 +76,7 @@ public class ExpressionValidator implements ExprVisitor<Void, ErrorCollector, Ru
   @Override
   public Void visitBooleanOperator(BooleanOperator op, ErrorCollector errors) throws RuntimeException {
     int i = 0;
-    for (LogicalExpression arg : op.args) {
+    for (LogicalExpression arg : op.args()) {
       if ( arg.getMajorType().getMinorType() != MinorType.BIT) {
         errors
             .addGeneralError(

--- a/logical/src/main/java/org/apache/drill/common/parser/LogicalExpressionParser.java
+++ b/logical/src/main/java/org/apache/drill/common/parser/LogicalExpressionParser.java
@@ -22,13 +22,14 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.parser.ExprLexer;
 import org.apache.drill.common.expression.parser.ExprParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class for parsing logical expression.
  */
 public class LogicalExpressionParser {
-
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LogicalExpressionParser.class);
+  private static final Logger logger = LoggerFactory.getLogger(LogicalExpressionParser.class);
 
   /**
    * Initializes logical expression lexer and parser, add error listener that converts all
@@ -51,5 +52,4 @@ public class LogicalExpressionParser {
     logger.trace("Tokens: [{}]. Parsing details: [{}].", tokens.getText(), parseContext.toInfoString(parser));
     return parseContext.e;
   }
-
 }


### PR DESCRIPTION
# [DRILL-7634](https://issues.apache.org/jira/browse/DRILL-7634): Rollup of code cleanup changes

## Description

Collection of code cleanup changes.

The most significant is to create constants for function names. We already had a pretty good list in `FunctionGenerationHelper`. I move this list to a new interface, `FunctionNames` and added to it. I then changed all references to hard-coded names to instead refer to these constants.

This change pointed out several places where code checks for variations of function names. Not sure why; perhaps an early version of the code did not have the map from alias to "canonical" name. Used constants for the canonical name, left the other names in place because I don't have enough knowledge to know if it is safe to remove them. Anyone know?

Also made the `args` member of `FunctionCall` private and added accessors.

## Documentation

None

## Testing

Reran all unit tests.