### PR TITLE
DRILL-7680: Place UDFs before plugins in contrib

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -39,6 +39,8 @@
   </dependencies>
 
   <modules>
+    <module>data</module>
+    <module>udfs</module>
     <module>storage-hbase</module>
     <module>format-maprdb</module>
     <module>format-syslog</module>
@@ -52,8 +54,6 @@
     <module>storage-kafka</module>
     <module>storage-kudu</module>
     <module>storage-opentsdb</module>
-    <module>data</module>
-    <module>udfs</module>
   </modules>
 
 </project>


### PR DESCRIPTION
# [DRILL-7680](https://issues.apache.org/jira/browse/DRILL-7680): Place UDFs before plugins in contrib

## Description

Several contrib plugins depend on UDFs for testing. However, the UDFs occur after the plugins in build order. This PR reverses the dependencies so that UDFs are built before the plguins that want to use them.

For example, suppose you add a new `Foo` data source that needs some UDFs. You want to test the `Foo` data source. But, you find that your tests cannot find your UDFs. After a bit of frustrating debugging, you find that your UDFs are not on your debug class path. Why? Because the UDFs appear in the build order after the storage plugins.

Since it is more often the case that a plugin (or its tests) depend on a UDF than the other way around, went ahead and reversed the order.

For developers, if you want to test a contributed UDF with a contributed plugin; put the test in the plugin project, not the UDF project.

## Documentation

N/A

## Testing

Did a full build, with unit tests, to ensure everything still works.
