### PR TITLE
DRILL-7665: Add UNION to schema parser

### DIFF
--- a/exec/vector/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaLexer.g4
+++ b/exec/vector/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaLexer.g4
@@ -57,6 +57,7 @@ SECOND: 'SECOND';
 MAP: 'MAP';
 STRUCT: 'STRUCT';
 ARRAY: 'ARRAY';
+UNION: 'UNION';
 
 // additional data types, primary used for Parquet
 UINT1: 'UINT1';

--- a/exec/vector/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
+++ b/exec/vector/src/main/antlr4/org/apache/drill/exec/record/metadata/schema/parser/SchemaParser.g4
@@ -31,7 +31,7 @@ columns: column_def (COMMA column_def)*;
 
 column_def: column property_values?;
 
-column: (primitive_column | struct_column | map_column | simple_array_column | complex_array_column);
+column: (primitive_column | struct_column | map_column | simple_array_column | complex_array_column | union_column);
 
 primitive_column: column_id simple_type nullability? format_value? default_value?;
 
@@ -42,6 +42,8 @@ struct_column: column_id struct_type nullability?;
 map_column: column_id map_type nullability?;
 
 complex_array_column: column_id complex_array_type nullability?;
+
+union_column: column_id union_type nullability?;
 
 column_id
 : ID # id
@@ -71,6 +73,8 @@ simple_type
 | SMALLINT # smallint
 ;
 
+union_type: UNION;
+
 array_type: (simple_array_type | complex_array_type);
 
 simple_array_type: ARRAY LEFT_ANGLE_BRACKET simple_array_value_type RIGHT_ANGLE_BRACKET;
@@ -79,6 +83,7 @@ simple_array_value_type
 : simple_type # array_simple_type_def
 | struct_type # array_struct_type_def
 | map_type # array_map_type_def
+| union_type # array_union_type_def
 ;
 
 complex_array_type: ARRAY LEFT_ANGLE_BRACKET array_type RIGHT_ANGLE_BRACKET;
@@ -100,6 +105,7 @@ map_value_type
 | struct_type # map_value_struct_type_def
 | map_type # map_value_map_type_def
 | array_type # map_value_array_type_def
+| union_type # map_value_union_type_def
 ;
 
 nullability: NOT NULL;

--- a/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestSchemaParser.java
+++ b/exec/vector/src/test/java/org/apache/drill/exec/record/metadata/schema/parser/TestSchemaParser.java
@@ -225,6 +225,10 @@ public class TestSchemaParser extends BaseTest {
           .nullableValue(TypeProtos.MinorType.INT)
         .resumeList()
       .resumeSchema()
+      .addList("union_array")
+        .addType(TypeProtos.MinorType.BIGINT)
+        .addType(TypeProtos.MinorType.DATE)
+      .resumeSchema()
       .buildSchema();
 
     checkSchema("simple_array array<int>"
@@ -232,7 +236,8 @@ public class TestSchemaParser extends BaseTest {
         + ", struct_array array<struct<s1 int, s2 varchar>>"
         + ", nested_array_struct array<array<struct<ns1 int, ns2 varchar>>>"
         + ", map_array array<map<varchar, int>>"
-        + ", nested_map_array array<array<map<varchar, int>>>",
+        + ", nested_map_array array<array<map<varchar, int>>>"
+        + ", union_array array<union>",
       schema);
   }
 
@@ -249,6 +254,9 @@ public class TestSchemaParser extends BaseTest {
         .addDict("map_col", TypeProtos.MinorType.VARCHAR)
           .nullableValue(TypeProtos.MinorType.INT)
         .resumeMap()
+        .addUnion("union_col")
+          .addType(TypeProtos.MinorType.INT)
+        .resumeMap()
       .resumeSchema()
       .buildSchema();
 
@@ -256,6 +264,7 @@ public class TestSchemaParser extends BaseTest {
       + ", array_col array<int>"
       + ", nested_struct struct<s1 int, s2 varchar>"
       + ", map_col map<varchar, int>"
+      + ", union_col union"
       + ">", schema);
   }
 
@@ -295,14 +304,35 @@ public class TestSchemaParser extends BaseTest {
             .nullableValue(TypeProtos.MinorType.FLOAT8)
           .resumeDict()
         .resumeSchema()
+        .addDict("dict_col_union", TypeProtos.MinorType.BIGINT)
+          .unionValue()
+            .addType(TypeProtos.MinorType.INT)
+         .resumeDict()
+        .resumeSchema()
       .buildSchema();
 
     checkSchema("dict_col_simple map<varchar, int>"
       + ", dict_col_simple_ps map<varchar(50), decimal(10, 2) not null>"
       + ", dict_col_struct map<int, struct<sb boolean not null, si int>>"
       + ", dict_col_dict map<varchar, map<int, boolean>>"
-      + ", dict_col_array map<bigint, array<map<date, double>>>",
+      + ", dict_col_array map<bigint, array<map<date, double>>>"
+      + ", dict_col_union map<bigint, union>",
       schema);
+  }
+
+  @Test
+  public void testUnion() throws Exception {
+    TupleMetadata schema = new SchemaBuilder()
+      .addUnion("col_union_not_null")
+        .addType(TypeProtos.MinorType.INT)
+        .addType(TypeProtos.MinorType.VARCHAR)
+      .resumeSchema()
+      .addUnion("col_union_null")
+        .addType(TypeProtos.MinorType.INT)
+      .resumeSchema()
+      .buildSchema();
+
+    checkSchema("col_union_not_null union not null, col_union_null union", schema);
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-7665](https://issues.apache.org/jira/browse/DRILL-7665): Add UNION to schema parser

## Description

After DRILL-7633 has defined proper type string for UNION it should be added to schema parser to allow proper column metadata ser / de.

## Documentation
NA

## Testing
Added unit tests.
