### PR TITLE
DRILL-7749: Drill-on-Yarn Application Master UI is broken due to boot…

### DIFF
--- a/drill-yarn/src/main/resources/drill-am/generic.ftl
+++ b/drill-yarn/src/main/resources/drill-am/generic.ftl
@@ -34,7 +34,7 @@
       <link href="/static/css/bootstrap.min.css" rel="stylesheet">
       <link href="/drill-am/static/css/drill-am.css" rel="stylesheet">
 
-      <script src="/static/js/jquery.min.js"></script>
+      <script src="/static/js/jquery-3.4.1.min.js"></script>
       <script src="/static/js/bootstrap.min.js"></script>
 
       <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -46,10 +46,10 @@
       <@page_head/>
     </head>
     <body role="document">
-      <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+      <div class="navbar navbar-dark bg-dark fixed-top navbar-expand" role="navigation">
         <div class="container-fluid">
           <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <button type="button" class="navbar-toggler" data-toggle="collapse" data-target=".navbar-collapse">
               <span class="sr-only">Toggle navigation</span>
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
@@ -58,19 +58,19 @@
             <a class="navbar-brand" href="/">Apache Drill</a>
           </div>
           <div class="navbar-collapse collapse">
-            <ul class="nav navbar-nav">
-              <li><a href="/config">Configuration</a></li>
-              <li><a href="/drillbits">Drillbits</a></li>
-              <li><a href="/manage">Manage</a></li>
-              <li><a href="/history">History</a></li>
+            <ul class="nav navbar-nav mr-auto">
+              <li class="nav-item"><a class="nav-link" href="/config">Configuration</a></li>
+              <li class="nav-item"><a class="nav-link" href="/drillbits">Drillbits</a></li>
+              <li class="nav-item"><a class="nav-link" href="/manage">Manage</a></li>
+              <li class="nav-item"><a class="nav-link" href="/history">History</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-              <li><a href="${docsLink}">Documentation</a>
+              <li class="nav-item"><a class="nav-link" href="${docsLink}">Documentation</a>
               <#if showLogin == true >
-              <li><a href="/login">Log In</a>
+              <li class="nav-item"><a class="nav-link" href="/login">Log In</a>
               </#if>
               <#if showLogout == true >
-              <li><a href="/logout">Log Out (${loggedInUserName})</a>
+              <li class="nav-item"><a class="nav-link" href="/logout">Log Out (${loggedInUserName})</a>
              </#if>
             </ul>
           </div>

--- a/drill-yarn/src/main/resources/drill-am/history.ftl
+++ b/drill-yarn/src/main/resources/drill-am/history.ftl
@@ -18,9 +18,6 @@
 
 -->
 <#include "*/generic.ftl">
-<#macro page_head>
-  <meta http-equiv="refresh" content="${refreshSecs}" >
-</#macro>
 
 <#macro page_body>
   <h4>Drillbit History</h4>

--- a/drill-yarn/src/main/resources/drill-am/index.ftl
+++ b/drill-yarn/src/main/resources/drill-am/index.ftl
@@ -19,7 +19,6 @@
 -->
 <#include "*/generic.ftl">
 <#macro page_head>
-  <meta http-equiv="refresh" content="${model.getRefreshSecs( )}" >
 </#macro>
 
 <#macro page_body>

--- a/drill-yarn/src/main/resources/drill-am/static/css/drill-am.css
+++ b/drill-yarn/src/main/resources/drill-am/static/css/drill-am.css
@@ -10,7 +10,7 @@
   language governing permissions and limitations under the License. */
   
 body {
-  padding-top: 50px;
+  padding-top: 80px;
 }
 .drill-am {
   padding: 0 15px 20px 15px;

--- a/drill-yarn/src/main/resources/drill-am/tasks.ftl
+++ b/drill-yarn/src/main/resources/drill-am/tasks.ftl
@@ -18,9 +18,6 @@
 
 -->
 <#include "*/generic.ftl">
-<#macro page_head>
-  <meta http-equiv="refresh" content="${refreshSecs}" >
-</#macro>
 
 <#macro page_body>
   <h4>Drillbit Status</h4>


### PR DESCRIPTION
…strap update

Fixed navigation classes in AM templates.

# [DRILL-7749](https://issues.apache.org/jira/browse/DRILL-7749): Drill-on-Yarn Application Master UI is broken due to bootstrap update

## Description

Fixed navigation classes in AM templates.

## Documentation
--

## Testing
Tested manually
