### PR TITLE
DRILL-7652: Add time_bucket() function for time series analysis

### DIFF
--- a/contrib/udfs/README.md
+++ b/contrib/udfs/README.md
@@ -167,6 +167,59 @@ POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))</pre>
 	</tbody>
 </table>
 
+## Time Series Analysis Functions
+When analyzing time based data, you will often have to aggregate by time grains. While some time grains will be easy to calculate, others, such as quarter, can be quite difficult. These functions enable a user to quickly and easily aggregate data by various units of time. Usage is as follows:
+```sql
+SELECT <fields>
+FROM <data>
+GROUP BY nearestDate(<timestamp_column>, <time increment>
+```
+So let's say that a user wanted to count the number of hits on a web server per 15 minute, the query might look like this:
+
+```sql
+SELECT nearestDate(`eventDate`, 'QUARTER_HOUR' ) AS eventDate,
+COUNT(*) AS hitCount
+FROM dfs.`log.httpd`
+GROUP BY nearestDate(`eventDate`, 'QUARTER_HOUR')
+```
+Currently supports the following time units:
+ * YEAR,
+ * QUARTER,
+ * MONTH,
+ * WEEK_SUNDAY,
+ * WEEK_MONDAY,
+ * DAY,
+ * HOUR,
+ * HALF_HOUR,
+ * QUARTER_HOUR,
+ * MINUTE,
+ * HALF_MINUTE,
+ * QUARTER_MINUTE,
+ * SECOND
+
+There are two versions of the function, one which accepts a date and interval, and the other accepts a string, format string and interval.
+
+### Time Bucket Functions
+These functions are useful for doing time series analysis by grouping the data into arbitrary intervals.  See: https://blog.timescale.com/blog/simplified-time-series-analytics
+-using-the-time_bucket-function/ for more examples. 
+
+There are two versions of the function:
+* `time_bucket(<timestamp>, <interval>)`
+* `time_bucket_ns(<timestamp>,<interval>)`
+
+Both functions accept a `BIGINT` timestamp and an interval in milliseconds as arguments. The `time_bucket_ns()` function accepts timestamps in nanoseconds and `time_bucket
+()` accepts timestamps in milliseconds.  Both return timestamps in the original format.
+
+### Example:
+The query below calculates the average for the `cpu` metric for every five minute interval.
+
+```sql
+SELECT time_bucket(time_stamp, 30000) AS five_min, avg(cpu)
+  FROM metrics
+  GROUP BY five_min
+  ORDER BY five_min DESC LIMIT 12;
+```
+
 ## User Agent Functions
 Drill UDF for parsing User Agent Strings.
 This function is based on Niels Basjes Java library for parsing user agent strings which is available here: <https://github.com/nielsbasjes/yauaa>.
@@ -178,7 +231,7 @@ SELECT parse_user_agent( columns[0] ) as ua
 FROM dfs.`/tmp/data/drill-httpd/ua.csv`;
 ```
 The query above returns:
-```
+```json
 {
   "DeviceClass":"Desktop",
   "DeviceName":"Macintosh",
@@ -204,7 +257,7 @@ The query above returns:
 ```
 The function returns a Drill map, so you can access any of the fields using Drill's table.map.key notation. For example, the query below illustrates how to extract a field from this map and summarize it:
 
-```
+```sql
 SELECT uadata.ua.AgentNameVersion AS Browser,
 COUNT( * ) AS BrowserCount
 FROM (
@@ -215,7 +268,7 @@ GROUP BY uadata.ua.AgentNameVersion
 ORDER BY BrowserCount DESC
 ```
 The function can also be called with an optional field as an argument. IE:
-```
+```sql
 SELECT parse_user_agent( `user_agent`, 'AgentName` ) as AgentName ...
 ```
 which will just return the requested field. If the user agent string is empty, all fields will have the value of `Hacker`.  

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/TimeBucketFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/TimeBucketFunctions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import org.apache.drill.exec.expr.DrillSimpleFunc;
+import org.apache.drill.exec.expr.annotations.FunctionTemplate;
+import org.apache.drill.exec.expr.annotations.Output;
+import org.apache.drill.exec.expr.annotations.Param;
+import org.apache.drill.exec.expr.holders.BigIntHolder;
+
+
+public class TimeBucketFunctions {
+
+  /**
+   * This function is used for facilitating time series analysis by creating buckets of time intervals.  See
+   * https://blog.timescale.com/blog/simplified-time-series-analytics-using-the-time_bucket-function/ for usage. The function takes two arguments:
+   * 1. The timestamp in nanoseconds
+   * 2. The desired bucket interval IN MILLISECONDS
+   *
+   * The function returns a BIGINT of the nearest time bucket.
+   */
+  @FunctionTemplate(name = "time_bucket_ns",
+    scope = FunctionTemplate.FunctionScope.SIMPLE,
+    nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+  public static class TimeBucketNSFunction implements DrillSimpleFunc {
+
+    @Param
+    BigIntHolder inputDate;
+
+    @Param
+    BigIntHolder interval;
+
+    @Output
+    BigIntHolder out;
+
+    @Override
+    public void setup() {
+    }
+
+    @Override
+    public void eval() {
+      // Get the timestamp in nanoseconds
+      long timestamp = inputDate.value;
+
+      // Get the interval in milliseconds and convert to nanoseconds
+      long intervalToAdd = interval.value * 1000000;
+
+      out.value = timestamp - (timestamp % intervalToAdd);
+    }
+  }
+
+  /**
+   * This function is used for facilitating time series analysis by creating buckets of time intervals.  See
+   * https://blog.timescale.com/blog/simplified-time-series-analytics-using-the-time_bucket-function/ for usage. The function takes two arguments:
+   * 1. The timestamp in milliseconds
+   * 2. The desired bucket interval IN milliseconds
+   *
+   * The function returns a BIGINT of the nearest time bucket.
+   */
+  @FunctionTemplate(name = "time_bucket",
+    scope = FunctionTemplate.FunctionScope.SIMPLE,
+    nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
+  public static class TimeBucketFunction implements DrillSimpleFunc {
+
+    @Param
+    BigIntHolder inputDate;
+
+    @Param
+    BigIntHolder interval;
+
+    @Output
+    BigIntHolder out;
+
+    @Override
+    public void setup() {
+    }
+
+    @Override
+    public void eval() {
+      // Get the timestamp in milliseconds
+      long timestamp = inputDate.value;
+
+      // Get the interval in milliseconds
+      long intervalToAdd = interval.value;
+
+      out.value = timestamp - (timestamp % intervalToAdd);
+    }
+  }
+}

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestTimeBucketFunction.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestTimeBucketFunction.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import org.apache.drill.categories.SqlFunctionTest;
+import org.apache.drill.categories.UnlikelyTest;
+import org.apache.drill.test.ClusterFixture;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category({UnlikelyTest.class, SqlFunctionTest.class})
+public class TestTimeBucketFunction extends ClusterTest {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
+    startCluster(builder);
+  }
+
+  @Test
+  public void testTimeBucketNanoSeconds() throws Exception {
+    String query = "SELECT time_bucket_ns(1451606760000000000, 300000) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues(1451606700000000000L)
+      .go();
+  }
+
+  @Test
+  public void testNullTimeBucketNanoSeconds() throws Exception {
+    String query = "SELECT time_bucket_ns(null, 300000) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+  @Test
+  public void testNullIntervalTimeBucketNanoSeconds() throws Exception {
+    String query = "SELECT time_bucket_ns(1451606760000000000, null) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+  @Test
+  public void testBothNullIntervalTimeBucketNanoSeconds() throws Exception {
+    String query = "SELECT time_bucket_ns(null, null) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+  @Test
+  public void testTimeBucket() throws Exception {
+    String query = "SELECT time_bucket(1451606760, 300000) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues(1451400000L)
+      .go();
+  }
+
+  @Test
+  public void testNullTimeBucket() throws Exception {
+    String query = "SELECT time_bucket(null, 300000) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+  @Test
+  public void testNullIntervalTimeBucket() throws Exception {
+    String query = "SELECT time_bucket(1451606760, null) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+  @Test
+  public void testBothNullIntervalTimeBucket() throws Exception {
+    String query = "SELECT time_bucket(null, null) AS high FROM (values(1))";
+    testBuilder()
+      .sqlQuery(query)
+      .ordered()
+      .baselineColumns("high")
+      .baselineValues((Long) null)
+      .go();
+  }
+
+}


### PR DESCRIPTION
# [DRILL-7652](https://issues.apache.org/jira/browse/DRILL-7652): Add time_bucket() function for Time Series Analysis

## Description

This PR adds two UDFs which facilitate time series analysis.  This PR also includes updates to the `README.md` in the `contrib/udf` folder to reflect the new UDF.

## Documentation
These functions are useful for doing time series analysis by grouping the data into arbitrary intervals.  See: https://blog.timescale.com/blog/simplified-time-series-analytics
-using-the-time_bucket-function/ for more examples. 

There are two versions of the function:
* `time_bucket(<timestamp>, <interval>)`
* `time_bucket_ns(<timestamp>,<interval>)`

Both functions accept a `BIGINT` timestamp and an interval in milliseconds as arguments. The `time_bucket_ns()` function accepts timestamps in nanoseconds and `time_bucket
()` accepts timestamps in milliseconds.  Both return timestamps in the original format.

### Example:
The query below calculates the average for the `cpu` metric for every five minute interval.

```sql
SELECT time_bucket(time_stamp, 30000) AS five_min, avg(cpu)
  FROM metrics
  GROUP BY five_min
  ORDER BY five_min DESC LIMIT 12;
```

## Testing
There are a series of unit tests included with this PR.