### PR TITLE
DRILL-7429: Wrong column order when selecting complex data using Hive storage plugin

### DIFF
--- a/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
+++ b/contrib/storage-hive/core/src/test/java/org/apache/drill/exec/hive/complex_types/TestHiveStructs.java
@@ -22,10 +22,14 @@ import java.nio.file.Paths;
 
 import org.apache.drill.categories.HiveStorageTest;
 import org.apache.drill.categories.SlowTest;
+import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.hive.HiveClusterTest;
 import org.apache.drill.exec.hive.HiveTestFixture;
 import org.apache.drill.exec.hive.HiveTestUtilities;
+import org.apache.drill.exec.record.BatchSchema;
+import org.apache.drill.exec.record.BatchSchemaBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.util.JsonStringHashMap;
 import org.apache.drill.exec.util.StoragePluginTestUtils;
 import org.apache.drill.exec.util.Text;
@@ -231,6 +235,21 @@ public class TestHiveStructs extends HiveClusterTest {
         .baselineValues(STR_N0_ROW_1)
         .baselineValues(STR_N0_ROW_2)
         .baselineValues(STR_N0_ROW_3)
+        .go();
+  }
+
+  @Test // DRILL-7429
+  public void testCorrectColumnOrdering() throws Exception {
+    BatchSchema expectedSchema = new BatchSchemaBuilder()
+        .withSchemaBuilder(new SchemaBuilder()
+            .addMap("a").resumeSchema()
+            .addNullable("b", TypeProtos.MinorType.INT))
+        .build();
+
+    String sql = "SELECT t.str_n0 a, rid b FROM hive.struct_tbl t LIMIT 1";
+    testBuilder()
+        .sqlQuery(sql)
+        .schemaBaseLine(expectedSchema)
         .go();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/project/ProjectBatchBuilder.java
@@ -17,9 +17,6 @@
  */
 package org.apache.drill.exec.physical.impl.project;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.drill.common.expression.FieldReference;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
@@ -32,9 +29,13 @@ import org.apache.drill.exec.record.TypedFieldId;
 import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.vector.FixedWidthVector;
 import org.apache.drill.exec.vector.SchemaChangeCallBack;
+import org.apache.drill.exec.vector.UntypedNullHolder;
 import org.apache.drill.exec.vector.ValueVector;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Implements callbacks to build the physical vectors for the project
@@ -100,7 +101,11 @@ public class ProjectBatchBuilder implements ProjectionMaterializer.BatchBuilder 
     } else {
       projectBatch.complexFieldReferencesList.clear();
     }
-
+    // reserve place for complex field in container
+    ValueVector lateVv = container.addOrGet(
+        MaterializedField.create(ref.getLastSegment().getNameSegment().getPath(), UntypedNullHolder.TYPE),
+        callBack);
+    projectBatch.allocationVectors.add(lateVv);
     // save the field reference for later for getting schema when input is empty
     projectBatch.complexFieldReferencesList.add(ref);
     projectBatch.memoryManager.addComplexField(null); // this will just add an estimate to the row width

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/union/UnionAllRecordBatch.java
@@ -198,6 +198,7 @@ public class UnionAllRecordBatch extends AbstractBinaryRecordBatch<UnionAll> {
         TransferPair tp = vvIn.makeTransferPair(vvOut);
         transfers.add(tp);
       } else if (inField.getType().getMinorType() == TypeProtos.MinorType.NULL) {
+        index++;
         continue;
       } else { // Copy data in order to rename the column
         SchemaPath inputPath = SchemaPath.getSimplePath(inField.getName());


### PR DESCRIPTION

# [DRILL-7429](https://issues.apache.org/jira/browse/DRILL-7429): Wrong column order when selecting complex data using Hive storage plugin

## Description

Column ordering was wrong when the first selected column had type STRUCT and second had a primitive type. 

## Documentation

No need to document it.

## Testing

Added unit test in TestHiveStructs. 