### PR TITLE
DRILL-6604: Upgrade Drill Hive client to Hive3.1 version

### DIFF
--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -30,6 +30,9 @@
   <artifactId>drill-storage-hive-core</artifactId>
   <packaging>jar</packaging>
   <name>contrib/hive-storage-plugin/core</name>
+  <properties>
+    <freemarker.conf.file>src/main/codegen/configHive3.fmpp</freemarker.conf.file>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -60,6 +63,14 @@
         <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-1.2-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -146,7 +157,7 @@
     <dependency>
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-hcatalog-core</artifactId>
-      <version>2.3.2</version>
+      <version>${hive.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -189,6 +200,18 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-web</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api-2.5</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -208,7 +231,7 @@
               <goal>generate</goal>
             </goals>
             <configuration>
-              <config>src/main/codegen/config.fmpp</config>
+              <config>${freemarker.conf.file}</config>
               <output>${project.build.directory}/generated-sources</output>
               <templates>src/main/codegen/templates</templates>
             </configuration>
@@ -220,6 +243,9 @@
   <profiles>
     <profile>
       <id>mapr</id>
+      <properties>
+        <freemarker.conf.file>src/main/codegen/config.fmpp</freemarker.conf.file>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/contrib/storage-hive/core/src/main/codegen/configHive3.fmpp
+++ b/contrib/storage-hive/core/src/main/codegen/configHive3.fmpp
@@ -17,7 +17,7 @@
 #
 
 data: {
-    drillDataType:  tdd(../data/Hive2DateTypes.tdd),
+    drillDataType:  tdd(../data/Hive3DateTypes.tdd),
     drillOI:        tdd(../data/HiveTypes.tdd)
 }
 freemarkerLinks: {

--- a/contrib/storage-hive/core/src/main/codegen/data/Hive2DateTypes.tdd
+++ b/contrib/storage-hive/core/src/main/codegen/data/Hive2DateTypes.tdd
@@ -16,10 +16,23 @@
 # limitations under the License.
 #
 
-data: {
-    drillDataType:  tdd(../data/Hive2DateTypes.tdd),
-    drillOI:        tdd(../data/HiveTypes.tdd)
-}
-freemarkerLinks: {
-    includes: includes/
+{
+  map: [
+    {
+      hiveType: "DATE",
+      hiveOI: "DateObjectInspector",
+      javaType: "java.sql.Date",
+      writableType: "org.apache.hadoop.hive.serde2.io.DateWritable",
+      drillType: "Date",
+      needOIForDrillType: true
+    },
+    {
+      hiveType: "TIMESTAMP",
+      hiveOI: "TimestampObjectInspector",
+      javaType: "java.sql.Timestamp",
+      writableType: "org.apache.hadoop.hive.serde2.io.TimestampWritable",
+      drillType: "TimeStamp",
+      needOIForDrillType: true
+    }
+  ]
 }

--- a/contrib/storage-hive/core/src/main/codegen/data/Hive3DateTypes.tdd
+++ b/contrib/storage-hive/core/src/main/codegen/data/Hive3DateTypes.tdd
@@ -16,10 +16,23 @@
 # limitations under the License.
 #
 
-data: {
-    drillDataType:  tdd(../data/Hive2DateTypes.tdd),
-    drillOI:        tdd(../data/HiveTypes.tdd)
-}
-freemarkerLinks: {
-    includes: includes/
+{
+  map: [
+    {
+      hiveType: "DATE",
+      hiveOI: "DateObjectInspector",
+      javaType: "org.apache.hadoop.hive.common.type.Date",
+      writableType: "org.apache.hadoop.hive.serde2.io.DateWritableV2",
+      drillType: "Date",
+      needOIForDrillType: true
+    },
+    {
+      hiveType: "TIMESTAMP",
+      hiveOI: "TimestampObjectInspector",
+      javaType: "org.apache.hadoop.hive.common.type.Timestamp",
+      writableType: "org.apache.hadoop.hive.serde2.io.TimestampWritableV2",
+      drillType: "TimeStamp",
+      needOIForDrillType: true
+    }
+  ]
 }

--- a/contrib/storage-hive/core/src/main/codegen/data/HiveTypes.tdd
+++ b/contrib/storage-hive/core/src/main/codegen/data/HiveTypes.tdd
@@ -96,24 +96,10 @@
       needOIForDrillType: true
     },
     {
-      hiveType: "TIMESTAMP",
-      hiveOI: "TimestampObjectInspector",
-      javaType: "java.sql.Timestamp",
-      drillType: "TimeStamp",
-      needOIForDrillType: true
-    },
-    {
       hiveType: "DECIMAL",
       hiveOI: "HiveDecimalObjectInspector",
       javaType: "org.apache.hadoop.hive.common.type.HiveDecimal",
       drillType: "VarDecimal",
-      needOIForDrillType: true
-    },
-    {
-      hiveType: "DATE",
-      hiveOI: "DateObjectInspector",
-      javaType: "java.sql.Date",
-      drillType: "Date",
       needOIForDrillType: true
     }
   ]

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveMetadataProvider.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
@@ -102,7 +102,7 @@ public class HiveMetadataProvider {
     HiveTableWithColumnCache table = hiveReadEntry.getTable();
     try {
       if (!isPartitionedTable) {
-        Properties properties = MetaStoreUtils.getTableMetadata(table);
+        Properties properties = new Table(table).getMetadata();
         HiveStats stats = HiveStats.getStatsFromProps(properties);
         if (stats.valid()) {
           return stats;

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/primitive/HiveDateWriter.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/primitive/HiveDateWriter.java
@@ -18,21 +18,25 @@
 package org.apache.drill.exec.store.hive.writers.primitive;
 
 import org.apache.drill.exec.vector.complex.writer.DateWriter;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-public class HiveDateWriter extends AbstractSingleValueWriter<DateObjectInspector, DateWriter> {
+import java.sql.Date;
 
-  public HiveDateWriter(DateObjectInspector inspector, DateWriter writer) {
+public class HiveDateWriter extends AbstractSingleValueWriter<PrimitiveObjectInspector, DateWriter> {
+
+  public HiveDateWriter(PrimitiveObjectInspector inspector, DateWriter writer) {
     super(inspector, writer);
   }
 
   @Override
   public void write(Object value) {
-    final java.sql.Date dateValue = inspector.getPrimitiveJavaObject(value);
-    final DateTime date = new DateTime(dateValue.getTime()).withZoneRetainFields(DateTimeZone.UTC);
-    writer.writeDate(date.getMillis());
+    String dateString = PrimitiveObjectInspectorUtils.getString(value, inspector);
+    long dateMillis = new DateTime(Date.valueOf(dateString).getTime())
+        .withZoneRetainFields(DateTimeZone.UTC).getMillis();
+    writer.writeDate(dateMillis);
   }
 
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/primitive/HiveTimestampWriter.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/writers/primitive/HiveTimestampWriter.java
@@ -18,21 +18,25 @@
 package org.apache.drill.exec.store.hive.writers.primitive;
 
 import org.apache.drill.exec.vector.complex.writer.TimeStampWriter;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-public class HiveTimestampWriter extends AbstractSingleValueWriter<TimestampObjectInspector, TimeStampWriter> {
+import java.sql.Timestamp;
 
-  public HiveTimestampWriter(TimestampObjectInspector inspector, TimeStampWriter writer) {
+public class HiveTimestampWriter extends AbstractSingleValueWriter<PrimitiveObjectInspector, TimeStampWriter> {
+
+  public HiveTimestampWriter(PrimitiveObjectInspector inspector, TimeStampWriter writer) {
     super(inspector, writer);
   }
 
   @Override
   public void write(Object value) {
-    final java.sql.Timestamp timestampValue = inspector.getPrimitiveJavaObject(value);
-    final DateTime ts = new DateTime(timestampValue.getTime()).withZoneRetainFields(DateTimeZone.UTC);
-    writer.writeTimeStamp(ts.getMillis());
+    String timestampString = PrimitiveObjectInspectorUtils.getString(value, inspector);
+    long timestampMillis = new DateTime(Timestamp.valueOf(timestampString).getTime())
+        .withZoneRetainFields(DateTimeZone.UTC).getMillis();
+    writer.writeTimeStamp(timestampMillis);
   }
 
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Hive uses class with the same full name from log4j-1.2-api.
+ * Added this class to avoid ClassNotFound errors from Hive.
+ *
+ * See <a href="https://issues.apache.org/jira/browse/HIVE-23088">HIVE-23088</a> for the problem description.
+ */
+public class Strings {
+
+  public static boolean isBlank(final String s) {
+    return StringUtils.isBlank(s);
+  }
+}

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestFixture.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/HiveTestFixture.java
@@ -167,6 +167,8 @@ public class HiveTestFixture {
       driverOption(ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
       driverOption(ConfVars.METASTORE_AUTO_CREATE_ALL, Boolean.toString(true));
       driverOption(ConfVars.METASTORE_SCHEMA_VERIFICATION, Boolean.toString(false));
+      driverOption(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING, Boolean.toString(false));
+      driverOption(HiveConf.ConfVars.HIVESESSIONSILENT, Boolean.toString(true));
       driverOption(ConfVars.HIVE_CBO_ENABLED, Boolean.toString(false));
     }
 

--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/HiveTestDataGenerator.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/store/hive/HiveTestDataGenerator.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.drill.exec.hive.HiveTestUtilities;
 import org.apache.drill.shaded.guava.com.google.common.io.Resources;
 import org.apache.drill.test.BaseDirTestWatcher;
 import org.apache.drill.test.BaseTestQuery;
@@ -442,7 +443,8 @@ public class HiveTestDataGenerator {
     executeQuery(hiveDriver, "CREATE OR REPLACE VIEW readtest_view AS SELECT * FROM readtest");
     executeQuery(hiveDriver, "CREATE VIEW IF NOT EXISTS hive_view AS SELECT * FROM kv");
     executeQuery(hiveDriver, "CREATE OR REPLACE VIEW kv_native_view AS SELECT * FROM kv_native");
-    executeQuery(hiveDriver, "CREATE MATERIALIZED VIEW IF NOT EXISTS hive_view_m AS SELECT * FROM kv WHERE key = 1");
+    String disableRewrite = HiveTestUtilities.isHive3() ? "DISABLE REWRITE" : "";
+    executeQuery(hiveDriver, String.format("CREATE MATERIALIZED VIEW IF NOT EXISTS hive_view_m %s AS SELECT * FROM kv WHERE key = 1", disableRewrite));
     executeQuery(hiveDriver, "CREATE OR REPLACE VIEW view_over_hive_view AS SELECT * FROM hive_view WHERE key BETWEEN 2 AND 3");
     executeQuery(hiveDriver, "CREATE OR REPLACE VIEW db1.two_table_view AS SELECT COUNT(dk.key) dk_key_count FROM db1.avro dk " +
         "INNER JOIN kv ON kv.key = dk.key");
@@ -592,7 +594,7 @@ public class HiveTestDataGenerator {
 
   private String generateTestDataWithHeadersAndFooters(String tableName, int rowCount, int headerLines, int footerLines) {
     StringBuilder sb = new StringBuilder();
-    sb.append("insert into table ").append(tableName).append(" (key, value) values ");
+    sb.append("insert into table ").append(tableName).append(" values ");
     sb.append(StringUtils.repeat("('key_header', 'value_header')", ",", headerLines));
     if (headerLines > 0) {
       sb.append(",");

--- a/exec/rpc/pom.xml
+++ b/exec/rpc/pom.xml
@@ -45,7 +45,7 @@
       <artifactId>drill-memory-base</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
@@ -54,7 +54,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <classifier>linux-x86_64</classifier>
-      <version>4.0.48.Final</version>
+      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
@@ -83,11 +83,5 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
   </dependencies>
-
-
-  <build>
-  </build>
-
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       Currently Hive storage plugin only supports Apache Hive 2.3.2 or vendor specific variants of the
       Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated.
     -->
-    <hive.version>2.3.2</hive.version>
+    <hive.version>3.1.2</hive.version>
     <hadoop.version>3.2.1</hadoop.version>
     <hbase.version>2.2.2</hbase.version>
     <fmpp.version>1.0</fmpp.version>
@@ -112,6 +112,7 @@
     <surefire.version>3.0.0-M4</surefire.version>
     <commons.compress.version>1.19</commons.compress.version>
     <hikari.version>3.4.2</hikari.version>
+    <netty.version>4.0.48.Final</netty.version>
   </properties>
 
   <scm>
@@ -1002,13 +1003,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>4.0.48.Final</version>
     </dependency>
 
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.0.48.Final</version>
     </dependency>
 
     <dependency>
@@ -1690,6 +1689,16 @@
         <classifier>${netty.tcnative.classifier}</classifier>
         <scope>runtime</scope>
         <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.tdunning</groupId>


### PR DESCRIPTION
# [DRILL-6604](https://issues.apache.org/jira/browse/DRILL-6604): Upgrade Drill Hive client to Hive3.1 version

## Description

One of the major changes in this PR is cleaning up the output for Hive tests. Now, almost all hive-related stuff is not printed to the stdout.

Additionally, the Hive version was updated to the latest (at the current time) version 3.1.2.
New Hive version introduced new `ObjectInspector` classes for date and timestamp values, so to be able to compile with other versions, code was updated to use correct class names (see changes in `tdd` files and related changes.

As for any other Hive update, Dill wouldn't be able to work with previous Hive versions, but for users, who still want to do it, it is possible to compile manually Drill with setting the following properties:
`hive.version=2.3.2` (or any other version in range [2.3.2-3.1.2]), `freemarker.conf.file=src/main/codegen/config.fmpp` (or `src/main/codegen/configHive3.fmpp` for versions where new date / timestamp classes were introduced).
Example of usage:
```
mvn clean install -DskipTests -Dhive.version=2.3.2 -Dfreemarker.conf.file=src/main/codegen/config.fmpp
```

Please note, that other profiles that use their own Hive version wouldn't be affected by this change and will work as before.

## Documentation
A new supported Hive version should be documented.

## Testing
Ran all tests suite, checked manually that Drill is able to select from new Hive.
