### PR TITLE
DRILL-7710: Fix TestMetastoreCommands#testDefaultSegment test

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
@@ -74,7 +74,7 @@ import static org.junit.Assert.assertTrue;
 @Category({SlowTest.class, MetastoreTest.class})
 public class TestMetastoreWithEasyFormatPlugin extends ClusterTest {
 
-  private static String SCHEMA_STRING = "'inline=(" +
+  private static final String SCHEMA_STRING = "'inline=(" +
       "`o_orderkey` INT not null, " +
       "`o_custkey` INT not null, " +
       "`o_orderstatus` VARCHAR not null, " +
@@ -105,7 +105,7 @@ public class TestMetastoreWithEasyFormatPlugin extends ClusterTest {
   @BeforeClass
   public static void setUp() throws Exception {
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
-    builder.configProperty(ExecConstants.ZK_ROOT, dirTestWatcher.getRootDir().getPath());
+    builder.configProperty(ExecConstants.ZK_ROOT, dirTestWatcher.getRootDir().getAbsolutePath());
     startCluster(builder);
   }
 
@@ -1087,7 +1087,6 @@ public class TestMetastoreWithEasyFormatPlugin extends ClusterTest {
           .sql("select * from dfs.tmp.`%s` limit 21", tableName)
           .planMatcher()
           .include("Limit", "numFiles=3")
-          .exclude("bird is the word")
           .match();
     } finally {
       run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchemaWithMetastore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestInfoSchemaWithMetastore.java
@@ -44,10 +44,8 @@ import org.apache.drill.test.ClusterFixtureBuilder;
 import org.apache.drill.test.ClusterTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -71,15 +69,12 @@ public class TestInfoSchemaWithMetastore extends ClusterTest {
     InfoSchemaConstants.TBLS_COL_NUM_ROWS,
     InfoSchemaConstants.TBLS_COL_LAST_MODIFIED_TIME);
 
-  @ClassRule
-  public static TemporaryFolder root = new TemporaryFolder();
-
   private static Metastore metastore;
 
   @BeforeClass
   public static void setup() throws Exception {
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
-    builder.configProperty(ExecConstants.ZK_ROOT, root.getRoot().toString());
+    builder.configProperty(ExecConstants.ZK_ROOT, dirTestWatcher.getRootDir().getAbsolutePath());
     builder.sessionOption(ExecConstants.METASTORE_ENABLED, true);
     startCluster(builder);
     MetastoreRegistry metastoreRegistry = client.cluster().drillbit().getContext().getMetastoreRegistry();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/sql/TestMetastoreCommands.java
@@ -188,7 +188,7 @@ public class TestMetastoreCommands extends ClusterTest {
   @BeforeClass
   public static void setUp() throws Exception {
     ClusterFixtureBuilder builder = ClusterFixture.builder(dirTestWatcher);
-    builder.configProperty(ExecConstants.ZK_ROOT, dirTestWatcher.getRootDir().getPath());
+    builder.configProperty(ExecConstants.ZK_ROOT, dirTestWatcher.getRootDir().getAbsolutePath());
     startCluster(builder);
 
     dirTestWatcher.copyResourceToRoot(Paths.get("multilevel/parquet"));
@@ -1869,7 +1869,7 @@ public class TestMetastoreCommands extends ClusterTest {
 
       assertEquals(defaultSegment, segmentMetadata.get(0));
     } finally {
-      run("analyze table dfs.`%s` drop metadata if exists", tableName);
+      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
     }
   }
 
@@ -2255,7 +2255,7 @@ public class TestMetastoreCommands extends ClusterTest {
           .baselineValues(true, String.format("Collected / refreshed metadata for table [dfs.default.%s]", tableName))
           .go();
 
-      String query = "select * from  dfs.`%s`";
+      String query = "select * from dfs.`%s`";
       long expectedRowCount = 50;
       int expectedNumFiles = 2;
 
@@ -2270,7 +2270,7 @@ public class TestMetastoreCommands extends ClusterTest {
           .include(numFilesPattern, usedMetaPattern)
           .match();
     } finally {
-      run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);
+      run("analyze table dfs.`%s` drop metadata if exists", tableName);
       run("drop table if exists dfs.`%s`", tableName);
     }
   }


### PR DESCRIPTION
# [DRILL-7710](https://issues.apache.org/jira/browse/DRILL-7710): Fix TestMetastoreCommands#testDefaultSegment test

## Description
Fixed deleting metadata for the failing test. Fixed `ZK_ROOT` location. Before changes, was passed relative folder location to the config, like `./target/org.apache.drill.exec.sql.TestMetastoreCommands/dfsTestTmp/...`. When drillbit for tests is started, it resolves this folder location in relation to the home directory, so table metadata wasn't dropped between two test runs.

## Documentation
NA

## Testing
Reran all tests.
