### PR TITLE
DRILL-7739: Allow implicit casts from required to nullable data type

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/TypeCastRules.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/resolver/TypeCastRules.java
@@ -877,8 +877,10 @@ public class TypeCastRules {
       for (int i = varArgIndex; i < numOfArgs; i++) {
         if (holder.isFieldReader(varArgIndex)) {
           break;
-        } else if (holder.getParamMajorType(varArgIndex).getMode() != argumentTypes.get(i).getMode()) {
+        } else if (holder.getParamMajorType(varArgIndex).getMode() == DataMode.REQUIRED
+            && holder.getParamMajorType(varArgIndex).getMode() != argumentTypes.get(i).getMode()) {
           // prohibit using vararg functions for types with different nullability
+          // if function accepts required arguments, but provided optional
           return -1;
         }
       }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarArgFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/fn/impl/TestVarArgFunctions.java
@@ -18,7 +18,6 @@
 package org.apache.drill.exec.fn.impl;
 
 import org.apache.drill.common.exceptions.DrillRuntimeException;
-import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.test.ClusterFixture;
 import org.apache.drill.test.ClusterTest;
@@ -99,10 +98,22 @@ public class TestVarArgFunctions extends ClusterTest {
 
   @Test
   public void testVarargUdfWithDifferentDataModes() throws Exception {
-    thrown.expect(UserException.class);
-    thrown.expectMessage(containsString("Missing function implementation: [concat_varchar"));
-    run("SELECT concat_varchar(first_name, ' ', last_name) as c1\n" +
-        "from cp.`employee.json` limit 10");
+    testBuilder()
+        .sqlQuery("SELECT concat_varchar(first_name, ' ', last_name) as c1\n" +
+          "from cp.`employee.json` limit 10")
+        .unOrdered()
+        .baselineColumns("c1")
+        .baselineValues("Sheri Nowmer")
+        .baselineValues("Derrick Whelply")
+        .baselineValues("Michael Spence")
+        .baselineValues("Maya Gutierrez")
+        .baselineValues("Roberta Damstra")
+        .baselineValues("Rebecca Kanagaki")
+        .baselineValues("Kim Brunner")
+        .baselineValues("Brenda Blumberg")
+        .baselineValues("Darren Stanz")
+        .baselineValues("Jonathan Murraiin")
+        .go();
   }
 
   @Test


### PR DESCRIPTION
# [DRILL-7739](https://issues.apache.org/jira/browse/DRILL-7739): Allow implicit casts from required to nullable data type

## Description
Added code to insert a cast of function argument to nullable type for the case when requiring nullable one, but required is provided.

## Documentation
NA

## Testing
Reran all unit tests.
