### PR TITLE
DRILL-7773: Incorrect conversion result to TIME_EPOCH_BE

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/TimeEpochBEConvertTo.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/fn/impl/conv/TimeEpochBEConvertTo.java
@@ -48,7 +48,7 @@ public class TimeEpochBEConvertTo implements DrillSimpleFunc {
   @Override
   public void eval() {
     buffer.clear();
-    buffer.writeLong(Integer.reverseBytes(in.value));
+    buffer.writeLong(Long.reverseBytes(in.value));
     out.buffer = buffer;
     out.start = 0;
     out.end = 8;

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestConvertFunctions.java
@@ -617,6 +617,11 @@ public class TestConvertFunctions extends BaseTestQuery {
     }
   }
 
+  @Test // DRILL-7773
+  public void testTimeEpochBE() throws Throwable {
+    verifyPhysicalPlan("cast(convert_from(convert_to('23:30:21', 'TIME_EPOCH_BE'), 'TIME_EPOCH_BE') as time)", LocalTime.of(23, 30, 21));
+  }
+
   protected <T> void verifySQL(String sql, T expectedResults) throws Throwable {
     verifyResults(sql, expectedResults, getRunResult(QueryType.SQL, sql));
   }


### PR DESCRIPTION
# [DRILL-7773](https://issues.apache.org/jira/browse/DRILL-7773): Incorrect conversion result to TIME_EPOCH_BE

## Description

An error was made when converting to BIG ENGIAN. 
First, the bytes of an integer were reversed, and only then the result was extended to long. 
Because of this, zero bytes at the beginning of long did not participate in the reverse operation

