### PR TITLE
DRILL-7644: Log SSL protocol version at Drill start up

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserServer.java
@@ -137,6 +137,7 @@ public class UserServer extends BasicServer<RpcType, BitToUserConnection> {
           .initializeSSLContext(true)
           .validateKeyStore(true)
           .build();
+      logger.info("Rpc server configured to use TLS protocol '{}'", sslConfig.getProtocol());
     } catch (DrillException e) {
       throw new DrillbitStartupException(e.getMessage(), e.getCause());
     }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
@@ -95,6 +95,7 @@ public class SslContextFactoryConfigurator {
     }
     sslFactory.setProtocol(sslConf.getProtocol());
     sslFactory.setIncludeProtocols(sslConf.getProtocol());
+    logger.info("Web server configured to use TLS protocol '{}'", sslConf.getProtocol());
     if (config.hasPath(ExecConstants.HTTP_JETTY_SSL_CONTEXT_FACTORY_OPTIONS_PREFIX)) {
       setStringIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CERT_ALIAS, sslFactory::setCertAlias);
       setStringIfPresent(ExecConstants.HTTP_JETTY_SERVER_SSL_CONTEXT_FACTORY_CRL_PATH, sslFactory::setCrlPath);


### PR DESCRIPTION
# [DRILL-7644](https://issues.apache.org/jira/browse/DRILL-7644): Log SSL protocol version at Drill start up

## Description

Added 2 log messages.

## Documentation

Two new messages will be available in logs when SSL enabled. 

## Testing

Tested manually. 