### PR TITLE
DRILL-7672: Make metadata type required when reading from / writing into Drill Metastore

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
@@ -32,6 +32,7 @@ import org.apache.drill.exec.store.dfs.FileSelection;
 import org.apache.drill.exec.store.dfs.FormatSelection;
 import org.apache.drill.exec.util.DrillFileSystemUtil;
 import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.BasicTablesRequests;
 import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
@@ -290,7 +291,7 @@ public class FileMetadataInfoCollector implements MetadataInfoCollector {
         .metadataKeys(metadataKeys)
         .paths(allFiles)
         .metadataType(MetadataType.ROW_GROUP)
-        .requestColumns(Arrays.asList(MetadataInfo.METADATA_KEY, MetadataInfo.METADATA_IDENTIFIER, MetadataInfo.METADATA_TYPE))
+        .requestColumns(Arrays.asList(MetastoreColumn.METADATA_KEY, MetastoreColumn.METADATA_IDENTIFIER, MetastoreColumn.METADATA_TYPE))
         .build();
 
     return basicRequests.request(requestMetadata).stream()

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/metastore/analyze/FileMetadataInfoCollector.java
@@ -289,7 +289,7 @@ public class FileMetadataInfoCollector implements MetadataInfoCollector {
         .tableInfo(tableInfo)
         .metadataKeys(metadataKeys)
         .paths(allFiles)
-        .metadataType(MetadataType.ROW_GROUP.name())
+        .metadataType(MetadataType.ROW_GROUP)
         .requestColumns(Arrays.asList(MetadataInfo.METADATA_KEY, MetadataInfo.METADATA_IDENTIFIER, MetadataInfo.METADATA_TYPE))
         .build();
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
@@ -64,6 +64,7 @@ import org.apache.drill.exec.vector.accessor.ObjectReader;
 import org.apache.drill.exec.vector.accessor.ObjectType;
 import org.apache.drill.exec.vector.accessor.TupleReader;
 import org.apache.drill.exec.vector.complex.reader.FieldReader;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.components.tables.Tables;
@@ -234,7 +235,7 @@ public class MetadataControllerBatch extends AbstractBinaryRecordBatch<MetadataC
 
     for (MetadataInfo metadataInfo : popConfig.getContext().metadataToRemove()) {
       deleteFilter = FilterExpression.and(deleteFilter,
-          FilterExpression.equal(MetadataInfo.METADATA_KEY, metadataInfo.key()));
+          FilterExpression.equal(MetastoreColumn.METADATA_KEY, metadataInfo.key()));
     }
 
     Modify<TableMetadataUnit> modify = tables.modify();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/metadata/MetadataControllerBatch.java
@@ -77,6 +77,7 @@ import org.apache.drill.metastore.metadata.PartitionMetadata;
 import org.apache.drill.metastore.metadata.RowGroupMetadata;
 import org.apache.drill.metastore.metadata.SegmentMetadata;
 import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.operate.Delete;
 import org.apache.drill.metastore.operate.Modify;
 import org.apache.drill.metastore.statistics.BaseStatisticsKind;
 import org.apache.drill.metastore.statistics.ColumnStatistics;
@@ -238,7 +239,10 @@ public class MetadataControllerBatch extends AbstractBinaryRecordBatch<MetadataC
 
     Modify<TableMetadataUnit> modify = tables.modify();
     if (!popConfig.getContext().metadataToRemove().isEmpty()) {
-      modify.delete(deleteFilter);
+      modify.delete(Delete.builder()
+        .metadataType(MetadataType.SEGMENT, MetadataType.FILE, MetadataType.ROW_GROUP, MetadataType.PARTITION)
+        .filter(deleteFilter)
+        .build());
     }
 
     MetastoreTableInfo metastoreTableInfo = popConfig.getContext().metastoreTableInfo();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/handlers/MetastoreDropTableMetadataHandler.java
@@ -30,7 +30,9 @@ import org.apache.drill.exec.work.foreman.ForemanSetupException;
 import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
 import org.apache.drill.metastore.components.tables.Tables;
 import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.drill.metastore.metadata.TableInfo;
+import org.apache.drill.metastore.operate.Delete;
 import org.apache.parquet.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,8 +86,11 @@ public class MetastoreDropTableMetadataHandler extends DefaultSqlHandler {
       }
 
       tables.modify()
-          .delete(tableInfo.toFilter())
-          .execute();
+        .delete(Delete.builder()
+          .metadataType(MetadataType.ALL)
+          .filter(tableInfo.toFilter())
+          .build())
+        .execute();
     } catch (MetastoreException e) {
       logger.error("Error when dropping metadata for table {}", dropTableMetadata.getName(), e);
       return DirectPlan.createDirectPlan(context, false, e.getMessage());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/RecordCollector.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/RecordCollector.java
@@ -33,6 +33,7 @@ import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.dfs.WorkspaceSchemaFactory;
 import org.apache.drill.exec.util.FileSystemUtil;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.Metastore;
 import org.apache.drill.metastore.components.tables.BasicTablesRequests;
 import org.apache.drill.metastore.components.tables.BasicTablesTransformer;
@@ -41,7 +42,6 @@ import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.BaseTableMetadata;
 import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
-import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.drill.metastore.statistics.ColumnStatistics;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -234,7 +234,6 @@ public interface RecordCollector {
     private static final Logger logger = getLogger(MetastoreRecordCollector.class);
 
     public static final int UNDEFINED_INDEX = -1;
-    public static final String SCHEMA = "schema";
 
     private final Metastore metastore;
     private final FilterEvaluator filterEvaluator;
@@ -263,8 +262,8 @@ public interface RecordCollector {
         try {
           baseTableMetadata = metastore.tables().basicRequests()
             .tablesMetadata(FilterExpression.and(
-              FilterExpression.equal(TableInfo.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
-              FilterExpression.equal(TableInfo.WORKSPACE, drillSchema.getSchemaPath().get(1))));
+              FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
+              FilterExpression.equal(MetastoreColumn.WORKSPACE, drillSchema.getSchemaPath().get(1))));
         } catch (Exception e) {
           // ignore all exceptions related to Metastore data retrieval, return empty result
           logger.warn("Error while retrieving Metastore table data: {}", e.getMessage());
@@ -294,10 +293,10 @@ public interface RecordCollector {
         try {
           baseTableMetadata = metastore.tables().basicRequests()
             .tablesMetadata(FilterExpression.and(
-              FilterExpression.equal(TableInfo.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
-              FilterExpression.equal(TableInfo.WORKSPACE, drillSchema.getSchemaPath().get(1)),
+              FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
+              FilterExpression.equal(MetastoreColumn.WORKSPACE, drillSchema.getSchemaPath().get(1)),
               // exclude tables without schema
-              FilterExpression.isNotNull(SCHEMA)));
+              FilterExpression.isNotNull(MetastoreColumn.SCHEMA)));
         } catch (Exception e) {
           // ignore all exceptions related to Metastore data retrieval, return empty result
           logger.warn("Error while retrieving Metastore table data: {}", e.getMessage());
@@ -370,10 +369,10 @@ public interface RecordCollector {
           BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
             .metadataTypes(MetadataType.SEGMENT, MetadataType.PARTITION)
             .customFilter(FilterExpression.and(
-              FilterExpression.equal(TableInfo.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
-              FilterExpression.equal(TableInfo.WORKSPACE, drillSchema.getSchemaPath().get(1)),
+              FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, drillSchema.getSchemaPath().get(0)),
+              FilterExpression.equal(MetastoreColumn.WORKSPACE, drillSchema.getSchemaPath().get(1)),
               // exclude DEFAULT_SEGMENT (used only for non-partitioned tables)
-              FilterExpression.notEqual(MetadataInfo.METADATA_KEY, MetadataInfo.DEFAULT_SEGMENT_KEY)))
+              FilterExpression.notEqual(MetastoreColumn.METADATA_KEY, MetadataInfo.DEFAULT_SEGMENT_KEY)))
             .build();
 
           List<TableMetadataUnit> units = metastore.tables().basicRequests().request(requestMetadata);

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -31,7 +31,7 @@
   <name>metastore/Drill Iceberg Metastore</name>
 
   <properties>
-    <iceberg.version>2d75130</iceberg.version>
+    <iceberg.version>93d51b9</iceberg.version>
     <caffeine.version>2.7.0</caffeine.version>
   </properties>
 

--- a/metastore/iceberg-metastore/pom.xml
+++ b/metastore/iceberg-metastore/pom.xml
@@ -139,6 +139,12 @@
       <version>${asm.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+      <version>${asm.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
@@ -17,12 +17,11 @@
  */
 package org.apache.drill.metastore.iceberg.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.Tables;
 import org.apache.drill.metastore.components.tables.TablesMetadataTypeValidator;
 import org.apache.drill.metastore.iceberg.operate.ExpirationHandler;
 import org.apache.drill.metastore.iceberg.operate.IcebergRead;
-import org.apache.drill.metastore.metadata.MetadataInfo;
-import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.drill.metastore.operate.Metadata;
 import org.apache.drill.metastore.operate.Modify;
 import org.apache.drill.metastore.operate.Read;
@@ -49,11 +48,11 @@ public class IcebergTables implements Tables, MetastoreContext<TableMetadataUnit
    * Metastore Tables component partition keys, order of partitioning will be determined based
    * on order in {@link List} holder.
    */
-  private static final List<String> PARTITION_KEYS = Arrays.asList(
-    TableInfo.STORAGE_PLUGIN,
-    TableInfo.WORKSPACE,
-    TableInfo.TABLE_NAME,
-    MetadataInfo.METADATA_KEY);
+  private static final List<MetastoreColumn> PARTITION_KEYS = Arrays.asList(
+    MetastoreColumn.STORAGE_PLUGIN,
+    MetastoreColumn.WORKSPACE,
+    MetastoreColumn.TABLE_NAME,
+    MetastoreColumn.METADATA_KEY);
 
   public static IcebergTableSchema SCHEMA = IcebergTableSchema.of(TableMetadataUnit.class, PARTITION_KEYS);
 

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/IcebergTables.java
@@ -18,7 +18,11 @@
 package org.apache.drill.metastore.iceberg.components.tables;
 
 import org.apache.drill.metastore.components.tables.Tables;
+import org.apache.drill.metastore.components.tables.TablesMetadataTypeValidator;
 import org.apache.drill.metastore.iceberg.operate.ExpirationHandler;
+import org.apache.drill.metastore.iceberg.operate.IcebergRead;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.drill.metastore.operate.Metadata;
 import org.apache.drill.metastore.operate.Modify;
 import org.apache.drill.metastore.operate.Read;
@@ -27,7 +31,6 @@ import org.apache.drill.metastore.iceberg.MetastoreContext;
 import org.apache.drill.metastore.iceberg.operate.IcebergMetadata;
 import org.apache.drill.metastore.iceberg.schema.IcebergTableSchema;
 import org.apache.drill.metastore.iceberg.operate.IcebergModify;
-import org.apache.drill.metastore.iceberg.operate.IcebergRead;
 import org.apache.drill.metastore.iceberg.transform.Transformer;
 import org.apache.drill.metastore.iceberg.write.FileWriter;
 import org.apache.drill.metastore.iceberg.write.ParquetFileWriter;
@@ -42,16 +45,15 @@ import java.util.List;
  */
 public class IcebergTables implements Tables, MetastoreContext<TableMetadataUnit> {
 
-  public static final String STORAGE_PLUGIN = "storagePlugin";
-  public static final String WORKSPACE = "workspace";
-  public static final String TABLE_NAME = "tableName";
-  public static final String METADATA_KEY = "metadataKey";
-
   /**
    * Metastore Tables component partition keys, order of partitioning will be determined based
    * on order in {@link List} holder.
    */
-  private static final List<String> PARTITION_KEYS = Arrays.asList(STORAGE_PLUGIN, WORKSPACE, TABLE_NAME, METADATA_KEY);
+  private static final List<String> PARTITION_KEYS = Arrays.asList(
+    TableInfo.STORAGE_PLUGIN,
+    TableInfo.WORKSPACE,
+    TableInfo.TABLE_NAME,
+    MetadataInfo.METADATA_KEY);
 
   public static IcebergTableSchema SCHEMA = IcebergTableSchema.of(TableMetadataUnit.class, PARTITION_KEYS);
 
@@ -74,12 +76,12 @@ public class IcebergTables implements Tables, MetastoreContext<TableMetadataUnit
 
   @Override
   public Read<TableMetadataUnit> read() {
-    return new IcebergRead<>(context());
+    return new IcebergRead<>(TablesMetadataTypeValidator.INSTANCE, context());
   }
 
   @Override
   public Modify<TableMetadataUnit> modify() {
-    return new IcebergModify<>(context());
+    return new IcebergModify<>(TablesMetadataTypeValidator.INSTANCE, context());
   }
 
   @Override

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TableKey.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TableKey.java
@@ -18,6 +18,7 @@
 package org.apache.drill.metastore.iceberg.components.tables;
 
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
+import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 
 import java.util.HashMap;
@@ -79,9 +80,9 @@ public class TableKey {
    */
   public Map<String, Object> toFilterConditions() {
     Map<String, Object> conditions = new HashMap<>();
-    conditions.put(IcebergTables.STORAGE_PLUGIN, storagePlugin);
-    conditions.put(IcebergTables.WORKSPACE, workspace);
-    conditions.put(IcebergTables.TABLE_NAME, tableName);
+    conditions.put(TableInfo.STORAGE_PLUGIN, storagePlugin);
+    conditions.put(TableInfo.WORKSPACE, workspace);
+    conditions.put(TableInfo.TABLE_NAME, tableName);
     return conditions;
   }
 

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TableKey.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TableKey.java
@@ -17,8 +17,8 @@
  */
 package org.apache.drill.metastore.iceberg.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
-import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 
 import java.util.HashMap;
@@ -78,11 +78,11 @@ public class TableKey {
    *
    * @return map of with condition references anf values
    */
-  public Map<String, Object> toFilterConditions() {
-    Map<String, Object> conditions = new HashMap<>();
-    conditions.put(TableInfo.STORAGE_PLUGIN, storagePlugin);
-    conditions.put(TableInfo.WORKSPACE, workspace);
-    conditions.put(TableInfo.TABLE_NAME, tableName);
+  public Map<MetastoreColumn, Object> toFilterConditions() {
+    Map<MetastoreColumn, Object> conditions = new HashMap<>();
+    conditions.put(MetastoreColumn.STORAGE_PLUGIN, storagePlugin);
+    conditions.put(MetastoreColumn.WORKSPACE, workspace);
+    conditions.put(MetastoreColumn.TABLE_NAME, tableName);
     return conditions;
   }
 

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TablesOperationTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TablesOperationTransformer.java
@@ -17,11 +17,11 @@
  */
 package org.apache.drill.metastore.iceberg.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.iceberg.MetastoreContext;
 import org.apache.drill.metastore.iceberg.operate.Overwrite;
 import org.apache.drill.metastore.iceberg.transform.OperationTransformer;
-import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.iceberg.expressions.Expression;
 
 import java.util.Collection;
@@ -62,8 +62,8 @@ public class TablesOperationTransformer extends OperationTransformer<TableMetada
 
           String location = tableKey.toLocation(context.table().location());
 
-          Map<String, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
-          filterConditions.put(MetadataInfo.METADATA_KEY, operationEntry.getKey());
+          Map<MetastoreColumn, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
+          filterConditions.put(MetastoreColumn.METADATA_KEY, operationEntry.getKey());
           Expression expression = context.transformer().filter().transform(filterConditions);
 
           return toOverwrite(location, expression, operationEntry.getValue());

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TablesOperationTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/components/tables/TablesOperationTransformer.java
@@ -21,6 +21,7 @@ import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.iceberg.MetastoreContext;
 import org.apache.drill.metastore.iceberg.operate.Overwrite;
 import org.apache.drill.metastore.iceberg.transform.OperationTransformer;
+import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.iceberg.expressions.Expression;
 
 import java.util.Collection;
@@ -62,7 +63,7 @@ public class TablesOperationTransformer extends OperationTransformer<TableMetada
           String location = tableKey.toLocation(context.table().location());
 
           Map<String, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
-          filterConditions.put(IcebergTables.METADATA_KEY, operationEntry.getKey());
+          filterConditions.put(MetadataInfo.METADATA_KEY, operationEntry.getKey());
           Expression expression = context.transformer().filter().transform(filterConditions);
 
           return toOverwrite(location, expression, operationEntry.getValue());

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergRead.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergRead.java
@@ -17,32 +17,31 @@
  */
 package org.apache.drill.metastore.iceberg.operate;
 
-import org.apache.drill.metastore.operate.Read;
-import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.iceberg.MetastoreContext;
+import org.apache.drill.metastore.iceberg.transform.FilterTransformer;
+import org.apache.drill.metastore.operate.AbstractRead;
+import org.apache.drill.metastore.operate.MetadataTypeValidator;
+import org.apache.drill.metastore.operate.Read;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Implementation of {@link Read} interface.
+ * Implementation of {@link Read} interface based on {@link AbstractRead} parent class.
  * Reads information from Iceberg table based on given filter expression.
  * Supports reading information for specific columns.
- *
- * @param <T> Metastore component unit type
  */
-public class IcebergRead<T> implements Read<T> {
+public class IcebergRead<T> extends AbstractRead<T> {
 
   private final MetastoreContext<T> context;
   private final String[] defaultColumns;
-  private final List<String> columns = new ArrayList<>();
-  private FilterExpression filter;
 
-  public IcebergRead(MetastoreContext<T> context) {
+  public IcebergRead(MetadataTypeValidator metadataTypeValidator, MetastoreContext<T> context) {
+    super(metadataTypeValidator);
     this.context = context;
     this.defaultColumns = context.table().schema().columns().stream()
       .map(Types.NestedField::name)
@@ -50,23 +49,16 @@ public class IcebergRead<T> implements Read<T> {
   }
 
   @Override
-  public Read<T> filter(FilterExpression filter) {
-    this.filter = filter;
-    return this;
-  }
-
-  @Override
-  public Read<T> columns(List<String> columns) {
-    this.columns.addAll(columns);
-    return this;
-  }
-
-  @Override
-  public List<T> execute() {
+  protected List<T> internalExecute() {
     String[] selectedColumns = columns.isEmpty() ? defaultColumns : columns.toArray(new String[0]);
+
+    FilterTransformer filterTransformer = context.transformer().filter();
+    Expression rowFilter = filterTransformer.combine(
+      filterTransformer.transform(metadataTypes), filterTransformer.transform(filter));
+
     Iterable<Record> records = IcebergGenerics.read(context.table())
       .select(selectedColumns)
-      .where(context.transformer().filter().transform(filter))
+      .where(rowFilter)
       .build();
 
     return context.transformer().outputData()

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergRead.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/operate/IcebergRead.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.metastore.iceberg.operate;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.iceberg.MetastoreContext;
 import org.apache.drill.metastore.iceberg.transform.FilterTransformer;
 import org.apache.drill.metastore.operate.AbstractRead;
@@ -50,7 +51,11 @@ public class IcebergRead<T> extends AbstractRead<T> {
 
   @Override
   protected List<T> internalExecute() {
-    String[] selectedColumns = columns.isEmpty() ? defaultColumns : columns.toArray(new String[0]);
+    String[] selectedColumns = columns.isEmpty()
+      ? defaultColumns
+      : columns.stream()
+         .map(MetastoreColumn::columnName)
+         .toArray(String[]::new);
 
     FilterTransformer filterTransformer = context.transformer().filter();
     Expression rowFilter = filterTransformer.combine(

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterExpressionVisitor.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterExpressionVisitor.java
@@ -39,52 +39,52 @@ public class FilterExpressionVisitor implements FilterExpression.Visitor<Express
 
   @Override
   public Expression visit(SimplePredicate.Equal<?> expression) {
-    return Expressions.equal(expression.reference(), expression.value());
+    return Expressions.equal(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(SimplePredicate.NotEqual<?> expression) {
-    return Expressions.notEqual(expression.reference(), expression.value());
+    return Expressions.notEqual(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(SimplePredicate.LessThan<?> expression) {
-    return Expressions.lessThan(expression.reference(), expression.value());
+    return Expressions.lessThan(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(SimplePredicate.LessThanOrEqual<?> expression) {
-    return Expressions.lessThanOrEqual(expression.reference(), expression.value());
+    return Expressions.lessThanOrEqual(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(SimplePredicate.GreaterThan<?> expression) {
-    return Expressions.greaterThan(expression.reference(), expression.value());
+    return Expressions.greaterThan(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(SimplePredicate.GreaterThanOrEqual<?> expression) {
-    return Expressions.greaterThanOrEqual(expression.reference(), expression.value());
+    return Expressions.greaterThanOrEqual(expression.column().columnName(), expression.value());
   }
 
   @Override
   public Expression visit(ListPredicate.In<?> expression) {
-    return Expressions.in(expression.reference(), expression.values());
+    return Expressions.in(expression.column().columnName(), expression.values());
   }
 
   @Override
   public Expression visit(ListPredicate.NotIn<?> expression) {
-    return Expressions.notIn(expression.reference(), expression.values());
+    return Expressions.notIn(expression.column().columnName(), expression.values());
   }
 
   @Override
   public Expression visit(IsPredicate.IsNull expression) {
-    return Expressions.isNull(expression.reference());
+    return Expressions.isNull(expression.column().columnName());
   }
 
   @Override
   public Expression visit(IsPredicate.IsNotNull expression) {
-    return Expressions.notNull(expression.reference());
+    return Expressions.notNull(expression.column().columnName());
   }
 
   @Override

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterExpressionVisitor.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterExpressionVisitor.java
@@ -26,8 +26,6 @@ import org.apache.drill.metastore.expressions.SingleExpressionPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 
-import java.util.List;
-
 /**
  * Visits {@link FilterExpression} implementations and transforms them into Iceberg {@link Expression}.
  */
@@ -71,13 +69,12 @@ public class FilterExpressionVisitor implements FilterExpression.Visitor<Express
 
   @Override
   public Expression visit(ListPredicate.In<?> expression) {
-    return toInExpression(expression.reference(), expression.values());
+    return Expressions.in(expression.reference(), expression.values());
   }
 
   @Override
   public Expression visit(ListPredicate.NotIn<?> expression) {
-    Expression in = toInExpression(expression.reference(), expression.values());
-    return Expressions.not(in);
+    return Expressions.notIn(expression.reference(), expression.values());
   }
 
   @Override
@@ -108,11 +105,5 @@ public class FilterExpressionVisitor implements FilterExpression.Visitor<Express
     Expression right = expression.right().accept(this);
     Expression left = expression.left().accept(this);
     return Expressions.or(right, left);
-  }
-
-  private Expression toInExpression(String reference, List<?> values) {
-    return values.stream()
-      .map(value -> (Expression) Expressions.equal(reference, value))
-      .reduce(Expressions.alwaysFalse(), Expressions::or);
   }
 }

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterTransformer.java
@@ -17,8 +17,8 @@
  */
 package org.apache.drill.metastore.iceberg.transform;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
-import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -40,13 +40,13 @@ public class FilterTransformer {
     return filter == null ? Expressions.alwaysTrue() : filter.accept(visitor);
   }
 
-  public Expression transform(Map<String, Object> conditions) {
+  public Expression transform(Map<MetastoreColumn, Object> conditions) {
     if (conditions == null || conditions.isEmpty()) {
       return Expressions.alwaysTrue();
     }
 
     List<Expression> expressions = conditions.entrySet().stream()
-      .map(entry -> Expressions.equal(entry.getKey(), entry.getValue()))
+      .map(entry -> Expressions.equal(entry.getKey().columnName(), entry.getValue()))
       .collect(Collectors.toList());
 
     if (expressions.size() == 1) {
@@ -67,10 +67,10 @@ public class FilterTransformer {
       .collect(Collectors.toList());
 
     if (inConditionValues.size() == 1) {
-      return Expressions.equal(MetadataInfo.METADATA_TYPE, inConditionValues.get(0));
+      return Expressions.equal(MetastoreColumn.METADATA_TYPE.columnName(), inConditionValues.get(0));
     }
 
-    return Expressions.in(MetadataInfo.METADATA_TYPE, inConditionValues);
+    return Expressions.in(MetastoreColumn.METADATA_TYPE.columnName(), inConditionValues);
   }
 
   public Expression combine(Expression... expressions) {

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/FilterTransformer.java
@@ -18,9 +18,12 @@
 package org.apache.drill.metastore.iceberg.transform;
 
 import org.apache.drill.metastore.expressions.FilterExpression;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,5 +55,34 @@ public class FilterTransformer {
 
     return Expressions.and(expressions.get(0), expressions.get(1),
       expressions.subList(2, expressions.size()).toArray(new Expression[0]));
+  }
+
+  public Expression transform(List<MetadataType> metadataTypes) {
+    if (metadataTypes.contains(MetadataType.ALL)) {
+      return Expressions.alwaysTrue();
+    }
+
+    List<String> inConditionValues = metadataTypes.stream()
+      .map(Enum::name)
+      .collect(Collectors.toList());
+
+    if (inConditionValues.size() == 1) {
+      return Expressions.equal(MetadataInfo.METADATA_TYPE, inConditionValues.get(0));
+    }
+
+    return Expressions.in(MetadataInfo.METADATA_TYPE, inConditionValues);
+  }
+
+  public Expression combine(Expression... expressions) {
+    if (expressions.length == 0) {
+      return Expressions.alwaysTrue();
+    }
+
+    if (expressions.length == 1) {
+      return expressions[0];
+    }
+
+    return Expressions.and(expressions[0], expressions[1],
+      Arrays.copyOfRange(expressions, 2, expressions.length));
   }
 }

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/InputDataTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/InputDataTransformer.java
@@ -17,7 +17,6 @@
  */
 package org.apache.drill.metastore.iceberg.transform;
 
-
 import org.apache.drill.metastore.iceberg.exceptions.IcebergMetastoreException;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;

--- a/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/OperationTransformer.java
+++ b/metastore/iceberg-metastore/src/main/java/org/apache/drill/metastore/iceberg/transform/OperationTransformer.java
@@ -64,14 +64,16 @@ public abstract class OperationTransformer<T> {
     return new Overwrite(dataFile, expression);
   }
 
-  public List<Delete> toDelete(List<FilterExpression> filters) {
-    return filters.stream()
-      .map(this::toDelete)
-      .collect(Collectors.toList());
-  }
-
   public Delete toDelete(FilterExpression filter) {
     return new Delete(context.transformer().filter().transform(filter));
+  }
+
+  public List<Delete> toDelete(List<org.apache.drill.metastore.operate.Delete> deletes) {
+    FilterTransformer filterTransformer = context.transformer().filter();
+    return deletes.stream()
+      // metadata types are ignored during delete since they are not part of the partition key
+      .map(delete -> new Delete(filterTransformer.transform(delete.filter())))
+      .collect(Collectors.toList());
   }
 
   /**

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
@@ -18,6 +18,7 @@
 package org.apache.drill.metastore.iceberg.components.tables;
 
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.BasicTablesRequests;
 import org.apache.drill.metastore.components.tables.BasicTablesTransformer;
 import org.apache.drill.metastore.components.tables.MetastoreTableInfo;
@@ -114,8 +115,8 @@ public class TestBasicRequests extends IcebergBaseTest {
   public void testTablesMetadataAbsent() {
     List<BaseTableMetadata> tablesMetadata = basicRequests.tablesMetadata(
       FilterExpression.and(
-        FilterExpression.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
-        FilterExpression.equal(TableInfo.WORKSPACE, "absent")));
+        FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+        FilterExpression.equal(MetastoreColumn.WORKSPACE, "absent")));
     assertTrue(tablesMetadata.isEmpty());
   }
 
@@ -123,8 +124,8 @@ public class TestBasicRequests extends IcebergBaseTest {
   public void testTablesMetadataExisting() {
     List<BaseTableMetadata> baseTableMetadata = basicRequests.tablesMetadata(
       FilterExpression.and(
-        FilterExpression.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
-        FilterExpression.equal(TableInfo.WORKSPACE, "tmp")));
+        FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+        FilterExpression.equal(MetastoreColumn.WORKSPACE, "tmp")));
     assertTrue(baseTableMetadata.size() > 1);
   }
 

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestBasicRequests.java
@@ -114,8 +114,8 @@ public class TestBasicRequests extends IcebergBaseTest {
   public void testTablesMetadataAbsent() {
     List<BaseTableMetadata> tablesMetadata = basicRequests.tablesMetadata(
       FilterExpression.and(
-        FilterExpression.equal(IcebergTables.STORAGE_PLUGIN, "dfs"),
-        FilterExpression.equal(IcebergTables.WORKSPACE, "absent")));
+        FilterExpression.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
+        FilterExpression.equal(TableInfo.WORKSPACE, "absent")));
     assertTrue(tablesMetadata.isEmpty());
   }
 
@@ -123,8 +123,8 @@ public class TestBasicRequests extends IcebergBaseTest {
   public void testTablesMetadataExisting() {
     List<BaseTableMetadata> baseTableMetadata = basicRequests.tablesMetadata(
       FilterExpression.and(
-        FilterExpression.equal(IcebergTables.STORAGE_PLUGIN, "dfs"),
-        FilterExpression.equal(IcebergTables.WORKSPACE, "tmp")));
+        FilterExpression.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
+        FilterExpression.equal(TableInfo.WORKSPACE, "tmp")));
     assertTrue(baseTableMetadata.size() > 1);
   }
 
@@ -455,7 +455,7 @@ public class TestBasicRequests extends IcebergBaseTest {
   public void testCustomRequest() {
     BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
       .column("n_nation")
-      .metadataType(MetadataType.PARTITION.name())
+      .metadataType(MetadataType.PARTITION)
       .build();
 
     List<TableMetadataUnit> units = basicRequests.request(requestMetadata);

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestIcebergTablesMetastore.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestIcebergTablesMetastore.java
@@ -20,6 +20,8 @@ package org.apache.drill.metastore.iceberg.components.tables;
 import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.metastore.components.tables.Tables;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.operate.Delete;
 import org.apache.drill.metastore.operate.Metadata;
 import org.apache.drill.metastore.Metastore;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
@@ -230,6 +232,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.ALL)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -260,6 +263,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.ALL)
       .filter(tableInfo.toFilter())
       .columns("tableName", "metadataKey")
       .execute();
@@ -274,6 +278,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
     Tables tables = new IcebergMetastore(config).tables();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.ALL)
       .filter(FilterExpression.equal("storagePlugin", "dfs"))
       .columns("tableName", "metadataKey")
       .execute();
@@ -297,6 +302,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir0")
+      .metadataType(MetadataType.TABLE.name())
       .tableType("parquet")
       .build();
 
@@ -305,6 +311,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.TABLE)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -316,6 +323,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace("tmp")
       .tableName("nation")
       .metadataKey("dir0")
+      .metadataType(MetadataType.TABLE.name())
       .tableType("text")
       .build();
 
@@ -324,6 +332,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> updatedUnits = tables.read()
+      .metadataType(MetadataType.TABLE)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -347,6 +356,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir0")
+      .metadataType(MetadataType.SEGMENT.name())
       .build();
 
     TableMetadataUnit secondUnit = TableMetadataUnit.builder()
@@ -354,6 +364,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir1")
+      .metadataType(MetadataType.SEGMENT.name())
       .build();
 
     tables.modify()
@@ -361,6 +372,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.SEGMENT)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -371,10 +383,14 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       FilterExpression.equal("metadataKey", "dir0"));
 
     tables.modify()
-      .delete(deleteFilter)
+      .delete(Delete.builder()
+        .metadataType(MetadataType.SEGMENT)
+        .filter(deleteFilter)
+        .build())
       .execute();
 
     List<TableMetadataUnit> updatedUnits = tables.read()
+      .metadataType(MetadataType.SEGMENT)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -398,6 +414,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir0")
+      .metadataType(MetadataType.SEGMENT.name())
       .tableType("parquet")
       .build();
 
@@ -406,6 +423,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir1")
+      .metadataType(MetadataType.SEGMENT.name())
       .tableType("parquet")
       .build();
 
@@ -414,6 +432,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> units = tables.read()
+      .metadataType(MetadataType.SEGMENT)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -428,15 +447,20 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .workspace(tableInfo.workspace())
       .tableName(tableInfo.name())
       .metadataKey("dir1")
+      .metadataType(MetadataType.SEGMENT.name())
       .tableType("text")
       .build();
 
     tables.modify()
-      .delete(deleteFilter)
+      .delete(Delete.builder()
+        .metadataType(MetadataType.SEGMENT)
+        .filter(deleteFilter)
+        .build())
       .overwrite(updatedUnit)
       .execute();
 
     List<TableMetadataUnit> updatedUnits = tables.read()
+      .metadataType(MetadataType.SEGMENT)
       .filter(tableInfo.toFilter())
       .execute();
 
@@ -470,15 +494,16 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
       .execute();
 
     List<TableMetadataUnit> initialUnits = tables.read()
+      .metadataType(MetadataType.ALL)
       .execute();
 
     assertEquals(2, initialUnits.size());
 
     tables.modify()
-      .purge()
-      .execute();
+      .purge();
 
     List<TableMetadataUnit> resultingUnits = tables.read()
+      .metadataType(MetadataType.ALL)
       .execute();
 
     assertTrue(resultingUnits.isEmpty());

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestIcebergTablesMetastore.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestIcebergTablesMetastore.java
@@ -19,6 +19,7 @@ package org.apache.drill.metastore.iceberg.components.tables;
 
 import com.typesafe.config.ConfigValueFactory;
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.Tables;
 import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.drill.metastore.operate.Delete;
@@ -265,7 +266,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
     List<TableMetadataUnit> units = tables.read()
       .metadataType(MetadataType.ALL)
       .filter(tableInfo.toFilter())
-      .columns("tableName", "metadataKey")
+      .columns(MetastoreColumn.TABLE_NAME, MetastoreColumn.METADATA_KEY)
       .execute();
 
     assertEquals(1, units.size());
@@ -279,8 +280,8 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
 
     List<TableMetadataUnit> units = tables.read()
       .metadataType(MetadataType.ALL)
-      .filter(FilterExpression.equal("storagePlugin", "dfs"))
-      .columns("tableName", "metadataKey")
+      .filter(FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"))
+      .columns(MetastoreColumn.TABLE_NAME, MetastoreColumn.METADATA_KEY)
       .execute();
 
     assertTrue(units.isEmpty());
@@ -380,7 +381,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
 
     FilterExpression deleteFilter = FilterExpression.and(
       tableInfo.toFilter(),
-      FilterExpression.equal("metadataKey", "dir0"));
+      FilterExpression.equal(MetastoreColumn.METADATA_KEY, "dir0"));
 
     tables.modify()
       .delete(Delete.builder()
@@ -440,7 +441,7 @@ public class TestIcebergTablesMetastore extends IcebergBaseTest {
 
     FilterExpression deleteFilter = FilterExpression.and(
       tableInfo.toFilter(),
-      FilterExpression.equal("metadataKey", "dir0"));
+      FilterExpression.equal(MetastoreColumn.METADATA_KEY, "dir0"));
 
     TableMetadataUnit updatedUnit = TableMetadataUnit.builder()
       .storagePlugin(tableInfo.storagePlugin())

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTableKey.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTableKey.java
@@ -19,6 +19,7 @@ package org.apache.drill.metastore.iceberg.components.tables;
 
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
+import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
@@ -59,9 +60,9 @@ public class TestTableKey extends IcebergBaseTest {
     TableKey tableKey = new TableKey("dfs", "tmp", "nation");
 
     Map<String, Object> expected = new HashMap<>();
-    expected.put(IcebergTables.STORAGE_PLUGIN, "dfs");
-    expected.put(IcebergTables.WORKSPACE, "tmp");
-    expected.put(IcebergTables.TABLE_NAME, "nation");
+    expected.put(TableInfo.STORAGE_PLUGIN, "dfs");
+    expected.put(TableInfo.WORKSPACE, "tmp");
+    expected.put(TableInfo.TABLE_NAME, "nation");
 
     assertEquals(expected, tableKey.toFilterConditions());
   }

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTableKey.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTableKey.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.metastore.iceberg.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
-import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
@@ -59,10 +59,10 @@ public class TestTableKey extends IcebergBaseTest {
   public void testToFilterConditions() {
     TableKey tableKey = new TableKey("dfs", "tmp", "nation");
 
-    Map<String, Object> expected = new HashMap<>();
-    expected.put(TableInfo.STORAGE_PLUGIN, "dfs");
-    expected.put(TableInfo.WORKSPACE, "tmp");
-    expected.put(TableInfo.TABLE_NAME, "nation");
+    Map<MetastoreColumn, Object> expected = new HashMap<>();
+    expected.put(MetastoreColumn.STORAGE_PLUGIN, "dfs");
+    expected.put(MetastoreColumn.WORKSPACE, "tmp");
+    expected.put(MetastoreColumn.TABLE_NAME, "nation");
 
     assertEquals(expected, tableKey.toFilterConditions());
   }

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTablesOperationTransformer.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTablesOperationTransformer.java
@@ -26,6 +26,9 @@ import org.apache.drill.metastore.iceberg.operate.Delete;
 import org.apache.drill.metastore.iceberg.operate.Overwrite;
 import org.apache.drill.metastore.iceberg.transform.FilterTransformer;
 import org.apache.drill.metastore.iceberg.transform.OperationTransformer;
+import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -62,7 +65,7 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
     TableKey tableKey = new TableKey(unit.storagePlugin(), unit.workspace(), unit.tableName());
 
     Map<String, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
-    filterConditions.put(IcebergTables.METADATA_KEY, unit.metadataKey());
+    filterConditions.put(MetadataInfo.METADATA_KEY, unit.metadataKey());
 
     String location = tableKey.toLocation(TestTablesOperationTransformer.location);
     Expression expression = new FilterTransformer().transform(filterConditions);
@@ -97,8 +100,8 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
       FilterExpression.equal("workspace", "tmp"));
 
     Expression expected = Expressions.and(
-      Expressions.equal(IcebergTables.STORAGE_PLUGIN, "dfs"),
-      Expressions.equal(IcebergTables.WORKSPACE, "tmp"));
+      Expressions.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
+      Expressions.equal(TableInfo.WORKSPACE, "tmp"));
 
     Delete operation = transformer.toDelete(filter);
 
@@ -107,8 +110,15 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
 
   @Test
   public void testToDeleteOperations() {
-    FilterExpression dfs = FilterExpression.equal("storagePlugin", "dfs");
-    FilterExpression s3 = FilterExpression.equal("storagePlugin", "s3");
+    org.apache.drill.metastore.operate.Delete dfs = org.apache.drill.metastore.operate.Delete.builder()
+      .metadataType(MetadataType.ALL)
+      .filter(FilterExpression.equal("storagePlugin", "dfs"))
+      .build();
+
+    org.apache.drill.metastore.operate.Delete s3 = org.apache.drill.metastore.operate.Delete.builder()
+      .metadataType(MetadataType.ALL)
+      .filter(FilterExpression.equal("storagePlugin", "s3"))
+      .build();
 
     List<Delete> operations = transformer.toDelete(Arrays.asList(dfs, s3));
 

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTablesOperationTransformer.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/components/tables/TestTablesOperationTransformer.java
@@ -18,6 +18,7 @@
 package org.apache.drill.metastore.iceberg.components.tables;
 
 import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
@@ -26,9 +27,7 @@ import org.apache.drill.metastore.iceberg.operate.Delete;
 import org.apache.drill.metastore.iceberg.operate.Overwrite;
 import org.apache.drill.metastore.iceberg.transform.FilterTransformer;
 import org.apache.drill.metastore.iceberg.transform.OperationTransformer;
-import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
-import org.apache.drill.metastore.metadata.TableInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -64,8 +63,8 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
 
     TableKey tableKey = new TableKey(unit.storagePlugin(), unit.workspace(), unit.tableName());
 
-    Map<String, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
-    filterConditions.put(MetadataInfo.METADATA_KEY, unit.metadataKey());
+    Map<MetastoreColumn, Object> filterConditions = new HashMap<>(tableKey.toFilterConditions());
+    filterConditions.put(MetastoreColumn.METADATA_KEY, unit.metadataKey());
 
     String location = tableKey.toLocation(TestTablesOperationTransformer.location);
     Expression expression = new FilterTransformer().transform(filterConditions);
@@ -96,12 +95,12 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
   @Test
   public void testToDeleteOperation() {
     FilterExpression filter = FilterExpression.and(
-      FilterExpression.equal("storagePlugin", "dfs"),
-      FilterExpression.equal("workspace", "tmp"));
+      FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+      FilterExpression.equal(MetastoreColumn.WORKSPACE, "tmp"));
 
     Expression expected = Expressions.and(
-      Expressions.equal(TableInfo.STORAGE_PLUGIN, "dfs"),
-      Expressions.equal(TableInfo.WORKSPACE, "tmp"));
+      Expressions.equal(MetastoreColumn.STORAGE_PLUGIN.columnName(), "dfs"),
+      Expressions.equal(MetastoreColumn.WORKSPACE.columnName(), "tmp"));
 
     Delete operation = transformer.toDelete(filter);
 
@@ -112,12 +111,12 @@ public class TestTablesOperationTransformer extends IcebergBaseTest {
   public void testToDeleteOperations() {
     org.apache.drill.metastore.operate.Delete dfs = org.apache.drill.metastore.operate.Delete.builder()
       .metadataType(MetadataType.ALL)
-      .filter(FilterExpression.equal("storagePlugin", "dfs"))
+      .filter(FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"))
       .build();
 
     org.apache.drill.metastore.operate.Delete s3 = org.apache.drill.metastore.operate.Delete.builder()
       .metadataType(MetadataType.ALL)
-      .filter(FilterExpression.equal("storagePlugin", "s3"))
+      .filter(FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "s3"))
       .build();
 
     List<Delete> operations = transformer.toDelete(Arrays.asList(dfs, s3));

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/schema/TestIcebergTableSchema.java
@@ -17,19 +17,23 @@
  */
 package org.apache.drill.metastore.iceberg.schema;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.MetastoreFieldDefinition;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
 import org.apache.drill.metastore.iceberg.exceptions.IcebergMetastoreException;
+import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.junit.Test;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.signature.SignatureWriter;
+import org.objectweb.asm.tree.AnnotationNode;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,32 +54,32 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
       @Override
       void addFields(ClassWriter classWriter) {
-        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
-        annotate(stringField);
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.STORAGE_PLUGIN, String.class);
+        annotate(stringField, MetastoreColumn.STORAGE_PLUGIN, MetadataType.ALL);
 
-        FieldVisitor intField = addField(classWriter, Opcodes.ACC_PRIVATE, "intField", int.class);
-        annotate(intField);
+        FieldVisitor intField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.COLUMN, int.class);
+        annotate(intField, MetastoreColumn.COLUMN, MetadataType.TABLE);
 
-        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
-        annotate(integerField);
+        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.ROW_GROUP_INDEX, Integer.class);
+        annotate(integerField, MetastoreColumn.ROW_GROUP_INDEX, MetadataType.SEGMENT);
 
-        FieldVisitor longField = addField(classWriter, Opcodes.ACC_PRIVATE, "longField", Long.class);
-        annotate(longField);
+        FieldVisitor longField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.LAST_MODIFIED_TIME, Long.class);
+        annotate(longField, MetastoreColumn.LAST_MODIFIED_TIME, MetadataType.FILE);
 
-        FieldVisitor floatField = addField(classWriter, Opcodes.ACC_PRIVATE, "floatField", Float.class);
-        annotate(floatField);
+        FieldVisitor floatField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.COLUMNS_STATISTICS, Float.class);
+        annotate(floatField, MetastoreColumn.COLUMNS_STATISTICS, MetadataType.ALL);
 
-        FieldVisitor doubleField = addField(classWriter, Opcodes.ACC_PRIVATE, "doubleField", Double.class);
-        annotate(doubleField);
+        FieldVisitor doubleField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.ADDITIONAL_METADATA, Double.class);
+        annotate(doubleField, MetastoreColumn.ADDITIONAL_METADATA, MetadataType.TABLE);
 
-        FieldVisitor booleanField = addField(classWriter, Opcodes.ACC_PRIVATE, "booleanField", Boolean.class);
-        annotate(booleanField);
+        FieldVisitor booleanField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.INTERESTING_COLUMNS, Boolean.class);
+        annotate(booleanField, MetastoreColumn.INTERESTING_COLUMNS, MetadataType.SEGMENT);
 
-        FieldVisitor listField = addField(classWriter, Opcodes.ACC_PRIVATE, "listField", List.class, String.class);
-        annotate(listField);
+        FieldVisitor listField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.LOCATIONS, List.class, String.class);
+        annotate(listField, MetastoreColumn.LOCATIONS, MetadataType.PARTITION);
 
-        FieldVisitor mapField = addField(classWriter, Opcodes.ACC_PRIVATE, "mapField", Map.class, String.class, Float.class);
-        annotate(mapField);
+        FieldVisitor mapField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.HOST_AFFINITY, Map.class, String.class, Float.class);
+        annotate(mapField, MetastoreColumn.HOST_AFFINITY, MetadataType.ROW_GROUP);
       }
 
     }.generate();
@@ -86,16 +90,16 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
     int complexTypesIndex = IcebergTableSchema.STARTING_COMPLEX_TYPES_INDEX;
 
     Schema expectedSchema = new Schema(
-      Types.NestedField.optional(schemaIndex++, "stringField", Types.StringType.get()),
-      Types.NestedField.optional(schemaIndex++, "intField", Types.IntegerType.get()),
-      Types.NestedField.optional(schemaIndex++, "integerField", Types.IntegerType.get()),
-      Types.NestedField.optional(schemaIndex++, "longField", Types.LongType.get()),
-      Types.NestedField.optional(schemaIndex++, "floatField", Types.FloatType.get()),
-      Types.NestedField.optional(schemaIndex++, "doubleField", Types.DoubleType.get()),
-      Types.NestedField.optional(schemaIndex++, "booleanField", Types.BooleanType.get()),
-      Types.NestedField.optional(schemaIndex++, "listField",
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.STORAGE_PLUGIN.columnName(), Types.StringType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.COLUMN.columnName(), Types.IntegerType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.ROW_GROUP_INDEX.columnName(), Types.IntegerType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.LAST_MODIFIED_TIME.columnName(), Types.LongType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.COLUMNS_STATISTICS.columnName(), Types.FloatType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.ADDITIONAL_METADATA.columnName(), Types.DoubleType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.INTERESTING_COLUMNS.columnName(), Types.BooleanType.get()),
+      Types.NestedField.optional(schemaIndex++, MetastoreColumn.LOCATIONS.columnName(),
         Types.ListType.ofOptional(complexTypesIndex++, Types.StringType.get())),
-      Types.NestedField.optional(schemaIndex, "mapField",
+      Types.NestedField.optional(schemaIndex, MetastoreColumn.HOST_AFFINITY.columnName(),
         Types.MapType.ofOptional(complexTypesIndex++, complexTypesIndex, Types.StringType.get(), Types.FloatType.get())));
 
     assertEquals(expectedSchema.asStruct(), schema.tableSchema().asStruct());
@@ -107,16 +111,16 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
       @Override
       void addFields(ClassWriter classWriter) {
-        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
-        annotate(stringField);
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.STORAGE_PLUGIN, String.class);
+        annotate(stringField, MetastoreColumn.STORAGE_PLUGIN, MetadataType.ALL);
 
-        addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
+        addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.ADDITIONAL_METADATA, Integer.class);
       }
     }.generate();
 
     IcebergTableSchema schema = IcebergTableSchema.of(clazz, Collections.emptyList());
-    assertNotNull(schema.tableSchema().findField("stringField"));
-    assertNull(schema.tableSchema().findField("integerField"));
+    assertNotNull(schema.tableSchema().findField(MetastoreColumn.STORAGE_PLUGIN.columnName()));
+    assertNull(schema.tableSchema().findField(MetastoreColumn.ADDITIONAL_METADATA.columnName()));
   }
 
   @Test
@@ -141,8 +145,8 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
             .buildSignature();
 
         FieldVisitor listField =
-            classWriter.visitField(Opcodes.ACC_PRIVATE, "stringField", descriptor, signature, null);
-        annotate(listField);
+            classWriter.visitField(Opcodes.ACC_PRIVATE, MetastoreColumn.ADDITIONAL_METADATA.columnName(), descriptor, signature, null);
+        annotate(listField, MetastoreColumn.ADDITIONAL_METADATA, MetadataType.ALL);
       }
     }.generate();
 
@@ -157,13 +161,13 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
       @Override
       void addFields(ClassWriter classWriter) {
-        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, "stringField", String.class);
-        annotate(stringField);
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.STORAGE_PLUGIN, String.class);
+        annotate(stringField, MetastoreColumn.STORAGE_PLUGIN, MetadataType.ALL);
       }
     }.generate();
 
     IcebergTableSchema schema = IcebergTableSchema.of(clazz, Collections.emptyList());
-    assertNotNull(schema.tableSchema().findField("stringField"));
+    assertNotNull(schema.tableSchema().findField(MetastoreColumn.STORAGE_PLUGIN.columnName()));
 
     assertEquals(PartitionSpec.unpartitioned(), schema.partitionSpec());
   }
@@ -174,36 +178,37 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
       @Override
       void addFields(ClassWriter classWriter) {
-        FieldVisitor partKey1 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey1", String.class);
-        annotate(partKey1);
+        FieldVisitor partKey1 = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.STORAGE_PLUGIN, String.class);
+        annotate(partKey1, MetastoreColumn.STORAGE_PLUGIN, MetadataType.ALL);
 
-        FieldVisitor partKey2 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey2", String.class);
-        annotate(partKey2);
+        FieldVisitor partKey2 = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.WORKSPACE, String.class);
+        annotate(partKey2, MetastoreColumn.WORKSPACE, MetadataType.ALL);
 
-        FieldVisitor partKey3 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey3", String.class);
-        annotate(partKey3);
+        FieldVisitor partKey3 = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.TABLE_NAME, String.class);
+        annotate(partKey3, MetastoreColumn.TABLE_NAME, MetadataType.ALL);
 
-        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
-        annotate(integerField);
+        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.ROW_GROUP_INDEX, Integer.class);
+        annotate(integerField, MetastoreColumn.ROW_GROUP_INDEX, MetadataType.ROW_GROUP);
 
-        FieldVisitor booleanField = addField(classWriter, Opcodes.ACC_PRIVATE, "booleanField", Boolean.class);
-        annotate(booleanField);
+        FieldVisitor stringField = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.OWNER, Boolean.class);
+        annotate(stringField, MetastoreColumn.OWNER, MetadataType.TABLE);
       }
     }.generate();
 
-    IcebergTableSchema schema = IcebergTableSchema.of(clazz, Arrays.asList("partKey1", "partKey2", "partKey3"));
+    IcebergTableSchema schema = IcebergTableSchema.of(clazz,
+      Arrays.asList(MetastoreColumn.STORAGE_PLUGIN, MetastoreColumn.WORKSPACE, MetastoreColumn.TABLE_NAME));
 
-    Types.NestedField partKey1 = schema.tableSchema().findField("partKey1");
+    Types.NestedField partKey1 = schema.tableSchema().findField(MetastoreColumn.STORAGE_PLUGIN.columnName());
     assertNotNull(partKey1);
 
-    Types.NestedField partKey2 = schema.tableSchema().findField("partKey2");
+    Types.NestedField partKey2 = schema.tableSchema().findField(MetastoreColumn.WORKSPACE.columnName());
     assertNotNull(partKey2);
 
-    Types.NestedField partKey3 = schema.tableSchema().findField("partKey3");
+    Types.NestedField partKey3 = schema.tableSchema().findField(MetastoreColumn.TABLE_NAME.columnName());
     assertNotNull(partKey3);
 
-    assertNotNull(schema.tableSchema().findField("integerField"));
-    assertNotNull(schema.tableSchema().findField("booleanField"));
+    assertNotNull(schema.tableSchema().findField(MetastoreColumn.ROW_GROUP_INDEX.columnName()));
+    assertNotNull(schema.tableSchema().findField(MetastoreColumn.OWNER.columnName()));
 
     Schema partitionSchema = new Schema(partKey1, partKey2, partKey3);
     PartitionSpec expectedPartitionSpec = PartitionSpec.builderFor(partitionSchema)
@@ -221,17 +226,17 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
 
       @Override
       void addFields(ClassWriter classWriter) {
-        FieldVisitor partKey1 = addField(classWriter, Opcodes.ACC_PRIVATE, "partKey1", String.class);
-        annotate(partKey1);
+        FieldVisitor storagePlugin = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.STORAGE_PLUGIN, String.class);
+        annotate(storagePlugin, MetastoreColumn.STORAGE_PLUGIN, MetadataType.ALL);
 
-        FieldVisitor integerField = addField(classWriter, Opcodes.ACC_PRIVATE, "integerField", Integer.class);
-        annotate(integerField);
+        FieldVisitor tableName = addField(classWriter, Opcodes.ACC_PRIVATE, MetastoreColumn.TABLE_NAME, Integer.class);
+        annotate(tableName, MetastoreColumn.TABLE_NAME, MetadataType.ALL);
       }
     }.generate();
 
     thrown.expect(IcebergMetastoreException.class);
 
-    IcebergTableSchema.of(clazz, Arrays.asList("partKey1", "partKey2"));
+    IcebergTableSchema.of(clazz, Arrays.asList(MetastoreColumn.STORAGE_PLUGIN, MetastoreColumn.WORKSPACE));
   }
 
   /**
@@ -257,7 +262,7 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
       }.injectClass(name, bytes);
     }
 
-    public FieldVisitor addField(ClassWriter classWriter, int access, String fieldName, Class<?> clazz, Class<?>... genericTypes) {
+    public FieldVisitor addField(ClassWriter classWriter, int access, MetastoreColumn column, Class<?> clazz, Class<?>... genericTypes) {
       String descriptor = Type.getType(clazz).getDescriptor();
 
       String signature = null;
@@ -277,11 +282,23 @@ public class TestIcebergTableSchema extends IcebergBaseTest {
             .buildSignature();
       }
 
-      return classWriter.visitField(access, fieldName, descriptor, signature, null);
+      return classWriter.visitField(access, column.columnName(), descriptor, signature, null);
     }
 
-    void annotate(FieldVisitor field) {
-      field.visitAnnotation(Type.getType(MetastoreFieldDefinition.class).getDescriptor(), true);
+    void annotate(FieldVisitor field, MetastoreColumn column, MetadataType... scopes) {
+      String annotationDescriptor = Type.getType(MetastoreFieldDefinition.class).getDescriptor();
+      AnnotationNode annotationNode = new AnnotationNode(annotationDescriptor);
+
+      annotationNode.visitEnum("column", Type.getType(MetastoreColumn.class).getDescriptor(), column.name());
+      annotationNode.visitEnd();
+
+      AnnotationVisitor scopesNode = annotationNode.visitArray("scopes");
+      Arrays.stream(scopes)
+        .forEach(scope -> scopesNode.visitEnum("scopes", Type.getType(MetadataType.class).getDescriptor(), scope.name()));
+      scopesNode.visitEnd();
+
+      AnnotationVisitor annotationVisitor = field.visitAnnotation(annotationDescriptor, true);
+      annotationNode.accept(annotationVisitor);
     }
 
     private ClassWriter generateClass() {

--- a/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/transform/TestFilterTransformer.java
+++ b/metastore/iceberg-metastore/src/test/java/org/apache/drill/metastore/iceberg/transform/TestFilterTransformer.java
@@ -17,9 +17,9 @@
  */
 package org.apache.drill.metastore.iceberg.transform;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.iceberg.IcebergBaseTest;
-import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -52,88 +52,88 @@ public class TestFilterTransformer extends IcebergBaseTest {
 
   @Test
   public void testToFilterEqual() {
-    Expression expected = Expressions.equal("a", 1);
-    Expression actual = transformer.transform(FilterExpression.equal("a", 1));
+    Expression expected = Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.equal(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterNotEqual() {
-    Expression expected = Expressions.notEqual("a", 1);
-    Expression actual = transformer.transform(FilterExpression.notEqual("a", 1));
+    Expression expected = Expressions.notEqual(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.notEqual(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterLessThan() {
-    Expression expected = Expressions.lessThan("a", 1);
-    Expression actual = transformer.transform(FilterExpression.lessThan("a", 1));
+    Expression expected = Expressions.lessThan(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.lessThan(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterLessThanOrEqual() {
-    Expression expected = Expressions.lessThanOrEqual("a", 1);
-    Expression actual = transformer.transform(FilterExpression.lessThanOrEqual("a", 1));
+    Expression expected = Expressions.lessThanOrEqual(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.lessThanOrEqual(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterGreaterThan() {
-    Expression expected = Expressions.greaterThan("a", 1);
-    Expression actual = transformer.transform(FilterExpression.greaterThan("a", 1));
+    Expression expected = Expressions.greaterThan(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.greaterThan(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterGreaterThanOrEqual() {
-    Expression expected = Expressions.greaterThanOrEqual("a", 1);
-    Expression actual = transformer.transform(FilterExpression.greaterThanOrEqual("a", 1));
+    Expression expected = Expressions.greaterThanOrEqual(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1);
+    Expression actual = transformer.transform(FilterExpression.greaterThanOrEqual(MetastoreColumn.ROW_GROUP_INDEX, 1));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterIn() {
-    Expression expected = Expressions.in("a", 1, 2);
-    Expression actual = transformer.transform(FilterExpression.in("a", 1, 2));
+    Expression expected = Expressions.in(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1, 2);
+    Expression actual = transformer.transform(FilterExpression.in(MetastoreColumn.ROW_GROUP_INDEX, 1, 2));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterNotIn() {
-    Expression expected = Expressions.notIn("a", 1, 2);
-    Expression actual = transformer.transform(FilterExpression.notIn("a", 1, 2));
+    Expression expected = Expressions.notIn(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1, 2);
+    Expression actual = transformer.transform(FilterExpression.notIn(MetastoreColumn.ROW_GROUP_INDEX, 1, 2));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterIsNull() {
-    Expression expected = Expressions.isNull("a");
-    Expression actual = transformer.transform(FilterExpression.isNull("a"));
+    Expression expected = Expressions.isNull(MetastoreColumn.ROW_GROUP_INDEX.columnName());
+    Expression actual = transformer.transform(FilterExpression.isNull(MetastoreColumn.ROW_GROUP_INDEX));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterIsNotNull() {
-    Expression expected = Expressions.notNull("a");
-    Expression actual = transformer.transform(FilterExpression.isNotNull("a"));
+    Expression expected = Expressions.notNull(MetastoreColumn.ROW_GROUP_INDEX.columnName());
+    Expression actual = transformer.transform(FilterExpression.isNotNull(MetastoreColumn.ROW_GROUP_INDEX));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterNot() {
-    Expression expected = Expressions.not(Expressions.equal("a", 1));
-    Expression actual = transformer.transform(FilterExpression.not(FilterExpression.equal("a", 1)));
+    Expression expected = Expressions.not(Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1));
+    Expression actual = transformer.transform(FilterExpression.not(FilterExpression.equal(MetastoreColumn.ROW_GROUP_INDEX, 1)));
 
     assertEquals(expected.toString(), actual.toString());
   }
@@ -141,21 +141,29 @@ public class TestFilterTransformer extends IcebergBaseTest {
   @Test
   public void testToFilterAnd() {
     Expression expected = Expressions.and(
-      Expressions.equal("a", 1), Expressions.equal("b", 2),
-      Expressions.equal("c", 3), Expressions.equal("d", 4));
+      Expressions.equal(MetastoreColumn.STORAGE_PLUGIN.columnName(), "dfs"),
+      Expressions.equal(MetastoreColumn.WORKSPACE.columnName(), "tmp"),
+      Expressions.equal(MetastoreColumn.TABLE_NAME.columnName(), "nation"),
+      Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 4));
 
     Expression actual = transformer.transform(FilterExpression.and(
-      FilterExpression.equal("a", 1), FilterExpression.equal("b", 2),
-      FilterExpression.equal("c", 3), FilterExpression.equal("d", 4)));
+      FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+      FilterExpression.equal(MetastoreColumn.WORKSPACE, "tmp"),
+      FilterExpression.equal(MetastoreColumn.TABLE_NAME, "nation"),
+      FilterExpression.equal(MetastoreColumn.ROW_GROUP_INDEX, 4)));
 
     assertEquals(expected.toString(), actual.toString());
   }
 
   @Test
   public void testToFilterOr() {
-    Expression expected = Expressions.or(Expressions.equal("a", 1), Expressions.equal("a", 2));
+    Expression expected = Expressions.or(
+      Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1),
+      Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 2));
     Expression actual = transformer.transform(
-      FilterExpression.or(FilterExpression.equal("a", 1), FilterExpression.equal("a", 2)));
+      FilterExpression.or(
+        FilterExpression.equal(MetastoreColumn.ROW_GROUP_INDEX, 1),
+        FilterExpression.equal(MetastoreColumn.ROW_GROUP_INDEX, 2)));
 
     assertEquals(expected.toString(), actual.toString());
   }
@@ -179,7 +187,7 @@ public class TestFilterTransformer extends IcebergBaseTest {
 
   @Test
   public void testToFilterConditionsNull() {
-    assertEquals(Expressions.alwaysTrue().toString(), transformer.transform((Map<String, Object>) null).toString());
+    assertEquals(Expressions.alwaysTrue().toString(), transformer.transform((Map<MetastoreColumn, Object>) null).toString());
   }
 
   @Test
@@ -189,35 +197,38 @@ public class TestFilterTransformer extends IcebergBaseTest {
 
   @Test
   public void testToFilterConditionsOne() {
-    Map<String, Object> conditions = new HashMap<>();
-    conditions.put("a", 1);
+    Map<MetastoreColumn, Object> conditions = new LinkedHashMap<>();
+    conditions.put(MetastoreColumn.ROW_GROUP_INDEX, 1);
 
-    assertEquals(Expressions.equal("a", 1).toString(), transformer.transform(conditions).toString());
+    assertEquals(Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 1).toString(), transformer.transform(conditions).toString());
   }
 
   @Test
   public void testToFilterConditionsTwo() {
-    Map<String, Object> conditions = new HashMap<>();
-    conditions.put("a", 1);
-    conditions.put("b", 2);
+    Map<MetastoreColumn, Object> conditions = new LinkedHashMap<>();
+    conditions.put(MetastoreColumn.STORAGE_PLUGIN, "dfs");
+    conditions.put(MetastoreColumn.WORKSPACE, "tmp");
 
     Expression expected = Expressions.and(
-      Expressions.equal("a", 1), Expressions.equal("b", 2));
+      Expressions.equal(MetastoreColumn.STORAGE_PLUGIN.columnName(), "dfs"),
+      Expressions.equal(MetastoreColumn.WORKSPACE.columnName(), "tmp"));
 
     assertEquals(expected.toString(), transformer.transform(conditions).toString());
   }
 
   @Test
   public void testToFilterConditionsFour() {
-    Map<String, Object> conditions = new HashMap<>();
-    conditions.put("a", 1);
-    conditions.put("b", 2);
-    conditions.put("c", 3);
-    conditions.put("d", 4);
+    Map<MetastoreColumn, Object> conditions = new LinkedHashMap<>();
+    conditions.put(MetastoreColumn.STORAGE_PLUGIN, "dfs");
+    conditions.put(MetastoreColumn.WORKSPACE, "tmp");
+    conditions.put(MetastoreColumn.TABLE_NAME, "nation");
+    conditions.put(MetastoreColumn.ROW_GROUP_INDEX, 4);
 
     Expression expected = Expressions.and(
-      Expressions.equal("a", 1), Expressions.equal("b", 2),
-      Expressions.equal("c", 3), Expressions.equal("d", 4));
+      Expressions.equal(MetastoreColumn.STORAGE_PLUGIN.columnName(), "dfs"),
+      Expressions.equal(MetastoreColumn.WORKSPACE.columnName(), "tmp"),
+      Expressions.equal(MetastoreColumn.TABLE_NAME.columnName(), "nation"),
+      Expressions.equal(MetastoreColumn.ROW_GROUP_INDEX.columnName(), 4));
 
     assertEquals(expected.toString(), transformer.transform(conditions).toString());
   }
@@ -234,7 +245,7 @@ public class TestFilterTransformer extends IcebergBaseTest {
 
   @Test
   public void testToFilterMetadataTypesOne() {
-    Expression expected = Expressions.equal(MetadataInfo.METADATA_TYPE, MetadataType.PARTITION.name());
+    Expression expected = Expressions.equal(MetastoreColumn.METADATA_TYPE.columnName(), MetadataType.PARTITION.name());
 
     Expression actual = transformer.transform(Collections.singletonList(MetadataType.PARTITION));
 
@@ -243,7 +254,7 @@ public class TestFilterTransformer extends IcebergBaseTest {
 
   @Test
   public void testToFilterMetadataTypesSeveral() {
-    Expression expected = Expressions.in(MetadataInfo.METADATA_TYPE,
+    Expression expected = Expressions.in(MetastoreColumn.METADATA_TYPE.columnName(),
       MetadataType.PARTITION.name(), MetadataType.FILE.name());
 
     Expression actual = transformer.transform(

--- a/metastore/metastore-api/README.md
+++ b/metastore/metastore-api/README.md
@@ -100,8 +100,8 @@ For convenience, `FilterExpression.Visitor` can be implemented to traverse filte
 Filter expression can be simple and contain only one condition:
 
 ```
-FilterExpression storagePlugin = FilterExpression.equal("storagePlugin", "dfs");
-FilterExpression workspaces = FilterExpression.in("workspace", "root", "tmp");
+FilterExpression storagePlugin = FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs");
+FilterExpression workspaces = FilterExpression.in(MetastoreColumn.WORKSPACE, "root", "tmp");
 
 ```
 
@@ -109,8 +109,8 @@ Or it can be complex and contain several conditions combined with `AND` or `OR` 
 
 ```
   FilterExpression filter = FilterExpression.and(
-    FilterExpression.equal("storagePlugin", "dfs"),
-    FilterExpression.in("workspace", "root", "tmp"));
+    FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+    FilterExpression.in(MetastoreColumn.WORKSPACE, "root", "tmp"));
   
   metastore.tables().read()
     .metadataType(MetadataType.TABLE)
@@ -132,6 +132,7 @@ SQL-like equivalent for the above operation is:
 In order to provide read functionality each component must implement `Read`.
 During implementation component unit type must be indicated.
 `Metastore.Read#columns` allows to specify list of columns to be retrieved from the Metastore component.
+Columns are represented by `MetastoreColumn` enum values.
 `Metastore.Read#filter` allows to specify filter expression by which data will be retrieved.
 `Metastore.Read#execute` executes read operation and returns the results.
 Data is returned in a form of list of component metadata units, it is caller responsibility to transform received
@@ -144,8 +145,8 @@ for all tables in the `dfs` storage plugin the following code can be used:
 ```
   List<TableMetadataUnit> units = metastore.tables().read()
     .metadataType(MetadataType.TABLE)
-    .columns("tableName", "lastModifiedTime")
-    .filter(FilterExpression.equal("storagePlugin", "dfs")
+    .columns(MetastoreColumn.TABLE_NAME, MetastoreColumn.LAST_MODIFIED_TIME)
+    .filter(FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs")
     .execute();
 ```
 
@@ -301,9 +302,9 @@ and caller needs to delete it and all its metadata. First, deletion filter must 
 
 ```
     FilterExpression deleteFilter = FilterExpression.and(
-      FilterExpression.equal("storagePlugin", "dfs"),
-      FilterExpression.equal("workspace", "tmp"),
-      FilterExpression.equal("tableName", "nation"));
+      FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs"),
+      FilterExpression.equal(MetastoreColumn.WORKSPACE, "tmp"),
+      FilterExpression.equal(MetastoreColumn.TABLE_NAME, "nation"));
 ```
 
 Such filter can be also generated using `TableInfo` class:

--- a/metastore/metastore-api/README.md
+++ b/metastore/metastore-api/README.md
@@ -75,9 +75,22 @@ Metastore component may or may not support properties depending on the implement
 If properties are supported, map with properties names and values is returned.
 otherwise empty map is returned. `Metadata#properties` is used to obtain properties information. 
 
-### Filter expression
+### Data filtering
 
-Metastore data can be read or deleted based on the filter expression.
+Metastore data can be read or deleted based on the filter expression and metadata types.
+
+#### Metadata types
+
+Each concrete Metastore component implementation supports specific metadata types
+which identify metadata inside Metastore component units. For example, for `tables`
+component, supported metadata types are` TABLE`, `SEGMENT`, `FILE`, `ROW_GROUP`, `PARTITION`.
+Metadata types are based on `org.apache.drill.metastore.metadata.MetadataType` enum names.
+
+Metadata types should be indicated during read or delete operations.
+If all metadata types are needed, `MetadataType#ALL` metadata type can be indicated.
+
+#### Filter expressions
+
 All filter expressions implement `FilterExpression` interface. 
 List of supported filter operators is indicated in `FilterExpression.Operator` enum.
 When filter expression is provided in read or delete operation, it's up to Metastore
@@ -100,6 +113,7 @@ Or it can be complex and contain several conditions combined with `AND` or `OR` 
     FilterExpression.in("workspace", "root", "tmp"));
   
   metastore.tables().read()
+    .metadataType(MetadataType.TABLE)
     .filters(filter)
     .execute();
 ```
@@ -110,6 +124,7 @@ SQL-like equivalent for the above operation is:
   select * from METASTORE.TABLES
   where storagePlugin = 'dfs'
   and workspace in ('root', 'tmp')
+  and metadataType = 'TABLE'
 ```
 
 ### Metastore Read
@@ -128,6 +143,7 @@ for all tables in the `dfs` storage plugin the following code can be used:
 
 ```
   List<TableMetadataUnit> units = metastore.tables().read()
+    .metadataType(MetadataType.TABLE)
     .columns("tableName", "lastModifiedTime")
     .filter(FilterExpression.equal("storagePlugin", "dfs")
     .execute();
@@ -276,13 +292,15 @@ all segment information must be overwritten.
 
 #### Delete
 
-`Read#delete` deletes data from the Metastore component based on the provided filter expression.
+`Read#delete` deletes data from the Metastore component based on the provided delete operation.
+
+Delete operation consists of delete filter and metadata types.
 
 Assume metadata for table `dfs.tmp.nation` already exists in the Metastore `tables` component
-and caller needs to delete it. First, deletion filter must be created:
+and caller needs to delete it and all its metadata. First, deletion filter must be created:
 
 ```
-    FilterExpression filter = FilterExpression.and(
+    FilterExpression deleteFilter = FilterExpression.and(
       FilterExpression.equal("storagePlugin", "dfs"),
       FilterExpression.equal("workspace", "tmp"),
       FilterExpression.equal("tableName", "nation"));
@@ -297,25 +315,35 @@ Such filter can be also generated using `TableInfo` class:
       .name("nation")
       .build();
       
-    FilterExpression filter = tableInfo.toFilter();  
+    FilterExpression deleteFilter = tableInfo.toFilter();  
+```
+
+Then metadata type should be indicated, since all table metadata needs to be deleted,
+`ALL` metadata type should be specified.
+
+```
+    Delete deleteOperation = Delete.builder()
+      .metadataType(MetadataType.ALL)
+      .filter(deleteFilter)
+      .build()
 ```
 
 Delete operation can be executed using the following code:
 
 ```
     metastore.tables().modify()
-      .delete(filter)
+      .delete(deleteOperation)
       .execute();
 ```
 
 #### Purge
 
-`Read#purge` deletes all data from the Metastore component.
+`Read#purge` deletes all data from the Metastore component. Purge is terminal operation
+and cannot be used together with overwrite or delete.
 
 ```
     metastore.tables().modify()
-      .purge()
-      .execute();
+      .purge();
 ```
 
 #### Transactions
@@ -328,7 +356,7 @@ If Metastore implementation does not support transactions, all operations will b
     metastore.tables().modify()
       .overwrite(tableUnit1, segmentUnit1)
       .overwrite(tableUnit2, segmentUnit2)
-      .delete(table3Filter)
-      .delete(table4Filter)
+      .delete(deleteOperation1)
+      .delete(deleteOperation2)
       .execute();
 ```

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/MetastoreColumn.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/MetastoreColumn.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore;
+
+import org.apache.drill.metastore.exceptions.MetastoreException;
+
+import java.util.stream.Stream;
+
+/**
+ * Metastore column definition, contains all Metastore column and their name
+ * to unique their usage in the code.
+ */
+public enum MetastoreColumn {
+
+  STORAGE_PLUGIN("storagePlugin"),
+  WORKSPACE("workspace"),
+  TABLE_NAME("tableName"),
+  OWNER("owner"),
+  TABLE_TYPE("tableType"),
+  METADATA_TYPE("metadataType"),
+  METADATA_KEY("metadataKey"),
+  LOCATION("location"),
+  INTERESTING_COLUMNS("interestingColumns"),
+  SCHEMA("schema"),
+  COLUMNS_STATISTICS("columnsStatistics"),
+  METADATA_STATISTICS("metadataStatistics"),
+  LAST_MODIFIED_TIME("lastModifiedTime"),
+  PARTITION_KEYS("partitionKeys"),
+  ADDITIONAL_METADATA("additionalMetadata"),
+  METADATA_IDENTIFIER("metadataIdentifier"),
+  COLUMN("column"),
+  LOCATIONS("locations"),
+  PARTITION_VALUES("partitionValues"),
+  PATH("path"),
+  ROW_GROUP_INDEX("rowGroupIndex"),
+  HOST_AFFINITY("hostAffinity");
+
+  private final String columnName;
+
+  MetastoreColumn(String columnName) {
+    this.columnName = columnName;
+  }
+
+  public String columnName() {
+    return columnName;
+  }
+
+  /**
+   * Looks up {@link MetastoreColumn} value for the given column name.
+   *
+   * @param columnName column name
+   * @return {@link MetastoreColumn} value
+   * @throws MetastoreException if {@link MetastoreColumn} value is not found
+   */
+  public static MetastoreColumn of(String columnName) {
+    return Stream.of(MetastoreColumn.values())
+      .filter(column -> column.columnName.equals(columnName))
+      // we don't expect duplicates by column name in the enum
+      .findAny()
+      .orElseThrow(() -> new MetastoreException(String.format("Column with name [%s] is absent.", columnName)));
+  }
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/MetastoreFieldDefinition.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/MetastoreFieldDefinition.java
@@ -35,6 +35,13 @@ import java.lang.annotation.Target;
 public @interface MetastoreFieldDefinition {
 
   /**
+   * Indicates Metastore column which can be used in select or filter.
+   *
+   * @return column enum value
+   */
+  MetastoreColumn column();
+
+  /**
    * Indicated metadata types to which field belongs to.
    *
    * @return array of metadata types field belongs to

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/BasicTablesRequests.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/BasicTablesRequests.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.metastore.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.BaseTableMetadata;
 import org.apache.drill.metastore.metadata.FileMetadata;
@@ -40,13 +41,6 @@ import java.util.stream.Collectors;
  * to write filters and transformers from {@link TableMetadataUnit} class.
  */
 public class BasicTablesRequests {
-
-  public static final String LAST_MODIFIED_TIME = "lastModifiedTime";
-  public static final String PATH = "path";
-  public static final String LOCATION = "location";
-  public static final String COLUMN = "column";
-  public static final String INTERESTING_COLUMNS = "interestingColumns";
-  public static final String PARTITION_KEYS = "partitionKeys";
 
   private final Tables tables;
 
@@ -73,7 +67,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(MetadataInfo.GENERAL_INFO_KEY)
       .metadataType(MetadataType.TABLE)
-      .requestColumns(LAST_MODIFIED_TIME)
+      .requestColumns(MetastoreColumn.LAST_MODIFIED_TIME)
       .build();
 
     long version = tables.metadata().version();
@@ -556,7 +550,7 @@ public class BasicTablesRequests {
       .metadataKey(metadataKey)
       .locations(locations)
       .metadataType(MetadataType.FILE)
-      .requestColumns(PATH, LAST_MODIFIED_TIME)
+      .requestColumns(MetastoreColumn.PATH, MetastoreColumn.LAST_MODIFIED_TIME)
       .build();
 
     return request(requestMetadata).stream()
@@ -586,7 +580,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .locations(locations)
       .metadataType(MetadataType.SEGMENT)
-      .requestColumns(MetadataInfo.METADATA_KEY, LAST_MODIFIED_TIME)
+      .requestColumns(MetastoreColumn.METADATA_KEY, MetastoreColumn.LAST_MODIFIED_TIME)
       .build();
 
     return request(requestMetadata).stream()
@@ -617,7 +611,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(MetadataInfo.GENERAL_INFO_KEY)
       .metadataType(MetadataType.TABLE)
-      .requestColumns(INTERESTING_COLUMNS, PARTITION_KEYS)
+      .requestColumns(MetastoreColumn.INTERESTING_COLUMNS, MetastoreColumn.PARTITION_KEYS)
       .build();
 
     return retrieveSingleElement(request(requestMetadata));
@@ -667,9 +661,9 @@ public class BasicTablesRequests {
 
     private List<MetadataType> metadataTypes;
     private final FilterExpression filter;
-    private final List<String> columns;
+    private final List<MetastoreColumn> columns;
 
-    private RequestMetadata(List<MetadataType> metadataTypes, FilterExpression filter, List<String> columns) {
+    private RequestMetadata(List<MetadataType> metadataTypes, FilterExpression filter, List<MetastoreColumn> columns) {
       this.metadataTypes = metadataTypes;
       this.filter = filter;
       this.columns = columns;
@@ -683,7 +677,7 @@ public class BasicTablesRequests {
       return filter;
     }
 
-    public List<String> columns() {
+    public List<MetastoreColumn> columns() {
       return columns;
     }
 
@@ -704,7 +698,7 @@ public class BasicTablesRequests {
       private List<String> identifiers;
       private FilterExpression customFilter;
       private List<MetadataType> metadataTypes = new ArrayList<>();
-      private final List<String> requestColumns = new ArrayList<>();
+      private final List<MetastoreColumn> requestColumns = new ArrayList<>();
 
       public RequestMetadata.Builder metadataType(MetadataType metadataType) {
         this.metadataTypes.add(metadataType);
@@ -771,12 +765,12 @@ public class BasicTablesRequests {
         return this;
       }
 
-      public RequestMetadata.Builder requestColumns(List<String> requestColumns) {
+      public RequestMetadata.Builder requestColumns(List<MetastoreColumn> requestColumns) {
         this.requestColumns.addAll(requestColumns);
         return this;
       }
 
-      public RequestMetadata.Builder requestColumns(String... requestColumns) {
+      public RequestMetadata.Builder requestColumns(MetastoreColumn... requestColumns) {
         return requestColumns(Arrays.asList(requestColumns));
       }
 
@@ -789,14 +783,14 @@ public class BasicTablesRequests {
         if (tableInfo != null) {
           filters.add(tableInfo.toFilter());
         }
-        addFilter(LOCATION, location, filters);
-        addFilter(LOCATION, locations, filters);
-        addFilter(COLUMN, column, filters);
-        addFilter(MetadataInfo.METADATA_KEY, metadataKey, filters);
-        addFilter(MetadataInfo.METADATA_KEY, metadataKeys, filters);
-        addFilter(PATH, path, filters);
-        addFilter(PATH, paths, filters);
-        addFilter(MetadataInfo.METADATA_IDENTIFIER, identifiers, filters);
+        addFilter(MetastoreColumn.LOCATION, location, filters);
+        addFilter(MetastoreColumn.LOCATION, locations, filters);
+        addFilter(MetastoreColumn.COLUMN, column, filters);
+        addFilter(MetastoreColumn.METADATA_KEY, metadataKey, filters);
+        addFilter(MetastoreColumn.METADATA_KEY, metadataKeys, filters);
+        addFilter(MetastoreColumn.PATH, path, filters);
+        addFilter(MetastoreColumn.PATH, paths, filters);
+        addFilter(MetastoreColumn.METADATA_IDENTIFIER, identifiers, filters);
         if (customFilter != null) {
           filters.add(customFilter);
         }
@@ -819,11 +813,11 @@ public class BasicTablesRequests {
        * creates {@link FilterExpression.Operator#IN} filter, if List is empty, does nothing.
        * For all other cases, creates {@link FilterExpression.Operator#EQUAL} filter.
        *
-       * @param reference filter reference
+       * @param column Metastore column to which filter will be applied
        * @param value filter value
        * @param filters current list of filters
        */
-      private <T> void addFilter(String reference, T value, List<FilterExpression> filters) {
+      private <T> void addFilter(MetastoreColumn column, T value, List<FilterExpression> filters) {
         if (value == null) {
           return;
         }
@@ -833,11 +827,11 @@ public class BasicTablesRequests {
           if (list.isEmpty()) {
             return;
           }
-          filters.add(FilterExpression.in(reference, list));
+          filters.add(FilterExpression.in(column, list));
           return;
         }
 
-        filters.add(FilterExpression.equal(reference, value));
+        filters.add(FilterExpression.equal(column, value));
       }
     }
   }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/BasicTablesRequests.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/BasicTablesRequests.java
@@ -72,7 +72,7 @@ public class BasicTablesRequests {
     RequestMetadata requestMetadata = RequestMetadata.builder()
       .tableInfo(tableInfo)
       .metadataKey(MetadataInfo.GENERAL_INFO_KEY)
-      .metadataType(MetadataType.TABLE.name())
+      .metadataType(MetadataType.TABLE)
       .requestColumns(LAST_MODIFIED_TIME)
       .build();
 
@@ -121,7 +121,7 @@ public class BasicTablesRequests {
     RequestMetadata requestMetadata = RequestMetadata.builder()
       .customFilter(filter)
       .metadataKey(MetadataInfo.GENERAL_INFO_KEY)
-      .metadataType(MetadataType.TABLE.name())
+      .metadataType(MetadataType.TABLE)
       .requestColumns(TableMetadataUnit.SCHEMA.tableColumns())
       .build();
 
@@ -172,7 +172,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .locations(locations)
       .metadataKey(metadataKey)
-      .metadataType(MetadataType.SEGMENT.name())
+      .metadataType(MetadataType.SEGMENT)
       .requestColumns(TableMetadataUnit.SCHEMA.segmentColumns())
       .build();
 
@@ -202,7 +202,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .locations(locations)
       .column(column)
-      .metadataType(MetadataType.SEGMENT.name())
+      .metadataType(MetadataType.SEGMENT)
       .requestColumns(TableMetadataUnit.SCHEMA.segmentColumns())
       .build();
 
@@ -237,7 +237,7 @@ public class BasicTablesRequests {
         .tableInfo(tableInfo)
         .metadataKeys(keys)
         .identifiers(identifiers)
-        .metadataType(MetadataType.SEGMENT.name())
+        .metadataType(MetadataType.SEGMENT)
         .requestColumns(TableMetadataUnit.SCHEMA.segmentColumns())
         .build();
 
@@ -253,6 +253,7 @@ public class BasicTablesRequests {
    *   select * from METASTORE
    *   where storage = 'dfs' and workspace = 'tmp' and tableName = 'nation'
    *   and identifier in ('part_int=3', …)
+   *   and metadataType in ('SEGMENT', …)
    * </pre>
    *
    * @param tableInfo table information
@@ -267,8 +268,8 @@ public class BasicTablesRequests {
         .map(MetadataInfo::identifier)
         .collect(Collectors.toList());
 
-    List<String> metadataTypes = metadataInfos.stream()
-        .map(metadataInfo -> metadataInfo.type().name())
+    List<MetadataType> metadataTypes = metadataInfos.stream()
+        .map(MetadataInfo::type)
         .collect(Collectors.toList());
 
     RequestMetadata requestMetadata = RequestMetadata.builder()
@@ -303,7 +304,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKeys(metadataKeys)
       .column(column)
-      .metadataType(MetadataType.PARTITION.name())
+      .metadataType(MetadataType.PARTITION)
       .requestColumns(TableMetadataUnit.SCHEMA.partitionColumns())
       .build();
 
@@ -333,7 +334,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(metadataKey)
       .paths(paths)
-      .metadataType(MetadataType.FILE.name())
+      .metadataType(MetadataType.FILE)
       .requestColumns(TableMetadataUnit.SCHEMA.fileColumns())
       .build();
 
@@ -368,7 +369,7 @@ public class BasicTablesRequests {
         .tableInfo(tableInfo)
         .metadataKeys(keys)
         .identifiers(identifiers)
-        .metadataType(MetadataType.FILE.name())
+        .metadataType(MetadataType.FILE)
         .requestColumns(TableMetadataUnit.SCHEMA.fileColumns())
         .build();
 
@@ -400,7 +401,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(metadataKey)
       .path(path)
-      .metadataType(MetadataType.FILE.name())
+      .metadataType(MetadataType.FILE)
       .requestColumns(TableMetadataUnit.SCHEMA.fileColumns())
       .build();
 
@@ -430,7 +431,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(metadataKey)
       .path(path)
-      .metadataType(MetadataType.ROW_GROUP.name())
+      .metadataType(MetadataType.ROW_GROUP)
       .requestColumns(TableMetadataUnit.SCHEMA.rowGroupColumns())
       .build();
 
@@ -460,7 +461,7 @@ public class BasicTablesRequests {
         .tableInfo(tableInfo)
         .metadataKeys(metadataKeys)
         .paths(paths)
-        .metadataType(MetadataType.ROW_GROUP.name())
+        .metadataType(MetadataType.ROW_GROUP)
         .requestColumns(TableMetadataUnit.SCHEMA.rowGroupColumns())
         .build();
 
@@ -495,7 +496,7 @@ public class BasicTablesRequests {
         .tableInfo(tableInfo)
         .metadataKeys(keys)
         .identifiers(identifiers)
-        .metadataType(MetadataType.ROW_GROUP.name())
+        .metadataType(MetadataType.ROW_GROUP)
         .requestColumns(TableMetadataUnit.SCHEMA.rowGroupColumns())
         .build();
 
@@ -525,7 +526,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKeys(metadataKeys)
       .locations(locations)
-      .metadataTypes(Arrays.asList(MetadataType.SEGMENT.name(), MetadataType.FILE.name(), MetadataType.ROW_GROUP.name()))
+      .metadataTypes(MetadataType.SEGMENT, MetadataType.FILE, MetadataType.ROW_GROUP)
       .build();
 
     List<TableMetadataUnit> units = request(requestMetadata);
@@ -554,7 +555,7 @@ public class BasicTablesRequests {
       .tableInfo(tableInfo)
       .metadataKey(metadataKey)
       .locations(locations)
-      .metadataType(MetadataType.FILE.name())
+      .metadataType(MetadataType.FILE)
       .requestColumns(PATH, LAST_MODIFIED_TIME)
       .build();
 
@@ -584,7 +585,7 @@ public class BasicTablesRequests {
     RequestMetadata requestMetadata = RequestMetadata.builder()
       .tableInfo(tableInfo)
       .locations(locations)
-      .metadataType(MetadataType.SEGMENT.name())
+      .metadataType(MetadataType.SEGMENT)
       .requestColumns(MetadataInfo.METADATA_KEY, LAST_MODIFIED_TIME)
       .build();
 
@@ -615,7 +616,7 @@ public class BasicTablesRequests {
     RequestMetadata requestMetadata = RequestMetadata.builder()
       .tableInfo(tableInfo)
       .metadataKey(MetadataInfo.GENERAL_INFO_KEY)
-      .metadataType(MetadataType.TABLE.name())
+      .metadataType(MetadataType.TABLE)
       .requestColumns(INTERESTING_COLUMNS, PARTITION_KEYS)
       .build();
 
@@ -630,6 +631,7 @@ public class BasicTablesRequests {
    */
   public List<TableMetadataUnit> request(RequestMetadata requestMetadata) {
     return tables.read()
+      .metadataTypes(requestMetadata.metadataTypes())
       .filter(requestMetadata.filter())
       .columns(requestMetadata.columns())
       .execute();
@@ -656,19 +658,25 @@ public class BasicTablesRequests {
   }
 
   /**
-   * Request metadata holder that provides request filters and columns.
+   * Request metadata holder that provides request metadata types, filters and columns.
    * Combines given filters using {@link FilterExpression.Operator#AND} operator.
    * Supports only {@link FilterExpression.Operator#EQUAL} and {@link FilterExpression.Operator#IN}
    * operators for predefined filter references, for other cases custom filter can be used.
    */
   public static class RequestMetadata {
 
+    private List<MetadataType> metadataTypes;
     private final FilterExpression filter;
     private final List<String> columns;
 
-    private RequestMetadata(FilterExpression filter, List<String> columns) {
+    private RequestMetadata(List<MetadataType> metadataTypes, FilterExpression filter, List<String> columns) {
+      this.metadataTypes = metadataTypes;
       this.filter = filter;
       this.columns = columns;
+    }
+
+    public List<MetadataType> metadataTypes() {
+      return metadataTypes;
     }
 
     public FilterExpression filter() {
@@ -689,15 +697,29 @@ public class BasicTablesRequests {
       private String location;
       private List<String> locations;
       private String column;
-      private String metadataType;
-      private List<String> metadataTypes;
       private String metadataKey;
       private List<String> metadataKeys;
       private String path;
       private List<String> paths;
       private List<String> identifiers;
       private FilterExpression customFilter;
+      private List<MetadataType> metadataTypes = new ArrayList<>();
       private final List<String> requestColumns = new ArrayList<>();
+
+      public RequestMetadata.Builder metadataType(MetadataType metadataType) {
+        this.metadataTypes.add(metadataType);
+        return this;
+      }
+
+      public RequestMetadata.Builder metadataTypes(MetadataType... metadataTypes) {
+        this.metadataTypes.addAll(Arrays.asList(metadataTypes));
+        return this;
+      }
+
+      public RequestMetadata.Builder metadataTypes(List<MetadataType> metadataTypes) {
+        this.metadataTypes.addAll(metadataTypes);
+        return this;
+      }
 
       public RequestMetadata.Builder tableInfo(TableInfo tableInfo) {
         this.tableInfo = tableInfo;
@@ -716,16 +738,6 @@ public class BasicTablesRequests {
 
       public RequestMetadata.Builder column(String column) {
         this.column = column;
-        return this;
-      }
-
-      public RequestMetadata.Builder metadataType(String metadataType) {
-        this.metadataType = metadataType;
-        return this;
-      }
-
-      public RequestMetadata.Builder metadataTypes(List<String> metadataTypes) {
-        this.metadataTypes = metadataTypes;
         return this;
       }
 
@@ -769,7 +781,7 @@ public class BasicTablesRequests {
       }
 
       public RequestMetadata build() {
-        return new RequestMetadata(createFilter(), requestColumns);
+        return new RequestMetadata(metadataTypes, createFilter(), requestColumns);
       }
 
       private FilterExpression createFilter() {
@@ -780,8 +792,6 @@ public class BasicTablesRequests {
         addFilter(LOCATION, location, filters);
         addFilter(LOCATION, locations, filters);
         addFilter(COLUMN, column, filters);
-        addFilter(MetadataInfo.METADATA_TYPE, metadataType, filters);
-        addFilter(MetadataInfo.METADATA_TYPE, metadataTypes, filters);
         addFilter(MetadataInfo.METADATA_KEY, metadataKey, filters);
         addFilter(MetadataInfo.METADATA_KEY, metadataKeys, filters);
         addFilter(PATH, path, filters);

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/TableMetadataUnit.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/TableMetadataUnit.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.metastore.components.tables;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.MetastoreFieldDefinition;
 import org.apache.drill.metastore.exceptions.MetastoreException;
 import org.apache.drill.metastore.metadata.MetadataType;
@@ -52,31 +53,31 @@ public class TableMetadataUnit {
 
   public static final Schema SCHEMA = Schema.of(TableMetadataUnit.class, Builder.class);
 
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String storagePlugin;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String workspace;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String tableName;
-  @MetastoreFieldDefinition(scopes = {TABLE}) private final String owner;
-  @MetastoreFieldDefinition(scopes = {TABLE}) private final String tableType;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String metadataType;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String metadataKey;
-  @MetastoreFieldDefinition(scopes = {TABLE, SEGMENT, FILE, ROW_GROUP}) private final String location;
-  @MetastoreFieldDefinition(scopes = {TABLE}) private final List<String> interestingColumns;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String schema;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final Map<String, String> columnsStatistics;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final List<String> metadataStatistics;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final Long lastModifiedTime;
-  @MetastoreFieldDefinition(scopes = {TABLE}) private final Map<String, String> partitionKeys;
-  @MetastoreFieldDefinition(scopes = {ALL}) private final String additionalMetadata;
+  @MetastoreFieldDefinition(column = MetastoreColumn.STORAGE_PLUGIN, scopes = {ALL}) private final String storagePlugin;
+  @MetastoreFieldDefinition(column = MetastoreColumn.WORKSPACE,scopes = {ALL}) private final String workspace;
+  @MetastoreFieldDefinition(column = MetastoreColumn.TABLE_NAME, scopes = {ALL}) private final String tableName;
+  @MetastoreFieldDefinition(column = MetastoreColumn.OWNER, scopes = {TABLE}) private final String owner;
+  @MetastoreFieldDefinition(column = MetastoreColumn.TABLE_TYPE, scopes = {TABLE}) private final String tableType;
+  @MetastoreFieldDefinition(column = MetastoreColumn.METADATA_TYPE, scopes = {ALL}) private final String metadataType;
+  @MetastoreFieldDefinition(column = MetastoreColumn.METADATA_KEY, scopes = {ALL}) private final String metadataKey;
+  @MetastoreFieldDefinition(column = MetastoreColumn.LOCATION, scopes = {TABLE, SEGMENT, FILE, ROW_GROUP}) private final String location;
+  @MetastoreFieldDefinition(column = MetastoreColumn.INTERESTING_COLUMNS, scopes = {TABLE}) private final List<String> interestingColumns;
+  @MetastoreFieldDefinition(column = MetastoreColumn.SCHEMA, scopes = {ALL}) private final String schema;
+  @MetastoreFieldDefinition(column = MetastoreColumn.COLUMNS_STATISTICS, scopes = {ALL}) private final Map<String, String> columnsStatistics;
+  @MetastoreFieldDefinition(column = MetastoreColumn.METADATA_STATISTICS, scopes = {ALL}) private final List<String> metadataStatistics;
+  @MetastoreFieldDefinition(column = MetastoreColumn.LAST_MODIFIED_TIME, scopes = {ALL}) private final Long lastModifiedTime;
+  @MetastoreFieldDefinition(column = MetastoreColumn.PARTITION_KEYS, scopes = {TABLE}) private final Map<String, String> partitionKeys;
+  @MetastoreFieldDefinition(column = MetastoreColumn.ADDITIONAL_METADATA, scopes = {ALL}) private final String additionalMetadata;
 
-  @MetastoreFieldDefinition(scopes = {SEGMENT, FILE, ROW_GROUP, PARTITION}) private final String metadataIdentifier;
-  @MetastoreFieldDefinition(scopes = {SEGMENT, PARTITION}) private final String column;
-  @MetastoreFieldDefinition(scopes = {SEGMENT, PARTITION}) private final List<String> locations;
-  @MetastoreFieldDefinition(scopes = {SEGMENT, PARTITION}) private final List<String> partitionValues;
+  @MetastoreFieldDefinition(column = MetastoreColumn.METADATA_IDENTIFIER, scopes = {SEGMENT, FILE, ROW_GROUP, PARTITION}) private final String metadataIdentifier;
+  @MetastoreFieldDefinition(column = MetastoreColumn.COLUMN, scopes = {SEGMENT, PARTITION}) private final String column;
+  @MetastoreFieldDefinition(column = MetastoreColumn.LOCATIONS, scopes = {SEGMENT, PARTITION}) private final List<String> locations;
+  @MetastoreFieldDefinition(column = MetastoreColumn.PARTITION_VALUES, scopes = {SEGMENT, PARTITION}) private final List<String> partitionValues;
 
-  @MetastoreFieldDefinition(scopes = {SEGMENT, FILE, ROW_GROUP}) private final String path;
+  @MetastoreFieldDefinition(column = MetastoreColumn.PATH, scopes = {SEGMENT, FILE, ROW_GROUP}) private final String path;
 
-  @MetastoreFieldDefinition(scopes = {ROW_GROUP}) private final Integer rowGroupIndex;
-  @MetastoreFieldDefinition(scopes = {ROW_GROUP}) private final Map<String, Float> hostAffinity;
+  @MetastoreFieldDefinition(column = MetastoreColumn.ROW_GROUP_INDEX, scopes = {ROW_GROUP}) private final Integer rowGroupIndex;
+  @MetastoreFieldDefinition(column = MetastoreColumn.HOST_AFFINITY, scopes = {ROW_GROUP}) private final Map<String, Float> hostAffinity;
 
   private TableMetadataUnit(Builder builder) {
     this.storagePlugin = builder.storagePlugin;
@@ -437,19 +438,19 @@ public class TableMetadataUnit {
    */
   public static class Schema {
 
-    private final List<String> tableColumns;
-    private final List<String> segmentColumns;
-    private final List<String> fileColumns;
-    private final List<String> rowGroupColumns;
-    private final List<String> partitionColumns;
+    private final List<MetastoreColumn> tableColumns;
+    private final List<MetastoreColumn> segmentColumns;
+    private final List<MetastoreColumn> fileColumns;
+    private final List<MetastoreColumn> rowGroupColumns;
+    private final List<MetastoreColumn> partitionColumns;
     private final Map<String, MethodHandle> unitGetters;
     private final Map<String, MethodHandle> unitBuilderSetters;
 
-    private Schema(List<String> tableColumns,
-                   List<String> segmentColumns,
-                   List<String> fileColumns,
-                   List<String> rowGroupColumns,
-                   List<String> partitionColumns,
+    private Schema(List<MetastoreColumn> tableColumns,
+                   List<MetastoreColumn> segmentColumns,
+                   List<MetastoreColumn> fileColumns,
+                   List<MetastoreColumn> rowGroupColumns,
+                   List<MetastoreColumn> partitionColumns,
                    Map<String, MethodHandle> unitGetters,
                    Map<String, MethodHandle> unitBuilderSetters) {
       this.tableColumns = tableColumns;
@@ -469,11 +470,11 @@ public class TableMetadataUnit {
      * are the same as annotated fields names.
      */
     public static Schema of(Class<?> unitClass, Class<?> builderClass) {
-      List<String> tableColumns = new ArrayList<>();
-      List<String> segmentColumns = new ArrayList<>();
-      List<String> fileColumns = new ArrayList<>();
-      List<String> rowGroupColumns = new ArrayList<>();
-      List<String> partitionColumns = new ArrayList<>();
+      List<MetastoreColumn> tableColumns = new ArrayList<>();
+      List<MetastoreColumn> segmentColumns = new ArrayList<>();
+      List<MetastoreColumn> fileColumns = new ArrayList<>();
+      List<MetastoreColumn> rowGroupColumns = new ArrayList<>();
+      List<MetastoreColumn> partitionColumns = new ArrayList<>();
       Map<String, MethodHandle> unitGetters = new HashMap<>();
       Map<String, MethodHandle> unitBuilderSetters = new HashMap<>();
 
@@ -486,30 +487,30 @@ public class TableMetadataUnit {
           continue;
         }
 
-        String name = field.getName();
+        MetastoreColumn column = definition.column();
         for (MetadataType scope : definition.scopes()) {
           switch (scope) {
             case TABLE:
-              tableColumns.add(name);
+              tableColumns.add(column);
               break;
             case SEGMENT:
-              segmentColumns.add(name);
+              segmentColumns.add(column);
               break;
             case FILE:
-              fileColumns.add(name);
+              fileColumns.add(column);
               break;
             case ROW_GROUP:
-              rowGroupColumns.add(name);
+              rowGroupColumns.add(column);
               break;
             case PARTITION:
-              partitionColumns.add(name);
+              partitionColumns.add(column);
               break;
             case ALL:
-              tableColumns.add(name);
-              segmentColumns.add(name);
-              fileColumns.add(name);
-              rowGroupColumns.add(name);
-              partitionColumns.add(name);
+              tableColumns.add(column);
+              segmentColumns.add(column);
+              fileColumns.add(column);
+              rowGroupColumns.add(column);
+              partitionColumns.add(column);
               break;
             default:
               throw new IllegalStateException(scope.name());
@@ -518,10 +519,12 @@ public class TableMetadataUnit {
 
         Class<?> type = field.getType();
         try {
-          MethodHandle getter = gettersLookup.findVirtual(unitClass, name, MethodType.methodType(type));
-          unitGetters.put(name, getter);
-          MethodHandle setter = settersLookup.findVirtual(builderClass, name, MethodType.methodType(builderClass, type));
-          unitBuilderSetters.put(name, setter);
+          String fieldName = field.getName();
+          String columnName = column.columnName();
+          MethodHandle getter = gettersLookup.findVirtual(unitClass, fieldName, MethodType.methodType(type));
+          unitGetters.put(columnName, getter);
+          MethodHandle setter = settersLookup.findVirtual(builderClass, fieldName, MethodType.methodType(builderClass, type));
+          unitBuilderSetters.put(columnName, setter);
         } catch (ReflectiveOperationException e) {
           throw new MetastoreException(String.format("Unable to init unit setter / getter method handlers " +
               "for unit [%s] and its builder [%s] classes", unitClass.getSimpleName(), builderClass.getSimpleName()), e);
@@ -532,23 +535,23 @@ public class TableMetadataUnit {
         unitGetters, unitBuilderSetters);
     }
 
-    public List<String> tableColumns() {
+    public List<MetastoreColumn> tableColumns() {
       return tableColumns;
     }
 
-    public List<String> segmentColumns() {
+    public List<MetastoreColumn> segmentColumns() {
       return segmentColumns;
     }
 
-    public List<String> fileColumns() {
+    public List<MetastoreColumn> fileColumns() {
       return fileColumns;
     }
 
-    public List<String> rowGroupColumns() {
+    public List<MetastoreColumn> rowGroupColumns() {
       return rowGroupColumns;
     }
 
-    public List<String> partitionColumns() {
+    public List<MetastoreColumn> partitionColumns() {
       return partitionColumns;
     }
 

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/TablesMetadataTypeValidator.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/components/tables/TablesMetadataTypeValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.components.tables;
+
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.metastore.operate.MetadataTypeValidator;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Implementation of {@link MetadataTypeValidator} interface which provides
+ * list of supported metadata types for Metastore Tables component.
+ */
+public class TablesMetadataTypeValidator implements MetadataTypeValidator {
+
+  public static final TablesMetadataTypeValidator INSTANCE = new TablesMetadataTypeValidator();
+
+  private static final List<MetadataType> SUPPORTED_METADATA_TYPES = Arrays.asList(
+    MetadataType.ALL,
+    MetadataType.TABLE,
+    MetadataType.SEGMENT,
+    MetadataType.FILE,
+    MetadataType.ROW_GROUP,
+    MetadataType.PARTITION);
+
+  @Override
+  public List<MetadataType> supportedMetadataTypes() {
+    return SUPPORTED_METADATA_TYPES;
+  }
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/FilterExpression.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/FilterExpression.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.metastore.expressions;
 
+import org.apache.drill.metastore.MetastoreColumn;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -77,54 +79,54 @@ public interface FilterExpression {
     }
   }
 
-  static <T> FilterExpression equal(String reference, T value) {
-    return new SimplePredicate.Equal<>(reference, value);
+  static <T> FilterExpression equal(MetastoreColumn column, T value) {
+    return new SimplePredicate.Equal<>(column, value);
   }
 
-  static <T> FilterExpression notEqual(String reference, T value) {
-    return new SimplePredicate.NotEqual<>(reference, value);
+  static <T> FilterExpression notEqual(MetastoreColumn column, T value) {
+    return new SimplePredicate.NotEqual<>(column, value);
   }
 
-  static <T> FilterExpression lessThan(String reference, T value) {
-    return new SimplePredicate.LessThan<>(reference, value);
+  static <T> FilterExpression lessThan(MetastoreColumn column, T value) {
+    return new SimplePredicate.LessThan<>(column, value);
   }
 
-  static <T> FilterExpression lessThanOrEqual(String reference, T value) {
-    return new SimplePredicate.LessThanOrEqual<>(reference, value);
+  static <T> FilterExpression lessThanOrEqual(MetastoreColumn column, T value) {
+    return new SimplePredicate.LessThanOrEqual<>(column, value);
   }
 
-  static <T> FilterExpression greaterThan(String reference, T value) {
-    return new SimplePredicate.GreaterThan<>(reference, value);
+  static <T> FilterExpression greaterThan(MetastoreColumn column, T value) {
+    return new SimplePredicate.GreaterThan<>(column, value);
   }
 
-  static <T> FilterExpression greaterThanOrEqual(String reference, T value) {
-    return new SimplePredicate.GreaterThanOrEqual<>(reference, value);
+  static <T> FilterExpression greaterThanOrEqual(MetastoreColumn column, T value) {
+    return new SimplePredicate.GreaterThanOrEqual<>(column, value);
   }
 
-  static <T> FilterExpression in(String reference, List<T> values) {
-    return new ListPredicate.In<>(reference, values);
-  }
-
-  @SafeVarargs
-  static <T> FilterExpression in(String reference, T... values) {
-    return in(reference, Arrays.asList(values));
-  }
-
-  static <T> FilterExpression notIn(String reference, List<T> values) {
-    return new ListPredicate.NotIn<>(reference, values);
+  static <T> FilterExpression in(MetastoreColumn column, List<T> values) {
+    return new ListPredicate.In<>(column, values);
   }
 
   @SafeVarargs
-  static <T> FilterExpression notIn(String reference, T... values) {
-    return notIn(reference, Arrays.asList(values));
+  static <T> FilterExpression in(MetastoreColumn column, T... values) {
+    return in(column, Arrays.asList(values));
   }
 
-  static FilterExpression isNull(String reference) {
-    return new IsPredicate.IsNull(reference);
+  static <T> FilterExpression notIn(MetastoreColumn column, List<T> values) {
+    return new ListPredicate.NotIn<>(column, values);
   }
 
-  static FilterExpression isNotNull(String reference) {
-    return new IsPredicate.IsNotNull(reference);
+  @SafeVarargs
+  static <T> FilterExpression notIn(MetastoreColumn column, T... values) {
+    return notIn(column, Arrays.asList(values));
+  }
+
+  static FilterExpression isNull(MetastoreColumn column) {
+    return new IsPredicate.IsNull(column);
+  }
+
+  static FilterExpression isNotNull(MetastoreColumn column) {
+    return new IsPredicate.IsNotNull(column);
   }
 
   static FilterExpression not(FilterExpression expression) {

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/IsPredicate.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/IsPredicate.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.metastore.expressions;
 
+import org.apache.drill.metastore.MetastoreColumn;
+
 import java.util.StringJoiner;
 
 /**
@@ -24,16 +26,16 @@ import java.util.StringJoiner;
  */
 public abstract class IsPredicate implements FilterExpression {
 
-  private final String reference;
+  private final MetastoreColumn column;
   private final Operator operator;
 
-  protected IsPredicate(String reference, Operator operator) {
-    this.reference = reference;
+  protected IsPredicate(MetastoreColumn column, Operator operator) {
+    this.column = column;
     this.operator = operator;
   }
 
-  public String reference() {
-    return reference;
+  public MetastoreColumn column() {
+    return column;
   }
 
   @Override
@@ -44,7 +46,7 @@ public abstract class IsPredicate implements FilterExpression {
   @Override
   public String toString() {
     return new StringJoiner(", ", IsPredicate.class.getSimpleName() + "[", "]")
-      .add("reference=" + reference)
+      .add("column=" + column)
       .add("operator=" + operator)
       .toString();
   }
@@ -55,8 +57,8 @@ public abstract class IsPredicate implements FilterExpression {
    */
   public static class IsNull extends IsPredicate {
 
-    public IsNull(String reference) {
-      super(reference, Operator.IS_NULL);
+    public IsNull(MetastoreColumn column) {
+      super(column, Operator.IS_NULL);
     }
 
     @Override
@@ -71,8 +73,8 @@ public abstract class IsPredicate implements FilterExpression {
    */
   public static class IsNotNull extends IsPredicate {
 
-    public IsNotNull(String reference) {
-      super(reference, Operator.IS_NOT_NULL);
+    public IsNotNull(MetastoreColumn column) {
+      super(column, Operator.IS_NOT_NULL);
     }
 
     @Override

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/ListPredicate.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/ListPredicate.java
@@ -17,28 +17,30 @@
  */
 package org.apache.drill.metastore.expressions;
 
+import org.apache.drill.metastore.MetastoreColumn;
+
 import java.util.List;
 import java.util.StringJoiner;
 
 /**
- * Indicates list predicate implementations which have reference and list of values.
+ * Indicates list predicate implementations which have column and list of values.
  *
  * @param <T> predicate value type
  */
 public abstract class ListPredicate<T> implements FilterExpression {
 
-  private final String reference;
+  private final MetastoreColumn column;
   private final Operator operator;
   private final List<T> values;
 
-  protected ListPredicate(String reference, Operator operator, List<T> values) {
-    this.reference = reference;
+  protected ListPredicate(MetastoreColumn column, Operator operator, List<T> values) {
+    this.column = column;
     this.operator = operator;
     this.values = values;
   }
 
-  public String reference() {
-    return reference;
+  public MetastoreColumn column() {
+    return column;
   }
 
   public List<T> values() {
@@ -53,7 +55,7 @@ public abstract class ListPredicate<T> implements FilterExpression {
   @Override
   public String toString() {
     return new StringJoiner(", ", ListPredicate.class.getSimpleName() + "[", "]")
-      .add("reference=" + reference)
+      .add("column=" + column)
       .add("operator=" + operator)
       .add("values=" + values)
       .toString();
@@ -67,8 +69,8 @@ public abstract class ListPredicate<T> implements FilterExpression {
    */
   public static class In<T> extends ListPredicate<T> {
 
-    public In(String reference, List<T> values) {
-      super(reference, Operator.IN, values);
+    public In(MetastoreColumn column, List<T> values) {
+      super(column, Operator.IN, values);
     }
 
     @Override
@@ -85,8 +87,8 @@ public abstract class ListPredicate<T> implements FilterExpression {
    */
   public static class NotIn<T> extends ListPredicate<T> {
 
-    public NotIn(String reference, List<T> values) {
-      super(reference, Operator.NOT_IN, values);
+    public NotIn(MetastoreColumn column, List<T> values) {
+      super(column, Operator.NOT_IN, values);
     }
 
     @Override

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/SimplePredicate.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/expressions/SimplePredicate.java
@@ -17,27 +17,29 @@
  */
 package org.apache.drill.metastore.expressions;
 
+import org.apache.drill.metastore.MetastoreColumn;
+
 import java.util.StringJoiner;
 
 /**
- * Indicates simple predicate implementations which have reference and one value.
+ * Indicates simple predicate implementations which have column and one value.
  *
  * @param <T> predicate value type
  */
 public abstract class SimplePredicate<T> implements FilterExpression {
 
-  private final String reference;
+  private final MetastoreColumn column;
   private final Operator operator;
   private final T value;
 
-  protected SimplePredicate(String reference, Operator operator, T value) {
-    this.reference = reference;
+  protected SimplePredicate(MetastoreColumn column, Operator operator, T value) {
+    this.column = column;
     this.operator = operator;
     this.value = value;
   }
 
-  public String reference() {
-    return reference;
+  public MetastoreColumn column() {
+    return column;
   }
 
   public T value() {
@@ -52,7 +54,7 @@ public abstract class SimplePredicate<T> implements FilterExpression {
   @Override
   public String toString() {
     return new StringJoiner(", ", SimplePredicate.class.getSimpleName() + "[", "]")
-      .add("reference=" + reference)
+      .add("column=" + column)
       .add("operator=" + operator)
       .add("value=" + value)
       .toString();
@@ -66,8 +68,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class Equal<T> extends SimplePredicate<T> {
 
-    public Equal(String reference, T value) {
-      super(reference, Operator.EQUAL, value);
+    public Equal(MetastoreColumn column, T value) {
+      super(column, Operator.EQUAL, value);
     }
 
     @Override
@@ -84,8 +86,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class NotEqual<T> extends SimplePredicate<T> {
 
-    public NotEqual(String reference, T value) {
-      super(reference, Operator.NOT_EQUAL, value);
+    public NotEqual(MetastoreColumn column, T value) {
+      super(column, Operator.NOT_EQUAL, value);
     }
 
     @Override
@@ -102,8 +104,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class LessThan<T> extends SimplePredicate<T> {
 
-    public LessThan(String reference, T value) {
-      super(reference, Operator.LESS_THAN, value);
+    public LessThan(MetastoreColumn column, T value) {
+      super(column, Operator.LESS_THAN, value);
     }
 
     @Override
@@ -120,8 +122,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class LessThanOrEqual<T> extends SimplePredicate<T> {
 
-    public LessThanOrEqual(String reference, T value) {
-      super(reference, Operator.LESS_THAN_OR_EQUAL, value);
+    public LessThanOrEqual(MetastoreColumn column, T value) {
+      super(column, Operator.LESS_THAN_OR_EQUAL, value);
     }
 
     @Override
@@ -138,8 +140,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class GreaterThan<T> extends SimplePredicate<T> {
 
-    public GreaterThan(String reference, T value) {
-      super(reference, Operator.GREATER_THAN, value);
+    public GreaterThan(MetastoreColumn column, T value) {
+      super(column, Operator.GREATER_THAN, value);
     }
 
     @Override
@@ -156,8 +158,8 @@ public abstract class SimplePredicate<T> implements FilterExpression {
    */
   public static class GreaterThanOrEqual<T> extends SimplePredicate<T> {
 
-    public GreaterThanOrEqual(String reference, T value) {
-      super(reference, Operator.GREATER_THAN_OR_EQUAL, value);
+    public GreaterThanOrEqual(MetastoreColumn column, T value) {
+      super(column, Operator.GREATER_THAN_OR_EQUAL, value);
     }
 
     @Override

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataInfo.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/MetadataInfo.java
@@ -40,9 +40,6 @@ public class MetadataInfo {
   public static final String GENERAL_INFO_KEY = "GENERAL_INFO";
   public static final String DEFAULT_SEGMENT_KEY = "DEFAULT_SEGMENT";
   public static final String DEFAULT_COLUMN_PREFIX = "_$SEGMENT_";
-  public static final String METADATA_TYPE = "metadataType";
-  public static final String METADATA_KEY = "metadataKey";
-  public static final String METADATA_IDENTIFIER = "metadataIdentifier";
 
   private final MetadataType type;
   private final String key;

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableInfo.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/metadata/TableInfo.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.drill.common.util.DrillStringUtils;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.components.tables.TableMetadataUnit;
 import org.apache.drill.metastore.expressions.FilterExpression;
 
@@ -43,10 +44,6 @@ public class TableInfo {
       .type(UNKNOWN)
       .owner(UNKNOWN)
       .build();
-
-  public static final String STORAGE_PLUGIN = "storagePlugin";
-  public static final String WORKSPACE = "workspace";
-  public static final String TABLE_NAME = "tableName";
 
   private final String storagePlugin;
   private final String workspace;
@@ -88,9 +85,9 @@ public class TableInfo {
   }
 
   public FilterExpression toFilter() {
-    FilterExpression storagePluginFilter = FilterExpression.equal(STORAGE_PLUGIN, storagePlugin);
-    FilterExpression workspaceFilter = FilterExpression.equal(WORKSPACE, workspace);
-    FilterExpression tableNameFilter = FilterExpression.equal(TABLE_NAME, name);
+    FilterExpression storagePluginFilter = FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, storagePlugin);
+    FilterExpression workspaceFilter = FilterExpression.equal(MetastoreColumn.WORKSPACE, workspace);
+    FilterExpression tableNameFilter = FilterExpression.equal(MetastoreColumn.TABLE_NAME, name);
     return FilterExpression.and(storagePluginFilter, workspaceFilter, tableNameFilter);
   }
 

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractModify.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractModify.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.operate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract implementation of {@link Modify<T>} interface which contains
+ * all boilerplace code for collecting overwrite units and delete operations.
+ * Delete operations metadata types are validated
+ * before adding to the list of pending delete operations.
+ *
+ * @param <T> Metastore metadata unit
+ */
+public abstract class AbstractModify<T> implements Modify<T> {
+
+  protected final List<T> overwriteUnits = new ArrayList<>();
+  protected final List<Delete> deletes = new ArrayList<>();
+
+  private final MetadataTypeValidator metadataTypeValidator;
+
+  protected AbstractModify(MetadataTypeValidator metadataTypeValidator) {
+    this.metadataTypeValidator = metadataTypeValidator;
+  }
+
+  @Override
+  public Modify<T> overwrite(List<T> units) {
+    overwriteUnits.addAll(units);
+    return this;
+  }
+
+  @Override
+  public Modify<T> delete(Delete delete) {
+    metadataTypeValidator.validate(delete.metadataTypes());
+    deletes.add(delete);
+    return this;
+  }
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractRead.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractRead.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.metastore.operate;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.MetadataType;
 
@@ -33,7 +34,7 @@ import java.util.List;
 public abstract class AbstractRead<T> implements Read<T> {
 
   protected final List<MetadataType> metadataTypes = new ArrayList<>();
-  protected final List<String> columns = new ArrayList<>();
+  protected final List<MetastoreColumn> columns = new ArrayList<>();
   protected FilterExpression filter;
 
   private final MetadataTypeValidator metadataTypeValidator;
@@ -55,7 +56,7 @@ public abstract class AbstractRead<T> implements Read<T> {
   }
 
   @Override
-  public Read<T> columns(List<String> columns) {
+  public Read<T> columns(List<MetastoreColumn> columns) {
     this.columns.addAll(columns);
     return this;
   }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractRead.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/AbstractRead.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.operate;
+
+import org.apache.drill.metastore.expressions.FilterExpression;
+import org.apache.drill.metastore.metadata.MetadataType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract implementation of {@link Read<T>} interface which contains
+ * all boilerplace code for collecting metadata types, columns and filter condition.
+ * Given metadata types are also validated during execution.
+ *
+ * @param <T> Metastore metadata unit
+ */
+public abstract class AbstractRead<T> implements Read<T> {
+
+  protected final List<MetadataType> metadataTypes = new ArrayList<>();
+  protected final List<String> columns = new ArrayList<>();
+  protected FilterExpression filter;
+
+  private final MetadataTypeValidator metadataTypeValidator;
+
+  protected AbstractRead (MetadataTypeValidator metadataTypeValidator) {
+    this.metadataTypeValidator = metadataTypeValidator;
+  }
+
+  @Override
+  public Read<T> metadataTypes(List<MetadataType> metadataTypes) {
+    this.metadataTypes.addAll(metadataTypes);
+    return this;
+  }
+
+  @Override
+  public Read<T> filter(FilterExpression filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  @Override
+  public Read<T> columns(List<String> columns) {
+    this.columns.addAll(columns);
+    return this;
+  }
+
+  @Override
+  public final List<T> execute() {
+    metadataTypeValidator.validate(metadataTypes);
+    return internalExecute();
+  }
+
+  protected abstract List<T> internalExecute();
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Delete.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Delete.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.operate;
+
+import org.apache.drill.metastore.expressions.FilterExpression;
+import org.apache.drill.metastore.metadata.MetadataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+
+/**
+ * Delete operation holder, it includes filter by which Metastore data will be deleted
+ * and list of metadata types to which filter will be applied.
+ *
+ * Note: providing at list one metadata type is required.
+ * If delete operation should be applied to all metadata types,
+ * {@link MetadataType#ALL} can be indicated.
+ */
+public class Delete {
+
+  private final List<MetadataType> metadataTypes;
+  private final FilterExpression filter;
+
+  private Delete(Builder builder) {
+    this.metadataTypes = builder.metadataTypes;
+    this.filter = builder.filter;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public List<MetadataType> metadataTypes() {
+    return metadataTypes;
+  }
+
+  public FilterExpression filter() {
+    return filter;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", Delete.class.getSimpleName() + "[", "]")
+      .add("metadataTypes=" + metadataTypes)
+      .add("filter=" + filter)
+      .toString();
+  }
+
+  public static class Builder {
+    private final List<MetadataType> metadataTypes = new ArrayList<>();
+    private FilterExpression filter;
+
+    public Builder metadataTypes(List<MetadataType> metadataTypes) {
+      this.metadataTypes.addAll(metadataTypes);
+      return this;
+    }
+
+    public Builder metadataType(MetadataType... metadataTypes) {
+      return metadataTypes(Arrays.asList(metadataTypes));
+    }
+
+    public Builder filter(FilterExpression filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    public Delete build() {
+      return new Delete(this);
+    }
+  }
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/MetadataTypeValidator.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/MetadataTypeValidator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.operate;
+
+import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.MetadataType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provides list of supported metadata types for concrete Metastore component unit
+ * and validates if given metadata types are supported.
+ */
+public interface MetadataTypeValidator {
+
+  /**
+   * @return list of supported metadata types for concrete Metastore component unit
+   */
+  List<MetadataType> supportedMetadataTypes();
+
+  /**
+   * Validates if given metadata types contain at least one metadata type
+   * and that all metadata types are supported.
+   *
+   * @param metadataTypes metadata types to be validated
+   * @throws MetastoreException if no metadata types were provided
+   *                            or given metadata types contain unsupported types
+   */
+  default void validate(List<MetadataType> metadataTypes) {
+    if (metadataTypes == null || metadataTypes.isEmpty()) {
+      throw new MetastoreException("Metadata type(s) must be indicated");
+    }
+
+    List<MetadataType> supportedMetadataTypes = supportedMetadataTypes();
+
+    List<MetadataType> unsupportedMetadataTypes = metadataTypes.stream()
+      .filter(metadataType -> !supportedMetadataTypes.contains(metadataType))
+      .collect(Collectors.toList());
+
+    if (!unsupportedMetadataTypes.isEmpty()) {
+      throw new MetastoreException("Unsupported metadata types are detected: " + unsupportedMetadataTypes);
+    }
+  }
+}

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Modify.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Modify.java
@@ -17,8 +17,6 @@
  */
 package org.apache.drill.metastore.operate;
 
-import org.apache.drill.metastore.expressions.FilterExpression;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +29,7 @@ import java.util.List;
 public interface Modify<T> {
 
   /**
-   * Adds overwrite operation for the Metastore component. For Metastore Tables compoenent,
+   * Adds overwrite operation for the Metastore component. For Metastore Tables component,
    * can be used to add new table data or replace partially / fully existing.
    * For example, if one of the table segments has changed,
    * all this segment data and table general information must be replaced with updated data.
@@ -48,27 +46,32 @@ public interface Modify<T> {
   }
 
   /**
-   * Adds delete operation for the Metastore component based on the given filter expression.
+   * Adds delete operation for the Metastore component based on the filter expression and metadata types.
    * For example for Metastore Tables component, if table has two segments
    * and data for one of the segments needs to be deleted.
    * Thus filter must be based on unique identifier of the table's top-level segment:
-   * storagePlugin = 'dfs' and workspace = 'tmp' and tableName = 'nation' and metadataKey = 'part_int=3'
+   * storagePlugin = 'dfs' and workspace = 'tmp' and tableName = 'nation' and metadataKey = 'part_int=3'.
+   * Metadata types should include all metadata types present in this segment:
+   * SEGMENT, FILE, ROW_GROUP, PARTITION.
+   * If all table metadata should be deleted, ALL segment can be indicated along with unique table identifier:
+   * storagePlugin = 'dfs' and workspace = 'tmp' and tableName = 'nation'.
    *
-   * @param filter filter expression
+   * @param delete delete operation holder
    * @return current instance of Modify interface implementation
    */
-  Modify<T> delete(FilterExpression filter);
-
-  /**
-   * Deletes all data from the Metastore component.
-   *
-   * @return current instance of Modify interface implementation
-   */
-  Modify<T> purge();
+  Modify<T> delete(Delete delete);
 
   /**
    * Executes list of provided metastore operations in one transaction if Metastore implementation
    * supports transactions, otherwise executes operations consecutively.
    */
   void execute();
+
+  /**
+   * Deletes all data from the Metastore component.
+   * Note, this is terminal operation and it does not take into account
+   * any previously set delete operations or overwrite units,
+   * it just deletes all data.
+   */
+  void purge();
 }

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Read.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Read.java
@@ -18,6 +18,7 @@
 package org.apache.drill.metastore.operate;
 
 import org.apache.drill.metastore.expressions.FilterExpression;
+import org.apache.drill.metastore.metadata.MetadataType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,20 @@ import java.util.List;
  * @param <T> component unit type
  */
 public interface Read<T> {
+
+  /**
+   * Provides list of metadata types to be read.
+   * Note: providing at least one metadata type is required.
+   * If all metadata types should be read, {@link MetadataType#ALL} can be passed.
+   *
+   * @param metadataTypes list of metadata types
+   * @return current instance of Read interface implementation
+   */
+  Read<T> metadataTypes(List<MetadataType> metadataTypes);
+
+  default Read<T> metadataType(MetadataType... metadataType) {
+    return metadataTypes(Arrays.asList(metadataType));
+  }
 
   /**
    * Provides filter expression by which metastore component data will be filtered.

--- a/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Read.java
+++ b/metastore/metastore-api/src/main/java/org/apache/drill/metastore/operate/Read.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.metastore.operate;
 
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.MetadataType;
 
@@ -63,15 +64,15 @@ public interface Read<T> {
    * @param columns list of columns to be read from Metastore component
    * @return current instance of Read interface implementation
    */
-  Read<T> columns(List<String> columns);
+  Read<T> columns(List<MetastoreColumn> columns);
 
-  default Read<T> columns(String... columns) {
+  default Read<T> columns(MetastoreColumn... columns) {
     return columns(Arrays.asList(columns));
   }
 
   /**
    * Executes read operation from Metastore component, returns obtained result in a form
-   * of list of component units  which later can be transformed into suitable format.
+   * of list of component units which later can be transformed into suitable format.
    *
    * @return list of component units
    */

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
@@ -20,6 +20,7 @@ package org.apache.drill.metastore.components.tables;
 import org.apache.drill.categories.MetastoreTest;
 import org.apache.drill.metastore.expressions.FilterExpression;
 import org.apache.drill.metastore.metadata.MetadataInfo;
+import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.drill.test.BaseTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -134,5 +135,25 @@ public class TestBasicTablesRequests extends BaseTest {
       customFilter);
 
     assertEquals(expected.toString(), requestMetadata.filter().toString());
+  }
+
+  @Test
+  public void testRequestMetadataWithMetadataType() {
+    BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
+      .metadataType(MetadataType.TABLE)
+      .build();
+
+    assertEquals(1, requestMetadata.metadataTypes().size());
+    assertEquals(MetadataType.TABLE, requestMetadata.metadataTypes().iterator().next());
+  }
+
+  @Test
+  public void testRequestMetadataWithMetadataTypes() {
+    BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
+      .metadataTypes(MetadataType.TABLE, MetadataType.SEGMENT)
+      .metadataTypes(Arrays.asList(MetadataType.PARTITION, MetadataType.FILE))
+      .build();
+
+    assertEquals(4, requestMetadata.metadataTypes().size());
   }
 }

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestBasicTablesRequests.java
@@ -18,8 +18,8 @@
 package org.apache.drill.metastore.components.tables;
 
 import org.apache.drill.categories.MetastoreTest;
+import org.apache.drill.metastore.MetastoreColumn;
 import org.apache.drill.metastore.expressions.FilterExpression;
-import org.apache.drill.metastore.metadata.MetadataInfo;
 import org.apache.drill.metastore.metadata.MetadataType;
 import org.apache.drill.test.BaseTest;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class TestBasicTablesRequests extends BaseTest {
 
   @Test
   public void testRequestMetadataWithRequestColumns() {
-    List<String> requestColumns = Arrays.asList("col1", "col2");
+    List<MetastoreColumn> requestColumns = Arrays.asList(MetastoreColumn.STORAGE_PLUGIN, MetastoreColumn.SCHEMA);
     BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
       .column("col")
       .metadataKeys(Arrays.asList("a", "b", "c"))
@@ -81,7 +81,7 @@ public class TestBasicTablesRequests extends BaseTest {
       .column("col")
       .build();
 
-    FilterExpression expected = FilterExpression.equal(BasicTablesRequests.COLUMN, "col");
+    FilterExpression expected = FilterExpression.equal(MetastoreColumn.COLUMN, "col");
 
     assertEquals(expected.toString(), requestMetadata.filter().toString());
   }
@@ -94,8 +94,8 @@ public class TestBasicTablesRequests extends BaseTest {
       .build();
 
     FilterExpression expected = FilterExpression.and(
-      FilterExpression.equal(BasicTablesRequests.LOCATION, "/tmp/dir"),
-      FilterExpression.equal(BasicTablesRequests.COLUMN, "col"));
+      FilterExpression.equal(MetastoreColumn.LOCATION, "/tmp/dir"),
+      FilterExpression.equal(MetastoreColumn.COLUMN, "col"));
 
     assertEquals(expected.toString(), requestMetadata.filter().toString());
   }
@@ -111,8 +111,8 @@ public class TestBasicTablesRequests extends BaseTest {
       .build();
 
     FilterExpression expected = FilterExpression.and(
-      FilterExpression.in(BasicTablesRequests.LOCATION, locations),
-      FilterExpression.in(MetadataInfo.METADATA_KEY, metadataKeys));
+      FilterExpression.in(MetastoreColumn.LOCATION, locations),
+      FilterExpression.in(MetastoreColumn.METADATA_KEY, metadataKeys));
 
     assertEquals(expected.toString(), requestMetadata.filter().toString());
   }
@@ -121,7 +121,7 @@ public class TestBasicTablesRequests extends BaseTest {
   public void testRequestMetadataWithCustomFilter() {
     String column = "col";
     List<String> metadataKeys = Arrays.asList("a", "b", "c");
-    FilterExpression customFilter = FilterExpression.equal("custom", true);
+    FilterExpression customFilter = FilterExpression.equal(MetastoreColumn.STORAGE_PLUGIN, "dfs");
 
     BasicTablesRequests.RequestMetadata requestMetadata = BasicTablesRequests.RequestMetadata.builder()
       .column(column)
@@ -130,8 +130,8 @@ public class TestBasicTablesRequests extends BaseTest {
       .build();
 
     FilterExpression expected = FilterExpression.and(
-      FilterExpression.equal(BasicTablesRequests.COLUMN, column),
-      FilterExpression.in(MetadataInfo.METADATA_KEY, metadataKeys),
+      FilterExpression.equal(MetastoreColumn.COLUMN, column),
+      FilterExpression.in(MetastoreColumn.METADATA_KEY, metadataKeys),
       customFilter);
 
     assertEquals(expected.toString(), requestMetadata.filter().toString());

--- a/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestTablesMetadataTypeValidator.java
+++ b/metastore/metastore-api/src/test/java/org/apache/drill/metastore/components/tables/TestTablesMetadataTypeValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.metastore.components.tables;
+
+import org.apache.drill.categories.MetastoreTest;
+import org.apache.drill.metastore.exceptions.MetastoreException;
+import org.apache.drill.metastore.metadata.MetadataType;
+import org.apache.drill.test.BaseTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@Category(MetastoreTest.class)
+public class TestTablesMetadataTypeValidator extends BaseTest {
+
+  @Test
+  public void testValidType() {
+    TablesMetadataTypeValidator.INSTANCE.validate(Collections.singletonList(MetadataType.ALL));
+    TablesMetadataTypeValidator.INSTANCE.validate(Collections.singletonList(MetadataType.TABLE));
+  }
+
+  @Test
+  public void testValidTypes() {
+    TablesMetadataTypeValidator.INSTANCE.validate(Arrays.asList(
+      MetadataType.TABLE,
+      MetadataType.SEGMENT,
+      MetadataType.FILE,
+      MetadataType.ROW_GROUP,
+      MetadataType.PARTITION));
+  }
+
+  @Test
+  public void testInvalidType() {
+    try {
+      TablesMetadataTypeValidator.INSTANCE.validate(Collections.singletonList(MetadataType.NONE));
+      fail();
+    } catch (MetastoreException e) {
+      assertThat(e.getMessage(), startsWith("Unsupported metadata types are detected"));
+    }
+  }
+
+  @Test
+  public void testValidAndInvalidTypes() {
+    try {
+      TablesMetadataTypeValidator.INSTANCE.validate(Arrays.asList(
+        MetadataType.TABLE,
+        MetadataType.ALL,
+        MetadataType.NONE,
+        MetadataType.VIEW));
+      fail();
+    } catch (MetastoreException e) {
+      assertThat(e.getMessage(), startsWith("Unsupported metadata types are detected"));
+    }
+  }
+}


### PR DESCRIPTION
# [DRILL-7672](https://issues.apache.org/jira/browse/DRILL-7672): Make metadata type required when reading from / writing into Drill Metastore

## Description

1. Upgraded Iceberg version and removed unneeded code for In / NotIn Expressions.
2. Updated Metastore Read / Modify interfaces to support required metadata types:
 a. introduced abstract Read / Modify classes with boilerplate code;
 b. added delete operation with filter and metadata type;
 c. added metadata type validator which checks supported metadata types for each component;
 d. made purge operation terminal;
 e. made necessary changes in REAME.md files.
3. Added / updated unit tests.

## Documentation
NA

## Testing
Added unit tests.
