### PR TITLE
DRILL-7764: Cleanup warning messages in GuavaPatcher class

### DIFF
--- a/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
+++ b/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
@@ -73,9 +73,13 @@ public class GuavaPatcher {
 
       logger.info("Google's Stopwatch patched for old HBase Guava version.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
-      logger.debug("Exception:", e);
+      logUnableToPatchException(e);
     }
+  }
+
+  private static void logUnableToPatchException(Exception e) {
+    logger.warn("Unable to patch Guava classes: {}", e.getMessage());
+    logger.debug("Exception:", e);
   }
 
   private static void patchCloseables() {
@@ -94,8 +98,7 @@ public class GuavaPatcher {
 
       logger.info("Google's Closeables patched for old HBase Guava version.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
-      logger.debug("Exception:", e);
+      logUnableToPatchException(e);
     }
   }
 
@@ -193,8 +196,7 @@ public class GuavaPatcher {
       cc.toClass();
       logger.info("Google's Preconditions were patched to hold new methods.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
-      logger.debug("Exception:", e);
+      logUnableToPatchException(e);
     }
   }
 

--- a/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
+++ b/common/src/main/java/org/apache/drill/common/util/GuavaPatcher.java
@@ -73,7 +73,8 @@ public class GuavaPatcher {
 
       logger.info("Google's Stopwatch patched for old HBase Guava version.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes.", e);
+      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
+      logger.debug("Exception:", e);
     }
   }
 
@@ -93,7 +94,8 @@ public class GuavaPatcher {
 
       logger.info("Google's Closeables patched for old HBase Guava version.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes.", e);
+      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
+      logger.debug("Exception:", e);
     }
   }
 
@@ -191,7 +193,8 @@ public class GuavaPatcher {
       cc.toClass();
       logger.info("Google's Preconditions were patched to hold new methods.");
     } catch (Exception e) {
-      logger.warn("Unable to patch Guava classes.", e);
+      logger.warn("Unable to patch Guava classes: {}", e.getMessage());
+      logger.debug("Exception:", e);
     }
   }
 


### PR DESCRIPTION
# [DRILL-7764](https://issues.apache.org/jira/browse/DRILL-7764): Cleanup warning messages in GuavaPatcher class

## Description

Removed unnecessary logging of stack trace (on `WARN` level) when patching Guava fails.

## Documentation
N/A

## Testing
Ran all existing tests.
