### PR TITLE
DRILL-7694: Register drill.queries.* counter metrics on Drillbit startup

### DIFF
--- a/common/src/main/java/org/apache/drill/exec/metrics/DrillCounters.java
+++ b/common/src/main/java/org/apache/drill/exec/metrics/DrillCounters.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.metrics;
+
+import com.codahale.metrics.Counter;
+
+/**
+ * Holder containing query state counter metrics.
+ */
+public class DrillCounters {
+
+  private static final DrillCounters INSTANCE = new DrillCounters();
+
+  private static final String QUERIES_METRICS_PREFIX = "drill.queries.";
+
+  private final Counter planningQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "planning");
+  private final Counter enqueuedQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "enqueued");
+  private final Counter runningQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "running");
+  private final Counter completedQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "completed");
+  private final Counter succeededQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "succeeded");
+  private final Counter failedQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "failed");
+  private final Counter canceledQueries = DrillMetrics.getRegistry().counter(QUERIES_METRICS_PREFIX + "canceled");
+
+  private DrillCounters() {
+  }
+
+  public static DrillCounters getInstance() {
+    return INSTANCE;
+  }
+
+  public Counter getPlanningQueries() {
+    return planningQueries;
+  }
+
+  public Counter getEnqueuedQueries() {
+    return enqueuedQueries;
+  }
+
+  public Counter getRunningQueries() {
+    return runningQueries;
+  }
+
+  public Counter getCompletedQueries() {
+    return completedQueries;
+  }
+
+  public Counter getSucceededQueries() {
+    return succeededQueries;
+  }
+
+  public Counter getFailedQueries() {
+    return failedQueries;
+  }
+
+  public Counter getCanceledQueries() {
+    return canceledQueries;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/DrillbitContext.java
@@ -28,6 +28,7 @@ import org.apache.drill.exec.coord.ClusterCoordinator;
 import org.apache.drill.exec.expr.fn.FunctionImplementationRegistry;
 import org.apache.drill.exec.expr.fn.registry.RemoteFunctionRegistry;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.metrics.DrillCounters;
 import org.apache.drill.exec.physical.impl.OperatorCreatorRegistry;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.sql.DrillOperatorTable;
@@ -77,6 +78,7 @@ public class DrillbitContext implements AutoCloseable {
   private final QueryProfileStoreContext profileStoreContext;
   private ResourceManager resourceManager;
   private final MetastoreRegistry metastoreRegistry;
+  private final DrillCounters counters;
 
   public DrillbitContext(
       DrillbitEndpoint endpoint,
@@ -125,6 +127,8 @@ public class DrillbitContext implements AutoCloseable {
     //This profile store context is built from the profileStoreProvider
     profileStoreContext = new QueryProfileStoreContext(config, profileStoreProvider, coord);
     this.metastoreRegistry = new MetastoreRegistry(config);
+
+    this.counters = DrillCounters.getInstance();
   }
 
   public QueryProfileStoreContext getProfileStoreContext() {
@@ -309,5 +313,9 @@ public class DrillbitContext implements AutoCloseable {
 
   public MetastoreRegistry getMetastoreRegistry() {
     return metastoreRegistry;
+  }
+
+  public DrillCounters getCounters() {
+    return counters;
   }
 }


### PR DESCRIPTION
# [DRILL-7694](https://issues.apache.org/jira/browse/DRILL-7694): Register drill.queries.* counter metrics on Drillbit startup

## Description

Currently these query state (`drill.queries.*`) counter metrics are registered when the first query on Drillbit is issued but should be registered when Drillbit is started because having `0` running/completed/etc. queries is itself a valid metric. Moreover, absence of these metrics can cause warnings in logs indicating there is no registered bean for such a metric or cause errors in case when no query was issued. 

## Documentation
N/A

## Testing
Ran existing test suit and unit tests.
