### PR TITLE
DRILL-7704: Update Maven to 3.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # Drill and copies built binaries into the target image based on openjdk:8u232-jdk image.
 
 # Uses intermediate image for building Drill to reduce target image size
-FROM maven:3.6-jdk-8 as build
+FROM maven:3.6.3-jdk-8 as build
 
 # Copy project sources into the container
 COPY . /src

--- a/docs/dev/Docker.md
+++ b/docs/dev/Docker.md
@@ -4,7 +4,7 @@
 
    To build an Apache Drill docker image, you need to have the following software installed on your system to successfully complete a build. 
   * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-  * [Maven 3.3.3 or greater](https://maven.apache.org/download.cgi)
+  * [Maven 3.6.3 or greater](https://maven.apache.org/download.cgi)
   * [Docker CE](https://store.docker.com/search?type=edition&offering=community)
 
    If you are using an older Mac or PC, additionally configure [docker-machine](https://docs.docker.com/machine/overview/#what-is-docker-machine) on your system

--- a/docs/dev/Environment.md
+++ b/docs/dev/Environment.md
@@ -4,7 +4,7 @@
 
 Currently, the Apache Drill build process is known to work on Linux, Windows and OSX.  To build, you need to have the following software installed on your system to successfully complete a build. 
   * Java 8
-  * Maven 3.3.3 or greater
+  * Maven 3.6.3 or greater
 
 ## Confirm settings
     # java -version
@@ -13,7 +13,7 @@ Currently, the Apache Drill build process is known to work on Linux, Windows and
     Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
     # mvn --version
-    Apache Maven 3.3.3
+    Apache Maven 3.6.3
 
 ## Checkout
 

--- a/docs/dev/InstantiatingComponents.md
+++ b/docs/dev/InstantiatingComponents.md
@@ -2,8 +2,8 @@
 
 There are a few techniques for creating instances classes in unit tests:
 
-* Use a mocking library. **(Depracated)**
-* Provide a simple impementation of an interface
+* Use a mocking library. **(Deprecated)**
+* Provide a simple implementation of an interface
 * Build a real instance of class using the class's builders / constructors
 * Use the [ClusterFixture](ClusterFixture.md) or [OperatorFixture](OperatorFixture.md) classes to create instances of objects.
 

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -27,8 +27,11 @@
   </parent>
   <artifactId>drill-java-exec</artifactId>
   <name>exec/Java Execution Engine</name>
+
   <properties>
     <libpam4j.version>1.8-rev2</libpam4j.version>
+    <aether.version>1.1.0</aether.version>
+    <wagon.version>3.3.4</wagon.version>
   </properties>
 
   <dependencies>
@@ -557,31 +560,31 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>${maven.embedder.version}</version>
+      <version>${maven.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <version>3.5.3</version>
+      <version>${maven.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-connector-basic</artifactId>
-      <version>1.1.0</version>
+      <version>${aether.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-transport-wagon</artifactId>
-      <version>1.1.0</version>
+      <version>${aether.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <version>3.0.0</version>
+      <version>${wagon.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -593,7 +596,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>3.0.0</version>
+      <version>${wagon.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
     <netty.tcnative.classifier />
     <commons.io.version>2.4</commons.io.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
-    <maven.embedder.version>3.5.3</maven.embedder.version>
     <curator.version>4.3.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
@@ -102,7 +101,7 @@
     <license.skip>true</license.skip>
     <docker.repository>apache/drill</docker.repository>
     <antlr.version>4.8-1</antlr.version>
-    <lowestMavenVersion>3.3.3</lowestMavenVersion>
+    <maven.version>3.6.3</maven.version>
     <commons.net.version>3.6</commons.net.version>
     <commons.validator.version>1.6</commons.validator.version>
     <commons.text.version>1.6</commons.text.version>
@@ -117,6 +116,7 @@
     <httpclient.version>4.5.12</httpclient.version>
     <libthrift.version>0.13.0</libthrift.version>
     <derby.version>10.14.2.0</derby.version>
+    <commons.cli.version>1.4</commons.cli.version>
   </properties>
 
   <scm>
@@ -256,7 +256,7 @@
             <dependency>
               <groupId>org.apache.maven</groupId>
               <artifactId>maven-embedder</artifactId>
-              <version>${maven.embedder.version}</version>
+              <version>${maven.version}</version>
             </dependency>
             <dependency>
               <groupId>org.apache.curator</groupId>
@@ -587,7 +587,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[{$lowestMavenVersion},4)</version>
+                  <version>[${maven.version},4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,15)</version>
@@ -1912,6 +1912,11 @@
         <groupId>org.apache.derby</groupId>
         <artifactId>derby-project</artifactId>
         <version>${derby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>${commons.cli.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tools/fmpp/pom.xml
+++ b/tools/fmpp/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${lowestMavenVersion}</version>
+      <version>${maven.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-logging</artifactId>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${lowestMavenVersion}</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.fmpp-maven-plugin</groupId>


### PR DESCRIPTION
# [DRILL-7704](https://issues.apache.org/jira/browse/DRILL-7704): Update Maven to 3.6.3

## Description

Update Maven dependency to 3.6.3

## Documentation
Need to update https://drill.apache.org/docs/compiling-drill-from-source/ page

## Testing
Ran all tests.
