### PR TITLE
DRILL-7650: Add option to enable Jetty's dump for troubleshooting

### DIFF
--- a/distribution/src/main/resources/drill-override-example.conf
+++ b/distribution/src/main/resources/drill-override-example.conf
@@ -115,6 +115,8 @@ drill.exec: {
     },
     jetty: {
       server: {
+        # development option which allows to log Jetty server state after start
+        dumpAfterStart: false,
         # Optional params to set on Jetty's org.eclipse.jetty.util.ssl.SslContextFactory when drill.exec.http.ssl_enabled
         sslContextFactory: {
           # allows to specify cert to use when multiple non-SNI certificates are available.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -210,6 +210,7 @@ public final class ExecConstants {
   public static final String HTTP_PROFILES_PER_PAGE = "drill.exec.http.profiles_per_page";
   public static final String HTTP_PORT = "drill.exec.http.port";
   public static final String HTTP_PORT_HUNT = "drill.exec.http.porthunt";
+  public static final String HTTP_JETTY_SERVER_DUMP_AFTER_START = "drill.exec.http.jetty.server.dumpAfterStart";
   public static final String HTTP_JETTY_SERVER_ACCEPTORS = "drill.exec.http.jetty.server.acceptors";
   public static final String HTTP_JETTY_SERVER_SELECTORS = "drill.exec.http.jetty.server.selectors";
   public static final String HTTP_JETTY_SERVER_HANDLERS = "drill.exec.http.jetty.server.handlers";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -162,6 +162,7 @@ public class WebServer implements AutoCloseable {
     threadPool.setMaxThreads(handlers + connector.getAcceptors() + connector.getSelectorManager().getSelectorCount());
     embeddedJetty.addConnector(connector);
 
+    embeddedJetty.setDumpAfterStart(config.getBoolean(ExecConstants.HTTP_JETTY_SERVER_DUMP_AFTER_START));
     final boolean portHunt = config.getBoolean(ExecConstants.HTTP_PORT_HUNT);
     for (int retry = 0; retry < PORT_HUNT_TRIES; retry++) {
       connector.setPort(port);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/ssl/SslContextFactoryConfigurator.java
@@ -93,7 +93,6 @@ public class SslContextFactoryConfigurator {
         sslFactory.setTrustStorePassword(sslConf.getTrustStorePassword());
       }
     }
-    sslFactory.setProtocol(sslConf.getProtocol());
     sslFactory.setIncludeProtocols(sslConf.getProtocol());
     logger.info("Web server configured to use TLS protocol '{}'", sslConf.getProtocol());
     if (config.hasPath(ExecConstants.HTTP_JETTY_SSL_CONTEXT_FACTORY_OPTIONS_PREFIX)) {

--- a/exec/java-exec/src/main/resources/drill-module.conf
+++ b/exec/java-exec/src/main/resources/drill-module.conf
@@ -157,7 +157,8 @@ drill.exec: {
       server : {
         acceptors : 1,
         selectors : 1,
-        handlers : 5
+        handlers : 5,
+        dumpAfterStart: false
       }
     }
     max_profiles: 100,


### PR DESCRIPTION
# [DRILL-7650](https://issues.apache.org/jira/browse/DRILL-7650): Add option to enable Jetty's dump for troubleshooting

## Description

Jetty server implements a useful tool for dumping the current state of the server, but in Drill, it's not possible to use it without code changes. This ticket aims to add option drill.exec.http.jetty.server.dumpAfterStart in Apache Drill.

Another change is to remove the redundant setProtocol(protocol) method call on sslContextFactory instance.

## Documentation

Set drill.exec.http.jetty.server.dumpAfterStart to true if you want to check server state in logs. 

## Testing

Checked manually. 
