### PR TITLE
DRILL-7728: SPI framework

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -104,7 +104,7 @@
   <build>
     <plugins>
       <plugin>
-        <!-- Creating a test artifact because javadoc needs to be able to find test classes -->
+        <!-- Creating a test artifact because Javadoc needs to be able to find test classes -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
       </plugin>
@@ -117,7 +117,76 @@
           </additionalClasspathElements>
         </configuration>
       </plugin>
-    </plugins>
 
+			<plugin>
+        <!--  Creates a set of mock extension jars for testing. -->
+			  <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+         <!--  Prevent these jars from being installed. -->
+         <attach>false</attach>
+          <descriptors>
+            <!-- Yes, must list the assembly files twice. -->
+            <descriptor>src/assembly/mock1.xml</descriptor>
+            <descriptor>src/assembly/mock2.xml</descriptor>
+            <descriptor>src/assembly/mock3.xml</descriptor>
+            <descriptor>src/assembly/mock4.xml</descriptor>
+          </descriptors>
+          <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
+        </configuration>
+			  <executions>
+			    <execution>
+			      <id>mock1</id>
+			      <!--  Use this phase to ensure jars are available for tests
+			            in the next phase. -->
+			      <phase>process-test-classes</phase>
+			      <goals>
+			        <goal>single</goal>
+			      </goals>
+			      <configuration>
+						  <descriptors>
+		            <descriptor>src/assembly/mock1.xml</descriptor>
+		          </descriptors>
+			      </configuration>
+			    </execution>
+        <execution>
+            <id>mock2</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/mock2.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        <execution>
+            <id>mock3</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/mock3.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        <execution>
+            <id>mock4</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+               <descriptors>
+                <descriptor>src/assembly/mock4.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+			  </executions>
+			</plugin>
+
+    </plugins>
   </build>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -187,6 +187,20 @@
 			  </executions>
 			</plugin>
 
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <excludes>
+            <exclude>**/*.txt</exclude>
+            <exclude>**/*.json</exclude>
+            <exclude>**/org.apache.drill.extn.MockProvider</exclude>
+            <exclude>**/README.md</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/common/src/assembly/mock1.xml
+++ b/common/src/assembly/mock1.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <!--  Builds a mock service provider jar for testing. -->
+  <id>mock1</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/test-classes/org/apache/drill/extn/mock1</directory>
+      <outputDirectory>org/apache/drill/extn/mock1</outputDirectory>
+    </fileSet>
+  </fileSets>
+  <files>
+    <file>
+      <source>src/test/resources/mockExtn/example1.txt</source>
+      <outputDirectory></outputDirectory>
+    </file>
+    <file>
+      <source>src/test/resources/providerConf/mock1/org.apache.drill.extn.MockProvider</source>
+      <outputDirectory>META-INF/services</outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/common/src/assembly/mock2.xml
+++ b/common/src/assembly/mock2.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <!--  Builds a mock service provider jar for testing.
+        Tests class path isolation as this file contains the same
+        classes as mock1. -->
+  <id>mock2</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/test-classes/org/apache/drill/extn/mock2</directory>
+      <outputDirectory>org/apache/drill/extn/mock1</outputDirectory>
+    </fileSet>
+  </fileSets>
+  <files>
+     <file>
+      <source>src/test/resources/mockExtn/example2.txt</source>
+      <outputDirectory></outputDirectory>
+     </file>
+    <file>
+      <source>src/test/resources/providerConf/mock2/org.apache.drill.extn.MockProvider</source>
+      <outputDirectory>META-INF/services</outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/common/src/assembly/mock3.xml
+++ b/common/src/assembly/mock3.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <!--  Builds a mock service provider jar for testing.
+        Does NOT include the service provider config. file. -->
+  <id>mock3</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/test-classes/org/apache/drill/extn/mock1</directory>
+      <outputDirectory>org/apache/drill/extn/mock1</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/common/src/assembly/mock4.xml
+++ b/common/src/assembly/mock4.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <!--  Builds a mock service provider jar for testing.
+        Uses an intentionally bogus provider config file. -->
+  <id>mock4</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/test-classes/org/apache/drill/extn/mock1</directory>
+      <outputDirectory>org/apache/drill/extn/mock1</outputDirectory>
+    </fileSet>
+  </fileSets>
+  <files>
+    <file>
+      <source>src/test/resources/providerConf/mock4/org.apache.drill.extn.MockProvider</source>
+      <outputDirectory>META-INF/services</outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/common/src/main/java/org/apache/drill/extn/ExtensionsRegistry.java
+++ b/common/src/main/java/org/apache/drill/extn/ExtensionsRegistry.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn;
+
+import java.util.List;
+
+/**
+ * Registry of extension points, and the providers which implement those
+ * points.
+ */
+public interface ExtensionsRegistry {
+
+  <T> ExtensionsRegistry.ServiceProviderRegistry<T> registryFor(Class<T> serviceClass);
+
+  interface ServiceProviderRegistry<T> {
+    List<T> providers();
+  }
+}

--- a/common/src/main/java/org/apache/drill/extn/ExtensionsRegistryImpl.java
+++ b/common/src/main/java/org/apache/drill/extn/ExtensionsRegistryImpl.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the extensions registry. Provides extensive logging
+ * to help debug the inevitable problems that will occur in the field.
+ */
+public class ExtensionsRegistryImpl implements ExtensionsRegistry {
+
+  // Attribute logging to the interface for easier debugging.
+  private static final Logger logger = LoggerFactory.getLogger(ExtensionsRegistry.class);
+
+  @SuppressWarnings("serial")
+  private static class ExtException extends Exception {
+
+    public ExtException(String msg, Exception e) {
+      super(msg, e);
+    }
+  }
+
+  private final File extDir;
+  private final Map<Class<?>, ExtensionsRegistryImpl.ServiceProviderRegistryImpl<?>> services = new IdentityHashMap<>();
+
+  public ExtensionsRegistryImpl(File extDir, List<Class<?>> services) {
+    this.extDir = extDir;
+    defineServices(services);
+    loadProviders();
+  }
+
+  private void defineServices(List<Class<?>> serviceClasses) {
+    for (Class<?> serviceClass : serviceClasses) {
+      services.put(serviceClass, new ExtensionsRegistryImpl.ServiceProviderRegistryImpl<>(serviceClass));
+      logger.info("Defined extension point: {}", serviceClass.getCanonicalName());
+    }
+  }
+
+  private void loadProviders() {
+    for (File extFile : extDir.listFiles()) {
+      if (extFile.isDirectory()) {
+        loadExtDir(extFile);
+      } else if (extFile.getName().endsWith(".jar")) {
+        loadExtJar(null, extFile);
+      }
+    }
+  }
+
+  private void loadExtDir(File providerDir) {
+    String jarName = providerDir.getName() + ".jar";
+    File providerJar = new File(providerDir, jarName);
+    if (providerDir.exists()) {
+      loadExtJar(providerDir, providerJar);
+    }
+  }
+
+  private void loadExtJar(File providerDir, File providerJar) {
+    try (JarFile jarFile = new JarFile(providerJar)) {
+      for (ExtensionsRegistryImpl.ServiceProviderRegistryImpl<?> serviceReg : services.values()) {
+        if (loadService(providerDir, providerJar, jarFile, serviceReg)) {
+          return;
+        }
+      }
+      logError(providerDir, providerJar,
+          "Did not find a provider config file in META_INF/services/, ignoring jar", null);
+    } catch (IOException e) {
+      logError(providerDir, providerJar,
+          "Could not open extension jar", e);
+    } catch (ExtException e) {
+      logError(providerDir, providerJar,
+          e.getMessage(), e.getCause());
+    }
+  }
+
+  private void logError(File providerDir, File providerJar, String msg, Throwable e) {
+    String path = providerDir == null ? "" : providerDir.getName() + "/";
+    path += providerJar.getName();
+    logger.error(String.format("%s - Jar: %s", msg, path), e);
+  }
+
+  private boolean loadService(File providerDir, File providerJar, JarFile jarFile,
+      ExtensionsRegistryImpl.ServiceProviderRegistryImpl<?> serviceReg)
+          throws ExtException {
+    String implClassName = readMappingFile(jarFile, serviceReg.serviceClass());
+    if (implClassName == null) {
+      return false;
+    }
+    ExtensionsRegistryImpl.ProviderHost providerHost = new ProviderHost(providerDir, providerJar, implClassName);
+    serviceReg.addProvider(providerHost);
+    logger.info("Successfully loaded extension jar {} with class {} implementing {}",
+        providerJar.getName(), implClassName,
+        serviceReg.serviceClass().getCanonicalName());
+    return true;
+  }
+
+  private String readMappingFile(JarFile jarFile, Class<?> serviceClass) throws ExtException {
+    String className = serviceClass.getCanonicalName();
+    String mapFilePath = "META-INF/services/" + className;
+    JarEntry jarEntry = jarFile.getJarEntry(mapFilePath);
+    if (jarEntry == null) {
+      // Should never occur: we got here because the entry exists.
+      return null;
+    }
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(jarFile.getInputStream(jarEntry)))) {
+      return br.readLine();
+    } catch (IOException e) {
+      throw new ExtException(String.format(
+          "Failed to read the provider configuration file %s",
+          className), e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> ExtensionsRegistry.ServiceProviderRegistry<T> registryFor(Class<T> serviceClass) {
+    return (ExtensionsRegistry.ServiceProviderRegistry<T>) services.get(serviceClass);
+  }
+
+  public static class ServiceProviderRegistryImpl<T> implements ExtensionsRegistry.ServiceProviderRegistry<T> {
+
+    private final Class<T> serviceClass;
+    private final List<ExtensionsRegistryImpl.ProviderHost> providerHosts = new ArrayList<>();
+    private final List<T> serviceImpls = new ArrayList<>();
+
+    public ServiceProviderRegistryImpl(Class<T> serviceClass) {
+      this.serviceClass = serviceClass;
+    }
+
+    protected Class<T> serviceClass() { return serviceClass; }
+
+    protected void addProvider(ExtensionsRegistryImpl.ProviderHost provider) {
+      providerHosts.add(provider);
+      serviceImpls.add(provider.serviceImpl());
+    }
+
+    @Override
+    public List<T> providers() {
+      return serviceImpls;
+    }
+  }
+
+  protected static class ProviderHost {
+
+    private final File providerDir;
+    private final File providerJar;
+    private final ClassLoader classLoader;
+    private final Class<?> serviceImplClass;
+    private final Object serviceImpl;
+
+    protected ProviderHost(File providerDir, File providerJar, String implClassName)
+        throws ExtException {
+      this.providerDir = providerDir;
+      this.providerJar = providerJar;
+      try {
+        this.classLoader = buildClassLoader();
+      } catch (MalformedURLException e) {
+        throw new ExtException(
+            "Failed to create a class loader for the extension. Malformed jar names?", e);
+      }
+      try {
+        this.serviceImplClass = classLoader.loadClass(implClassName);
+      } catch (ClassNotFoundException e) {
+        throw new ExtException(String.format(
+            "Extension jar has a provider config file " +
+            "in META_INF/services/, but the named class %s not found.",
+            implClassName), e);
+      }
+      try {
+        this.serviceImpl = serviceImplClass.newInstance();
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new ExtException(String.format(
+            "Could not create an instance of provider class %s " +
+            "using the no-argument constructor", implClassName), e);
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T serviceImpl() {
+      return (T) serviceImpl;
+    }
+
+    private ClassLoader buildClassLoader() throws MalformedURLException {
+      List<URL> jars = new ArrayList<>();
+      if (providerDir != null) {
+        expandJars(jars);
+      } else {
+        jars.add(providerJar.toURI().toURL());
+      }
+      URL[] urls = new URL[jars.size()];
+      jars.toArray(urls);
+
+      // TODO: Replace this with a custom, Tomcat-like class loader.
+      return new URLClassLoader(urls, getClass().getClassLoader());
+    }
+
+    private void expandJars(List<URL> jars) throws MalformedURLException {
+      for (File file : providerDir.listFiles()) {
+        if (file.getName().endsWith(".jar")) {
+          jars.add(file.toURI().toURL());
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/drill/extn/README.md
+++ b/common/src/main/java/org/apache/drill/extn/README.md
@@ -1,0 +1,125 @@
+# Drill Service Provider Interface (SPI)
+
+The Drill SPI allows extensions (AKA plugins, providers) to extend Drill.
+This package provides the core extension mechanism and is a minor refinement
+of the standard Java
+[`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)
+mechanism.
+
+## Layout
+
+A _service provider_ provides one or more _services_. The provider implements a
+provider interface, defined in the Drill SPI package. That interface provides factory
+methods to implement services.
+
+The provider developer creates a jar file with the properties described below. The jar
+file is then placed in Drill's extension directory which is either:
+
+* `$DRILL_HOME/ext` if using the "classic" approach, or
+* `$DRILL_SITE/ext` if usign a separate "site" directory.
+
+### Simple Jars
+
+The simplest service is one with no dependencies other than the JDK and Drill.
+These reside in a single jar file placed in the `ext` directory. A UDF is a typical
+example:
+
+```
+$DRILL_SITE
+|- ext
+   |- coolUdfs.jar
+   |- fancyUdfs.jar
+```
+
+The name of the jar can be anything, though Drill recommends Maven-style naming:
+
+```
+collUdfs-1.3.0.jar
+```
+
+### Extension Packages
+
+More complex extensions (such as storage pugins) have dependencies in the form
+of additional jars. In this case, the provider developer provides a directory
+which contains any number of jars and other files:
+
+```
+$DRILL_SITE
+|- ext
+   |- coolUdfs-1.3.0.jar
+   |- fancyUdfs-2.1.0.jar
+   |- megaDbPlugin-0.7.0
+      |- metadbplugin-0.7.0.jar
+      |- dependency1.jar
+      |- dependency2.jar
+      |- README.md
+```
+
+The directory should also have Maven-format name, though this is not required.
+The directory contains the provider jar which *must* have the same name as the
+extension directory (this is how Drill knows which jar is the main one.)
+
+## Provider Configuration File
+
+Each extension jar must contain a _provider-configuration file_ as defined
+by the Java `ServiceLoader`. The file has the name of the Drill-defined
+provider interface, and contains a single line which is the fully-qualified
+name of the provider class which implements the interface.
+
+```
+coolUdfs-1.3.0.jar
+|- META-INF
+|   |- services
+|   |  |- org.apache.drill.spi
+|- com/foo/drill/udfs
+   |- SpiImpl.class
+   |- class files
+```
+
+The contents of `org.apache.drill.spi` would be:
+
+```
+com.foo.drill.uds.SpiImpl
+```
+
+### Drill Clusters
+
+The provider must be installed on each node in the Drill cluster. To avoid
+race conditions, Drill ignores any providers added after Drill starts. To
+install a new provider, first copy it to all Drillbits, then restart the
+cluster so that all Drillbits see the same set of providers.
+
+## Bootstrap Process
+
+Drill performs the following operations on bootstrap:
+
+* Determine the extension directory name as explained above.
+* Scan through each jar in the directory, and each subdirectory.
+* If a subdirectory, look for the main jar with the same name as the directory.
+* Look for the provider configuration file.
+* Load the class named in the config file.
+* Create an instance of the provider class.
+
+If any of the above steps fail, a message is logged to the log file explaining
+the issue. Drill also logs those providers which pass the gauntlet and are
+successfully loaded.
+
+## Drill Extension Class Loader
+
+The eventual goal is to provide class loader isolation for extensions.
+
+Extensions normally run in a class loader separate from that for Drill. The
+extension has visibility only to the SPI interfaces, but not to Drill's implemetation.
+As a result, the extension is isolated from changes to Drill's internals across
+Drill versions. Also, the extension's dependencies to not conflict with Drill's
+own dependencies. This is the "servlet" model from JEE as explained in the
+[Tomcat documentation](https://tomcat.apache.org/tomcat-8.0-doc/class-loader-howto.html).
+
+An extension may also elect to be loaded in the same class loader as Drill.
+Use this for extensions built as part of Drill, or extensions that need to use
+Drill internals which have not yet been abstracted out by the SPI interfaces.
+
+*TODO*: For now, each extension has its own class loader so that
+one extension does not conflict with another, but every plugin has visibility to
+Drill's internal classes. Per normal Java behavior, Drill's class loader is searched
+first to find a class, then the extension's class loader.

--- a/common/src/test/java/org/apache/drill/extn/MockProvider.java
+++ b/common/src/test/java/org/apache/drill/extn/MockProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn;
+
+public interface MockProvider {
+  MockService newMock();
+}

--- a/common/src/test/java/org/apache/drill/extn/MockService.java
+++ b/common/src/test/java/org/apache/drill/extn/MockService.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn;
+
+public interface MockService {
+  String get();
+}

--- a/common/src/test/java/org/apache/drill/extn/TestExtFramework.java
+++ b/common/src/test/java/org/apache/drill/extn/TestExtFramework.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.drill.extn.ExtensionsRegistry.ServiceProviderRegistry;
+import org.apache.drill.test.BaseTest;
+import org.apache.drill.test.DirTestWatcher;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class TestExtFramework extends BaseTest {
+
+  @ClassRule
+  public static final DirTestWatcher dirTestWatcher = new DirTestWatcher();
+  public static File extDir;
+
+  /**
+   * The Maven packager insists on prepending the coordinate name:<br>
+   * {@code drill-common-x.y.z-mockx.jar}, but we want only the base
+   * name. So, we have to search for the files and ignore the
+   * variable prefix.
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void setup() throws IOException {
+    extDir = new File(dirTestWatcher.getDir(), "ext");
+    File testJarsDir = new File("target/test-jars");
+    assertTrue("target/test-jars/ is missing. Check build.", testJarsDir.isDirectory());
+    File mock1Jar = null;
+    File mock2Jar = null;
+    File mock3Jar = null;
+    File mock4Jar = null;
+    for (File file : testJarsDir.listFiles()) {
+      if (file.getName().endsWith("-mock1.jar")) {
+        mock1Jar = file;
+      }
+      if (file.getName().endsWith("-mock2.jar")) {
+        mock2Jar = file;
+      }
+      if (file.getName().endsWith("-mock3.jar")) {
+        mock3Jar = file;
+      }
+      if (file.getName().endsWith("-mock4.jar")) {
+        mock4Jar = file;
+      }
+    }
+    assertNotNull("target/test-jars/drill-common-<version>-mock1.jar is missing. Check build.", mock1Jar);
+    assertNotNull("target/test-jars/drill-common-<version>-mock2.jar is missing. Check build.", mock2Jar);
+    assertNotNull("target/test-jars/drill-common-<version>-mock3.jar is missing. Check build.", mock3Jar);
+    assertNotNull("target/test-jars/drill-common-<version>-mock4.jar is missing. Check build.", mock4Jar);
+
+    // Mock1.jar: valid extension as a simple jar
+    FileUtils.copyFile(mock1Jar, new File(extDir, "mock1.jar"));
+
+    // Mock2.jar: valid extension within a directory
+    File mock2Dir = new File(extDir, "mock2");
+    mock2Dir.mkdir();
+    FileUtils.copyFile(mock2Jar, new File(mock2Dir, "mock2.jar"));
+
+    // Mock3.jar: missing the provider config file
+    FileUtils.copyFile(mock3Jar, new File(extDir, "mock3.jar"));
+
+    // Mock4.jar: missing the provider class (config file is bogus)
+    FileUtils.copyFile(mock4Jar, new File(extDir, "mock4.jar"));
+  }
+
+  @Test
+  public void testFramework() {
+    ExtensionsRegistry reg = new ExtensionsRegistryImpl(extDir,
+        Collections.singletonList(MockProvider.class));
+    ServiceProviderRegistry<MockProvider> providerReg = reg.registryFor(MockProvider.class);
+    assertNotNull(providerReg);
+    List<MockProvider> providers = providerReg.providers();
+    assertNotNull(providers);
+    assertEquals(2, providers.size());
+
+    // Lame, but the extension loading order is random
+    List<String> results = new ArrayList<>();
+
+    MockProvider provider1 = providers.get(0);
+    assertNotNull(provider1);
+    MockService service1 = provider1.newMock();
+    assertNotNull(service1);
+    results.add(service1.get());
+
+    MockProvider provider2 = providers.get(1);
+    assertNotNull(provider2);
+    MockService service2 = provider2.newMock();
+    assertNotNull(service2);
+    results.add(service2.get());
+
+    assertNotSame(provider1, provider2);
+    assertNotSame(provider1.getClass(), provider2.getClass());
+
+    Collections.sort(results);
+    assertEquals("Hello, Drill", results.get(0));
+    assertEquals("Hello, world", results.get(1));
+  }
+}

--- a/common/src/test/java/org/apache/drill/extn/mock1/MockProviderImpl.java
+++ b/common/src/test/java/org/apache/drill/extn/mock1/MockProviderImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn.mock1;
+
+import org.apache.drill.extn.MockProvider;
+import org.apache.drill.extn.MockService;
+
+public class MockProviderImpl implements MockProvider {
+
+  @Override
+  public MockService newMock() {
+    return new MockServiceImpl();
+  }
+}

--- a/common/src/test/java/org/apache/drill/extn/mock1/MockServiceImpl.java
+++ b/common/src/test/java/org/apache/drill/extn/mock1/MockServiceImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn.mock1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.apache.drill.extn.MockService;
+
+public class MockServiceImpl implements MockService {
+
+  // Test class resolution: should look for this file in the local jar before
+  // the drill jar. File is replaced in mock2.
+  @Override
+  public String get() {
+    try (InputStream is = getClass().getResourceAsStream("/mockExtn/example1.txt")) {
+      if (is == null) {
+        return null;
+      }
+      BufferedReader br = new BufferedReader(new InputStreamReader(is));
+      return br.readLine();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/common/src/test/java/org/apache/drill/extn/mock2/MockProviderImpl.java
+++ b/common/src/test/java/org/apache/drill/extn/mock2/MockProviderImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn.mock2;
+
+import org.apache.drill.extn.MockProvider;
+import org.apache.drill.extn.MockService;
+
+public class MockProviderImpl implements MockProvider {
+
+  @Override
+  public MockService newMock() {
+    return new MockServiceImpl();
+  }
+}

--- a/common/src/test/java/org/apache/drill/extn/mock2/MockServiceImpl.java
+++ b/common/src/test/java/org/apache/drill/extn/mock2/MockServiceImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.extn.mock2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.apache.drill.extn.MockService;
+
+public class MockServiceImpl implements MockService {
+
+  // Test class resolution: should look for this file in the local jar before
+  // the drill jar. File is replaced in mock2.
+  @Override
+  public String get() {
+    try (InputStream is = getClass().getResourceAsStream("/mockExtn/example2.txt")) {
+      if (is == null) {
+        return null;
+      }
+      BufferedReader br = new BufferedReader(new InputStreamReader(is));
+      return br.readLine();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/common/src/test/resources/mockExtn/example1.txt
+++ b/common/src/test/resources/mockExtn/example1.txt
@@ -1,0 +1,1 @@
+Hello, world

--- a/common/src/test/resources/mockExtn/example2.txt
+++ b/common/src/test/resources/mockExtn/example2.txt
@@ -1,0 +1,1 @@
+Hello, Drill

--- a/common/src/test/resources/providerConf/mock1/org.apache.drill.extn.MockProvider
+++ b/common/src/test/resources/providerConf/mock1/org.apache.drill.extn.MockProvider
@@ -1,0 +1,1 @@
+org.apache.drill.extn.mock1.MockProviderImpl

--- a/common/src/test/resources/providerConf/mock2/org.apache.drill.extn.MockProvider
+++ b/common/src/test/resources/providerConf/mock2/org.apache.drill.extn.MockProvider
@@ -1,0 +1,1 @@
+org.apache.drill.extn.mock2.MockProviderImpl

--- a/common/src/test/resources/providerConf/mock4/org.apache.drill.extn.MockProvider
+++ b/common/src/test/resources/providerConf/mock4/org.apache.drill.extn.MockProvider
@@ -1,0 +1,1 @@
+org.apache.drill.extn.mock1.BogusProviderImpl


### PR DESCRIPTION
# [DRILL-7728](https://issues.apache.org/jira/browse/DRILL-7728): SPI framework

## Description

We have discussed moving Drill to a "Service Provider Interface" (SPI) model similar to what Presto uses, and modelled after the Java [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) concept.

There are several parts. This PR is for the core mechanism explained [here](https://github.com/paul-rogers/drill/blob/03b36378c6380e6cda76328f5d77bb1d298fe65d/common/src/main/java/org/apache/drill/extn/README.md) to host extensions in Drill. The layout seems the simplest possible way to handle complex plugins; comments and suggestions welcome. In particular, is there some existing model we can adopt? I didn't find any and the Java `ServiceLoader` is just a bit *too* simple.

The eventual goal is to provide class loader isolation so that an extension can use one version of Guava, say, and Drill another. This PR implements a lesser form: classes from one extension will not clash with those from another. However, it uses the default class lookup: Drill's own classes are resolved first, then the extension's classes. This interim solution works fine except when we have a conflict. We can add the stricter form later.

Some effort went into ensuring this approach will work with Java 9 (and later) modules, but have not done extensive testing.

Once the core mechanism is available, the next step is to define the SPI interfaces for things like UDFs, storage plugins and format plugins.

## Documentation

The file linked above will eventually be the basis for user documentation for how to build and install extensions using SPI.

## Testing

Added unit tests. Doing so required the use of test jar files. After much gnashing of teeth, was able to get Maven to build them and *not* install them in the local repo.
