### PR TITLE
DRILL-7692: Add dropdown to select default storage

### DIFF
--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -82,7 +82,17 @@
       Submit
     </button>
     <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
-    <label> Default Schema <input type="text" size="10" name="defaultSchema" id="defaultSchema"> </label>
+    <label for="defaultSchema">
+      Default Schema
+      <input type="text" name="defaultSchema" id="defaultSchema" list="enabledPlugins" placeholder="-- default schema --">
+      <datalist id="enabledPlugins">
+        <#list model.getEnabledPlugins() as pluginModel>
+          <#if pluginModel.getPlugin()?? && pluginModel.getPlugin().enabled() == true>
+            <option value="${pluginModel.getPlugin().getName()}">
+          </#if>
+        </#list>
+      </datalist>
+    </label>
     <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names, and for SHOW FILES and SHOW TABLES" style="cursor:pointer"></span>
     <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
   </form>


### PR DESCRIPTION
# [DRILL-7692](https://issues.apache.org/jira/browse/DRILL-7692): Select default schema from enabled storage plugins in query page
## Description
In v1.18.0, users specify a schema through an input field but this is error prone and doesn't restrict options to enabled storage plugins.

![image](https://user-images.githubusercontent.com/24235441/78713950-08e28f00-78e9-11ea-9085-a5cacda280ac.png)

 I propose that it be changed to a dropdown that lists enabled storages as options, and automatically defaults if there is only one available storage.

![image](https://user-images.githubusercontent.com/24235441/78830136-7a880f00-79b5-11ea-8805-4091ad261720.png)


## Documentation
N/A

## Testing
Manually tested through Web UI both locally and in Shopify's production deployment of Apache Drill.
https://drill.shopifycloud.com/query