### PR TITLE
DRILL-7654: Add support for JDK 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Java versions to run unit tests
-        java: [ '1.8', '11', '13' ]
+        java: [ '1.8', '11', '14' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,14 @@
     <hbase.version>2.2.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
     <freemarker.version>2.3.28</freemarker.version>
-    <javassist.version>3.26.0-GA</javassist.version>
+    <javassist.version>3.27.0-GA</javassist.version>
     <msgpack.version>0.6.6</msgpack.version>
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.9.1</avro.version>
     <metrics.version>4.0.2</metrics.version>
     <jetty.version>9.3.25.v20180904</jetty.version>
     <jersey.version>2.25.1</jersey.version>
-    <asm.version>7.2</asm.version>
+    <asm.version>7.3.1</asm.version>
     <excludedGroups />
     <memoryMb>4096</memoryMb>
     <directMemoryMb>4096</directMemoryMb>
@@ -585,7 +585,7 @@
                   <version>[{$lowestMavenVersion},4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.8,14)</version>
+                  <version>[1.8,15)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
# [DRILL-7654](https://issues.apache.org/jira/browse/DRILL-7654): Add support for JDK 14

## Description
Allowed building Drill with JDK 14, updated ASM and javassist to the latest versions, updated GitHub Actions script to build and run tests for Java 14 instead of 13.

## Documentation
NA

## Testing
Checked that Drill is starting without errors or new warnings on Linux and Windows, made sanity checks to ensure that functionality is preserved.
