### PR TITLE
DRILL-7603 and DRILL-7604: Add schema, options to REST query

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ExecConstants.java
@@ -472,7 +472,8 @@ public final class ExecConstants {
   public static final String JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG = "store.json.reader.print_skipped_invalid_record_number";
   public static final BooleanValidator JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG_VALIDATOR = new BooleanValidator(JSON_READER_PRINT_INVALID_RECORDS_LINE_NOS_FLAG,
       new OptionDescription("Enables Drill to log the bad records that the JSON record reader skips when reading JSON files. Default is false. (Drill 1.9+)"));
-  public static final DoubleValidator TEXT_ESTIMATED_ROW_SIZE = new RangeDoubleValidator("store.text.estimated_row_size_bytes", 1, Long.MAX_VALUE,
+  public static final String TEXT_ESTIMATED_ROW_SIZE_KEY = "store.text.estimated_row_size_bytes";
+  public static final DoubleValidator TEXT_ESTIMATED_ROW_SIZE = new RangeDoubleValidator(TEXT_ESTIMATED_ROW_SIZE_KEY, 1, Long.MAX_VALUE,
       new OptionDescription("Estimate of the row size in a delimited text file, such as csv. The closer to actual, the better the query plan. Used for all csv files in the system/session where the value is set. Impacts the decision to plan a broadcast join or not."));
 
   public static final String TEXT_WRITER_ADD_HEADER = "store.text.writer.add_header";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/BaseOptionManager.java
@@ -19,6 +19,8 @@ package org.apache.drill.exec.server.options;
 
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.server.options.OptionValue.Kind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 
@@ -28,7 +30,7 @@ import java.util.Iterator;
  */
 
 public abstract class BaseOptionManager implements OptionManager {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseOptionManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(BaseOptionManager.class);
 
   /**
    * Gets the current option value given a validator.
@@ -142,33 +144,14 @@ public abstract class BaseOptionManager implements OptionManager {
     final OptionValue.AccessibleScopes type = definition.getMetaData().getAccessibleScopes();
     final OptionValue.OptionScope scope = getScope();
     checkOptionPermissions(name, type, scope);
-    final OptionValue optionValue = OptionValue.create(type, name, value, scope);
+    final OptionValue optionValue = OptionValue.create(type, name, value, scope, validator.getKind());
     validator.validate(optionValue, metaData, this);
     setLocalOptionHelper(optionValue);
   }
 
   @Override
   public void setLocalOption(final OptionValue.Kind kind, final String name, final String valueStr) {
-    Object value;
-
-    switch (kind) {
-      case LONG:
-        value = Long.valueOf(valueStr);
-        break;
-      case DOUBLE:
-        value = Double.valueOf(valueStr);
-        break;
-      case STRING:
-        value = valueStr;
-        break;
-      case BOOLEAN:
-        value = Boolean.valueOf(valueStr);
-        break;
-      default:
-        throw new IllegalArgumentException(String.format("Unsupported kind %s", kind));
-    }
-
-    setLocalOption(name, value);
+    setLocalOption(name, valueStr);
   }
 
   private static void checkOptionPermissions(String name, OptionValue.AccessibleScopes type, OptionValue.OptionScope scope) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/FallbackOptionManager.java
@@ -22,13 +22,15 @@ import java.util.Iterator;
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
 
 /**
- * An {@link OptionManager} which allows for falling back onto another {@link OptionManager} when retrieving options.
+ * An {@link OptionManager} which allows for falling back onto another
+ * {@link OptionManager} when retrieving options.
  * <p/>
- * {@link FragmentOptionManager} and {@link SessionOptionManager} use {@link SystemOptionManager} as the fall back
- * manager. {@link QueryOptionManager} uses {@link SessionOptionManager} as the fall back manager.
+ * {@link FragmentOptionManager} and {@link SessionOptionManager} use
+ * {@link SystemOptionManager} as the fall back manager.
+ * {@link QueryOptionManager} uses {@link SessionOptionManager} as the fall back
+ * manager.
  */
 public abstract class FallbackOptionManager extends BaseOptionManager {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FallbackOptionManager.class);
 
   protected final OptionManager fallback;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/InMemoryOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/InMemoryOptionManager.java
@@ -20,12 +20,13 @@ package org.apache.drill.exec.server.options;
 import java.util.Map;
 
 /**
- * This is an {@link OptionManager} that holds options in memory rather than in a persistent store. Options stored in
- * {@link SessionOptionManager}, {@link QueryOptionManager}, and {@link FragmentOptionManager} are held in memory
- * (see {@link #options}) whereas the {@link SystemOptionManager} stores options in a persistent store.
+ * This is an {@link OptionManager} that holds options in memory rather than in
+ * a persistent store. Options stored in {@link SessionOptionManager},
+ * {@link QueryOptionManager}, and {@link FragmentOptionManager} are held in
+ * memory (see {@link #options}) whereas the {@link SystemOptionManager} stores
+ * options in a persistent store.
  */
 public abstract class InMemoryOptionManager extends FallbackOptionManager {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InMemoryOptionManager.class);
 
   protected final Map<String, OptionValue> options;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/options/SessionOptionManager.java
@@ -38,7 +38,6 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Collections2;
  * in the reset query itself.
  */
 public class SessionOptionManager extends InMemoryOptionManager {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SessionOptionManager.class);
 
   private final UserSession session;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRoot.java
@@ -58,6 +58,8 @@ import org.apache.drill.exec.work.foreman.rm.ResourceManager;
 import org.apache.drill.exec.work.foreman.rm.ThrottledResourceManager;
 import org.apache.http.client.methods.HttpPost;
 import org.glassfish.jersey.server.mvc.Viewable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -66,7 +68,7 @@ import static org.apache.drill.exec.server.rest.auth.DrillUserPrincipal.ADMIN_RO
 @Path("/")
 @PermitAll
 public class DrillRoot {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRoot.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillRoot.class);
 
   @Inject
   UserAuthEnabled authEnabled;
@@ -234,7 +236,7 @@ public class DrillRoot {
         endpoint1.getUserPort() == endpoint2.getUserPort();
   }
 
-  private Response setResponse(Map entity) {
+  private Response setResponse(Map<String, ?> entity) {
     return Response.ok()
             .entity(entity)
             .header("Access-Control-Allow-Origin", "*")

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -17,46 +17,38 @@
  */
 package org.apache.drill.exec.server.rest;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.calcite.schema.SchemaPlus;
-import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.exceptions.UserException;
-import org.apache.drill.common.exceptions.UserRemoteException;
-import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.proto.UserBitShared;
-import org.apache.drill.exec.proto.UserBitShared.QueryId;
-import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
-import org.apache.drill.exec.proto.UserBitShared.QueryType;
-import org.apache.drill.exec.proto.UserProtos.QueryResultsMode;
-import org.apache.drill.exec.proto.UserProtos.RunQuery;
-import org.apache.drill.exec.proto.helper.QueryIdHelper;
-import org.apache.drill.exec.rpc.user.InboundImpersonationManager;
-import org.apache.drill.exec.server.options.SessionOptionManager;
-import org.apache.drill.exec.store.SchemaTreeProvider;
-import org.apache.drill.exec.util.ImpersonationUtil;
-import org.apache.drill.exec.work.WorkManager;
-import org.apache.parquet.Strings;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlRootElement;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.shaded.guava.com.google.common.base.CharMatcher;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.parquet.Strings;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @XmlRootElement
 public class QueryWrapper {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryWrapper.class);
 
   private final String query;
   private final String queryType;
-  private final int autoLimitRowCount;
-  private final String userName;
-  private final String defaultSchema;
+  final int autoLimitRowCount;
+  final String userName;
+  final String defaultSchema;
+  final Map<String, String> options;
 
-  private static MemoryMXBean memMXBean = ManagementFactory.getMemoryMXBean();
+  protected QueryWrapper(String query, String queryType,
+      int rowCountLimit, String userName, String defaultSchema,
+      Map<String, String> options) {
+    this.query = query;
+    this.queryType = queryType.toUpperCase();
+    this.autoLimitRowCount = rowCountLimit;
+    this.userName = userName;
+    this.defaultSchema = defaultSchema;
+    this.options = options;
+  }
 
   @JsonCreator
   public QueryWrapper(
@@ -64,152 +56,98 @@ public class QueryWrapper {
     @JsonProperty("queryType") String queryType,
     @JsonProperty("autoLimit") String autoLimit,
     @JsonProperty("userName") String userName,
-    @JsonProperty("defaultSchema") String defaultSchema) {
-    this.query = query;
-    this.queryType = queryType.toUpperCase();
-    this.autoLimitRowCount = autoLimit != null && autoLimit.matches("[0-9]+") ? Integer.valueOf(autoLimit) : 0;
-    this.userName = userName;
-    this.defaultSchema = defaultSchema;
+    @JsonProperty("defaultSchema") String defaultSchema,
+    @JsonProperty("options") Map<String, String> options) {
+    this(query, queryType, mapCount(autoLimit), userName, defaultSchema, options);
   }
 
-  public String getQuery() {
-    return query;
-  }
-
-  public String getQueryType() {
-    return queryType;
-  }
-
-  public QueryType getType() {
-    return QueryType.valueOf(queryType);
-  }
-
-  public QueryResult run(final WorkManager workManager, final WebUserConnection webUserConnection) throws Exception {
-    final RunQuery runQuery = RunQuery.newBuilder().setType(getType())
-        .setPlan(getQuery())
-        .setResultsMode(QueryResultsMode.STREAM_FULL)
-        .setAutolimitRowcount(autoLimitRowCount)
-        .build();
-
-    applyUserName(workManager, webUserConnection);
-
-    int defaultMaxRows = webUserConnection.getSession().getOptions().getOption(ExecConstants.QUERY_MAX_ROWS).num_val.intValue();
-    if (!Strings.isNullOrEmpty(defaultSchema)) {
-      SessionOptionManager options = webUserConnection.getSession().getOptions();
-      SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(workManager.getContext());
-      SchemaPlus rootSchema = schemaTreeProvider.createRootSchema(options);
-      webUserConnection.getSession().setDefaultSchemaPath(defaultSchema, rootSchema);
+  private static int mapCount(String rowLimit) {
+    if (Strings.isNullOrEmpty(rowLimit)) {
+      return 0;
     }
-
-    int maxRows;
-    if (autoLimitRowCount > 0 && defaultMaxRows > 0) {
-      maxRows = Math.min(autoLimitRowCount, defaultMaxRows);
-    } else {
-      maxRows = Math.max(autoLimitRowCount, defaultMaxRows);
-    }
-    webUserConnection.setAutoLimitRowCount(maxRows);
-
-    // Heap usage threshold/trigger to provide resiliency on web server for queries submitted via HTTP
-    double memoryFailureThreshold = workManager.getContext().getConfig().getDouble(ExecConstants.HTTP_MEMORY_HEAP_FAILURE_THRESHOLD);
-
-    // Submit user query to Drillbit work queue.
-    final QueryId queryId = workManager.getUserWorker().submitWork(webUserConnection, runQuery);
-
-    boolean isComplete = false;
-    boolean nearlyOutOfHeapSpace = false;
-    float usagePercent = getHeapUsage();
-
-    // Wait until the query execution is complete or there is error submitting the query
-    logger.debug("Wait until the query execution is complete or there is error submitting the query");
-    do {
-      try {
-        isComplete = webUserConnection.await(TimeUnit.SECONDS.toMillis(1)); //periodically timeout 1 sec to check heap
-      } catch (InterruptedException e) {}
-      usagePercent = getHeapUsage();
-      if (memoryFailureThreshold > 0 && usagePercent > memoryFailureThreshold) {
-        nearlyOutOfHeapSpace = true;
-      }
-    } while (!isComplete && !nearlyOutOfHeapSpace);
-
-    //Fail if nearly out of heap space
-    if (nearlyOutOfHeapSpace) {
-      UserException almostOutOfHeapException = UserException.resourceError()
-          .message("There is not enough heap memory to run this query using the web interface. ")
-          .addContext("Please try a query with fewer columns or with a filter or limit condition to limit the data returned. ")
-          .addContext("You can also try an ODBC/JDBC client. ")
-          .build(logger);
-      //Add event
-      workManager.getBee().getForemanForQueryId(queryId)
-        .addToEventQueue(QueryState.FAILED, almostOutOfHeapException);
-      //Return NearlyOutOfHeap exception
-      throw almostOutOfHeapException;
-    }
-
-    logger.trace("Query {} is completed ", queryId);
-
-    if (webUserConnection.getError() != null) {
-      throw new UserRemoteException(webUserConnection.getError());
-    }
-
-    // Return the QueryResult.
-    return new QueryResult(queryId, webUserConnection, webUserConnection.results);
-  }
-
-  private void applyUserName(WorkManager workManager, WebUserConnection webUserConnection) {
-    SessionOptionManager options = webUserConnection.getSession().getOptions();
-    DrillConfig config = workManager.getContext().getConfig();
-    if (!Strings.isNullOrEmpty(userName)) {
-      if (!config.getBoolean(ExecConstants.IMPERSONATION_ENABLED)) {
-        throw UserException.permissionError().message("User impersonation is not enabled").build(logger);
-      }
-      InboundImpersonationManager inboundImpersonationManager = new InboundImpersonationManager();
-      boolean isAdmin = !config.getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED) ||
-        ImpersonationUtil.hasAdminPrivileges(webUserConnection.getSession().getCredentials().getUserName(),
-          ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(options),
-          ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(options));
-      if (isAdmin) {
-        // Admin user can impersonate any user they want to (when authentication is disabled, all users are admin)
-        webUserConnection.getSession().replaceUserCredentials(
-          inboundImpersonationManager,
-          UserBitShared.UserCredentials.newBuilder().setUserName(userName).build());
-      } else {
-        // Check configured impersonation rules to see if this user is allowed to impersonate the given user
-        inboundImpersonationManager.replaceUserOnSession(userName, webUserConnection.getSession());
-      }
+    try {
+      return Integer.parseInt(rowLimit.trim());
+    } catch (NumberFormatException e) {
+      return 0;
     }
   }
 
-  //Detect possible excess heap
-  private float getHeapUsage() {
-    return (float) memMXBean.getHeapMemoryUsage().getUsed() / memMXBean.getHeapMemoryUsage().getMax();
-  }
+  public String getQuery() { return query; }
 
-  public static class QueryResult {
-    private final String queryId;
-    public final Collection<String> columns;
-    public final List<Map<String, String>> rows;
-    public final List<String> metadata;
-    public final String queryState;
-    public final int attemptedAutoLimit;
+  public String getQueryType() { return queryType; }
 
-    //DRILL-6847:  Modified the constructor so that the method has access to all the properties in webUserConnection
-    public QueryResult(QueryId queryId, WebUserConnection webUserConnection, List<Map<String, String>> rows) {
-        this.queryId = QueryIdHelper.getQueryId(queryId);
-        this.columns = webUserConnection.columns;
-        this.metadata = webUserConnection.metadata;
-        this.queryState = webUserConnection.getQueryState();
-        this.rows = rows;
-        this.attemptedAutoLimit = webUserConnection.getAutoLimitRowCount();
-      }
+  public String getUserName() { return userName; }
 
-    public String getQueryId() {
-      return queryId;
-    }
-  }
+  public int getAutoLimitRowCount() { return autoLimitRowCount; }
+
+  public String getDefaultSchema() { return defaultSchema; }
+
+  public Map<String, String> getOptions() { return options; }
 
   @Override
   public String toString() {
-    return "QueryRequest [queryType=" + queryType + ", query=" + query + "]";
+    return new PlanStringBuilder(this)
+        .field("query", query)
+        .field("query type", queryType)
+        .field("user name", userName)
+        .field("default schema", defaultSchema)
+        .field("row limit", autoLimitRowCount)
+        .toString();
   }
 
+  public static final class RestQueryBuilder {
+
+    private String query;
+    private String queryType = "SQL";
+    private int rowLimit;
+    private String userName;
+    private String defaultSchema;
+    private Map<String, String> options;
+
+    public RestQueryBuilder query(String query) {
+      this.query = query;
+      return this;
+    }
+
+    public RestQueryBuilder queryType(String queryType) {
+      this.queryType = queryType;
+      return this;
+    }
+
+    public RestQueryBuilder rowLimit(int rowLimit) {
+      this.rowLimit = rowLimit;
+      return this;
+    }
+
+    public RestQueryBuilder rowLimit(String rowLimit) {
+      this.rowLimit = mapCount(rowLimit);
+      return this;
+    }
+
+    public RestQueryBuilder userName(String userName) {
+      this.userName = userName;
+      return this;
+    }
+
+    public RestQueryBuilder defaultSchema(String defaultSchema) {
+      this.defaultSchema = defaultSchema;
+      return this;
+    }
+
+    /**
+     * Optional session option values encoded as strings.
+     */
+    public RestQueryBuilder sessionOptions(Map<String, String> options) {
+      this.options = options;
+      return this;
+    }
+
+    public QueryWrapper build() {
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(query));
+      query = CharMatcher.is(';').trimTrailingFrom(query.trim());
+      Preconditions.checkArgument(!query.isEmpty());
+      return new QueryWrapper(query, queryType, rowLimit, userName,
+          defaultSchema, options);
+    }
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/RestQueryRunner.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/RestQueryRunner.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.tools.ValidationException;
+import org.apache.drill.common.config.DrillConfig;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.exceptions.UserRemoteException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.QueryType;
+import org.apache.drill.exec.proto.UserBitShared.QueryResult.QueryState;
+import org.apache.drill.exec.proto.UserProtos.QueryResultsMode;
+import org.apache.drill.exec.proto.UserProtos.RunQuery;
+import org.apache.drill.exec.proto.helper.QueryIdHelper;
+import org.apache.drill.exec.rpc.user.InboundImpersonationManager;
+import org.apache.drill.exec.server.options.SessionOptionManager;
+import org.apache.drill.exec.store.SchemaTreeProvider;
+import org.apache.drill.exec.util.ImpersonationUtil;
+import org.apache.drill.exec.work.WorkManager;
+import org.apache.parquet.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestQueryRunner {
+  private static final Logger logger = LoggerFactory.getLogger(QueryWrapper.class);
+  private static final MemoryMXBean memMXBean = ManagementFactory.getMemoryMXBean();
+
+  private final QueryWrapper query;
+  private final WorkManager workManager;
+  private final WebUserConnection webUserConnection;
+  private final SessionOptionManager options;
+
+  public RestQueryRunner(final QueryWrapper query, final WorkManager workManager, final WebUserConnection webUserConnection) {
+    this.query = query;
+    this.workManager = workManager;
+    this.webUserConnection = webUserConnection;
+    this.options = webUserConnection.getSession().getOptions();
+  }
+
+  public RestQueryRunner.QueryResult run() throws Exception {
+    applyUserName();
+    applyOptions();
+    applyDefaultSchema();
+    int maxRows = applyRowLimit();
+    return submitQuery(maxRows);
+  }
+
+  private void applyUserName() {
+    String userName = query.getUserName();
+    if (!Strings.isNullOrEmpty(userName)) {
+      DrillConfig config = workManager.getContext().getConfig();
+      if (!config.getBoolean(ExecConstants.IMPERSONATION_ENABLED)) {
+        throw UserException.permissionError()
+          .message("User impersonation is not enabled")
+          .build(logger);
+      }
+      InboundImpersonationManager inboundImpersonationManager = new InboundImpersonationManager();
+      boolean isAdmin = !config.getBoolean(ExecConstants.USER_AUTHENTICATION_ENABLED) ||
+        ImpersonationUtil.hasAdminPrivileges(
+            webUserConnection.getSession().getCredentials().getUserName(),
+            ExecConstants.ADMIN_USERS_VALIDATOR.getAdminUsers(options),
+            ExecConstants.ADMIN_USER_GROUPS_VALIDATOR.getAdminUserGroups(options));
+      if (isAdmin) {
+        // Admin user can impersonate any user they want to (when authentication is disabled, all users are admin)
+        webUserConnection.getSession().replaceUserCredentials(
+          inboundImpersonationManager,
+          UserBitShared.UserCredentials.newBuilder().setUserName(userName).build());
+      } else {
+        // Check configured impersonation rules to see if this user is allowed to impersonate the given user
+        inboundImpersonationManager.replaceUserOnSession(userName, webUserConnection.getSession());
+      }
+    }
+  }
+
+  private void applyOptions() {
+    Map<String, String> options = query.getOptions();
+    if (options != null) {
+      SessionOptionManager sessionOptionManager = webUserConnection.getSession().getOptions();
+      for (Map.Entry<String, String> entry : options.entrySet()) {
+        sessionOptionManager.setLocalOption(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  private void applyDefaultSchema() throws ValidationException {
+    String defaultSchema = query.getDefaultSchema();
+    if (!Strings.isNullOrEmpty(defaultSchema)) {
+      SessionOptionManager options = webUserConnection.getSession().getOptions();
+      @SuppressWarnings("resource")
+      SchemaTreeProvider schemaTreeProvider = new SchemaTreeProvider(workManager.getContext());
+      SchemaPlus rootSchema = schemaTreeProvider.createRootSchema(options);
+      webUserConnection.getSession().setDefaultSchemaPath(defaultSchema, rootSchema);
+    }
+  }
+
+  private int applyRowLimit() {
+    int defaultMaxRows = webUserConnection.getSession().getOptions().getInt(ExecConstants.QUERY_MAX_ROWS);
+    int maxRows;
+    int limit = query.getAutoLimitRowCount();
+    if (limit > 0 && defaultMaxRows > 0) {
+      maxRows = Math.min(limit, defaultMaxRows);
+    } else {
+      maxRows = Math.max(limit, defaultMaxRows);
+    }
+    webUserConnection.setAutoLimitRowCount(maxRows);
+    return maxRows;
+  }
+
+  public RestQueryRunner.QueryResult submitQuery(int maxRows) {
+    final RunQuery runQuery = RunQuery.newBuilder()
+        .setType(QueryType.valueOf(query.getQueryType()))
+        .setPlan(query.getQuery())
+        .setResultsMode(QueryResultsMode.STREAM_FULL)
+        .setAutolimitRowcount(maxRows)
+        .build();
+
+    // Heap usage threshold/trigger to provide resiliency on web server for queries submitted via HTTP
+    double memoryFailureThreshold = workManager.getContext().getConfig().getDouble(ExecConstants.HTTP_MEMORY_HEAP_FAILURE_THRESHOLD);
+
+    // Submit user query to Drillbit work queue.
+    final QueryId queryId = workManager.getUserWorker().submitWork(webUserConnection, runQuery);
+
+    boolean isComplete = false;
+    boolean nearlyOutOfHeapSpace = false;
+    float usagePercent = getHeapUsage();
+
+    // Wait until the query execution is complete or there is error submitting the query
+    logger.debug("Wait until the query execution is complete or there is error submitting the query");
+    do {
+      try {
+        isComplete = webUserConnection.await(TimeUnit.SECONDS.toMillis(1)); //periodically timeout 1 sec to check heap
+      } catch (InterruptedException e) {}
+      usagePercent = getHeapUsage();
+      if (memoryFailureThreshold > 0 && usagePercent > memoryFailureThreshold) {
+        nearlyOutOfHeapSpace = true;
+      }
+    } while (!isComplete && !nearlyOutOfHeapSpace);
+
+    //Fail if nearly out of heap space
+    if (nearlyOutOfHeapSpace) {
+      UserException almostOutOfHeapException = UserException.resourceError()
+          .message("There is not enough heap memory to run this query using the web interface. ")
+          .addContext("Please try a query with fewer columns or with a filter or limit condition to limit the data returned. ")
+          .addContext("You can also try an ODBC/JDBC client. ")
+          .build(logger);
+      //Add event
+      workManager.getBee().getForemanForQueryId(queryId)
+        .addToEventQueue(QueryState.FAILED, almostOutOfHeapException);
+      //Return NearlyOutOfHeap exception
+      throw almostOutOfHeapException;
+    }
+
+    logger.trace("Query {} is completed ", queryId);
+
+    if (webUserConnection.getError() != null) {
+      throw new UserRemoteException(webUserConnection.getError());
+    }
+
+    // Return the QueryResult.
+    return new QueryResult(queryId, webUserConnection, webUserConnection.results);
+  }
+
+  //Detect possible excess heap
+  private float getHeapUsage() {
+    return (float) memMXBean.getHeapMemoryUsage().getUsed() / memMXBean.getHeapMemoryUsage().getMax();
+  }
+
+  public static class QueryResult {
+    private final String queryId;
+    public final Collection<String> columns;
+    public final List<Map<String, String>> rows;
+    public final List<String> metadata;
+    public final String queryState;
+    public final int attemptedAutoLimit;
+
+    //DRILL-6847:  Modified the constructor so that the method has access to all the properties in webUserConnection
+    public QueryResult(QueryId queryId, WebUserConnection webUserConnection, List<Map<String, String>> rows) {
+        this.queryId = QueryIdHelper.getQueryId(queryId);
+        this.columns = webUserConnection.columns;
+        this.metadata = webUserConnection.metadata;
+        this.queryState = webUserConnection.getQueryState();
+        this.rows = rows;
+        this.attemptedAutoLimit = webUserConnection.getAutoLimitRowCount();
+      }
+
+    public String getQueryId() {
+      return queryId;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileResources.java
@@ -58,13 +58,15 @@ import org.apache.drill.exec.store.sys.PersistentStoreProvider;
 import org.apache.drill.exec.work.WorkManager;
 import org.apache.drill.exec.work.foreman.Foreman;
 import org.glassfish.jersey.server.mvc.Viewable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @Path("/")
 @RolesAllowed(DrillUserPrincipal.AUTHENTICATED_ROLE)
 public class ProfileResources {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProfileResources.class);
+  private static final Logger logger = LoggerFactory.getLogger(ProfileResources.class);
 
   @Inject
   UserAuthEnabled authEnabled;
@@ -208,9 +210,9 @@ public class ProfileResources {
 
   @XmlRootElement
   public class QProfiles {
-    private List<ProfileInfo> runningQueries;
-    private List<ProfileInfo> finishedQueries;
-    private List<String> errors;
+    private final List<ProfileInfo> runningQueries;
+    private final List<ProfileInfo> finishedQueries;
+    private final List<String> errors;
 
     public QProfiles(List<ProfileInfo> runningQueries, List<ProfileInfo> finishedQueries, List<String> errors) {
       this.runningQueries = runningQueries;
@@ -368,7 +370,6 @@ public class ProfileResources {
     .build(logger);
   }
 
-
   @GET
   @Path("/profiles/{queryid}.json")
   @Produces(MediaType.APPLICATION_JSON)
@@ -440,4 +441,3 @@ public class ProfileResources {
     }
   }
 }
-

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -87,7 +87,7 @@
     //Injects Estimated Rows
     function injectEstimatedRows() {
       Object.keys(opRowCountMap).forEach(key => {
-        var tgtElem = $("td.estRowsAnchor[key='" + key + "']"); 
+        var tgtElem = $("td.estRowsAnchor[key='" + key + "']");
         var status = tgtElem.append("<div class='estRows' title='Estimated'>(" + opRowCountMap[key] + ")</div>");
       });
     }
@@ -164,18 +164,16 @@
     <div id="query-edit" class="tab-pane">
       <p>
 
-        <#if model.isOnlyImpersonationEnabled()>
+       <#-- DRILL-7697: merge with copy in query.ftl -->
+       <form role="form" id="queryForm" action="/query" method="POST">
+          <#if model.isOnlyImpersonationEnabled()>
+            <div class="form-group">
+              <label for="userName">User Name</label>
+              <input type="text" size="30" name="userName" id="userName" placeholder="User Name" value="${model.getProfile().user}">
+            </div>
+          </#if>
           <div class="form-group">
-            <label for="userName">User Name</label>
-            <input type="text" size="30" name="userName" id="userName" placeholder="User Name" value="${model.getProfile().user}">
-          </div>
-        </#if>
-
-        <form role="form" id="queryForm" action="/query" method="POST">
-          <div id="query-editor" class="form-group">${model.getProfile().query}</div>
-          <input class="form-control" id="query" name="query" type="hidden" value="${model.getProfile().query}"/>
-          <div style="padding:5px"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
-          <div class="form-group">
+            <label for="queryType">Query type:&nbsp;&nbsp;</label>
             <div class="radio-inline">
               <label>
                 <input type="radio" name="queryType" id="sql" value="SQL" checked>
@@ -185,22 +183,39 @@
             <div class="radio-inline">
               <label>
                  <input type="radio" name="queryType" id="physical" value="PHYSICAL">
-                     PHYSICAL
+                     Physical
               </label>
             </div>
             <div class="radio-inline">
               <label>
                 <input type="radio" name="queryType" id="logical" value="LOGICAL">
-                    LOGICAL
+                    Logical
               </label>
             </div>
+
+            <div class="form-group">
+              <div style="display: inline-block"><label for="query">Query</label></div>
+              <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use
+                <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
+              <div id="query-editor">${model.getProfile().query}</div>
+              <input class="form-control" id="query" name="query" type="hidden" value="${model.getProfile().query}"/>
             </div>
+
             <div>
-              <button class="btn btn-default" type="button" id="rerunButton" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
-            Re-run query
+              <button class="btn btn-primary" type="button" id="rerunButton" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
+                Re-run query
               </button>
-              <input type="checkbox" name="forceLimit" value="limit" <#if model.hasAutoLimit()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="<#if model.hasAutoLimit()>${model.getAutoLimit()?c}<#else>${model.getDefaultAutoLimit()?c}</#if>" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
-            </div>
+              &nbsp;&nbsp;&nbsp;
+              <input type="checkbox" name="forceLimit" value="limit" <#if model.hasAutoLimit()>checked</#if>>
+                Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0"
+                  value="<#if model.hasAutoLimit()>${model.getAutoLimit()?c}<#else>${model.getDefaultAutoLimit()?c}</#if>" size="6" pattern="[0-9]*">
+                  rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query.
+                  Ignored if query has a limit already" style="cursor:pointer"></span>
+              &nbsp;&nbsp;&nbsp;
+              Default schema: <input type="text" size="10" name="defaultSchema" id="defaultSchema">
+                <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names
+                and for SHOW FILES and SHOW TABLES." style="cursor:pointer"></span>
+           </div>
             <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
           </form>
       </p>
@@ -620,7 +635,7 @@
     document.getElementById('queryForm')
             .addEventListener('keydown', function(e) {
       if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
-      if (e.target.form) 
+      if (e.target.form)
         <#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>;
     });
 

--- a/exec/java-exec/src/main/resources/rest/query/query.ftl
+++ b/exec/java-exec/src/main/resources/rest/query/query.ftl
@@ -43,6 +43,7 @@
 
 <#include "*/runningQuery.ftl">
 
+  <#-- DRILL-7697: merge with copy in profile.ftl -->
   <form role="form" id="queryForm" action="/query" method="POST">
     <#if model.isOnlyImpersonationEnabled()>
       <div class="form-group">
@@ -51,49 +52,55 @@
       </div>
     </#if>
     <div class="form-group">
-      <label for="queryType">Query Type</label>
-      <div class="radio">
+      <label for="queryType">Query type:&nbsp;&nbsp;</label>
+      <div class="radio-inline">
         <label>
           <input type="radio" name="queryType" id="sql" value="SQL" checked>
           SQL
         </label>
       </div>
-      <div class="radio">
+      <div class="radio-inline">
         <label>
           <input type="radio" name="queryType" id="physical" value="PHYSICAL">
-          PHYSICAL
+          Physical
         </label>
       </div>
-      <div class="radio">
+      <div class="radio-inline">
         <label>
           <input type="radio" name="queryType" id="logical" value="LOGICAL">
-          LOGICAL
+          Logical
         </label>
       </div>
     </div>
+
     <div class="form-group">
       <div style="display: inline-block"><label for="query">Query</label></div>
-      <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
+      <div style="display: inline-block; float:right; padding-right:5%"><b>Hint: </b>Use
+        <div id="keyboardHint" style="display:inline-block; font-style:italic"></div> to submit</div>
       <div id="query-editor-format"></div>
       <input class="form-control" type="hidden" id="query" name="query" autofocus/>
     </div>
 
-    <button class="btn btn-default" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
+    <button class="btn btn-primary" type="button" onclick="<#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>">
       Submit
     </button>
-    <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>> Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*"> rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query. Ignored if query has a limit already" style="cursor:pointer"></span>
-    <label for="defaultSchema">
-      Default Schema
-      <input type="text" name="defaultSchema" id="defaultSchema" list="enabledPlugins" placeholder="-- default schema --">
-      <datalist id="enabledPlugins">
-        <#list model.getEnabledPlugins() as pluginModel>
-          <#if pluginModel.getPlugin()?? && pluginModel.getPlugin().enabled() == true>
-            <option value="${pluginModel.getPlugin().getName()}">
-          </#if>
-        </#list>
-      </datalist>
-    </label>
-    <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names, and for SHOW FILES and SHOW TABLES" style="cursor:pointer"></span>
+    &nbsp;&nbsp;&nbsp;
+    <input type="checkbox" name="forceLimit" value="limit" <#if model.isAutoLimitEnabled()>checked</#if>>
+      Limit results to <input type="text" id="autoLimit" name="autoLimit" min="0" value="${model.getDefaultRowsAutoLimited()?c}" size="6" pattern="[0-9]*">
+      rows <span class="glyphicon glyphicon-info-sign" title="Limits the number of records retrieved in the query.
+      Ignored if query has a LIMIT clause." style="cursor:pointer"></span>
+    &nbsp;&nbsp;&nbsp;
+    Default schema:
+    <input type="text" name="defaultSchema" id="defaultSchema" list="enabledPlugins" placeholder="schema">
+    <datalist id="enabledPlugins">
+      <#list model.getEnabledPlugins() as pluginModel>
+        <#if pluginModel.getPlugin()?? && pluginModel.getPlugin().enabled() == true>
+          <option value="${pluginModel.getPlugin().getName()}">
+        </#if>
+      </#list>
+    </datalist>
+     <span class="glyphicon glyphicon-info-sign" title="Set the default schema used to find table names
+      and for SHOW FILES and SHOW TABLES." style="cursor:pointer"></span>
     <input type="hidden" name="csrfToken" value="${model.getCsrfToken()}">
   </form>
 
@@ -179,7 +186,7 @@
     document.getElementById('queryForm')
             .addEventListener('keydown', function(e) {
       if (!(e.keyCode == 13 && (e.metaKey || e.ctrlKey))) return;
-      if (e.target.form) //Submit [Wrapped] Query 
+      if (e.target.form) //Submit [Wrapped] Query
         <#if model.isOnlyImpersonationEnabled()>doSubmitQueryWithUserName()<#else>doSubmitQueryWithAutoLimit()</#if>;
     });
   </script>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/OptionValueTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/options/OptionValueTest.java
@@ -17,11 +17,15 @@
  */
 package org.apache.drill.exec.server.options;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.test.BaseTest;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class OptionValueTest extends BaseTest {
+
   @Test
   public void createBooleanKindTest() {
     final OptionValue createdValue = OptionValue.create(
@@ -31,7 +35,7 @@ public class OptionValueTest extends BaseTest {
     final OptionValue expectedValue = OptionValue.create(
       OptionValue.AccessibleScopes.ALL, "myOption", true, OptionValue.OptionScope.SYSTEM);
 
-    Assert.assertEquals(expectedValue, createdValue);
+    assertEquals(expectedValue, createdValue);
   }
 
   @Test
@@ -43,7 +47,16 @@ public class OptionValueTest extends BaseTest {
     final OptionValue expectedValue = OptionValue.create(
       OptionValue.AccessibleScopes.ALL, "myOption", 1.5, OptionValue.OptionScope.SYSTEM);
 
-    Assert.assertEquals(expectedValue, createdValue);
+    assertEquals(expectedValue, createdValue);
+
+    try {
+      OptionValue.create(
+          OptionValue.Kind.DOUBLE, OptionValue.AccessibleScopes.ALL,
+          "myOption", "bogus", OptionValue.OptionScope.SYSTEM);
+      fail();
+    } catch (UserException e) {
+      // Expected
+    }
   }
 
   @Test
@@ -55,7 +68,16 @@ public class OptionValueTest extends BaseTest {
     final OptionValue expectedValue = OptionValue.create(
       OptionValue.AccessibleScopes.ALL, "myOption", 3000l, OptionValue.OptionScope.SYSTEM);
 
-    Assert.assertEquals(expectedValue, createdValue);
+    assertEquals(expectedValue, createdValue);
+
+    try {
+      OptionValue.create(
+          OptionValue.Kind.LONG, OptionValue.AccessibleScopes.ALL,
+          "myOption", "bogus", OptionValue.OptionScope.SYSTEM);
+      fail();
+    } catch (UserException e) {
+      // Expected
+    }
   }
 
   @Test
@@ -67,6 +89,6 @@ public class OptionValueTest extends BaseTest {
     final OptionValue expectedValue = OptionValue.create(
       OptionValue.AccessibleScopes.ALL, "myOption", "wabalubawubdub", OptionValue.OptionScope.SYSTEM);
 
-    Assert.assertEquals(expectedValue, createdValue);
+    assertEquals(expectedValue, createdValue);
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/InteractiveUI.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/InteractiveUI.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest;
+
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.test.ClusterFixtureBuilder;
+import org.apache.drill.test.ClusterTest;
+
+/**
+ * Quick-and-dirty tool to run the Web UI for debugging without having
+ * to wait or a full build to run using {@code drillbit.sh}.
+ */
+public class InteractiveUI extends ClusterTest {
+
+  public static void main(String[] args) {
+    ClusterFixtureBuilder builder = new ClusterFixtureBuilder();
+    builder.configBuilder().put(ExecConstants.HTTP_ENABLE, true);
+    try {
+      startCluster(builder);
+      for (;;) {
+        Thread.sleep(1000);
+      }
+    } catch (Exception e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/server/rest/TestQueryWrapperImpersonation.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.server.rest;
 
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.server.rest.RestQueryRunner.QueryResult;
 import org.apache.drill.test.ClusterFixture;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public final class TestQueryWrapperImpersonation extends RestServerTest {
+
   @BeforeClass
   public static void setupServer() throws Exception {
     startCluster(ClusterFixture.bareBuilder(dirTestWatcher)
@@ -36,7 +38,8 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
 
   @Test
   public void testImpersonation() throws Exception {
-    QueryWrapper.QueryResult result = runQueryWithUsername("SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "alfred");
+    QueryResult result = runQueryWithUsername(
+        "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", "alfred");
     UserBitShared.QueryProfile queryProfile = getQueryProfile(result);
     assertNotNull(queryProfile);
     assertEquals("alfred", queryProfile.getUser());
@@ -44,10 +47,10 @@ public final class TestQueryWrapperImpersonation extends RestServerTest {
 
   @Test
   public void testImpersonationEnabledButUserNameNotProvided() throws Exception {
-    QueryWrapper.QueryResult result = runQueryWithUsername("SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", null);
+    QueryResult result = runQueryWithUsername(
+        "SELECT CATALOG_NAME, SCHEMA_NAME FROM information_schema.SCHEMATA", null);
     UserBitShared.QueryProfile queryProfile = getQueryProfile(result);
     assertNotNull(queryProfile);
     assertEquals("anonymous", queryProfile.getUser());
   }
-
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -248,6 +248,11 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
   }
 
   private void configureStoragePlugins(Drillbit bit) throws Exception {
+
+    // Skip plugins if not running in test mode.
+    if (builder.dirTestWatcher == null) {
+      return;
+    }
     // Create the dfs name space
     builder.dirTestWatcher.newDfsTestTmpDir();
 

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
@@ -30,6 +30,15 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  * Build a Drillbit and client with the options provided. The simplest
  * builder starts an embedded Drillbit, with the "dfs" name space,
  * a max width (parallelization) of 2.
+ * <p>
+ * Designed primarily for unit tests: the builders provide control
+ * over all aspects of the Drillbit or cluster. Can also be used to
+ * create an embedded Drillbit, use the zero-argument
+ * constructor which will omit creating set of test-only directories
+ * and will skip creating the test-only storage plugins and other
+ * configuration. In this mode, you should configure the builder
+ * to read from a config file, or specify all the non-default
+ * config options needed.
  */
 public class ClusterFixtureBuilder {
 
@@ -57,6 +66,10 @@ public class ClusterFixtureBuilder {
   protected boolean usingZk;
   protected Properties clientProps;
   protected final BaseDirTestWatcher dirTestWatcher;
+
+  public ClusterFixtureBuilder() {
+    this.dirTestWatcher = null;
+  }
 
   public ClusterFixtureBuilder(BaseDirTestWatcher dirTestWatcher) {
     this.dirTestWatcher = Preconditions.checkNotNull(dirTestWatcher);


### PR DESCRIPTION
# [DRILL-7603](https://issues.apache.org/jira/browse/DRILL-7603): Add schema, options to REST query

Also includes:

* [DRILL-7604](https://issues.apache.org/jira/browse/DRILL-7604): Cannot set session options using REST API / Web UI
* [DRILL-7655](https://issues.apache.org/jira/browse/DRILL-7655): Add Default Schema text box to Edit Query page in query profile
## Description

Update and revision of work originally done by @dobesv. All credit to @dobesv for these nice enhancements.

* DRILL-7603: Allow default schema to be set for HTTP queries, #1996
* DRILL-7604: Allow session options to be set in HTTP queries, #1997

Merges the two PRs since they touch the same files. Work stalled when a reviewer requested that the author use existing mechanisms to parse option values. Doing so was a bit tricky, and the author didn't have time. This PR does that work, which turned out to require some changes in the option mechanism. (The option mechanism has a generic set-from-Object; this PR adds a generic set-from-String.)

The revisions made it clear that the original code structure was getting a bit creaky. So, separated the REST query runner from the JSON-serializable `QueryWrapper`. The number of query options has grown to make the original constructor unwieldy, so added a `RESTQueryBuilder`.

### DRILL-7604: Allow session options to be set in HTTP queries

@dobesv's original description:

> This allows REST API requests and Web UI requests to specify a default
schema. Otherwise this is not possible for HTTP clients because the
"USE" command requires a session, which HTTP clients do not have.
> Normally session options must be set using the SET command. However,
this command does not work for HTTP clients (REST API and Web UI)
because it doesn't keep a session between requests.

### DRILL-7604: Allow session options to be set in HTTP queries

@dobesv's original description:

> This changes it so that a request can contain the options you might want
to set using the SET command. It also updates the Web UI to include a
widget to select the `store.format `option so users can specify the file
format that will be used by `CREATE TABLE AS`. Additional options could
be added later if desired without much difficulty.

> Normally session options must be set using the SET command. However,
this command does not work for HTTP clients (REST API and Web UI)
because it doesn't keep a session between requests.

## Documentation

(Adapted from @dobesv's original description.)

To submit a query:

`POST /query.json`

Parameters:

* `queryType`-- `SQL`, `PHYSICAL`, or `LOGICAL` are valid types. Use only `SQL`. Other types are for internal use only.
* `query` -- A SQL query that runs in Drill.
* `autoLimit` -- Limits the number of rows returned from the result set. (Drill 1.16+)
* `options`-- Object containing session options that you could have set using the SET command. Values may be provided as strings or typed values. A common use case would be to set `store.format`:"json" to specify that `CREATE TABLE` AS should output in JSON format. (Drill 1.18+)
* `defaultSchema` - -Specify the default schema for the request, as if the USE command was run before the query. (Drill 1.18+)

Screenshot (of original version, this PR slightly updates spacing and capitalization):

![Drill Web Console screenshot](https://user-images.githubusercontent.com/327833/75385306-5b657000-5894-11ea-8ff7-d0f2150d043a.png)

## Testing

Includes unit tests from the original PRs. Revised tests for slightly different option parsing rules. Checks both the positive and negative cases for both of the new parameters.
