### PR TITLE
DRILL-7656: Support injecting BufferManager into UDF

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BaseFragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/BaseFragmentContext.java
@@ -122,4 +122,9 @@ public abstract class BaseFragmentContext implements FragmentContext {
   public QueryContext.SqlStatementType getSQLStatementType() {
     return null;
   }
+
+  @Override
+  public BufferManager getManagedBufferManager() {
+    return getBufferManager();
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentContext.java
@@ -167,6 +167,8 @@ public interface FragmentContext extends UdfUtilities, AutoCloseable {
 
   DrillBuf getManagedBuffer(int size);
 
+  BufferManager getManagedBufferManager();
+
   @Override
   void close();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/UdfUtilities.java
@@ -41,6 +41,7 @@ public interface UdfUtilities {
           .put(PartitionExplorer.class, "getPartitionExplorer")
           .put(ContextInformation.class, "getContextInformation")
           .put(OptionManager.class, "getOptions")
+          .put(BufferManager.class, "getManagedBufferManager")
           .build();
 
 


### PR DESCRIPTION
# [DRILL-7656](https://issues.apache.org/jira/browse/DRILL-7656): Support injecting BufferManager into UDF

## Description
This PR is to allow users to implement their UDF by using injected BufferManager to allocate they wanted number of  sized `DrillBuf`s. The reason why we need this which is not satisfied by the injected DrillBuf is described in the issue.

## Documentation
When implement a UDF , you could assign @Inject annotation to an BufferManager type class member. 

## Testing
have no testing
