### PR TITLE
DRILL-7711: Add data path, parameter filter pushdown to HTTP plugin

### DIFF
--- a/common/src/main/java/org/apache/drill/common/PlanStringBuilder.java
+++ b/common/src/main/java/org/apache/drill/common/PlanStringBuilder.java
@@ -107,6 +107,11 @@ public class PlanStringBuilder {
     return field(key, StringEscapeUtils.escapeJava(value));
   }
 
+  public PlanStringBuilder maskedField(String key, String value) {
+    // Intentionally ignore length
+    return field(key, value == null ? null : "*******");
+  }
+
   private void startField(String key) {
     if (fieldCount++ != 0) {
       buf.append(", ");

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.common.map.CaseInsensitiveMap;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.http.filter.ExprNode;
+import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.http.filter.ExprNode.ColRelOpConstNode;
+import org.apache.drill.exec.store.http.filter.ExprNode.OrNode;
+import org.apache.drill.exec.store.http.filter.FilterPushDownListener;
+import org.apache.drill.exec.store.http.filter.FilterPushDownStrategy;
+
+/**
+ * The HTTP storage plugin accepts filters which are:
+ * <ul>
+ * <li>A single column = value expression, where the column is
+ * a filter column from the config, or</li>
+ * <li>An AND'ed set of such expressions,</li>
+ * <li>If the value is one with an unambiguous conversion to
+ * a string. (That is, not dates, binary, maps, etc.)</li>
+ * </ul>
+ */
+public class HttpPushDownListener implements FilterPushDownListener {
+
+  public static Set<StoragePluginOptimizerRule> rulesFor(
+      OptimizerRulesContext optimizerRulesContext) {
+    return FilterPushDownStrategy.rulesFor(
+        new HttpPushDownListener());
+  }
+
+  @Override
+  public String prefix() {
+    return "Http";
+  }
+
+  @Override
+  public boolean isTargetScan(GroupScan groupScan) {
+    return groupScan instanceof HttpGroupScan;
+  }
+
+  @Override
+  public ScanPushDownListener builderFor(GroupScan groupScan) {
+    HttpGroupScan httpScan = (HttpGroupScan) groupScan;
+    if (httpScan.hasFilters() || !httpScan.allowsFilters()) {
+      return null;
+    } else {
+      return new HttpScanPushDownListener(httpScan);
+    }
+  }
+
+  private static class HttpScanPushDownListener implements ScanPushDownListener {
+
+    private final HttpGroupScan groupScan;
+    private final Map<String, String> filterParams = CaseInsensitiveMap.newHashMap();
+
+    HttpScanPushDownListener(HttpGroupScan groupScan) {
+      this.groupScan = groupScan;
+      for (String field : groupScan.getHttpConfig().params()) {
+        filterParams.put(field, field);
+      }
+    }
+
+    @Override
+    public ExprNode accept(ExprNode node) {
+      if (node instanceof OrNode) {
+        return null;
+      } else if (node instanceof ColRelOpConstNode) {
+        return acceptRelOp((ColRelOpConstNode) node);
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * Only accept equality conditions.
+     */
+    private ColRelOpConstNode acceptRelOp(ColRelOpConstNode relOp) {
+      switch (relOp.op) {
+      case EQ:
+        return acceptColumn(relOp.colName) &&
+               acceptType(relOp.value.type) ? relOp : null;
+      default:
+        return null;
+      }
+    }
+
+    /**
+     * Only accept columns in the filter params list.
+     */
+    private boolean acceptColumn(String colName) {
+      return filterParams.containsKey(colName);
+    }
+
+    /**
+     * Only accept types which have an unambiguous mapping to
+     * String.
+     */
+    private boolean acceptType(MinorType type) {
+      switch (type) {
+      case BIGINT:
+      case BIT:
+      case FLOAT4:
+      case FLOAT8:
+      case INT:
+      case SMALLINT:
+      case VARCHAR:
+      case VARDECIMAL:
+        return true;
+      default:
+        return false;
+      }
+    }
+
+    /**
+     * Convert the equality nodes to a map of param/string pairs using
+     * the case specified in the storage plugin config.
+     */
+    @Override
+    public Pair<GroupScan, List<RexNode>> transform(AndNode andNode) {
+      Map<String, String> filters = new HashMap<>();
+      double selectivity = 1;
+      for (ExprNode expr : andNode.children) {
+        ColRelOpConstNode relOp = (ColRelOpConstNode) expr;
+        filters.put(filterParams.get(relOp.colName), relOp.value.value.toString());
+        selectivity *= relOp.op.selectivity();
+      }
+      HttpGroupScan newScan = new HttpGroupScan(groupScan, filters, selectivity);
+      return Pair.of(newScan, Collections.emptyList());
+    }
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanSpec.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanSpec.java
@@ -26,28 +26,30 @@ import org.apache.drill.common.PlanStringBuilder;
 @JsonTypeName("http-scan-spec")
 public class HttpScanSpec {
 
-  protected final String schemaName;
-
-  protected final String database;
-
-  protected final String tableName;
-
-  protected final HttpStoragePluginConfig config;
+  private final String pluginName;
+  private final String connectionName;
+  private final String tableName;
+  private final HttpStoragePluginConfig config;
 
   @JsonCreator
-  public HttpScanSpec(@JsonProperty("schemaName") String schemaName,
-                      @JsonProperty("database") String database,
+  public HttpScanSpec(@JsonProperty("pluginName") String pluginName,
+                      @JsonProperty("connection") String connectionName,
                       @JsonProperty("tableName") String tableName,
                       @JsonProperty("config") HttpStoragePluginConfig config) {
-    this.schemaName = schemaName;
-    this.database = database;
+    this.pluginName = pluginName;
+    this.connectionName = connectionName;
     this.tableName = tableName;
     this.config = config;
   }
 
-  @JsonProperty("database")
-  public String database() {
-    return database;
+  @JsonProperty("pluginName")
+  public String pluginName() {
+    return pluginName;
+  }
+
+  @JsonProperty("connection")
+  public String connection() {
+    return connectionName;
   }
 
   @JsonProperty("tableName")
@@ -55,16 +57,26 @@ public class HttpScanSpec {
     return tableName;
   }
 
+  @JsonProperty("config")
+  public HttpStoragePluginConfig config() {
+    return config;
+  }
+
   @JsonIgnore
   public String getURL() {
-    return database;
+    return connectionName;
+  }
+
+  @JsonIgnore
+  public HttpApiConfig connectionConfig() {
+    return config.getConnection(connectionName);
   }
 
   @Override
   public String toString() {
     return new PlanStringBuilder(this)
-      .field("schemaName", schemaName)
-      .field("database", database)
+      .field("schemaName", pluginName)
+      .field("database", connectionName)
       .field("tableName", tableName)
       .field("config", config)
       .toString();

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
@@ -17,14 +17,21 @@
  */
 package org.apache.drill.exec.store.http;
 
+import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.drill.common.JSONOptions;
+import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.AbstractGroupScan;
+import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
+import org.apache.drill.exec.store.http.filter.FilterPushDownUtils;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
+import java.util.Set;
 
 public class HttpStoragePlugin extends AbstractStoragePlugin {
 
@@ -35,7 +42,7 @@ public class HttpStoragePlugin extends AbstractStoragePlugin {
   public HttpStoragePlugin(HttpStoragePluginConfig configuration, DrillbitContext context, String name) {
     super(context, name);
     this.config = configuration;
-    this.schemaFactory = new HttpSchemaFactory(this, name);
+    this.schemaFactory = new HttpSchemaFactory(this);
   }
 
   @Override
@@ -56,6 +63,20 @@ public class HttpStoragePlugin extends AbstractStoragePlugin {
   @Override
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection) throws IOException {
     HttpScanSpec scanSpec = selection.getListWith(context.getLpPersistence().getMapper(), new TypeReference<HttpScanSpec>() {});
-    return new HttpGroupScan(config, scanSpec, null);
+    return new HttpGroupScan(scanSpec);
   }
-}
+
+  @Override
+  public Set<? extends RelOptRule> getOptimizerRules(OptimizerRulesContext optimizerContext, PlannerPhase phase) {
+
+    // Push-down planning is done at the logical phase so it can
+    // influence parallelization in the physical phase. Note that many
+    // existing plugins perform filter push-down at the physical
+    // phase, which also works fine if push-down is independent of
+    // parallelization.
+    if (FilterPushDownUtils.isFilterPushDownPhase(phase)) {
+      return HttpPushDownListener.rulesFor(optimizerContext);
+    } else {
+      return ImmutableSet.of();
+    }
+  }}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.store.http;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -38,19 +39,20 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 public class HttpSubScan extends AbstractBase implements SubScan {
 
   private final HttpScanSpec tableSpec;
-  private final HttpStoragePluginConfig config;
   private final List<SchemaPath> columns;
+  private final Map<String, String> filters;
 
   @JsonCreator
   public HttpSubScan(
-    @JsonProperty("config") HttpStoragePluginConfig config,
     @JsonProperty("tableSpec") HttpScanSpec tableSpec,
-    @JsonProperty("columns") List<SchemaPath> columns) {
+    @JsonProperty("columns") List<SchemaPath> columns,
+    @JsonProperty("filters") Map<String, String> filters) {
     super("user-if-needed");
-    this.config = config;
     this.tableSpec = tableSpec;
     this.columns = columns;
+    this.filters = filters;
   }
+
   @JsonProperty("tableSpec")
   public HttpScanSpec tableSpec() {
     return tableSpec;
@@ -61,21 +63,9 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     return columns;
   }
 
-  @JsonProperty("config")
-  public HttpStoragePluginConfig config() {
-    return config;
-  }
-
-  @JsonIgnore
-  public String getURL() {
-    return tableSpec.getURL();
-  }
-
-  @JsonIgnore
-  public String getFullURL() {
-    String selectedConnection = tableSpec.database();
-    String url = config.connections().get(selectedConnection).url();
-    return url + tableSpec.tableName();
+  @JsonProperty("filters")
+  public Map<String, String> filters() {
+    return filters;
   }
 
  @Override
@@ -86,7 +76,7 @@ public class HttpSubScan extends AbstractBase implements SubScan {
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
-    return new HttpSubScan(config, tableSpec, columns);
+    return new HttpSubScan(tableSpec, columns, filters);
   }
 
   @Override
@@ -105,13 +95,13 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     return new PlanStringBuilder(this)
       .field("tableSpec", tableSpec)
       .field("columns", columns)
-      .field("config", config)
+      .field("filters", filters)
       .toString();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableSpec,columns,config);
+    return Objects.hash(tableSpec, columns, filters);
   }
 
   @Override
@@ -125,6 +115,6 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     HttpSubScan other = (HttpSubScan) obj;
     return Objects.equals(tableSpec, other.tableSpec)
       && Objects.equals(columns, other.columns)
-      && Objects.equals(config, other.config);
+      && Objects.equals(filters, other.filters);
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/ConstantHolder.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/ConstantHolder.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+import java.math.BigDecimal;
+
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Description of a constant argument of an expression.
+ * Each constant is a (type, value) pair.
+ */
+
+@JsonPropertyOrder({"type", "value"})
+public class ConstantHolder implements Comparable<ConstantHolder> {
+  @JsonProperty("type")
+  public final MinorType type;
+  @JsonProperty("value")
+  public final Object value;
+
+  @JsonCreator
+  public ConstantHolder(
+      @JsonProperty("type") MinorType type,
+      @JsonProperty("value") Object value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  public static ConstantHolder bitValue(boolean value) {
+    return new ConstantHolder(MinorType.BIT, value);
+  }
+
+  public static ConstantHolder smallIntValue(int value) {
+    return new ConstantHolder(MinorType.SMALLINT, (short) value);
+  }
+
+  public static ConstantHolder intValue(int value) {
+    return new ConstantHolder(MinorType.INT, value);
+  }
+
+  public static ConstantHolder bigIntValue(long value) {
+    return new ConstantHolder(MinorType.BIGINT, value);
+  }
+
+  public static ConstantHolder float4Value(float value) {
+    return new ConstantHolder(MinorType.FLOAT4, value);
+  }
+
+  public static ConstantHolder float8Value(double value) {
+    return new ConstantHolder(MinorType.FLOAT8, value);
+  }
+
+  public static ConstantHolder decimalValue(BigDecimal value) {
+    return new ConstantHolder(MinorType.VARDECIMAL, value);
+  }
+
+  public static ConstantHolder varcharValue(String value) {
+    return new ConstantHolder(MinorType.VARCHAR, value);
+  }
+
+  /**
+   * Convert a constant to the given type. Conversion is defined only for
+   * some types (where conversion makes sense) and only for some values
+   * (only those that would result in a valid conversion.)
+   *
+   * @param toType the target type
+   * @return a constant of the requested type
+   * @throws RuntimeException if the conversion is not legal
+   * @see {@link #normalize(MinorType)} for a "save" version of this
+   * method
+   */
+  public ConstantHolder convertTo(MinorType toType) {
+    if (type == toType) {
+      return this;
+    }
+    switch (toType) {
+    case INT:
+      return toInt();
+    case BIGINT:
+      return toBigInt();
+    case TIMESTAMP:
+      return toTimestamp(null);
+    case VARCHAR:
+      return toVarChar();
+    case FLOAT4:
+      return toFloat();
+    case FLOAT8:
+      return toDouble();
+    case VARDECIMAL:
+      return toDecimal();
+    default:
+      throw conversionError(toType);
+    }
+  }
+
+  /**
+   * Normalize the constant to the given type. Return null if the constant
+   * cannot be converted. Use this test to determine if the constant is of
+   * a form that can be pushed down when push-down only supports certain
+   * types. In such a case, the query will likely fail at execution time
+   * when Drill tries to compare the remaining filter with an incompatible
+   * column type.
+   *
+   * @param toType the target type
+   * @return a constant of the requested type or null if the conversion
+   * is not defined or is not legal for the given value
+   */
+  public ConstantHolder normalize(MinorType toType) {
+    try {
+      return convertTo(toType);
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  public ConstantHolder toInt() {
+    int intValue;
+    switch (type) {
+      case SMALLINT:
+        intValue = (Short) value;
+        break;
+      case INT:
+        return this;
+      case BIGINT: {
+        long value = (long) this.value;
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+          throw conversionError(MinorType.INT);
+        }
+        intValue = (int) value;
+        break;
+      }
+      case VARCHAR:
+        try {
+          intValue = Integer.parseInt((String) value);
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.INT);
+        }
+        break;
+      case VARDECIMAL:
+        try {
+          intValue = ((BigDecimal) value).intValueExact();
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.INT);
+        }
+        break;
+      default:
+        throw conversionError(MinorType.INT);
+    }
+    return new ConstantHolder(MinorType.INT, intValue);
+  }
+
+  public ConstantHolder toBigInt() {
+    long longValue;
+    switch (type) {
+      case SMALLINT:
+        longValue = (Short) value;
+        break;
+      case INT:
+        longValue = (Integer) value;
+        break;
+      case BIGINT:
+        return this;
+      case VARCHAR:
+        try {
+          longValue = Long.parseLong((String) value);
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.BIGINT);
+        }
+        break;
+      case VARDECIMAL:
+        try {
+          longValue = ((BigDecimal) value).longValueExact();
+        } catch (NumberFormatException e) {
+          throw conversionError(MinorType.INT);
+        }
+        break;
+      default:
+        throw conversionError(MinorType.BIGINT);
+    }
+    return new ConstantHolder(MinorType.BIGINT, longValue);
+  }
+
+  public ConstantHolder toTimestamp(String tz) {
+    long longValue;
+    switch (type) {
+      case TIMESTAMP:
+        return this;
+      case INT:
+        longValue = (Integer) value;
+        break;
+      case BIGINT:
+        longValue = (Long) value;
+        break;
+      case VARCHAR: {
+        DateTimeFormatter format = ISODateTimeFormat.dateTimeNoMillis();
+        if (tz != null) {
+          format = format.withZone(DateTimeZone.forID(tz));
+        }
+        try {
+          longValue = format.parseDateTime((String) value).getMillis();
+        } catch (Exception e) {
+          throw conversionError(MinorType.TIMESTAMP);
+        }
+        break;
+      }
+      default:
+        throw conversionError(MinorType.TIMESTAMP);
+    }
+    return new ConstantHolder(MinorType.TIMESTAMP, longValue);
+  }
+
+  /**
+   * Convert the value to a String. Consider this as a debug tool as
+   * no attempt is made to format values in any particular way. Date, time,
+   * interval and bit values will appear as numbers, which is probably
+   * not what most target systems expect.
+   * @return the value as a string using the {@code toString()} method
+   * on the value
+   */
+  public ConstantHolder toVarChar() {
+    if (type == MinorType.VARCHAR) {
+      return this;
+    } else {
+      return new ConstantHolder(MinorType.VARCHAR, value.toString());
+    }
+  }
+
+  public ConstantHolder toFloat() {
+    float floatValue;
+    switch (type) {
+    case BIGINT:
+      floatValue = (Long) value;
+      break;
+    case INT:
+      floatValue = (Integer) value;
+      break;
+    case FLOAT4:
+      return this;
+    case VARCHAR:
+      try {
+        floatValue = Float.parseFloat((String) value);
+      } catch (Exception e) {
+        throw conversionError(MinorType.FLOAT8);
+      }
+      break;
+    case VARDECIMAL:
+      floatValue = ((BigDecimal) value).floatValue();
+      break;
+    default:
+      throw conversionError(MinorType.FLOAT4);
+    }
+    return new ConstantHolder(MinorType.FLOAT4, floatValue);
+  }
+
+  public ConstantHolder toDouble() {
+    double doubleValue;
+    switch (type) {
+    case SMALLINT:
+      doubleValue = (Short) value;
+      break;
+    case INT:
+      doubleValue = (Integer) value;
+      break;
+    case BIGINT:
+      doubleValue = (Long) value;
+      break;
+    case FLOAT4:
+      doubleValue = (Float) value;
+      break;
+    case FLOAT8:
+      return this;
+    case VARCHAR:
+      try {
+        doubleValue = Double.parseDouble((String) value);
+      } catch (Exception e) {
+        throw conversionError(MinorType.FLOAT8);
+      }
+      break;
+    case VARDECIMAL:
+      doubleValue = ((BigDecimal) value).doubleValue();
+      break;
+    default:
+      throw conversionError(MinorType.FLOAT8);
+    }
+    return new ConstantHolder(MinorType.FLOAT8, doubleValue);
+  }
+
+  public ConstantHolder toDecimal() {
+    BigDecimal decimalValue;
+    switch (type) {
+    case SMALLINT:
+      decimalValue = BigDecimal.valueOf((Short) value);
+      break;
+    case INT:
+      decimalValue = BigDecimal.valueOf((Integer) value);
+      break;
+    case BIGINT:
+      decimalValue = BigDecimal.valueOf((Long) value);
+      break;
+    case FLOAT4:
+      decimalValue = BigDecimal.valueOf((Float) value);
+      break;
+    case FLOAT8:
+      decimalValue = BigDecimal.valueOf((Double) value);
+      break;
+    case VARCHAR:
+      try {
+        decimalValue = new BigDecimal((String) value);
+      } catch (Exception e) {
+        throw conversionError(MinorType.VARDECIMAL);
+      }
+      break;
+    case VARDECIMAL:
+      return this;
+    default:
+      throw conversionError(MinorType.VARDECIMAL);
+    }
+    return new ConstantHolder(MinorType.VARDECIMAL, decimalValue);
+  }
+
+  public RuntimeException conversionError(MinorType toType) {
+    return new IllegalStateException(String.format(
+        "Cannot convert a constant %s of type %s to type %s",
+        value.toString(), type.name(), toType.name()));
+  }
+
+  @Override
+  public String toString() {
+    return new PlanStringBuilder("Constant")
+      .field("type", type.name())
+      .field("value", value)
+      .toString();
+  }
+
+  @Override
+  public int compareTo(ConstantHolder other) {
+    Preconditions.checkArgument(type == other.type);
+    switch (type) {
+    case BIGINT:
+      return Long.compare((Long) value, (Long) other.value);
+    case BIT:
+      return Boolean.compare((Boolean) value, (Boolean) other.value);
+    case FLOAT4:
+      return Float.compare((Float) value, (Float) other.value);
+    case FLOAT8:
+      return Double.compare((Double) value, (Double) other.value);
+    case INT:
+      return Integer.compare((Integer) value, (Integer) other.value);
+    case VARCHAR:
+      return ((String) value).compareTo((String) other.value);
+    case VARDECIMAL:
+      return ((BigDecimal) value).compareTo((BigDecimal) other.value);
+    default:
+      throw new UnsupportedOperationException(
+          String.format(
+              "Unsupported comparison between types %s and %s. Convert values first.",
+              type.name(), other.type.name()));
+    }
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/ExprNode.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/ExprNode.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+import java.util.List;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * Condensed form of a Drill WHERE clause expression
+ * node. Models only those nodes that are typically used
+ * in rewrite-style filter push-down. Not intended for
+ * the more complex interpreted form of filter push-down
+ * such as that needed for directory-based partitions.
+ * <p>
+ * Each node references the source Calcite node as well as
+ * the selectivity that Calcite attaches to the node. Any
+ * expressions pushed to a scan must reduce the scan
+ * cost by the amount of the selectivity, else Calcite will
+ * conclude that the orginal plan (without push-down) is
+ * cheaper.
+ */
+public abstract class ExprNode {
+
+  @JsonIgnore
+  private RexNode rexNode;
+
+  public ExprNode() {
+    rexNode = null;
+  }
+
+  public void tag(RexNode rexNode) {
+    this.rexNode = rexNode;
+  }
+
+  public RexNode rexNode() { return rexNode; }
+
+  public abstract double selectivity();
+
+  public interface ColumnTypeNode {
+    String colName();
+    MinorType type();
+  }
+
+  /**
+   * An expression node with an unlimited set of children.
+   */
+  public abstract static class ListNode extends ExprNode {
+    @JsonProperty("children")
+    public final List<ExprNode> children;
+
+    public ListNode(List<ExprNode> children) {
+      this.children = children;
+    }
+  }
+
+  /**
+   * Represents a set of AND'ed expressions in Conjunctive Normal
+   * Form (CNF). Typically the WHERE clause is rewritten to gather
+   * all expressions into a single CNF node. The children are often
+   * called "conjuncts."
+   */
+  public static class AndNode extends ListNode {
+
+    @JsonCreator
+    public AndNode(@JsonProperty("children") List<ExprNode> children) {
+      super(children);
+    }
+
+    @Override
+    public double selectivity() {
+      double selectivity = 1;
+      for (ExprNode child : children) {
+        selectivity *= child.selectivity();
+      }
+      return selectivity;
+    }
+  }
+
+  /**
+   * Represents a set of OR'ed expressions in Disjunctive Normal
+   * Form (CNF). Or'ed expresssions often cannot be pushed down except in the
+   * special case of a series of expressions on the same column, which can
+   * sometimes be handled as a series of requests, each for a different disjunct.
+   *
+   */
+  public static class OrNode extends ListNode {
+
+    @JsonCreator
+    public OrNode(@JsonProperty("children") List<ExprNode> children) {
+      super(children);
+    }
+
+    /**
+     * Compute the selectivity of this DNF (OR) clause. Drill assumes
+     * the selectivity of = is 0.15. An OR is a series of equal statements,
+     * so selectivity is n * 0.15. However, limit total selectivity to
+     * 0.9 (that is, if there are more than 6 clauses in the DNF, assume
+     * at least some reduction.)
+     *
+     * @return the estimated selectivity of this DNF clause
+     */
+    @Override
+    public double selectivity() {
+      if (children.size() == 0) {
+        return 1.0;
+      }
+      double selectivity = 0;
+      for (ExprNode child : children) {
+        selectivity += child.selectivity();
+      }
+      return Math.min(0.9, selectivity);
+    }
+  }
+
+  public abstract static class RelOpNode extends ExprNode {
+    @JsonProperty("op")
+    public final RelOp op;
+
+    public RelOpNode(RelOp op) {
+      this.op = op;
+    }
+
+    @Override
+    public double selectivity() {
+      return op.selectivity();
+    }
+  }
+
+  /**
+   * Semanticized form of a Calcite relational operator. Abstracts
+   * out the Drill implementation details to capture just the
+   * column name, operator and value. Supports only expressions
+   * of the form:<br>
+   * {@code <column> <relop> <const>}<br>
+   * Where the column is a simple name (not an array or map reference),
+   * the relop is one of a defined set, and the constant is one
+   * of the defined Drill types.
+   * <p>
+   * (The driver will convert expressions of the form:<br>
+   * {@code <const> <relop> <column>}<br>
+   * into the normalized form represented here.
+   */
+  @JsonInclude(Include.NON_NULL)
+  @JsonPropertyOrder({"colName", "op", "value"})
+  public static class ColRelOpConstNode extends RelOpNode {
+    @JsonProperty("colName")
+    public final String colName;
+    @JsonProperty("value")
+    public final ConstantHolder value;
+
+    @JsonCreator
+    public ColRelOpConstNode(
+        @JsonProperty("colName") String colName,
+        @JsonProperty("op") RelOp op,
+        @JsonProperty("value") ConstantHolder value) {
+      super(op);
+      Preconditions.checkArgument(op.argCount() == 1 || value != null);
+      this.colName = colName;
+      this.value = value;
+    }
+
+    /**
+     * Rewrite the RelOp with a normalized value.
+     *
+     * @param from the original RelOp
+     * @param value the new value with a different type and matching
+     * value
+     */
+    public ColRelOpConstNode(ColRelOpConstNode from, ConstantHolder value) {
+      super(from.op);
+      Preconditions.checkArgument(from.op.argCount() == 2);
+      this.colName = from.colName;
+      this.value = value;
+    }
+
+    /**
+     * Rewrite a relop using the given normalized value.
+     *
+     * @return a new RelOp with the normalized value. Will be the same relop
+     * if the normalized value is the same as the unnormalized value.
+     */
+    public ColRelOpConstNode normalize(ConstantHolder normalizedValue) {
+      if (value == normalizedValue) {
+        return this;
+      }
+      return new ColRelOpConstNode(this, normalizedValue);
+    }
+
+    public ColRelOpConstNode rewrite(String newName, ConstantHolder newValue) {
+      if (value == newValue && colName.equals(newName)) {
+        return this;
+      }
+      return new ColRelOpConstNode(newName, op, newValue);
+    }
+
+    @Override
+    public String toString() {
+      PlanStringBuilder builder = new PlanStringBuilder(this)
+        .field("op", op.name())
+        .field("colName", colName);
+      if (value != null) {
+        builder.field("type", value.type.name())
+               .field("value", value.value);
+      }
+      return builder.toString();
+    }
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownListener.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownListener.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+import java.util.List;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
+
+/**
+ * Call-back (listener) implementation for a push-down filter.
+ * Abstracts away the common work; plugins implement this class
+ * to do work specific to the plugin.
+ * <p>
+ * Supports two kinds of filter push down:
+ * <dl>
+ * <dt>Conjunctive Normal Form (CNF)</dt>
+ * <dd>A series of expressions joined by an AND: the scan should
+ * produce only rows that satisfy all the conditions.</dd>
+ * <dt>Disjunctive Normal Form (DNF)</dt>
+ * <dd>A series of alternative values for a single column, essentially
+ * a set of expressions joined by OR. The scan spits into multiple
+ * scans, each scanning one of the partitions (or regions or
+ * queries) identified by the case. This is an implementation of the
+ * SQL {@code IN} clause.</dd>
+ * <dl>
+ * <p>
+ * In both cases, the conditions are in the form of a
+ * {@link ColRelOpConst} in which one side refers to a column in the scan
+ * and the other is a constant expression. The "driver" will ensure
+ * the rel op is of the correct form; this class ensures that the
+ * column is valid for the scan and the type of the value matches the
+ * column type (or can be converted.)
+ * <p>
+ * The DNF form further ensures that all rel ops refer to the same
+ * column, and that only the equality operator appears in the
+ * terms.
+ */
+public interface FilterPushDownListener {
+
+  /**
+   * @return a prefix to display in filter rules
+   */
+  String prefix();
+
+  /**
+   * Broad check to see if the scan is of the correct type for this
+   * listener. Generally implemented as: <code><pre>
+   * public boolean isTargetScan(ScanPrel scan) {
+   *   return scan.getGroupScan() instanceof MyGroupScan;
+   * }
+   * </pre></code>
+   * @return true if the given group scan is one this listener can
+   * handle, false otherwise
+   */
+  boolean isTargetScan(GroupScan groupScan);
+
+  /**
+   * Check if the filter rule should be applied to the target group scan,
+   * and if so, return the builder to use.
+   * <p>
+   * Calcite will run this rule multiple times during planning, but the
+   * transform only needs to occur once.
+   * Allows the group scan to mark in its own way whether the rule has
+   * been applied.
+   *
+   * @param groupScan the scan node
+   * @return builder instance if the push-down should be applied,
+   * null otherwise
+   */
+  ScanPushDownListener builderFor(GroupScan groupScan);
+
+  /**
+   * Listener for a one specific group scan.
+   */
+  public interface ScanPushDownListener {
+
+    /**
+     * Determine if the given relational operator (which is already in the form
+     * {@code <col name> <relop> <const>}, qualifies for push down for
+     * this scan.
+     * <p>
+     * If so, return an equivalent RelOp with the value normalized to what
+     * the plugin needs. The returned value may be the same as the original
+     * one if the value is already normalized.
+     *
+     * @param groupScan the scan element. Use {@code scan.getGroupScan()}
+     * to get the group scan
+     * @param relOp the description of the relational operator expression
+     * @return a normalized RelOp if this relop can be transformed into a filter
+     * push-down, @{code null} if not and thus the relop should remain in
+     * the Drill plan
+     * @see {@link ConstantHolder#normalize(org.apache.drill.common.types.TypeProtos.MinorType)}
+     */
+    ExprNode accept(ExprNode conjunct);
+
+    /**
+     * Transform a normalized DNF term into a new scan. Normalized form is:
+     * <br><code><pre>
+     * (a AND b AND (x OR y))</pre></code><br>
+     * In which each {@code OR} term represents a scan partition. It
+     * is up to the code here to determine if the scan partition can be handled,
+     * corresponds to a storage partition, or can be done as a separate
+     * scan (as for a JDBC or REST plugin, say.)
+     * <p>
+     * Each term is accompanied by the Calcite expression from which it was
+     * derived. The caller is responsible for determining which expressions,
+     * if any, to leave in the query by returning a list AND'ed (CNF) terms
+     * to leave in the query. Those terms can be the ones passed in, or
+     * new terms to handle special needs.
+     *
+     * @param groupScan the scan node
+     * @param andTerms a list of the CNF (AND) terms, in which each is given
+     * by the Calcite AND node and the derived RelOp expression.
+     * @param orTerm the DNF (OR) term, if any, that includes the Calcite
+     * node for that term and the set of OR terms. Only provided if the OR
+     * term represents a simple list of values (all OR clauses are on the
+     * same column). The OR term itself is AND'ed with the CNF terms.
+     * @return a pair of elements: a new scan (that represents the pushed filters),
+     * and the original or new expression to appear in the WHERE clause
+     * joined by AND with any non-candidate expressions. That is, if analysis
+     * determines that the plugin can't handle (or cannot completely handle)
+     * a term, return the Calcite node for that term back as part of the
+     * return value and it will be left in the query. Any Calcite nodes
+     * not returned are removed from the query and it is the scan's responsibility
+     * to handle them. Either the group scan or the list of Calcite nodes
+     * must be non-null. Or, return null if the filter condition can't be handled
+     * and the query should remain unchanged.
+     */
+    Pair<GroupScan, List<RexNode>> transform(AndNode expr);
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownStrategy.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownStrategy.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.util.Pair;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.exec.physical.base.GroupScan;
+import org.apache.drill.exec.planner.common.DrillRelOptUtil;
+import org.apache.drill.exec.planner.logical.DrillFilterRel;
+import org.apache.drill.exec.planner.logical.DrillOptiq;
+import org.apache.drill.exec.planner.logical.DrillParseContext;
+import org.apache.drill.exec.planner.logical.DrillProjectRel;
+import org.apache.drill.exec.planner.logical.DrillScanRel;
+import org.apache.drill.exec.planner.logical.RelOptHelper;
+import org.apache.drill.exec.planner.physical.FilterPrel;
+import org.apache.drill.exec.planner.physical.PrelUtil;
+import org.apache.drill.exec.store.StoragePluginOptimizerRule;
+import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.http.filter.FilterPushDownListener.ScanPushDownListener;
+import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
+
+/**
+ * Generalized filter push-down strategy which performs all the tree-walking
+ * and tree restructuring work, allowing a "listener" to do the work needed
+ * for a particular scan.
+ * <p>
+ * General usage in a storage plugin: <code><pre>
+ * public Set<StoragePluginOptimizerRule> getPhysicalOptimizerRules(
+ *        OptimizerRulesContext optimizerRulesContext) {
+ *   return FilterPushDownStrategy.rulesFor(optimizerRulesContext,
+ *      new MyPushDownListener(...));
+ * }
+ * </pre></code>
+ */
+public class FilterPushDownStrategy {
+
+  private static final Collection<String> BANNED_OPERATORS =
+      Collections.singletonList("flatten");
+
+  /**
+   * Base rule that passes target information to the push-down strategy
+   */
+  private static abstract class AbstractFilterPushDownRule extends StoragePluginOptimizerRule {
+
+    protected final FilterPushDownStrategy strategy;
+
+    public AbstractFilterPushDownRule(RelOptRuleOperand operand, String description,
+        FilterPushDownStrategy strategy) {
+      super(operand, description);
+      this.strategy = strategy;
+    }
+  }
+
+  /**
+   * Custom rule passed to Calcite for FILTER --> PROJECT --> SCAN
+   */
+  private static class ProjectAndFilterRule extends AbstractFilterPushDownRule {
+
+    private ProjectAndFilterRule(FilterPushDownStrategy strategy) {
+      super(RelOptHelper.some(FilterPrel.class, RelOptHelper.some(DrillProjectRel.class, RelOptHelper.any(DrillScanRel.class))),
+            strategy.namePrefix() + "PushDownFilter:Filter_On_Project",
+            strategy);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      if (!super.matches(call)) {
+        return false;
+      }
+      DrillScanRel scan = call.rel(2);
+      return strategy.isTargetScan(scan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      DrillFilterRel filterRel = call.rel(0);
+      DrillProjectRel projectRel = call.rel(1);
+      DrillScanRel scanRel = call.rel(2);
+      strategy.onMatch(call, filterRel, projectRel, scanRel);
+    }
+  }
+
+  /**
+   * Custom rule passed to Calcite to handle FILTER --> SCAN
+   */
+  private static class FilterWithoutProjectRule extends AbstractFilterPushDownRule {
+
+    private FilterWithoutProjectRule(FilterPushDownStrategy strategy) {
+      super(RelOptHelper.some(DrillFilterRel.class, RelOptHelper.any(DrillScanRel.class)),
+            strategy.namePrefix() + "PushDownFilter:Filter_On_Scan",
+            strategy);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+      if (!super.matches(call)) {
+        return false;
+      }
+      DrillScanRel scan = call.rel(1);
+      return strategy.isTargetScan(scan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      DrillFilterRel filterRel = call.rel(0);
+      DrillScanRel scanRel = call.rel(1);
+      strategy.onMatch(call, filterRel, null, scanRel);
+    }
+  }
+
+  /**
+   * Implement filter push-down for one scan.
+   */
+  private static class FilterPushDownBuilder {
+
+    private final RelOptRuleCall call;
+    private final DrillFilterRel filter;
+    private final DrillProjectRel project;
+    private final DrillScanRel scan;
+    private final ScanPushDownListener scanListener;
+    // Predicates which cannot be converted to a filter predicate
+    List<RexNode> nonConvertedPreds = new ArrayList<>();
+
+    protected FilterPushDownBuilder(RelOptRuleCall call, DrillFilterRel filter, DrillProjectRel project, DrillScanRel scan, ScanPushDownListener scanListener) {
+      this.call = call;
+      this.filter = filter;
+      this.project = project;
+      this.scan = scan;
+      this.scanListener = scanListener;
+    }
+
+    void apply() {
+      AndNode cnfNode = sortPredicates();
+      if (cnfNode == null) {
+        return;
+      }
+
+      Pair<GroupScan, List<RexNode>> translated =
+          scanListener.transform(cnfNode);
+
+      // Listener abandoned effort. (Allows a stub early in development.)
+      if (translated == null) {
+        return;
+      }
+
+      // Listener rejected the DNF terms
+      GroupScan newGroupScan = translated.left;
+      if (newGroupScan == null) {
+        return;
+      }
+
+      // Gather unqualified and rewritten predicates
+      List<RexNode> remainingPreds = new ArrayList<>();
+      remainingPreds.addAll(nonConvertedPreds);
+      if (translated.right != null) {
+        remainingPreds.addAll(translated.right);
+      }
+
+      // Replace the child with the new filter on top of the child/scan
+      call.transformTo(rebuildTree(newGroupScan, remainingPreds));
+    }
+
+    private AndNode sortPredicates() {
+
+      // Get the filter expression
+      RexNode condition;
+      if (project == null) {
+        condition = filter.getCondition();
+      } else {
+        // get the filter as if it were below the projection.
+        condition = RelOptUtil.pushPastProject(filter.getCondition(), project);
+      }
+
+      // Skip if no expression or expression is trivial.
+      // This seems to never happen because Calcite optimizes away
+      // any expression of the form WHERE true, 1 = 1 or 0 = 1.
+      if (condition == null || condition.isAlwaysTrue() || condition.isAlwaysFalse()) {
+        return null;
+      }
+
+      // Get a conjunction of the filter conditions. For each conjunction, if it refers
+      // to ITEM or FLATTEN expression then it cannot be pushed down. Otherwise, it's
+      // qualified to be pushed down.
+      List<RexNode> filterPreds = RelOptUtil.conjunctions(
+          RexUtil.toCnf(filter.getCluster().getRexBuilder(), condition));
+
+      DrillParseContext parseContext = new DrillParseContext(PrelUtil.getPlannerSettings(call.getPlanner()));
+      List<ExprNode> conjuncts = new ArrayList<>();
+      for (RexNode pred : filterPreds) {
+        ExprNode conjunct = identifyCandidate(parseContext, scan, pred);
+        if (conjunct == null) {
+          nonConvertedPreds.add(pred);
+        } else {
+          conjunct.tag(pred);
+          conjuncts.add(conjunct);
+        }
+      }
+      return conjuncts.isEmpty() ? null : new AndNode(conjuncts);
+    }
+
+    public ExprNode identifyCandidate(DrillParseContext parseContext, DrillScanRel scan, RexNode pred) {
+      if (DrillRelOptUtil.findOperators(pred, Collections.emptyList(), BANNED_OPERATORS) != null) {
+        return null;
+      }
+
+      // Extract an AND term, which may be an OR expression.
+      LogicalExpression drillPredicate = DrillOptiq.toDrill(parseContext, scan, pred);
+      ExprNode expr = drillPredicate.accept(FilterPushDownUtils.REL_OP_EXTRACTOR, null);
+      if (expr == null) {
+        return null;
+      }
+
+      // Check if each term can be pushed down, and, if so, return a new RelOp
+      // with the value normalized.
+      return scanListener.accept(expr);
+    }
+
+    /**
+     * Rebuilds the query plan subtree to include any substitutions and removals requested
+     * by the listener.
+     *
+     * @param oldScan the original scan node
+     * @param newGroupScan the optional replacement scan node given by the listener
+     * @param filter the original filter
+     * @param project the original optional project node
+     * @param remainingPreds the Calcite predicates which the listener *does not* handle
+     * and which should remain in the plan tree
+     * @return a rebuilt query subtree
+     */
+    private RelNode rebuildTree(GroupScan newGroupScan, List<RexNode> remainingPreds) {
+
+      // Rebuild the subtree with transformed nodes.
+
+      // Scan: new if available, else existing.
+      RelNode newNode;
+      if (newGroupScan == null) {
+        newNode = scan;
+      } else {
+        newNode = new DrillScanRel(scan.getCluster(), scan.getTraitSet(), scan.getTable(),
+            newGroupScan, scan.getRowType(), scan.getColumns());
+      }
+
+      // Copy project, if exists
+      if (project != null) {
+        newNode = project.copy(project.getTraitSet(), Collections.singletonList(newNode));
+      }
+
+      // Add filter, if any predicates remain.
+      if (!remainingPreds.isEmpty()) {
+
+        // If some of the predicates weren't used in the filter, creates new filter with them
+        // on top of current scan. Excludes the case when all predicates weren't used in the filter.
+        // FILTER(a, b, c) --> SCAN becomes FILTER(a, d) --> SCAN
+        newNode = filter.copy(filter.getTraitSet(), newNode,
+            RexUtil.composeConjunction(
+                filter.getCluster().getRexBuilder(),
+                remainingPreds,
+                true));
+      }
+
+      return newNode;
+    }
+  }
+
+  private final FilterPushDownListener listener;
+
+  public FilterPushDownStrategy(FilterPushDownListener listener) {
+    this.listener = listener;
+  }
+
+  public Set<StoragePluginOptimizerRule> rules() {
+    return ImmutableSet.of(
+        new ProjectAndFilterRule(this),
+        new FilterWithoutProjectRule(this));
+  }
+
+  public static Set<StoragePluginOptimizerRule> rulesFor(
+      FilterPushDownListener listener) {
+    return new FilterPushDownStrategy(listener).rules();
+  }
+
+  private String namePrefix() { return listener.prefix(); }
+
+  private boolean isTargetScan(DrillScanRel scan) {
+    return listener.isTargetScan(scan.getGroupScan());
+  }
+
+  public void onMatch(RelOptRuleCall call, DrillFilterRel filter, DrillProjectRel project, DrillScanRel scan) {
+
+    // Skip if rule has already been applied.
+    ScanPushDownListener scanListener = listener.builderFor(scan.getGroupScan());
+    if (scanListener != null) {
+      new FilterPushDownBuilder(call, filter, project, scan, scanListener).apply();
+    }
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownUtils.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/FilterPushDownUtils.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.util.Pair;
+import org.apache.drill.common.FunctionNames;
+import org.apache.drill.common.expression.BooleanOperator;
+import org.apache.drill.common.expression.FunctionCall;
+import org.apache.drill.common.expression.LogicalExpression;
+import org.apache.drill.common.expression.SchemaPath;
+import org.apache.drill.common.expression.ValueExpressions.BooleanExpression;
+import org.apache.drill.common.expression.ValueExpressions.DateExpression;
+import org.apache.drill.common.expression.ValueExpressions.DoubleExpression;
+import org.apache.drill.common.expression.ValueExpressions.FloatExpression;
+import org.apache.drill.common.expression.ValueExpressions.IntExpression;
+import org.apache.drill.common.expression.ValueExpressions.IntervalDayExpression;
+import org.apache.drill.common.expression.ValueExpressions.IntervalYearExpression;
+import org.apache.drill.common.expression.ValueExpressions.LongExpression;
+import org.apache.drill.common.expression.ValueExpressions.QuotedString;
+import org.apache.drill.common.expression.ValueExpressions.TimeExpression;
+import org.apache.drill.common.expression.ValueExpressions.TimeStampExpression;
+import org.apache.drill.common.expression.ValueExpressions.VarDecimalExpression;
+import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
+import org.apache.drill.common.types.TypeProtos.MinorType;
+import org.apache.drill.exec.planner.PlannerPhase;
+import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.http.filter.ExprNode.ColRelOpConstNode;
+import org.apache.drill.exec.store.http.filter.ExprNode.OrNode;
+
+public class FilterPushDownUtils {
+
+  /**
+   * Extracted selected constants from an argument. Finds literals, omits
+   * expressions, columns and so on.
+   * <p>
+   * The core types (INT, BIGINT, BIT (Boolean), VARCHAR and VARDECIMAL) are
+   * known to work. The others may or may not work depending on Drill's
+   * parser/planner; testing is needed.
+   */
+  private static class ConstantExtractor extends AbstractExprVisitor<ConstantHolder, Void, RuntimeException> {
+
+    @Override
+    public ConstantHolder visitIntConstant(IntExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.INT, expr.getInt());
+    }
+
+    @Override
+    public ConstantHolder visitLongConstant(LongExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.BIGINT, expr.getLong());
+    }
+
+    @Override
+    public ConstantHolder visitBooleanConstant(BooleanExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.BIT, expr.getBoolean());
+    }
+
+    @Override
+    public ConstantHolder visitQuotedStringConstant(QuotedString expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.VARCHAR, expr.getString());
+    }
+
+    // Float mapped to Double for storage to simplify clients
+    // Not clear that Drill generates floats rather than doubles.
+    @Override
+    public ConstantHolder visitFloatConstant(FloatExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.FLOAT8, (double) expr.getFloat());
+    }
+
+    // Seems to not be used. Anything float-like is instead represented as a
+    // VarDecimal constant.
+    @Override
+    public ConstantHolder visitDoubleConstant(DoubleExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.FLOAT8, expr.getDouble());
+    }
+
+    // Legacy decimals no longer supported, so not implemented.
+    @Override
+    public ConstantHolder visitVarDecimalConstant(VarDecimalExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.VARDECIMAL, expr.getBigDecimal());
+    }
+
+    // Example: DATE '2008-2-23'
+    @Override
+    public ConstantHolder visitDateConstant(DateExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.DATE, expr.getDate());
+    }
+
+    // Example: TIME '12:23:34'
+    @Override
+    public ConstantHolder visitTimeConstant(TimeExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.TIME, expr.getTime());
+    }
+
+    // Example: TIMESTAMP '2008-2-23 12:23:34.456'
+    @Override
+    public ConstantHolder visitTimeStampConstant(TimeStampExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.TIMESTAMP, expr.getTimeStamp());
+    }
+
+    // Example: INTERVAL '1' YEAR
+    @Override
+    public ConstantHolder visitIntervalYearConstant(IntervalYearExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.INTERVALYEAR, expr.getIntervalYear());
+    }
+
+    // Example: INTERVAL '1 10:20:30' DAY TO SECOND
+    // This field has two parts, encoded as a Pair.
+    @Override
+    public ConstantHolder visitIntervalDayConstant(IntervalDayExpression expr, Void value) throws RuntimeException {
+      return new ConstantHolder(MinorType.INTERVALDAY,
+          Pair.of(expr.getIntervalDay(), expr.getIntervalMillis()));
+    }
+
+   @Override
+    public ConstantHolder visitUnknown(LogicalExpression e, Void valueArg) throws RuntimeException {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a column name argument, or null if the argument is not a column, or is
+   * a complex column (a[10], a.b).
+   */
+  private static class ColRefExtractor extends AbstractExprVisitor<String, Void, RuntimeException> {
+
+    @Override
+    public String visitSchemaPath(SchemaPath path, Void value) throws RuntimeException {
+
+      // Can't handle names such as a.b or a[10]
+      if (! path.isLeaf()) {
+        return null;
+      }
+
+      // Can only handle columns known to the scan
+      return path.getRootSegmentPath();
+    }
+
+    @Override
+    public String visitUnknown(LogicalExpression e, Void valueArg) throws RuntimeException {
+      return null;
+    }
+  }
+
+  /**
+   * Extract a relational operator of the pattern<br>
+   * <tt>&lt;col> &lt;relop> &lt;const></tt> or<br>
+   * <tt>&lt;col> &lt;relop></tt>.
+   */
+  private static class RelOpExtractor extends AbstractExprVisitor<ExprNode, Void, RuntimeException> {
+
+    @Override
+    public ExprNode visitBooleanOperator(BooleanOperator op, Void value) throws RuntimeException {
+      switch (op.getName()) {
+        case FunctionNames.OR:
+          break;
+        case FunctionNames.AND:
+          break;
+        default:
+          return null;
+      }
+
+      List<ExprNode> args = op.args()
+          .stream()
+          .map(a -> a.accept(this, null))
+          .collect(Collectors.toList());
+      switch (op.getName()) {
+        case FunctionNames.OR:
+          return new OrNode(args);
+        case FunctionNames.AND:
+          return new AndNode(args);
+        default:
+          return null;
+      }
+    }
+
+    @Override
+    public ExprNode visitFunctionCall(FunctionCall call, Void value) throws RuntimeException {
+
+      RelOp op;
+      switch(call.getName()) {
+      case FunctionNames.EQ:
+        op = RelOp.EQ;
+        break;
+      case FunctionNames.NE:
+        op = RelOp.NE;
+        break;
+      case FunctionNames.LT:
+        op = RelOp.LT;
+        break;
+      case FunctionNames.LE:
+        op = RelOp.LE;
+        break;
+      case FunctionNames.GT:
+        op = RelOp.GT;
+        break;
+      case FunctionNames.GE:
+        op = RelOp.GE;
+        break;
+      case FunctionNames.IS_NULL:
+        op = RelOp.IS_NULL;
+        break;
+      case FunctionNames.IS_NOT_NULL:
+        op = RelOp.IS_NOT_NULL;
+        break;
+      default:
+        return null;
+      }
+
+      if (op.argCount() == 1) {
+        return checkCol(op, call);
+      } else {
+        ExprNode relOpNode = checkColOpConst(op, call);
+        if (relOpNode == null) {
+          relOpNode = checkConstOpCol(op, call);
+        }
+        return relOpNode;
+      }
+    }
+
+    /**
+     * Check just the one argument for a unary operator:
+     * IS NULL, IS NOT NULL.
+     */
+    private ExprNode checkCol(RelOp op, FunctionCall call) {
+      String colName = call.arg(0).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      return new ColRelOpConstNode(colName, op, null);
+    }
+
+    /**
+     * Extracts a relational operator of the "normal" form of:<br>
+     * <tt>&lt;col> &lt;relop> &lt;const>.
+     */
+    private ExprNode checkColOpConst(RelOp op, FunctionCall call) {
+      String colName = call.arg(0).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      ConstantHolder constArg = call.arg(1).accept(CONSTANT_EXTRACTOR, null);
+      if (constArg == null) {
+        return null;
+      }
+
+      return new ColRelOpConstNode(colName, op, constArg);
+    }
+
+    /**
+     * Extracts a relational operator of the "reversed" form of:<br>
+     * <tt>&lt;const> &lt;relop> &lt;col>. (Unfortunately, Calcite
+     * does not normalize predicates.) Reverses the sense of the
+     * relational operator to put the predicate into normalized
+     * form.
+     */
+    private ExprNode checkConstOpCol(RelOp op, FunctionCall call) {
+      ConstantHolder constArg = call.arg(0).accept(CONSTANT_EXTRACTOR, null);
+      if (constArg == null) {
+        return null;
+      }
+
+      String colName = call.arg(1).accept(COL_REF_EXTRACTOR, null);
+      if (colName == null) {
+        return null;
+      }
+
+      return new ColRelOpConstNode(colName, op.invert(), constArg);
+    }
+
+    @Override
+    public ExprNode visitUnknown(LogicalExpression e, Void value) throws RuntimeException {
+      // Catches OR clauses among other things
+      return null;
+    }
+  }
+
+  private static final ConstantExtractor CONSTANT_EXTRACTOR = new ConstantExtractor();
+
+  private static final ColRefExtractor COL_REF_EXTRACTOR = new ColRefExtractor();
+
+  public static final RelOpExtractor REL_OP_EXTRACTOR = new RelOpExtractor();
+
+  /**
+   * Filter push-down is best done during logical planning so that the result can
+   * influence parallelization in the physical phase. The specific phase differs
+   * depending on which planning mode is enabled. This check hides those details
+   * from storage plugins that simply want to know "should I add my filter
+   * push-down rules in the given phase?"
+   *
+   * @return true if filter push-down rules should be applied in this phase
+   */
+  public static boolean isFilterPushDownPhase(PlannerPhase phase) {
+    switch (phase) {
+    case LOGICAL_PRUNE_AND_JOIN: // HEP is disabled
+    case PARTITION_PRUNING:      // HEP partition push-down enabled
+    case LOGICAL_PRUNE:          // HEP partition push-down disabled
+      return true;
+    default:
+      return false;
+    }
+  }
+}

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/RelOp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/filter/RelOp.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.http.filter;
+
+/**
+ * Fixed set of Drill relational operators, using well-defined
+ * names. Distilled from the more general string function names
+ * used in the query plan tree.
+ */
+public enum RelOp {
+  // Order of LT, LE, GE, GT is important for
+  // value comparisons
+  EQ, NE, LT, LE, GE, GT, IS_NULL, IS_NOT_NULL;
+
+  /**
+   * Return the result of flipping the sides of an
+   * expression:</br>
+   * {@code a op b} &rarr; {@code b op.invert() a}
+   *
+   * @return a new relop resulting from flipping the sides
+   * of the expression, or this relop if the operation
+   * is symmetric.
+   */
+  public RelOp invert() {
+    switch(this) {
+      case LT:
+        return GT;
+      case LE:
+        return GE;
+      case GT:
+        return LT;
+      case GE:
+        return LE;
+      default:
+        return this;
+    }
+  }
+
+  /**
+   * Returns the number of arguments for the relop.
+   * @return 1 for IS (NOT) NULL, 2 otherwise
+   */
+  public int argCount() {
+    switch (this) {
+      case IS_NULL:
+      case IS_NOT_NULL:
+        return 1;
+      default:
+        return 2;
+    }
+  }
+
+  /**
+   * Poor-man's guess at selectivity of each operator.
+   * Should match Calcite's built-in defaults. The Calcite estimates
+   * are not great, but we need to match them.
+   * <p>
+   * If a query has access to metadata, then each predicates should
+   * have a computed selectivity based on that metadata. This
+   * mechanism should be extended to include that selectivity as a field,
+   * and pass it back from this method.
+   *
+   * @return crude estimate of operator selectivity
+   * @see {@code package org.apache.calcite.rel.metadata.RelMdUtil}
+   */
+  public double selectivity() {
+    switch (this) {
+      case EQ:
+        return 0.15;
+      case GE:
+      case GT:
+      case LE:
+      case LT:
+      case NE: // Very bad estimate!
+        return 0.5;
+      case IS_NOT_NULL:
+      case IS_NULL:
+        return 0.9;
+      default:
+        return 0.25;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/ScanStats.java
@@ -20,6 +20,15 @@ package org.apache.drill.exec.physical.base;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Cost estimate for a scan. In general, relative costs are more important
+ * than absolute costs. If a scan supports filter push-down, the cost of
+ * the scan after the push-down must be less than the combined cost of
+ * the scan + project before push down, else Calcite will ignore the
+ * push-down. Also, the estimated row count may influence whether the
+ * table can be broadcast or hash partitioned. Otherwise, Calcite has
+ * no real choices based on scan cost.
+ */
 public class ScanStats {
 
   public static final ScanStats TRIVIAL_TABLE = new ScanStats(GroupScanProperty.NO_EXACT_ROW_COUNT, 20, 1, 1);
@@ -30,8 +39,21 @@ public class ScanStats {
   private final GroupScanProperty groupScanProperty;
   @JsonProperty
   private final double recordCount;
+
+  /**
+   * CPU cost for the scan which should consider both row and column
+   * count, and the effect of filters. Considered only if the group scan property is
+   * set to {@link GroupScanProperty#ESTIMATED_TOTAL_COST FULL_COST}. Default
+   * CPU cost is simply row count * column count.
+   */
   @JsonProperty
   private final double cpuCost;
+
+  /**
+   * I/O cost for the scan. Considered only if the group scan property is
+   * set to {@link GroupScanProperty#ESTIMATED_TOTAL_COST FULL_COST}. Drill does not
+   * differentiate between network and disk I/O, despite the field name.
+   */
   @JsonProperty
   private final double diskCost;
 
@@ -82,7 +104,15 @@ public class ScanStats {
 
   public enum GroupScanProperty {
     NO_EXACT_ROW_COUNT(false, false),
-    EXACT_ROW_COUNT(true, true);
+    EXACT_ROW_COUNT(true, true),
+
+    /**
+     * Tells the planner to consider the full cost represented
+     * here. Else, the planner only looks at row count. However,
+     * we don't know the actual row count, a COUNT(*) query must
+     * still look at the input source if it wants an accurate count.
+     */
+    ESTIMATED_TOTAL_COST(false, true);
 
     private boolean hasExactRowCount, hasExactColumnValueCount;
 
@@ -97,6 +127,10 @@ public class ScanStats {
 
     public boolean hasExactColumnValueCount() {
       return hasExactColumnValueCount;
+    }
+
+    public boolean hasFullCost() {
+      return this == ESTIMATED_TOTAL_COST;
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/cost/DrillCostBase.java
@@ -152,6 +152,7 @@ public class DrillCostBase implements DrillRelOptCost {
     return network;
   }
 
+  @Override
   public double getMemory() {
     return memory;
   }
@@ -307,29 +308,34 @@ public class DrillCostBase implements DrillRelOptCost {
       return new DrillCostBase(dRows, dCpu, dIo, dNetwork, dMemory);
     }
 
+    @Override
     public RelOptCost makeCost(double dRows, double dCpu, double dIo, double dNetwork) {
       return new DrillCostBase(dRows, dCpu, dIo, dNetwork, 0);
     }
 
+    @Override
     public RelOptCost makeCost(double dRows, double dCpu, double dIo) {
       return new DrillCostBase(dRows, dCpu, dIo, 0, 0);
     }
 
+    @Override
     public RelOptCost makeHugeCost() {
       return DrillCostBase.HUGE;
     }
 
+    @Override
     public RelOptCost makeInfiniteCost() {
       return DrillCostBase.INFINITY;
     }
 
+    @Override
     public RelOptCost makeTinyCost() {
       return DrillCostBase.TINY;
     }
 
+    @Override
     public RelOptCost makeZeroCost() {
       return DrillCostBase.ZERO;
     }
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchemaFactory.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/AbstractSchemaFactory.java
@@ -32,5 +32,4 @@ public abstract class AbstractSchemaFactory implements SchemaFactory {
   public String getName() {
     return name;
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/loader/JsonLoaderImpl.java
@@ -141,6 +141,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
     private CustomErrorContext errorContext;
     private InputStream stream;
     private Reader reader;
+    private String dataPath;
     private MessageParser messageParser;
 
     public JsonLoaderBuilder resultSetLoader(ResultSetLoader rsLoader) {
@@ -180,6 +181,11 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
 
     public JsonLoaderBuilder messageParser(MessageParser messageParser) {
       this.messageParser = messageParser;
+      return this;
+    }
+
+    public JsonLoaderBuilder dataPath(String dataPath) {
+      this.dataPath = dataPath;
       return this;
     }
 
@@ -230,6 +236,7 @@ public class JsonLoaderImpl implements JsonLoader, ErrorFactory {
             .rootListener(rowListener)
             .errorFactory(this)
             .messageParser(builder.messageParser)
+            .dataPath(builder.dataPath)
             .build();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/MessageParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/MessageParser.java
@@ -38,6 +38,7 @@ public interface MessageParser {
       this.nextElement = nextElement;
     }
   }
+
   boolean parsePrefix(TokenIterator tokenizer) throws MessageContextException;
   void parseSuffix(TokenIterator tokenizer) throws MessageContextException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/parser/RootParser.java
@@ -18,6 +18,7 @@
 package org.apache.drill.exec.store.easy.json.parser;
 
 import org.apache.drill.exec.store.easy.json.parser.MessageParser.MessageContextException;
+import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +27,11 @@ import com.fasterxml.jackson.core.JsonToken;
 /**
  * The root parsers are special: they must detect EOF. Drill supports
  * top-level objects either enclosed in an array (which forms legal
- * JSON), or as a series JSON objects (which is a common, if not
- * entirely legal, form of JSON.)
+ * JSON), or as the
+ * <a href="http://jsonlines.org/">jsonlines</a> format, restricted
+ * to a list of objects (but not scalars or arrays.) Although jsonlines
+ * requires newline separators between objects, this parser allows
+ * any amount of whitespace, including none.
  */
 public abstract class RootParser implements ElementParser {
   protected static final Logger logger = LoggerFactory.getLogger(RootParser.class);
@@ -40,13 +44,32 @@ public abstract class RootParser implements ElementParser {
     this.rootObject = new ObjectParser(this, structParser.rootListener());
   }
 
+  /**
+   * Parse one data object. This is the "root" object which may contain
+   * nested objects. Overridden to handle different end-of-data indicators
+   * for different contexts.
+   *
+   * @return {@code true} if an object was found, {@code false} if the
+   * end of data was reached.
+   */
   public abstract boolean parseRoot(TokenIterator tokenizer);
 
+  // Generic parsing not allowed at the root since the root must
+  // report EOF. Use parseRoot() instead.
   @Override
   public void parse(TokenIterator tokenizer) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException(
+        "Call parseRoot() at the root level to check for EOF.");
   }
 
+  /**
+   * Parse one data object. This is the "root" object which may contain
+   * nested objects. Called when the outer parser detects a start
+   * object token for a data object.
+   *
+   * @return {@code true} if an object was found, {@code false} if the
+   * end of data was reached.
+   */
   protected boolean parseRootObject(JsonToken token, TokenIterator tokenizer) {
     // Position: ^ ?
     switch (token) {
@@ -77,6 +100,11 @@ public abstract class RootParser implements ElementParser {
   @Override
   public JsonStructureParser structParser() { return structParser; }
 
+  /**
+   * Parser for a <a href="http://jsonlines.org/">jsonlines</a>-style
+   * data set which consists of a series of objects. EOF from the parser
+   * indicates the end of the data set.
+   */
   public static class RootObjectParser extends RootParser {
 
     public RootObjectParser(JsonStructureParser structParser) {
@@ -89,12 +117,20 @@ public abstract class RootParser implements ElementParser {
       if (token == null) {
         // Position: EOF ^
         return false;
-      } else {
+      } else if (token == JsonToken.START_OBJECT) {
         return parseRootObject(token, tokenizer);
+      } else {
+        throw errorFactory().syntaxError(token); // Nothing else is valid
       }
     }
   }
 
+  /**
+   * Parser for a compliant JSON data set which consists of an
+   * array at the top level, where each element of the array is a
+   * JSON object that represents a data record. A closing array
+   * bracket indicates end of data.
+   */
   public static class RootArrayParser extends RootParser {
 
     public RootArrayParser(JsonStructureParser structParser) {
@@ -112,43 +148,96 @@ public abstract class RootParser implements ElementParser {
         logger.warn("Failed to close outer array. {}",
             tokenizer.context());
         return false;
-      } else if (token == JsonToken.END_ARRAY) {
-        return false;
-      } else {
-        return parseRootObject(token, tokenizer);
+      }
+      switch (token) {
+        case END_ARRAY:
+          return false;
+        case START_OBJECT:
+          return parseRootObject(token, tokenizer);
+        default:
+          throw errorFactory().syntaxError(token); // Nothing else is valid
       }
     }
   }
 
-  public static class NestedRootArrayParser extends RootParser {
+  /**
+   * Parser for data embedded within a message structure which is
+   * encoded as an array of objects. Example:
+   * <pre><code>
+   * { status: "ok", results: [ { ... }, { ... } ] }</code></pre>
+   * <p>
+   * The closing array bracket indicates the end of data; the
+   * message parser will parse any content after the closing
+   * bracket.
+   */
+  public static class EmbeddedArrayParser extends RootParser {
 
     private final MessageParser messageParser;
 
-    public NestedRootArrayParser(JsonStructureParser structParser, MessageParser messageParser) {
+    public EmbeddedArrayParser(JsonStructureParser structParser, MessageParser messageParser) {
       super(structParser);
       this.messageParser = messageParser;
     }
 
     @Override
     public boolean parseRoot(TokenIterator tokenizer) {
-      JsonToken token = tokenizer.next();
-      if (token == null) {
-        // Position: { ... EOF ^
-        // Saw EOF, but no closing ]. Warn and ignore.
-        // Note that the Jackson parser won't let us get here;
-        // it will have already thrown a syntax error.
-        logger.warn("Failed to close outer array. {}",
-            tokenizer.context());
+      JsonToken token = tokenizer.requireNext();
+      switch (token) {
+        case END_ARRAY:
+          break;
+        case START_OBJECT:
+          return parseRootObject(token, tokenizer);
+        default:
+          throw errorFactory().syntaxError(token); // Nothing else is valid
+      }
+
+      // Parse the trailing message content.
+      try {
+        messageParser.parseSuffix(tokenizer);
         return false;
-      } else if (token == JsonToken.END_ARRAY) {
-        try {
-          messageParser.parseSuffix(tokenizer);
-        } catch (MessageContextException e) {
-          throw errorFactory().messageParseError(e);
+      } catch (MessageContextException e) {
+        throw errorFactory().messageParseError(e);
+      }
+    }
+  }
+
+  /**
+   * Parser for data embedded within a message structure which is encoded
+   * as a single JSON object. Example:
+   * <pre><code>
+   * { status: "ok", results: { ... } }</code></pre>
+   * <p>
+   * The parser counts over the single object. The
+   * message parser will parse any content after the closing
+   * bracket.
+   */
+  public static class EmbeddedObjectParser extends RootParser {
+
+    private final MessageParser messageParser;
+    private int objectCount;
+
+    public EmbeddedObjectParser(JsonStructureParser structParser, MessageParser messageParser) {
+      super(structParser);
+      this.messageParser = messageParser;
+    }
+
+    @Override
+    public boolean parseRoot(TokenIterator tokenizer) {
+      Preconditions.checkState(objectCount <= 1);
+      if (objectCount == 0) {
+        objectCount++;
+        JsonToken token = tokenizer.requireNext();
+        if (token == JsonToken.START_OBJECT) {
+          return parseRootObject(token, tokenizer);
+        } else {
+          throw errorFactory().syntaxError(token); // Nothing else is valid
         }
+      }
+      try {
+        messageParser.parseSuffix(tokenizer);
         return false;
-      } else {
-        return parseRootObject(token, tokenizer);
+      } catch (MessageContextException e) {
+        throw errorFactory().messageParseError(e);
       }
     }
   }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/BaseTestJsonParser.java
@@ -329,6 +329,16 @@ public class BaseTestJsonParser {
     fixture.close();
   }
 
+  protected static void expectOpenError(String json, String kind) {
+    JsonParserFixture fixture = new JsonParserFixture();
+    try {
+      fixture.open(json);
+      fail();
+    } catch (JsonErrorFixture e) {
+      assertEquals(kind, e.errorType);
+    }
+  }
+
   protected static void expectError(JsonParserFixture fixture, String kind) {
     try {
       fixture.read();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserErrors.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/easy/json/parser/TestJsonParserErrors.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
- * Tests the un-happy path cases in the JSON structure parser. Some
+ * Tests the unhappy path cases in the JSON structure parser. Some
  * error cases can't occur because the Jackson parser catches them
  * first.
  */
@@ -60,6 +60,26 @@ public class TestJsonParserErrors extends BaseTestJsonParser {
   @Test
   public void testBlankKey() {
     expectError("{\"  \": 10}", "structureError");
+  }
+
+  @Test
+  public void testRootScalar() {
+    expectOpenError("10", "syntaxError");
+  }
+
+  // Should we treat a root null as an empty result set?
+  @Test
+  public void testRootNull() {
+    expectOpenError("null", "syntaxError");
+  }
+
+  @Test
+  public void testRootArrayScalar() {
+    expectError("[ {a: \"ok\" }, 10 ]", "syntaxError");
+  }
+  @Test
+  public void testRootArrayNull() {
+    expectError("[ {a: \"ok\" }, null ]", "syntaxError");
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-7711](https://issues.apache.org/jira/browse/DRILL-7711): Add data path, parameter filter pushdown to HTTP plugin

## Description

Adds an option to specify the path to data so the plugin will ignore REST message "overhead" except the actual data.

Allows specifying HTTP URL parameters as filter push-downs from SQL.

Includes improvements to the JSON structure parser to handle a few more conditions. Also includes a generic filter push-down framework for the case where filters are translated to expressions as here. (The framework is not applicable to cases where expressions are interpreted, as in partition pruning.)

## Documentation

Please see the [README.md](https://github.com/apache/drill/blob/0c01fb619d869c9cc0fd8ee094bc4ddd9042b552/contrib/storage-http/README.md) file for full details.

## Testing

Added unit tests for new functionality. Reran all existing tests.
