### PR TITLE
DRILL-7702: Update zookeeper, curator, guava, jetty-server, libthrift, httpclient, commons-compress and httpdlog-parser

### DIFF
--- a/common/src/main/java/org/apache/drill/common/concurrent/AbstractCheckedFuture.java
+++ b/common/src/main/java/org/apache/drill/common/concurrent/AbstractCheckedFuture.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.concurrent;
+
+import org.apache.drill.shaded.guava.com.google.common.util.concurrent.ForwardingListenableFuture;
+import org.apache.drill.shaded.guava.com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A delegating wrapper around a {@link ListenableFuture} that adds support for the {@link
+ * #checkedGet()} and {@link #checkedGet(long, TimeUnit)} methods.
+ *
+ * This class is moved from Guava, since there it was deleted.
+ */
+public abstract class AbstractCheckedFuture<T, E extends Exception>
+    extends ForwardingListenableFuture.SimpleForwardingListenableFuture<T> implements CheckedFuture<T, E> {
+
+  protected AbstractCheckedFuture(ListenableFuture<T> delegate) {
+    super(delegate);
+  }
+
+  /**
+   * Translates from an {@link InterruptedException},
+   * {@link CancellationException} or {@link ExecutionException} thrown by
+   * {@code get} to an exception of type {@code X} to be thrown by
+   * {@code checkedGet}. Subclasses must implement this method.
+   *
+   * <p>If {@code e} is an {@code InterruptedException}, the calling
+   * {@code checkedGet} method has already restored the interrupt after catching
+   * the exception. If an implementation of {@link #mapException(Exception)}
+   * wishes to swallow the interrupt, it can do so by calling
+   * {@link Thread#interrupted()}.
+   *
+   * <p>Subclasses may choose to throw, rather than return, a subclass of
+   * {@code RuntimeException} to allow creating a CheckedFuture that throws
+   * both checked and unchecked exceptions.
+   */
+  protected abstract E mapException(Exception e);
+
+  /**
+   * Exception checking version of {@link Future#get()} that will translate
+   * {@link InterruptedException}, {@link CancellationException} and
+   * {@link ExecutionException} into application-specific exceptions.
+   *
+   * @return the result of executing the future.
+   * @throws E on interruption, cancellation or execution exceptions.
+   */
+  public T checkedGet() throws E {
+    try {
+      return get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw mapException(e);
+    } catch (CancellationException | ExecutionException e) {
+      throw mapException(e);
+    }
+  }
+
+  /**
+   * Exception checking version of {@link Future#get(long, TimeUnit)} that will
+   * translate {@link InterruptedException}, {@link CancellationException} and
+   * {@link ExecutionException} into application-specific exceptions.  On
+   * timeout this method throws a normal {@link TimeoutException}.
+   *
+   * @return the result of executing the future.
+   * @throws TimeoutException if retrieving the result timed out.
+   * @throws E on interruption, cancellation or execution exceptions.
+   */
+  public T checkedGet(long timeout, TimeUnit unit) throws TimeoutException, E {
+    try {
+      return get(timeout, unit);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw mapException(e);
+    } catch (CancellationException | ExecutionException e) {
+      throw mapException(e);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/drill/common/concurrent/CheckedFuture.java
+++ b/common/src/main/java/org/apache/drill/common/concurrent/CheckedFuture.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.common.concurrent;
+
+import org.apache.drill.shaded.guava.com.google.common.util.concurrent.Futures;
+import org.apache.drill.shaded.guava.com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@code CheckedFuture} is a {@link ListenableFuture} that includes versions of the {@code get}
+ * methods that can throw a checked exception. This makes it easier to create a future that executes
+ * logic which can throw an exception.
+ *
+ * <p>Implementations of this interface must adapt the exceptions thrown by {@code Future#get()}:
+ * {@link CancellationException}, {@link ExecutionException} and {@link InterruptedException} into
+ * the type specified by the {@code X} type parameter.
+ *
+ * <p>This interface also extends the ListenableFuture interface to allow listeners to be added.
+ * This allows the future to be used as a normal {@link Future} or as an asynchronous callback
+ * mechanism as needed. This allows multiple callbacks to be registered for a particular task, and
+ * the future will guarantee execution of all listeners when the task completes.
+ *
+ * <p>For a simpler alternative to CheckedFuture, consider accessing Future values with {@link
+ * Futures#getChecked(Future, Class) Futures.getChecked()}.
+ *
+ * This interface is moved from Guava, since there it was deleted.
+ *
+ */
+public interface CheckedFuture<V, X extends Exception> extends ListenableFuture<V> {
+
+  /**
+   * Exception checking version of {@link Future#get()} that will translate {@link
+   * InterruptedException}, {@link CancellationException} and {@link ExecutionException} into
+   * application-specific exceptions.
+   *
+   * @return the result of executing the future.
+   * @throws X on interruption, cancellation or execution exceptions.
+   */
+  V checkedGet() throws X;
+
+  /**
+   * Exception checking version of {@link Future#get(long, TimeUnit)} that will translate {@link
+   * InterruptedException}, {@link CancellationException} and {@link ExecutionException} into
+   * application-specific exceptions.  On timeout this method throws a normal {@link
+   * TimeoutException}.
+   *
+   * @return the result of executing the future.
+   * @throws TimeoutException if retrieving the result timed out.
+   * @throws X on interruption, cancellation or execution exceptions.
+   */
+  V checkedGet(long timeout, TimeUnit unit) throws TimeoutException, X;
+}

--- a/common/src/main/java/org/apache/drill/common/exceptions/DrillIOException.java
+++ b/common/src/main/java/org/apache/drill/common/exceptions/DrillIOException.java
@@ -20,7 +20,7 @@ package org.apache.drill.common.exceptions;
 import java.io.IOException;
 
 @SuppressWarnings("serial")
-public class DrillIOException extends IOException{
+public class DrillIOException extends IOException {
 
   public DrillIOException() { }
 

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -59,7 +59,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
-
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
     </dependencies>
@@ -143,6 +146,18 @@
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/contrib/format-maprdb/pom.xml
+++ b/contrib/format-maprdb/pom.xml
@@ -140,6 +140,10 @@
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/binary/BinaryTableGroupScan.java
@@ -22,6 +22,7 @@ import static org.apache.drill.exec.store.mapr.db.util.CommonFns.isNullOrEmpty;
 import java.util.List;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rex.RexNode;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
@@ -56,7 +57,6 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.RegionLocator;
-import org.codehaus.jackson.annotate.JsonCreator;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/json/JsonTableGroupScan.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.mapr.db.impl.ConditionImpl;
 import com.mapr.db.impl.ConditionNode.RowkeyRange;
 
@@ -67,7 +68,6 @@ import org.apache.drill.exec.util.Utilities;
 import org.apache.drill.exec.metastore.store.FileSystemMetadataProviderManager;
 import org.apache.drill.exec.metastore.MetadataProviderManager;
 import org.apache.drill.metastore.metadata.TableMetadataProvider;
-import org.codehaus.jackson.annotate.JsonCreator;
 import org.ojai.store.QueryCondition;
 
 import com.fasterxml.jackson.annotation.JacksonInject;

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -200,6 +200,7 @@
         <dependency>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-testing-util</artifactId>
+          <scope>test</scope>
           <classifier>tests</classifier>
           <exclusions>
             <exclusion>
@@ -210,8 +211,23 @@
               <groupId>commons-codec</groupId>
               <artifactId>commons-codec</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-core-asl</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-mapper-asl</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-jaxrs</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-xc</artifactId>
+            </exclusion>
           </exclusions>
-          <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
@@ -257,6 +273,10 @@
               <groupId>commons-logging</groupId>
               <artifactId>commons-logging</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-mapper-asl</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
         <dependency>
@@ -272,6 +292,14 @@
             <exclusion>
               <groupId>commons-httpclient</groupId>
               <artifactId>commons-httpclient</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-jaxrs</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-xc</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/contrib/storage-hbase/pom.xml
+++ b/contrib/storage-hbase/pom.xml
@@ -173,25 +173,25 @@
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-client</artifactId>
           <exclusions>
-              <exclusion>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-mapreduce-client-core</artifactId>
-              </exclusion>
             <exclusion>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
+              <groupId>org.apache.hadoop</groupId>
+              <artifactId>hadoop-mapreduce-client-core</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
+              <groupId>io.netty</groupId>
+              <artifactId>netty</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-all</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
             </exclusion>
           </exclusions>
         </dependency>
@@ -206,10 +206,10 @@
               <artifactId>log4j</artifactId>
               <groupId>log4j</groupId>
             </exclusion>
-              <exclusion>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-              </exclusion>
+            <exclusion>
+              <groupId>commons-codec</groupId>
+              <artifactId>commons-codec</artifactId>
+            </exclusion>
           </exclusions>
           <scope>test</scope>
         </dependency>
@@ -222,10 +222,10 @@
               <artifactId>log4j</artifactId>
               <groupId>log4j</groupId>
             </exclusion>
-              <exclusion>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-              </exclusion>
+            <exclusion>
+              <groupId>commons-codec</groupId>
+              <artifactId>commons-codec</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
       </dependencies>
@@ -242,22 +242,22 @@
           <artifactId>hbase-client</artifactId>
           <exclusions>
             <exclusion>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
+              <groupId>io.netty</groupId>
+              <artifactId>netty</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-all</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
             </exclusion>
-        </exclusions>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.apache.hbase</groupId>
@@ -268,6 +268,10 @@
             <exclusion>
               <artifactId>log4j</artifactId>
               <groupId>log4j</groupId>
+            </exclusion>
+            <exclusion>
+              <groupId>commons-httpclient</groupId>
+              <artifactId>commons-httpclient</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -94,6 +94,10 @@
           <artifactId>hadoop-auth</artifactId>
           <groupId>org.apache.hadoop</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -211,6 +215,18 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/contrib/storage-hive/core/pom.xml
+++ b/contrib/storage-hive/core/pom.xml
@@ -228,6 +228,22 @@
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -80,6 +80,30 @@
           <groupId>com.github.joshelser</groupId>
           <artifactId>dropwizard-metrics-hadoop-metrics2-reporter</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-1.2-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/contrib/storage-hive/hive-exec-shade/pom.xml
+++ b/contrib/storage-hive/hive-exec-shade/pom.xml
@@ -104,6 +104,22 @@
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/distribution/src/assemble/component.xml
+++ b/distribution/src/assemble/component.xml
@@ -159,6 +159,7 @@
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.zookeeper:zookeeper-jute</include>
       </includes>
       <scope>runtime</scope>
     </dependencySet>

--- a/drill-shaded/drill-shaded-guava/pom.xml
+++ b/drill-shaded/drill-shaded-guava/pom.xml
@@ -28,11 +28,11 @@
   </parent>
 
   <artifactId>drill-shaded-guava</artifactId>
-  <version>23.0</version>
+  <version>28.2-jre</version>
   <name>drill-shaded/drill-shaded-guava</name>
 
   <properties>
-    <guava.version>23.0</guava.version>
+    <guava.version>${project.version}</guava.version>
   </properties>
 
   <dependencies>
@@ -52,6 +52,7 @@
           <artifactSet>
             <includes>
               <include>com.google.guava:guava</include>
+              <include>com.google.guava:failureaccess</include>
             </includes>
           </artifactSet>
           <relocations>

--- a/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKClusterCoordinator.java
+++ b/drill-yarn/src/main/java/org/apache/drill/yarn/zk/ZKClusterCoordinator.java
@@ -174,7 +174,7 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
     // serviceCache before discovery to prevent
     // double releasing and disallowing jvm to spit bothering warnings. simply
     // put, we are great!
-    AutoCloseables.close(serviceCache, discovery, curator, factory);
+    AutoCloseables.close(serviceCache, discovery, factory, curator);
   }
 
   @Override

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -526,7 +526,7 @@
     <dependency>
       <groupId>nl.basjes.parse.httpdlog</groupId>
       <artifactId>httpdlog-parser</artifactId>
-      <version>5.2</version>
+      <version>5.3</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKClusterCoordinator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/coord/zk/ZKClusterCoordinator.java
@@ -173,7 +173,7 @@ public class ZKClusterCoordinator extends ClusterCoordinator {
     // discovery attempts to close its caches(ie serviceCache) already. however, being good citizens we make sure to
     // explicitly close serviceCache. Not only that we make sure to close serviceCache before discovery to prevent
     // double releasing and disallowing jvm to spit bothering warnings. simply put, we are great!
-    AutoCloseables.close(serviceCache, discovery, curator, factory);
+    AutoCloseables.close(serviceCache, discovery, factory, curator);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserClient.java
@@ -17,12 +17,12 @@
  */
 package org.apache.drill.exec.rpc.user;
 
+import org.apache.drill.common.concurrent.AbstractCheckedFuture;
+import org.apache.drill.common.concurrent.CheckedFuture;
 import org.apache.drill.shaded.guava.com.google.common.base.Strings;
 import org.apache.drill.shaded.guava.com.google.common.base.Throwables;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
-import org.apache.drill.shaded.guava.com.google.common.util.concurrent.AbstractCheckedFuture;
-import org.apache.drill.shaded.guava.com.google.common.util.concurrent.CheckedFuture;
 import org.apache.drill.shaded.guava.com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.MessageLite;
 import io.netty.buffer.ByteBuf;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/QueryWorkUnit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/QueryWorkUnit.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.work;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.drill.exec.physical.base.FragmentRoot;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.fragment.Wrapper;
@@ -31,7 +32,6 @@ import org.apache.drill.exec.work.foreman.ForemanSetupException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.codehaus.jackson.map.ObjectMapper;
 
 public class QueryWorkUnit {
 

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -459,6 +459,7 @@
                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
                <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
                <exclude>org/apache/drill/shaded/guava/com/google/common/io/BaseEncoding*</exclude>
+               <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
                <exclude>com/google/common/math</exclude>
                <exclude>com/google/common/net</exclude>
                <exclude>com/google/common/primitives</exclude>
@@ -787,6 +788,7 @@
                       <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
                       <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Tree*</exclude>
                       <exclude>org/apache/drill/shaded/guava/com/google/common/collect/Standard*</exclude>
+                      <exclude>org/apache/drill/shaded/guava/com/google/common/graph/**</exclude>
                       <exclude>com/google/common/math</exclude>
                       <exclude>com/google/common/net</exclude>
                       <exclude>com/google/common/primitives</exclude>

--- a/exec/jdbc-all/pom.xml
+++ b/exec/jdbc-all/pom.xml
@@ -536,7 +536,7 @@
                   This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                   </message>
-                  <maxsize>43000000</maxsize>
+                  <maxsize>45000000</maxsize>
                   <minsize>15000000</minsize>
                   <files>
                    <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>
@@ -596,7 +596,7 @@
                           This is likely due to you adding new dependencies to a java-exec and not updating the excludes in this module. This is important as it minimizes the size of the dependency of Drill application users.
 
                         </message>
-                        <maxsize>44000000</maxsize>
+                        <maxsize>46000000</maxsize>
                         <minsize>15000000</minsize>
                         <files>
                           <file>${project.build.directory}/drill-jdbc-all-${project.version}.jar</file>

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/DrillRpcFuture.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/DrillRpcFuture.java
@@ -18,11 +18,12 @@
 package org.apache.drill.exec.rpc;
 
 import io.netty.buffer.ByteBuf;
+import org.apache.drill.common.concurrent.CheckedFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.drill.shaded.guava.com.google.common.util.concurrent.CheckedFuture;
+public interface DrillRpcFuture<T> extends CheckedFuture<T, RpcException> {
+  Logger logger = LoggerFactory.getLogger(DrillRpcFuture.class);
 
-public interface DrillRpcFuture<T> extends CheckedFuture<T,RpcException> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRpcFuture.class);
-
-  public ByteBuf getBuffer();
+  ByteBuf getBuffer();
 }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/DrillRpcFutureImpl.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/DrillRpcFutureImpl.java
@@ -19,16 +19,15 @@ package org.apache.drill.exec.rpc;
 
 import io.netty.buffer.ByteBuf;
 
-import org.apache.drill.shaded.guava.com.google.common.util.concurrent.AbstractCheckedFuture;
+import org.apache.drill.common.concurrent.AbstractCheckedFuture;
 import org.apache.drill.shaded.guava.com.google.common.util.concurrent.AbstractFuture;
 
-class DrillRpcFutureImpl<V> extends AbstractCheckedFuture<V, RpcException> implements DrillRpcFuture<V>, RpcOutcomeListener<V>{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DrillRpcFutureImpl.class);
-
+class DrillRpcFutureImpl<V> extends AbstractCheckedFuture<V, RpcException>
+    implements DrillRpcFuture<V>, RpcOutcomeListener<V> {
   private volatile ByteBuf buffer;
 
   public DrillRpcFutureImpl() {
-    super(new InnerFuture<V>());
+    super(new InnerFuture<>());
   }
 
   @Override
@@ -51,19 +50,19 @@ class DrillRpcFutureImpl<V> extends AbstractCheckedFuture<V, RpcException> imple
 
   @Override
   public void failed(RpcException ex) {
-    ( (InnerFuture<V>)delegate()).setException(ex);
+    ((InnerFuture<V>) delegate()).setException(ex);
   }
 
   @Override
   public void success(V value, ByteBuf buffer) {
     this.buffer = buffer;
-    ( (InnerFuture<V>)delegate()).setValue(value);
+    ((InnerFuture<V>) delegate()).setValue(value);
   }
 
   @Override
   public void interrupted(final InterruptedException ex) {
     // Propagate the interrupt to inner future
-    ( (InnerFuture<V>)delegate()).cancel(true);
+    delegate().cancel(true);
   }
 
   @Override

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcCheckedFuture.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcCheckedFuture.java
@@ -19,12 +19,12 @@ package org.apache.drill.exec.rpc;
 
 import io.netty.buffer.ByteBuf;
 
-import org.apache.drill.shaded.guava.com.google.common.util.concurrent.AbstractCheckedFuture;
+import org.apache.drill.common.concurrent.AbstractCheckedFuture;
 import org.apache.drill.shaded.guava.com.google.common.util.concurrent.ListenableFuture;
 
-public class RpcCheckedFuture<T> extends AbstractCheckedFuture<T, RpcException> implements DrillRpcFuture<T>{
+public class RpcCheckedFuture<T> extends AbstractCheckedFuture<T, RpcException> implements DrillRpcFuture<T> {
 
-  volatile ByteBuf buffer;
+  private volatile ByteBuf buffer;
 
   public RpcCheckedFuture(ListenableFuture<T> delegate) {
     super(delegate);

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcException.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcException.java
@@ -26,9 +26,8 @@ import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 /**
  * Parent class for all rpc exceptions.
  */
-public class RpcException extends DrillIOException{
+public class RpcException extends DrillIOException {
   private static final long serialVersionUID = -5964230316010502319L;
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RpcException.class);
 
   public RpcException() {
     super();
@@ -52,7 +51,7 @@ public class RpcException extends DrillIOException{
 
   public static RpcException mapException(Throwable t) {
     while (t instanceof ExecutionException) {
-      t = ((ExecutionException)t).getCause();
+      t = t.getCause();
     }
     if (t instanceof RpcException) {
       return ((RpcException) t);
@@ -62,16 +61,16 @@ public class RpcException extends DrillIOException{
 
   public static RpcException mapException(String message, Throwable t) {
     while (t instanceof ExecutionException) {
-      t = ((ExecutionException)t).getCause();
+      t = t.getCause();
     }
     return new RpcException(message, t);
   }
 
-  public boolean isRemote(){
+  public boolean isRemote() {
     return false;
   }
 
-  public DrillPBError getRemoteError(){
+  public DrillPBError getRemoteError() {
     throw new UnsupportedOperationException();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <sqlline.version>1.9.0</sqlline.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson.databind.version>2.9.9</jackson.databind.version>
-    <zookeeper.version>3.4.12</zookeeper.version>
+    <zookeeper.version>3.5.7</zookeeper.version>
     <mapr.release.version>6.1.0-mapr</mapr.release.version>
     <ojai.version>3.0-mapr-1808</ojai.version>
     <kerby.version>1.0.0</kerby.version>
@@ -72,7 +72,7 @@
     <commons.io.version>2.4</commons.io.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
     <maven.embedder.version>3.5.3</maven.embedder.version>
-    <curator.version>2.7.1</curator.version>
+    <curator.version>4.3.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
     <logback.version>1.2.3</logback.version>
@@ -2293,6 +2293,14 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
 
@@ -2656,8 +2664,8 @@
             <scope>test</scope>
             <exclusions>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -2815,6 +2823,9 @@
         <hbase.version>1.1.1-mapr-1602-m7-5.2.0</hbase.version>
         <hadoop.version>2.7.0-mapr-1808</hadoop.version>
         <zookeeper.version>3.4.11-mapr-1808</zookeeper.version>
+        <!-- TODO: Remove this property and use a common dependency of curator-test after ZooKeeper 3.5+
+        for MapR profile is released. See problem description in https://issues.apache.org/jira/browse/CURATOR-428 -->
+        <curator.test.version>2.13.0</curator.test.version>
       </properties>
       <dependencyManagement>
         <dependencies>
@@ -3148,8 +3159,16 @@
                 <artifactId>netty-all</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3183,8 +3202,8 @@
             <version>${hbase.version}</version>
             <exclusions>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
               <exclusion>
                 <groupId>io.netty</groupId>
@@ -3225,6 +3244,14 @@
               <exclusion>
                 <groupId>com.sun.jersey</groupId>
                 <artifactId>jersey-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -3349,6 +3376,18 @@
               <exclusion>
                 <groupId>tomcat</groupId>
                 <artifactId>jasper-runtime</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.test.version}</version>
+            <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
               </exclusion>
             </exclusions>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <proto.cas.path>${project.basedir}/src/main/protobuf/</proto.cas.path>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <shaded.guava.version>23.0</shaded.guava.version>
+    <shaded.guava.version>28.2-jre</shaded.guava.version>
     <guava.version>19.0</guava.version>
     <forkCount>2</forkCount>
     <parquet.version>1.11.0</parquet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,9 @@
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.28.2</mockito.version>
     <!--
-      Currently Hive storage plugin only supports Apache Hive 2.3.2 or vendor specific variants of the
-      Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated.
+      Currently Hive storage plugin only supports Apache Hive 3.1.2 or vendor specific variants of the
+      Apache Hive 2.3.2. If the version is changed, make sure the jars and their dependencies are updated,
+      for example parquet-hadoop-bundle and derby dependencies.
     -->
     <hive.version>3.1.2</hive.version>
     <hadoop.version>3.2.1</hadoop.version>
@@ -91,7 +92,7 @@
     <reflections.version>0.9.10</reflections.version>
     <avro.version>1.9.1</avro.version>
     <metrics.version>4.0.2</metrics.version>
-    <jetty.version>9.3.25.v20180904</jetty.version>
+    <jetty.version>9.3.28.v20191105</jetty.version>
     <jersey.version>2.25.1</jersey.version>
     <asm.version>7.3.1</asm.version>
     <excludedGroups />
@@ -110,9 +111,12 @@
     <joda.version>2.10.5</joda.version>
     <javax.el.version>3.0.0</javax.el.version>
     <surefire.version>3.0.0-M4</surefire.version>
-    <commons.compress.version>1.19</commons.compress.version>
+    <commons.compress.version>1.20</commons.compress.version>
     <hikari.version>3.4.2</hikari.version>
     <netty.version>4.0.48.Final</netty.version>
+    <httpclient.version>4.5.12</httpclient.version>
+    <libthrift.version>0.13.0</libthrift.version>
+    <derby.version>10.14.2.0</derby.version>
   </properties>
 
   <scm>
@@ -606,10 +610,13 @@
                     <exclude>org.mortbay.jetty:servlet-api</exclude>
                     <exclude>org.mortbay.jetty:servlet-api-2.5</exclude>
                     <exclude>log4j:log4j</exclude>
+                    <exclude>org.apache.logging.log4j:log4j-core</exclude>
                     <exclude>jdk.tools:jdk.tools</exclude>
                     <exclude>org.json:json</exclude>
                     <exclude>org.beanshell:bsh</exclude>
                     <exclude>org.apache.calcite:*</exclude>
+                    <exclude>commons-httpclient:*</exclude>
+                    <exclude>tomcat:*</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>
@@ -1891,6 +1898,21 @@
         <artifactId>HikariCP</artifactId>
         <version>${hikari.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>${libthrift.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby-project</artifactId>
+        <version>${derby.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -2045,8 +2067,8 @@
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -2192,8 +2214,12 @@
                 <artifactId>jackson-jaxrs</artifactId>
               </exclusion>
               <exclusion>
-                  <groupId>io.netty</groupId>
-                  <artifactId>netty</artifactId>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
               </exclusion>
             </exclusions>
           </dependency>
@@ -2886,6 +2912,10 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -3311,6 +3341,14 @@
               <exclusion>
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-annotations</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>tomcat</groupId>
+                <artifactId>jasper-compiler</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>tomcat</groupId>
+                <artifactId>jasper-runtime</artifactId>
               </exclusion>
             </exclusions>
           </dependency>


### PR DESCRIPTION
# [DRILL-7702](https://issues.apache.org/jira/browse/DRILL-7702): Update zookeeper, curator, guava, jetty-server, libthrift, httpclient, commons-compress and httpdlog-parser

## Description
This pull request contains 3 commits where different libraries are updated.
- The first commit contains changes for updating `jetty`, `commons-compress`, `httpclient`, `httpdlog-parser`, `libthrift` and `derby` libraries. Such libraries as `log4j-core`, `commons-httpclient` and `tomcat` (`jasper-compiler`, etc.) are banned to avoid adding them occasionally as transitive dependencies to the project.
- The second commit contains changes for updating ZooKeeper and Curator versions. The latest available curator version (4.3.0) doesn't support Zookeeper 3.6.0 yet, so updated Zookeeper to 3.5.7. Updating Curator helped to avoid using the outdated `org.codehaus.jackson` libraries, but they weren't added to banned dependencies since they are transitively used by other non-default supported profiles, in particular by `hbase-server` of one of non-default profile. Fixed error after the update when Drill is shutting down from distributed mode and `TransientStoreFactory` is closed after closing `CuratorFramework`, so the client was already closed.
- The latest commit contains changes for updating the shaded Guava version. In new version were removed `AbstractCheckedFuture` and `CheckedFuture` classes. But since Drill actively uses the approach of mapping exceptions for `Future`, was used advice from Guava docs to move these classes into the project. Additionally, Guava had a hard dependency on `com.google.guava:failureaccess` library which has packages that match the shaded package pattern. So this library was also added to be shaded.

P.S. As for regular shaded Guava updates, the build will fail until PR is approved and a new version is published to Maven central.

## Documentation
NA

## Testing
Tested manually, started Drill in distributed mode, connected to Apache Zookeeper Docker container, checked custom authenticator with JDBC driver.
