### PR TITLE
DRILL-7774: IS NOT NULL predicate fails with NPE for the case of non-existing columns with non-deterministic expression

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/expr/FilterBuilder.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/expr/FilterBuilder.java
@@ -304,7 +304,9 @@ public class FilterBuilder extends AbstractExprVisitor<LogicalExpression, Set<Lo
     }
     LogicalExpression arg = functionHolderExpression.args.get(0);
 
-    return IsPredicate.createIsPredicate(funcName, arg.accept(this, value));
+    LogicalExpression expression = arg.accept(this, value);
+
+    return expression == null ? null : IsPredicate.createIsPredicate(funcName, expression);
   }
 
   private static boolean isCompareFunction(String funcName) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -684,6 +684,19 @@ public class TestParquetFilterPushDown extends PlanTestBase {
   }
 
   @Test
+  public void tesNonDeterministicIsNotNullWithNonExistingColumn() throws Exception {
+    String query = "select count(*) as cnt from cp.`tpch/nation.parquet`\n" +
+        "where (case when random() = 1 then true else null end * t) is not null";
+
+    testBuilder()
+        .sqlQuery(query)
+        .unOrdered()
+        .baselineColumns("cnt")
+        .baselineValues(0L)
+        .go();
+  }
+
+  @Test
   public void testParquetSingleRowGroupFilterRemoving() throws Exception {
     test("create table dfs.tmp.`singleRowGroupTable` as select * from cp.`tpch/nation.parquet`");
 


### PR DESCRIPTION
# [DRILL-7774](https://issues.apache.org/jira/browse/DRILL-7774): IS NOT NULL predicate fails with NPE for the case of non-existing columns with non-deterministic expression

## Description
Added null check.

## Documentation
NA

## Testing
Added unit test for the issue.
