### PR TITLE
DRILL-7663: Code refactor to DefaultFunctionResolver

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/DefaultFunctionResolver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/DefaultFunctionResolver.java
@@ -19,8 +19,7 @@ package org.apache.drill.exec.resolver;
 
 import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import java.util.stream.Collectors;
 import org.apache.drill.common.expression.FunctionCall;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.types.TypeProtos;
@@ -38,12 +37,10 @@ public class DefaultFunctionResolver implements FunctionResolver {
     int currcost = Integer.MAX_VALUE;
     DrillFuncHolder bestmatch = null;
     final List<DrillFuncHolder> bestMatchAlternatives = new LinkedList<>();
-
+    List<TypeProtos.MajorType> argumentTypes = call.args().stream()
+            .map(LogicalExpression::getMajorType)
+            .collect(Collectors.toList());
     for (DrillFuncHolder h : methods) {
-      final List<TypeProtos.MajorType> argumentTypes = Lists.newArrayList();
-      for (LogicalExpression expression : call.args()) {
-        argumentTypes.add(expression.getMajorType());
-      }
       currcost = TypeCastRules.getCost(argumentTypes, h);
 
       // if cost is lower than 0, func implementation is not matched, either w/ or w/o implicit casts


### PR DESCRIPTION
# [DRILL-7663](https://issues.apache.org/jira/browse/DRILL-7663): Code refactor to DefaultFunctionResolver

## Description
extract common static logic from the for loop

## Documentation
NO
## Testing
NO
