### PR TITLE
DRILL-7707: Unable to analyze table metadata is it resides in non-writable workspace

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
+++ b/exec/java-exec/src/main/java/org/apache/calcite/jdbc/DynamicRootSchema.java
@@ -22,11 +22,11 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.calcite.util.BuiltInMethod;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserExceptionUtils;
 import org.apache.drill.exec.planner.sql.SchemaUtilites;
+import org.apache.drill.exec.store.AbstractSchema;
 import org.apache.drill.exec.store.SchemaConfig;
 import org.apache.drill.exec.store.StoragePlugin;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,12 +47,14 @@ import java.util.List;
 public class DynamicRootSchema extends DynamicSchema {
   private static final Logger logger = LoggerFactory.getLogger(DynamicRootSchema.class);
 
+  private static final String ROOT_SCHEMA_NAME = "";
+
   private final SchemaConfig schemaConfig;
   private final StoragePluginRegistry storages;
 
   /** Creates a root schema. */
   DynamicRootSchema(StoragePluginRegistry storages, SchemaConfig schemaConfig) {
-    super(null, new RootSchema(), "");
+    super(null, new RootSchema(), ROOT_SCHEMA_NAME);
     this.schemaConfig = schemaConfig;
     this.storages = storages;
   }
@@ -131,6 +134,16 @@ public class DynamicRootSchema extends DynamicSchema {
   }
 
   static class RootSchema extends AbstractSchema {
+
+    public RootSchema() {
+      super(Collections.emptyList(), ROOT_SCHEMA_NAME);
+    }
+
+    @Override
+    public String getTypeName() {
+      return ROOT_SCHEMA_NAME;
+    }
+
     @Override public Expression getExpression(SchemaPlus parentSchema,
                                               String name) {
       return Expressions.call(

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/sql/SchemaUtilites.java
@@ -216,7 +216,7 @@ public class SchemaUtilites {
       throwSchemaNotFoundException(defaultSchema, SCHEMA_PATH_JOINER.join(schemaPath));
     }
 
-    if (isRootSchema(schema)) {
+    if (checkMutable && isRootSchema(schema)) {
       throw UserException.validationError()
           .message("Root schema is immutable. Drill does not allow creating or deleting tables or views in the root schema. " +
               "Select a schema using 'USE schema' command.")
@@ -224,7 +224,7 @@ public class SchemaUtilites {
     }
 
     final AbstractSchema drillSchema = unwrapAsDrillSchemaInstance(schema);
-    if (!drillSchema.isMutable()) {
+    if (checkMutable && !drillSchema.isMutable()) {
       throw UserException.validationError()
           .message("Unable to create or drop objects. Schema [%s] is immutable.", getSchemaPath(schema))
           .build(logger);

--- a/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/ClusterFixture.java
@@ -481,9 +481,19 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
 
   public void defineWorkspace(String pluginName, String schemaName, String path,
       String defaultFormat, FormatPluginConfig format) {
+    defineWorkspace(pluginName, schemaName, path, defaultFormat, format, true);
+  }
+
+  public void defineImmutableWorkspace(String pluginName, String schemaName, String path,
+      String defaultFormat, FormatPluginConfig format) {
+    defineWorkspace(pluginName, schemaName, path, defaultFormat, format, false);
+  }
+
+  private void defineWorkspace(String pluginName, String schemaName, String path,
+      String defaultFormat, FormatPluginConfig format, boolean writable) {
     for (Drillbit bit : drillbits()) {
       try {
-        defineWorkspace(bit, pluginName, schemaName, path, defaultFormat, format);
+        defineWorkspace(bit, pluginName, schemaName, path, defaultFormat, format, writable);
       } catch (PluginException e) {
         // This functionality is supposed to work in tests. Change
         // exception to unchecked to make test code simpler.
@@ -496,11 +506,11 @@ public class ClusterFixture extends BaseFixture implements AutoCloseable {
   }
 
   private void defineWorkspace(Drillbit drillbit, String pluginName,
-      String schemaName, String path, String defaultFormat, FormatPluginConfig format)
+      String schemaName, String path, String defaultFormat, FormatPluginConfig format, boolean writable)
       throws PluginException {
     final StoragePluginRegistry pluginRegistry = drillbit.getContext().getStorage();
     final FileSystemConfig pluginConfig = (FileSystemConfig) pluginRegistry.getStoredConfig(pluginName);
-    final WorkspaceConfig newTmpWSConfig = new WorkspaceConfig(path, true, defaultFormat, false);
+    final WorkspaceConfig newTmpWSConfig = new WorkspaceConfig(path, writable, defaultFormat, false);
 
     Map<String, WorkspaceConfig> newWorkspaces = new HashMap<>();
     Optional.ofNullable(pluginConfig.getWorkspaces())


### PR DESCRIPTION
# [DRILL-7707](https://issues.apache.org/jira/browse/DRILL-7707): Unable to analyze table metadata is it resides in non-writable workspace

## Description
Fixed checking mutability of workspace in `SchemaUtilites.resolveToDrillSchemaInternal()` method. Replaced base class of `RootSchema` to fix exception when root schema is used.
Please note, that for `cp` storage plugin, it is still impossible to do `analyze` since classpath file system cannot list files.

## Documentation
NA

## Testing
Added tests for cases from Jira ticket.
