### PR TITLE
DRILL-7708: Downgrade maven from 3.6.3 to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <license.skip>true</license.skip>
     <docker.repository>apache/drill</docker.repository>
     <antlr.version>4.8-1</antlr.version>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.6.0</maven.version>
     <commons.net.version>3.6</commons.net.version>
     <commons.validator.version>1.6</commons.validator.version>
     <commons.text.version>1.6</commons.text.version>


### PR DESCRIPTION
# [DRILL-7708](https://issues.apache.org/jira/browse/DRILL-7708): Downgrade maven from 3.6.3 to 3.6.0

## Description

Thanks to @arina-ielchiieva for recently upgrading Drill's Maven version to 3.6.3.

As it turns out, I use Ubuntu (Linux Mint) for development. Maven is installed as a package using apt-get. Packages can lag behind a bit. The latest maven available via apt-get is 3.6.0.

It is a nuisance to install a new version outside the package manager. I changed the Maven version in the root pom.xml to 3.6.0 and the build seemed to work. This PR adjusts the required Maven version to 3.6.0.

## Documentation

Maven 3.6.0 is required to build Drill.

## Testing

Ran the full build.