### PR TITLE
DRILL-7637: Add an option to retrieve MapR SSL truststore/keystore cr…

### DIFF
--- a/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
+++ b/common/src/main/java/org/apache/drill/common/config/DrillProperties.java
@@ -82,6 +82,7 @@ public final class DrillProperties extends Properties {
   public static final String TLS_HANDSHAKE_TIMEOUT = "TLSHandshakeTimeout";
   public static final String TLS_PROVIDER = "TLSProvider";
   public static final String USE_SYSTEM_TRUSTSTORE = "useSystemTrustStore";
+  public static final String USE_MAPR_SSL_CONFIG = "useMapRSSLConfig";
 
   public static final String QUERY_TAGS = "queryTags";
 

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -29,6 +29,7 @@
   <name>exec/Java Execution Engine</name>
   <properties>
     <libpam4j.version>1.8-rev2</libpam4j.version>
+    <maprfs.version>6.1.0-mapr</maprfs.version>
   </properties>
 
   <dependencies>
@@ -666,6 +667,28 @@
     </profile>
     <profile>
       <id>mapr</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-mapr-sources</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>srcMapr/main/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
         <dependency>
           <groupId>com.mapr.hadoop</groupId>
@@ -675,6 +698,11 @@
         <dependency>
           <groupId>com.tdunning</groupId>
           <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.mapr.security</groupId>
+          <artifactId>mapr-security-web</artifactId>
+          <version>${maprfs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -199,6 +199,7 @@ public final class ExecConstants {
   public static final String SSL_TRUSTSTORE_PATH = "drill.exec.ssl.trustStorePath"; // path to keystore. default : $JRE_HOME/lib/security/cacerts.jks
   public static final String SSL_TRUSTSTORE_PASSWORD = "drill.exec.ssl.trustStorePassword"; // default: changeit
   public static final String SSL_USE_HADOOP_CONF = "drill.exec.ssl.useHadoopConfig"; // Initialize ssl params from hadoop if not provided by drill. default: true
+  public static final String SSL_USE_MAPR_CONFIG = "drill.exec.ssl.useMapRSSLConfig"; // Use keyStore and trustStore credentials provided by MapR platform.
   public static final String SSL_HANDSHAKE_TIMEOUT = "drill.exec.security.user.encryption.ssl.handshakeTimeout"; // Default 10 seconds
 
   public static final String TEXT_LINE_READER_BATCH_SIZE = "drill.exec.storage.file.text.batch.size";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -51,9 +51,14 @@ public class SSLConfigClient extends SSLConfig {
   public SSLConfigClient(Properties properties) throws DrillException {
     this.properties = properties;
     userSslEnabled = getBooleanProperty(DrillProperties.ENABLE_TLS);
-    trustStoreType = getStringProperty(DrillProperties.TRUSTSTORE_TYPE, "JKS");
-    trustStorePath = getStringProperty(DrillProperties.TRUSTSTORE_PATH, "");
-    trustStorePassword = getStringProperty(DrillProperties.TRUSTSTORE_PASSWORD, "");
+    SSLCredentialsProvider credentialsProvider = SSLCredentialsProvider.getSSLCredentialsProvider(
+        this::getStringProperty,
+        Mode.CLIENT,
+        getBooleanProperty(DrillProperties.USE_MAPR_SSL_CONFIG)
+    );
+    trustStoreType = credentialsProvider.getTrustStoreType(DrillProperties.TRUSTSTORE_TYPE, "JKS");
+    trustStorePath = credentialsProvider.getTrustStoreLocation(DrillProperties.TRUSTSTORE_PATH, "");
+    trustStorePassword = credentialsProvider.getTrustStorePassword(DrillProperties.TRUSTSTORE_PASSWORD, "");
     disableHostVerification = getBooleanProperty(DrillProperties.DISABLE_HOST_VERIFICATION);
     disableCertificateVerification = getBooleanProperty(DrillProperties.DISABLE_CERT_VERIFICATION);
     useSystemTrustStore = getBooleanProperty(DrillProperties.USE_SYSTEM_TRUSTSTORE);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -74,21 +74,25 @@ public class SSLConfigServer extends SSLConfig {
     }
     userSslEnabled =
         config.hasPath(ExecConstants.USER_SSL_ENABLED) && config.getBoolean(ExecConstants.USER_SSL_ENABLED);
-    trustStoreType = getConfigParam(ExecConstants.SSL_TRUSTSTORE_TYPE,
-        resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_TYPE_TPL_KEY, mode));
-    trustStorePath = getConfigParam(ExecConstants.SSL_TRUSTSTORE_PATH,
-        resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_LOCATION_TPL_KEY, mode));
-    trustStorePassword = getConfigParam(ExecConstants.SSL_TRUSTSTORE_PASSWORD,
-        resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_PASSWORD_TPL_KEY, mode));
-    keyStoreType = getConfigParam(ExecConstants.SSL_KEYSTORE_TYPE,
-        resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_TYPE_TPL_KEY, mode));
-    keyStorePath = getConfigParam(ExecConstants.SSL_KEYSTORE_PATH,
-        resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_LOCATION_TPL_KEY, mode));
-    keyStorePassword = getConfigParam(ExecConstants.SSL_KEYSTORE_PASSWORD,
-        resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_PASSWORD_TPL_KEY, mode));
+    SSLCredentialsProvider credentialsProvider = SSLCredentialsProvider.getSSLCredentialsProvider(
+        this::getConfigParam,
+        Mode.SERVER,
+        config.getBoolean(ExecConstants.SSL_USE_MAPR_CONFIG));
+    trustStoreType = credentialsProvider.getTrustStoreType(
+        ExecConstants.SSL_TRUSTSTORE_TYPE, resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_TYPE_TPL_KEY, mode));
+    trustStorePath = credentialsProvider.getTrustStoreLocation(
+        ExecConstants.SSL_TRUSTSTORE_PATH, resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_LOCATION_TPL_KEY, mode));
+    trustStorePassword = credentialsProvider.getTrustStorePassword(
+        ExecConstants.SSL_TRUSTSTORE_PASSWORD, resolveHadoopPropertyName(HADOOP_SSL_TRUSTSTORE_PASSWORD_TPL_KEY, mode));
+    keyStoreType = credentialsProvider.getKeyStoreType(
+        ExecConstants.SSL_KEYSTORE_TYPE, resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_TYPE_TPL_KEY, mode));
+    keyStorePath = credentialsProvider.getKeyStoreLocation(
+        ExecConstants.SSL_KEYSTORE_PATH, resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_LOCATION_TPL_KEY, mode));
+    keyStorePassword = credentialsProvider.getKeyStorePassword(
+        ExecConstants.SSL_KEYSTORE_PASSWORD, resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_PASSWORD_TPL_KEY, mode));
+    String keyPass = credentialsProvider.getKeyPassword(
+        ExecConstants.SSL_KEY_PASSWORD, resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_KEYPASSWORD_TPL_KEY, mode));
     // if no keypassword specified, use keystore password
-    String keyPass = getConfigParam(ExecConstants.SSL_KEY_PASSWORD,
-        resolveHadoopPropertyName(HADOOP_SSL_KEYSTORE_KEYPASSWORD_TPL_KEY, mode));
     keyPassword = keyPass.isEmpty() ? keyStorePassword : keyPass;
     protocol = config.getString(ExecConstants.SSL_PROTOCOL);
     // If provider is OPENSSL then to debug or run this code in an IDE, you will need to enable

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLCredentialsProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLCredentialsProvider.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ssl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Provides an implementation of credentials provider depending on "useMapRSSLConfig" option value
+ * and whether Drill was built with mapr profile or not.
+ */
+abstract class SSLCredentialsProvider {
+
+  private static final String MAPR_CREDENTIALS_PROVIDER_CLIENT = "org.apache.drill.exec.ssl.SSLCredentialsProviderMaprClient";
+  private static final String MAPR_CREDENTIALS_PROVIDER_SERVER = "org.apache.drill.exec.ssl.SSLCredentialsProviderMaprServer";
+
+  private static final Logger logger = LoggerFactory.getLogger(SSLCredentialsProvider.class);
+
+  /**
+   * Provides a concrete implementation of {@link SSLCredentialsProvider}.
+   *
+   * @param getPropertyMethod a reference to a method to retrieve credentials from config:
+   *                          <ul>
+   *                            <li>String parameter1 - property name</li>
+   *                            <li>String parameter2 - default value</li>
+   *                            <li>returns the property value or default value</li>
+   *                          </ul>
+   * @param mode              CLIENT or SERVER
+   * @param useMapRSSLConfig  use a MapR credential provider
+   * @return concrete implementation of SSLCredentialsProvider
+   */
+  static SSLCredentialsProvider getSSLCredentialsProvider(BiFunction<String, String, String> getPropertyMethod, SSLConfig.Mode mode, boolean useMapRSSLConfig) {
+    return useMapRSSLConfig ? getMaprCredentialsProvider(mode)
+        .orElseGet(() -> new SSLCredentialsProviderImpl(getPropertyMethod)) :
+        new SSLCredentialsProviderImpl(getPropertyMethod);
+  }
+
+  private static Optional<SSLCredentialsProvider> getMaprCredentialsProvider(SSLConfig.Mode mode) {
+    String maprCredentialsProviderClass = "";
+    switch (mode) {
+      case SERVER:
+        maprCredentialsProviderClass = MAPR_CREDENTIALS_PROVIDER_SERVER;
+        break;
+      case CLIENT:
+        maprCredentialsProviderClass = MAPR_CREDENTIALS_PROVIDER_CLIENT;
+        break;
+      default:
+        throw new IllegalStateException("Should never occur.");
+    }
+    try {
+      return Optional.of((SSLCredentialsProvider) Class.forName(maprCredentialsProviderClass).newInstance());
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      logger.warn("Trying to use MapR credentials provider on a non-MapR platform", e);
+      return Optional.empty();
+    }
+  }
+
+  abstract String getTrustStoreType(String propertyName, String defaultValue);
+
+  abstract String getTrustStoreLocation(String propertyName, String defaultValue);
+
+  abstract String getTrustStorePassword(String propertyName, String defaultValue);
+
+  abstract String getKeyStoreType(String propertyName, String defaultValue);
+
+  abstract String getKeyStoreLocation(String propertyName, String defaultValue);
+
+  abstract String getKeyStorePassword(String propertyName, String defaultValue);
+
+  abstract String getKeyPassword(String propertyName, String defaultValue);
+
+
+  /**
+   * Default implementation of {@link SSLCredentialsProvider}.
+   * Delegates retrieving credentials to a class where it is used.
+   */
+  private static class SSLCredentialsProviderImpl extends SSLCredentialsProvider {
+
+    private final BiFunction<String, String, String> getPropertyMethod;
+
+    private SSLCredentialsProviderImpl(BiFunction<String, String, String> getPropertyMethod) {
+      this.getPropertyMethod = getPropertyMethod;
+    }
+
+    @Override
+    String getTrustStoreType(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getTrustStoreLocation(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getTrustStorePassword(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getKeyStoreType(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getKeyStoreLocation(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getKeyStorePassword(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+
+    @Override
+    String getKeyPassword(String propertyName, String defaultValue) {
+      return getPropertyMethod.apply(propertyName, defaultValue);
+    }
+  }
+}

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -212,6 +212,8 @@ drill.exec: {
     # if true, then Drill will read SSL parameters from the
     # Hadoop configuration files.
     useHadoopConfig : true,
+    # Use keyStore and trustStore credentials provided by MapR platform.
+    useMapRSSLConfig : false,
     #Drill can use either the JDK implementation or the OpenSSL implementation.
     provider: "JDK"
   },

--- a/exec/java-exec/srcMapr/main/java/org/apache/drill/exec/ssl/SSLCredentialsProviderMaprClient.java
+++ b/exec/java-exec/srcMapr/main/java/org/apache/drill/exec/ssl/SSLCredentialsProviderMaprClient.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ssl;
+
+import com.mapr.web.security.SslConfig;
+import com.mapr.web.security.WebSecurityManager;
+
+/**
+ * Provides SSL credentials for Client using {@link WebSecurityManager}.
+ */
+class SSLCredentialsProviderMaprClient extends SSLCredentialsProvider {
+
+  private final SslConfig sslConfig = WebSecurityManager.getSslConfig();
+
+  @Override
+  String getTrustStoreType(String propertyName, String defaultValue) {
+    return sslConfig.getClientTruststoreType();
+  }
+
+  @Override
+  String getTrustStoreLocation(String propertyName, String defaultValue) {
+    return sslConfig.getClientTruststoreLocation();
+  }
+
+  @Override
+  String getTrustStorePassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getClientTruststorePassword());
+  }
+
+  @Override
+  String getKeyStoreType(String propertyName, String defaultValue) {
+    return sslConfig.getClientKeystoreType();
+  }
+
+  @Override
+  String getKeyStoreLocation(String propertyName, String defaultValue) {
+    return sslConfig.getClientKeystoreLocation();
+  }
+
+  @Override
+  String getKeyStorePassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getClientKeystorePassword());
+  }
+
+  @Override
+  String getKeyPassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getClientKeyPassword());
+  }
+}

--- a/exec/java-exec/srcMapr/main/java/org/apache/drill/exec/ssl/SSLCredentialsProviderMaprServer.java
+++ b/exec/java-exec/srcMapr/main/java/org/apache/drill/exec/ssl/SSLCredentialsProviderMaprServer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.ssl;
+
+import com.mapr.web.security.SslConfig;
+import com.mapr.web.security.WebSecurityManager;
+
+/**
+ * Provides SSL credentials for Server using {@link WebSecurityManager}.
+ */
+class SSLCredentialsProviderMaprServer extends SSLCredentialsProvider {
+
+  private final SslConfig sslConfig = WebSecurityManager.getSslConfig();
+
+  @Override
+  String getTrustStoreType(String propertyName, String defaultValue) {
+    return sslConfig.getServerTruststoreType();
+  }
+
+  @Override
+  String getTrustStoreLocation(String propertyName, String defaultValue) {
+    return sslConfig.getServerTruststoreLocation();
+  }
+
+  @Override
+  String getTrustStorePassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getServerTruststorePassword());
+  }
+
+  @Override
+  String getKeyStoreType(String propertyName, String defaultValue) {
+    return sslConfig.getServerKeystoreType();
+  }
+
+  @Override
+  String getKeyStoreLocation(String propertyName, String defaultValue) {
+    return sslConfig.getServerKeystoreLocation();
+  }
+
+  @Override
+  String getKeyStorePassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getServerKeystorePassword());
+  }
+
+  @Override
+  String getKeyPassword(String propertyName, String defaultValue) {
+    return String.valueOf(sslConfig.getServerKeyPassword());
+  }
+}

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -596,7 +596,7 @@
                           This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                         </message>
-                        <maxsize>37500000</maxsize>
+                        <maxsize>43000000</maxsize>
                         <minsize>15000000</minsize>
                         <files>
                           <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>


### PR DESCRIPTION
…edentials using MapR Web Security Manager

# [DRILL-7637](https://issues.apache.org/jira/browse/DRILL-7637): Add an option to retrieve MapR SSL truststore/keystore credentials using MapR Web Security Manager

## Description
An option added to provide MapR truststore/keystore credentials using MapR Web Security Manager instead of setting passwords openly in the config.  

## Documentation
To use this feature user need to:
- Install Drill on MapR platform.
- Enable the corresponding option in the Drill config:
`drill.exec.ssl.useMapRSSLConfig: true`
- Pass this option with the connection string using sqlline: 
`./bin/sqlline -u "jdbc:drill:drillbit=node1.cluster.com:31010;enableTLS=true;useMapRSSLConfig=true"`

## Testing
- Unit tests passed w/ and w/o mapr profile.
- Functional/Advanced tests passed.
- Manually tested Web UI and sqlline with the feature enabled/disabled.
