### PR TITLE
DRILL-7635: Mongo tests fail for profiles with the non-file default file system

### DIFF
--- a/contrib/storage-mongo/src/test/resources/core-site.xml
+++ b/contrib/storage-mongo/src/test/resources/core-site.xml
@@ -20,33 +20,43 @@
 -->
 <configuration>
 
-    <property>
-        <name>drill.exec.store.mongo.username</name>
-        <value>test</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongo.username</name>
+    <value>test</value>
+  </property>
 
-    <property>
-        <name>drill.exec.store.mongo.password</name>
-        <value>pw</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongo.password</name>
+    <value>pw</value>
+  </property>
 
-    <property>
-        <name>drill.exec.store.mongosec.username</name>
-        <value>!@#$%//:+^*()</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongosec.username</name>
+    <value>!@#$%//:+^*()</value>
+  </property>
 
-    <property>
-        <name>drill.exec.store.mongosec.password</name>
-        <value>:;[]}{!@#/?$#@</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongosec.password</name>
+    <value>:;[]}{!@#/?$#@</value>
+  </property>
 
-    <property>
-        <name>drill.exec.store.mongomooch.username</name>
-        <value>mooch_${drill.exec.store.mongo.username}</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongomooch.username</name>
+    <value>mooch_${drill.exec.store.mongo.username}</value>
+  </property>
 
-    <property>
-        <name>drill.exec.store.mongomooch.password</name>
-        <value>mooch_${drill.exec.store.mongo.password}</value>
-    </property>
+  <property>
+    <name>drill.exec.store.mongomooch.password</name>
+    <value>mooch_${drill.exec.store.mongo.password}</value>
+  </property>
+
+  <property>
+    <name>fs.defaultFS</name>
+    <value>file:///</value>
+    <description>The name of the default file system.  A URI whose
+      scheme and authority determine the FileSystem implementation.  The
+      uri's scheme determines the config property (fs.SCHEME.impl) naming
+      the FileSystem implementation class.  The uri's authority is used to
+      determine the host, port, etc. for a filesystem.</description>
+  </property>
 </configuration>


### PR DESCRIPTION
# [DRILL-7635](https://issues.apache.org/jira/browse/DRILL-7635): Mongo tests fail for profiles with the non-file default file system

## Description
Please see Jira for details.

## Documentation
NA

## Testing
Ran all tests.
