### PR TITLE
DRILL-7703: Support for 3+D arrays in EVF JSON loader

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
 import org.apache.drill.exec.physical.resultSet.RowSetLoader;
@@ -183,6 +184,13 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     }
 
     public JsonLoader build() {
+      // Defaults, primarily for testing.
+      if (options == null) {
+        options = new JsonLoaderOptions();
+      }
+      if (errorContext == null) {
+        errorContext  = EmptyErrorContext.INSTANCE;
+      }
       return new JsonLoaderImpl(this);
     }
   }
@@ -313,6 +321,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
   public RuntimeException syntaxError(JsonParseException e) {
     throw buildError(
         UserException.dataReadError(e)
+          .message("Error parsing JSON - %s", e.getMessage())
           .addContext("Syntax error"));
   }
 
@@ -376,14 +385,6 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
           .message("JSON reader does not support the JSON data type")
           .addContext("Field", key)
           .addContext("JSON type", jsonType.toString()));
-  }
-
-  public UserException unsupportedArrayException(String key, int dims) {
-    return buildError(
-        UserException.validationError()
-          .message("JSON reader does not arrays deeper than two levels")
-          .addContext("Field", key)
-          .addContext("Array nesting", dims));
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderOptions.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderOptions.java
@@ -29,6 +29,7 @@ import org.apache.drill.exec.store.easy.json.parser.JsonStructureOptions;
 public class JsonLoaderOptions extends JsonStructureOptions {
 
   public boolean readNumbersAsDouble;
+  public boolean unionEnabled;
 
   /**
    * Drill prior to version 1.18 would read a null string
@@ -49,5 +50,6 @@ public class JsonLoaderOptions extends JsonStructureOptions {
   public JsonLoaderOptions(OptionSet options) {
     super(options);
     this.readNumbersAsDouble = options.getBoolean(ExecConstants.JSON_READ_NUMBERS_AS_DOUBLE);
+    this.unionEnabled = options.getBoolean(ExecConstants.ENABLE_UNION_TYPE_KEY);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/UnknownFieldListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/UnknownFieldListener.java
@@ -105,7 +105,7 @@ public class UnknownFieldListener extends AbstractValueListener implements NullT
 
   @Override
   public ObjectListener object() {
-    return resolveScalar(JsonType.OBJECT).object();
+    return resolveTo(parentTuple.objectListenerForValue(key)).object();
   }
 
   /**
@@ -115,7 +115,7 @@ public class UnknownFieldListener extends AbstractValueListener implements NullT
    */
   protected ValueListener resolveScalar(JsonType type) {
     if (unknownArray == null) {
-      return resolveTo(parentTuple.scalarListenerFor(key, type));
+      return resolveTo(parentTuple.scalarListenerForValue(key, type));
     } else {
 
       // Saw {a: []}, {a: 10}. Since we infer that 10 is a
@@ -154,11 +154,11 @@ public class UnknownFieldListener extends AbstractValueListener implements NullT
     if (unknownArray == null) {
       logger.warn("Ambiguous type! JSON field {}" +
           " contains all nulls. Assuming VARCHAR.", key);
-      resolveTo(parentTuple.scalarListenerFor(key, JsonType.STRING));
+      resolveTo(parentTuple.scalarListenerForValue(key, JsonType.STRING));
     } else {
       logger.warn("Ambiguous type! JSON array field {}" +
           " contains all empty arrays. Assuming repeated VARCHAR.", key);
-      resolveTo(parentTuple.arrayListenerFor(key, JsonType.STRING));
+      resolveTo(parentTuple.scalarArrayListenerForValue(key, JsonType.STRING));
     }
   }
 
@@ -168,7 +168,7 @@ public class UnknownFieldListener extends AbstractValueListener implements NullT
           " starts with null element. Assuming repeated VARCHAR.", key);
       valueDef = new ValueDef(JsonType.STRING, valueDef.dimensions());
     }
-    return resolveTo(parentTuple.listenerFor(key, valueDef));
+    return resolveTo(parentTuple.listenerForValue(key, valueDef));
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/JsonStructureParser.java
@@ -36,28 +36,33 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Parser for JSON that converts a stream of tokens from the Jackson JSON
- * parser into a set of events on listeners structured to follow the
- * data structure of the incoming data. JSON can assume many forms. This
- * class assumes that the data is in a tree structure that corresponds
- * to the Drill row structure: a series of object with (mostly) the
- * same schema. Members of the top-level object can be Drill types:
- * scalars, arrays, nested objects (Drill "MAP"s), and so on.
+ * Parser for a subset of the <a href="http://jsonlines.org/">jsonlines</a>
+ * format. In particular, supports line-delimited JSON objects, or a single
+ * array which holds a list of JSON objects.
  * <p>
- * The structure parser follows the structure of the incoming data,
- * whatever it might be. This class imposes no semantic rules on that
- * data, it just "calls 'em as it sees 'em" as they say. The listeners
- * are responsible for deciding if the data data makes sense, and if
- * so, how it should be handled.
+ * Alternatively, a message parser can provide a path to an array of JSON
+ * objects within a messages such as a REST response.
  * <p>
- * The root listener will receive an event to fields in the top-level
- * object as those fields first appear. Each field is a value object
- * and can correspond to a scalar, array, another object, etc. The
- * type of the value is declared when known, but sometimes it is not
- * known, such as if the value is {@code null}. And, of course, according
- * to JSON, the value is free to change from one row to the next. The
- * listener decides it if wants to handle such "schema change", and if
- * so, how.
+ * Implemented as a parser which converts a stream of tokens from the Jackson
+ * JSON parser into a set of events on listeners structured to follow the data
+ * structure of the incoming data. JSON can assume many forms. This class
+ * assumes that the data is in a tree structure that corresponds to the Drill
+ * row structure: a series of object with (mostly) the same schema. Members of
+ * the top-level object can be Drill types: scalars, arrays, nested objects
+ * (Drill "MAP"s), and so on.
+ * <p>
+ * The structure parser follows the structure of the incoming data, whatever it
+ * might be. This class imposes no semantic rules on that data, it just "calls
+ * 'em as it sees 'em" as they say. The listeners are responsible for deciding
+ * if the data data makes sense, and if so, how it should be handled.
+ * <p>
+ * The root listener will receive an event to fields in the top-level object as
+ * those fields first appear. Each field is a value object and can correspond to
+ * a scalar, array, another object, etc. The type of the value is declared when
+ * known, but sometimes it is not known, such as if the value is {@code null}.
+ * And, of course, according to JSON, the value is free to change from one row
+ * to the next. The listener decides it if wants to handle such "schema change",
+ * and if so, how.
  */
 public class JsonStructureParser {
   protected static final Logger logger = LoggerFactory.getLogger(JsonStructureParser.class);

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/TokenIterator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/TokenIterator.java
@@ -128,6 +128,8 @@ public class TokenIterator {
   public String textValue() {
     try {
       return parser.getText();
+    } catch (JsonParseException e) {
+      throw errorFactory.syntaxError(e);
     } catch (IOException e) {
       throw errorFactory.ioException(e);
     }
@@ -136,6 +138,8 @@ public class TokenIterator {
   public long longValue() {
     try {
       return parser.getLongValue();
+    } catch (JsonParseException e) {
+      throw errorFactory.syntaxError(e);
     } catch (IOException e) {
       throw errorFactory.ioException(e);
     } catch (UnsupportedConversionError e) {
@@ -146,6 +150,8 @@ public class TokenIterator {
   public String stringValue() {
     try {
       return parser.getValueAsString();
+    } catch (JsonParseException e) {
+      throw errorFactory.syntaxError(e);
     } catch (IOException e) {
       throw errorFactory.ioException(e);
     } catch (UnsupportedConversionError e) {
@@ -156,6 +162,8 @@ public class TokenIterator {
   public double doubleValue() {
     try {
       return parser.getValueAsDouble();
+    } catch (JsonParseException e) {
+      throw errorFactory.syntaxError(e);
     } catch (IOException e) {
       throw errorFactory.ioException(e);
     } catch (UnsupportedConversionError e) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestObjects.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestObjects.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -32,7 +33,9 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(RowSetTests.class)
 public class TestObjects extends BaseJsonLoaderTest {
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestScalarArrays.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestScalarArrays.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
@@ -33,6 +34,7 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test scalar arrays. Without a schema, the first array token
@@ -44,6 +46,7 @@ import org.junit.Test;
  * Verifies that null array elements are converted to a default
  * value for the type (false, 0 or empty string.)
  */
+@Category(RowSetTests.class)
 public class TestScalarArrays extends BaseJsonLoaderTest {
 
   @Test

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestScalars.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestScalars.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.resultSet.project.Projections;
@@ -31,6 +32,7 @@ import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests JSON scalar handling. Without a schema, the first non-null value
@@ -44,6 +46,7 @@ import org.junit.Test;
  * to a few messy rows a billion rows in, or due to the order that the scanners
  * see the data.
  */
+@Category(RowSetTests.class)
 public class TestScalars extends BaseJsonLoaderTest {
 
   /**

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestVariant.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/loader/TestVariant.java
@@ -22,13 +22,16 @@ import static org.apache.drill.test.rowSet.RowSetUtilities.objArray;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import org.apache.drill.categories.RowSetTests;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.physical.rowSet.RowSet;
 import org.apache.drill.exec.record.metadata.SchemaBuilder;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.test.rowSet.RowSetUtilities;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(RowSetTests.class)
 public class TestVariant extends BaseJsonLoaderTest {
 
   @Test

--- a/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
+++ b/exec/vector/src/main/java/org/apache/drill/exec/record/metadata/MetadataUtils.java
@@ -304,4 +304,9 @@ public class MetadataUtils {
     }
     return false;
   }
+
+  public static boolean isRepeatedList(ColumnMetadata col) {
+    return col.type() == MinorType.LIST &&
+           col.mode() == DataMode.REPEATED;
+  }
 }


### PR DESCRIPTION
# [DRILL-7703](https://issues.apache.org/jira/browse/DRILL-7703): Support for 3+D arrays in EVF JSON loader

## Description

As work continues on adding the new JSON reader to Drill, running unit tests reveals that some include list with three (perhaps more) dimensions.

Revises the EVF-based JSON loader to support nested repeated lists.

Took this opportunity to review and clean up the many "create listener for" methods in the JSON loader object listener.

## Documentation

N/A

## Testing

Added new tests to verify 3D lists. Reran all existing unit tests to verify no regressions after refactoring.