### PR TITLE
DRILL-7648: Scrypt j_security_check works without security headers

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpSecurityHandlerProvider.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/auth/DrillHttpSecurityHandlerProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.server.rest.auth;
 
+import org.apache.drill.exec.server.rest.header.ResponseHeadersSettingFilter;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.common.exceptions.DrillException;
@@ -54,11 +55,14 @@ public class DrillHttpSecurityHandlerProvider extends ConstraintSecurityHandler 
   private final Map<String, DrillHttpConstraintSecurityHandler> securityHandlers =
       CaseInsensitiveMap.newHashMapWithExpectedSize(2);
 
+  private final Map<String, String> responseHeaders;
+
   @SuppressWarnings("unchecked")
   public DrillHttpSecurityHandlerProvider(DrillConfig config, DrillbitContext drillContext)
       throws DrillbitStartupException {
 
     Preconditions.checkState(config.getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED));
+    this.responseHeaders = ResponseHeadersSettingFilter.retrieveResponseHeaders(config);
     final Set<String> configuredMechanisms = getHttpAuthMechanisms(config);
 
     final ScanResult scan = drillContext.getClasspathScan();
@@ -122,7 +126,7 @@ public class DrillHttpSecurityHandlerProvider extends ConstraintSecurityHandler 
       throws IOException, ServletException {
 
     Preconditions.checkState(securityHandlers.size() > 0);
-
+    responseHeaders.forEach(response::setHeader);
     HttpSession session = request.getSession(true);
     SessionAuthentication authentication =
         (SessionAuthentication) session.getAttribute(SessionAuthentication.__J_AUTHENTICATED);


### PR DESCRIPTION
# [DRILL-7648](https://issues.apache.org/jira/browse/DRILL-7648): Scrypt j_security_check works without security headers

## Description

1. Added callback for setting headers in DrillHttpSecurityHandlerProvider,
   since ResponseHeadersSettingFilter doesn't cover this flow.

## Documentation

No need to document the bugfix.

## Testing

Tested manually since the security configuration for using form-based authentication is hard to do in unit tests.
