### PR TITLE
DRILL-7699: Update javax.validation Dependency

### DIFF
--- a/exec/jdbc/pom.xml
+++ b/exec/jdbc/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
+      <version>2.0.1.Final</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
# [DRILL-7699](https://issues.apache.org/jira/browse/DRILL-7699): Update javax.validation Dependency

## Description
This PR fixes a bug by updating the `javax.validation` dependency to the most current version.

## Documentation
No user visible changes.

## Testing
Ran existing unit tests for `jdbc` package.