### PR TITLE
DRILL-7750: Drill fails to read KeyStore password from Credential provider

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfig.java
@@ -22,6 +22,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.memory.BufferAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -30,10 +32,11 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.security.KeyStore;
+import java.text.MessageFormat;
 
 public abstract class SSLConfig {
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SSLConfig.class);
+  private static final Logger logger = LoggerFactory.getLogger(SSLConfig.class);
 
   public static final String DEFAULT_SSL_PROVIDER = "JDK"; // JDK or OPENSSL
   public static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
@@ -60,7 +63,7 @@ public abstract class SSLConfig {
   // copy of Hadoop's SSLFactory.Mode. Done so that we do not
   // need to include hadoop-common as a dependency in
   // jdbc-all-jar.
-  public enum Mode { CLIENT, SERVER };
+  public enum Mode { CLIENT, SERVER }
 
 
   public SSLConfig() {
@@ -228,6 +231,10 @@ public abstract class SSLConfig {
       }
     }
     return engine;
+  }
+
+  String resolveHadoopPropertyName(String nameTemplate, Mode mode) {
+    return MessageFormat.format(nameTemplate, mode.toString().toLowerCase());
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigBuilder.java
@@ -42,12 +42,12 @@ public class SSLConfigBuilder {
     if (mode == SSLConfig.Mode.SERVER) {
       sslConfig = new SSLConfigServer(config, hadoopConfig);
     } else {
-      sslConfig = new SSLConfigClient(properties);
+      sslConfig = new SSLConfigClient(properties, hadoopConfig);
     }
-    if(validateKeyStore){
+    if (validateKeyStore) {
       sslConfig.validateKeyStore();
     }
-    if(initializeSSLContext){
+    if (initializeSSLContext) {
       sslConfig.initContext();
     }
     return sslConfig;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigClient.java
@@ -31,7 +31,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
-import java.io.IOException;
 import java.util.Properties;
 
 public class SSLConfigClient extends SSLConfig {
@@ -105,18 +104,7 @@ public class SSLConfigClient extends SSLConfig {
   }
 
   private String getPasswordStringProperty(String name, String hadoopName) {
-    String value = null;
-    if (hadoopConfig != null) {
-      try {
-        char[] password = hadoopConfig.getPassword(hadoopName);
-        if (password != null) {
-          value = String.valueOf(password);
-        }
-      } catch (IOException e) {
-        logger.warn("Unable to obtain password {} from CredentialProvider API: {}", hadoopName, e.getMessage());
-        // fallthrough
-      }
-    }
+    String value = getPassword(hadoopName);
 
     if (value == null) {
       value = getStringProperty(name, "");
@@ -307,7 +295,13 @@ public class SSLConfigClient extends SSLConfig {
     return useSystemTrustStore;
   }
 
+  @Override
   public boolean isSslValid() {
     return true;
+  }
+
+  @Override
+  Configuration getHadoopConfig() {
+    return hadoopConfig;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -33,7 +33,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
-import java.io.IOException;
 
 public class SSLConfigServer extends SSLConfig {
 
@@ -231,18 +230,7 @@ public class SSLConfigServer extends SSLConfig {
   }
 
   private String getPasswordConfigParam(String name, String hadoopName) {
-    String value = null;
-    if (hadoopConfig != null) {
-      try {
-        char[] password = hadoopConfig.getPassword(hadoopName);
-        if (password != null) {
-          value = String.valueOf(password);
-        }
-      } catch (IOException e) {
-        logger.warn("Unable to obtain password {} from CredentialProvider API: {}", hadoopName, e.getMessage());
-        // fallthrough
-      }
-    }
+    String value = getPassword(hadoopName);
 
     if (value == null) {
       value = getConfigParam(name, hadoopName);
@@ -341,7 +329,13 @@ public class SSLConfigServer extends SSLConfig {
     return false; // Client only, notsupported by the server
   }
 
+  @Override
   public boolean isSslValid() {
     return !keyStorePath.isEmpty() && !keyStorePassword.isEmpty();
+  }
+
+  @Override
+  Configuration getHadoopConfig() {
+    return hadoopConfig;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ssl/SSLConfigServer.java
@@ -26,16 +26,18 @@ import org.apache.drill.common.exceptions.DrillException;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.memory.BufferAllocator;
 import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
-import java.text.MessageFormat;
+import java.io.IOException;
 
 public class SSLConfigServer extends SSLConfig {
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SSLConfigServer.class);
+  private static final Logger logger = LoggerFactory.getLogger(SSLConfigServer.class);
 
   private final DrillConfig config;
   private final Configuration hadoopConfig;
@@ -76,6 +78,7 @@ public class SSLConfigServer extends SSLConfig {
         config.hasPath(ExecConstants.USER_SSL_ENABLED) && config.getBoolean(ExecConstants.USER_SSL_ENABLED);
     SSLCredentialsProvider credentialsProvider = SSLCredentialsProvider.getSSLCredentialsProvider(
         this::getConfigParam,
+        this::getPasswordConfigParam,
         Mode.SERVER,
         config.getBoolean(ExecConstants.SSL_USE_MAPR_CONFIG));
     trustStoreType = credentialsProvider.getTrustStoreType(
@@ -106,6 +109,7 @@ public class SSLConfigServer extends SSLConfig {
     provider = config.getString(ExecConstants.SSL_PROVIDER);
   }
 
+  @Override
   public void validateKeyStore() throws DrillException {
     //HTTPS validates the keystore is not empty. User Server SSL context initialization also validates keystore, but
     // much more strictly. User Client context initialization does not validate keystore.
@@ -226,11 +230,26 @@ public class SSLConfigServer extends SSLConfig {
     return value;
   }
 
-  private String resolveHadoopPropertyName(String nameTemplate, Mode mode) {
-    return MessageFormat.format(nameTemplate, mode.toString().toLowerCase());
+  private String getPasswordConfigParam(String name, String hadoopName) {
+    String value = null;
+    if (hadoopConfig != null) {
+      try {
+        char[] password = hadoopConfig.getPassword(hadoopName);
+        if (password != null) {
+          value = String.valueOf(password);
+        }
+      } catch (IOException e) {
+        logger.warn("Unable to obtain password {} from CredentialProvider API: {}", hadoopName, e.getMessage());
+        // fallthrough
+      }
+    }
+
+    if (value == null) {
+      value = getConfigParam(name, hadoopName);
+    }
+
+    return value;
   }
-
-
 
   @Override
   public boolean isUserSslEnabled() {
@@ -325,5 +344,4 @@ public class SSLConfigServer extends SSLConfig {
   public boolean isSslValid() {
     return !keyStorePath.isEmpty() && !keyStorePassword.isEmpty();
   }
-
 }


### PR DESCRIPTION
# [DRILL-7750](https://issues.apache.org/jira/browse/DRILL-7750): Drill fails to read KeyStore password from Credential provider

## Description

Added support for Hadoop CredentialProvider API for keystore and trustore passwords.

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)

## Testing
Manually tested the fix and ran existing test suits.
