### PR TITLE
DRILL-7649: Replace maprfs.version property usage by mapr.release.ver…

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -437,6 +437,10 @@
           <groupId>com.mapr.db</groupId>
           <artifactId>maprdb-mapreduce</artifactId>
         </dependency>
+        <dependency>
+          <groupId>com.mapr.security</groupId>
+          <artifactId>mapr-security-web</artifactId>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -29,7 +29,6 @@
   <name>exec/Java Execution Engine</name>
   <properties>
     <libpam4j.version>1.8-rev2</libpam4j.version>
-    <maprfs.version>6.1.0-mapr</maprfs.version>
   </properties>
 
   <dependencies>
@@ -702,7 +701,6 @@
         <dependency>
           <groupId>com.mapr.security</groupId>
           <artifactId>mapr-security-web</artifactId>
-          <version>${maprfs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1660,6 +1660,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.mapr.security</groupId>
+        <artifactId>mapr-security-web</artifactId>
+        <version>${mapr.release.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.ojai</groupId>
         <artifactId>ojai</artifactId>
         <version>${ojai.version}</version>


### PR DESCRIPTION
…sion

Also added mapr-security-web to the Dependency Management and Distribution POM
to fix a problem, where the jar file is not being added to the distribution in some build environments.

# [DRILL-7649](https://issues.apache.org/jira/browse/DRILL-7649): DRILL-7649: Replace maprfs.version property usage by mapr.release.version

## Description

There are no functional changes, just a small refactoring.

## Documentation
-

## Testing
Built with default and "mapr" profiles, built dependency tree. All looks good.
