### PR TITLE
DRILL-7726: Update boost requirement to 1.54

### DIFF
--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
     #    set(Boost_NAMESPACE drill_boost)
 endif()
 
-find_package(Boost 1.53.0 REQUIRED COMPONENTS regex system date_time chrono thread random)
+find_package(Boost 1.54.0 REQUIRED COMPONENTS regex system date_time chrono thread random)
 include_directories(${Boost_INCLUDE_DIRS})
 
 

--- a/contrib/native/client/readme.linux
+++ b/contrib/native/client/readme.linux
@@ -57,34 +57,14 @@ Install Prerequisites
     $> ./configure --enable-debug --with-syncapi --enable-static --enable-shared
     $> make && sudo make install
 
-4) Install boost. The minimum version required is 1.53, which will probably have to be built from source
+4) Install boost. The minimum version required is 1.54, which will probably have to be built from source
 
-    # Remove any previous boost
-    $> sudo yum -y erase boost
-
-    # fetch the boost source rpm and create binary rpms
-    $> wget ftp://ftp.icm.edu.pl/vol/rzm2/linux-fedora-secondary/development/rawhide/source/SRPMS/b/boost-1.53.0-6.fc19.src.rpm
-    $> rpmbuild --rebuild boost-1.53.0-6.fc19.src.rpm
-
-    #install the binary rpms
-    #(Note: the "rpm" utility does not clean up old versions very well.)
-    $> sudo yum -y install ~/rpmbuild/RPMS/x86_64/*
-OR
     # Build boost for Drill using instruction from readme.boost.
     # Uncomment set(Boost_NAMESPACE drill_boost) line in client/CMakeLists.txt
 OR 
     Download and build using boost build. 
-    See this link for how to build: http://www.boost.org/doc/libs/1_53_0/more/getting_started/unix-variants.html#prepare-to-use-a-boost-library-binary 
-    After building boost the hard way, you will need to do some symlinks for compatibility:
-    cd /usr/lib
-    ln -svf libboost_regex.so libboost_regex-mt.so
-    ln -svf libboost_system.so libboost_system-mt.so
-    ln -svf libboost_filesystem.so libboost_filesystem-mt.so
-    ln -svf libboost_date_time.so libboost_date_time-mt.so
-    ln -svf libboost_regex.a libboost_regex-mt.a
-    ln -svf libboost_system.a libboost_system-mt.a
-    ln -svf libboost_filesystem.a libboost_filesystem-mt.a
-    ln -svf libboost_date_time.a libboost_date_time-mt.a
+    See this link for how to build: http://www.boost.org/doc/libs/1_54_0/more/getting_started/unix-variants.html#prepare-to-use-a-boost-library-binary 
+    After building boost from the source, you will need to specify where to find it by adding -DBOOST_ROOT=<boost install directory> to your cmake command
 
 5) Install or  build Cyrus SASL 
    To Install 

--- a/contrib/native/client/test/ssl/testClient.cpp
+++ b/contrib/native/client/test/ssl/testClient.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
         boost::asio::ip::tcp::resolver::query query(argv[1], argv[2]);
         boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
 
-        boost::asio::ssl::context ctx(io_service, boost::asio::ssl::context::sslv23);
+        boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
         ctx.set_verify_mode(boost::asio::ssl::context::verify_peer);
         ctx.load_verify_file("../../../test/ssl/drillTestCert.pem");
 

--- a/contrib/native/client/test/ssl/testServer.cpp
+++ b/contrib/native/client/test/ssl/testServer.cpp
@@ -102,7 +102,7 @@ class server
             : io_service_(io_service),
             acceptor_(io_service,
                     boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
-            context_(io_service, boost::asio::ssl::context::sslv23)
+            context_(boost::asio::ssl::context::sslv23)
     {
         context_.set_options(
                 boost::asio::ssl::context::default_workarounds


### PR DESCRIPTION
## Description

To support TLS1.2 flag, Boost ASIO 1.54 is required.

Also replace deprecated use of
`ssl::context::context(boost::asio::io_service &, method m)` which has
been removed from recent versions of Boost ASIO (>= 1.66).
(Please describe the change. If more than one ticket is fixed, include a reference to those tickets.)

## Testing
Tested against macos and linux
