### PR TITLE
DRILL-7780: Fix string reference comparisons

### DIFF
--- a/common/src/main/java/org/apache/drill/common/KerberosUtil.java
+++ b/common/src/main/java/org/apache/drill/common/KerberosUtil.java
@@ -47,7 +47,7 @@ public final class KerberosUtil {
     checkNotNull(realm);
 
     return primary +
-        ((instance != "") ? "/" + instance : "")
+        ((!"".equals(instance)) ? "/" + instance : "")
         + "@" + realm;
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/BootStrapContext.java
@@ -139,7 +139,7 @@ public class BootStrapContext implements AutoCloseable {
               ExecConstants.SERVICE_PRINCIPAL));
         }
 
-        parts[1] = (parts[1] == "") ? "" : KerberosUtil.canonicalizeInstanceName(parts[1], hostName);
+        parts[1] = ("".equals(parts[1])) ? "" : KerberosUtil.canonicalizeInstanceName(parts[1], hostName);
 
         final String canonicalizedPrincipal = KerberosUtil.getPrincipalFromParts(parts[0], parts[1], parts[2]);
         final String keytab = config.getString(ExecConstants.SERVICE_KEYTAB_LOCATION);


### PR DESCRIPTION
# [DRILL-7780](https://issues.apache.org/jira/browse/DRILL-7780): Fix string reference comparisons

## Description

Refactor string comparisons to prevent comparing string object references for equality. See [here](https://errorprone.info/bugpattern/ReferenceEquality) for more details.

This instance was found using the Muse analysis platform (of which I am a developer). See other results [here](https://console.muse.dev/result/nescohen/drill/01EG1E4GWANR2JVAJQ9V9ZZ152?tab=results). Analysis of Drill has worked out of the box to deliver errorprone and infer results among other analyses. We should consider [enabling](https://github.com/marketplace/muse-dev) Muse for the project in general. This will cause Muse to leave comments on future pull requests like [this](https://github.com/TomMD/shiro/pull/2).

## Documentation

No user visible changes, just stability improvement

## Testing

Build with `mvn install`, observe unit tests pass
