### PR TITLE
DRILL-7730: Improve web query efficiency

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/DumpCat.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/DumpCat.java
@@ -250,7 +250,7 @@ public class DumpCat {
       System.out.println(getBatchMetaInfo(vcSerializable).toString());
 
       System.out.println("Schema Information");
-      for (final VectorWrapper w : vectorContainer) {
+      for (final VectorWrapper<?> w : vectorContainer) {
         final MaterializedField field = w.getValueVector().getField();
         System.out.println (String.format("name : %s, minor_type : %s, data_mode : %s",
                                           field.getName(),
@@ -279,7 +279,7 @@ public class DumpCat {
       selectedRows = vcSerializable.getSv2().getCount();
     }
 
-    for (final VectorWrapper w : vectorContainer) {
+    for (final VectorWrapper<?> w : vectorContainer) {
        totalDataSize += w.getValueVector().getBufferSize();
     }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/InvalidConnectionInfoException.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/InvalidConnectionInfoException.java
@@ -22,6 +22,7 @@ import org.apache.drill.exec.rpc.NonTransientRpcException;
 /**
  * Exception for malformed connection string from client
  */
+@SuppressWarnings("serial")
 public class InvalidConnectionInfoException extends NonTransientRpcException {
 
   public InvalidConnectionInfoException(String message) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/LoggingResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/LoggingResultsListener.java
@@ -36,11 +36,13 @@ import org.apache.drill.exec.rpc.user.UserResultsListener;
 import org.apache.drill.exec.util.VectorUtil;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.DrillBuf;
 
 public class LoggingResultsListener implements UserResultsListener {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LoggingResultsListener.class);
+  private static Logger logger = LoggerFactory.getLogger(LoggingResultsListener.class);
 
   private final AtomicInteger count = new AtomicInteger();
   private final Stopwatch w = Stopwatch.createUnstarted();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/client/QuerySubmitter.java
@@ -201,7 +201,5 @@ public class QuerySubmitter {
       watch.reset();
     }
     return 0;
-
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AccountingUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/AccountingUserConnection.java
@@ -17,7 +17,7 @@
  */
 package org.apache.drill.exec.ops;
 
-import org.apache.drill.exec.physical.impl.materialize.QueryWritableBatch;
+import org.apache.drill.exec.physical.impl.materialize.QueryDataPackage;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
 import org.apache.drill.exec.rpc.UserClientConnection;
@@ -31,14 +31,15 @@ public class AccountingUserConnection {
   private final SendingAccountor sendingAccountor;
   private final RpcOutcomeListener<Ack> statusHandler;
 
-  public AccountingUserConnection(UserClientConnection connection, SendingAccountor sendingAccountor, RpcOutcomeListener<Ack> statusHandler) {
+  public AccountingUserConnection(UserClientConnection connection, SendingAccountor sendingAccountor,
+      RpcOutcomeListener<Ack> statusHandler) {
     this.connection = connection;
     this.sendingAccountor = sendingAccountor;
     this.statusHandler = statusHandler;
   }
 
-  public void sendData(QueryWritableBatch batch) {
+  public void sendData(QueryDataPackage data) {
     sendingAccountor.increment();
-    connection.sendData(statusHandler, batch);
+    connection.sendData(statusHandler, data);
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/Filterer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/filter/Filterer.java
@@ -24,9 +24,12 @@ import org.apache.drill.exec.record.RecordBatch;
 import org.apache.drill.exec.record.TransferPair;
 
 public interface Filterer {
-  TemplateClassDefinition<Filterer> TEMPLATE_DEFINITION2 = new TemplateClassDefinition<Filterer>(Filterer.class, FilterTemplate2.class);
-  TemplateClassDefinition<Filterer> TEMPLATE_DEFINITION4 = new TemplateClassDefinition<Filterer>(Filterer.class, FilterTemplate4.class);
+  TemplateClassDefinition<Filterer> TEMPLATE_DEFINITION2 =
+      new TemplateClassDefinition<Filterer>(Filterer.class, FilterTemplate2.class);
+  TemplateClassDefinition<Filterer> TEMPLATE_DEFINITION4 =
+      new TemplateClassDefinition<Filterer>(Filterer.class, FilterTemplate4.class);
 
-  void setup(FragmentContext context, RecordBatch incoming, RecordBatch outgoing, TransferPair[] transfers) throws SchemaChangeException;
+  void setup(FragmentContext context, RecordBatch incoming,
+      RecordBatch outgoing, TransferPair[] transfers) throws SchemaChangeException;
   void filterBatch(int recordCount) throws SchemaChangeException;
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/QueryDataPackage.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/QueryDataPackage.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.physical.impl.materialize;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.drill.exec.ops.OperatorStats;
+import org.apache.drill.exec.physical.impl.ScreenCreator.ScreenRoot.Metric;
+import org.apache.drill.exec.proto.UserBitShared.QueryData;
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.proto.UserBitShared.RecordBatchDef;
+import org.apache.drill.exec.proto.UserBitShared.SerializedField;
+import org.apache.drill.exec.record.VectorContainer;
+import org.apache.drill.exec.record.VectorWrapper;
+
+/**
+ * Packages a batch from the Screen operator to send to its
+ * user connection. In the original Drill, that connection was always a
+ * network connection, and so the outgoing batch is serialized to a set
+ * of buffers ready to send. However, the REST server runs in the same process.
+ * The original REST query implementation serialized the data to buffers, then
+ * copied the data to a big buffer to be deserialized, causing significant memory
+ * pressure. This version allows the user connection to elect for serialization,
+ * or just to access the original source batch.
+ */
+public interface QueryDataPackage {
+
+  QueryId queryId();
+  QueryWritableBatch toWritableBatch();
+  VectorContainer batch();
+  List<SerializedField> fields();
+
+  /**
+   * Package that contains only a query ID. Send for a query that
+   * finishes with no data. The results are null: no data, no schema.
+   */
+  public static class EmptyResultsPackage implements QueryDataPackage {
+
+    private final QueryId queryId;
+
+    public EmptyResultsPackage(QueryId queryId) {
+      this.queryId = queryId;
+    }
+
+    @Override
+    public QueryId queryId() { return queryId; }
+
+    /**
+     * Creates a message that sends only the query ID to the
+     * client.
+     */
+    @Override
+    public QueryWritableBatch toWritableBatch() {
+      QueryData header = QueryData.newBuilder()
+        .setQueryId(queryId)
+        .setRowCount(0)
+        .setDef(RecordBatchDef.getDefaultInstance())
+        .build();
+      return new QueryWritableBatch(header);
+    }
+
+    @Override
+    public VectorContainer batch() { return null; }
+
+    @Override
+    public List<SerializedField> fields() {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Represents a batch of data with a schema.
+   */
+  public static class DataPackage implements QueryDataPackage {
+    private final RecordMaterializer materializer;
+    private final OperatorStats stats;
+
+    public DataPackage(RecordMaterializer materializer, OperatorStats stats) {
+      this.materializer = materializer;
+      this.stats = stats;
+    }
+
+    @Override
+    public QueryId queryId() { return materializer.queryId(); }
+
+    @Override
+    public QueryWritableBatch toWritableBatch() {
+      QueryWritableBatch batch = materializer.convertNext();
+      stats.addLongStat(Metric.BYTES_SENT, batch.getByteCount());
+      return batch;
+    }
+
+    @Override
+    public VectorContainer batch() {
+      return materializer.incoming();
+    }
+
+    @Override
+    public List<SerializedField> fields() {
+      List<SerializedField> metadata = new ArrayList<>();
+      for (VectorWrapper<?> vw : batch()) {
+        metadata.add(vw.getValueVector().getMetadata());
+      }
+      return metadata;
+    }
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/QueryWritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/QueryWritableBatch.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import org.apache.drill.exec.proto.UserBitShared.QueryData;
 
 public class QueryWritableBatch {
-//  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(QueryWritableBatch.class);
 
   private final QueryData header;
   private final ByteBuf[] buffers;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/RecordMaterializer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/impl/materialize/RecordMaterializer.java
@@ -17,9 +17,14 @@
  */
 package org.apache.drill.exec.physical.impl.materialize;
 
+import org.apache.drill.exec.proto.UserBitShared.QueryId;
+import org.apache.drill.exec.record.VectorContainer;
 
 public interface RecordMaterializer {
 
   public QueryWritableBatch convertNext();
 
+  public QueryId queryId();
+
+  public VectorContainer incoming();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/AbstractSingleRecordBatch.java
@@ -25,7 +25,7 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
  * Implements an AbstractUnaryRecordBatch where the incoming record batch is
  * known at the time of creation
  *
- * @param <T>
+ * @param <T> the plan definition of the operator
  */
 public abstract class AbstractSingleRecordBatch<T extends PhysicalOperator> extends AbstractUnaryRecordBatch<T> {
 
@@ -43,12 +43,15 @@ public abstract class AbstractSingleRecordBatch<T extends PhysicalOperator> exte
   }
 
   /**
-   * Based on lastKnownOutcome and if there are more records to be output for current record boundary detected by
-   * EMIT outcome, this method returns EMIT or OK outcome.
+   * Based on lastKnownOutcome and if there are more records to be output for
+   * current record boundary detected by EMIT outcome, this method returns EMIT
+   * or OK outcome.
+   *
    * @param hasMoreRecordInBoundary
-   * @return - EMIT - If the lastknownOutcome was EMIT and output records corresponding to all the incoming records in
-   * current record boundary is already produced.
-   *         - OK - otherwise
+   * @return EMIT - If the lastknownOutcome was EMIT and output records
+   *         corresponding to all the incoming records in current record
+   *         boundary is already produced.
+   *         OK - otherwise
    */
   protected IterOutcome getFinalOutcome(boolean hasMoreRecordInBoundary) {
     final IterOutcome lastOutcome = getLastKnownOutcome();

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/BatchSchema.java
@@ -30,7 +30,6 @@ import org.apache.drill.common.types.TypeProtos.MajorType;
  * {@link org.apache.drill.exec.record.metadata.TupleMetadata} instead.
  */
 public class BatchSchema implements Iterable<MaterializedField> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BatchSchema.class);
 
   private final SelectionVectorMode selectionVectorMode;
   private final List<MaterializedField> fields;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/record/WritableBatch.java
@@ -19,6 +19,7 @@ package org.apache.drill.exec.record;
 
 import io.netty.buffer.DrillBuf;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.drill.exec.memory.BufferAllocator;
@@ -28,7 +29,6 @@ import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.exec.vector.ValueVector;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 /**
  * A specialized version of record batch that can moves out buffers and preps
@@ -52,7 +52,7 @@ public class WritableBatch implements AutoCloseable {
   }
 
   public WritableBatch transfer(BufferAllocator allocator) {
-    List<DrillBuf> newBuffers = Lists.newArrayList();
+    List<DrillBuf> newBuffers = new ArrayList<>();
     for (DrillBuf buf : buffers) {
       int writerIndex = buf.writerIndex();
       DrillBuf newBuf = buf.transferOwnership(allocator).buffer;
@@ -135,7 +135,7 @@ public class WritableBatch implements AutoCloseable {
   }
 
   public static WritableBatch getBatchNoHVWrap(int recordCount, Iterable<VectorWrapper<?>> vws, boolean isSV2) {
-    List<ValueVector> vectors = Lists.newArrayList();
+    List<ValueVector> vectors = new ArrayList<>();
     for (VectorWrapper<?> vw : vws) {
       Preconditions.checkArgument(!vw.isHyper());
       vectors.add(vw.getValueVector());
@@ -144,8 +144,8 @@ public class WritableBatch implements AutoCloseable {
   }
 
   public static WritableBatch getBatchNoHV(int recordCount, Iterable<ValueVector> vectors, boolean isSV2) {
-    List<DrillBuf> buffers = Lists.newArrayList();
-    List<SerializedField> metadata = Lists.newArrayList();
+    List<DrillBuf> buffers = new ArrayList<>();
+    List<SerializedField> metadata = new ArrayList<>();
 
     for (ValueVector vv : vectors) {
       metadata.add(vv.getMetadata());

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/AbstractDisposableUserClientConnection.java
@@ -18,6 +18,8 @@
 package org.apache.drill.exec.rpc;
 
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
 import org.apache.drill.exec.proto.UserBitShared.DrillPBError;
 import org.apache.drill.exec.proto.UserBitShared.QueryId;
@@ -29,13 +31,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Helps to run a query and await on the results. All the inheriting sub-class manages the session/connection
- * state and submits query with respect to that state. The subclass instance lifetime is per query lifetime
- * and is not re-used.
+ * Helps to run a query and await on the results. All the inheriting sub-class
+ * manages the session/connection state and submits query with respect to that
+ * state. The subclass instance lifetime is per query lifetime and is not
+ * re-used.
  */
 public abstract class AbstractDisposableUserClientConnection implements UserClientConnection {
-  private static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(AbstractDisposableUserClientConnection.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(AbstractDisposableUserClientConnection.class);
 
   protected final CountDownLatch latch = new CountDownLatch(1);
 
@@ -72,7 +75,8 @@ public abstract class AbstractDisposableUserClientConnection implements UserClie
     final QueryId queryId = result.getQueryId();
 
     if (logger.isDebugEnabled()) {
-      logger.debug("Result arrived for QueryId: {} with QueryState: {}", QueryIdHelper.getQueryId(queryId), state);
+      logger.debug("Result arrived for QueryId: {} with QueryState: {}",
+          QueryIdHelper.getQueryId(queryId), state);
     }
 
     switch (state) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/UserClientConnection.java
@@ -18,7 +18,8 @@
 package org.apache.drill.exec.rpc;
 
 import io.netty.channel.ChannelFuture;
-import org.apache.drill.exec.physical.impl.materialize.QueryWritableBatch;
+
+import org.apache.drill.exec.physical.impl.materialize.QueryDataPackage;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
 import org.apache.drill.exec.proto.UserBitShared.QueryResult;
 import org.apache.drill.exec.rpc.user.UserSession;
@@ -26,12 +27,14 @@ import org.apache.drill.exec.rpc.user.UserSession;
 import java.net.SocketAddress;
 
 /**
- * Interface for getting user session properties and interacting with user connection. Separating this interface from
- * {@link AbstractRemoteConnection} implementation for user connection:
+ * Interface for getting user session properties and interacting with user
+ * connection. Separating this interface from {@link AbstractRemoteConnection}
+ * implementation for user connection:
  * <p><ul>
- * <li> Connection is passed to Foreman and Screen operators. Instead passing this interface exposes few details.
- * <li> Makes it easy to have wrappers around user connection which can be helpful to tap the messages and data
- * going to the actual client.
+ * <li>Connection is passed to Foreman and Screen operators. Instead passing
+ * this interface exposes few details.
+ * <li>Makes it easy to have wrappers around user connection which can be
+ * helpful to tap the messages and data going to the actual client.
  * </ul>
  */
 public interface UserClientConnection {
@@ -41,7 +44,7 @@ public interface UserClientConnection {
   UserSession getSession();
 
   /**
-   * Send query result outcome to client. Outcome is returned through <code>listener</code>
+   * Send query result outcome to client. Outcome is returned through {@code listener}.
    *
    * @param listener
    * @param result
@@ -49,12 +52,12 @@ public interface UserClientConnection {
   void sendResult(RpcOutcomeListener<Ack> listener, QueryResult result);
 
   /**
-   * Send query data to client. Outcome is returned through <code>listener</code>
+   * Send query data to client. Outcome is returned through {@code listener}.
    *
    * @param listener
    * @param result
    */
-  void sendData(RpcOutcomeListener<Ack> listener, QueryWritableBatch result);
+  void sendData(RpcOutcomeListener<Ack> listener, QueryDataPackage data);
 
   /**
    * Returns the {@link ChannelFuture} which will be notified when this

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/AwaitableUserResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/AwaitableUserResultsListener.java
@@ -78,5 +78,4 @@ public class AwaitableUserResultsListener implements UserResultsListener {
     }
     return count.get();
   }
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/QueryResultHandler.java
@@ -120,13 +120,13 @@ public class QueryResultHandler {
 
     try {
       if (isFailureResult) {
-        // Failure case--pass on via submissionFailed(...).
 
+        // Failure case--pass on via submissionFailed(...).
         resultsListener.submissionFailed(new UserRemoteException(queryResult.getError(0)));
         // Note: Listener is removed in finally below.
       } else if (isTerminalResult) {
-        // A successful completion/canceled case--pass on via resultArrived
 
+        // A successful completion/canceled case--pass on via resultArrived
         try {
           resultsListener.queryCompleted(queryState);
         } catch (Exception e) {
@@ -189,9 +189,9 @@ public class QueryResultHandler {
     UserResultsListener resultsListener = queryIdToResultsListenersMap.get(queryId);
     logger.trace("For QueryId [{}], retrieved results listener {}", queryId, resultsListener);
     if (null == resultsListener) {
+
       // WHO?? didn't get query ID response and set submission listener yet,
       // so install a buffering listener for now
-
       BufferingResultsListener bl = new BufferingResultsListener();
       resultsListener = queryIdToResultsListenersMap.putIfAbsent(queryId, bl);
       // If we had a successful insertion, use that reference.  Otherwise, just
@@ -272,8 +272,7 @@ public class QueryResultHandler {
     }
 
     @Override
-    public void queryIdArrived(QueryId queryId) {
-    }
+    public void queryIdArrived(QueryId queryId) { }
   }
 
   private class SubmissionListener extends BaseRpcOutcomeListener<QueryId> {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserResultsListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserResultsListener.java
@@ -25,14 +25,21 @@ import org.apache.drill.exec.rpc.ConnectionThrottle;
 public interface UserResultsListener {
 
   /**
-   * QueryId is available. Called when a query is successfully submitted to the server.
-   * @param queryId sent by the server along {@link org.apache.drill.exec.rpc.Acks.OK Acks.OK}
+   * QueryId is available. Called when a query is successfully submitted to the
+   * server.
+   *
+   * @param queryId
+   *          sent by the server along {@link org.apache.drill.exec.rpc.Acks.OK
+   *          Acks.OK}
    */
   void queryIdArrived(QueryId queryId);
 
   /**
-   * The query has failed. Most likely called when the server returns a FAILED query state. Can also be called if
-   * {@link #dataArrived(QueryDataBatch, ConnectionThrottle) dataArrived()} throws an exception
+   * The query has failed. Most likely called when the server returns a FAILED
+   * query state. Can also be called if
+   * {@link #dataArrived(QueryDataBatch, ConnectionThrottle) dataArrived()}
+   * throws an exception
+   *
    * @param ex exception describing the cause of the failure
    */
   void submissionFailed(UserException ex);
@@ -45,10 +52,9 @@ public interface UserResultsListener {
   void dataArrived(QueryDataBatch result, ConnectionThrottle throttle);
 
   /**
-   * The query has completed (successsful completion or cancellation). The listener will not receive any other
-   * data or result message. Called when the server returns a terminal-non failing- state (COMPLETED or CANCELLED)
-   * @param state
+   * The query has completed (successful completion or cancellation). The
+   * listener will not receive any other data or result message. Called when the
+   * server returns a terminal-non failing- state (COMPLETED or CANCELLED)
    */
   void queryCompleted(QueryState state);
-
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/rpc/user/UserSession.java
@@ -49,11 +49,13 @@ import org.apache.drill.exec.store.dfs.DrillFileSystem;
 import org.apache.drill.exec.store.dfs.WorkspaceSchemaFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserSession implements AutoCloseable {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UserSession.class);
+  private static final Logger logger = LoggerFactory.getLogger(UserSession.class);
 
-  private boolean supportComplexTypes = false;
+  private boolean supportComplexTypes;
   private UserCredentials credentials;
   private DrillProperties properties;
   private SessionOptionManager sessionOptions;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseWebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/BaseWebUserConnection.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest;
+
+import java.net.SocketAddress;
+
+import org.apache.drill.exec.rpc.AbstractDisposableUserClientConnection;
+import org.apache.drill.exec.rpc.ConnectionThrottle;
+import org.apache.drill.exec.rpc.user.UserSession;
+
+import io.netty.channel.ChannelFuture;
+
+public abstract class BaseWebUserConnection extends AbstractDisposableUserClientConnection implements ConnectionThrottle {
+
+  protected WebSessionResources webSessionResources;
+
+  public BaseWebUserConnection(WebSessionResources webSessionResources) {
+    this.webSessionResources = webSessionResources;
+  }
+
+  @Override
+  public UserSession getSession() {
+    return webSessionResources.getSession();
+  }
+
+  @Override
+  public ChannelFuture getChannelClosureFuture() {
+    return webSessionResources.getCloseFuture();
+  }
+
+  @Override
+  public SocketAddress getRemoteAddress() {
+    return webSessionResources.getRemoteAddress();
+  }
+
+  @Override
+  public void setAutoRead(boolean enableAutoRead) { }
+
+  public WebSessionResources resources() {
+    return webSessionResources;
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/DrillRestServer.java
@@ -237,9 +237,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(WebUserConnection instance) {
-
-    }
+    public void dispose(WebUserConnection instance) { }
   }
 
   public static class AnonWebUserConnectionProvider implements Factory<WebUserConnection> {
@@ -300,14 +298,14 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(WebUserConnection instance) {
-
-    }
+    public void dispose(WebUserConnection instance) { }
 
     /**
-     * Creates session user principal. If impersonation is enabled without authentication and User-Name header is present and valid,
-     * will create session user principal with provided user name, otherwise anonymous user name will be used.
-     * In both cases session user principal will have admin rights.
+     * Creates session user principal. If impersonation is enabled without
+     * authentication and User-Name header is present and valid, will create
+     * session user principal with provided user name, otherwise anonymous user
+     * name will be used. In both cases session user principal will have admin
+     * rights.
      *
      * @param config drill config
      * @param request client request
@@ -322,10 +320,12 @@ public class DrillRestServer extends ResourceConfig {
       }
       return new AnonDrillUserPrincipal();
     }
-
   }
 
-  // Provider which injects DrillUserPrincipal directly instead of getting it from SecurityContext and typecasting
+  /**
+   * Provider which injects DrillUserPrincipal directly instead of getting it
+   * from SecurityContext and typecasting
+   */
   public static class DrillUserPrincipalProvider implements Factory<DrillUserPrincipal> {
 
     @Inject HttpServletRequest request;
@@ -336,9 +336,7 @@ public class DrillRestServer extends ResourceConfig {
     }
 
     @Override
-    public void dispose(DrillUserPrincipal principal) {
-      // No-Op
-    }
+    public void dispose(DrillUserPrincipal principal) { }
   }
 
   // Provider which creates and cleanups DrillUserPrincipal for anonymous (auth disabled) mode

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
@@ -150,7 +150,7 @@ public class LogsResources {
   private File getFileByName(File folder, final String name) {
     File[] files = folder.listFiles((dir, fileName) -> fileName.equals(name));
     if (files.length == 0) {
-      throw new DrillRuntimeException (name + " doesn't exist");
+      throw new DrillRuntimeException(name + " doesn't exist");
     }
     return files[0];
   }
@@ -159,9 +159,9 @@ public class LogsResources {
   @XmlRootElement
   public class Log implements Comparable<Log> {
 
-    private String name;
-    private long size;
-    private DateTime lastModified;
+    private final String name;
+    private final long size;
+    private final DateTime lastModified;
 
     @JsonCreator
     public Log (@JsonProperty("name") String name, @JsonProperty("size") long size, @JsonProperty("lastModified") long lastModified) {
@@ -190,9 +190,9 @@ public class LogsResources {
 
   @XmlRootElement
   public class LogContent {
-    private String name;
-    private Collection<String> lines;
-    private int maxLines;
+    private final String name;
+    private final Collection<String> lines;
+    private final int maxLines;
 
     @JsonCreator
     public LogContent (@JsonProperty("name") String name, @JsonProperty("lines") Collection<String> lines, @JsonProperty("maxLines") int maxLines) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/LogsResources.java
@@ -28,6 +28,8 @@ import org.glassfish.jersey.server.mvc.Viewable;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
@@ -56,7 +58,7 @@ import static org.apache.drill.exec.server.rest.auth.DrillUserPrincipal.ADMIN_RO
 @Path("/")
 @RolesAllowed(ADMIN_ROLE)
 public class LogsResources {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LogsResources.class);
+  private static final Logger logger = LoggerFactory.getLogger(LogsResources.class);
 
   @Inject DrillRestServer.UserAuthEnabled authEnabled;
   @Inject SecurityContext sc;
@@ -155,7 +157,6 @@ public class LogsResources {
     return files[0];
   }
 
-
   @XmlRootElement
   public class Log implements Comparable<Log> {
 
@@ -164,7 +165,9 @@ public class LogsResources {
     private final DateTime lastModified;
 
     @JsonCreator
-    public Log (@JsonProperty("name") String name, @JsonProperty("size") long size, @JsonProperty("lastModified") long lastModified) {
+    public Log (@JsonProperty("name") String name,
+                @JsonProperty("size") long size,
+                @JsonProperty("lastModified") long lastModified) {
       this.name = name;
       this.size = size;
       this.lastModified = new DateTime(lastModified);
@@ -195,7 +198,9 @@ public class LogsResources {
     private final int maxLines;
 
     @JsonCreator
-    public LogContent (@JsonProperty("name") String name, @JsonProperty("lines") Collection<String> lines, @JsonProperty("maxLines") int maxLines) {
+    public LogContent (@JsonProperty("name") String name,
+                       @JsonProperty("lines") Collection<String> lines,
+                       @JsonProperty("maxLines") int maxLines) {
       this.name = name;
       this.lines = lines;
       this.maxLines = maxLines;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/QueryWrapper.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.drill.common.PlanStringBuilder;
+import org.apache.drill.exec.proto.UserBitShared.QueryType;
 import org.apache.drill.shaded.guava.com.google.common.base.CharMatcher;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.parquet.Strings;
@@ -98,7 +99,7 @@ public class QueryWrapper {
   public static final class RestQueryBuilder {
 
     private String query;
-    private String queryType = "SQL";
+    private String queryType = QueryType.SQL.name();
     private int rowLimit;
     private String userName;
     private String defaultSchema;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/RestQueryRunner.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/RestQueryRunner.java
@@ -62,7 +62,7 @@ public class RestQueryRunner {
     this.options = webUserConnection.getSession().getOptions();
   }
 
-  public RestQueryRunner.QueryResult run() throws Exception {
+  public QueryResult run() throws Exception {
     applyUserName();
     applyOptions();
     applyDefaultSchema();
@@ -131,7 +131,7 @@ public class RestQueryRunner {
     return maxRows;
   }
 
-  public RestQueryRunner.QueryResult submitQuery(int maxRows) {
+  public QueryResult submitQuery(int maxRows) {
     final RunQuery runQuery = RunQuery.newBuilder()
         .setType(QueryType.valueOf(query.getQueryType()))
         .setPlan(query.getQuery())
@@ -161,7 +161,7 @@ public class RestQueryRunner {
       }
     } while (!isComplete && !nearlyOutOfHeapSpace);
 
-    //Fail if nearly out of heap space
+    // Fail if nearly out of heap space
     if (nearlyOutOfHeapSpace) {
       UserException almostOutOfHeapException = UserException.resourceError()
           .message("There is not enough heap memory to run this query using the web interface. ")
@@ -185,7 +185,7 @@ public class RestQueryRunner {
     return new QueryResult(queryId, webUserConnection, webUserConnection.results);
   }
 
-  //Detect possible excess heap
+  // Detect possible excess heap
   private float getHeapUsage() {
     return (float) memMXBean.getHeapMemoryUsage().getUsed() / memMXBean.getHeapMemoryUsage().getMax();
   }
@@ -198,15 +198,16 @@ public class RestQueryRunner {
     public final String queryState;
     public final int attemptedAutoLimit;
 
-    //DRILL-6847:  Modified the constructor so that the method has access to all the properties in webUserConnection
+    // DRILL-6847:  Modified the constructor so that the method has access
+    // to all the properties in webUserConnection
     public QueryResult(QueryId queryId, WebUserConnection webUserConnection, List<Map<String, String>> rows) {
-        this.queryId = QueryIdHelper.getQueryId(queryId);
-        this.columns = webUserConnection.columns;
-        this.metadata = webUserConnection.metadata;
-        this.queryState = webUserConnection.getQueryState();
-        this.rows = rows;
-        this.attemptedAutoLimit = webUserConnection.getAutoLimitRowCount();
-      }
+      this.queryId = QueryIdHelper.getQueryId(queryId);
+      this.columns = webUserConnection.columns;
+      this.metadata = webUserConnection.metadata;
+      this.queryState = webUserConnection.getQueryState();
+      this.rows = rows;
+      this.attemptedAutoLimit = webUserConnection.getAutoLimitRowCount();
+    }
 
     public String getQueryId() {
       return queryId;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebServer.java
@@ -262,12 +262,11 @@ public class WebServer implements AutoCloseable {
     responseHeadersSettingFilter.setInitParameters(ResponseHeadersSettingFilter.retrieveResponseHeaders(config));
     servletContextHandler.addFilter(responseHeadersSettingFilter, "/*", EnumSet.of(DispatcherType.REQUEST));
 
-
     return servletContextHandler;
   }
 
   /**
-   * It creates A {@link SessionHandler} which contains a {@link HashSessionManager}
+   * Create a {@link SessionHandler} which contains a {@link HashSessionManager}
    *
    * @param securityHandler Set of init parameters that are used by the Authentication
    * @return session handler
@@ -279,9 +278,7 @@ public class WebServer implements AutoCloseable {
     sessionManager.getSessionCookieConfig().setHttpOnly(true);
     sessionManager.addEventListener(new HttpSessionListener() {
       @Override
-      public void sessionCreated(HttpSessionEvent se) {
-
-      }
+      public void sessionCreated(HttpSessionEvent se) { }
 
       @Override
       public void sessionDestroyed(HttpSessionEvent se) {
@@ -338,8 +335,9 @@ public class WebServer implements AutoCloseable {
   }
 
   /**
-   * Create an HTTPS connector for given jetty server instance. If the admin has specified keystore/truststore settings
-   * they will be used else a self-signed certificate is generated and used.
+   * Create an HTTPS connector for given jetty server instance. If the admin has
+   * specified keystore/truststore settings they will be used else a self-signed
+   * certificate is generated and used.
    *
    * @return Initialized {@link ServerConnector} for HTTPS connections.
    */

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebSessionResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebSessionResources.java
@@ -22,22 +22,23 @@ import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.drill.exec.rpc.ChannelClosedException;
 import org.apache.drill.exec.rpc.user.UserSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 
 /**
- * Class holding all the resources required for Web User Session. This class is responsible for the proper cleanup of
- * all the resources.
+ * Holds the resources required for Web User Session. This class is responsible
+ * for the proper cleanup of all the resources.
  */
 public class WebSessionResources implements AutoCloseable {
+  private static final Logger logger = LoggerFactory.getLogger(WebSessionResources.class);
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WebSessionResources.class);
-
-  private BufferAllocator allocator;
+  private final BufferAllocator allocator;
 
   private final SocketAddress remoteAddress;
 
-  private UserSession webUserSession;
+  private final UserSession webUserSession;
 
   private ChannelPromise closeFuture;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/WebUserConnection.java
@@ -17,177 +17,128 @@
  */
 package org.apache.drill.exec.server.rest;
 
-import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.util.ValueVectorElementFormatter;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
 import org.apache.drill.shaded.guava.com.google.common.collect.Sets;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DrillBuf;
-import io.netty.channel.ChannelFuture;
-import org.apache.drill.common.exceptions.UserException;
+
 import org.apache.drill.common.types.TypeProtos;
-import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.physical.impl.materialize.QueryWritableBatch;
+import org.apache.drill.exec.physical.impl.materialize.QueryDataPackage;
 import org.apache.drill.exec.proto.GeneralRPCProtos.Ack;
-import org.apache.drill.exec.record.RecordBatchLoader;
+import org.apache.drill.exec.record.VectorAccessible;
+import org.apache.drill.exec.record.VectorContainer;
 import org.apache.drill.exec.record.VectorWrapper;
-import org.apache.drill.exec.rpc.AbstractDisposableUserClientConnection;
 import org.apache.drill.exec.rpc.Acks;
-import org.apache.drill.exec.rpc.ConnectionThrottle;
 import org.apache.drill.exec.rpc.RpcOutcomeListener;
-import org.apache.drill.exec.rpc.user.UserSession;
 import org.apache.drill.exec.vector.ValueVector.Accessor;
+import org.apache.drill.exec.record.BatchSchema;
 import org.apache.drill.exec.record.MaterializedField;
 
-import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.Set;
 
 /**
- * WebUserConnectionWrapper which represents the UserClientConnection between WebServer and Foreman, for the WebUser
- * submitting the query. It provides access to the UserSession executing the query. There is no actual physical
+ * {@code WebUserConnectionWrapper} which represents the {@code UserClientConnection} between
+ * WebServer and Foreman, for the WebUser submitting the query. It provides
+ * access to the {@code UserSession} executing the query. There is no actual physical
  * channel corresponding to this connection wrapper.
  *
- * It returns a close future with no actual underlying {@link io.netty.channel.Channel} associated with it but do have an
- * EventExecutor out of BitServer EventLoopGroup. Since there is no actual connection established using this class,
- * hence the close event will never be fired by underlying layer and close future is set only when the
+ * It returns a close future with no actual underlying
+ * {@link io.netty.channel.Channel} associated with it but do have an
+ * {@code EventExecutor} out of BitServer EventLoopGroup. Since there is no actual
+ * connection established using this class, hence the close event will never be
+ * fired by underlying layer and close future is set only when the
  * {@link WebSessionResources} are closed.
  */
-
-public class WebUserConnection extends AbstractDisposableUserClientConnection implements ConnectionThrottle {
-
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WebUserConnection.class);
-
-  protected WebSessionResources webSessionResources;
+public class WebUserConnection extends BaseWebUserConnection {
 
   public final List<Map<String, String>> results = Lists.newArrayList();
-
   public final Set<String> columns = Sets.newLinkedHashSet();
-
   public final List<String> metadata = new ArrayList<>();
-
   private int autoLimitRowCount;
+  private int rowCount;
 
   WebUserConnection(WebSessionResources webSessionResources) {
-    this.webSessionResources = webSessionResources;
+    super(webSessionResources);
   }
 
   @Override
-  public UserSession getSession() {
-    return webSessionResources.getSession();
+  public void sendData(RpcOutcomeListener<Ack> listener, QueryDataPackage data) {
+    processBatch(data.batch());
+    listener.success(Acks.OK, null);
   }
 
-  @Override
-  public void sendData(RpcOutcomeListener<Ack> listener, QueryWritableBatch result) {
-    // There can be overflow here but DrillBuf doesn't support allocating with
-    // bytes in long. Hence we are just preserving the earlier behavior and logging debug log for the case.
-    final int dataByteCount = (int) result.getByteCount();
-
-    if (dataByteCount < 0) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("There is BufferOverflow in dataByteCount: {}",
-            dataByteCount);
-      }
-      listener.success(Acks.OK, null);
+  private void processBatch(VectorContainer batch) {
+    if (batch == null) {
+      // Empty query: no data, no schema.
       return;
     }
 
-    // Create a ByteBuf with all the data in it.
-    final int rows = result.getHeader().getRowCount();
-    final BufferAllocator allocator = webSessionResources.getAllocator();
-    final DrillBuf bufferWithData = allocator.buffer(dataByteCount);
-    try {
-      final ByteBuf[] resultDataBuffers = result.getBuffers();
+    // Build metadata only on first batch, or if the schema changes
+    if (metadata.isEmpty() || batch.isSchemaChanged()) {
+      columns.clear();
+      metadata.clear();
+      buildMetadata(batch.getSchema());
+    }
+    addResults(batch.getRecordCount(), batch);
+    batch.zeroVectors();
+  }
 
-      for (final ByteBuf buffer : resultDataBuffers) {
-        bufferWithData.writeBytes(buffer);
-        buffer.release();
-      }
+  private void buildMetadata(BatchSchema schema) {
+    for (int i = 0; i < schema.getFieldCount(); ++i) {
+      // DRILL-6847:  This section adds query metadata to the REST results
+      MaterializedField col = schema.getColumn(i);
+      columns.add(col.getName());
+      StringBuilder dataType = new StringBuilder(col.getType().getMinorType().name());
 
-      final RecordBatchLoader loader = new RecordBatchLoader(allocator);
-      try {
-        loader.load(result.getHeader().getDef(), bufferWithData);
-        // TODO:  Clean:  DRILL-2933:  That load(...) no longer throws
-        // SchemaChangeException, so check/clean catch clause below.
-        for (int i = 0; i < loader.getSchema().getFieldCount(); ++i) {
-          //DRILL-6847:  This section adds query metadata to the REST results
-          MaterializedField col = loader.getSchema().getColumn(i);
-          columns.add(col.getName());
-          StringBuilder dataType = new StringBuilder(col.getType().getMinorType().name());
+      // For DECIMAL type
+      if (col.getType().hasPrecision()) {
+        dataType.append("(");
+        dataType.append(col.getType().getPrecision());
 
-          //For DECIMAL type
-          if (col.getType().hasPrecision()) {
-            dataType.append("(");
-            dataType.append(col.getType().getPrecision());
-
-            if (col.getType().hasScale()) {
-              dataType.append(", ");
-              dataType.append(col.getType().getScale());
-            }
-
-            dataType.append(")");
-          } else if (col.getType().hasWidth()) {
-            //Case for VARCHAR columns with specified width
-            dataType.append("(");
-            dataType.append(col.getType().getWidth());
-            dataType.append(")");
-          }
-          metadata.add(dataType.toString());
+        if (col.getType().hasScale()) {
+          dataType.append(", ");
+          dataType.append(col.getType().getScale());
         }
-        ValueVectorElementFormatter formatter = new ValueVectorElementFormatter(webSessionResources.getSession().getOptions());
-        for (int i = 0; i < rows; ++i) {
-          final Map<String, String> record = Maps.newHashMap();
-          for (VectorWrapper<?> vw : loader) {
-            final String field = vw.getValueVector().getMetadata().getNamePart().getName();
-            final TypeProtos.MinorType fieldMinorType = vw.getValueVector().getMetadata().getMajorType().getMinorType();
-            final Accessor accessor = vw.getValueVector().getAccessor();
-            final Object value = i < accessor.getValueCount() ? accessor.getObject(i) : null;
-            final String display = value == null ? null : formatter.format(value, fieldMinorType);
-            record.put(field, display);
-          }
-          results.add(record);
-        }
-      } finally {
-        loader.clear();
+
+        dataType.append(")");
+      } else if (col.getType().hasWidth()) {
+        // Case for VARCHAR columns with specified width
+        dataType.append("(");
+        dataType.append(col.getType().getWidth());
+        dataType.append(")");
       }
-    } catch (Exception e) {
-      boolean verbose = webSessionResources.getSession().getOptions().getBoolean(ExecConstants.ENABLE_VERBOSE_ERRORS_KEY);
-      // Wrapping the exception into UserException and then into DrillPBError.
-      // It will be thrown as exception in QueryWrapper class.
-      // It's verbosity depends on system option "exec.errors.verbose".
-      error = UserException.systemError(e).build(logger).getOrCreatePBError(verbose);
-    } finally {
-      // Notify the listener with ACK.OK both in error/success case because data was send successfully from Drillbit.
-      bufferWithData.release();
-      listener.success(Acks.OK, null);
+      metadata.add(dataType.toString());
     }
   }
 
-  @Override
-  public ChannelFuture getChannelClosureFuture() {
-    return webSessionResources.getCloseFuture();
-  }
-
-  @Override
-  public SocketAddress getRemoteAddress() {
-    return webSessionResources.getRemoteAddress();
-  }
-
-  @Override
-  public void setAutoRead(boolean enableAutoRead) {
-    // no-op
+  private void addResults(int rows, VectorAccessible batch) {
+    ValueVectorElementFormatter formatter = new ValueVectorElementFormatter(webSessionResources.getSession().getOptions());
+    if (autoLimitRowCount > 0) {
+      rows = Math.max(0, Math.min(rows, autoLimitRowCount - rowCount));
+    }
+    for (int i = 0; i < rows; ++i) {
+      rowCount++;
+      final Map<String, String> record = Maps.newHashMap();
+      for (VectorWrapper<?> vw : batch) {
+        final String field = vw.getValueVector().getMetadata().getNamePart().getName();
+        final TypeProtos.MinorType fieldMinorType = vw.getValueVector().getMetadata().getMajorType().getMinorType();
+        final Accessor accessor = vw.getValueVector().getAccessor();
+        final Object value = i < accessor.getValueCount() ? accessor.getObject(i) : null;
+        final String display = value == null ? null : formatter.format(value, fieldMinorType);
+        record.put(field, display);
+      }
+      results.add(record);
+    }
   }
 
   /**
    * For authenticated WebUser no cleanup of {@link WebSessionResources} is done since it's re-used
    * for all the queries until lifetime of the web session.
    */
-  public void cleanupSession() {
-    // no-op
-  }
+  public void cleanupSession() { }
 
   public static class AnonWebUserConnection extends WebUserConnection {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/WorkManager.java
@@ -21,6 +21,8 @@ import com.codahale.metrics.Gauge;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.drill.shaded.guava.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.drill.common.SelfCleaningRunnable;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.exec.coord.ClusterCoordinator;
@@ -60,11 +62,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Manages the running fragments in a Drillbit. Periodically requests run-time stats updates from fragments
- * running elsewhere.
+ * Manages the running fragments in a Drillbit. Periodically requests run-time
+ * stats updates from fragments running elsewhere.
  */
 public class WorkManager implements AutoCloseable {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WorkManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(WorkManager.class);
 
   private static final int EXIT_TIMEOUT_MS = 5000;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/UserWorker.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/work/user/UserWorker.java
@@ -41,9 +41,11 @@ import org.apache.drill.exec.work.foreman.Foreman;
 import org.apache.drill.exec.work.metadata.MetadataProvider;
 import org.apache.drill.exec.work.metadata.ServerMetaProvider.ServerMetaWorker;
 import org.apache.drill.exec.work.prepare.PreparedStatementProvider.PreparedStatementWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserWorker{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UserWorker.class);
+  static final Logger logger = LoggerFactory.getLogger(UserWorker.class);
 
   private final WorkerBee bee;
   private final QueryCountIncrementer incrementer = new QueryCountIncrementer() {

--- a/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
+++ b/exec/memory/base/src/main/java/io/netty/buffer/DrillBuf.java
@@ -42,8 +42,9 @@ import org.slf4j.LoggerFactory;
 import io.netty.util.internal.PlatformDependent;
 
 /**
- * Drill data structure for accessing and manipulating data buffers. This class is integrated with the
- * Drill memory management layer for quota enforcement and buffer sharing.
+ * Drill data structure for accessing and manipulating data buffers. This class
+ * is integrated with the Drill memory management layer for quota enforcement
+ * and buffer sharing.
  */
 @SuppressWarnings("unused")
 public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
@@ -121,18 +122,22 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
-   * Create a new DrillBuf that is associated with an alternative allocator for the purposes of memory ownership and
-   * accounting. This has no impact on the reference counting for the current DrillBuf except in the situation where the
-   * passed in Allocator is the same as the current buffer.
+   * Create a new DrillBuf that is associated with an alternative allocator for
+   * the purposes of memory ownership and accounting. This has no impact on the
+   * reference counting for the current DrillBuf except in the situation where
+   * the passed in Allocator is the same as the current buffer.
    *
-   * This operation has no impact on the reference count of this DrillBuf. The newly created DrillBuf with either have a
-   * reference count of 1 (in the case that this is the first time this memory is being associated with the new
-   * allocator) or the current value of the reference count + 1 for the other AllocationManager/BufferLedger combination
-   * in the case that the provided allocator already had an association to this underlying memory.
+   * This operation has no impact on the reference count of this DrillBuf. The
+   * newly created DrillBuf with either have a reference count of 1 (in the case
+   * that this is the first time this memory is being associated with the new
+   * allocator) or the current value of the reference count + 1 for the other
+   * AllocationManager/BufferLedger combination in the case that the provided
+   * allocator already had an association to this underlying memory.
    *
    * @param target
    *          The target allocator to create an association with.
-   * @return A new DrillBuf which shares the same underlying memory as this DrillBuf.
+   * @return A new DrillBuf which shares the same underlying memory as this
+   *         DrillBuf.
    */
   public DrillBuf retain(BufferAllocator target) {
 
@@ -148,28 +153,35 @@ public final class DrillBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
-   * Transfer the memory accounting ownership of this DrillBuf to another allocator. This will generate a new DrillBuf
-   * that carries an association with the underlying memory of this DrillBuf. If this DrillBuf is connected to the
-   * owning BufferLedger of this memory, that memory ownership/accounting will be transferred to the target allocator. If
-   * this DrillBuf does not currently own the memory underlying it (and is only associated with it), this does not
-   * transfer any ownership to the newly created DrillBuf.
+   * Transfer the memory accounting ownership of this DrillBuf to another
+   * allocator. This will generate a new DrillBuf that carries an association
+   * with the underlying memory of this DrillBuf. If this DrillBuf is connected
+   * to the owning BufferLedger of this memory, that memory ownership/accounting
+   * will be transferred to the target allocator. If this DrillBuf does not
+   * currently own the memory underlying it (and is only associated with it),
+   * this does not transfer any ownership to the newly created DrillBuf.
    * <p>
-   * This operation has no impact on the reference count of this DrillBuf. The newly created DrillBuf with either have a
-   * reference count of 1 (in the case that this is the first time this memory is being associated with the new
-   * allocator) or the current value of the reference count for the other AllocationManager/BufferLedger combination in
-   * the case that the provided allocator already had an association to this underlying memory.
+   * This operation has no impact on the reference count of this DrillBuf. The
+   * newly created DrillBuf with either have a reference count of 1 (in the case
+   * that this is the first time this memory is being associated with the new
+   * allocator) or the current value of the reference count for the other
+   * AllocationManager/BufferLedger combination in the case that the provided
+   * allocator already had an association to this underlying memory.
    * <p>
-   * Transfers will always succeed, even if that puts the other allocator into an overlimit situation. This is possible
-   * due to the fact that the original owning allocator may have allocated this memory out of a local reservation
-   * whereas the target allocator may need to allocate new memory from a parent or RootAllocator. This operation is done
-   * in a mostly-lockless but consistent manner. As such, the overlimit==true situation could occur slightly prematurely
-   * to an actual overlimit==true condition. This is simply conservative behavior which means we may return overlimit
-   * slightly sooner than is necessary.
+   * Transfers will always succeed, even if that puts the other allocator into
+   * an overlimit situation. This is possible due to the fact that the original
+   * owning allocator may have allocated this memory out of a local reservation
+   * whereas the target allocator may need to allocate new memory from a parent
+   * or RootAllocator. This operation is done in a mostly-lockless but
+   * consistent manner. As such, the overlimit==true situation could occur
+   * slightly prematurely to an actual overlimit==true condition. This is simply
+   * conservative behavior which means we may return overlimit slightly sooner
+   * than is necessary.
    *
    * @param target
    *          The allocator to transfer ownership to.
-   * @return A new transfer result with the impact of the transfer (whether it was overlimit) as well as the newly
-   *         created DrillBuf.
+   * @return A new transfer result with the impact of the transfer (whether it
+   *         was overlimit) as well as the newly created DrillBuf.
    */
   public TransferResult transferOwnership(BufferAllocator target) {
 

--- a/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
+++ b/exec/memory/base/src/main/java/org/apache/drill/exec/memory/AllocationManager.java
@@ -43,11 +43,11 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  * UDLE. Ensures that one allocator owns the memory that multiple allocators may
  * be referencing. Manages a BufferLedger between each of its associated
  * allocators. This class is also responsible for managing when memory is
- * allocated and returned to the Netty-based PooledByteBufAllocatorL.
- *
+ * allocated and returned to the Netty-based {code PooledByteBufAllocatorL}.
+ * <p>
  * The only reason that this isn't package private is we're forced to put
  * DrillBuf in Netty's package which need access to these objects or methods.
- *
+ * <p>
  * Threading: AllocationManager manages thread-safety internally. Operations
  * within the context of a single BufferLedger are lockless in nature and can be
  * leveraged by multiple threads. Operations that cross the context of two
@@ -56,7 +56,6 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  * allocation. As such, there will be thousands of these in a typical query. The
  * contention of acquiring a lock on AllocationManager should be very low.
  */
-
 public class AllocationManager {
 
   private static final AtomicLong MANAGER_ID_GENERATOR = new AtomicLong(0);
@@ -151,7 +150,6 @@ public class AllocationManager {
    * AllocationManager that it now longer needs to hold a reference to
    * particular piece of memory.
    */
-
   private class ReleaseListener {
 
     private final BufferAllocator allocator;
@@ -163,7 +161,6 @@ public class AllocationManager {
     /**
      * Can only be called when you already hold the writeLock.
      */
-
     public void release() {
       allocator.assertOpen();
 
@@ -200,7 +197,6 @@ public class AllocationManager {
    * only reason this is public is due to DrillBuf being in io.netty.buffer
    * package.
    */
-
   public class BufferLedger {
 
     private final IdentityHashMap<DrillBuf, Object> buffers =
@@ -223,8 +219,10 @@ public class AllocationManager {
     }
 
     /**
-     * Transfer any balance the current ledger has to the target ledger. In the case that the current ledger holds no
-     * memory, no transfer is made to the new ledger.
+     * Transfer any balance the current ledger has to the target ledger. In the
+     * case that the current ledger holds no memory, no transfer is made to the
+     * new ledger.
+     *
      * @param target
      *          The ledger to transfer ownership account to.
      * @return Whether transfer fit within target ledgers limits.
@@ -241,8 +239,8 @@ public class AllocationManager {
         return true;
       }
 
-      // since two balance transfers out from the allocator manager could cause incorrect accounting, we need to ensure
-      // that this won't happen by synchronizing on the allocator manager instance.
+      // since two balance transfers out from the allocator manager could cause incorrect accounting,
+      // we need to ensure that this won't happen by synchronizing on the allocator manager instance.
       try (@SuppressWarnings("unused") Closeable write = writeLock.open()) {
         if (owningLedger != this) {
           return true;
@@ -316,7 +314,6 @@ public class AllocationManager {
      * zero, this ledger should release its ownership back to the
      * AllocationManager
      */
-
     public int decrement(int decrement) {
       allocator.assertOpen();
 
@@ -346,7 +343,6 @@ public class AllocationManager {
      * @param allocator
      * @return The ledger associated with a particular BufferAllocator.
      */
-
     public BufferLedger getLedgerForAllocator(BufferAllocator allocator) {
       return associate((BaseAllocator) allocator);
     }
@@ -362,7 +358,6 @@ public class AllocationManager {
      * @return A new DrillBuf that shares references with all DrillBufs
      *         associated with this BufferLedger
      */
-
     public DrillBuf newDrillBuf(int offset, int length) {
       allocator.assertOpen();
       return newDrillBuf(offset, length, null);
@@ -411,7 +406,6 @@ public class AllocationManager {
      *
      * @return Size in bytes
      */
-
     public int getSize() {
       return size;
     }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BaseRpcOutcomeListener.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/BaseRpcOutcomeListener.java
@@ -20,20 +20,16 @@ package org.apache.drill.exec.rpc;
 import io.netty.buffer.ByteBuf;
 
 public class BaseRpcOutcomeListener<T> implements RpcOutcomeListener<T> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseRpcOutcomeListener.class);
 
   @Override
-  public void failed(RpcException ex) {
-  }
+  public void failed(RpcException ex) { }
 
   @Override
-  public void success(T value, ByteBuf buffer) {
-  }
+  public void success(T value, ByteBuf buffer) { }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void interrupted(final InterruptedException ex) {
-  }
+  public void interrupted(final InterruptedException ex) { }
 }

--- a/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcOutcomeListener.java
+++ b/exec/rpc/src/main/java/org/apache/drill/exec/rpc/RpcOutcomeListener.java
@@ -27,13 +27,11 @@ public interface RpcOutcomeListener<V> {
    */
   void failed(RpcException ex);
 
-
   void success(V value, ByteBuf buffer);
 
   /**
-   * Called when the sending thread is interrupted. Possible when the fragment is cancelled due to query cancellations or
-   * failures.
+   * Called when the sending thread is interrupted. Possible when the fragment
+   * is cancelled due to query cancellations or failures.
    */
   void interrupted(final InterruptedException e);
-
 }


### PR DESCRIPTION
# DRILL-7730](https://issues.apache.org/jira/browse/DRILL-7730): Improve web query efficiency

## Description

Drill provides a REST API to run queries: `http://<host>:8047/query` and `/query.json`. This PR improves the memory efficiency of these queries.

Drill runs queries as a DAG of operators, rooted on the "Screen" operator. The Screen operator takes each output batch of the query and hands it over to a `UserClientConnection` object. The original design is that `UserClientConnection` corresponded to an RPC connection. So, the Screen operator converted the vectors in the outgoing batch into a `QueryWritableBatch` which is an ordered list of buffers ready to send via Netty.

When the REST API was added, the simplest thing was to add a new REST-specific version of `UserClientConnection`, called `WebUserConnection`. Rather than sending our list of buffers off to the network, the web version converts the buffers back into a set of value vectors using the same deserialization code used in the Drill client. However, that deserialization code needs the data in the form of a single large buffer. So, the REST code copies the entire batch from the list of buffers into one large direct memory buffer. Then it converts that back into vectors.

Clearly, all this work simply gets us back where we started: the Screen operator has a batch of vectors, the `WebUserConnection` recreates them, consuming lots of memory and CPU in the process. All of this work occurs in the query thread (not the REST request thread), making the query more costly than necessary.

So, the major part of this PR is to avoid the copy: allow the REST code to work with the batch given to Screen.

This is done by creating a new level of indirection, the `QueryDataPackage` class. Now, Screen simply wraps the outgoing batch of vectors in a data package and hands that off to the `UserClientConnection`. The RPC version calls a method which does the conversion from vectors into a list of buffers. But, the REST version calls a different method which returns the original batch of vectors. Voila, no more copying and no more extra direct memory overhead.

The `WebUserConnection` use the vectors to create three on-heap structures: a list of column names, a list of column types, and a list of maps of rows. The rows are particularly inefficient and will be addressed in a separate PR. As it turns out, the code that handled the column and metadata list had a bug: every incoming batch of data would append another copy to the in-memory list, resulting in many redundant objects. That bug is fixed in this PR.

The work to understand all this resulted in "grand tour" of parts of Drill. Much code cleanup resulted. Also, WebUserConnection` is split into two classes as part of the next phase (removing the on-heap buffered results.)

## Documentation

N/A: the user visible behavior of Drill is unchanged (though REST queries might be a bit faster.)

## Testing

Reran all unit tests. Though, to be fair, the test suite include basically no tests of the REST API. The test run instead ensured that nothing was broken in the main RPC pathway.
