### PR TITLE
DRILL-7678: Update Yauaa Dependency

### DIFF
--- a/contrib/udfs/pom.xml
+++ b/contrib/udfs/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>nl.basjes.parse.useragent</groupId>
       <artifactId>yauaa</artifactId>
-      <version>5.13</version>
+      <version>5.16</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentAnalyzerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.udfs;
+
+import nl.basjes.parse.useragent.UserAgentAnalyzer;
+
+public class UserAgentAnalyzerProvider {
+
+  public static UserAgentAnalyzer getInstance() {
+    return UserAgentAnalyzerHolder.INSTANCE;
+  }
+
+  private static class UserAgentAnalyzerHolder {
+    private static final UserAgentAnalyzer INSTANCE = UserAgentAnalyzer.newBuilder()
+            .dropTests()
+            .hideMatcherLoadStats()
+            .immediateInitialization()
+            .build();
+  }
+}

--- a/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentFunctions.java
+++ b/contrib/udfs/src/main/java/org/apache/drill/exec/udfs/UserAgentFunctions.java
@@ -46,11 +46,14 @@ public class UserAgentFunctions {
     DrillBuf outBuffer;
 
     @Workspace
-    nl.basjes.parse.useragent.UserAgentAnalyzerDirect uaa;
+    nl.basjes.parse.useragent.UserAgentAnalyzer uaa;
+
+    @Workspace
+    java.util.List<String> allFields;
 
     public void setup() {
-      uaa = nl.basjes.parse.useragent.UserAgentAnalyzerDirect.newBuilder().dropTests().hideMatcherLoadStats().build();
-      uaa.getAllPossibleFieldNamesSorted();
+      uaa = org.apache.drill.exec.udfs.UserAgentAnalyzerProvider.getInstance();
+      allFields = uaa.getAllPossibleFieldNamesSorted();
     }
 
     public void eval() {
@@ -60,7 +63,7 @@ public class UserAgentFunctions {
 
       nl.basjes.parse.useragent.UserAgent agent = uaa.parse(userAgentString);
 
-      for (String fieldName : agent.getAvailableFieldNamesSorted()) {
+      for (String fieldName: allFields) {
 
         org.apache.drill.exec.expr.holders.VarCharHolder rowHolder = new org.apache.drill.exec.expr.holders.VarCharHolder();
         String field = agent.getValue(fieldName);
@@ -92,11 +95,14 @@ public class UserAgentFunctions {
     DrillBuf outBuffer;
 
     @Workspace
-    nl.basjes.parse.useragent.UserAgentAnalyzerDirect uaa;
+    nl.basjes.parse.useragent.UserAgentAnalyzer uaa;
+
+    @Workspace
+    java.util.List<String> allFields;
 
     public void setup() {
-      uaa = nl.basjes.parse.useragent.UserAgentAnalyzerDirect.newBuilder().dropTests().hideMatcherLoadStats().build();
-      uaa.getAllPossibleFieldNamesSorted();
+      uaa = org.apache.drill.exec.udfs.UserAgentAnalyzerProvider.getInstance();
+      allFields = uaa.getAllPossibleFieldNamesSorted();
     }
 
     public void eval() {
@@ -111,7 +117,7 @@ public class UserAgentFunctions {
 
       nl.basjes.parse.useragent.UserAgent agent = uaa.parse(userAgentString);
 
-      for (String fieldName : agent.getAvailableFieldNamesSorted()) {
+      for (String fieldName: allFields) {
 
         org.apache.drill.exec.expr.holders.VarCharHolder rowHolder = new org.apache.drill.exec.expr.holders.VarCharHolder();
         String field = agent.getValue(fieldName);
@@ -146,11 +152,10 @@ public class UserAgentFunctions {
     DrillBuf outBuffer;
 
     @Workspace
-    nl.basjes.parse.useragent.UserAgentAnalyzerDirect uaa;
+    nl.basjes.parse.useragent.UserAgentAnalyzer uaa;
 
     public void setup() {
-      uaa = nl.basjes.parse.useragent.UserAgentAnalyzerDirect.newBuilder().dropTests().hideMatcherLoadStats().build();
-      uaa.getAllPossibleFieldNamesSorted();
+      uaa = org.apache.drill.exec.udfs.UserAgentAnalyzerProvider.getInstance();
     }
 
     public void eval() {

--- a/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
+++ b/contrib/udfs/src/test/java/org/apache/drill/exec/udfs/TestUserAgentFunctions.java
@@ -27,7 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 @Category({UnlikelyTest.class, SqlFunctionTest.class})
@@ -102,7 +102,7 @@ public class TestUserAgentFunctions extends ClusterTest {
   @Test
   public void testNullUserAgent() throws Exception {
     String query = "SELECT parse_user_agent(CAST(null as VARCHAR)) AS agent FROM (values(1))";
-    Map emptyMap = new HashMap();
+    Map<?, ?> emptyMap = Collections.emptyMap();
     testBuilder()
       .sqlQuery(query)
       .ordered()


### PR DESCRIPTION
# [DRILL-7678](https://issues.apache.org/jira/browse/DRILL-7678): Update Yauaa Dependency

## Description

This is to update the version of the useragent analyzer to the latest released version.
Changes:
- Update to latest version of Yauaa
- Extracted the instantiation of the analyzer into a separate class because the dynamic code compiler could not handle the way the classes and builders work together (see https://github.com/nielsbasjes/yauaa/issues/204 reported by @cgivre )
- Only 1 instance of the analyzer (saves a lot of memory)
- Now use the caching also present in the analyzer (i.e. do not use the 'Direct' version)
- Cache the 'allFields' as this has a direct performance impact.
- Fix a java warning around generics in the test class.

## Documentation
No changes.

## Testing
All existing tests were sufficient.
