### PR TITLE
DRILL-7727 Fix protobuf warning message

### DIFF
--- a/contrib/native/client/CMakeLists.txt
+++ b/contrib/native/client/CMakeLists.txt
@@ -25,6 +25,13 @@ cmake_policy(SET CMP0043 NEW)
 cmake_policy(SET CMP0048 NEW)
 enable_testing()
 
+#
+# required version for dependencies
+#
+set (BOOST_MINIMUM_VERSION 1.54.0)
+set (PROTOBUF_MINIMUM_VERSION 3.6.1)
+
+
 set (DRILL_ROOT ${CMAKE_SOURCE_DIR}/../../..)
 if (NOT DEFINED DRILL_VERSION)
     message("Detecting Drill version:")
@@ -100,7 +107,7 @@ else()
     #    set(Boost_NAMESPACE drill_boost)
 endif()
 
-find_package(Boost 1.54.0 REQUIRED COMPONENTS regex system date_time chrono thread random)
+find_package(Boost ${BOOST_MINIMUM_VERSION} REQUIRED COMPONENTS regex system date_time chrono thread random)
 include_directories(${Boost_INCLUDE_DIRS})
 
 
@@ -127,7 +134,7 @@ endif()
 
 
 # Find Protobufs
-find_package(Protobuf REQUIRED )
+find_package(Protobuf ${PROTOBUF_MINIMUM_VERSION} REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
 if (MSVC)

--- a/contrib/native/client/src/clientlib/rpcMessage.cpp
+++ b/contrib/native/client/src/clientlib/rpcMessage.cpp
@@ -205,9 +205,9 @@ bool encode(DataBuf& buf, const OutBoundRpcMessage& msg) {
     header.set_rpc_type(msg.m_rpc_type);
 
     // calcute the length of the message
-    int header_length = header.ByteSize();
-    int proto_body_length = msg.m_pbody->ByteSize();
-    int full_length = HEADER_TAG_LENGTH + CodedOutputStream::VarintSize32(header_length) + header_length + \
+    long header_length = header.ByteSizeLong();
+    long proto_body_length = msg.m_pbody->ByteSizeLong();
+    long full_length = HEADER_TAG_LENGTH + CodedOutputStream::VarintSize32(header_length) + header_length + \
                       PROTOBUF_BODY_TAG_LENGTH + CodedOutputStream::VarintSize32(proto_body_length) + proto_body_length;
 
     /*

--- a/contrib/native/client/src/protobuf/CMakeLists.txt
+++ b/contrib/native/client/src/protobuf/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 
 # Find Protobufs
-find_package(Protobuf REQUIRED)
+find_package(Protobuf ${PROTOBUF_MINIMUM_VERSION} REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
 #Generate Protobuf code


### PR DESCRIPTION
## [DRILL-7727](https://issues.apache.org/jira/browse/DRILL-7727) Fix protobuf warning message

## Description

Fix protobuf warning message about the use of ByteSize(), replaced with
ByteSizeLong().

Also add a minimum version requirement to match what is described in the
docs.

## Testing
build on linux and macos
