### PR TITLE
DRILL-7785: Some hive tables fail with UndeclaredThrowableException

### DIFF
--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/readers/HiveDefaultRecordReader.java
@@ -271,10 +271,13 @@ public class HiveDefaultRecordReader extends AbstractRecordReader {
         this.partitionToTableSchemaConverter = (obj) -> obj;
         this.finalObjInspector = tableObjInspector;
 
+        HiveUtilities.addConfToJob(job, hiveTableProperties);
         job.setInputFormat(HiveUtilities.getInputFormatClass(job, hiveTable.getSd(), hiveTable));
         HiveUtilities.verifyAndAddTransactionalProperties(job, hiveTable.getSd());
       } else {
-        this.partitionDeserializer = createDeserializer(job, partition.getSd(), HiveUtilities.getPartitionMetadata(partition, hiveTable));
+        Properties partitionProperties = HiveUtilities.getPartitionMetadata(partition, hiveTable);
+        HiveUtilities.addConfToJob(job, partitionProperties);
+        this.partitionDeserializer = createDeserializer(job, partition.getSd(), partitionProperties);
         this.partitionObjInspector = getStructOI(partitionDeserializer);
 
         this.finalObjInspector = (StructObjectInspector) ObjectInspectorConverters.getConvertedOI(partitionObjInspector, tableObjInspector);


### PR DESCRIPTION
# [DRILL-7785](https://issues.apache.org/jira/browse/DRILL-7785): Some hive tables fail with UndeclaredThrowableException

## Description
Moved back the code which sets table / partition properties to job conf when creating readers

## Documentation
NA

## Testing
Checked manually.