### PR TITLE
DRILL-7701: EVF V2 Scan Framework

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ReaderSchemaOrchestrator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/project/ReaderSchemaOrchestrator.java
@@ -217,7 +217,7 @@ public class ReaderSchemaOrchestrator implements VectorSource {
     // Do the table-schema level projection; the final matching
     // of projected columns to available columns.
 
-    TupleMetadata readerSchema = tableLoader.harvestSchema();
+    TupleMetadata readerSchema = tableLoader.outputSchema();
     if (scanOrchestrator.schemaSmoother != null) {
       doSmoothedProjection(readerSchema);
     } else {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ManagedReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ManagedReader.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+/**
+ * Extended version of a record reader which uses a size-aware batch mutator.
+ * Use this for all new readers. Replaces the original
+ * {@link org.apache.drill.exec.store.RecordReader} interface.
+ * <p>
+ * This interface is used to create readers that work with the projection
+ * mechanism to provide services for handling projection, setting up the result
+ * set loader, handling schema smoothing, sharing vectors across batches, etc.
+ * <p>
+ * Note that this interface reads a <b>batch</b> of rows, not a single row. (The
+ * original {@code RecordReader} could be confusing in this aspect.)
+ * <p>
+ * The expected lifecycle is:
+ * <ul>
+ * <li>The reader factory creates the reader just before using it. (Unlike
+ * the old {@code ScanBatch} which created all readers at the start of the
+ * scan.)</li>
+ * <li>Constructor: open the reader using the
+ * {@link SchemaNegotiator} to configure the
+ * scanner framework for this reader by specifying a schema (if known), desired
+ * row counts and other configuration options. Call {@link SchemaNegotiator#build()}
+ * to obtain a {@link org.apache.drill.exec.physical.resultSet.RowSetLoader}
+ * to use to capture the rows that the reader reads.</li>
+ * <li>{@link #next()}: called for each batch. The batch is written using the
+ * result set loader obtained above. The scanner framework handles details of
+ * tracking version changes, handling overflow, limiting record counts, and
+ * so on. Return <tt>true</tt> to indicate a batch is available, <tt>false</tt>
+ * to indicate EOF. The first call to <tt>next()</tt> can return <tt>false</tt>
+ * if the data source has no rows.</li>
+ * <li>{@link #close()}: called to release resources. May be called before
+ * <tt>next()</tt> returns </tt>false</tt>.</li>
+ * <p>
+ * If an error occurs, the reader can throw a {@link RuntimeException}
+ * from any method. A <tt>UserException</tt> is preferred to provide
+ * detailed information about the source of the problem.
+ */
+public interface ManagedReader {
+
+  /**
+   * Exception thrown from the constructor if the data source is empty and
+   * can produce no data or schema. The scan will skip over the reader.
+   */
+  @SuppressWarnings("serial")
+  public class EarlyEofException extends Exception {
+  }
+
+  /**
+   * Read the next batch. Reading continues until either EOF,
+   * or until the mutator indicates that the batch is full.
+   * The batch is considered valid if it is non-empty. Returning
+   * <tt>true</tt> with an empty batch is valid, and is helpful on
+   * the very first batch (returning schema only.) An empty batch
+   * with a <tt>false</tt> return code indicates EOF and the batch
+   * will be discarded. A non-empty batch along with a <tt>false</tt>
+   * return result indicates a final, valid batch, but that EOF was
+   * reached and no more data is available.
+   * <p>
+   * This somewhat complex protocol avoids the need to allocate a
+   * final batch just to find out that no more data is available;
+   * it allows EOF to be returned along with the final batch.
+   *
+   * @return <tt>true</tt> if more data may be available (and so
+   * <tt>next()</tt> should be called again, <tt>false</tt> to indicate
+   * that EOF was reached
+   *
+   * @throws RuntimeException (<tt>UserException</tt> preferred) if an
+   * error occurs that should fail the query.
+   */
+  boolean next();
+
+  /**
+   * Release resources. Called just after a failure, when the scanner
+   * is cancelled, or after <tt>next()</tt> returns EOF. Release
+   * all resources and close files. Guaranteed to be called if
+   * <tt>open()</tt> returns normally; will not be called if <tt>open()</tt>
+   * throws an exception.
+   *
+   * @throws RuntimeException (<tt>UserException</tt> preferred) if an
+   * error occurs that should fail the query.
+   */
+  void close();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ReaderFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ReaderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+
+/**
+ * Creates a batch reader on demand. Unlike earlier versions of Drill,
+ * this framework creates readers one by one, when they are needed.
+ * Doing so avoids excessive resource demands that come from creating
+ * potentially thousands of readers up front.
+ * <p>
+ * The reader itself is unique to each file type. This interface
+ * provides a common interface that this framework can use to create the
+ * file-specific reader on demand.
+ * <p>
+ * Also manages opening the reader using a scan-specific schema
+ * negotiator.
+ */
+public interface ReaderFactory<T extends SchemaNegotiator> {
+  boolean hasNext();
+  ManagedReader next(T negotiator) throws EarlyEofException;
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ScanLifecycleBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/ScanLifecycleBuilder.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.EmptyErrorContext;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.protocol.OperatorDriver;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ScanEventListener;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ScanLifecycle;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Gathers options for the {@link ScanLifecycle} then builds a scan lifecycle
+ * instance.
+ * <p>
+ * This framework is a bridge between operator logic and the scan
+ * internals. It gathers scan-specific options in a builder abstraction, then
+ * passes them on the scan lifecycle at the right time. By abstracting out this
+ * plumbing, a scan batch creator simply chooses the proper framework builder, passes
+ * config options, and implements the matching "managed reader" and factory. All details
+ * of setup, projection, and so on are handled by the framework and the components
+ * that the framework builds upon.
+ *
+ * <h4>Inputs</h4>
+ *
+ * At this basic level, a scan framework requires just a few simple inputs:
+ * <ul>
+ * <li>The options defined by the scan projection framework such as the
+ * projection list.</li>
+ * <li>A reader factory to create a reader for each of the files or blocks
+ * to be scanned. (Readers are expected to be created one-by-one as files
+ * are read.)</li>
+ * <li>The operator context which provides access to a memory allocator and
+ * other plumbing items.</li>
+ * </ul>
+ * <p>
+ * In practice, there are other options to fine tune behavior (provided schema,
+ * custom error context, various limits, etc.)
+ */
+public class ScanLifecycleBuilder {
+
+  public static final int MIN_BATCH_BYTE_SIZE = 256 * 1024;
+  public static final int MAX_BATCH_BYTE_SIZE = Integer.MAX_VALUE;
+  public static final int DEFAULT_BATCH_ROW_COUNT = 4096;
+  public static final int DEFAULT_BATCH_BYTE_COUNT = ValueVector.MAX_BUFFER_SIZE;
+  public static final int MAX_BATCH_ROW_COUNT = ValueVector.MAX_ROW_COUNT;
+
+  public static class DummyReaderFactory implements ReaderFactory<SchemaNegotiator> {
+
+    @Override
+    public boolean hasNext() { return false; }
+
+    @Override
+    public ManagedReader next(SchemaNegotiator negotiator) {
+      return null;
+    }
+  }
+
+  private ReaderFactory<?> readerFactory;
+  protected String userName;
+  protected MajorType nullType;
+  private int scanBatchRecordLimit = DEFAULT_BATCH_ROW_COUNT;
+  private int scanBatchByteLimit = DEFAULT_BATCH_BYTE_COUNT;
+  protected boolean allowRequiredNullColumns;
+  private List<SchemaPath> projection;
+  protected TupleMetadata definedSchema;
+  protected TupleMetadata providedSchema;
+
+  /**
+   * Option that enables whether the scan operator starts with an empty
+   * schema-only batch (the so-called "fast schema" that Drill once tried
+   * to provide) or starts with a non-empty data batch (which appears to
+   * be the standard since the "Empty Batches" project some time back.)
+   * See more details in {@link OperatorDriver} Javadoc.
+   * <p>
+   * Defaults to <tt>false</tt>, meaning to <i>not</i> provide the empty
+   * schema batch. DRILL-7305 explains that many operators fail when
+   * presented with an empty batch, so do not enable this feature until
+   * those issues are fixed. Of course, do enable the feature if you want
+   * to track down the DRILL-7305 bugs.
+   */
+  protected boolean enableSchemaBatch;
+
+  /**
+   * Option to disable empty results. An empty result occurs if no
+   * reader has any data, but at least one reader can provide a schema.
+   * In this case, the scan can return a single, empty batch, with
+   * an associated schema. This is the correct SQL result for an
+   * empty query. However, if this result triggers empty-batch bugs
+   * in other operators, we can, instead, disable this feature and
+   * return a null result set: no schema, no batch, just a "fast NONE",
+   * an immediate return of NONE from the Volcano iterator.
+   * <p>
+   * Disabling this option is not desirable: it means that the user
+   * gets no schema for queries that should be able to return one. So,
+   * disable this option only if we cannot find or fix empty-batch
+   * bugs.
+   */
+  protected boolean disableEmptyResults;
+
+  /**
+   * Option to disable schema changes. If {@code false}, then the first
+   * batch commits the scan to a single, unchanged schema. If {@code true}
+   * (the legacy default), then each batch or reader can change the schema,
+   * even though downstream operators generally cannot handle a schema
+   * change. The goal is to evolve all readers so that they do not
+   * generate schema changes.
+   */
+  protected boolean allowSchemaChange = true;
+
+  /**
+   * Context for error messages.
+   */
+  protected CustomErrorContext errorContext;
+
+  public void readerFactory(ReaderFactory<?> readerFactory) {
+    this.readerFactory = readerFactory;
+  }
+
+  public void userName(String userName) {
+    this.userName = userName;
+  }
+
+  public String userName() {
+    return userName;
+  }
+
+  /**
+   * Specify a custom batch record count. This is the maximum number of records
+   * per batch for this scan. Readers can adjust this, but the adjustment is capped
+   * at the value specified here
+   *
+   * @param batchRecordLimit maximum records per batch
+   */
+  public void batchRecordLimit(int batchRecordLimit) {
+    scanBatchRecordLimit = Math.max(1,
+        Math.min(batchRecordLimit, ValueVector.MAX_ROW_COUNT));
+  }
+
+  public void batchByteLimit(int byteLimit) {
+    scanBatchByteLimit = Math.max(MIN_BATCH_BYTE_SIZE,
+        Math.min(byteLimit, MAX_BATCH_BYTE_SIZE));
+  }
+
+  /**
+   * Specify the type to use for null columns in place of the standard
+   * nullable int. This type is used for all missing columns. (Readers
+   * that need per-column control need a different mechanism.)
+   *
+   * @param nullType the type to use for null columns
+   */
+  public void nullType(MajorType nullType) {
+    this.nullType = nullType;
+  }
+
+  public void allowRequiredNullColumns(boolean flag) {
+    allowRequiredNullColumns = flag;
+  }
+
+  public boolean allowRequiredNullColumns() {
+    return allowRequiredNullColumns;
+  }
+
+  public void allowSchemaChange(boolean flag) {
+    allowSchemaChange = flag;
+  }
+
+  public boolean allowSchemaChange() {
+    return allowSchemaChange;
+  }
+
+  public void projection(List<SchemaPath> projection) {
+    this.projection = projection;
+  }
+
+  public void enableSchemaBatch(boolean option) {
+    enableSchemaBatch = option;
+  }
+
+  public void disableEmptyResults(boolean option) {
+    disableEmptyResults = option;
+  }
+
+  public void definedSchema(TupleMetadata definedSchema) {
+    this.definedSchema = definedSchema;
+  }
+
+  public TupleMetadata definedSchema() {
+    return definedSchema;
+  }
+
+  public void providedSchema(TupleMetadata providedSchema) {
+    this.providedSchema = providedSchema;
+  }
+
+  public TupleMetadata providedSchema() {
+    return providedSchema;
+  }
+
+  public void errorContext(CustomErrorContext context) {
+    this.errorContext = context;
+  }
+
+  public CustomErrorContext errorContext() {
+    if (errorContext == null) {
+      errorContext = new EmptyErrorContext();
+    }
+    return errorContext;
+  }
+
+  public List<SchemaPath> projection() {
+    if (projection == null) {
+      projection = Collections.singletonList(SchemaPath.STAR_COLUMN);
+    }
+    return projection;
+  }
+
+  public int scanBatchRecordLimit() {
+    return Math.max(1, Math.min(scanBatchRecordLimit, MAX_BATCH_ROW_COUNT));
+  }
+
+  public int scanBatchByteLimit() {
+    return Math.max(MIN_BATCH_BYTE_SIZE, Math.min(scanBatchByteLimit, MAX_BATCH_BYTE_SIZE));
+  }
+
+  public MajorType nullType() {
+    return nullType;
+  }
+
+  public ReaderFactory<?> readerFactory() {
+    if (readerFactory == null) {
+      readerFactory = new DummyReaderFactory();
+    }
+    return readerFactory;
+  }
+
+  public ScanLifecycle build(OperatorContext context) {
+    return new ScanLifecycle(context, this);
+  }
+
+  @VisibleForTesting
+  public ScanOperatorExec buildScan() {
+    return new ScanOperatorExec(
+        new ScanEventListener(this),
+        !disableEmptyResults);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/SchemaNegotiator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/SchemaNegotiator.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+
+/**
+ * Negotiates the table schema with the scanner framework and provides
+ * context information for the reader. Scans use either a "dynamic" or
+ * a defined schema.
+ * <p>
+ * Regardless of the schema type, the result of building the schema is a
+ * result set loader used to prepare batches for use in the query. The reader
+ * can simply read all columns, allowing the framework to discard unwanted
+ * values. Or for efficiency, the reader can check the column metadata to
+ * determine if a column is projected, and if not, then don't even read
+ * the column from the input source.
+ *
+ * <h4>Defined Schema</h4>
+ *
+ * If defined, the execution plan provides the output schema (presumably
+ * computed from an accurate metadata source.) The reader must populate
+ * the proscribed rows, performing column type conversions as needed.
+ * The reader can determine if the schema is defined by calling
+ * {@link hasOutputSchema()}.
+ * <p>
+ * At present, the scan framework filters the "provided schema" against
+ * the project list so that this class presents only the actual output
+ * schema. Future versions may do the filtering in the planner, but
+ * the result for readers will be the same either way.
+ *
+ * <h4>Dynamic Schema</h4>
+ *
+ * A dynamic schema occurs when the plan does not specify a schema.
+ * Drill is unique in its support for "schema on read" in the sense
+ * that Drill does not know the schema until the reader defines it at
+ * scan time.
+ * <p>
+ * The reader and scan framework coordinate to form the output schema.
+ * The reader offers the columns it has available. The scan framework
+ * uses the projection list to decide which to accept. Either way the
+ * scan framework provides a column reader for the column (returning a
+ * do-nothing "dummy" reader if the column is unprojected.)
+ * <p>
+ * With a dynamic schema, readers offer a schema in one of two ways:
+ * <p>
+ * The reader provides the table schema in one of two ways: early schema
+ * or late schema. Either way, the project list from the physical plan
+ * determines which
+ * table columns are materialized and which are not. Readers are provided
+ * for all table columns for readers that must read sequentially, but
+ * only the materialized columns are written to value vectors.
+ *
+ * <h4>Early Dynamic Schema</h4>
+ *
+ * Some readers can determine the source schema at the start of a scan.
+ * For example, a CSV file has headers, a Parquet file has footers, both
+ * of which define a schema. This case is called "early schema." The
+ * reader fefines the schema by calling
+ * {@link #tableSchema(TupleMetadata)} to provide the known schema.
+ *
+ * <h4>Late Dynamic Schema</h4>
+ *
+ * Other readers don't know the input schema until the reader actually
+ * reads the data. For example, JSON typically has no schema, but does
+ * have sufficient structure (name/value pairs) to infer one.
+ * <p>
+ * The late schema reader calls {@link RowSetLoader#addColumn()} to
+ * add each column as it is discovered during the scan.
+ * <p>
+ * Note that, to avoid schema conflicts, a late schema reader
+ * <i><b>must</b></i> define the full set of columns in the first batch,
+ * and must stick to that schema for all subsequent batches. This allows
+ * the reader to look one batch ahead to learn the columns.
+ * <p>
+ * Drill, however, cannot predict the future. Without a defined schema,
+ * downstream operators cannot know which columns might appear later
+ * in the scan, with which types. Today this is a strong guideline.
+ * Future versions may enforce this rule.
+ */
+public interface SchemaNegotiator {
+
+  OperatorContext context();
+
+  /**
+   * The context to use as a parent when creating a custom context.
+   * <p>
+   * (Obtain the error context for this reader from the
+   * {@link ResultSetLoader}.
+   */
+  CustomErrorContext parentErrorContext();
+
+  /**
+   * Specify an advanced error context which allows the reader to
+   * fill in custom context values.
+   */
+  void setErrorContext(CustomErrorContext context);
+
+  /**
+   * Name of the user running the query.
+   */
+  String userName();
+
+  /**
+   * Report whether the projection list is empty, as occurs in two
+   * cases:
+   * <ul>
+   * <li><tt>SELECT COUNT(*) ...</tt> -- empty project.</ul>
+   * <li><tt>SELECT a, b FROM table(c d)</tt> -- disjoint project.</li>
+   * </ul>
+   * @return true if no columns are projected, and the client can
+   * make use of {@link ResultSetLoader#skipRows(int)} to indicate the
+   * row count, false if at least one column is projected and so
+   * data must be written using the loader
+   */
+  boolean isProjectionEmpty();
+
+  /**
+   * Returns the provided schema, if defined. The provided schema is a
+   * description of the source schema viewed as a Drill schema.
+   * <p>
+   * If a schema is provided,
+   * the reader should use that schema, converting or ignoring columns
+   * as needed. A scan without a provided schema has a "dynamic" schema
+   * to be defined by the scan operator itself along with the column
+   * projection list.
+   * <p>
+   * The provided schema describes the columns that the reader is
+   * capable of providing. Any given query may choose to project a subset
+   * of these columns.
+   *
+   * @return the provided schema if the execution plan defines the output
+   * schema, {@code null} if the schema should be computed dynamically
+   * from the source schema and column projections
+   */
+  TupleMetadata providedSchema();
+
+  /**
+   * Returns the reader input schema: the schema which describes the
+   * set of columns this reader should produce. The schema can be
+   * fully dynamic (a wildcard), fully concrete (a list of columns
+   * and their types) or partially dynamic (a list of columns, but some
+   * types are not known.) If the reader has a choice of ways to map
+   * input columns to types, the reader must choose the type specified
+   * in the schema. Presumably, the specified types are those that the
+   * reader is capable of providing; there is no expectation that the
+   * reader will convert to arbitrary types.
+   * <p>
+   * If the type is {@code LATE} (dynamic), then the reader can choose
+   * the type. Subsequent readers in the same scan will then see the
+   * same column as concrete, with the type selected by the present
+   * reader.
+   * <p>
+   * The reader is free to add additional columns. The internal mechanism
+   * will just ignore those columns and return a dummy reader for them.
+   * <p>
+   * The reader is also free to ignore columns. In this case, the internal
+   * mechanism will fill in {@code NULL} or default values.
+   */
+  TupleMetadata inputSchema();
+
+  /**
+   * Specify the table schema if this is an early-schema reader. Need
+   * not be called for a late-schema readers. The schema provided here,
+   * if any, is a base schema: the reader is free to discover additional
+   * columns during the read.
+   *
+   * @param schema the table schema if known at open time
+   * @param isComplete true if the schema is complete: if it can be used
+   * to define an empty schema-only batch for the first reader. Set to
+   * false if the schema is partial: if the reader must read rows to
+   * determine the full schema
+   */
+  void tableSchema(TupleMetadata schema, boolean isComplete);
+  void tableSchema(TupleMetadata schema);
+  void schemaIsComplete(boolean isComplete);
+
+  /**
+   * Set the preferred batch size (which may be overridden by the
+   * result set loader in order to limit vector or batch size.)
+   *
+   * @param maxRecordsPerBatch preferred number of record per batch
+   */
+  void batchSize(int maxRecordsPerBatch);
+
+  /**
+   * Build the schema, plan the required projections and static
+   * columns and return a loader used to populate value vectors.
+   * If the select list includes a subset of table columns, then
+   * the loader will be set up in table schema order, but the unneeded
+   * column loaders will be null, meaning that the batch reader should
+   * skip setting those columns.
+   *
+   * @return the loader for the table with columns arranged in table
+   * schema order
+   */
+  ResultSetLoader build();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileReaderFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileReaderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import java.util.Iterator;
+
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.ReaderFactory;
+import org.apache.drill.exec.store.dfs.easy.FileWork;
+
+/**
+ * Iterates over the splits for the present scan. For each, creates a
+ * new reader. The file framework passes the file split (and the Drill
+ * file system) in via the schema negotiator to the constructor which
+ * should open the file.
+ */
+public abstract class FileReaderFactory implements ReaderFactory<FileSchemaNegotiator> {
+  private Iterator<FileWork> splitIter;
+
+  protected void bind(FileScanLifecycle scan) {
+    this.splitIter = scan.fileScanOptions().splits().iterator();
+  }
+
+  @Override
+  public boolean hasNext() { return splitIter.hasNext(); }
+
+  @Override
+  public ManagedReader next(FileSchemaNegotiator negotiator) throws EarlyEofException {
+    FileSchemaNegotiatorImpl negotiatorImpl = (FileSchemaNegotiatorImpl) negotiator;
+    negotiatorImpl.bindSplit(splitIter.next());
+    return newReader(negotiator);
+  }
+
+  public abstract ManagedReader newReader(FileSchemaNegotiator negotiator) throws EarlyEofException;
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanLifecycle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanLifecycle.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import java.io.IOException;
+
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ReaderLifecycle;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ScanLifecycle;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.SchemaNegotiatorImpl;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The file scan framework adds into the scan framework support for
+ * reading from DFS splits (a file and a block) and for the file-related
+ * implicit and partition columns. The file scan builder gathers
+ * file-related options for the scan as a whole, including the list
+ * of splits. The associated {@link FileSchemaNegotiator} passes
+ * file information to each reader.
+ * <p>
+ * Only a single storage plugin uses the file scan framework:
+ * the {@link FileSystemPlugin} via the {@link EasyFormatPlugin}. To
+ * make client code as simple as possible, the Drill file system and list
+ * of files is passed though this framework to the
+ * {@link FileReaderFactory}, then to the {@link FileSchemaNegotiator}
+ * which presents them to the reader. This approach avoids the need
+ * for each format handle this common boilerplate code.
+ * <p>
+ * The {@link FileScanOptions} holds the list of splits to scan. The
+ * {@link FileReaderFactory} iterates over those splits, and
+ * creates each reader just-in-time to process that split.
+ * <p>
+ * Implicit columns are defined here at the beginning of the scan as
+ * part of the scan schema mechanism. Each consists of a column "marker"
+ * that identifies the column purposes. Then, on each file, the implicit
+ * column is resolved to a value specific to that file. A
+ * {@link StaticBatchBuilder} then fills in the needed column values
+ * for each batch which the reader produces.
+ */
+public class FileScanLifecycle extends ScanLifecycle {
+  private static final Logger logger = LoggerFactory.getLogger(FileScanLifecycle.class);
+
+  private final DrillFileSystem dfs;
+  private final ImplicitFileColumnsHandler implicitColumnsHandler;
+
+  public FileScanLifecycle(OperatorContext context, FileScanLifecycleBuilder options) {
+    super(context, options);
+
+    // Create the Drill file system.
+    try {
+      dfs = context.newFileSystem(options.fileSystemConfig());
+    } catch (IOException e) {
+      throw UserException.dataReadError(e)
+        .addContext("Failed to create FileSystem")
+        .addContext(options.errorContext())
+        .build(logger);
+    }
+
+    // Create the implicit columns manager
+    this.implicitColumnsHandler = new ImplicitFileColumnsHandler(
+        context, options, vectorCache(), schemaTracker());
+
+    // Bind the reader factory which intializes the list
+    // of splits from the builder.
+    FileReaderFactory readerFactory = (FileReaderFactory) readerFactory();
+    readerFactory.bind(this);
+  }
+
+  public FileScanLifecycleBuilder fileScanOptions() { return (FileScanLifecycleBuilder) options(); }
+  public DrillFileSystem fileSystem() { return dfs; }
+  public ImplicitFileColumnsHandler implicitColumnsHandler() { return implicitColumnsHandler; }
+
+  @Override
+  protected SchemaNegotiatorImpl newNegotiator(ReaderLifecycle readerLifecycle) {
+    return new FileSchemaNegotiatorImpl(readerLifecycle);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    try {
+      dfs.close();
+    } catch (IOException e) {
+      logger.warn("Failed to close the Drill file system", e);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanLifecycleBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanLifecycleBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import java.util.List;
+
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ScanLifecycle;
+import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+public class FileScanLifecycleBuilder extends ScanLifecycleBuilder {
+  protected int maxPartitionDepth;
+  protected boolean useLegacyWildcardExpansion;
+  protected Path rootDir;
+  private List<FileWork> splits;
+  private Configuration fsConf;
+
+  public void fileSystemConfig(Configuration fsConf) {
+    this.fsConf = fsConf;
+  }
+
+  public void fileSplits(List<FileWork> splits) {
+    this.splits = splits;
+  }
+
+  public void maxPartitionDepth(int maxPartitionDepth) {
+    this.maxPartitionDepth = maxPartitionDepth;
+  }
+
+  public void useLegacyWildcardExpansion(boolean useLegacyWildcardExpansion) {
+    this.useLegacyWildcardExpansion = useLegacyWildcardExpansion;
+  }
+
+  public void rootDir(Path rootDir) {
+    this.rootDir = rootDir;
+  }
+
+  public List<FileWork> splits() {
+    return Preconditions.checkNotNull(splits);
+  }
+
+  public Configuration fileSystemConfig() {
+    if (fsConf == null) {
+      fsConf = new Configuration();
+    }
+    return fsConf;
+  }
+
+  @Override
+  public ScanLifecycle build(OperatorContext context) {
+    return new FileScanLifecycle(context, this);
+  }
+
+  public int maxPartitionDepth() {
+    return maxPartitionDepth;
+  }
+
+  public boolean useLegacyWildcardExpansion() {
+    return useLegacyWildcardExpansion;
+  }
+
+  public Path rootDir() {
+    return rootDir;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileSchemaNegotiator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileSchemaNegotiator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.hadoop.mapred.FileSplit;
+
+/**
+ * The file schema negotiator provides access to the Drill file system
+ * and to the file split which the reader is to consume.
+ */
+public interface FileSchemaNegotiator extends SchemaNegotiator {
+
+  /**
+   * Gives the Drill file system for this operator.
+   */
+  DrillFileSystem fileSystem();
+
+  /**
+   * Describes the file split (path and block offset) for this scan.
+   *
+   * @return Hadoop file split object with the file path, block
+   * offset, and length.
+   */
+  FileSplit split();
+
+  /**
+   * Returns Drill's version of the Hadoop file split.
+   */
+  FileWork fileWork();
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileSchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileSchemaNegotiatorImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.UserException.Builder;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ReaderLifecycle;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.SchemaNegotiatorImpl;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder;
+import org.apache.drill.exec.store.dfs.DrillFileSystem;
+import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+/**
+ * Implementation of the file-level schema negotiator which holds the
+ * file split which the reader is to process. This class presents the
+ * split in both Hadoop and Drill formats. Adds the file name to the
+ * error context.
+ */
+public class FileSchemaNegotiatorImpl extends SchemaNegotiatorImpl
+    implements FileSchemaNegotiator {
+
+  public class SplitErrorContext extends ChildErrorContext {
+
+    public SplitErrorContext(CustomErrorContext parent) {
+      super(parent);
+    }
+
+    @Override
+    public void addContext(Builder builder) {
+      super.addContext(builder);
+      builder.addContext("File", Path.getPathWithoutSchemeAndAuthority(split.getPath()).toString());
+      if (split.getStart() != 0) {
+        builder.addContext("Offset", split.getStart());
+        builder.addContext("Length", split.getLength());
+      }
+    }
+  }
+
+  private FileWork fileWork;
+  private FileSplit split;
+
+  public FileSchemaNegotiatorImpl(ReaderLifecycle readerLifecycle) {
+    super(readerLifecycle);
+    baseErrorContext = new SplitErrorContext(baseErrorContext);
+    readerErrorContext = baseErrorContext;
+  }
+
+  public void bindSplit(FileWork fileWork) {
+    this.fileWork = fileWork;
+    Path path = fileScan().fileSystem().makeQualified(fileWork.getPath());
+    split = new FileSplit(path, fileWork.getStart(), fileWork.getLength(), new String[]{""});
+  }
+
+  @Override
+  public DrillFileSystem fileSystem() { return fileScan().fileSystem(); }
+
+  @Override
+  public FileSplit split() { return split; }
+
+  @Override
+  public FileWork fileWork() { return fileWork; }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ManagedReader newReader(ReaderFactory<?> readerFactory) throws EarlyEofException {
+    return ((ReaderFactory<FileSchemaNegotiator>) readerFactory).next(this);
+  }
+
+  @Override
+  public StaticBatchBuilder implicitColumnsLoader() {
+    return fileScan().implicitColumnsHandler().forFile(split.getPath());
+  }
+
+  private FileScanLifecycle fileScan() {
+    return (FileScanLifecycle) readerLifecycle.scanLifecycle();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/ImplicitFileColumnsHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/file/ImplicitFileColumnsHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import java.util.List;
+
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder.RepeatedBatchBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ImplicitColumnResolver;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ImplicitColumnResolver.ColumnMarker;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ImplicitColumnResolver.ImplicitColumnOptions;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ImplicitColumnResolver.ParseResult;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Manages implicit columns for files and partition columns for
+ * directories. Splits the work into a schema-time implicit column
+ * resolver, and a run-time class to populate the resulting
+ * vectors.
+ * <p>
+ * Uses system/session options for the configured name of the
+ * implicit columns.
+ */
+public class ImplicitFileColumnsHandler {
+
+  private final ImplicitColumnResolver parser;
+  private final ResultVectorCache vectorCache;
+  private final Path rootDir;
+  private final ParseResult parseResult;
+
+  public ImplicitFileColumnsHandler(OperatorContext context, FileScanLifecycleBuilder scanOptions,
+      ResultVectorCache vectorCache, ScanSchemaTracker schemaTracker) {
+    ImplicitColumnOptions options = new ImplicitColumnOptions()
+        .optionSet(context.getFragmentContext().getOptions())
+        .maxPartitionDepth(scanOptions.maxPartitionDepth())
+        .useLegacyWildcardExpansion(scanOptions.useLegacyWildcardExpansion());
+    this.rootDir = scanOptions.rootDir();
+    this.parser = new ImplicitColumnResolver(options, scanOptions.errorContext());
+    this.vectorCache = vectorCache;
+    this.parseResult = parser.parse(schemaTracker);
+  }
+
+  public StaticBatchBuilder forFile(Path filePath) {
+    FileDescrip fileInfo = new FileDescrip(filePath, rootDir);
+    List<ColumnMarker> columns = parseResult.columns();
+    if (columns.isEmpty()) {
+      return null;
+    }
+    Object values[] = new Object[columns.size()];
+    for (int i = 0; i < columns.size(); i++) {
+      values[i] = columns.get(i).resolve(fileInfo);
+    }
+    return new RepeatedBatchBuilder(vectorCache, parseResult.schema(), values);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/MissingColumnHandlerBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/MissingColumnHandlerBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder.NullBatchBuilder;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
+
+/**
+ * Builds the handler which provides values for columns in
+ * an explicit project list but for which
+ * the reader provides no values. Obtains types from a defined or provided
+ * schema, or using a configurable default type. Fills in null values,
+ * or a default value configured in a provided schema.
+ * <p>
+ * The set of missing columns may differ per reader or even per batch
+ * within a reader. If reader 1 reads all columns, but reader 2 reads
+ * a subset, then this class will use the column types from reader 1
+ * when creating the columns missing from reader 2.
+ * <p>
+ * Unfortunately, Drill cannot predict the future, so the opposite
+ * scenario will end badly: Reader 2 comes first, omits column "c",
+ * this class chooses a default value, then Reader 1 wants the column
+ * to be some other type. The query will fail with a type mismatch error.
+ * <p>
+ * Specifically, the mechanism uses the following rules to infer column
+ * type:
+ * <ul>
+ * <li>For <i>resolved</i> columns (those with a type), use that type.
+ * If the type is non-nullable, fill in a default value (generally 0 or
+ * blank.) A column is resolved if given by a defined schema, a provided
+ * schema or a prior reader.</li>
+ * <li>For <i>unresolved</i> columns (those without a type), use the
+ * default type configured in this builder. If no type is provied,
+ * use a "default default" of Nullable INT, Drill's classic choice.</li>
+ * <ul>
+ * <p>
+ * Note that Drill is not magic: relying on the default type is likely
+ * to cause a type conflict across readers or across scans. A default
+ * has no way of knowing if it matches the same column read in some other
+ * fragment on some other node.
+ * <p>
+ * Work is separated in a schema-time part (to resolve column types)
+ * and a read-time part (to create and fill the needed vectors.)
+ *
+ * <h4>Caveats</h4>
+ *
+ * The project mechanism handles nested "missing" columns as mentioned
+ * above. This works to create null columns within maps that are defined by the
+ * data source. However, the mechanism does not currently handle creating null
+ * columns within repeated maps or lists. Doing so is possible, but requires
+ * adding a level of cardinality computation to create the proper number of
+ * "inner" values.
+ */
+public class MissingColumnHandlerBuilder {
+  public static final MajorType DEFAULT_NULL_TYPE = MajorType.newBuilder()
+      .setMinorType(MinorType.INT)
+      .setMode(DataMode.OPTIONAL)
+      .build();
+
+  protected TupleMetadata inputSchema;
+  protected MajorType nullType;
+  protected boolean allowRequiredNullColumns;
+  protected ResultVectorCache vectorCache;
+  protected TupleMetadata outputSchema;
+
+  public MissingColumnHandlerBuilder inputSchema(TupleMetadata inputSchema) {
+    this.inputSchema = inputSchema;
+    return this;
+  }
+
+  public MissingColumnHandlerBuilder nullType(MajorType nullType) {
+    this.nullType = nullType;
+    return this;
+  }
+
+  public MissingColumnHandlerBuilder allowRequiredNullColumns(boolean flag) {
+    allowRequiredNullColumns = flag;
+    return this;
+  }
+
+  public MissingColumnHandlerBuilder vectorCache(ResultVectorCache vectorCache) {
+    this.vectorCache = vectorCache;
+    return this;
+  }
+
+  public TupleMetadata buildSchema() {
+    if (inputSchema == null || inputSchema.isEmpty()) {
+      return null;
+    }
+    outputSchema = new TupleSchema();
+    MajorType selectedNullType = nullType == null
+        ? DEFAULT_NULL_TYPE : nullType;
+    for (ColumnMetadata inputCol : inputSchema) {
+      if (inputCol.isDynamic()) {
+        outputSchema.addColumn(MetadataUtils.newScalar(inputCol.name(), selectedNullType));
+      } else {
+        outputSchema.addColumn(inputCol);
+      }
+    }
+    return outputSchema;
+  }
+
+  public StaticBatchBuilder build() {
+    buildSchema();
+    if (outputSchema == null) {
+      return null;
+    } else {
+      return new NullBatchBuilder(vectorCache, outputSchema);
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/OutputBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/OutputBatchBuilder.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.drill.exec.expr.BasicTypeHelper;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.exec.vector.complex.AbstractMapVector;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+/**
+ * Builds an output batch based on an output schema and one or more input
+ * schemas. The input schemas must represent disjoint subsets of the output
+ * schema.
+ * <p>
+ * Handles maps, which can overlap at the map level (two inputs can hold a map
+ * column named {@code `m`}, say), but the map members must be disjoint. Applies
+ * the same rule recursively to nested maps.
+ * <p>
+ * Maps must be built with members in the same order as the corresponding
+ * schema. Though maps are usually thought of as unordered name/value pairs,
+ * they are actually tuples, with both a name and a defined ordering.
+ * <p>
+ * This code uses a name lookup in maps because the semantics of maps do not
+ * guarantee a uniform numbering of members from {@code 0} to {@code n-1}, where
+ * {code n} is the number of map members. Map members are ordered, but the
+ * ordinal used by the map vector is not necessarily sequential.
+ * <p>
+ * Once the output container is built, the same value vectors reside in the
+ * input and output containers. This works because Drill requires vector
+ * persistence: the same vectors must be presented downstream in every batch
+ * until a schema change occurs.
+ *
+ * <h4>Projection</h4>
+ *
+ * To visualize projection, assume we have numbered table columns, lettered
+ * implicit, null or partition columns:<pre><code>
+ * [ 1 | 2 | 3 | 4 ]    Table columns in table order
+ * [ A | B | C ]        Static columns
+ * </code></pre>
+ * Now, we wish to project them into select order.
+ * Let's say that the SELECT clause looked like this, with "t"
+ * indicating table columns:<pre><code>
+ * SELECT t2, t3, C, B, t1, A, t2 ...
+ * </code></pre>
+ * Then the projection looks like this:<pre><code>
+ * [ 2 | 3 | C | B | 1 | A | 2 ]
+ * </code></pre>
+ * Often, not all table columns are projected. In this case, the
+ * result set loader presents the full table schema to the reader,
+ * but actually writes only the projected columns. Suppose we
+ * have:<pre><code>
+ * SELECT t3, C, B, t1,, A ...
+ * </code></pre>
+ * Then the abbreviated table schema looks like this:<pre><code>
+ * [ 1 | 3 ]</code></pre>
+ * Note that table columns retain their table ordering.
+ * The projection looks like this:<pre><code>
+ * [ 2 | C | B | 1 | A ]
+ * </code></pre>
+ * <p>
+ * The projector is created once per schema, then can be reused for any
+ * number of batches.
+ * <p>
+ * Merging is done in one of two ways, depending on the input source:
+ * <ul>
+ * <li>For the table loader, the merger discards any data in the output,
+ * then exchanges the buffers from the input columns to the output,
+ * leaving projected columns empty. Note that unprojected columns must
+ * be cleared by the caller.</li>
+ * <li>For implicit and null columns, the output vector is identical
+ * to the input vector.</li>
+ */
+public class OutputBatchBuilder {
+
+  /**
+   * Describes an input batch with a schema and a vector container.
+   */
+  public static class BatchSource {
+    private final TupleMetadata schema;
+    private final VectorContainer container;
+
+    public BatchSource(TupleMetadata schema, VectorContainer container) {
+      this.schema = schema;
+      this.container = container;
+     }
+  }
+
+  /**
+   * Describes a vector source: an index to a batch source (or nested map
+   * source), and an offset into that source. (Actually, an offset into the
+   * source schema which is the same as the container offset for the top-level
+   * row, but which translates to a name lookup for maps.)
+   */
+  private static class VectorSource {
+    protected final int source;
+    protected final int offset;
+
+    public VectorSource(int source, int offset) {
+      this.source = source;
+      this.offset = offset;
+    }
+
+    @Override
+    public String toString() {
+      return "[source=" + source +
+             ", offset=" + offset + "]";
+    }
+  }
+
+  /**
+   * Source map as a map schema and map vector.
+   */
+  public static class MapSource {
+    protected final TupleMetadata mapSchema;
+    protected final AbstractMapVector mapVector;
+
+    public MapSource(TupleMetadata mapSchema, AbstractMapVector mapVector) {
+      this.mapSchema = mapSchema;
+      this.mapVector = mapVector;
+    }
+  }
+
+  /**
+   * Construct a map from an output schema and a set of input maps. The logic
+   * is very similar to that for a batch, but just different enough that we need
+   * a separate implementation.
+   */
+  private static class MapBuilder {
+    ColumnMetadata outputCol;
+    TupleMetadata mapSchema;
+    List<MapSource> sourceMaps;
+    Object memberSources[];
+
+    private MapBuilder(ColumnMetadata outputCol, List<MapSource> sourceMaps) {
+      this.outputCol = outputCol;
+      this.mapSchema = outputCol.tupleSchema();
+      this.sourceMaps = sourceMaps;
+      this.memberSources = new Object[mapSchema.size()];
+      for (int i = 0; i < sourceMaps.size(); i++) {
+        defineSourceMapMapping(sourceMaps.get(i).mapSchema, i);
+      }
+    }
+
+    /**
+     * Define the mapping for one of the sources. Mappings are
+     * stored in output order as a set of (source, offset) pairs.
+     */
+    @SuppressWarnings("unchecked")
+    private void defineSourceMapMapping(TupleMetadata sourceSchema, int source) {
+      for (int i = 0; i < sourceSchema.size(); i++) {
+        ColumnMetadata col = sourceSchema.metadata(i);
+        int outputIndex = mapSchema.index(col.name());
+        Preconditions.checkState(outputIndex >= 0);
+        VectorSource vectorSource = new VectorSource(source, i);
+        if (col.isMap()) {
+          if (memberSources[outputIndex] == null) {
+            memberSources[outputIndex] = new ArrayList<VectorSource>();
+          }
+          ((List<VectorSource>) memberSources[outputIndex]).add(vectorSource);
+        } else {
+          assert memberSources[outputIndex] == null;
+          memberSources[outputIndex] = vectorSource;
+        }
+      }
+    }
+
+    /**
+     * Creates a new output map vector to hold the merger of member
+     * vectors from the source maps.
+     */
+    @SuppressWarnings("unchecked")
+    public AbstractMapVector build(BufferAllocator allocator) {
+      AbstractMapVector mapVector = (AbstractMapVector)
+          BasicTypeHelper.getNewVector(outputCol.name(),
+              allocator, outputCol.majorType(), null);
+      for (int i = 0; i < mapSchema.size(); i++) {
+        ColumnMetadata outputCol = mapSchema.metadata(i);
+        ValueVector outputVector;
+        if (outputCol.isMap()) {
+          outputVector = buildNestedMap(allocator, outputCol, (List<VectorSource>) memberSources[i]);
+        } else {
+          outputVector = getMember((VectorSource) memberSources[i]);
+        }
+        mapVector.putChild(outputCol.name(), outputVector);
+      }
+
+      return mapVector;
+    }
+
+    private ValueVector buildNestedMap(BufferAllocator allocator, ColumnMetadata outputCol,
+        List<VectorSource> vectorSources) {
+      List<MapSource> childMaps = new ArrayList<>();
+      for (VectorSource source : vectorSources) {
+        childMaps.add(
+            new MapSource(
+                sourceMaps.get(source.source).mapSchema
+                  .metadata(source.offset).tupleSchema(),
+                (AbstractMapVector) getMember(source)));
+      }
+      return new MapBuilder(outputCol, childMaps).build(allocator);
+    }
+
+    public ValueVector getMember(VectorSource source) {
+      MapSource sourceMap = sourceMaps.get(source.source);
+      ColumnMetadata sourceCol = sourceMap.mapSchema.metadata(source.offset);
+      return sourceMap.mapVector.getChild(sourceCol.name());
+    }
+  }
+
+  private final TupleMetadata outputSchema;
+  private final List<BatchSource> sources;
+  private final Object vectorSources[];
+  private final VectorContainer outputContainer;
+
+  public OutputBatchBuilder(TupleMetadata outputSchema, List<BatchSource> sources,
+      BufferAllocator allocator) {
+    this.outputSchema = outputSchema;
+    this.sources = sources;
+    this.outputContainer = new VectorContainer(allocator);
+    this.vectorSources = new Object[outputSchema.size()];
+    for (int i = 0; i < sources.size(); i++) {
+      defineSourceBatchMapping(sources.get(i).schema, i);
+    }
+    physicalProjection();
+  }
+
+  /**
+   * Define the mapping for one of the sources. Mappings are
+   * stored in output order as a set of (source, offset) pairs.
+   */
+  @SuppressWarnings("unchecked")
+  protected void defineSourceBatchMapping(TupleMetadata schema, int source) {
+    for (int i = 0; i < schema.size(); i++) {
+      ColumnMetadata col = schema.metadata(i);
+      int outputIndex = outputSchema.index(col.name());
+      Preconditions.checkState(outputIndex >= 0);
+      VectorSource vectorSource = new VectorSource(source, i);
+      if (col.isMap()) {
+        if (vectorSources[outputIndex] == null) {
+          vectorSources[outputIndex] = new ArrayList<VectorSource>();
+        }
+        ((List<VectorSource>) vectorSources[outputIndex]).add(vectorSource);
+      } else {
+        assert vectorSources[outputIndex] == null;
+        vectorSources[outputIndex] = vectorSource;
+      }
+    }
+  }
+
+  /**
+   * Project the source vectors to the output container, merging
+   * maps along the way.
+   */
+  @SuppressWarnings("unchecked")
+  private void physicalProjection() {
+    outputContainer.removeAll();
+    for (int i = 0; i < outputSchema.size(); i++) {
+      ValueVector outputVector;
+      ColumnMetadata outputCol = outputSchema.metadata(i);
+      if (outputCol.isMap()) {
+        outputVector = buildTopMap(outputCol, (List<VectorSource>) vectorSources[i]);
+      } else {
+        outputVector = getVector((VectorSource) vectorSources[i]);
+      }
+      outputContainer.add(outputVector);
+    }
+    outputContainer.buildSchema(SelectionVectorMode.NONE);
+  }
+
+  private ValueVector buildTopMap(ColumnMetadata outputCol,
+      List<VectorSource> vectorSources) {
+    List<MapSource> sourceMaps = new ArrayList<>();
+    for (VectorSource source : vectorSources) {
+      sourceMaps.add(
+          new MapSource(
+              sources.get(source.source).schema.metadata(source.offset).tupleSchema(),
+              (AbstractMapVector) getVector(source)));
+    }
+    return new MapBuilder(outputCol, sourceMaps).build(outputContainer.getAllocator());
+  }
+
+  public ValueVector getVector(VectorSource source) {
+    return sources.get(source.source).container
+        .getValueVector(source.offset).getValueVector();
+  }
+
+  public void load(int rowCount) {
+    outputContainer.setRecordCount(rowCount);
+  }
+
+  public VectorContainer outputContainer() { return outputContainer; }
+
+  /**
+   * Release per-reader resources. Does not release the actual value
+   * vectors as those reside in a cache.
+   */
+  public void close() {
+    outputContainer.removeAll();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ReaderLifecycle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ReaderLifecycle.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.OutputBatchBuilder.BatchSource;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetOptionBuilder;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the schema and batch construction for a managed reader.
+ * Allows the reader itself to be as simple as possible. This class
+ * implements the basic {@link RowBatchReader} protocol based on
+ * three methods, and converts it to the two-method protocol of
+ * the managed reader. The {@code open()} call of the
+ * {@code RowBatchReader} is combined with the constructor of the
+ * {@link ManagedReader}, enforcing the rule that the managed reader
+ * is created just-in-time when it is to be used, which avoids
+ * accidentally holding resources for the life of the scan.
+ * <p>
+ * Coordinates the components that wrap a reader to create the final
+ * output batch:
+ * <ul>
+ * <li>The actual reader which load (possibly a subset of) the
+ * columns requested from the input source.</li>
+ * <li>Implicit columns manager instance which populates implicit
+ * file columns, partition columns, and Drill's internal metadata
+ * columns.</li>
+ * <li>The missing columns handler which "makes up" values for projected
+ * columns not read by the reader.</li>
+ * <li>Batch assembler, which combines the three sources of vectors
+ * to create the output batch with the schema specified by the
+ * schema tracker.</li>
+ * </ul>
+ * <p>
+ * This class coordinates the reader-visible aspects of the scan:
+ * <ul>
+ * <li>The {@link SchemaNegotiator} (or subclass) which provides
+ * schema-related input to the reader and which creates the reader's
+ * {@link ResultSetLoader}, among other tasks. The schema negotiator
+ * is specific to each kind of scan and is thus created via the
+ * {@link ScanLifecycleBuilder}.</li>
+ * <li>The reader, which is designed to be as simple as possible,
+ * with all generic overhead tasks handled by this "shim" between
+ * the scan operator and the actual reader implementation.</li>
+ * </ul>
+ * <p>
+ * The reader is schema-driven. See {@link ScanSchemaTracker} for
+ * an overview.
+ * <ul>
+ * <li>The reader is given a <i>reader input schema</i>, via the
+ * schema negotiator, which specifies the desired output schema.
+ * The schema can be fully dynamic (a wildcard), fully defined (a
+ * prior reader already chose column types), or a hybrid.</li>
+ * <li>The reader can load a subset of columns. Those that are
+ * left out become "missing columns" to be filled in by this
+ * class.</li>
+ * <li>The <i>reader output schema</i> along with implicit and missing
+ * columns, together define the scan's output schema.</li>
+ * </ul>
+ * <p>
+ * The framework handles the projection task so the
+ * reader does not have to worry about it. Reading an unwanted column
+ * is low cost: the result set loader will have provided a "dummy" column
+ * writer that simply discards the value. This is just as fast as having the
+ * reader use if-statements or a table to determine which columns to save.
+ */
+public class ReaderLifecycle implements RowBatchReader {
+  private static final Logger logger = LoggerFactory.getLogger(ReaderLifecycle.class);
+
+  private final ScanLifecycle scanLifecycle;
+  protected final TupleMetadata readerInputSchema;
+  private ManagedReader reader;
+  private final SchemaNegotiatorImpl schemaNegotiator;
+  protected ResultSetLoader tableLoader;
+  private int prevTableSchemaVersion;
+  private StaticBatchBuilder implicitColumnsLoader;
+  private StaticBatchBuilder missingColumnsHandler;
+  private OutputBatchBuilder outputBuilder;
+
+  /**
+   * True once the reader reports EOF. This shim may keep going for another
+   * batch to handle any look-ahead row on the last batch.
+   */
+  private boolean eof;
+
+  public ReaderLifecycle(ScanLifecycle scanLifecycle) {
+    this.scanLifecycle = scanLifecycle;
+    this.readerInputSchema = schemaTracker().readerInputSchema();
+    this.schemaNegotiator = scanLifecycle.newNegotiator(this);
+  }
+
+  public ScanLifecycle scanLifecycle() { return scanLifecycle; }
+  public TupleMetadata readerInputSchema() { return readerInputSchema; }
+  public CustomErrorContext errorContext() { return schemaNegotiator.errorContext(); }
+
+  public ScanSchemaTracker schemaTracker() {
+    return scanLifecycle.schemaTracker();
+  }
+
+  public ScanLifecycleBuilder scanOptions() {
+    return scanLifecycle.options();
+  }
+
+  @Override
+  public String name() {
+    return reader.getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean open() {
+    try {
+      reader = schemaNegotiator.newReader(scanLifecycle.readerFactory());
+    } catch (EarlyEofException e) {
+      logger.info("Reader has no data or schema, skipped. Factory: {}",
+          scanLifecycle.readerFactory().getClass().getSimpleName());
+      reader = null;
+      return false;
+    } catch (UserException e) {
+      throw e;
+    } catch (Exception e) {
+      throw UserException.dataReadError(e)
+        .addContext("Failed to open reader")
+        .addContext(errorContext())
+        .build(logger);
+    }
+
+    // Storage plugins are extensible: a novice developer may not
+    // have known to create the table loader. Fail in this case.
+    if (tableLoader == null) {
+      throw UserException.internalError()
+        .message("Reader returned true from open, but did not call SchemaNegotiator.build().")
+        .addContext("Reader", reader.getClass().getSimpleName())
+        .addContext(errorContext())
+        .build(logger);
+    }
+    return true;
+  }
+
+  public ResultSetLoader buildLoader() {
+    ResultSetOptionBuilder options = new ResultSetOptionBuilder()
+        .rowCountLimit(Math.min(schemaNegotiator.batchSize, scanOptions().scanBatchRecordLimit()))
+        .vectorCache(scanLifecycle.vectorCache())
+        .batchSizeLimit(scanOptions().scanBatchByteLimit())
+        .errorContext(errorContext())
+        .projectionFilter(schemaTracker().projectionFilter(errorContext()))
+        .readerSchema(schemaNegotiator.readerSchema);
+
+    // Resolve the scan scame if possible.
+    applyEarlySchema();
+
+    // Create the table loader
+    tableLoader = new ResultSetLoaderImpl(scanLifecycle.allocator(), options.build());
+    implicitColumnsLoader = schemaNegotiator.implicitColumnsLoader();
+    return tableLoader;
+  }
+
+  /**
+   * If schema is complete, update the output schema. The reader schema provided
+   * by the negotiator contains all the columns the reader could provide and is
+   * not adjusted for projection. The schema tracker will apply the same projection
+   * filter as used when loading data. As usual, the reader may not provided all
+   * projected columns, so we apply missing columns early to produce a fully-resolved
+   * scan schema.
+   */
+  private void applyEarlySchema() {
+    if (schemaNegotiator.isSchemaComplete()) {
+      schemaTracker().applyEarlyReaderSchema(schemaNegotiator.readerSchema);
+      TupleMetadata missingCols = missingColumnsBuilder(schemaNegotiator.readerSchema).buildSchema();
+      if (missingCols != null) {
+        schemaTracker().resolveMissingCols(missingCols);
+      }
+    }
+  }
+
+  @Override
+  public boolean defineSchema() {
+    if (!schemaNegotiator.isSchemaComplete()) {
+      return false;
+    }
+    tableLoader.startBatch();
+    endBatch();
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+
+    // The reader may report EOF, but the result set loader might
+    // have a lookahead row.
+    if (isEof()) {
+      return false;
+    }
+
+    // Prepare for the batch.
+    tableLoader.startBatch();
+
+    // Read the batch. The reader should report EOF if it hits the
+    // end of data, even if the reader returns rows. This will prevent allocating
+    // a new batch just to learn about EOF. Don't read if the reader
+    // already reported EOF. In that case, we're just processing any last
+    // lookahead row in the result set loader.
+    if (!eof) {
+      try {
+        eof = !reader.next();
+      } catch (UserException e) {
+        throw e;
+      } catch (Exception e) {
+        throw UserException.dataReadError(e)
+          .addContext("File read failed")
+          .addContext(errorContext())
+          .build(logger);
+      }
+    }
+
+    // Add implicit columns, if any.
+    // Identify the output container and its schema version.
+    // Having a correct row count, even if 0, is important to
+    // the scan operator.
+    endBatch();
+
+    // Return EOF (false) only when the reader reports EOF
+    // and the result set loader has drained its rows from either
+    // this batch or lookahead rows.
+    return !isEof();
+  }
+
+  public boolean isEof() {
+    return eof && !tableLoader.hasRows();
+  }
+
+  /**
+   * Build the final output batch by projecting columns from the three input sources
+   * to the output batch. First, build the metadata and/or null columns for the
+   * table row count. Then, merge the sources.
+   */
+  private void endBatch() {
+    VectorContainer readerOutput = tableLoader.harvest();
+
+    // Corner case: Reader produced no rows and defined no schema.
+    // We assume this is a null file and skip it as if we got an
+    // EOF from the constructor. There may be some actual case in
+    // which a file is known to have no records and no columns,
+    // which is an empty file. At present, there is no way to differentiate
+    // an intentional empty file from a null file.
+    if (readerOutput.getRecordCount() == 0 && tableLoader.schemaVersion() == 0) {
+      readerOutput.clear();
+      return;
+    }
+
+    // If not the first batch, and there are no rows, discard the batch
+    // as it adds no new information.
+    if (readerOutput.getRecordCount() == 0 && tableLoader.batchCount() > 1) {
+      readerOutput.clear();
+      outputBuilder = null;
+      return;
+    }
+
+    // If the schema changed, set up the final projection based on
+    // the new (or first) schema.
+    if (tableLoader.batchCount() == 1 || prevTableSchemaVersion < tableLoader.schemaVersion()) {
+      reviseOutputProjection(tableLoader.outputSchema());
+    }
+    buildOutputBatch(readerOutput);
+  }
+
+  private void reviseOutputProjection(TupleMetadata readerOutputSchema) {
+    schemaTracker().applyReaderSchema(readerOutputSchema, schemaNegotiator.errorContext());
+    missingColumnsHandler = missingColumnsBuilder(readerOutputSchema).build();
+    if (missingColumnsHandler != null) {
+      schemaTracker().resolveMissingCols(missingColumnsHandler.schema());
+    }
+    outputBuilder = null;
+    prevTableSchemaVersion = tableLoader.schemaVersion();
+  }
+
+  public MissingColumnHandlerBuilder missingColumnsBuilder(TupleMetadata readerSchema) {
+    return new MissingColumnHandlerBuilder()
+        .allowRequiredNullColumns(scanOptions().allowRequiredNullColumns())
+        .inputSchema(schemaTracker().missingColumns(readerSchema))
+        .vectorCache(scanLifecycle.vectorCache())
+        .nullType(scanOptions().nullType());
+  }
+
+  private void buildOutputBatch(VectorContainer readerContainer) {
+
+    // Get the batch results in a container.
+    int rowCount = readerContainer.getRecordCount();
+    if (implicitColumnsLoader != null) {
+      implicitColumnsLoader.load(rowCount);
+    }
+    if (missingColumnsHandler != null) {
+      missingColumnsHandler.load(rowCount);
+    }
+
+    if (outputBuilder == null) {
+      createOutputBuilder();
+    }
+    outputBuilder.load(rowCount);
+  }
+
+  private void createOutputBuilder() {
+    List<BatchSource> sources = new ArrayList<>();
+    sources.add(new BatchSource(tableLoader.outputSchema(), tableLoader.outputContainer()));
+    if (implicitColumnsLoader != null) {
+      sources.add(new BatchSource(implicitColumnsLoader.schema(), implicitColumnsLoader.outputContainer()));
+    }
+    if (missingColumnsHandler != null) {
+      sources.add(new BatchSource(missingColumnsHandler.schema(), missingColumnsHandler.outputContainer()));
+    }
+    outputBuilder = new OutputBatchBuilder(schemaTracker().outputSchema(), sources,
+        scanLifecycle.allocator());
+  }
+
+  public TupleMetadata readerOutputSchema() {
+    return tableLoader == null ? null : tableLoader.outputSchema();
+  }
+
+  @Override
+  public VectorContainer output() {
+    return outputBuilder == null ? null : outputBuilder.outputContainer();
+  }
+
+  @Override
+  public int schemaVersion() {
+    return tableLoader.schemaVersion();
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (reader != null) {
+        reader.close();
+      }
+    } catch (UserException e) {
+
+      // Reader threw a user exception; assume that this is serious and must
+      // kill the query.
+      throw e;
+    } catch (Exception e) {
+      throw UserException.dataReadError(e)
+        .addContext("Reader close failed")
+        .addContext(errorContext())
+        .build(logger);
+    } finally {
+      reader = null;
+      if (tableLoader != null) {
+        tableLoader.close();
+        tableLoader = null;
+      }
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ScanEventListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ScanEventListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorEvents;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+
+/**
+ * Binds the scan lifeycle to the scan operator. Defers creating
+ * the scan lifecycle until the operator context is available
+ * to allow most fields in the scan lifecycle to be immutable.
+ */
+public class ScanEventListener implements ScanOperatorEvents {
+
+  private final ScanLifecycleBuilder scanOptions;
+  private ScanLifecycle scanLifecycle;
+
+  public ScanEventListener(ScanLifecycleBuilder scanOptions) {
+    this.scanOptions = scanOptions;
+  }
+
+  @Override
+  public void bind(OperatorContext context) {
+    scanLifecycle = scanOptions.build(context);
+  }
+
+  @Override
+  public RowBatchReader nextReader() {
+    return scanLifecycle.nextReader();
+  }
+
+  @Override
+  public void close() {
+    if (scanLifecycle != null) {
+      scanLifecycle.close();
+      scanLifecycle = null;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ScanLifecycle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/ScanLifecycle.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.exec.memory.BufferAllocator;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaConfigBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultVectorCacheImpl;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+
+/**
+/**
+ * Basic scan framework for a set of "managed" readers and which uses the
+ * scan schema tracker to evolve the scan output schema.
+ * Readers are created and managed via a reader
+ * factory class unique to each type of scan. The reader factory also provides
+ * the scan-specific schema negotiator to be passed to the reader.
+ *
+ * <h4>Lifecycle</h4>
+ *
+ * The options provided in the {@link ScanLifecycleBuilder} are
+ * sufficient to drive the entire scan operator functionality.
+ * Schema resolution and projection is done generically and is the same for all
+ * data sources. Only the
+ * reader (created via the factory class) differs from one type of file to
+ * another.
+ * <p>
+ * The framework achieves the work described below by composing a
+ * set of detailed classes, each of which performs some specific task. This
+ * structure leaves the reader to simply infer schema and read data.
+ *
+ * <h4>Reader Integration</h4>
+ *
+ * The details of how a file is structured, how a schema is inferred, how
+ * data is decoded: all that is encapsulated in the reader. The only real
+ * Interaction between the reader and the framework is:
+ * <ul>
+ * <li>The reader factory creates a reader and the corresponding schema
+ * negotiator.</li>
+ * <li>The reader "negotiates" a schema with the framework. The framework
+ * knows the projection list from the query plan, knows something about
+ * data types (whether a column should be scalar, a map or an array), and
+ * knows about the schema already defined by prior readers. The reader knows
+ * what schema it can produce (if "early schema.") The schema negotiator
+ * class handles this task.</li>
+ * <li>The reader reads data from the file and populates value vectors a
+ * batch at a time. The framework creates the result set loader to use for
+ * this work. The schema negotiator returns that loader to the reader, which
+ * uses it during read.<p>
+ * A reader may be "late schema", true "schema on read." In this case, the
+ * reader simply tells the result set loader to create a new column reader
+ * on the fly. The framework will work out if that new column is to be
+ * projected and will return either a real column writer (projected column)
+ * or a dummy column writer (unprojected column.)</li>
+ * <li>The reader then reads batches of data until all data is read. The
+ * result set loader signals when a batch is full; the reader should not
+ * worry about this detail itself.</li>
+ * <li>The reader then releases its resources.</li>
+ * </ul>
+ * <p>
+ * See {@link ScanSchemaTracker} for details about how the scan schema
+ * evolves over the scan lifecycle.
+ *
+ * <h4>Lifecycle</h4>
+ *
+ * Coordinates the components that make up a scan implementation:
+ * <ul>
+ * <li>{@link ScanSchemaTracker} which resolves the scan schema over the
+ * lifetime of the scan.</li>
+ * <li>Implicit columns manager which identifies and populates implicit
+ * file columns, partition columns, and Drill's internal metadata
+ * columns.</li>
+ * <li>The actual readers which load (possibly a subset of) the
+ * columns requested from the input source.</li>
+ * </ul>
+ * <p>
+ * Implicit columns are unique to each storage plugin. At present, they
+ * are defined only for the file system plugin. To handle such variation,
+ * each extension defines a subclass of the {@link ScanLifecycleBuilder} class to
+ * create the implicit columns manager (and schema negotiator) unique to
+ * a certain kind of scan.
+ * <p>
+ * Each reader is tracked by a {@link ReaderLifecycle} which handles:
+ * <ul>
+ * <li>Setting up the {@link ResultSetLoader} for the reader.</li>
+ * <li>The concrete values for implicit columns for that reader
+ * (and its file, if file-based.)</li>
+ * <li>The missing columns handler which "makes up" values for projected
+ * columns not read by the reader.</li>
+ * <li>Batch asssembler, which combines the three sources of vectors
+ * to create the output batch with the schema specified by the
+ * schema tracker.</li>
+ * </ul>
+ *
+ * <h4>Publishing the Final Result Set<h4>
+ *
+ * This class "publishes" a vector container that has the final, projected
+ * form of a scan. The projected schema include:
+ * <ul>
+ * <li>Columns from the reader.</li>
+ * <li>Static columns, such as implicit or partition columns.</li>
+ * <li>Null columns for items in the select list, but not found in either
+ * of the above two categories.</li>
+ * </ul>
+ * The order of columns is that set by the select list (or, by the reader for
+ * a <tt>SELECT *</tt> query.
+ *
+ * @see ScanSchemaTracker for a description of the schema lifecycle
+ * which drives a scan
+ */
+public class ScanLifecycle {
+
+  private final OperatorContext context;
+  private final ScanLifecycleBuilder options;
+  private final ScanSchemaTracker schemaTracker;
+  private final ReaderFactory<?> readerFactory;
+
+  /**
+   * Cache used to preserve the same vectors from one output batch to the
+   * next to keep the Project operator happy (which depends on exactly the
+   * same vectors.
+   * <p>
+   * If the Project operator ever changes so that it depends on looking up
+   * vectors rather than vector instances, this cache can be deprecated.
+   */
+  private final ResultVectorCacheImpl vectorCache;
+
+  public ScanLifecycle(OperatorContext context, ScanLifecycleBuilder options) {
+    this.context = context;
+    this.options = options;
+    this.schemaTracker = new ScanSchemaConfigBuilder()
+        .projection(options.projection())
+        .definedSchema(options.definedSchema())
+        .providedSchema(options.providedSchema())
+        .allowSchemaChange(options.allowSchemaChange())
+        .build();
+    this.vectorCache = new ResultVectorCacheImpl(allocator(), false);
+    this.readerFactory = options.readerFactory();
+  }
+
+  public OperatorContext context() { return context; }
+  public ScanLifecycleBuilder options() { return options; }
+  public ScanSchemaTracker schemaTracker() { return schemaTracker; }
+  public ResultVectorCacheImpl vectorCache() { return vectorCache; }
+  public ReaderFactory<?> readerFactory() { return readerFactory; }
+  public boolean hasOutputSchema() { return schemaTracker.isResolved(); }
+  public CustomErrorContext errorContext() { return options.errorContext(); }
+  public BufferAllocator allocator() { return context.getAllocator(); }
+
+  public RowBatchReader nextReader() {
+    if (readerFactory.hasNext()) {
+      return new ReaderLifecycle(this);
+    } else {
+      return null;
+    }
+  }
+
+  protected SchemaNegotiatorImpl newNegotiator(ReaderLifecycle readerLifecycle) {
+    return new SchemaNegotiatorImpl(readerLifecycle);
+  }
+
+  public TupleMetadata outputSchema() {
+    return schemaTracker.outputSchema();
+  }
+
+  public void close() { }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/SchemaNegotiatorImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker.ProjectionType;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+
+/**
+ * Implementation of the schema negotiation between scan operator and
+ * batch reader. Anticipates that the select list (and/or the list of
+ * predefined fields (implicit, partition) might be set by the scanner.
+ * For now, all readers have their own implementation of the select
+ * set.
+ * <p>
+ * Handles both early- and late-schema readers. Early-schema readers
+ * provide a table schema, late-schema readers do not.
+ * <p>
+ * If the reader (or, later, the scanner) has a SELECT list, then that
+ * select list is pushed down into the result set loader created for
+ * the reader.
+ * <p>
+ * Also handles parsing out various column types, filling in null
+ * columns and (via the vector cache), minimizing changes across
+ * readers. In the worst case, a reader might have a column "c" in
+ * one file, might skip "c" in the second file, and "c" may appear again
+ * in a third file. This negotiator, along with the scan projection
+ * and vector cache, "smoothes out" schema changes by preserving the vector
+ * for "c" across all three files. In the first and third files "c" is
+ * a vector written by the reader, in the second, it is a null column
+ * filled in by the scan projector (assuming, of course, that "c"
+ * is nullable or an array.)
+ */
+public class SchemaNegotiatorImpl implements SchemaNegotiator {
+
+  protected final ReaderLifecycle readerLifecycle;
+  protected TupleMetadata readerSchema;
+  protected boolean isSchemaComplete;
+  protected int batchSize = ValueVector.MAX_ROW_COUNT;
+  protected CustomErrorContext baseErrorContext;
+  protected CustomErrorContext readerErrorContext;
+
+  public SchemaNegotiatorImpl(ReaderLifecycle readerLifecycle) {
+    this.readerLifecycle = readerLifecycle;
+    this.baseErrorContext = readerLifecycle.scanLifecycle().errorContext();
+  }
+
+  @Override
+  public boolean isProjectionEmpty() {
+    return readerLifecycle.schemaTracker().projectionType() == ProjectionType.NONE;
+  }
+
+  @Override
+  public TupleMetadata providedSchema() {
+    return readerLifecycle.scanOptions().providedSchema();
+  }
+
+  @Override
+  public TupleMetadata inputSchema() {
+    return readerLifecycle.readerInputSchema();
+  }
+
+  @Override
+  public OperatorContext context() {
+    return readerLifecycle.scanLifecycle().context();
+  }
+
+  @Override
+  public CustomErrorContext parentErrorContext() {
+    return baseErrorContext;
+  }
+
+  public CustomErrorContext errorContext() {
+    return readerErrorContext == null ? baseErrorContext : readerErrorContext;
+  }
+
+  @Override
+  public void setErrorContext(CustomErrorContext errorContext) {
+    this.readerErrorContext = errorContext;
+  }
+
+  @Override
+  public void tableSchema(TupleMetadata schema, boolean isComplete) {
+    readerSchema = schema;
+    isSchemaComplete = schema != null && isComplete;
+  }
+
+  @Override
+  public void tableSchema(TupleMetadata schema) {
+    readerSchema = schema;
+  }
+
+  @Override
+  public void schemaIsComplete(boolean isComplete) {
+    isSchemaComplete = isComplete;
+  }
+
+  public boolean isSchemaComplete() { return readerSchema != null && isSchemaComplete; }
+
+  @Override
+  public void batchSize(int maxRecordsPerBatch) {
+    batchSize = maxRecordsPerBatch;
+  }
+
+  @Override
+  public String userName() {
+    return readerLifecycle.scanOptions().userName();
+  }
+
+  /**
+   * Callback from the schema negotiator to build the schema from information from
+   * both the table and scan operator. Returns the result set loader to be used
+   * by the reader to write to the table's value vectors.
+   *
+   * @param schemaNegotiator builder given to the reader to provide it's
+   * schema information
+   * @return the result set loader to be used by the reader
+   */
+  @Override
+  public ResultSetLoader build() {
+    return readerLifecycle.buildLoader();
+  }
+
+  public StaticBatchBuilder implicitColumnsLoader() {
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  public ManagedReader newReader(ReaderFactory<?> readerFactory) throws EarlyEofException {
+    return ((ReaderFactory<SchemaNegotiator>) readerFactory).next(this);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/StaticBatchBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/StaticBatchBuilder.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetLoaderImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultSetOptionBuilder;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.accessor.ScalarWriter;
+
+/**
+ * Base class for columns that take values based on the
+ * reader, not individual rows. E.g. null columns (values
+ * are all null) or implicit file columns
+ * that take values based on the file.
+ * <p>
+ * If a column needs a default value, that value can be set either via
+ * the values vector or as a column
+ * property on the column schema. The result set loader uses the default
+ * value to fill empty values. Otherwise, the column is assumed to be nullable
+ * and is filled with nulls.
+ */
+public abstract class StaticBatchBuilder {
+  protected final TupleMetadata schema;
+  protected final ResultSetLoader loader;
+
+  public static class NullBatchBuilder extends StaticBatchBuilder {
+    public NullBatchBuilder(ResultVectorCache vectorCache, TupleMetadata schema) {
+      super(vectorCache, schema);
+    }
+
+    @Override
+    protected void loadBatch(int rowCount) {
+      loader.skipRows(rowCount);
+    }
+  }
+
+  public static class RepeatedBatchBuilder extends StaticBatchBuilder {
+    private final ScalarWriter writers[];
+    private final Object values[];
+
+    public RepeatedBatchBuilder(ResultVectorCache vectorCache, TupleMetadata schema, Object values[]) {
+      super(vectorCache, schema);
+      this.values = values;
+      RowSetLoader writer = loader.writer();
+      writers = new ScalarWriter[schema.size()];
+      for (int i = 0; i < writers.length; i++) {
+        writers[i] = writer.scalar(i);
+      }
+    }
+
+    @Override
+    protected void loadBatch(int rowCount) {
+      RowSetLoader writer = loader.writer();
+      int n = Math.min(values.length, schema.size());
+      for (int i = 0; i < rowCount; i++) {
+        writer.start();
+        for (int j = 0; j < n; j++) {
+          writers[j].setValue(values[j]);
+        }
+        writer.save();
+      }
+    }
+  }
+
+  public StaticBatchBuilder(ResultVectorCache vectorCache, TupleMetadata schema) {
+    this.schema = schema;
+    ResultSetLoaderImpl.ResultSetOptions options = new ResultSetOptionBuilder()
+          .vectorCache(vectorCache)
+          .readerSchema(schema)
+          .build();
+    this.loader = new ResultSetLoaderImpl(vectorCache.allocator(), options);
+  }
+
+  public TupleMetadata schema() { return schema; }
+
+  /**
+   * Populate static vectors with the defined static values.
+   *
+   * @param rowCount number of rows to generate. Must match the
+   * row count in the batch returned by the reader
+   */
+
+  public VectorContainer load(int rowCount) {
+    loader.startBatch();
+    loadBatch(rowCount);
+    return loader.harvest();
+  }
+
+  protected abstract void loadBatch(int rowCount);
+
+  public void close() {
+    loader.close();
+  }
+
+  public VectorContainer outputContainer() {
+    return loader.outputContainer();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/package-info.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Implements the details of the scan lifecycle for a set of readers,
+ * primarily the process of resolving the scan output schema from a variety
+ * of input schemas, then running each reader, each of which will produce
+ * some number of batches. Handles missing and implicit columns.
+ * <p>
+ * Defines the projection, vector continuity and other operations for
+ * a set of one or more readers. Separates the core reader protocol from
+ * the logic of working with batches.
+ *
+ * <h4>Schema Evolution</h4>
+ *
+ * Drill discovers schema on the fly. The scan operator hosts multiple readers.
+ * In general, each reader may have a distinct schema, though the user typically
+ * arranges data in a way that scanned files have a common schema (else SQL
+ * is the wrong tool for analysis.) Still, subtle changes can occur: file A
+ * is an old version without a new column c, while file B includes the column.
+ * And so on.
+ * <p>
+ * The scan operator resolves the scan schema, striving to send a single, uniform
+ * schema downstream. That schema should represent the data from all readers
+ * in this scan and in other fragments of the same logical scan. The difficulty
+ * arises when the information available underdetermines the output schema:
+ * the mechanism here attempts to fill in gaps, and flags conflicts. Only a
+ * provided or defined schema (see {@link ScanSchemaTracker} resolves all
+ * ambiguities.)
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/package-info.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/scan/v3/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides the "version 3" scan framework (which can also be thought of
+ * as EVF version 2). This version provides basically the same API as
+ * version 2, but with an implementation driven by schema rather than
+ * vectors.
+ * <p>
+ * Build a scan using the {@link ScanLifecycleBuilder}. Provide a subclass
+ * of {@link ReaderFactory} that will create each of your
+ * {@link ManagedReader} instances as needed. The framework handles the
+ * details of schemas, missing columns, implicit columns and the rest.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ResultSetLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/ResultSetLoader.java
@@ -188,6 +188,15 @@ public interface ResultSetLoader {
   boolean isProjectionEmpty();
 
   /**
+   * Returns the active output schema; the schema used by the writers,
+   * minus any unprojected columns. This is usually the same as the
+   * output schema, but may differ if the writer adds columns during
+   * an overflow row. Unlike the output schema, this schema is defined
+   * as long as the loader is open.
+   */
+  TupleMetadata activeSchema();
+
+  /**
    * Returns the output container which holds (or will hold) batches
    * from this loader. For use when the container is needed prior
    * to "harvesting" a batch. The data is not valid until
@@ -226,7 +235,7 @@ public interface ResultSetLoader {
    * @return the extended schema of the harvested batch which includes
    * any allocation hints used when creating the batch
    */
-  TupleMetadata harvestSchema();
+  TupleMetadata outputSchema();
 
   /**
    * Peek at the internal vector cache for readers that need a bit of help

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/ResultSetLoaderImpl.java
@@ -712,8 +712,13 @@ public class ResultSetLoaderImpl implements ResultSetLoader, LoaderInternals {
   }
 
   @Override
-  public TupleMetadata harvestSchema() {
+  public TupleMetadata outputSchema() {
     return rootState.outputSchema();
+  }
+
+  @Override
+  public TupleMetadata activeSchema() {
+    return rootState.schema();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
@@ -57,7 +57,8 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 
@@ -69,8 +70,8 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
  * measure IO wait time and tracking file open/close operations.
  */
 public class DrillFileSystem extends FileSystem implements OpenFileTracker {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillFileSystem.class);
-  private final static boolean TRACKING_ENABLED = AssertionUtil.isAssertionsEnabled();
+  private static final Logger logger = LoggerFactory.getLogger(DrillFileSystem.class);
+  private static final boolean TRACKING_ENABLED = AssertionUtil.isAssertionsEnabled();
 
   public static final String UNDERSCORE_PREFIX = "_";
   public static final String DOT_PREFIX = ".";

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/util/VectorUtil.java
@@ -31,12 +31,13 @@ import org.apache.drill.exec.vector.AllocationHelper;
 import org.apache.drill.exec.vector.ValueVector;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.shaded.guava.com.google.common.base.Joiner;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class VectorUtil {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(VectorUtil.class);
+  private static final Logger logger = LoggerFactory.getLogger(VectorUtil.class);
   public static final int DEFAULT_COLUMN_WIDTH = 15;
 
   public static void logVectorAccessibleContent(VectorAccessible va, final String delimiter) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/BaseMockBatchReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/BaseMockBatchReader.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+
+/**
+ * Base class for the "mock" readers used in this test. The mock readers
+ * follow the normal (enhanced) reader API, but instead of actually reading
+ * from a data source, they just generate data with a known schema.
+ * They also expose internal state such as identifying which methods
+ * were actually called.
+ */
+public abstract class BaseMockBatchReader implements ManagedReader {
+  public boolean closeCalled;
+  public int startIndex;
+  public int batchCount;
+  public int batchLimit;
+  protected ResultSetLoader tableLoader;
+
+  protected void makeBatch() {
+    RowSetLoader writer = tableLoader.writer();
+    int offset = (batchCount - 1) * 20 + startIndex;
+    writeRow(writer, offset + 10, "fred");
+    writeRow(writer, offset + 20, "wilma");
+  }
+
+  protected void writeRow(RowSetLoader writer, int col1, String col2) {
+    writer.start();
+    if (writer.column(0) != null) {
+      writer.scalar(0).setInt(col1);
+    }
+    if (writer.column(1) != null) {
+      writer.scalar(1).setString(col2);
+    }
+    writer.save();
+  }
+
+  @Override
+  public void close() {
+    closeCalled = true;
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/BaseScanTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/BaseScanTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanFixture.ScanFixtureBuilder;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.OperatorFixture;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+
+/**
+ * Test of the scan operator framework. Here the focus is on the
+ * implementation of the scan operator itself. This operator is
+ * based on a number of lower-level abstractions, each of which has
+ * its own unit tests. To make this more concrete: review the scan
+ * operator code paths. Each path should be exercised by one or more
+ * of the tests here. If, however, the code path depends on the
+ * details of another, supporting class, then tests for that class
+ * appear elsewhere.
+ */
+public class BaseScanTest extends SubOperatorTest {
+
+  /**
+   * Mock reader that pretends to have a schema at open time
+   * like an HBase or JDBC reader.
+   */
+  protected static class MockEarlySchemaReader extends BaseMockBatchReader {
+
+    public MockEarlySchemaReader(SchemaNegotiator schemaNegotiator) {
+      TupleMetadata schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .addNullable("b", MinorType.VARCHAR, 10)
+          .buildSchema();
+      schemaNegotiator.tableSchema(schema, true);
+      tableLoader = schemaNegotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      }
+
+      makeBatch();
+      return true;
+    }
+  }
+
+  protected TupleMetadata expectedSchema() {
+    return new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("b", MinorType.VARCHAR, 10)
+        .buildSchema();
+  }
+
+  protected SingleRowSet makeExpected() {
+    return makeExpected(0);
+  }
+
+  protected SingleRowSet makeExpected(int offset) {
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema())
+        .addRow(offset + 10, "fred")
+        .addRow(offset + 20, "wilma")
+        .build();
+    return expected;
+  }
+
+  protected void verifyBatch(int offset, VectorContainer output) {
+    SingleRowSet expected = makeExpected(offset);
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+  }
+
+  /**
+   * Fixture that creates the reader and gives a test access to
+   * the reader.
+   */
+  public interface ReaderCreator {
+    ManagedReader instance(SchemaNegotiator negotiator) throws EarlyEofException;
+  }
+
+  /**
+   * Fixture that creates the reader and gives a test access to
+   * the reader.
+   */
+  protected static abstract class ObservableCreator implements ReaderCreator {
+    public ManagedReader reader;
+
+    @Override
+    public ManagedReader instance(SchemaNegotiator negotiator) throws EarlyEofException {
+      reader = create(negotiator);
+      return reader;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends ManagedReader> T reader() { return (T) reader; }
+
+    public abstract ManagedReader create(SchemaNegotiator negotiator) throws EarlyEofException;
+  }
+
+  /**
+   * Mock reader that returns no schema and no records.
+   */
+  protected static class EofOnOpenReader implements ManagedReader {
+    public EofOnOpenReader(SchemaNegotiator schemaNegotiator) throws EarlyEofException {
+      throw new EarlyEofException();
+    }
+
+    @Override
+    public boolean next() { return false; }
+
+    @Override
+    public void close() { }
+  }
+
+  public static class ReaderFactoryFixture implements ReaderFactory<SchemaNegotiator> {
+
+    private final Iterator<ReaderCreator> iterator;
+
+    public ReaderFactoryFixture(Iterator<ReaderCreator> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public ManagedReader next(SchemaNegotiator negotiator) throws EarlyEofException {
+      return iterator.next().instance(negotiator);
+    }
+  }
+
+  public static class BaseScanFixtureBuilder extends ScanFixtureBuilder {
+
+    public ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    public final List<ReaderCreator> readers = new ArrayList<>();
+
+    public BaseScanFixtureBuilder(OperatorFixture fixture) {
+      super(fixture);
+    }
+
+    @Override
+    public ScanLifecycleBuilder builder() { return builder; }
+
+    public void addReader(ReaderCreator reader) {
+      readers.add(reader);
+    }
+
+    public void addReaders(List<ReaderCreator> readers) {
+      this.readers.addAll(readers);
+    }
+
+    public void addReaders(ReaderCreator...readers) {
+      for (ReaderCreator reader : readers) {
+        addReader(reader);
+      }
+    }
+
+    @Override
+    public ScanFixture build() {
+      builder.readerFactory(new ReaderFactoryFixture(readers.iterator()));
+      return super.build();
+    }
+  }
+
+  @SafeVarargs
+  public static BaseScanFixtureBuilder simpleBuilder(ReaderCreator...readers) {
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    builder.projectAll();
+    builder.addReaders(readers);
+    return builder;
+  }
+
+  @SafeVarargs
+  public static ScanFixture simpleFixture(ReaderCreator...readers) {
+    return simpleBuilder(readers).build();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/ScanFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/ScanFixture.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import java.util.List;
+
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.ops.OperatorContext;
+import org.apache.drill.exec.physical.base.AbstractSubScan;
+import org.apache.drill.exec.physical.base.Scan;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.test.OperatorFixture;
+
+/**
+ * Holds the scan operator and its context to simplify tests.
+ */
+public class ScanFixture {
+
+  private final OperatorContext opContext;
+  public ScanOperatorExec scanOp;
+
+  public ScanFixture(OperatorContext opContext, ScanOperatorExec scanOp) {
+    this.opContext = opContext;
+    this.scanOp = scanOp;
+  }
+
+  public void close() {
+    try {
+      scanOp.close();
+    } finally {
+      opContext.close();
+    }
+  }
+
+  /**
+   * Wraps a scan lifecycle builder to build the scan fixture.
+   */
+  public static abstract class ScanFixtureBuilder {
+
+    public final OperatorFixture opFixture;
+    // All tests are designed to use the schema batch
+    public boolean enableSchemaBatch = true;
+
+    public ScanFixtureBuilder(OperatorFixture opFixture) {
+      this.opFixture = opFixture;
+    }
+
+    public abstract ScanLifecycleBuilder builder();
+
+    public void projectAll() {
+      builder().projection(RowSetTestUtils.projectAll());
+    }
+
+    public void setProjection(String... projCols) {
+      builder().projection(RowSetTestUtils.projectList(projCols));
+    }
+
+    public void setProjection(List<SchemaPath> projection) {
+      builder().projection(projection);
+    }
+
+    public ScanFixture build() {
+      builder().enableSchemaBatch(enableSchemaBatch);
+      ScanOperatorExec scanOp = builder().buildScan();
+      Scan scanConfig = new AbstractSubScan("bob") {
+
+        @Override
+        public int getOperatorType() {
+          return 0;
+        }
+      };
+      OperatorContext opContext = opFixture.newOperatorContext(scanConfig);
+      scanOp.bind(opContext);
+      return new ScanFixture(opContext, scanOp);
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanBasics.java
@@ -1,0 +1,533 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.exceptions.ExecutionSetupException;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.record.VectorContainer;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests the basics of the scan operator protocol: error conditions,
+ * etc.
+ */
+@Category(EvfTests.class)
+public class TestScanBasics extends BaseScanTest {
+  private static final Logger logger = LoggerFactory.getLogger(TestScanBasics.class);
+
+  /**
+   * Pathological case that a scan operator is provided no readers.
+   * It will throw a user exception because the downstream operators
+   * can't handle this case so we choose to stop the show early to
+   * avoid getting into a strange state.
+   */
+  @Test
+  public void testNoReader() {
+
+    // Create the scan operator
+    ScanFixture scanFixture = simpleFixture();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    try {
+      scan.buildSchema();
+    } catch (UserException e) {
+
+      // Expected
+      assertTrue(e.getCause() instanceof ExecutionSetupException);
+    }
+
+    // Must close the DAG (context and scan operator) even on failures
+    scanFixture.close();
+  }
+
+  public static final String ERROR_MSG = "My Bad!";
+
+  private static class GenericCrashReader implements ManagedReader {
+    public GenericCrashReader(SchemaNegotiator schemaNegotiator) {
+      throw new IllegalStateException(ERROR_MSG);
+    }
+
+    @Override
+    public boolean next() { return false; }
+
+    @Override
+    public void close() { }
+  }
+
+  @Test
+  public void testExceptionOnOpen() {
+
+    // Reader which fails on open with a known error message
+    // using an exception other than UserException.
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        return new GenericCrashReader(negotiator);
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    try {
+      scan.buildSchema();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  private static class UserExceptionCrashReader implements ManagedReader {
+    public UserExceptionCrashReader(SchemaNegotiator schemaNegotiator) {
+      throw UserException.dataReadError()
+        .message(ERROR_MSG)
+        .build(logger);
+    }
+
+    @Override
+    public boolean next() { return false; }
+
+    @Override
+    public void close() { }
+  }
+
+  @Test
+  public void testUserExceptionOnOpen() {
+
+    // Reader which fails on open with a known error message
+    // using a UserException.
+
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        return new UserExceptionCrashReader(negotiator);
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    try {
+      scan.buildSchema();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertNull(e.getCause());
+    }
+
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testExceptionOnFirstNext() {
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public boolean next() {
+            super.next(); // Load some data
+            throw new IllegalStateException(ERROR_MSG);
+          }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+    MockEarlySchemaReader reader = creator.reader();
+    assertTrue(reader.closeCalled);
+  }
+
+  @Test
+  public void testUserExceptionOnFirstNext() {
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public boolean next() {
+            super.next(); // Load some data
+            throw UserException.dataReadError()
+              .message(ERROR_MSG)
+              .build(logger);
+          }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+
+    // EOF
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertNull(e.getCause());
+    }
+
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+    MockEarlySchemaReader reader = creator.reader();
+    assertTrue(reader.closeCalled);
+  }
+
+  /**
+   * Test throwing an exception after the first batch, but while
+   * "reading" the second. Note that the first batch returns data
+   * and is spread over two next() calls, so the error is on the
+   * third call to the scan operator next().
+   */
+  @Test
+  public void testExceptionOnSecondNext() {
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public boolean next() {
+            if (batchCount == 1) {
+              super.next(); // Load some data
+              throw new IllegalStateException(ERROR_MSG);
+            }
+            return super.next();
+          }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Schema
+    assertTrue(scan.buildSchema());
+
+    // First batch
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    // Fail
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+
+    scanFixture.close();
+    MockEarlySchemaReader reader = creator.reader();
+    assertTrue(reader.closeCalled);
+  }
+
+  @Test
+  public void testUserExceptionOnSecondNext() {
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public boolean next() {
+            boolean result = super.next(); // Load some data
+            if (batchCount == 2) {
+              throw UserException.dataReadError()
+                  .message(ERROR_MSG)
+                  .build(logger);
+            }
+            return result;
+          }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Schema
+
+    assertTrue(scan.buildSchema());
+
+    // First batch
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    // Fail
+
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertNull(e.getCause());
+    }
+
+    scanFixture.close();
+    MockEarlySchemaReader reader = creator.reader();
+    assertTrue(reader.closeCalled);
+  }
+
+  @Test
+  public void testExceptionOnClose() {
+    ObservableCreator creator1 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public void close() {
+            super.close();
+            throw new IllegalStateException(ERROR_MSG);
+           }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ObservableCreator creator2 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator1, creator2);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    // Fail on close of first reader
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+    assertNull(creator2.reader);
+
+    scanFixture.close();
+  }
+
+  @Test
+  public void testUserExceptionOnClose() {
+    ObservableCreator creator1 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator) {
+          @Override
+          public void close() {
+            super.close();
+            throw UserException.dataReadError()
+                .message(ERROR_MSG)
+                .build(logger);
+           }
+        };
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ObservableCreator creator2 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator1, creator2);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    // Fail on close of first reader
+
+    try {
+      scan.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains(ERROR_MSG));
+      assertNull(e.getCause());
+    }
+    assertNull(creator2.reader);
+
+    scanFixture.close();
+  }
+
+  @Test
+  public void testEOFOnFirstOpen() {
+    ObservableCreator creator1 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) throws EarlyEofException {
+        return new EofOnOpenReader(negotiator);
+      }
+    };
+
+    ObservableCreator creator2 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator1, creator2);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  /**
+   * Test multiple readers, all EOF on first batch.
+   * The scan will return one empty batch to declare the
+   * early schema. Results in an empty (rather than null)
+   * result set.
+   */
+  @Test
+  public void testMultiEOFOnFirstBatch() {
+    ObservableCreator creator1 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 0;
+        return reader;
+      }
+    };
+
+    ObservableCreator creator2 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 0;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator1, creator2);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // EOF
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    VectorContainer container = scan.batchAccessor().container();
+    assertEquals(0, container.getRecordCount());
+    assertEquals(2, container.getNumberOfColumns());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scan.batchAccessor().release();
+
+    MockEarlySchemaReader reader1 = creator1.reader();
+    assertTrue(reader1.closeCalled);
+    MockEarlySchemaReader reader2 = creator2.reader();
+    assertTrue(reader2.closeCalled);
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testEarlyScanClose() {
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 2;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertTrue(scan.next());
+    scan.batchAccessor().release();
+
+    scanFixture.close();
+    MockEarlySchemaReader reader = creator.reader();
+    assertTrue(reader.closeCalled);
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanEarlySchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanEarlySchema.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test "early schema" readers: those that can declare a schema at
+ * open time.
+ */
+@Category(EvfTests.class)
+public class TestScanEarlySchema extends BaseScanTest {
+
+  @Test
+  public void testEarlySchemaLifecycle() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+        reader.batchLimit = 1;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    SingleRowSet expected = makeExpected();
+    RowSetComparison verifier = new RowSetComparison(expected);
+
+    // First batch: return schema.
+    assertTrue(scan.buildSchema());
+    MockEarlySchemaReader reader = creator.reader();
+    assertEquals(0, reader.batchCount);
+    assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Next again: no-op
+    assertFalse(scan.next());
+    scanFixture.close();
+
+    // Close again: no-op
+    scan.close();
+  }
+
+  @Test
+  public void testEarlySchemaLifecycleNoSchemaBatch() {
+
+    // Create a mock reader, return one batch with data.
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Create the scan operator
+    BaseScanFixtureBuilder builder = simpleBuilder(creator);
+    builder.enableSchemaBatch = false;
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    SingleRowSet expected = makeExpected();
+    RowSetComparison verifier = new RowSetComparison(expected);
+
+    // First batch: return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Next again: no-op
+    assertFalse(scan.next());
+    scanFixture.close();
+
+    // Close again: no-op
+    scan.close();
+  }
+
+  private static class MockEarlySchemaReader3 extends MockEarlySchemaReader {
+
+    public MockEarlySchemaReader3(SchemaNegotiator schemaNegotiator) {
+      super(schemaNegotiator);
+    }
+
+    @Override
+    public boolean next() {
+      if (batchCount >= batchLimit) {
+        return false;
+      }
+      batchCount++;
+
+      makeBatch();
+      return batchCount < batchLimit;
+    }
+  }
+
+  @Test
+  public void testEarlySchemaDataWithEof() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader3(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Create the scan operator
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    SingleRowSet expected = makeExpected();
+    RowSetComparison verifier = new RowSetComparison(expected);
+
+    // First batch: return schema.
+    assertTrue(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Next again: no-op
+    assertFalse(scan.next());
+    scanFixture.close();
+
+    // Close again: no-op
+    scan.close();
+  }
+
+  /**
+   * Test EOF on the first batch. Is allowed, but will result in the scan operator
+   * passing a null batch to the parent.
+   */
+  @Test
+  public void testEOFOnSchema() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator ->
+      new EofOnOpenReader(negotiator);
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // EOF
+    assertFalse(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    scanFixture.close();
+  }
+
+  @Test
+  public void testEOFOnFirstBatch() {
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 0;
+      return reader;
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+    assertTrue(scan.buildSchema());
+
+    // EOF. Returns a single empty batch with early schema
+    // in order to provide an empty result set.
+
+    assertTrue(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    RowSetUtilities.verify(
+        RowSetBuilder.emptyBatch(fixture.allocator(), expectedSchema()),
+        fixture.wrap(scan.batchAccessor().container()));
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  /**
+   * Test normal case with multiple readers. These return
+   * the same schema, so no schema change.
+   */
+
+  @Test
+  public void testMultipleReaders() {
+    ReaderCreator creator1 = negotiator ->
+      new EofOnOpenReader(negotiator);
+
+    ReaderCreator creator2 = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 2;
+      return reader;
+    };
+    ReaderCreator creator3 = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 2;
+      reader.startIndex = 100;
+      return reader;
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator1, creator2, creator3);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch, schema only.
+    assertTrue(scan.buildSchema());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    scan.batchAccessor().release();
+
+    // Second batch.
+    assertTrue(scan.next());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    verifyBatch(0, scan.batchAccessor().container());
+
+    // Third batch.
+    assertTrue(scan.next());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    verifyBatch(20, scan.batchAccessor().container());
+
+    // Second reader. First batch includes data, no special first-batch
+    // handling for the second reader.
+    assertTrue(scan.next());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    verifyBatch(100, scan.batchAccessor().container());
+
+    // Second batch from second reader.
+    assertTrue(scan.next());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    verifyBatch(120, scan.batchAccessor().container());
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLateSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanLateSchema.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.ColumnBuilder;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.test.rowSet.RowSetComparison;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test "late schema" readers: those like JSON that discover their schema
+ * as they read data.
+ */
+@Category(EvfTests.class)
+public class TestScanLateSchema extends BaseScanTest {
+
+  /**
+   * "Late schema" reader, meaning that the reader does not know the schema on
+   * open, but must "discover" it when reading data.
+   */
+  private static class MockLateSchemaReader extends BaseMockBatchReader {
+
+    public boolean returnDataOnFirst;
+
+    public MockLateSchemaReader(SchemaNegotiator schemaNegotiator) {
+
+      // No schema or file, just build the table loader.
+      tableLoader = schemaNegotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      } else if (batchCount == 1) {
+
+        // On first batch, pretend to discover the schema.
+        RowSetLoader rowSet = tableLoader.writer();
+        MaterializedField a = SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.REQUIRED);
+        rowSet.addColumn(a);
+        MaterializedField b = new ColumnBuilder("b", MinorType.VARCHAR)
+            .setMode(DataMode.OPTIONAL)
+            .setWidth(10)
+            .build();
+        rowSet.addColumn(b);
+        if (!returnDataOnFirst) {
+          return true;
+        }
+      }
+
+      makeBatch();
+      return true;
+    }
+  }
+
+  /**
+   * Most basic test of a reader that discovers its schema as it goes along.
+   * The purpose is to validate the most basic life-cycle steps before trying
+   * more complex variations.
+   */
+  @Test
+  public void testLateSchemaLifecycle() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 2;
+      reader.returnDataOnFirst = false;
+      return reader;
+    };
+
+    // Create the scan operator
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch: build schema. The reader does not help: it returns an
+    // empty first batch.
+    assertTrue(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Create the expected result.
+    SingleRowSet expected = makeExpected(20);
+    RowSetComparison verifier = new RowSetComparison(expected);
+    assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testLateSchemaLifecycleNoSchemaBatch() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 2;
+      reader.returnDataOnFirst = true;
+      return reader;
+    };
+
+    BaseScanFixtureBuilder builder = simpleBuilder(creator);
+    builder.enableSchemaBatch = false;
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Create the expected result.
+
+    // First batch with data.
+    assertTrue(scan.next());
+    RowSetUtilities.verify(makeExpected(0),
+        fixture.wrap(scan.batchAccessor().container()));
+
+    // Second batch.
+    assertTrue(scan.next());
+    RowSetUtilities.verify(makeExpected(20),
+        fixture.wrap(scan.batchAccessor().container()));
+
+     // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  /**
+   * Test the case that a late scan operator is closed before
+   * the first reader is opened.
+   */
+  @Test
+  public void testLateSchemaEarlyClose() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator);
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+
+    // Reader never opened.
+    scanFixture.close();
+    assertNull(creator.reader);
+  }
+
+  /**
+   * Test the case that a late schema reader is closed after discovering
+   * schema, before any calls to next().
+   */
+  @Test
+  public void testLateSchemaEarlyReaderClose() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+        reader.batchLimit = 2;
+        reader.returnDataOnFirst = false;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Get the schema as above.
+    assertTrue(scan.buildSchema());
+
+    // No lookahead batch created.
+    scanFixture.close();
+    MockLateSchemaReader reader = creator.reader();
+    assertEquals(1, reader.batchCount);
+    assertTrue(reader.closeCalled);
+  }
+
+  /**
+   * Test the case that a late schema reader is closed before
+   * consuming the look-ahead batch used to infer schema.
+   */
+  @Test
+  public void testLateSchemaEarlyCloseWithData() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ObservableCreator creator = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+        reader.batchLimit = 2;
+        reader.returnDataOnFirst = true;
+        return reader;
+      }
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Get the schema as above.
+    assertTrue(scan.buildSchema());
+
+    // Lookahead batch created.
+    scanFixture.close();
+    MockLateSchemaReader reader = creator.reader();
+    assertEquals(1, reader.batchCount);
+    assertTrue(reader.closeCalled);
+  }
+
+  /**
+   * Test a late-schema source that has no file information.
+   * (Like a Hive or JDBC data source.)
+   */
+  @Test
+  public void testLateSchemaLifecycleNoFile() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 2;
+      reader.returnDataOnFirst = false;
+      return reader;
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch: build schema. The reader helps: it returns an
+    // empty first batch.
+    assertTrue(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Create the expected result.
+    SingleRowSet expected = makeExpected(20);
+    RowSetComparison verifier = new RowSetComparison(expected);
+    assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testLateSchemaNoData() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 0;
+      reader.returnDataOnFirst = false;
+      return reader;
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch: EOF.
+    assertFalse(scan.buildSchema());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testLateSchemaDataOnFirst() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 1;
+      reader.returnDataOnFirst = true;
+      return reader;
+    };
+
+    ScanFixture scanFixture = simpleFixture(creator);
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch: build schema. The reader helps: it returns an
+    // empty first batch.
+    assertTrue(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    SingleRowSet expected = makeExpected();
+    RowSetComparison verifier = new RowSetComparison(expected);
+    assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    verifier.verifyAndClearAll(fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  /**
+  * Test the case where the reader does not play the "first batch contains
+  * only schema" game, and instead returns data. The Scan operator will
+  * split the first batch into two: one with schema only, another with
+  * data.
+  */
+ @Test
+ public void testNonEmptyFirstBatch() {
+
+   ReaderCreator creator = negotiator -> {
+     MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+     reader.batchLimit = 2;
+     reader.returnDataOnFirst = true;
+     return reader;
+   };
+
+   ScanFixture scanFixture = simpleFixture(creator);
+   ScanOperatorExec scan = scanFixture.scanOp;
+
+   // First batch. The reader returns a non-empty batch. The scan
+   // operator strips off the schema and returns just that.
+   assertTrue(scan.buildSchema());
+   SingleRowSet expected = makeExpected();
+   assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+   assertEquals(0, scan.batchAccessor().rowCount());
+   scan.batchAccessor().release();
+
+   // Second batch. Returns the "look-ahead" batch returned by
+   // the reader earlier.
+   assertTrue(scan.next());
+   RowSetUtilities.verify(expected,
+     fixture.wrap(scan.batchAccessor().container()));
+
+   // Third batch, normal case.
+
+   assertTrue(scan.next());
+   RowSetUtilities.verify(makeExpected(20),
+     fixture.wrap(scan.batchAccessor().container()));
+
+   // EOF
+   assertFalse(scan.next());
+   assertEquals(0, scan.batchAccessor().rowCount());
+   scanFixture.close();
+ }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanOuputSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanOuputSchema.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.impl.scan.convert.StandardConversions;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.exec.record.metadata.ColumnMetadata;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleNameSpace;
+import org.apache.drill.exec.vector.accessor.ValueWriter;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test the addition of an output schema to a reader. The output schema
+ * defines the schema to be output from the scan operator, and forces
+ * conversions between reader and output data types.
+ */
+@Category(EvfTests.class)
+public class TestScanOuputSchema extends BaseScanTest {
+
+  private static class MockSimpleReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+    private final TupleNameSpace<ValueWriter> writers = new TupleNameSpace<>();
+
+    public MockSimpleReader(SchemaNegotiator schemaNegotiator) {
+      TupleMetadata providedSchema = schemaNegotiator.providedSchema();
+      schemaNegotiator.tableSchema(providedSchema);
+      tableLoader = schemaNegotiator.build();
+      TupleMetadata schema = new SchemaBuilder()
+          // Schema provided in test
+          .add("a", MinorType.VARCHAR)
+          // No schema provided
+          .add("b", MinorType.VARCHAR)
+          // No schema and not projected in test
+          .add("c", MinorType.VARCHAR)
+          .buildSchema();
+      buildWriters(providedSchema, schema);
+    }
+
+    /**
+     * Simple mock version of convert from an imaginary input type to
+     * the provided schema. The reader schema is in terms of types which
+     * the standard conversions can convert. Add columns not in the provided
+     * schema, convert those which are in the provided schema.
+     * <p>
+     * A real reader would likely have its own column adapters and its
+     * own type conversion rules.
+     */
+    private void buildWriters(TupleMetadata providedSchema,
+        TupleMetadata schema) {
+      RowSetLoader rowWriter = tableLoader.writer();
+      for (int i = 0; i < schema.size(); i++) {
+        ColumnMetadata colSchema = schema.metadata(i);
+        String colName = colSchema.name();
+        ColumnMetadata providedCol;
+        if (i < providedSchema.size()) {
+          providedCol = providedSchema.metadata(colName);
+        } else {
+          providedCol = null;
+        }
+        if (providedCol == null) {
+          int colIndex = rowWriter.addColumn(colSchema);
+          writers.add(colSchema.name(), rowWriter.scalar(colIndex));
+        } else {
+          writers.add(colSchema.name(),
+              StandardConversions.converterFor(rowWriter.scalar(colSchema.name()), colSchema));
+        }
+      }
+    }
+
+    @Override
+    public boolean next() {
+
+      if (tableLoader.batchCount() >= 1) {
+        return false;
+      }
+      RowSetLoader writer = tableLoader.writer();
+      writer.start();
+      writers.get(0).setString("10");
+      writers.get(1).setString("foo");
+      writers.get(2).setString("bar");
+      writer.save();
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  /**
+   * Test an output schema.
+   * <ul>
+   * <li>Column a has an input type of VARCHAR, and output type of INT,
+   * and the framework will insert an implicit conversion.</li>
+   * <li>Column b has an output type of BIGINT, is projected, but is
+   * not provided by the reader. It will use the default value of 20L.</li>
+   * <li>Column c is not in the output schema, is not provided by the
+   * reader, but is projected, so it will use the default null type
+   * of VARCHAR, with a null value.</li>
+   * </ul>
+   */
+  @Test
+  public void testProvidedSchema() {
+    TupleMetadata providedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT) // Projected, in reader
+        .add("d", MinorType.BIGINT) // Projected, not in reader
+        .add("e", MinorType.BIGINT) // Not projected, not in reader
+        .buildSchema();
+    providedSchema.metadata("d").setDefaultValue("20");
+    providedSchema.metadata("e").setDefaultValue("30");
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    builder.setProjection(new String[]{"a", "b", "d", "f"});
+    builder.addReader(negotiator -> new MockSimpleReader(negotiator));
+    builder.builder.providedSchema(providedSchema);
+    builder.builder.nullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("b", MinorType.VARCHAR)
+        .add("d", MinorType.BIGINT)
+        .addNullable("f", MinorType.VARCHAR)
+        .buildSchema();
+
+    // Initial schema
+    assertTrue(scan.buildSchema());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+           .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    // Batch with defaults and null types
+    assertTrue(scan.next());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+          .addRow(10, "foo", 20L, null)
+          .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  /**
+   * Test non-strict specified schema, with a wildcard, with extra
+   * reader columns. Reader columns are included in output.
+   */
+  @Test
+  public void testProvidedSchemaWithWildcard() {
+    TupleMetadata providedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)    // Projected, in reader
+        .add("d", MinorType.BIGINT) // Projected, not in reader
+        .add("e", MinorType.BIGINT) // Not projected, not in reader
+        .buildSchema();
+    providedSchema.metadata("d").setDefaultValue("20");
+    providedSchema.metadata("e").setDefaultValue("30");
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    builder.setProjection(RowSetTestUtils.projectAll());
+    builder.addReader(negotiator -> new MockSimpleReader(negotiator));
+    builder.builder.providedSchema(providedSchema);
+    builder.builder.nullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("d", MinorType.BIGINT)
+        .add("e", MinorType.BIGINT)
+        .add("b", MinorType.VARCHAR)
+        .add("c", MinorType.VARCHAR)
+        .buildSchema();
+
+    // Initial schema
+    assertTrue(scan.buildSchema());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+           .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    // Batch with defaults and null types
+    assertTrue(scan.next());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+          .addRow(10, 20L, 30L, "foo", "bar")
+          .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testStrictProvidedSchemaWithWildcard() {
+    TupleMetadata providedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)    // Projected, in reader
+        .add("d", MinorType.BIGINT) // Projected, not in reader
+        .add("e", MinorType.BIGINT) // Not projected, not in reader
+        .buildSchema();
+    providedSchema.metadata("d").setDefaultValue("20");
+    providedSchema.metadata("e").setDefaultValue("30");
+    providedSchema.setProperty(TupleMetadata.IS_STRICT_SCHEMA_PROP, Boolean.TRUE.toString());
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    // Project schema only
+    builder.setProjection(RowSetTestUtils.projectAll());
+    builder.addReader(negotiator -> new MockSimpleReader(negotiator));
+    builder.builder.providedSchema(providedSchema);
+    builder.builder.nullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("d", MinorType.BIGINT)
+        .add("e", MinorType.BIGINT)
+         .buildSchema();
+
+    // Initial schema
+    assertTrue(scan.buildSchema());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+           .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    // Batch with defaults and null types
+    assertTrue(scan.next());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+          .addRow(10, 20L, 30L)
+          .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testStrictProvidedSchemaWithWildcardAndSpecialCols() {
+    TupleMetadata providedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)    // Projected, in reader
+        .add("d", MinorType.BIGINT) // Projected, not in reader
+        .add("e", MinorType.BIGINT) // Not projected, not in reader
+        .buildSchema();
+    providedSchema.metadata("d").setDefaultValue("20");
+    providedSchema.metadata("e").setDefaultValue("30");
+    providedSchema.setProperty(TupleMetadata.IS_STRICT_SCHEMA_PROP, Boolean.TRUE.toString());
+    providedSchema.metadata("a").setBooleanProperty(ColumnMetadata.EXCLUDE_FROM_WILDCARD, true);
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    // Project schema only
+    builder.setProjection(RowSetTestUtils.projectAll());
+    builder.addReader(negotiator -> new MockSimpleReader(negotiator));
+    builder.builder.providedSchema(providedSchema);
+    builder.builder.nullType(Types.optional(MinorType.VARCHAR));
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("d", MinorType.BIGINT)
+        .add("e", MinorType.BIGINT)
+         .buildSchema();
+
+    // Initial schema
+    assertTrue(scan.buildSchema());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+           .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    // Batch with defaults and null types
+    assertTrue(scan.next());
+    {
+      SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+          .addRow(20L, 30L)
+          .build();
+      RowSetUtilities.verify(expected,
+          fixture.wrap(scan.batchAccessor().container()));
+    }
+
+    assertFalse(scan.next());
+    scanFixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanOverflow.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/TestScanOverflow.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test vector overflow in the context of the scan operator.
+ */
+@Category(EvfTests.class)
+public class TestScanOverflow extends BaseScanTest {
+
+  /**
+   * Mock reader that produces "jumbo" batches that cause a vector to
+   * fill and a row to overflow from one batch to the next.
+   */
+  private static class OverflowReader extends BaseMockBatchReader {
+
+    private final String value;
+    public int rowCount;
+    /**
+     * If true, the reader will report EOF after filling a batch
+     * to overflow. This simulates the corner case in which a reader
+     * has, say, 1000 rows, hits overflow on row 1000, then declares
+     * it has nothing more to read.
+     * <p>
+     * If false, reports EOF on a call to next() without reading more
+     * rows. The overflow row from the prior batch still exists in
+     * the result set loader.
+     */
+    public boolean reportEofWithOverflow;
+
+    public OverflowReader(SchemaNegotiator schemaNegotiator) {
+      char buf[] = new char[512];
+      Arrays.fill(buf, 'x');
+      value = new String(buf);
+      TupleMetadata schema = new SchemaBuilder()
+          .add("a", MinorType.VARCHAR)
+          .buildSchema();
+      schemaNegotiator.tableSchema(schema, true);
+      tableLoader = schemaNegotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      }
+
+      RowSetLoader writer = tableLoader.writer();
+      while (! writer.isFull()) {
+        writer.start();
+        writer.scalar(0).setString(value);
+        writer.save();
+        rowCount++;
+      }
+
+      // The vector overflowed on the last row. But, we still had to write the row.
+      // The row is tucked away in the loader to appear as the first row in
+      // the next batch.
+      //
+      // Depending on the flag set by the test routine, either report the EOF
+      // during this read, or report it next time around.
+      return reportEofWithOverflow
+          ? batchCount < batchLimit
+          : true;
+    }
+  }
+
+  /**
+   * Test multiple readers, with one of them creating "jumbo" batches
+   * that overflow. Specifically, test a corner case. A batch ends right
+   * at file EOF, but that last batch overflowed.
+   */
+  @Test
+  public void testMultipleReadersWithOverflowEofWithData() {
+    runOverflowTest(true);
+  }
+
+  @Test
+  public void testMultipleReadersWithOverflowEofWithoutData() {
+    runOverflowTest(false);
+  }
+
+  private void runOverflowTest(boolean eofWithData) {
+    ObservableCreator creator1 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        OverflowReader reader = new OverflowReader(negotiator);
+        reader.batchLimit = 2;
+        reader.reportEofWithOverflow = eofWithData;
+        return reader;
+      };
+    };
+    ObservableCreator creator2 = new ObservableCreator() {
+      @Override
+      public ManagedReader create(SchemaNegotiator negotiator) {
+        OverflowReader reader = new OverflowReader(negotiator);
+        reader.batchLimit = 2;
+        return reader;
+      };
+    };
+
+    BaseScanFixtureBuilder builder = new BaseScanFixtureBuilder(fixture);
+    builder.projectAll();
+    builder.addReader(creator1);
+    builder.addReader(creator2);
+
+    // Want overflow, set size and row counts at their limits.
+    builder.builder.batchByteLimit(ScanLifecycleBuilder.MAX_BATCH_BYTE_SIZE);
+    builder.builder.batchRecordLimit(ScanLifecycleBuilder.MAX_BATCH_ROW_COUNT);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    assertTrue(scan.buildSchema());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    scan.batchAccessor().release();
+
+    // Second batch. Should be 1 less than the reader's row
+    // count because the loader has its own one-row lookahead batch.
+    assertTrue(scan.next());
+    OverflowReader reader1 = creator1.reader();
+    assertEquals(1, reader1.batchCount);
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    int prevRowCount = scan.batchAccessor().rowCount();
+    assertEquals(reader1.rowCount - 1, prevRowCount);
+    scan.batchAccessor().release();
+
+    // Third batch, adds more data to the lookahead batch. Also overflows
+    // so returned records is one less than total produced so far minus
+    // those returned earlier.
+    assertTrue(scan.next());
+    assertEquals(2, reader1.batchCount);
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    assertEquals(reader1.rowCount - prevRowCount - 1, scan.batchAccessor().rowCount());
+    scan.batchAccessor().release();
+    int prevReaderRowCount = reader1.rowCount;
+
+    // Third batch. Returns the overflow row from the second batch of
+    // the first reader.
+    assertTrue(scan.next());
+    assertEquals(eofWithData ? 2 : 3, reader1.batchCount);
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    assertEquals(1, scan.batchAccessor().rowCount());
+    assertEquals(prevReaderRowCount, reader1.rowCount);
+    scan.batchAccessor().release();
+
+    // Second reader.
+    assertTrue(scan.next());
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    scan.batchAccessor().release();
+
+    // Second batch from second reader.
+    assertTrue(scan.next());
+    OverflowReader reader2 = creator2.reader();
+    assertEquals(2, reader2.batchCount);
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    scan.batchAccessor().release();
+
+    // Third batch. Returns the overflow row from the second batch of
+    // the second reader.
+    assertTrue(scan.next());
+    assertEquals(3, reader2.batchCount);
+    assertEquals(1, scan.batchAccessor().schemaVersion());
+    assertEquals(1, scan.batchAccessor().rowCount());
+    assertEquals(prevReaderRowCount, reader2.rowCount);
+    scan.batchAccessor().release();
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/BaseFileScanTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/BaseFileScanTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanFixture;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanFixture.ScanFixtureBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.store.dfs.easy.FileWork;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+public class BaseFileScanTest extends SubOperatorTest implements MockFileNames {
+
+  /**
+   * Fixture that creates the reader and gives a test access to
+   * the reader.
+   */
+  protected interface ReaderCreator {
+    ManagedReader instance(FileSchemaNegotiator negotiator) throws EarlyEofException;
+  }
+
+  protected static class ReaderFactoryFixture extends FileReaderFactory {
+
+    private final Iterator<ReaderCreator> iterator;
+
+    public ReaderFactoryFixture(Iterator<ReaderCreator> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public ManagedReader newReader(FileSchemaNegotiator negotiator) throws EarlyEofException {
+      return iterator.next().instance(negotiator);
+    }
+  }
+
+  /**
+   * For schema-based testing, we only need the file path from the file work.
+   */
+  public static class DummyFileWork implements FileWork {
+
+    private final Path path;
+
+    public DummyFileWork(Path path) {
+      this.path = path;
+    }
+
+    @Override
+    public Path getPath() { return path; }
+
+    @Override
+    public long getStart() { return 0; }
+
+    @Override
+    public long getLength() { return 0; }
+  }
+
+  protected static class FileScanFixtureBuilder extends ScanFixtureBuilder {
+
+    public FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    public List<ReaderCreator> readers = new ArrayList<>();
+    public List<FileWork> blocks = new ArrayList<>();
+
+    public FileScanFixtureBuilder() {
+      super(fixture);
+      builder.rootDir(MOCK_ROOT_PATH);
+      builder.maxPartitionDepth(3);
+    }
+
+    public void projectAllWithImplicit(int dirs) {
+      builder().projection(FileScanUtils.projectAllWithMetadata(dirs));
+    }
+
+    public void addReader(ReaderCreator reader) {
+      addReader(reader, new DummyFileWork(new Path(MOCK_FILE_SYSTEM_NAME)));
+    }
+
+    public void addReader(ReaderCreator reader, FileWork block) {
+      readers.add(reader);
+      blocks.add(block);
+    }
+
+    @Override
+    public ScanLifecycleBuilder builder() { return builder; }
+
+    @Override
+    public ScanFixture build() {
+      builder.fileSystemConfig(new Configuration());
+      builder.fileSplits(blocks);
+      builder.readerFactory(new ReaderFactoryFixture(readers.iterator()));
+      return super.build();
+    }
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/FileScanUtils.java
@@ -17,11 +17,11 @@
  */
 package org.apache.drill.exec.physical.impl.scan.v3.file;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 public class FileScanUtils {
 
@@ -38,7 +38,10 @@ public class FileScanUtils {
   }
 
   public static List<SchemaPath> expandMetadata(int dirCount) {
-    List<String> selected = Arrays.asList(
+    // Use of Guava rather than Arrays.asList() because
+    // we need a mutable list so we an add the partition
+    // columns.
+    List<String> selected = Lists.newArrayList(
         FULLY_QUALIFIED_NAME_COL,
         FILE_PATH_COL,
         FILE_NAME_COL,

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestFileScan.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestFileScan.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.impl.scan.ScanOperatorExec;
+import org.apache.drill.exec.physical.impl.scan.v3.BaseMockBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanFixture;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.record.MaterializedField;
+import org.apache.drill.exec.record.metadata.MetadataUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests the implicit column extensions to the file operator framework.
+ * Focuses on the file implicit columns, assumes that other tests have
+ * verified the underlying mechanisms.
+ */
+@Category(EvfTests.class)
+public class TestFileScan extends BaseFileScanTest {
+
+  /**
+   * "Late schema" reader, meaning that the reader does not know the schema on
+   * open, but must "discover" it when reading data.
+   */
+  private static class MockLateSchemaReader extends BaseMockBatchReader {
+
+    public boolean returnDataOnFirst;
+
+    public MockLateSchemaReader(FileSchemaNegotiator negotiator) {
+
+      // Verify the path
+      assertEquals(MOCK_FILE_SYSTEM_NAME, negotiator.fileWork().getPath().toString());
+      assertEquals(MOCK_FILE_SYSTEM_NAME, negotiator.split().getPath().toString());
+
+      // No schema or file, just build the table loader.
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      } else if (batchCount == 1) {
+
+        // On first batch, pretend to discover the schema.
+        RowSetLoader rowSet = tableLoader.writer();
+        MaterializedField a = SchemaBuilder.columnSchema("a", MinorType.INT, DataMode.REQUIRED);
+        rowSet.addColumn(a);
+        rowSet.addColumn(MetadataUtils.newScalar("b", Types.optional(MinorType.VARCHAR)));
+        if (!returnDataOnFirst) {
+          return true;
+        }
+      }
+
+      makeBatch();
+      return true;
+    }
+  }
+
+  /**
+   * Mock reader with an early schema: the schema is known before the first
+   * record. Think Parquet or JDBC.
+   */
+  private static class MockEarlySchemaReader extends BaseMockBatchReader {
+
+    public MockEarlySchemaReader(FileSchemaNegotiator schemaNegotiator) {
+      TupleMetadata schema = new SchemaBuilder()
+          .add("a", MinorType.INT)
+          .addNullable("b", MinorType.VARCHAR)
+          .buildSchema();
+      schemaNegotiator.tableSchema(schema, true);
+      tableLoader = schemaNegotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      }
+
+      makeBatch();
+      return true;
+    }
+  }
+
+  @Test
+  public void testLateSchemaFileWildcards() {
+
+    // Create a mock reader, return two batches: one schema-only, another with data.
+    ReaderCreator creator = negotiator -> {
+      MockLateSchemaReader reader = new MockLateSchemaReader(negotiator);
+      reader.batchLimit = 1;
+      reader.returnDataOnFirst = true;
+      return reader;
+    };
+
+    // Create the scan operator
+    FileScanFixtureBuilder builder = new FileScanFixtureBuilder();
+    builder.projectAllWithImplicit(3);
+    builder.addReader(creator);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // First batch: build schema. The reader helps: it returns an
+    // empty first batch.
+    assertTrue(scan.buildSchema());
+    assertEquals(0, scan.batchAccessor().rowCount());
+
+    // Create the expected result.
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("b", MinorType.VARCHAR)
+        .add(FileScanUtils.FULLY_QUALIFIED_NAME_COL, MinorType.VARCHAR)
+        .add(FileScanUtils.FILE_PATH_COL, MinorType.VARCHAR)
+        .add(FileScanUtils.FILE_NAME_COL, MinorType.VARCHAR)
+        .add(FileScanUtils.SUFFIX_COL, MinorType.VARCHAR)
+        .addNullable(FileScanUtils.partitionColName(0), MinorType.VARCHAR)
+        .addNullable(FileScanUtils.partitionColName(1), MinorType.VARCHAR)
+        .addNullable(FileScanUtils.partitionColName(2), MinorType.VARCHAR)
+        .buildSchema();
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "fred", MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .addRow(20, "wilma", MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .build();
+    assertEquals(expected.batchSchema(), scan.batchAccessor().schema());
+
+    // Next call, return with data.
+    assertTrue(scan.next());
+    RowSetUtilities.verify(expected,
+        fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  /**
+   * Basic sanity test of a couple of implicit columns, along
+   * with all table columns in table order. Full testing of implicit
+   * columns is done on lower-level components.
+   */
+  @Test
+  public void testImplicitColumns() {
+
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Select table and implicit columns.
+    FileScanFixtureBuilder builder = new FileScanFixtureBuilder();
+    builder.setProjection("a", "b", "filename", "suffix");
+    builder.addReader(creator);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Expect data and implicit columns
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("b", MinorType.VARCHAR)
+        .add("filename", MinorType.VARCHAR)
+        .add("suffix", MinorType.VARCHAR)
+        .build();
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "fred", MOCK_FILE_NAME, MOCK_SUFFIX)
+        .addRow(20, "wilma", MOCK_FILE_NAME, MOCK_SUFFIX)
+        .build();
+
+    // Schema should include implicit columns.
+    assertTrue(scan.buildSchema());
+    assertEquals(expected.container().getSchema(), scan.batchAccessor().schema());
+    scan.batchAccessor().release();
+
+    // Read one batch, should contain implicit columns
+    assertTrue(scan.next());
+    RowSetUtilities.verify(expected,
+        fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  /**
+   * Exercise the major project operations: subset of table
+   * columns, implicit, partition, missing columns, and output
+   * order (and positions) different than table. These cases
+   * are more fully test on lower level components; here we verify
+   * that the components are wired up correctly.
+   */
+  @Test
+  public void testFullProject() {
+
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Select table and implicit columns.
+    FileScanFixtureBuilder builder = new FileScanFixtureBuilder();
+    builder.setProjection("dir0", "b", "filename", "c", "suffix");
+    builder.addReader(creator);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Expect data and implicit columns
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("dir0", MinorType.VARCHAR)
+        .addNullable("b", MinorType.VARCHAR)
+        .add("filename", MinorType.VARCHAR)
+        .addNullable("c", MinorType.INT)
+        .add("suffix", MinorType.VARCHAR)
+        .build();
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(MOCK_DIR0, "fred", MOCK_FILE_NAME, null, MOCK_SUFFIX)
+        .addRow(MOCK_DIR0, "wilma", MOCK_FILE_NAME, null, MOCK_SUFFIX)
+        .build();
+
+    // Schema should include implicit columns.
+    assertTrue(scan.buildSchema());
+    assertEquals(expected.container().getSchema(), scan.batchAccessor().schema());
+    scan.batchAccessor().release();
+
+    // Read one batch, should contain implicit columns
+    assertTrue(scan.next());
+    RowSetUtilities.verify(expected,
+        fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  @Test
+  public void testEmptyProject() {
+
+    ReaderCreator creator = negotiator -> {
+      MockEarlySchemaReader reader = new MockEarlySchemaReader(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Select no columns
+    FileScanFixtureBuilder builder = new FileScanFixtureBuilder();
+    builder.setProjection();
+    builder.addReader(creator);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Expect data and implicit columns
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .build();
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow()
+        .addRow()
+        .build();
+
+    // Schema should include implicit columns.
+    assertTrue(scan.buildSchema());
+    assertEquals(expected.container().getSchema(), scan.batchAccessor().schema());
+    scan.batchAccessor().release();
+
+    // Read one batch, should contain implicit columns
+    assertTrue(scan.next());
+    RowSetUtilities.verify(expected,
+        fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+
+  private static class MockMapReader extends BaseMockBatchReader {
+
+    public MockMapReader(FileSchemaNegotiator schemaNegotiator) {
+      TupleMetadata schema = new SchemaBuilder()
+          .addMap("m1")
+            .add("a", MinorType.INT)
+            .add("b", MinorType.INT)
+            .resumeSchema()
+          .buildSchema();
+      schemaNegotiator.tableSchema(schema, true);
+      tableLoader = schemaNegotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      }
+
+      tableLoader.writer()
+        .addRow(new Object[] {new Object[] {10, 11}})
+        .addRow(new Object[] {new Object[] {20, 21}});
+      return true;
+    }
+  }
+
+  @Test
+  public void testMapProject() {
+
+    ReaderCreator creator = negotiator -> {
+      MockMapReader reader = new MockMapReader(negotiator);
+      reader.batchLimit = 1;
+      return reader;
+    };
+
+    // Select one of the two map columns
+    FileScanFixtureBuilder builder = new FileScanFixtureBuilder();
+    builder.setProjection("m1.a");
+    builder.addReader(creator);
+    ScanFixture scanFixture = builder.build();
+    ScanOperatorExec scan = scanFixture.scanOp;
+
+    // Expect data and implicit columns
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("m1")
+          .add("a", MinorType.INT)
+          .resumeSchema()
+        .build();
+    SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addSingleCol(new Object[] {10})
+        .addSingleCol(new Object[] {20})
+        .build();
+    assertTrue(scan.buildSchema());
+    assertEquals(expected.container().getSchema(), scan.batchAccessor().schema());
+    scan.batchAccessor().release();
+
+    assertTrue(scan.next());
+    RowSetUtilities.verify(expected,
+         fixture.wrap(scan.batchAccessor().container()));
+
+    // EOF
+    assertFalse(scan.next());
+    assertEquals(0, scan.batchAccessor().rowCount());
+    scanFixture.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestFileScanLifecycle.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestFileScanLifecycle.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.file.BaseFileScanTest.DummyFileWork;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.BaseTestScanLifecycle;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.ScanLifecycle;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker.ProjectionType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(EvfTests.class)
+public class TestFileScanLifecycle extends BaseTestScanLifecycle implements MockFileNames {
+
+  /**
+   * Sanity test that the file scan framework works the same as the base framework
+   * when no implicit columns are present.
+   */
+  @Test
+  public void testNoImplicit() {
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(MOCK_FILE_PATH)));
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  @Test
+  public void testSingleCol() {
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList(FileScanUtils.FILE_NAME_COL, SchemaPath.DYNAMIC_STAR));
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(MOCK_FILE_PATH)));
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add(FileScanUtils.FILE_NAME_COL, IMPLICIT_COL_TYPE)
+        .addAll(SCHEMA)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(MOCK_FILE_NAME, 10, "fred")
+        .addRow(MOCK_FILE_NAME, 20, "wilma")
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  @Test
+  public void testWildcard() {
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.maxPartitionDepth(3);
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(MOCK_FILE_PATH)));
+    builder.useLegacyWildcardExpansion(true);
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addAll(SCHEMA)
+        .add(FileScanUtils.partitionColName(0), PARTITION_COL_TYPE)
+        .add(FileScanUtils.partitionColName(1), PARTITION_COL_TYPE)
+        .add(FileScanUtils.partitionColName(2), PARTITION_COL_TYPE)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "fred", MOCK_DIR0, MOCK_DIR1, null)
+        .addRow(20, "wilma", MOCK_DIR0, MOCK_DIR1, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  @Test
+  public void testAllColumns() {
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.maxPartitionDepth(3);
+    builder.projection(FileScanUtils.projectAllWithMetadata(3));
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(MOCK_FILE_PATH)));
+    builder.useLegacyWildcardExpansion(true);
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addAll(SCHEMA)
+        .add(FileScanUtils.FULLY_QUALIFIED_NAME_COL, IMPLICIT_COL_TYPE)
+        .add(FileScanUtils.FILE_PATH_COL, IMPLICIT_COL_TYPE)
+        .add(FileScanUtils.FILE_NAME_COL, IMPLICIT_COL_TYPE)
+        .add(FileScanUtils.SUFFIX_COL, IMPLICIT_COL_TYPE)
+        .add(FileScanUtils.partitionColName(0), PARTITION_COL_TYPE)
+        .add(FileScanUtils.partitionColName(1), PARTITION_COL_TYPE)
+        .add(FileScanUtils.partitionColName(2), PARTITION_COL_TYPE)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "fred", MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .addRow(20, "wilma", MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test the obscure case that the partition column contains two digits:
+   * dir11. Also tests the obscure case that the output only has partition
+   * columns.
+   */
+  @Test
+  public void testPartitionColumnTwoDigits() {
+    Path filePath = new Path("file:/w/0/1/2/3/4/5/6/7/8/9/10/d11/z.csv");
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.maxPartitionDepth(11);
+    builder.projection(RowSetTestUtils.projectList(
+        "a", "b", FileScanUtils.partitionColName(11)));
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(filePath)));
+    builder.useLegacyWildcardExpansion(true);
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addAll(SCHEMA)
+        .add(FileScanUtils.partitionColName(11), PARTITION_COL_TYPE)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "fred", "d11")
+        .addRow(20, "wilma", "d11")
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Verify that errors thrown from file-based readers include the file name
+   * in addition to the scan and reader level error contexts.
+   */
+  @Test
+  public void testCtorUserError() {
+    FileScanLifecycleBuilder builder = new FileScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.rootDir(MOCK_ROOT_PATH);
+    builder.maxPartitionDepth(3);
+    builder.projection(FileScanUtils.projectAllWithMetadata(3));
+    builder.fileSplits(Collections.singletonList(new DummyFileWork(MOCK_FILE_PATH)));
+    builder.useLegacyWildcardExpansion(true);
+    builder.readerFactory(new FileReaderFactory() {
+      @Override
+      public ManagedReader newReader(FileSchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "ctor-u");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops ctor"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertTrue(msg.contains(MOCK_FILE_NAME));
+      assertNull(e.getCause());
+    }
+    scan.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestImplicitColumnLoader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/file/TestImplicitColumnLoader.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.file;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.exec.physical.impl.scan.ScanTestUtils;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.StaticBatchBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.BaseTestScanLifecycle.DummySubScan;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaConfigBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.physical.resultSet.impl.NullResultVectorCacheImpl;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests the file implicit column handler which identifies implicit columns
+ * and populates them. Assumes that the implicit column parser tests pass.
+ */
+@Category(EvfTests.class)
+public class TestImplicitColumnLoader extends SubOperatorTest implements MockFileNames {
+
+  public StaticBatchBuilder buildHandler(List<SchemaPath> projList, Path root, Path input) {
+    FileScanLifecycleBuilder options = new FileScanLifecycleBuilder();
+    options.rootDir(root);
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    final ScanSchemaTracker schemaTracker = new ScanSchemaConfigBuilder()
+        .projection(projList)
+        .build();
+    ImplicitFileColumnsHandler handler = new ImplicitFileColumnsHandler(
+        fixture.operatorContext(new DummySubScan()), options, cache, schemaTracker);
+    return handler.forFile(input);
+  }
+
+  @Test
+  public void testNoColumns() {
+    assertNull(buildHandler(RowSetTestUtils.projectNone(), MOCK_ROOT_PATH, MOCK_FILE_PATH));
+  }
+
+  @Test
+  public void testOneColumn() {
+    StaticBatchBuilder batchLoader = buildHandler(
+        RowSetTestUtils.projectList("a", ScanTestUtils.FILE_NAME_COL, "b"),
+        MOCK_ROOT_PATH, MOCK_FILE_PATH);
+    assertNotNull(batchLoader);
+    batchLoader.load(2);
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add(ScanTestUtils.FILE_NAME_COL, IMPLICIT_COL_TYPE)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(MOCK_FILE_NAME)
+        .addRow(MOCK_FILE_NAME)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(batchLoader.outputContainer()));
+  }
+
+  @Test
+  public void testAllColumns() {
+    StaticBatchBuilder batchLoader = buildHandler(
+        ScanTestUtils.projectAllWithMetadata(3),
+        MOCK_ROOT_PATH, MOCK_FILE_PATH);
+    assertNotNull(batchLoader);
+    batchLoader.load(2);
+
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add(ScanTestUtils.FULLY_QUALIFIED_NAME_COL, IMPLICIT_COL_TYPE)
+        .add(ScanTestUtils.FILE_PATH_COL, IMPLICIT_COL_TYPE)
+        .add(ScanTestUtils.FILE_NAME_COL, IMPLICIT_COL_TYPE)
+        .add(ScanTestUtils.SUFFIX_COL, IMPLICIT_COL_TYPE)
+        .add(ScanTestUtils.partitionColName(0), PARTITION_COL_TYPE)
+        .add(ScanTestUtils.partitionColName(1), PARTITION_COL_TYPE)
+        .add(ScanTestUtils.partitionColName(2), PARTITION_COL_TYPE)
+        .build();
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .addRow(MOCK_FILE_FQN, MOCK_FILE_DIR_PATH, MOCK_FILE_NAME, MOCK_SUFFIX, MOCK_DIR0, MOCK_DIR1, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(batchLoader.outputContainer()));
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
@@ -1,0 +1,468 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.common.exceptions.UserException.Builder;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.base.AbstractSubScan;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ReaderFactory;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.record.metadata.TupleSchema;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseTestScanLifecycle extends SubOperatorTest {
+  private static final Logger logger = LoggerFactory.getLogger(BaseTestScanLifecycle.class);
+
+  public static class DummySubScan extends AbstractSubScan {
+
+    public DummySubScan() {
+      super("fake-user");
+    }
+
+    @Override
+    public int getOperatorType() { return 0; }
+  }
+
+  protected static abstract class SingleReaderFactory implements ReaderFactory<SchemaNegotiator> {
+
+    private int counter;
+
+    @Override
+    public boolean hasNext() {
+      return counter == 0;
+    }
+  }
+
+  protected static abstract class TwoReaderFactory implements ReaderFactory<SchemaNegotiator> {
+
+    private int counter;
+
+    @Override
+    public ManagedReader next(SchemaNegotiator negotiator) {
+      counter++;
+      switch (counter) {
+        case 1:
+          return firstReader(negotiator);
+        case 2:
+          return secondReader(negotiator);
+        default:
+          return null;
+      }
+    }
+
+    public abstract ManagedReader firstReader(SchemaNegotiator negotiator);
+    public abstract ManagedReader secondReader(SchemaNegotiator negotiator);
+
+    @Override
+    public boolean hasNext() {
+      return counter < 2;
+    }
+  }
+
+  public static final TupleMetadata SCHEMA = new SchemaBuilder()
+      .add("a", MinorType.INT)
+      .addNullable("b", MinorType.VARCHAR)
+      .build();
+
+  /**
+   * Base class for the "mock" readers used in this test. The mock readers
+   * follow the normal (enhanced) reader API, but instead of actually reading
+   * from a data source, they just generate data with a known schema.
+   * They also expose internal state such as identifying which methods
+   * were actually called.
+   */
+  protected static abstract class BaseMockBatchReader implements ManagedReader {
+    protected int startIndex;
+    protected int batchCount;
+    protected int batchLimit;
+    protected ResultSetLoader tableLoader;
+
+    public BaseMockBatchReader(int batchLimit) {
+      this.batchLimit = batchLimit;
+    }
+
+    protected void makeBatch() {
+      RowSetLoader writer = tableLoader.writer();
+      int offset = (batchCount - 1) * 20 + startIndex;
+      writer.addRow(offset + 10, "fred");
+      writer.addRow(offset + 20, "wilma");
+    }
+
+    @Override
+    public boolean next() {
+      batchCount++;
+      if (batchCount > batchLimit) {
+        return false;
+      }
+
+      makeBatch();
+      return true;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+
+  /**
+   * Mock reader with no data or schema, indicated by an early EOF
+   * exception.
+   */
+  protected static class NoDataReader extends BaseMockBatchReader {
+
+    public NoDataReader(SchemaNegotiator sn) throws EarlyEofException {
+      super(0);
+      throw new EarlyEofException();
+    }
+
+    @Override
+    public boolean next() { return false; }
+  }
+
+  protected static class MockEmptySchemaReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public MockEmptySchemaReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(new TupleSchema(), true);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader writer = tableLoader.writer();
+      writer.addRow();
+      writer.addRow();
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  /**
+   * "Early schema" refers to the case in which the reader can provide a schema
+   * when the reader is opened. Examples: CSV, HBase, MapR-DB binary, JDBC.
+   */
+  protected static class MockEarlySchemaReader extends BaseMockBatchReader {
+
+    public MockEarlySchemaReader(SchemaNegotiator negotiator, int batchCount) {
+      super(batchCount);
+      negotiator.tableSchema(SCHEMA);
+      negotiator.schemaIsComplete(true);
+      tableLoader = negotiator.build();
+    }
+  }
+
+  protected static class MockLateSchemaReader extends BaseMockBatchReader {
+
+    public MockLateSchemaReader(SchemaNegotiator negotiator, int batchCount) {
+      super(batchCount);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (batchLimit == 0) {
+        return false;
+      }
+      if (batchCount == 0) {
+        RowSetLoader rowSet = tableLoader.writer();
+        rowSet.addColumn(SCHEMA.metadata(0));
+        rowSet.addColumn(SCHEMA.metadata(1));
+      }
+      return super.next();
+    }
+  }
+
+  protected static class MockSingleColReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public MockSingleColReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .build());
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      rowSet.addSingleCol(101);
+      rowSet.addSingleCol(102);
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  protected static class MockThreeColReader implements ManagedReader {
+
+    public static final TupleMetadata READER_SCHEMA = new SchemaBuilder()
+        .addAll(SCHEMA)
+        .add("c", MinorType.BIGINT)
+        .build();
+
+    private final ResultSetLoader tableLoader;
+
+    public MockThreeColReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(READER_SCHEMA);
+      negotiator.schemaIsComplete(true);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      rowSet.addRow(101, "wilma", 1001);
+      rowSet.addRow(102, "betty", 1002);
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  public static final TupleMetadata CONFLICT_SCHEMA = new SchemaBuilder()
+      .add("a", MinorType.INT)
+      .addNullable("b", MinorType.BIGINT)
+      .build();
+
+  protected static class MockEarlySchemaTypeConflictReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public MockEarlySchemaTypeConflictReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(CONFLICT_SCHEMA);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      rowSet.addRow(101, 1001);
+      rowSet.addRow(102, 1002);
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  protected static class MockLateSchemaTypeConflictReader implements ManagedReader {
+
+    private final ResultSetLoader tableLoader;
+
+    public MockLateSchemaTypeConflictReader(SchemaNegotiator negotiator) {
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      if (tableLoader.batchCount() == 0) {
+        rowSet.addColumn(CONFLICT_SCHEMA.metadata(0).copy());
+        rowSet.addColumn(CONFLICT_SCHEMA.metadata(1).copy());
+      }
+      rowSet.addRow(101, 1001);
+      rowSet.addRow(102, 1002);
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  protected static class MockModeConflictReader implements ManagedReader {
+
+    public static final TupleMetadata READER_SCHEMA = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("b", MinorType.VARCHAR) // Nullable in base reader
+        .build();
+
+    private final ResultSetLoader tableLoader;
+
+    public MockModeConflictReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(READER_SCHEMA);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader rowSet = tableLoader.writer();
+      rowSet.addRow(101, "wilma");
+      rowSet.addRow(102, "betty");
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  protected static class MockReorderedReader implements ManagedReader {
+
+    public static final TupleMetadata READER_SCHEMA = new SchemaBuilder()
+        .add(SCHEMA.metadata(1).copy())
+        .add(SCHEMA.metadata(0).copy())
+        .build();
+
+    private final ResultSetLoader tableLoader;
+
+    public MockReorderedReader(SchemaNegotiator negotiator) {
+      negotiator.tableSchema(READER_SCHEMA);
+      tableLoader = negotiator.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (tableLoader.batchCount() > 0) {
+        return false;
+      }
+      RowSetLoader writer = tableLoader.writer();
+      writer.addRow("barney", 30);
+      writer.addRow("betty", 40);
+      return true;
+    }
+
+    @Override
+    public void close() { }
+  }
+
+  protected static class FailingReader implements ManagedReader {
+
+    public final String failType;
+    public final CustomErrorContext ec;
+
+    public FailingReader(SchemaNegotiator sn, String failType) {
+      this.failType = failType;
+      this.ec = new ChildErrorContext(sn.parentErrorContext()) {
+        @Override
+        public void addContext(Builder builder) {
+          super.addContext(builder);
+          builder.addContext("My custom context");
+        }
+      };
+      sn.setErrorContext(ec);
+      if (failType.equals("ctor")) {
+        throw new IllegalStateException("Oops ctor");
+      }
+      if (failType.equals("ctor-u")) {
+        throw UserException.dataReadError()
+          .message("Oops ctor")
+          .addContext(ec)
+          .build(logger);
+      }
+      sn.build();
+    }
+
+    @Override
+    public boolean next() {
+      if (failType.equals("next")) {
+        throw new IllegalStateException("Oops next");
+      }
+      if (failType.equals("next-u")) {
+        throw UserException.dataReadError()
+          .message("Oops next")
+          .addContext(ec)
+          .build(logger);
+      }
+      return false;
+    }
+
+    @Override
+    public void close() {
+      if (failType.equals("close")) {
+        throw new IllegalStateException("Oops close");
+      }
+      if (failType.equals("close-u")) {
+        throw UserException.dataReadError()
+          .message("Oops close")
+          .addContext(ec)
+          .build(logger);
+      }
+    }
+  }
+
+  protected ScanLifecycle buildScan(ScanLifecycleBuilder builder) {
+    return builder.build(
+        fixture.operatorContext(new DummySubScan()));
+  }
+
+  protected RowSet simpleExpected(int startIndex) {
+    int offset = startIndex * 20;
+    return fixture.rowSetBuilder(SCHEMA)
+      .addRow(offset + 10, "fred")
+      .addRow(offset + 20, "wilma")
+      .build();
+  }
+
+  protected void verifyEmptyReader(ScanLifecycle scan) {
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertFalse(reader.next());
+    assertFalse(scan.hasOutputSchema());
+    reader.close();
+  }
+
+  protected void verifyStandardReader(ScanLifecycle scan, int offset) {
+    RowBatchReader reader = scan.nextReader();
+    reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestMissingColumnLoader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestMissingColumnLoader.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.DataMode;
+import org.apache.drill.common.types.TypeProtos.MajorType;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.resultSet.ResultVectorCache;
+import org.apache.drill.exec.physical.resultSet.impl.NullResultVectorCacheImpl;
+import org.apache.drill.exec.physical.resultSet.impl.ResultVectorCacheImpl;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.exec.vector.ValueVector;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test the mechanism that handles all-null columns during projection.
+ * An all-null column is one projected in the query, but which does
+ * not actually exist in the underlying data source (or input
+ * operator.)
+ * <p>
+ * In anticipation of having type information, this mechanism
+ * can create the classic nullable Int null column, or one of
+ * any other type and mode.
+ */
+@Category(EvfTests.class)
+public class TestMissingColumnLoader extends SubOperatorTest {
+
+  /**
+   * Test the simplest case: default null type, nothing in the vector
+   * cache. Specify no column type, the special NULL type, or a
+   * predefined type. Output types should be set accordingly.
+   */
+  @Test
+  public void testBasics() {
+
+    TupleMetadata missingCols = new SchemaBuilder()
+        .addDynamic("unspecified")
+        .addNullable("specifiedOpt", MinorType.VARCHAR)
+        .add("specifiedReq", MinorType.VARCHAR)
+        .addArray("specifiedArray", MinorType.VARCHAR)
+        .build();
+
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .build();
+    assertNotNull(handler);
+
+    // Create a batch
+    handler.load(2);
+
+    // Verify values and types
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("unspecified", MissingColumnHandlerBuilder.DEFAULT_NULL_TYPE)
+        .addNullable("specifiedOpt", MinorType.VARCHAR)
+        .add("specifiedReq", MinorType.VARCHAR)
+        .addArray("specifiedArray", MinorType.VARCHAR)
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(null, null, "", new String[] {})
+        .addRow(null, null, "", new String[] {})
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(handler.outputContainer()));
+    handler.close();
+  }
+
+  @Test
+  public void testEmpty() {
+
+    TupleMetadata missingCols = new SchemaBuilder()
+        .build();
+
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .build();
+    assertNull(handler);
+  }
+
+  /**
+   * Test the ability to use a type other than nullable INT for null
+   * columns. This occurs, for example, in the CSV reader where no
+   * column is ever INT (nullable or otherwise) and we want our null
+   * columns to be (non-nullable) VARCHAR.
+   */
+  @Test
+  public void testCustomNullType() {
+
+    TupleMetadata missingCols = new SchemaBuilder()
+        .addDynamic("unspecified")
+        .build();
+
+    // Null required is an oxymoron, so is not tested.
+    // Null type array does not make sense, so is not tested.
+
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    final MajorType nullType = MajorType.newBuilder()
+        .setMinorType(MinorType.VARCHAR)
+        .setMode(DataMode.OPTIONAL)
+        .build();
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .nullType(nullType)
+        .build();
+    assertNotNull(handler);
+
+    // Create a batch
+    handler.load(2);
+
+    // Verify values and types
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("unspecified", nullType)
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(handler.outputContainer()));
+    handler.close();
+  }
+
+  /**
+   * Test the ability to provide a default value for a "null" column.
+   * Default values are only allowed for required "null" columns. For
+   * nullable columns, NULL is already the default.
+   */
+  @Test
+  public void testDefaultValue() {
+
+    TupleMetadata missingCols = new SchemaBuilder()
+        .add("int", MinorType.INT)
+        .add("str", MinorType.VARCHAR)
+        .add("dub", MinorType.FLOAT8)
+        .build();
+    missingCols.metadata("int").setDefaultValue("10");
+    missingCols.metadata("str").setDefaultValue("foo");
+    missingCols.metadata("dub").setDefaultValue("20.0");
+
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .build();
+    assertNotNull(handler);
+
+    // Create a batch
+    handler.load(2);
+
+    // Verify values and types
+
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("int", MinorType.INT)
+        .add("str", MinorType.VARCHAR)
+        .add("dub", MinorType.FLOAT8)
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, "foo", 20.0D)
+        .addRow(10, "foo", 20.0D)
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(handler.outputContainer()));
+    handler.close();
+  }
+
+  /**
+   * Drill requires "schema persistence": if a scan operator
+   * reads two files, F1 and F2, then the scan operator must
+   * provide the same vectors from both readers. Not just the
+   * same types, the same value vector instances (but, of course,
+   * populated with different data.)
+   * <p>
+   * Test the case in which the reader for F1 found columns
+   * (a, b, c) but, F2 found only (a, b), requiring that we
+   * fill in column c, filled with nulls, but of the same type that it
+   * was in file F1. We use a vector cache to pull off this trick.
+   * This test ensures that the null column mechanism looks in that
+   * vector cache when asked to create a nullable column.
+   */
+  @Test
+  public void testVectorCache() {
+
+    TupleMetadata missingCols = new SchemaBuilder()
+        .addNullable("req", MinorType.FLOAT8)
+        .addNullable("opt", MinorType.FLOAT8)
+        .addArray("rep", MinorType.FLOAT8)
+        .addDynamic("unk")
+        .build();
+
+    // Populate the cache with a column of each mode.
+    final ResultVectorCacheImpl cache = new ResultVectorCacheImpl(fixture.allocator());
+    cache.vectorFor(SchemaBuilder.columnSchema("req", MinorType.FLOAT8, DataMode.REQUIRED));
+    final ValueVector opt = cache.vectorFor(SchemaBuilder.columnSchema("opt", MinorType.FLOAT8, DataMode.OPTIONAL));
+    final ValueVector rep = cache.vectorFor(SchemaBuilder.columnSchema("rep", MinorType.FLOAT8, DataMode.REPEATED));
+
+    // Use nullable Varchar for unknown null columns.
+    final MajorType nullType = Types.optional(MinorType.VARCHAR);
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .nullType(nullType)
+        .build();
+    assertNotNull(handler);
+
+    // Create a batch
+    handler.load(2);
+    final VectorContainer output = handler.outputContainer();
+
+    // Verify vectors are reused
+    assertSame(opt, output.getValueVector(1).getValueVector());
+    assertSame(rep, output.getValueVector(2).getValueVector());
+
+    // Verify values and types
+    final TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("req", MinorType.FLOAT8)
+        .addNullable("opt", MinorType.FLOAT8)
+        .addArray("rep", MinorType.FLOAT8)
+        .addNullable("unk", MinorType.VARCHAR)
+        .buildSchema();
+    final SingleRowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(null, null, new int[] { }, null)
+        .addRow(null, null, new int[] { }, null)
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+    handler.close();
+  }
+
+  /**
+   * More extensive schema test.
+   */
+  @Test
+  public void testAllModes() {
+
+    final TupleMetadata missingCols = new SchemaBuilder()
+        .add("intReq", MinorType.INT)
+        .add("strReq", MinorType.VARCHAR)
+        .add("dubReq", MinorType.FLOAT8) // No default
+        .addNullable("intOpt", MinorType.INT)
+        .addNullable("strOpt", MinorType.VARCHAR)
+        .addNullable("dubOpt", MinorType.FLOAT8)
+        .buildSchema();
+    missingCols.metadata("intReq").setDefaultValue("10");
+    missingCols.metadata("strReq").setDefaultValue("foo");
+    missingCols.metadata("intOpt").setDefaultValue("20");
+    missingCols.metadata("strOpt").setDefaultValue("bar");
+
+    final ResultVectorCache cache = new NullResultVectorCacheImpl(fixture.allocator());
+    StaticBatchBuilder handler = new MissingColumnHandlerBuilder()
+        .inputSchema(missingCols)
+        .vectorCache(cache)
+        .nullType(Types.optional(MinorType.VARCHAR))
+        .build();
+    assertNotNull(handler);
+
+    handler.load(2);
+
+    final SingleRowSet expected = fixture.rowSetBuilder(missingCols)
+        .addRow(10, "foo", 0.0D, null, null, null)
+        .addRow(10, "foo", 0.0D, null, null, null)
+        .build();
+
+    RowSetUtilities.verify(expected, fixture.wrap(handler.outputContainer()));
+    handler.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestOutputBatchBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestOutputBatchBuilder.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.apache.drill.test.rowSet.RowSetUtilities.mapValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.physical.impl.scan.v3.lifecycle.OutputBatchBuilder.BatchSource;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSet.SingleRowSet;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.apache.drill.test.SubOperatorTest;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(EvfTests.class)
+public class TestOutputBatchBuilder extends SubOperatorTest {
+
+  public TupleMetadata firstSchema() {
+    return new SchemaBuilder()
+      .add("d", MinorType.VARCHAR)
+      .add("a", MinorType.INT)
+      .buildSchema();
+  }
+
+  private VectorContainer makeFirst(TupleMetadata firstSchema) {
+    return fixture.rowSetBuilder(firstSchema)
+      .addRow("barney", 10)
+      .addRow("wilma", 20)
+      .build()
+      .container();
+  }
+
+  public TupleMetadata secondSchema() {
+    return new SchemaBuilder()
+      .add("b", MinorType.INT)
+      .add("c", MinorType.VARCHAR)
+      .buildSchema();
+  }
+
+  private VectorContainer makeSecond(TupleMetadata secondSchema) {
+    return fixture.rowSetBuilder(secondSchema)
+      .addRow(1, "foo.csv")
+      .addRow(2, "foo.csv")
+      .build()
+      .container();
+  }
+
+  @Test
+  public void testSingleInput() {
+
+    TupleMetadata schema = firstSchema();
+    VectorContainer input = makeFirst(schema);
+
+    OutputBatchBuilder builder = new OutputBatchBuilder(schema,
+        Collections.singletonList(new BatchSource(schema, input)),
+        fixture.allocator());
+    builder.load(input.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    RowSetUtilities.verify(fixture.wrap(input), fixture.wrap(output));
+  }
+
+  @Test
+  public void testReorder() {
+
+    TupleMetadata schema = firstSchema();
+    VectorContainer input = makeFirst(schema);
+
+    TupleMetadata outputSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("d", MinorType.VARCHAR)
+        .buildSchema();
+    OutputBatchBuilder builder = new OutputBatchBuilder(outputSchema,
+        Collections.singletonList(new BatchSource(schema, input)),
+        fixture.allocator());
+    builder.load(input.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    RowSet expected = fixture.rowSetBuilder(outputSchema)
+        .addRow(10, "barney")
+        .addRow(20, "wilma")
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+  }
+
+  @Test
+  public void testTwoInputs() {
+
+    TupleMetadata schema1 = firstSchema();
+    VectorContainer input1 = makeFirst(schema1);
+    TupleMetadata schema2 = secondSchema();
+    VectorContainer input2 = makeSecond(schema2);
+
+    TupleMetadata outputSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .add("b", MinorType.INT)
+        .add("c", MinorType.VARCHAR)
+        .add("d", MinorType.VARCHAR)
+        .buildSchema();
+    OutputBatchBuilder builder = new OutputBatchBuilder(outputSchema,
+        Lists.newArrayList(
+            new BatchSource(schema1, input1),
+            new BatchSource(schema2, input2)),
+        fixture.allocator());
+    builder.load(input1.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    SingleRowSet expected = fixture.rowSetBuilder(outputSchema)
+        .addRow(10, 1, "foo.csv", "barney")
+        .addRow(20, 2, "foo.csv", "wilma")
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+  }
+
+  @Test
+  public void testMap() {
+    final TupleMetadata schema = new SchemaBuilder()
+        .add("a", MinorType.VARCHAR)
+        .addMap("m")
+          .add("x", MinorType.INT)
+          .add("y", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final VectorContainer input = fixture.rowSetBuilder(schema)
+        .addRow("barney", mapValue(1, "betty"))
+        .addRow("fred", mapValue(2, "wilma"))
+        .build()
+        .container();
+
+    final OutputBatchBuilder builder = new OutputBatchBuilder(schema,
+        Collections.singletonList(new BatchSource(schema, input)),
+        fixture.allocator());
+    builder.load(input.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    RowSetUtilities.verify(fixture.wrap(input), fixture.wrap(output));
+  }
+
+  @Test
+  public void testTwoMaps() {
+    final TupleMetadata schema1 = new SchemaBuilder()
+        .add("a", MinorType.VARCHAR)
+        .addMap("m")
+          .add("y", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+
+    final VectorContainer input1 = fixture.rowSetBuilder(schema1)
+        .addRow("barney", mapValue("betty"))
+        .addRow("fred", mapValue("wilma"))
+        .build()
+        .container();
+
+    final TupleMetadata schema2 = new SchemaBuilder()
+        .addMap("m")
+          .add("x", MinorType.INT)
+          .resumeSchema()
+        .buildSchema();
+
+    final VectorContainer input2 = fixture.rowSetBuilder(schema2)
+        .addSingleCol(mapValue(1))
+        .addSingleCol(mapValue(2))
+        .build()
+        .container();
+
+    final TupleMetadata outputSchema = new SchemaBuilder()
+        .add("a", MinorType.VARCHAR)
+        .addMap("m")
+          .add("x", MinorType.INT)
+          .add("y", MinorType.VARCHAR)
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = fixture.rowSetBuilder(outputSchema)
+        .addRow("barney", mapValue(1, "betty"))
+        .addRow("fred", mapValue(2, "wilma"))
+        .build();
+
+    OutputBatchBuilder builder = new OutputBatchBuilder(outputSchema,
+        Lists.newArrayList(
+            new BatchSource(schema1, input1),
+            new BatchSource(schema2, input2)),
+        fixture.allocator());
+    builder.load(input1.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+  }
+
+  @Test
+  public void testNestedMaps() {
+    final TupleMetadata schema1 = new SchemaBuilder()
+        .add("a", MinorType.VARCHAR)
+        .addMap("m1")
+          .add("p", MinorType.VARCHAR)
+          .addMap("m2")
+            .add("x", MinorType.VARCHAR)
+            .resumeMap()
+          .resumeSchema()
+        .buildSchema();
+
+    final VectorContainer input1 = fixture.rowSetBuilder(schema1)
+        .addRow("barney", mapValue("betty", mapValue("pebbles")))
+        .addRow("fred", mapValue("wilma", mapValue("bambam")))
+        .build()
+        .container();
+
+    final TupleMetadata schema2 = new SchemaBuilder()
+        .addMap("m1")
+          .add("q", MinorType.INT)
+          .addMap("m2")
+            .add("y", MinorType.INT)
+            .resumeMap()
+          .resumeSchema()
+        .buildSchema();
+
+    final VectorContainer input2 = fixture.rowSetBuilder(schema2)
+        .addSingleCol(mapValue(1, mapValue(10)))
+        .addSingleCol(mapValue(2, mapValue(20)))
+        .build()
+        .container();
+
+    final TupleMetadata outputSchema = new SchemaBuilder()
+        .add("a", MinorType.VARCHAR)
+        .addMap("m1")
+          .add("p", MinorType.VARCHAR)
+          .add("q", MinorType.INT)
+          .addMap("m2")
+            .add("x", MinorType.VARCHAR)
+            .add("y", MinorType.INT)
+            .resumeMap()
+          .resumeSchema()
+        .buildSchema();
+    final RowSet expected = fixture.rowSetBuilder(outputSchema)
+        .addRow("barney", mapValue("betty", 1,  mapValue("pebbles", 10)))
+        .addRow("fred", mapValue("wilma", 2, mapValue("bambam", 20)))
+        .build();
+
+    OutputBatchBuilder builder = new OutputBatchBuilder(outputSchema,
+        Arrays.asList(
+            new BatchSource(schema1, input1),
+            new BatchSource(schema2, input2)),
+        fixture.allocator());
+    builder.load(input1.getRecordCount());
+    VectorContainer output = builder.outputContainer();
+
+    RowSetUtilities.verify(expected, fixture.wrap(output));
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestReaderErrors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestReaderErrors.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies proper handling of errors from a reader, including use of the
+ * scan and reader error contexts.
+ */
+@Category(EvfTests.class)
+public class TestReaderErrors extends BaseTestScanLifecycle {
+
+  @Test
+  public void testCtorError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "ctor");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops ctor"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+    scan.close();
+  }
+
+  @Test
+  public void testCtorUserError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "ctor-u");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops ctor"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertNull(e.getCause());
+    }
+    scan.close();
+  }
+
+  @Test
+  public void testNextError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "next");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    try {
+      reader.next();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops next"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertTrue(e.getCause() instanceof IllegalStateException);
+    }
+    scan.close();
+  }
+
+  @Test
+  public void testNextUserError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "next-u");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    try {
+      reader.next();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops next"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertNull(e.getCause());
+    }
+    scan.close();
+  }
+
+  @Test
+  public void testCloseError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "close");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertFalse(reader.next());
+
+    try {
+      reader.close();
+      fail();
+    } catch (UserException e) {
+      // Expected
+    }
+    scan.close();
+  }
+
+  @Test
+  public void testCloseUserError() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.errorContext(b -> b.addContext("Scan context"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new FailingReader(negotiator, "close-u");
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertFalse(reader.next());
+
+    // User exceptions fail the query. Handles case of, say, a
+    // failed transaction, or something that tried, and failed,
+    // to update an external system.
+    try {
+      reader.close();
+      fail();
+    } catch (UserException e) {
+      String msg = e.getMessage();
+      assertTrue(msg.contains("Oops close"));
+      assertTrue(msg.contains("My custom context"));
+      assertTrue(msg.contains("Scan context"));
+      assertNull(e.getCause());
+    }
+    scan.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleBasics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleBasics.java
@@ -1,0 +1,540 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.common.types.Types;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader.EarlyEofException;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker.ProjectionType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(EvfTests.class)
+public class TestScanLifecycleBasics extends BaseTestScanLifecycle {
+
+  /**
+   * Simplest possible do-nothing, default config case.
+   * Scan produces no valid schema.
+   */
+  @Test
+  public void testNoReaders() {
+    ScanLifecycle scan = buildScan(new ScanLifecycleBuilder());
+    assertNull(scan.nextReader());
+    assertFalse(scan.hasOutputSchema());
+    scan.close();
+  }
+
+  /**
+   * Single reader, late schema, early EOF.
+   * The scan never has a valid schema in this case.
+   */
+  @Test
+  public void testEarlyEOF() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator)
+          throws EarlyEofException {
+        return new NoDataReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertFalse(reader.open());
+    reader.close();
+    assertFalse(scan.hasOutputSchema());
+    scan.close();
+  }
+
+  /**
+   * Single reader empty schema, EOF on first next().
+   * Since both no schema and no rows, we assume this to be a
+   * null (not empty) result set, so no output schema.
+   */
+  @Test
+  public void testNullReader() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 0);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertFalse(reader.next());
+    assertFalse(scan.hasOutputSchema());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Single reader early schema, EOF on first next().
+   * Since this is an early-schema reader, there is an output
+   * schema even without any rows.
+   */
+  @Test
+  public void testNullReaderWithSchema() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 0);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    assertTrue(scan.hasOutputSchema());
+    assertEquals(SCHEMA, scan.outputSchema());
+    assertFalse(reader.next());
+    reader.close();
+
+    // Early schema with no additional columns discovered
+    assertEquals(SCHEMA, scan.outputSchema());
+    scan.close();
+  }
+
+  /**
+   * Test SELECT * from an early-schema table of (a, b)
+   */
+  @Test
+  public void testEarlySchemaOneBatch() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    assertEquals(SCHEMA, scan.outputSchema());
+    assertTrue(reader.next());
+
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  @Test
+  public void testEarlySchemaTwoBatches() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 2);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertEquals(SCHEMA, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+
+    assertTrue(reader.next());
+    RowSetUtilities.verify(simpleExpected(1), fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * Single reader late schema, one batch.
+   */
+  @Test
+  public void testLateSchemaOneBatch() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Late schema: so no output schema is available after open
+    assertFalse(scan.hasOutputSchema());
+    assertTrue(reader.next());
+
+    // Late schema, output schema available after first batch
+    assertTrue(scan.hasOutputSchema());
+    assertEquals(SCHEMA, scan.outputSchema());
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  @Test
+  public void testLateSchemaTwoBatches() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+     builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 2);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Late schema: so no output schema is available after open
+    assertFalse(scan.hasOutputSchema());
+    assertTrue(reader.next());
+
+    // Late schema, output schema available after first batch
+    assertEquals(SCHEMA, scan.outputSchema());
+    RowSetUtilities.verify(simpleExpected(0), fixture.wrap(reader.output()));
+
+    assertTrue(reader.next());
+    RowSetUtilities.verify(simpleExpected(1), fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * Test SELECT a, c FROM table(a, b)
+   */
+  @Test
+  public void testEarlySchemaWithProject() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a", "c"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.SOME, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("c", MinorType.INT)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, null)
+        .addRow(20, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT a, c FROM table(a, b)
+   * c will be null
+   */
+  @Test
+  public void testLateSchemaWithProject() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a", "c"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.SOME, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    // Late schema: so output schema is available after next()
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("c", MinorType.INT)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, null)
+        .addRow(20, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT b, a FROM table(a, b)
+   */
+  @Test
+  public void testEarlySchemaReorder() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("b", "a"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.SOME, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("b", MinorType.VARCHAR)
+        .add("a", MinorType.INT)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow("fred", 10)
+        .addRow("wilma", 20)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  @Test
+  public void testEarlySchemaWithProjectNone() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectNone());
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.NONE, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+         .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow()
+        .addRow()
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT * from an early-schema table of () (that is,
+   * a schema that consists of zero columns.
+   */
+  @Test
+  public void testLateSchemaWithCustomType() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a", "c"));
+    builder.nullType(Types.optional(MinorType.VARCHAR));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+
+    // Late schema: so output schema is available after next()
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .addNullable("c", MinorType.VARCHAR)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10, null)
+        .addRow(20, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT a FROM table(a, b)
+   */
+  @Test
+  public void testEarlySchemaSubset() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.SOME, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .add("a", MinorType.INT)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow(10)
+        .addRow(20)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT * from an early-schema table of () (that is,
+   * a schema that consists of zero columns.
+   */
+  @Test
+  public void testEarlySchemaEmpty() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEmptySchemaReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+         .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addRow()
+        .addRow()
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Test SELECT a from an early-schema table of () (that is,
+   * a schema that consists of zero columns.
+   */
+  @Test
+  public void testEarlySchemaEmptyWithProject() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a"));
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEmptySchemaReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+
+    // Early schema: so output schema is available after open
+    TupleMetadata expectedSchema = new SchemaBuilder()
+        .addNullable("a", MinorType.INT)
+        .build();
+    assertEquals(expectedSchema, scan.outputSchema());
+
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(expectedSchema)
+        .addSingleCol(null)
+        .addSingleCol(null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleSchema.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.impl.scan.v3.schema.ScanSchemaTracker.ProjectionType;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.record.metadata.SchemaBuilder;
+import org.apache.drill.exec.record.metadata.TupleMetadata;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(EvfTests.class)
+public class TestScanLifecycleSchema extends BaseTestScanLifecycle {
+
+  /**
+   * Simplest defined schema case: the defined schema agrees
+   * with the the schema the reader will produce. The defined schema
+   * implies the project list, which is not visible here.
+   */
+  @Test
+  public void testDefinedSchemaSimple() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.definedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    // Projection defaults to SELECT *, but defined schema
+    // overrides that setting.
+    assertSame(ProjectionType.SOME, scan.schemaTracker().projectionType());
+
+    verifyStandardReader(scan, 0);
+    scan.close();
+  }
+
+  /**
+   * The defined schema is a subset of the reader's schema; the
+   * defined schema acts as a project list.
+   */
+  @Test
+  public void testDefinedSchemaSubset() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.definedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockThreeColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertEquals(SCHEMA, scan.outputSchema());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+      .addRow(101, "wilma")
+      .addRow(102, "betty")
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * The defined schema is a superset of the reader's schema; the
+   * defined schema defines the missing column type.
+   */
+  @Test
+  public void testDefinedSchemaSupersset() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.definedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockSingleColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertEquals(SCHEMA, scan.outputSchema());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+      .addRow(101, null)
+      .addRow(102, null)
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * Reader produces a schema which conflicts with the defined schema.
+   * The defined schema should be something the reader can implement; so
+   * it is an error if the reader does not do so.
+   */
+  @Test
+  public void testDefinedSchemaConflict() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.definedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaTypeConflictReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("conflict"));
+    }
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * Simplest provided schema case: the defined schema agrees
+   * with the the schema the reader will produce. The provided schema
+   * is separate from the project list.
+   */
+  @Test
+  public void testProvidedSchemaSimple() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.providedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+
+    verifyStandardReader(scan, 0);
+    scan.close();
+  }
+
+  /**
+   * Lenient provided schema which is a subset of the reader's schema; the
+   * provided schema agrees with the reader types
+   */
+  @Test
+  public void testLenientProvidedSchemaSubset() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.providedSchema(SCHEMA);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockThreeColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+    assertSame(ProjectionType.ALL, scan.schemaTracker().projectionType());
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertEquals(MockThreeColReader.READER_SCHEMA, scan.outputSchema());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(MockThreeColReader.READER_SCHEMA)
+      .addRow(101, "wilma", 1001)
+      .addRow(102, "betty", 1002)
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * Lenient provided schema which is a subset of the reader's schema; the
+   * provided schema agrees with the reader types
+   */
+  @Test
+  public void testStrictProvidedSchemaSubset() {
+    TupleMetadata schema = new SchemaBuilder()
+        .addAll(SCHEMA)
+        .build();
+    schema.setBooleanProperty(TupleMetadata.IS_STRICT_SCHEMA_PROP, true);
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.providedSchema(schema);
+    builder.readerFactory(new SingleReaderFactory() {
+      @Override
+      public ManagedReader next(SchemaNegotiator negotiator) {
+        return new MockThreeColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertEquals(SCHEMA, scan.outputSchema());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+      .addRow(101, "wilma")
+      .addRow(102, "betty")
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleTwoReaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/TestScanLifecycleTwoReaders.java
@@ -1,0 +1,528 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.scan.v3.lifecycle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.drill.categories.EvfTests;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.physical.impl.scan.RowBatchReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ManagedReader;
+import org.apache.drill.exec.physical.impl.scan.v3.ScanLifecycleBuilder;
+import org.apache.drill.exec.physical.impl.scan.v3.SchemaNegotiator;
+import org.apache.drill.exec.physical.rowSet.RowSet;
+import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
+import org.apache.drill.test.rowSet.RowSetUtilities;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test two readers in succession in various cases: empty readers, normal readers,
+ * type conflicts, etc.
+ */
+@Category(EvfTests.class)
+public class TestScanLifecycleTwoReaders extends BaseTestScanLifecycle {
+
+  /**
+   * Two null readers: neither provides a valid scan schema.
+   */
+  @Test
+  public void testTwoNullReaders() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 0);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 0);
+       }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyEmptyReader(scan);
+    verifyEmptyReader(scan);
+    scan.close();
+  }
+
+  @Test
+  public void testNullThenValidReader() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 0);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+       }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyEmptyReader(scan);
+    verifyStandardReader(scan, 0);
+    scan.close();
+  }
+
+  @Test
+  public void testValidThenNullReader() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 0);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertFalse(reader.next());
+    assertTrue(scan.hasOutputSchema());
+    reader.close();
+    scan.close();
+  }
+
+  @Test
+  public void testTwoValidReaders() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+    verifyStandardReader(scan, 0);
+    scan.close();
+  }
+
+  /**
+   * SELECT * FROM two readers, one with (a, b), the other with just (a).
+   * The scan will reuse the type of b from the first reader when filling
+   * the missing column in the second reader. Since the schema shrinks,
+   * the result is the same whether schema change is allowed or not.
+   */
+  @Test
+  public void testShrinkingSchema() {
+    doTestShrinkingSchema(true);
+    doTestShrinkingSchema(false);
+  }
+
+  private void doTestShrinkingSchema(boolean allowSchemaChange) {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+     builder.allowSchemaChange(allowSchemaChange);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockSingleColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+        .addRow(101, null)
+        .addRow(102, null)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * Shrinking schema, as above. Explicit projection:<pre><code>
+   * SELECT a, b FROM (a) then (a,b)
+   * </code></pre><p>
+   * But choose a missing column type (the default
+   * Nullable INT) in the first reader that will conflict with the actual column type
+   * (VARCHAR) in the second.
+   */
+  @Test
+  public void testShrinkingSchemaWithConflict() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a", "b"));
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockSingleColReader(negotiator);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    reader.output().clear();
+    assertFalse(reader.next());
+    reader.close();
+
+    reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("conflict"));
+    }
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * SELECT * FROM two readers, one (a, b), the other (a, b, c).
+   * With schema change enabled, the third column shows up only
+   * in the second batch, forcing a schema change downstream.
+   */
+  @Test
+  public void testExpandingSchemaAllowingSchemaChange() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.allowSchemaChange(true);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockThreeColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(MockThreeColReader.READER_SCHEMA)
+        .addRow(101, "wilma", 1001)
+        .addRow(102, "betty", 1002)
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * SELECT * FROM two readers, one (a, b), the other (a, b, c).
+   * With schema change disabled, the third column is ignored in the
+   * second reader: the first reader "fixes" projection to just (a, b)
+   * even though projection started as wildcard.
+   * <p>
+   * We can argue if this behavior is correct. We know most operators,
+   * and no ODBC or JDBC client can handle schema change. So, our other
+   * options are do the schema change anyway (the above test), fail, or
+   * this choice, which is to try to muddle though. The correct solution
+   * is to provide a schema (tested elsewhere.)
+   */
+  @Test
+  public void testExpandingSchemaDisallowingSchemaChange() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.allowSchemaChange(false);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockThreeColReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+        .addRow(101, "wilma")
+        .addRow(102, "betty")
+        .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    scan.close();
+  }
+
+  /**
+   * SELECT * from two readers: both (a, b), but with a conflicting
+   * type for the column b. The reader fail will with a type conflict.
+   */
+  @Test
+  public void testEarlySchemaTypeConflict() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.allowSchemaChange(true);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockEarlySchemaTypeConflictReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("conflict"));
+    }
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * SELECT * from two readers: both (a, b), but with a conflicting
+   * type for the column b. The reader fail will with a type conflict.
+   */
+  @Test
+  public void testLateSchemaTypeConflict() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.allowSchemaChange(true);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaTypeConflictReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    assertTrue(reader.open());
+    try {
+      reader.next();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("conflict"));
+    }
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * SELECT * from two readers: both (a, b), but with a conflicting
+   * type for the column b. The reader fail will with a type conflict.
+   * We could possibly try to handle a NULLABLE --> NON NULLABLE conflict,
+   * but there does not yet appear to be a compelling case for doing so.
+   */
+  @Test
+  public void testModeConflict() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.allowSchemaChange(true);
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockModeConflictReader(negotiator);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    try {
+      reader.open();
+      fail();
+    } catch (UserException e) {
+      assertTrue(e.getMessage().contains("conflict"));
+    }
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * {@code SELECT * FROM} (a, b) then (b,a). The order of the first
+   * table drives the order of the results.
+   */
+  @Test
+  public void testColumnReorderingAB() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+     builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockReorderedReader(negotiator);
+      }
+    });
+     ScanLifecycle scan = buildScan(builder);
+
+    verifyStandardReader(scan, 0);
+
+    RowBatchReader reader = scan.nextReader();
+    reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+      .addRow(30, "barney")
+      .addRow(40, "betty")
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * {@code SELECT * FROM} (b,a) then (a, b). The order of the first
+   * table drives the order of the results.
+   */
+  @Test
+  public void testColumnReorderingBA() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockReorderedReader(negotiator);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(MockReorderedReader.READER_SCHEMA)
+      .addRow("barney", 30)
+      .addRow("betty", 40)
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    reader = scan.nextReader();
+    reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    expected = fixture.rowSetBuilder(MockReorderedReader.READER_SCHEMA)
+      .addRow("fred", 10)
+      .addRow("wilma", 20)
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+    scan.close();
+  }
+
+  /**
+   * {@code SELECT , b FROM} (b,a) then (a, b). The order of the project list
+   * drives the order of the results.
+   */
+  @Test
+  public void testSpecifiedColumnOrder() {
+    ScanLifecycleBuilder builder = new ScanLifecycleBuilder();
+    builder.projection(RowSetTestUtils.projectList("a", "b"));
+    builder.readerFactory(new TwoReaderFactory() {
+      @Override
+      public ManagedReader firstReader(SchemaNegotiator negotiator) {
+        return new MockReorderedReader(negotiator);
+      }
+
+      @Override
+      public ManagedReader secondReader(SchemaNegotiator negotiator) {
+        return new MockLateSchemaReader(negotiator, 1);
+      }
+    });
+    ScanLifecycle scan = buildScan(builder);
+
+    RowBatchReader reader = scan.nextReader();
+    reader = scan.nextReader();
+    assertTrue(reader.open());
+    assertTrue(reader.next());
+    RowSet expected = fixture.rowSetBuilder(SCHEMA)
+      .addRow(30, "barney")
+      .addRow(40, "betty")
+      .build();
+    RowSetUtilities.verify(expected, fixture.wrap(reader.output()));
+    assertFalse(reader.next());
+    reader.close();
+
+    verifyStandardReader(scan, 0);
+    scan.close();
+  }
+}

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvHeader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvHeader.java
@@ -23,7 +23,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.test.BaseTestQuery;
 import org.apache.drill.test.TestBuilder;
@@ -31,7 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvHeader extends BaseTestQuery{
 
   private static final String ROOT = "store/text/data/cars.csvh";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvIgnoreHeaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvIgnoreHeaders.java
@@ -22,7 +22,7 @@ import static org.apache.drill.test.rowSet.RowSetUtilities.strArray;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -33,7 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvIgnoreHeaders extends BaseCsvTest{
 
   private static String withHeaders[] = {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvTableProperties.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvTableProperties.java
@@ -18,7 +18,7 @@
 package org.apache.drill.exec.store.easy.text.compliant;
 
 import org.apache.drill.TestSelectWithOption;
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.physical.rowSet.RowSetBuilder;
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
  * @see TestSelectWithOption for similar tests using table
  * properties within SQL
  */
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvTableProperties extends BaseCsvTest {
 
   @BeforeClass

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithHeaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithHeaders.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Iterator;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.DirectRowSet;
@@ -60,7 +60,7 @@ import static org.junit.Assert.fail;
  *
  * @see TestHeaderBuilder
  */
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvWithHeaders extends BaseCsvTest {
 
   private static final String TEST_FILE_NAME = "basic.csv";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithSchema.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
@@ -48,7 +48,7 @@ import org.junit.experimental.categories.Category;
  * The focus here is on the schema mechanism, which can be explored
  * with simple tables of just a few rows.
  */
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvWithSchema extends BaseCsvTest {
 
   protected static final String FILE1_NAME = "file1.csv";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithoutHeaders.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestCsvWithoutHeaders.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.TestEmptyInputSql;
@@ -47,7 +47,7 @@ import org.junit.experimental.categories.Category;
  * and without an external schema. Data is represented with the
  * `columns` array column.
  */
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestCsvWithoutHeaders extends BaseCsvTest {
 
   private static final String TEST_FILE_NAME = "simple.csv";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestPartitionRace.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/text/compliant/TestPartitionRace.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.apache.drill.categories.RowSetTests;
+import org.apache.drill.categories.EvfTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
@@ -54,7 +54,7 @@ import org.junit.experimental.categories.Category;
  * current "V3" version. The tests here verify this behavior.
  */
 
-@Category(RowSetTests.class)
+@Category(EvfTests.class)
 public class TestPartitionRace extends BaseCsvTest {
 
   @BeforeClass

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixtureBuilder.java
@@ -89,7 +89,6 @@ public class ClusterFixtureBuilder {
     // TypeSafe gets unhappy about a leading slash, but other functions
     // require it. Silently discard the leading slash if given to
     // preserve the test writer's sanity.
-
     configBuilder.resource(ClusterFixture.trimSlash(configResource));
     return this;
   }

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -36,6 +36,8 @@ import org.apache.drill.exec.memory.BoundsChecking;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.ops.BufferManager;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.util.internal.PlatformDependent;
 
@@ -45,7 +47,7 @@ import io.netty.util.internal.PlatformDependent;
  */
 @SuppressWarnings("unused")
 public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillBuf.class);
+  private static final Logger logger = LoggerFactory.getLogger(DrillBuf.class);
 
   private static final AtomicLong idGenerator = new AtomicLong(0);
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/NullableScalarWriter.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/accessor/writer/NullableScalarWriter.java
@@ -307,6 +307,6 @@ public class NullableScalarWriter extends AbstractScalarWriterImpl {
   @Override
   public void setDefaultValue(Object value) {
     throw new UnsupportedOperationException(
-        "Default values not supported for nullable types:" + value);
+        "Default values not supported for nullable types: " + value);
   }
 }

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractContainerVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractContainerVector.java
@@ -34,6 +34,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Function;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Iterables;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for composite vectors.
@@ -41,7 +43,7 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
  * This class implements common functionality of composite vectors.
  */
 public abstract class AbstractContainerVector implements ValueVector {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractContainerVector.class);
+  static final Logger logger = LoggerFactory.getLogger(AbstractContainerVector.class);
 
   protected MaterializedField field;
   protected final BufferAllocator allocator;
@@ -56,7 +58,8 @@ public abstract class AbstractContainerVector implements ValueVector {
   @Override
   public void allocateNew() throws OutOfMemoryException {
     if (!allocateNewSafe()) {
-      throw new OutOfMemoryException();
+      throw new OutOfMemoryException(
+          "Failed to allocate memory for " + getClass().getSimpleName());
     }
   }
 

--- a/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/vector/complex/AbstractMapVector.java
@@ -35,12 +35,14 @@ import org.apache.drill.exec.vector.ValueVector;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for MapVectors. Currently used by AbstractRepeatedMapVector and MapVector
  */
 public abstract class AbstractMapVector extends AbstractContainerVector {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractContainerVector.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractContainerVector.class);
 
   // Maintains a map with key as field name and value is the vector itself
   private final MapWithOrdinal<String, ValueVector> vectors = new MapWithOrdinal<>();


### PR DESCRIPTION
# [DRILL-7701](https://issues.apache.org/jira/browse/DRILL-7701): EVF V2 Scan Framework

## Description

Revises the scan framework to use the revised schema resolution introduced in DRILL-7696.

In EVF, the scan has three layers:

* The operator layer which handles the Volcano-style iterator `RecordBatch` API.
* The scan framework (this PR) which handles the details of schema, building batches, populating implicit columns, filling in missing columns and so on.
* The schema resolution mechanism (DRILL-7696) which figures out projection, column names, etc.

By splitting the scan into these layers, it turns out to be easier to upgrade one layer without making wholesale changes to others.

In this PR, the ad-hoc classes of EVF V1 are renamed and restructured into a few simple concepts:

* A scan builder, as in EVF V1.
* The scan lifecycle that coordinates work across readers (like the former `ScanSchemaOrchestrator`)
* A reader lifecycle which, along with the `SchemaNegotiator`, does all the "back office" setup and book-keeping for the reader.
* A number of helper classes to handle things like implicit columns, missing columns, and so on.

This version learns from V1 to reduce the reader from three to two operations. The `open()` call of the V1 reader is merged into the constructor for V2. This allows many more reader fields to be declared `final` and should further simplify readers.

As in V1, the lifecycle comes in two "versions" a base "scan" version which is agnostic about the data source, and a "file" version which adds support for the `DrillFileSystem` and implicit columns.

At present, no code uses V2; future PRs will switch existing readers over to this version one by one.

Code is in the `v3` package. The goal is to eventually replace existing code and move the code here up a level to eliminate the "v3" naming.

## Documentation

No user-visible changes (except that described in DRILL-7696.)

Developers will need to be aware of the slight differences to build a reader using V2 EVF vs. V1. Those details will appear in the first PR that performs a conversion. Extensive Javadoc appears in the code.
 
## Testing

Added new unit tests to parallel (and eventually replace) those for the V1 framework. Reran all unit tests to ensure no regressions.
