### PR TITLE
DRILL-7744: Move Filters from HTTP Storage Plugin to Drill Core

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpPushDownListener.java
@@ -17,12 +17,6 @@
  */
 package org.apache.drill.exec.store.http;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.common.map.CaseInsensitiveMap;
@@ -30,12 +24,18 @@ import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.ops.OptimizerRulesContext;
 import org.apache.drill.exec.physical.base.GroupScan;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
-import org.apache.drill.exec.store.http.filter.ExprNode;
-import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
-import org.apache.drill.exec.store.http.filter.ExprNode.ColRelOpConstNode;
-import org.apache.drill.exec.store.http.filter.ExprNode.OrNode;
-import org.apache.drill.exec.store.http.filter.FilterPushDownListener;
-import org.apache.drill.exec.store.http.filter.FilterPushDownStrategy;
+import org.apache.drill.exec.store.base.filter.ExprNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.ColRelOpConstNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.OrNode;
+import org.apache.drill.exec.store.base.filter.FilterPushDownListener;
+import org.apache.drill.exec.store.base.filter.FilterPushDownStrategy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The HTTP storage plugin accepts filters which are:

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpStoragePlugin.java
@@ -26,7 +26,7 @@ import org.apache.drill.exec.planner.PlannerPhase;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.AbstractStoragePlugin;
 import org.apache.drill.exec.store.SchemaConfig;
-import org.apache.drill.exec.store.http.filter.FilterPushDownUtils;
+import org.apache.drill.exec.store.base.filter.FilterPushDownUtils;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ConstantHolder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ConstantHolder.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 import java.math.BigDecimal;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ExprNode.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/ExprNode.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 import java.util.List;
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownListener.java
@@ -15,14 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 import java.util.List;
 
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 import org.apache.drill.exec.physical.base.GroupScan;
-import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.AndNode;
 
 /**
  * Call-back (listener) implementation for a push-down filter.

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownStrategy.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,8 +42,8 @@ import org.apache.drill.exec.planner.logical.RelOptHelper;
 import org.apache.drill.exec.planner.physical.FilterPrel;
 import org.apache.drill.exec.planner.physical.PrelUtil;
 import org.apache.drill.exec.store.StoragePluginOptimizerRule;
-import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
-import org.apache.drill.exec.store.http.filter.FilterPushDownListener.ScanPushDownListener;
+import org.apache.drill.exec.store.base.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.base.filter.FilterPushDownListener.ScanPushDownListener;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 
 /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownUtils.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/FilterPushDownUtils.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,9 +41,9 @@ import org.apache.drill.common.expression.ValueExpressions.VarDecimalExpression;
 import org.apache.drill.common.expression.visitors.AbstractExprVisitor;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.exec.planner.PlannerPhase;
-import org.apache.drill.exec.store.http.filter.ExprNode.AndNode;
-import org.apache.drill.exec.store.http.filter.ExprNode.ColRelOpConstNode;
-import org.apache.drill.exec.store.http.filter.ExprNode.OrNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.AndNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.ColRelOpConstNode;
+import org.apache.drill.exec.store.base.filter.ExprNode.OrNode;
 
 public class FilterPushDownUtils {
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/base/filter/RelOp.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.drill.exec.store.http.filter;
+package org.apache.drill.exec.store.base.filter;
 
 /**
  * Fixed set of Drill relational operators, using well-defined


### PR DESCRIPTION
# [DRILL-7744](https://issues.apache.org/jira/browse/DRILL-7744): Move Filters from HTTP Storage Plugin to Drill Core

## Description
This PR moves the filter abstraction code used in the HTTP plugin to Drill core.  This enables other storage plugins to use this code. 

## Documentation
No user visible changes.

## Testing
Ran tests for HTTP plugin. 
