### PR TITLE
DRILL-7763: Add Limit Pushdown to File Based Storage Plugins

### DIFF
--- a/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
+++ b/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpBatchReader.java
@@ -75,6 +75,7 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private RowSetLoader rowWriter;
   private int srid;
   private SpatialReference spatialReference;
+  private final int maxRecords;
 
   public static class ShpReaderConfig {
     protected final ShpFormatPlugin plugin;
@@ -84,8 +85,9 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
     }
   }
 
-  public ShpBatchReader(ShpReaderConfig readerConfig) {
+  public ShpBatchReader(ShpReaderConfig readerConfig, int maxRecords) {
     this.readerConfig = readerConfig;
+    this.maxRecords = maxRecords;
   }
 
   @Override
@@ -180,6 +182,10 @@ public class ShpBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private void processShapefileSet(RowSetLoader rowWriter, final int gid, final Geometry geom, final Object[] dbfRow) {
+    if (rowWriter.limitReached(maxRecords)) {
+      return;
+    }
+
     rowWriter.start();
 
     gidWriter.setInt(gid);

--- a/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpFormatPlugin.java
+++ b/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpFormatPlugin.java
@@ -47,13 +47,16 @@ public class ShpFormatPlugin extends EasyFormatPlugin<ShpFormatConfig> {
   public static class ShpReaderFactory extends FileReaderFactory {
     private final ShpReaderConfig readerConfig;
 
-    public ShpReaderFactory(ShpReaderConfig config) {
+    private final int maxRecords;
+
+    public ShpReaderFactory(ShpReaderConfig config, int maxRecords) {
       readerConfig = config;
+      this.maxRecords = maxRecords;
     }
 
     @Override
     public ManagedReader<? extends FileScanFramework.FileSchemaNegotiator> newReader() {
-      return new ShpBatchReader(readerConfig);
+      return new ShpBatchReader(readerConfig, maxRecords);
     }
   }
 
@@ -63,13 +66,13 @@ public class ShpFormatPlugin extends EasyFormatPlugin<ShpFormatConfig> {
 
   @Override
   public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(EasySubScan scan, OptionManager options) throws ExecutionSetupException {
-    return new ShpBatchReader(formatConfig.getReaderConfig(this));
+    return new ShpBatchReader(formatConfig.getReaderConfig(this), scan.getMaxRecords());
   }
 
   @Override
   protected FileScanFramework.FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanFramework.FileScanBuilder builder = new FileScanFramework.FileScanBuilder();
-    builder.setReaderFactory(new ShpReaderFactory(new ShpReaderConfig(this)));
+    builder.setReaderFactory(new ShpReaderFactory(new ShpReaderConfig(this), scan.getMaxRecords()));
     initScanBuilder(builder, scan);
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
     return builder;
@@ -87,6 +90,7 @@ public class ShpFormatPlugin extends EasyFormatPlugin<ShpFormatConfig> {
     config.defaultName = PLUGIN_NAME;
     config.readerOperatorType = CoreOperatorType.SHP_SUB_SCAN_VALUE;
     config.useEnhancedScan = true;
+    config.supportsLimitPushdown = true;
     return config;
   }
 }

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelBatchReader.java
@@ -120,6 +120,7 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
   private static final int BUFFER_SIZE = 4096;
 
   private final ExcelReaderConfig readerConfig;
+  private final int maxRecords;
   private Sheet sheet;
   private Row currentRow;
   private StreamingWorkbook streamingWorkbook;
@@ -159,8 +160,9 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
     }
   }
 
-  public ExcelBatchReader(ExcelReaderConfig readerConfig) {
+  public ExcelBatchReader(ExcelReaderConfig readerConfig, int maxRecords) {
     this.readerConfig = readerConfig;
+    this.maxRecords = maxRecords;
     firstLine = true;
   }
 
@@ -372,6 +374,11 @@ public class ExcelBatchReader implements ManagedReader<FileSchemaNegotiator> {
     if (readerConfig.lastColumn != 0) {
       finalColumn = readerConfig.lastColumn - 1;
     }
+
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
     rowWriter.start();
     for (int colWriterIndex = 0; colPosition < finalColumn; colWriterIndex++) {
       Cell cell = currentRow.getCell(colPosition);

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
@@ -46,14 +46,16 @@ public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
 
   private static class ExcelReaderFactory extends FileReaderFactory {
     private final ExcelBatchReader.ExcelReaderConfig readerConfig;
+    private final int maxRecords;
 
-    public ExcelReaderFactory(ExcelReaderConfig config) {
+    public ExcelReaderFactory(ExcelReaderConfig config, int maxRecords) {
       readerConfig = config;
+      this.maxRecords = maxRecords;
     }
 
     @Override
     public ManagedReader<? extends FileSchemaNegotiator> newReader() {
-      return new ExcelBatchReader(readerConfig);
+      return new ExcelBatchReader(readerConfig, maxRecords);
     }
   }
 
@@ -75,13 +77,14 @@ public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
     config.defaultName = DEFAULT_NAME;
     config.readerOperatorType = UserBitShared.CoreOperatorType.EXCEL_SUB_SCAN_VALUE;
     config.useEnhancedScan = true;
+    config.supportsLimitPushdown = true;
     return config;
   }
 
   @Override
   public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(
     EasySubScan scan, OptionManager options) throws ExecutionSetupException {
-    return new ExcelBatchReader(formatConfig.getReaderConfig(this));
+    return new ExcelBatchReader(formatConfig.getReaderConfig(this), scan.getMaxRecords());
   }
 
   @Override
@@ -90,7 +93,7 @@ public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
     ExcelReaderConfig readerConfig = new ExcelReaderConfig(this);
 
     verifyConfigOptions(readerConfig);
-    builder.setReaderFactory(new ExcelReaderFactory(readerConfig));
+    builder.setReaderFactory(new ExcelReaderFactory(readerConfig, scan.getMaxRecords()));
 
     initScanBuilder(builder, scan);
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));

--- a/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
+++ b/contrib/format-excel/src/test/java/org/apache/drill/exec/store/excel/TestExcelFormat.java
@@ -420,4 +420,15 @@ public class TestExcelFormat extends ClusterTest {
 
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
+
+  @Test
+  public void testLimitPushdown() throws Exception {
+    String sql = "SELECT id, first_name, order_count FROM cp.`excel/test_data.xlsx` LIMIT 5";
+
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=5")
+      .match();
+  }
 }

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5BatchReader.java
@@ -111,6 +111,8 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   private final List<HDF5DataWriter> dataWriters;
 
+  private final int maxRecords;
+
   private FileSplit split;
 
   private IHDF5Reader hdf5Reader;
@@ -158,8 +160,9 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
     }
   }
 
-  public HDF5BatchReader(HDF5ReaderConfig readerConfig) {
+  public HDF5BatchReader(HDF5ReaderConfig readerConfig, int maxRecords) {
     this.readerConfig = readerConfig;
+    this.maxRecords = maxRecords;
     dataWriters = new ArrayList<>();
   }
 
@@ -369,6 +372,12 @@ public class HDF5BatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   @Override
   public boolean next() {
+
+    // Limit pushdown
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
     while (!rowWriter.isFull()) {
       if (readerConfig.defaultPath == null || readerConfig.defaultPath.isEmpty()) {
         if (!metadataIterator.hasNext()){

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5FormatPlugin.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5FormatPlugin.java
@@ -66,6 +66,7 @@ public class HDF5FormatPlugin extends EasyFormatPlugin<HDF5FormatConfig> {
     config.defaultName = DEFAULT_NAME;
     config.readerOperatorType = UserBitShared.CoreOperatorType.HDF5_SUB_SCAN_VALUE;
     config.useEnhancedScan = true;
+    config.supportsLimitPushdown = true;
     return config;
   }
 
@@ -73,7 +74,7 @@ public class HDF5FormatPlugin extends EasyFormatPlugin<HDF5FormatConfig> {
   protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) throws ExecutionSetupException {
     FileScanBuilder builder = new FileScanBuilder();
 
-    builder.setReaderFactory(new HDF5ReaderFactory(new HDF5BatchReader.HDF5ReaderConfig(this, formatConfig)));
+    builder.setReaderFactory(new HDF5ReaderFactory(new HDF5BatchReader.HDF5ReaderConfig(this, formatConfig), scan.getMaxRecords()));
     initScanBuilder(builder, scan);
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
     return builder;
@@ -81,14 +82,17 @@ public class HDF5FormatPlugin extends EasyFormatPlugin<HDF5FormatConfig> {
 
   public static class HDF5ReaderFactory extends FileScanFramework.FileReaderFactory {
     private final HDF5ReaderConfig readerConfig;
+    private final int maxRecords;
 
-    HDF5ReaderFactory(HDF5ReaderConfig config) {
+
+    HDF5ReaderFactory(HDF5ReaderConfig config, int maxRecords) {
       readerConfig = config;
+      this.maxRecords = maxRecords;
     }
 
     @Override
     public ManagedReader<? extends FileScanFramework.FileSchemaNegotiator> newReader() {
-      return new HDF5BatchReader(readerConfig);
+      return new HDF5BatchReader(readerConfig, maxRecords);
     }
   }
 

--- a/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssBatchReader.java
+++ b/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssBatchReader.java
@@ -47,6 +47,8 @@ public class SpssBatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   private static final String VALUE_LABEL = "_value";
 
+  private final int maxRecords;
+
   private FileSplit split;
 
   private InputStream fsStream;
@@ -69,6 +71,10 @@ public class SpssBatchReader implements ManagedReader<FileSchemaNegotiator> {
     public SpssReaderConfig(SpssFormatPlugin plugin) {
       this.plugin = plugin;
     }
+  }
+
+  public SpssBatchReader(int maxRecords) {
+    this.maxRecords = maxRecords;
   }
 
   @Override
@@ -117,6 +123,11 @@ public class SpssBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private boolean processNextRow() {
+    // Check to see if the limit has been reached
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
     try {
       // Stop reading when you run out of data
       if (!spssReader.readNextCase()) {

--- a/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssFormatPlugin.java
+++ b/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssFormatPlugin.java
@@ -40,9 +40,15 @@ public class SpssFormatPlugin extends EasyFormatPlugin<SpssFormatConfig> {
 
   private static class SpssReaderFactory extends FileReaderFactory {
 
+    private final int maxRecords;
+
+    public SpssReaderFactory(int maxRecords) {
+      this.maxRecords = maxRecords;
+    }
+
     @Override
     public ManagedReader<? extends FileSchemaNegotiator> newReader() {
-      return new SpssBatchReader();
+      return new SpssBatchReader(maxRecords);
     }
   }
 
@@ -64,19 +70,20 @@ public class SpssFormatPlugin extends EasyFormatPlugin<SpssFormatConfig> {
     config.defaultName = DEFAULT_NAME;
     config.readerOperatorType = UserBitShared.CoreOperatorType.SPSS_SUB_SCAN_VALUE;
     config.useEnhancedScan = true;
+    config.supportsLimitPushdown = true;
     return config;
   }
 
   @Override
   public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(
     EasySubScan scan, OptionManager options)  {
-    return new SpssBatchReader();
+    return new SpssBatchReader(scan.getMaxRecords());
   }
 
   @Override
   protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanBuilder builder = new FileScanBuilder();
-    builder.setReaderFactory(new SpssReaderFactory());
+    builder.setReaderFactory(new SpssReaderFactory(scan.getMaxRecords()));
 
     initScanBuilder(builder, scan);
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/RowSetLoader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/RowSetLoader.java
@@ -108,6 +108,15 @@ public interface RowSetLoader extends TupleWriter {
   boolean isFull();
 
   /**
+   * Used to push a limit down to the file reader. This method checks to see whether
+   * the maxRecords parameter is not zero (for no limit) and is not greater than the
+   * current record count.
+   * @param maxRecords Maximum rows to be returned. (From the limit clause of the query)
+   * @return True if the row count exceeds the maxRecords, false if not.
+   */
+  boolean limitReached(int maxRecords);
+
+  /**
    * The number of rows in the current row set. Does not count any overflow row
    * saved for the next batch.
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RowSetLoaderImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/resultSet/impl/RowSetLoaderImpl.java
@@ -26,6 +26,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.vector.accessor.writer.AbstractObjectWriter;
 import org.apache.drill.exec.vector.accessor.writer.AbstractTupleWriter;
 
+
 /**
  * Implementation of the row set loader. Provides row-level operations, leaving the
  * result set loader to provide batch-level operations. However, all control
@@ -95,6 +96,11 @@ public class RowSetLoaderImpl extends AbstractTupleWriter implements RowSetLoade
       state = State.IN_WRITE;
     }
     endWrite();
+  }
+
+  @Override
+  public boolean limitReached(int maxRecords) {
+    return (maxRecords > 0 && this.rowCount() >= maxRecords);
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroBatchReader.java
@@ -52,6 +52,11 @@ public class AvroBatchReader implements ManagedReader<FileScanFramework.FileSche
   private List<ColumnConverter> converters;
   // re-use container instance
   private GenericRecord record;
+  private int maxRecords;
+
+  public AvroBatchReader(int maxRecords) {
+    this.maxRecords = maxRecords;
+  }
 
   @Override
   public boolean open(FileScanFramework.FileSchemaNegotiator negotiator) {
@@ -151,6 +156,10 @@ public class AvroBatchReader implements ManagedReader<FileScanFramework.FileSche
   }
 
   private boolean nextLine(RowSetLoader rowWriter) {
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
+
     try {
       if (!reader.hasNext() || reader.pastSync(endPosition)) {
         return false;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroFormatPlugin.java
@@ -56,13 +56,14 @@ public class AvroFormatPlugin extends EasyFormatPlugin<AvroFormatConfig> {
     config.defaultName = DEFAULT_NAME;
     config.readerOperatorType = CoreOperatorType.AVRO_SUB_SCAN_VALUE;
     config.useEnhancedScan = true;
+    config.supportsLimitPushdown = true;
     return config;
   }
 
   @Override
   protected FileScanFramework.FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanFramework.FileScanBuilder builder = new FileScanFramework.FileScanBuilder();
-    builder.setReaderFactory(new AvroReaderFactory());
+    builder.setReaderFactory(new AvroReaderFactory(scan.getMaxRecords()));
     initScanBuilder(builder, scan);
     builder.nullType(Types.optional(TypeProtos.MinorType.VARCHAR));
     return builder;
@@ -70,9 +71,14 @@ public class AvroFormatPlugin extends EasyFormatPlugin<AvroFormatConfig> {
 
   private static class AvroReaderFactory extends FileScanFramework.FileReaderFactory {
 
+    private final int maxRecords;
+    public AvroReaderFactory(int maxRecords) {
+      this.maxRecords = maxRecords;
+    }
+
     @Override
     public ManagedReader<? extends FileScanFramework.FileSchemaNegotiator> newReader() {
-      return new AvroBatchReader();
+      return new AvroBatchReader(maxRecords);
     }
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.hadoop.fs.Path;
 
+
 @JsonTypeName("fs-sub-scan")
 public class EasySubScan extends AbstractSubScan {
 
@@ -44,6 +45,7 @@ public class EasySubScan extends AbstractSubScan {
   private final Path selectionRoot;
   private final int partitionDepth;
   private final TupleMetadata schema;
+  private final int maxRecords;
 
   @JsonCreator
   public EasySubScan(
@@ -55,7 +57,8 @@ public class EasySubScan extends AbstractSubScan {
     @JsonProperty("columns") List<SchemaPath> columns,
     @JsonProperty("selectionRoot") Path selectionRoot,
     @JsonProperty("partitionDepth") int partitionDepth,
-    @JsonProperty("schema") TupleMetadata schema
+    @JsonProperty("schema") TupleMetadata schema,
+    @JsonProperty("maxRecords") int maxRecords
     ) throws ExecutionSetupException {
     super(userName);
     this.formatPlugin = engineRegistry.resolveFormat(storageConfig, formatConfig, EasyFormatPlugin.class);
@@ -64,10 +67,11 @@ public class EasySubScan extends AbstractSubScan {
     this.selectionRoot = selectionRoot;
     this.partitionDepth = partitionDepth;
     this.schema = schema;
+    this.maxRecords = maxRecords;
   }
 
   public EasySubScan(String userName, List<FileWorkImpl> files, EasyFormatPlugin<?> plugin,
-      List<SchemaPath> columns, Path selectionRoot, int partitionDepth, TupleMetadata schema) {
+      List<SchemaPath> columns, Path selectionRoot, int partitionDepth, TupleMetadata schema, int maxRecords) {
     super(userName);
     this.formatPlugin = plugin;
     this.files = files;
@@ -75,6 +79,7 @@ public class EasySubScan extends AbstractSubScan {
     this.selectionRoot = selectionRoot;
     this.partitionDepth = partitionDepth;
     this.schema = schema;
+    this.maxRecords = maxRecords;
   }
 
   @JsonProperty
@@ -100,6 +105,9 @@ public class EasySubScan extends AbstractSubScan {
 
   @JsonProperty("schema")
   public TupleMetadata getSchema() { return schema; }
+
+  @JsonProperty("maxRecords")
+  public int getMaxRecords() { return maxRecords; }
 
   @Override
   public int getOperatorType() { return formatPlugin.getReaderOperatorType(); }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapBatchReader.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapBatchReader.java
@@ -145,6 +145,7 @@ public class PcapBatchReader implements ManagedReader<FileSchemaNegotiator> {
 
   private ScalarWriter remoteDataWriter;
 
+  private final int maxRecords;
 
   private Map<Long, TcpSession> sessionQueue;
 
@@ -164,11 +165,12 @@ public class PcapBatchReader implements ManagedReader<FileSchemaNegotiator> {
     }
   }
 
-  public PcapBatchReader(PcapReaderConfig readerConfig) {
+  public PcapBatchReader(PcapReaderConfig readerConfig, int maxRecords) {
     this.readerConfig = readerConfig;
     if (readerConfig.sessionizeTCPStreams) {
       sessionQueue = new HashMap<>();
     }
+    this.maxRecords = maxRecords;
   }
 
   @Override
@@ -296,6 +298,11 @@ public class PcapBatchReader implements ManagedReader<FileSchemaNegotiator> {
   }
 
   private boolean parseNextPacket(RowSetLoader rowWriter) {
+
+    // Push down limit
+    if (rowWriter.limitReached(maxRecords)) {
+      return false;
+    }
 
     // Decode the packet
     Packet packet = new Packet();

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/metastore/TestMetastoreWithEasyFormatPlugin.java
@@ -1079,14 +1079,14 @@ public class TestMetastoreWithEasyFormatPlugin extends ClusterTest {
       queryBuilder()
           .sql("select * from dfs.tmp.`%s` limit 1", tableName)
           .planMatcher()
-          .include("Limit", "numFiles=1,")
+          .include("Limit", "numFiles=1", "maxRecords=1")
           .match();
 
       // each file has 10 records, so 3 files should be picked
       queryBuilder()
           .sql("select * from dfs.tmp.`%s` limit 21", tableName)
           .planMatcher()
-          .include("Limit", "numFiles=3")
+          .include("Limit", "numFiles=3", "maxRecords=21")
           .match();
     } finally {
       run("analyze table dfs.tmp.`%s` drop metadata if exists", tableName);


### PR DESCRIPTION
# [DRILL-7763](https://issues.apache.org/jira/browse/DRILL-7763): Add Limit Pushdown to File Based Storage Plugins

## Description

As currently implemented, when querying a file, Drill will read the entire file even if a limit is specified in the query.  This PR does a few things:
* Refactors the `EasyGroupScan`, `EasySubScan`, and `EasyFormatConfig` to allow the option of pushing down limits.
* Applies this to all the EVF based format plugins which are: `Avro`, `LogRegex`, `PCAP`, `SPSS`, `Esri`, `Excel` and `Text (CSV)`. 
Due to JSON's fluid schema, it would be unwise to adopt the limit pushdown as it could result in very inconsistent schemata.

This capability is disabled by default, and has to be manually added to each format plugin if appropriate.

## Documentation
No user visible changes.  Queries with limits on large files are considerably faster.

## Testing
All existing unit tests are run. 