### PR TITLE
DRILL-7683: Add "message parsing" to new JSON loader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiator.java
@@ -22,6 +22,9 @@ import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.server.options.OptionSet;
+
+import com.typesafe.config.Config;
 
 /**
  * Negotiates the table schema with the scanner framework and provides
@@ -100,6 +103,8 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 public interface SchemaNegotiator {
 
   OperatorContext context();
+  Config drillConfig();
+  OptionSet queryOptions();
 
   /**
    * Specify an advanced error context which allows the reader to

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/framework/SchemaNegotiatorImpl.java
@@ -21,7 +21,10 @@ import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.exec.ops.OperatorContext;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.vector.ValueVector;
+
+import com.typesafe.config.Config;
 
 /**
  * Implementation of the schema negotiation between scan operator and
@@ -91,6 +94,16 @@ public class SchemaNegotiatorImpl implements SchemaNegotiator {
   @Override
   public OperatorContext context() {
     return framework.context();
+  }
+
+  @Override
+  public Config drillConfig() {
+    return context().getFragmentContext().getConfig();
+  }
+
+  @Override
+  public OptionSet queryOptions() {
+    return context().getFragmentContext().getOptions();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoader.java
@@ -56,13 +56,7 @@ public interface JsonLoader {
    * @throws RuntimeException for unexpected errors, most often due
    * to code errors
    */
-  boolean next();
-
-  /**
-   * Indicates that a batch is complete. Tells the loader to materialize
-   * any deferred null fields. (See {@link TupleListener} for details.)
-   */
-  void endBatch();
+  boolean readBatch();
 
   /**
    * Releases resources held by this class including the input stream.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -33,7 +33,8 @@ import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.store.easy.json.parser.ErrorFactory;
 import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser;
 import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.JsonStructureParserBuilder;
-import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.MessageParser;
+import org.apache.drill.exec.store.easy.json.parser.MessageParser;
+import org.apache.drill.exec.store.easy.json.parser.MessageParser.MessageContextException;
 import org.apache.drill.exec.store.easy.json.parser.ValueDef;
 import org.apache.drill.exec.store.easy.json.parser.ValueDef.JsonType;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
@@ -383,6 +384,16 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
           .message("JSON reader does not arrays deeper than two levels")
           .addContext("Field", key)
           .addContext("Array nesting", dims));
+  }
+
+  @Override
+  public RuntimeException messageParseError(MessageContextException e) {
+    return buildError(
+        UserException.validationError(e)
+          .message("Syntax error when parsing a JSON message")
+          .addContext(e.getMessage())
+          .addContext("Looking for field", e.nextElement)
+          .addContext("On token", e.token.name()));
   }
 
   protected UserException buildError(ColumnMetadata schema, UserException.Builder builder) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderOptions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderOptions.java
@@ -17,6 +17,8 @@
  */
 package org.apache.drill.exec.store.easy.json.loader;
 
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.options.OptionSet;
 import org.apache.drill.exec.store.easy.json.parser.JsonStructureOptions;
 
 /**
@@ -41,4 +43,11 @@ public class JsonLoaderOptions extends JsonStructureOptions {
    * </ul>
    */
   public boolean classicArrayNulls;
+
+  public JsonLoaderOptions() { }
+
+  public JsonLoaderOptions(OptionSet options) {
+    super(options);
+    this.readNumbersAsDouble = options.getBoolean(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ErrorFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/ErrorFactory.java
@@ -69,8 +69,14 @@ public interface ErrorFactory {
   RuntimeException syntaxError(JsonToken token);
 
   /**
-   * Error recover is on, the structure parser tried to recover, but
+   * Error recovery is on, the structure parser tried to recover, but
    * encountered too many other errors and gave up.
    */
   RuntimeException unrecoverableError();
+
+  /**
+   * Parser is configured to find a message tag within the JSON
+   * and a syntax occurred when following the data path.
+   */
+  RuntimeException messageParseError(MessageParser.MessageContextException e);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureOptions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureOptions.java
@@ -17,6 +17,9 @@
  */
 package org.apache.drill.exec.store.easy.json.parser;
 
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.server.options.OptionSet;
+
 /**
  * Input to the JSON structure parser which defines guidelines
  * for low-level parsing as well as listeners for higher-level
@@ -51,4 +54,15 @@ public class JsonStructureOptions {
    * two or three valid records before it stabilizes.
    */
   public boolean skipMalformedRecords;
+
+  public boolean enableEscapeAnyChar;
+
+  public JsonStructureOptions() { }
+
+  public JsonStructureOptions(OptionSet options) {
+    this.allTextMode = options.getBoolean(ExecConstants.JSON_ALL_TEXT_MODE);
+    this.allowNanInf = options.getBoolean(ExecConstants.JSON_READER_NAN_INF_NUMBERS);
+    this.skipMalformedRecords = options.getBoolean(ExecConstants.JSON_READER_SKIP_INVALID_RECORDS_FLAG);
+    this.enableEscapeAnyChar = options.getBoolean(ExecConstants.JSON_READER_ESCAPE_ANY_CHAR);
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
@@ -19,7 +19,9 @@ package org.apache.drill.exec.store.easy.json.parser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 
+import org.apache.drill.exec.store.easy.json.parser.RootParser.NestedRootArrayParser;
 import org.apache.drill.exec.store.easy.json.parser.RootParser.RootArrayParser;
 import org.apache.drill.exec.store.easy.json.parser.RootParser.RootObjectParser;
 import org.apache.drill.exec.store.easy.json.parser.TokenIterator.RecoverableJsonException;
@@ -59,6 +61,54 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class JsonStructureParser {
   protected static final Logger logger = LoggerFactory.getLogger(JsonStructureParser.class);
 
+  public interface MessageParser {
+    boolean parsePrefix(TokenIterator tokenizer);
+    void parseSuffix(TokenIterator tokenizer);
+  }
+
+  public static class JsonStructureParserBuilder {
+    private InputStream stream;
+    private Reader reader;
+    private JsonStructureOptions options;
+    private ObjectListener rootListener;
+    private ErrorFactory errorFactory;
+    private MessageParser messageParser;
+
+    public JsonStructureParserBuilder options(JsonStructureOptions options) {
+      this.options = options;
+      return this;
+    }
+
+    public JsonStructureParserBuilder rootListener(ObjectListener rootListener) {
+      this.rootListener = rootListener;
+      return this;
+    }
+
+    public JsonStructureParserBuilder errorFactory(ErrorFactory errorFactory) {
+      this.errorFactory = errorFactory;
+      return this;
+    }
+
+    public JsonStructureParserBuilder fromStream(InputStream stream) {
+      this.stream = stream;
+      return this;
+    }
+
+    public JsonStructureParserBuilder fromReader(Reader reader) {
+      this.reader = reader;
+      return this;
+    }
+
+    public JsonStructureParserBuilder messageParser(MessageParser messageParser) {
+      this.messageParser = messageParser;
+      return this;
+    }
+
+    public JsonStructureParser build() {
+      return new JsonStructureParser(this);
+    }
+  }
+
   private final JsonParser parser;
   private final JsonStructureOptions options;
   private final ObjectListener rootListener;
@@ -78,30 +128,45 @@ public class JsonStructureParser {
    * @param errorFactory factory for errors thrown for various
    * conditions
    */
-  public JsonStructureParser(InputStream stream, JsonStructureOptions options,
-      ObjectListener rootListener, ErrorFactory errorFactory) {
-    this.options = Preconditions.checkNotNull(options);
-    this.rootListener = Preconditions.checkNotNull(rootListener);
-    this.errorFactory = Preconditions.checkNotNull(errorFactory);
+  private JsonStructureParser(JsonStructureParserBuilder builder) {
+    this.options = Preconditions.checkNotNull(builder.options);
+    this.rootListener = Preconditions.checkNotNull(builder.rootListener);
+    this.errorFactory = Preconditions.checkNotNull(builder.errorFactory);
     try {
       ObjectMapper mapper = new ObjectMapper()
           .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
           .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
-          .configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, options.allowNanInf);
+          .configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, options.allowNanInf)
+          .configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, options.enableEscapeAnyChar);
 
-      parser = mapper.getFactory().createParser(stream);
+      if (builder.stream != null) {
+        parser = mapper.getFactory().createParser(builder.stream);
+      } else {
+        parser = mapper.getFactory().createParser(Preconditions.checkNotNull(builder.reader));
+      }
     } catch (JsonParseException e) {
       throw errorFactory().parseError("Failed to create the JSON parser", e);
     } catch (IOException e) {
       throw errorFactory().ioException(e);
     }
     tokenizer = new TokenIterator(parser, options, errorFactory());
-    rootState = makeRootState();
+    if (builder.messageParser == null) {
+      rootState = makeRootState();
+    } else {
+      rootState = makeCustomRoot(builder.messageParser);
+    }
   }
 
   public JsonStructureOptions options() { return options; }
   public ErrorFactory errorFactory() { return errorFactory; }
   public ObjectListener rootListener() { return rootListener; }
+
+  private RootParser makeCustomRoot(MessageParser messageParser) {
+    if (! messageParser.parsePrefix(tokenizer)) {
+      return null;
+    }
+    return new NestedRootArrayParser(this, messageParser);
+  }
 
   private RootParser makeRootState() {
     JsonToken token = tokenizer.next();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/MessageParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/MessageParser.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * Optional custom parser for the portion of a JSON message that
+ * surrounds the data "payload". Can be used to extract status codes.
+ * See {@link SimpleMessageParser} to simply skip all fields but
+ * a given path.
+ */
+public interface MessageParser {
+
+  @SuppressWarnings("serial")
+  class MessageContextException extends Exception {
+    public final JsonToken token;
+    public final String nextElement;
+
+    public MessageContextException(JsonToken token, String nextElement, String descrip) {
+      super(descrip);
+      this.token = token;
+      this.nextElement = nextElement;
+    }
+  }
+  boolean parsePrefix(TokenIterator tokenizer) throws MessageContextException;
+  void parseSuffix(TokenIterator tokenizer) throws MessageContextException;
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.easy.json.parser;
 
+import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.MessageParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +113,35 @@ public abstract class RootParser implements ElementParser {
             tokenizer.context());
         return false;
       } else if (token == JsonToken.END_ARRAY) {
+        return false;
+      } else {
+        return parseRootObject(token, tokenizer);
+      }
+    }
+  }
+
+  public static class NestedRootArrayParser extends RootParser {
+
+    private final MessageParser messageParser;
+
+    public NestedRootArrayParser(JsonStructureParser structParser, MessageParser messageParser) {
+      super(structParser);
+      this.messageParser = messageParser;
+    }
+
+    @Override
+    public boolean parseRoot(TokenIterator tokenizer) {
+      JsonToken token = tokenizer.next();
+      if (token == null) {
+        // Position: { ... EOF ^
+        // Saw EOF, but no closing ]. Warn and ignore.
+        // Note that the Jackson parser won't let us get here;
+        // it will have already thrown a syntax error.
+        logger.warn("Failed to close outer array. {}",
+            tokenizer.context());
+        return false;
+      } else if (token == JsonToken.END_ARRAY) {
+        messageParser.parseSuffix(tokenizer);
         return false;
       } else {
         return parseRootObject(token, tokenizer);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.store.easy.json.parser;
 
-import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.MessageParser;
+import org.apache.drill.exec.store.easy.json.parser.MessageParser.MessageContextException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +141,11 @@ public abstract class RootParser implements ElementParser {
             tokenizer.context());
         return false;
       } else if (token == JsonToken.END_ARRAY) {
-        messageParser.parseSuffix(tokenizer);
+        try {
+          messageParser.parseSuffix(tokenizer);
+        } catch (MessageContextException e) {
+          throw errorFactory().messageParseError(e);
+        }
         return false;
       } else {
         return parseRootObject(token, tokenizer);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/SimpleMessageParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/SimpleMessageParser.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+/**
+ * A message parser which accepts a path to the data encoded as a
+ * slash-separated string. Given the following JSON message:
+ *
+ * <pre><code:
+ * { status: {
+ *     succeeded: true,
+ *     runTimeMs: 123,
+ *   }
+ *   response: {
+ *     rowCount: 10,
+ *     rows: [
+ *       { ... },
+ *       { ... } ]
+ *     },
+ *   footer: "something interesting"
+ *  }
+ * </code></pre>
+ *
+ * The path to the actual data would be {@code "response/rows"}.
+ * <p>
+ * The message parser will "free-wheel" over all objects not on the
+ * data path. Thus, this class will skip over the nested structure
+ * within the {@code status} member.
+ * <p>
+ * If the data path is not found then this class reports EOF of
+ * the whole data stream. It may have skipped over the actual payload
+ * if the path is mis-configured.
+ */
+public class SimpleMessageParser implements MessageParser {
+
+  private final String[] path;
+
+  public SimpleMessageParser(String dataPath) {
+    path = dataPath.split("/");
+    Preconditions.checkArgument(path.length > 0,
+        "Data path should not be empty.");
+  }
+
+  @Override
+  public boolean parsePrefix(TokenIterator tokenizer) throws MessageContextException {
+    JsonToken token = tokenizer.next();
+    if (token == null) {
+      return false;
+    }
+    if (token != JsonToken.START_OBJECT) {
+      throw new MessageContextException(token,
+          path[0], "Unexpected top-level array");
+    }
+    return parseToElement(tokenizer, 0);
+  }
+
+  private boolean parseToElement(TokenIterator tokenizer, int level) throws MessageContextException {
+    for (;;) {
+      JsonToken token = tokenizer.requireNext();
+      switch (token) {
+        case FIELD_NAME:
+          break;
+        case END_OBJECT:
+          return false;
+        default:
+          throw new MessageContextException(token,
+              path[0], "Unexpected token");
+      }
+
+      String fieldName = tokenizer.textValue();
+      if (fieldName.equals(path[level])) {
+        return parseInnerLevel(tokenizer, level);
+      } else {
+        skipElement(tokenizer);
+      }
+    }
+  }
+
+  private boolean parseInnerLevel(TokenIterator tokenizer, int level) throws MessageContextException {
+    JsonToken token = tokenizer.requireNext();
+    if (level == path.length - 1) {
+      switch (token) {
+      case VALUE_NULL:
+        return false;
+      case START_ARRAY:
+        return true;
+      default:
+        throw new MessageContextException(token,
+            path[level], "Expected JSON array for final path element");
+      }
+    }
+    if (token != JsonToken.START_OBJECT) {
+      throw new MessageParser.MessageContextException(token,
+          path[level], "Expected JSON object");
+    }
+    return parseToElement(tokenizer, level + 1);
+  }
+
+  private void skipElement(TokenIterator tokenizer) {
+    int level = 0;
+    do {
+      JsonToken token = tokenizer.requireNext();
+      switch (token) {
+        case START_OBJECT:
+        case START_ARRAY:
+          level++;
+          break;
+        case END_OBJECT:
+        case END_ARRAY:
+          level--;
+          break;
+        default:
+          break;
+      }
+    } while (level > 0);
+  }
+
+  @Override
+  public void parseSuffix(TokenIterator tokenizer) {
+    // No need to parse the unwanted tail elements.
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
@@ -64,37 +64,42 @@ public class BaseTestJsonParser {
 
     @Override
     public RuntimeException parseError(String msg, JsonParseException e) {
-      throw new JsonErrorFixture("parseError", msg, e);
+      return new JsonErrorFixture("parseError", msg, e);
     }
 
     @Override
     public RuntimeException ioException(IOException e) {
-      throw new JsonErrorFixture("ioException", "", e);
+      return new JsonErrorFixture("ioException", "", e);
     }
 
     @Override
     public RuntimeException structureError(String msg) {
-      throw new JsonErrorFixture("structureError", msg);
+      return new JsonErrorFixture("structureError", msg);
     }
 
     @Override
     public RuntimeException syntaxError(JsonParseException e) {
-      throw new JsonErrorFixture("syntaxError", "", e);
+      return new JsonErrorFixture("syntaxError", "", e);
     }
 
     @Override
     public RuntimeException typeError(UnsupportedConversionError e) {
-      throw new JsonErrorFixture("typeError", "", e);
+      return new JsonErrorFixture("typeError", "", e);
     }
 
     @Override
     public RuntimeException syntaxError(JsonToken token) {
-      throw new JsonErrorFixture("syntaxError", token.toString());
+      return new JsonErrorFixture("syntaxError", token.toString());
     }
 
     @Override
     public RuntimeException unrecoverableError() {
-      throw new JsonErrorFixture("unrecoverableError", "");
+      return new JsonErrorFixture("unrecoverableError", "");
+    }
+
+    @Override
+    public RuntimeException messageParseError(MessageParser.MessageContextException e) {
+      return new JsonErrorFixture("messageParseError", "Message parse error", e);
     }
   }
 

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.JsonStructureParserBuilder;
 import org.apache.drill.exec.vector.accessor.UnsupportedConversionError;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -252,16 +253,25 @@ public class BaseTestJsonParser {
   }
 
   protected static class JsonParserFixture {
+    JsonStructureParserBuilder builder;
     JsonStructureOptions options = new JsonStructureOptions();
     JsonStructureParser parser;
     ObjectListenerFixture rootObject = new ObjectListenerFixture();
     ErrorFactory errorFactory = new ErrorFactoryFixture();
 
+    public JsonParserFixture() {
+      builder = new JsonStructureParserBuilder();
+    }
+
     public void open(String json) {
       InputStream inStream = new
           ReaderInputStream(new StringReader(json));
-      parser = new JsonStructureParser(inStream, options, rootObject,
-          errorFactory);
+      builder
+          .fromStream(inStream)
+          .options(options)
+          .rootListener(rootObject)
+          .errorFactory(errorFactory);
+      parser = builder.build();
     }
 
     public boolean next() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserBasics.java
@@ -24,10 +24,13 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashSet;
 
 import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.exec.store.easy.json.parser.JsonStructureParser.MessageParser;
 import org.apache.drill.exec.store.easy.json.parser.ObjectListener.FieldType;
 import org.apache.drill.exec.store.easy.json.parser.ValueDef.JsonType;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import com.fasterxml.jackson.core.JsonToken;
 
 /**
  * Tests JSON structure parser functionality excluding nested objects
@@ -321,6 +324,66 @@ public class TestJsonParserBasics extends BaseTestJsonParser {
     fixture.expect("a",
         new Object[] {"{}", "{\"b\": null}", "{\"b\": null, \"b\": null}",
             "{\"b\": {\"c\": {\"d\": [{\"e\": 10}, null, 20], \"f\": \"foo\"}, \"g\": 30}, \"h\": 40}"});
+    assertFalse(fixture.next());
+    fixture.close();
+  }
+
+  /**
+   * Example message parser. A real parser would provide much better
+   * error messages for badly-formed JSON or error codes.
+   */
+  private static class MessageParserFixture implements MessageParser {
+
+    @Override
+    public boolean parsePrefix(TokenIterator tokenizer) {
+      assertEquals(JsonToken.START_OBJECT, tokenizer.requireNext());
+      assertEquals(JsonToken.FIELD_NAME, tokenizer.requireNext());
+      assertEquals(JsonToken.VALUE_STRING, tokenizer.requireNext());
+      if (!"ok".equals(tokenizer.stringValue())) {
+        return false;
+      }
+      assertEquals(JsonToken.FIELD_NAME, tokenizer.requireNext());
+      assertEquals(JsonToken.START_ARRAY, tokenizer.requireNext());
+      return true;
+    }
+
+    @Override
+    public void parseSuffix(TokenIterator tokenizer) {
+      assertEquals(JsonToken.END_OBJECT, tokenizer.requireNext());
+    }
+  }
+
+  /**
+   * Test the ability to wrap the data objects with a custom message
+   * structure, typical of a REST call.
+   */
+  @Test
+  public void testMessageParser() {
+    final String json =
+        "{ status: \"ok\", data: [{a: 0}, {a: 100}, {a: null}]}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
+    assertTrue(fixture.next());
+    ValueListenerFixture a = fixture.field("a");
+    assertEquals(JsonType.INTEGER, a.valueDef.type());
+    assertEquals(2, fixture.read());
+    assertEquals(1, a.nullCount);
+    assertEquals(100L, a.value);
+    fixture.close();
+  }
+
+  /**
+   * Test the ability to cancel the data load if a message header
+   * indicates that there is no data.
+   */
+  @Test
+  public void testMessageParserEOF() {
+    final String json =
+        "{ status: \"fail\", data: [{a: 0}, {a: 100}, {a: null}]}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
     assertFalse(fixture.next());
     fixture.close();
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserMessage.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserMessage.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.easy.json.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.exec.store.easy.json.parser.ValueDef.JsonType;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+public class TestJsonParserMessage extends BaseTestJsonParser {
+
+  /**
+   * Example message parser. A real parser would provide much better
+   * error messages for badly-formed JSON or error codes.
+   */
+  private static class MessageParserFixture implements MessageParser {
+
+    @Override
+    public boolean parsePrefix(TokenIterator tokenizer) {
+      assertEquals(JsonToken.START_OBJECT, tokenizer.requireNext());
+      assertEquals(JsonToken.FIELD_NAME, tokenizer.requireNext());
+      assertEquals(JsonToken.VALUE_STRING, tokenizer.requireNext());
+      if (!"ok".equals(tokenizer.stringValue())) {
+        return false;
+      }
+      assertEquals(JsonToken.FIELD_NAME, tokenizer.requireNext());
+      assertEquals(JsonToken.START_ARRAY, tokenizer.requireNext());
+      return true;
+    }
+
+    @Override
+    public void parseSuffix(TokenIterator tokenizer) {
+      assertEquals(JsonToken.END_OBJECT, tokenizer.requireNext());
+    }
+  }
+
+  /**
+   * Test the ability to wrap the data objects with a custom message
+   * structure, typical of a REST call.
+   */
+  @Test
+  public void testMessageParser() {
+    final String json =
+        "{ status: \"ok\", data: [{a: 0}, {a: 100}, {a: null}]}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
+    assertTrue(fixture.next());
+    ValueListenerFixture a = fixture.field("a");
+    assertEquals(JsonType.INTEGER, a.valueDef.type());
+    assertEquals(2, fixture.read());
+    assertEquals(1, a.nullCount);
+    assertEquals(100L, a.value);
+    fixture.close();
+  }
+
+  /**
+   * Test the ability to cancel the data load if a message header
+   * indicates that there is no data.
+   */
+  @Test
+  public void testMessageParserEOF() {
+    final String json =
+        "{ status: \"fail\", data: [{a: 0}, {a: 100}, {a: null}]}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
+    assertFalse(fixture.next());
+    fixture.close();
+  }
+
+  @Test
+  public void testDataPath() {
+    final String json =
+        "{ status: \"ok\", data: [{a: 0}, {a: 100}, {a: null}]}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.dataPath("data");
+    fixture.open(json);
+    assertTrue(fixture.next());
+    ValueListenerFixture a = fixture.field("a");
+    assertEquals(JsonType.INTEGER, a.valueDef.type());
+    assertEquals(2, fixture.read());
+    assertEquals(1, a.nullCount);
+    assertEquals(100L, a.value);
+    fixture.close();
+  }
+
+  @Test
+  public void testComplexDataPath() {
+    final String json =
+        "{ status: {result : \"ok\", runtime: 123},\n" +
+        "  response: { rowCount: 1,\n" +
+        "    data: [{a: 0}, {a: 100}, {a: null}]},\n" +
+        "  footer: \"some stuff\"}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.dataPath("response/data");
+    fixture.open(json);
+    assertTrue(fixture.next());
+    ValueListenerFixture a = fixture.field("a");
+    assertEquals(JsonType.INTEGER, a.valueDef.type());
+    assertEquals(2, fixture.read());
+    assertEquals(1, a.nullCount);
+    assertEquals(100L, a.value);
+    fixture.close();
+  }
+
+  @Test
+  public void testDataPathNull() {
+    final String json =
+        "{ status: \"fail\", data: null}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
+    assertFalse(fixture.next());
+    fixture.close();
+  }
+
+  @Test
+  public void testDataPathMissing() {
+    final String json =
+        "{ status: \"fail\"}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.messageParser(new MessageParserFixture());
+    fixture.open(json);
+    assertFalse(fixture.next());
+    fixture.close();
+  }
+
+  @Test
+  public void testDataPathErrorRoot() {
+    final String json = "\"Bogus!\"";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.dataPath("data");
+    try {
+      fixture.open(json);
+      fail();
+    } catch (JsonErrorFixture e) {
+      assertTrue(e.errorType.equals("messageParseError"));
+      assertTrue(e.getCause() instanceof MessageParser.MessageContextException);
+    }
+    fixture.close();
+  }
+
+  @Test
+  public void testDataPathErrorLeaf() {
+    final String json =
+        "{ status: \"bogus\", data: { notValid: \"must be array\"}}";
+    JsonParserFixture fixture = new JsonParserFixture();
+    fixture.builder.dataPath("data");
+    try {
+      fixture.open(json);
+      fail();
+    } catch (JsonErrorFixture e) {
+      assertTrue(e.errorType.equals("messageParseError"));
+      assertTrue(e.getCause() instanceof MessageParser.MessageContextException);
+    }
+    fixture.close();
+  }
+}


### PR DESCRIPTION
# [DRILL-7683](https://issues.apache.org/jira/browse/DRILL-7683): Add "message parsing" to new JSON loader

## Description

Worked on a project that uses the new JSON loader to parse a REST response that includes a set of "wrapper" fields around the JSON payload. Example:

```
{ "status": "ok", "results: [ data here ]}
```

To solve this cleanly, added the ability to specify a "message parser" to consume JSON tokens up to the start of the data. This parser can be written as needed for each different data source.

When working on the REST data source, it became clear we need a no-code way to handle the same issue. So, extended the message parser to handle the simple case, a path to the data. In the above, the path would be just `results`. The path can contain any number of slash-separated elements: `response/body/rows` for example.

Since this change adds two more parameters to the JSON structure parser, added builders to gather the needed parameters rather than making the constructor even larger.

Note that, aside from the private plugin mentioned above, no other code uses the JSON loader yet.

## Developer Documentation

This PR is part of the "new" V2 EVF-based JSON parser. An example of usage appears in PR #1892 (REST storage plugin.) To use the simple path-based form of message parsing, add the following option to the JSON parser builder:

```
    .dataPath("path/to/data")
```

The tail element should be the one that holds an array of JSON records.

To add custom message parsing (to check return status, say), use a different option of the builder:

```
      .messageParser(parser)
```

Then implement the `MessageParser` class to do the parsing. The present version works at the level of JSON tokens: you must use the provided "tokenizer" to read each token and do the right thing.

Since working at the token level is tedious, the goal is to provide a read-made parser that takes a path to the data, such as "response.data" and skips all fields except those in the path.

The goal here is to get the mechanism added to the JSON parser so we can then try it in the REST plugin and work out exactly what we need in that higher-level parser level.

## User Documentation

N/A

## Testing

Added unit tests. Reran all existing tests.