### PR TITLE
DRILL-7793: Fix syntax error in "drill-config.sh"

### DIFF
--- a/distribution/src/main/resources/drill-config.sh
+++ b/distribution/src/main/resources/drill-config.sh
@@ -141,7 +141,7 @@ function checkExecutableLineCount() {
   #Not valid file
   if [ ! -f "$1" ]; then echo $lineCount; return; fi
   # Filtering out commented and empty lines
-  let lineCount=`cat $1 | grep -v '#' | grep -v ^$ | wc -l`
+  let "lineCount=`cat $1 | grep -v '#' | grep -v ^$ | wc -l`"
   echo $lineCount
   return
 }


### PR DESCRIPTION
The drill-config.sh has a syntax error on line 144 with the usage of "let". The command following let should be enclosed in quotes, otherwise the following syntax error occurs:

> /home/someone/proj/apache-drill-1.17.0/bin/drill-config.sh: line 144: let: lineCount=: syntax error: operand expected (error token is "=")
