### PR TITLE
DRILL-7639: Replace DBCP2 with HikariCP in RDBMS (JDBC) plugin

### DIFF
--- a/contrib/storage-jdbc/pom.xml
+++ b/contrib/storage-jdbc/pom.xml
@@ -43,8 +43,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestDataSource.java
@@ -17,14 +17,15 @@
  */
 package org.apache.drill.exec.store.jdbc;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTest;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,71 +33,83 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
-public class TestBasicDataSource extends BaseTest {
+public class TestDataSource extends BaseTest {
+
+  @Rule
+  public BaseDirTestWatcher dirTestWatcher = new BaseDirTestWatcher();
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
+  private static final String DRIVER = "org.h2.Driver";
+
+  private String url;
+
+  @Before
+  public void init() throws Exception {
+    url = "jdbc:h2:" + dirTestWatcher.getTmpDir().getCanonicalPath();
+  }
+
   @Test
-  public void testInitWithoutUserAndPassword() throws Exception {
+  public void testInitWithoutUserAndPassword() {
     JdbcStorageConfig config = new JdbcStorageConfig(
-      "driver", "url", null, null, false, null);
-    try (BasicDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
-      assertEquals("driver", dataSource.getDriverClassName());
-      assertEquals("url", dataSource.getUrl());
+      DRIVER, url, null, null, false, null);
+    try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
+      assertEquals(DRIVER, dataSource.getDriverClassName());
+      assertEquals(url, dataSource.getJdbcUrl());
       assertNull(dataSource.getUsername());
       assertNull(dataSource.getPassword());
     }
   }
 
   @Test
-  public void testInitWithUserAndPassword() throws Exception {
+  public void testInitWithUserAndPassword() {
     JdbcStorageConfig config = new JdbcStorageConfig(
-      "driver", "url", "user", "password", false, null);
-    try (BasicDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
+      DRIVER, url, "user", "password", false, null);
+    try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
       assertEquals("user", dataSource.getUsername());
       assertEquals("password", dataSource.getPassword());
     }
   }
 
   @Test
-  public void testInitWithSourceParameters() throws Exception {
+  public void testInitWithSourceParameters() {
     Map<String, Object> sourceParameters = new HashMap<>();
-    sourceParameters.put("maxIdle", 5);
-    sourceParameters.put("cacheState", false);
-    sourceParameters.put("validationQuery", "select * from information_schema.collations");
+    sourceParameters.put("minimumIdle", 5);
+    sourceParameters.put("autoCommit", false);
+    sourceParameters.put("connectionTestQuery", "select * from information_schema.collations");
+    sourceParameters.put("dataSource.cachePrepStmts", true);
+    sourceParameters.put("dataSource.prepStmtCacheSize", 250);
     JdbcStorageConfig config = new JdbcStorageConfig(
-      "driver", "url", "user", "password", false, sourceParameters);
-    try (BasicDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
-      assertEquals(5, dataSource.getMaxIdle());
-      assertFalse(dataSource.getCacheState());
-      assertEquals("select * from information_schema.collations", dataSource.getValidationQuery());
+      DRIVER, url, "user", "password", false, sourceParameters);
+    try (HikariDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
+      assertEquals(5, dataSource.getMinimumIdle());
+      assertFalse(dataSource.isAutoCommit());
+      assertEquals("select * from information_schema.collations", dataSource.getConnectionTestQuery());
+      assertEquals(true, dataSource.getDataSourceProperties().get("cachePrepStmts"));
+      assertEquals(250, dataSource.getDataSourceProperties().get("prepStmtCacheSize"));
     }
   }
 
   @Test
-  public void testInitWithIncorrectSourceParameterName() throws Exception {
+  public void testInitWithIncorrectSourceParameterName() {
     Map<String, Object> sourceParameters = new HashMap<>();
-    sourceParameters.put("maxIdle", 5);
     sourceParameters.put("abc", "abc");
-    sourceParameters.put("cacheState", false);
-    sourceParameters.put("validationQuery", null);
     JdbcStorageConfig config = new JdbcStorageConfig(
-      "driver", "url", "user", "password", false, sourceParameters);
-    try (BasicDataSource dataSource = JdbcStoragePlugin.initDataSource(config)) {
-      // "abc" parameter will be ignored
-      assertEquals(5, dataSource.getMaxIdle());
-      assertFalse(dataSource.getCacheState());
-      assertNull(dataSource.getValidationQuery());
-    }
+      DRIVER, url, "user", "password", false, sourceParameters);
+
+    thrown.expect(UserException.class);
+    thrown.expectMessage(UserBitShared.DrillPBError.ErrorType.CONNECTION.name());
+
+    JdbcStoragePlugin.initDataSource(config);
   }
 
   @Test
   public void testInitWithIncorrectSourceParameterValue() {
     Map<String, Object> sourceParameters = new HashMap<>();
-    sourceParameters.put("maxIdle", "abc");
+    sourceParameters.put("minimumIdle", "abc");
     JdbcStorageConfig config = new JdbcStorageConfig(
-      "driver", "url", "user", "password", false, sourceParameters);
+      DRIVER, url, "user", "password", false, sourceParameters);
 
     thrown.expect(UserException.class);
     thrown.expectMessage(UserBitShared.DrillPBError.ErrorType.CONNECTION.name());

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithH2IT.java
@@ -63,8 +63,7 @@ public class TestJdbcPluginWithH2IT extends ClusterTest {
       RunScript.execute(connection, fileReader);
     }
     Map<String, Object> sourceParameters =  new HashMap<>();
-    sourceParameters.put("maxIdle", 5);
-    sourceParameters.put("maxTotal", 5);
+    sourceParameters.put("minimumIdle", 1);
     JdbcStorageConfig jdbcStorageConfig = new JdbcStorageConfig("org.h2.Driver", connString, "root", "root", true, sourceParameters);
     jdbcStorageConfig.setEnabled(true);
     cluster.defineStoragePlugin("h2", jdbcStorageConfig);

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <javax.el.version>3.0.0</javax.el.version>
     <surefire.version>3.0.0-M4</surefire.version>
     <commons.compress.version>1.19</commons.compress.version>
-    <commons.dbcp2.version>2.7.0</commons.dbcp2.version>
+    <hikari.version>3.4.2</hikari.version>
   </properties>
 
   <scm>
@@ -1873,15 +1873,9 @@
         <version>${commons.compress.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-dbcp2</artifactId>
-        <version>${commons.dbcp2.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>${hikari.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# [DRILL-7639](https://issues.apache.org/jira/browse/DRILL-7639): Replace DBCP2 with HikariCP in RDBMS (JDBC) plugin

## Description

This PR replace DBCP2 with HikariCP in RDBMS (JDBC) plugin since HikariCP is much faster and more reliable.

https://beansroasted.wordpress.com/2017/07/29/connection-pool-analysis/
https://github.com/brettwooldridge/HikariCP

## Documentation
NA

## Testing
Added unit tests, ran all tests, tested manually.
