### PR TITLE
DRILL-7626: Add ability to set HTTP response headers

### DIFF
--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -176,6 +176,16 @@ drill.exec: {
           validatePeerCerts: false,
           # true if SSL wants client authentication.
           wantClientAuth: false
+        },
+        response: {
+          # any response headers with constant values may be configured like this
+          headers: {
+            "X-XSS-Protection": "1; mode=block",
+            "X-Content-Type-Options": "nosniff",
+            "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+            # NOTE: 'unsafe-inline' is required until DRILL-7642 is resolved
+            "Content-Security-Policy": "default-src https:; script-src 'unsafe-inline' https:; style-src 'unsafe-inline' https:; font-src data: https:; img-src data: https:"
+          }
         }
       }
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -212,7 +212,7 @@ public final class ExecConstants {
   public static final String HTTP_JETTY_SERVER_ACCEPTORS = "drill.exec.http.jetty.server.acceptors";
   public static final String HTTP_JETTY_SERVER_SELECTORS = "drill.exec.http.jetty.server.selectors";
   public static final String HTTP_JETTY_SERVER_HANDLERS = "drill.exec.http.jetty.server.handlers";
-
+  public static final String HTTP_JETTY_SERVER_RESPONSE_HEADERS = "drill.exec.http.jetty.server.response.headers";
   public static final String HTTP_JETTY_SSL_CONTEXT_FACTORY_OPTIONS_PREFIX = "drill.exec.http.jetty.server.sslContextFactory";
   public static final String HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CERT_ALIAS = "drill.exec.http.jetty.server.sslContextFactory.certAlias";
   public static final String HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CRL_PATH = "drill.exec.http.jetty.server.sslContextFactory.crlPath";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.rest.header.ResponseHeadersSettingFilter;
 import org.apache.drill.exec.server.rest.ssl.SslContextFactoryConfigurator;
 import org.apache.drill.exec.exception.DrillbitStartupException;
 import org.apache.drill.exec.expr.fn.registry.FunctionHolder;
@@ -250,6 +251,11 @@ public class WebServer implements AutoCloseable {
     filterHolder.setInitParameter("allowedOrigins", "*");
     //Allowing CORS for metrics only
     servletContextHandler.addFilter(filterHolder, STATUS_METRICS_PATH, null);
+
+    FilterHolder responseHeadersSettingFilter = new FilterHolder(ResponseHeadersSettingFilter.class);
+    responseHeadersSettingFilter.setInitParameters(ResponseHeadersSettingFilter.retrieveResponseHeaders(config));
+    servletContextHandler.addFilter(responseHeadersSettingFilter, "/*", EnumSet.of(DispatcherType.REQUEST));
+
 
     return servletContextHandler;
   }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/header/ResponseHeadersSettingFilter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/header/ResponseHeadersSettingFilter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest.header;
+
+import com.typesafe.config.ConfigObject;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.exec.ExecConstants;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Responsible for setting configured {@link ExecConstants#HTTP_JETTY_SERVER_RESPONSE_HEADERS}
+ * to {@link HttpServletResponse} object.
+ */
+public class ResponseHeadersSettingFilter implements Filter {
+
+  private Map<String, String> responseHeaders;
+
+  public static Map<String, String> retrieveResponseHeaders(DrillConfig config) {
+    Map<String, String> headers = new HashMap<>();
+    if (config.hasPath(ExecConstants.HTTP_JETTY_SERVER_RESPONSE_HEADERS)) {
+      ConfigObject headersConf = config.getObject(ExecConstants.HTTP_JETTY_SERVER_RESPONSE_HEADERS);
+      for (String header : headersConf.keySet()) {
+        Object val = headersConf.get(header).unwrapped();
+        headers.put(header, val == null ? null : val.toString());
+      }
+    }
+    return headers;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    responseHeaders = new HashMap<>();
+    Enumeration<String> headers = filterConfig.getInitParameterNames();
+    while (headers.hasMoreElements()) {
+      String header = headers.nextElement();
+      String value = filterConfig.getInitParameter(header);
+      responseHeaders.put(header, value);
+    }
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    responseHeaders.forEach(((HttpServletResponse) response)::setHeader);
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy() {
+    responseHeaders = null;
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestResponseHeaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestResponseHeaders.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.HashMap;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.apache.drill.test.RestClientFixture;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.drill.exec.ExecConstants.HTTP_ENABLE;
+import static org.apache.drill.exec.ExecConstants.HTTP_JETTY_SERVER_RESPONSE_HEADERS;
+import static org.apache.drill.exec.ExecConstants.HTTP_PORT_HUNT;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestResponseHeaders extends ClusterTest {
+
+  private static final String BASE_URL = "";
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher)
+        .configProperty(HTTP_ENABLE, true)
+        .configProperty(HTTP_PORT_HUNT, true)
+        .configProperty(ExecConstants.SYS_STORE_PROVIDER_LOCAL_ENABLE_WRITE, false);
+    builder.configBuilder().put(HTTP_JETTY_SERVER_RESPONSE_HEADERS, new HashMap<String, String>() {{
+      put("MyHeader", "102030");
+    }});
+    startCluster(builder);
+  }
+
+  @Test
+  public void checkConfiguredHeaders() throws Exception {
+    try (RestClientFixture restClient = cluster.restClientFixture()) {
+      MultivaluedMap<String, String> responseHeaders = restClient.getResponseHeaders(BASE_URL);
+      assertThat(responseHeaders.get("MyHeader").get(0), equalTo("102030"));
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ConfigBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ConfigBuilder.java
@@ -27,8 +27,8 @@ import org.apache.drill.exec.memory.BoundsChecking;
 import org.apache.drill.exec.physical.impl.BaseRootExec;
 import org.apache.drill.exec.server.options.OptionDefinition;
 import org.apache.drill.exec.server.options.SystemOptionManager;
+import org.apache.drill.shaded.guava.com.google.common.primitives.Primitives;
 
-import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -115,10 +115,10 @@ public class ConfigBuilder {
       throw new IllegalArgumentException( "Cannot provide both a config resource and config properties.");
     }
 
-    if (value instanceof Collection) {
-      configProps.put(key, value);
-    } else {
+    if (value instanceof  String || Primitives.isWrapperType(value.getClass())) {
       configProps.put(key, value.toString());
+    } else {
+      configProps.put(key, value);
     }
 
     return this;
@@ -164,10 +164,11 @@ public class ConfigBuilder {
     // Filter out the collection type configs and other configs
     // which can be converted to string.
     for (Entry<Object, Object> entry : configProps.entrySet()) {
-      if (entry.getValue() instanceof Collection<?>) {
-        collectionProps.put(entry.getKey(), entry.getValue());
+      Object value = entry.getValue();
+      if (value instanceof String || Primitives.isWrapperType(value.getClass())) {
+        stringProps.setProperty(entry.getKey().toString(), value.toString());
       } else {
-        stringProps.setProperty(entry.getKey().toString(), entry.getValue().toString());
+        collectionProps.put(entry.getKey(), value);
       }
     }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/RestClientFixture.java
@@ -28,6 +28,8 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 import java.util.List;
 
@@ -78,6 +80,13 @@ public class RestClientFixture implements AutoCloseable {
     return baseTarget.path(StatusResources.PATH_INTERNAL_OPTIONS_JSON)
       .request(MediaType.APPLICATION_JSON)
       .get(new GenericType<List<StatusResources.OptionWrapper>>() {});
+  }
+
+  public MultivaluedMap<String, String> getResponseHeaders(String relativeResourcePath) {
+    Response response = baseTarget.path(relativeResourcePath)
+        .request(MediaType.TEXT_HTML)
+        .get();
+    return response.getStringHeaders();
   }
 
   /**


### PR DESCRIPTION
# [DRILL-7626](https://issues.apache.org/jira/browse/DRILL-7626): Add ability to set HTTP response headers

## Description

1. Created ResponseHeadersSettingFilter for adding configured values to each response.
2. Now for when drill.exec.http.ssl_enabled is set to true, users can add following headers
   to improve security:
      "X-XSS-Protection" : "1; mode=block",
      "X-Content-Type-Options" : "nosniff",
      "Strict-Transport-Security" : "max-age=31536000;includeSubDomains",
      "Content-Security-Policy" : "Content-Security-Policy": "default-src https:; script-src 'unsafe-inline' https:; style-src 'unsafe-inline' https:; font-src data: https:; img-src data: https:"

## Documentation

Adding of new response headers now available in drill-override.conf under key drill.exec.http.jetty.server.response.headers . For example:

```
drill.exec: {
  cluster-id: "drillbits1",
  zk.connect: "localhost:2181", 
  http: {
    ssl_enabled: true, 
    jetty.server.response.headers: {
      "X-XSS-Protection": "1; mode=block",
      "X-Content-Type-Options": "nosniff",
      "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
      "Content-Security-Policy": "default-src https:; script-src 'unsafe-inline' https:; style-src 'unsafe-inline' https:; font-src data: https:; img-src data: https:"    
    }
  }
}
```


## Testing

Tested manually with Web UI.