### PR TITLE
DRILL-7799: REST Queries Fail if Caching is Enabled

### DIFF
--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpBatchReader.java
@@ -40,10 +40,13 @@ import java.util.Map;
 
 public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
   private final HttpSubScan subScan;
+  private final int maxRecords;
   private JsonLoader jsonLoader;
+  private int recordCount;
 
   public HttpBatchReader(HttpSubScan subScan) {
     this.subScan = subScan;
+    this.maxRecords = subScan.maxRecords();
   }
 
   @Override
@@ -141,6 +144,12 @@ public class HttpBatchReader implements ManagedReader<SchemaNegotiator> {
 
   @Override
   public boolean next() {
+    recordCount++;
+
+    // Stop after the limit has been reached
+    if (maxRecords >= 1 && recordCount > maxRecords) {
+      return false;
+    }
     return jsonLoader.readBatch();
   }
 

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpCSVBatchReader.java
@@ -44,6 +44,7 @@ import java.util.List;
 public class HttpCSVBatchReader extends HttpBatchReader {
   private final HttpSubScan subScan;
   private final CsvParserSettings csvSettings;
+  private final int maxRecords;
   private CsvParser csvReader;
   private List<StringColumnWriter> columnWriters;
   private String[] firstRow;
@@ -55,6 +56,7 @@ public class HttpCSVBatchReader extends HttpBatchReader {
   public HttpCSVBatchReader(HttpSubScan subScan) {
     super(subScan);
     this.subScan = subScan;
+    this.maxRecords = subScan.maxRecords();
 
     this.csvSettings = new CsvParserSettings();
     csvSettings.setLineSeparatorDetectionEnabled(true);
@@ -102,6 +104,10 @@ public class HttpCSVBatchReader extends HttpBatchReader {
   @Override
   public boolean next() {
     while (!rowWriter.isFull()) {
+      if (rowWriter.limitReached(maxRecords)) {
+        return false;
+      }
+
       if (!processRow()) {
         return false;
       }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
@@ -41,16 +41,20 @@ public class HttpSubScan extends AbstractBase implements SubScan {
   private final HttpScanSpec tableSpec;
   private final List<SchemaPath> columns;
   private final Map<String, String> filters;
+  private final int maxRecords;
 
   @JsonCreator
   public HttpSubScan(
     @JsonProperty("tableSpec") HttpScanSpec tableSpec,
     @JsonProperty("columns") List<SchemaPath> columns,
-    @JsonProperty("filters") Map<String, String> filters) {
+    @JsonProperty("filters") Map<String, String> filters,
+    @JsonProperty("maxRecords") int maxRecords
+    ) {
     super("user-if-needed");
     this.tableSpec = tableSpec;
     this.columns = columns;
     this.filters = filters;
+    this.maxRecords = maxRecords;
   }
 
   @JsonProperty("tableSpec")
@@ -68,6 +72,11 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     return filters;
   }
 
+  @JsonProperty("maxRecords")
+  public int maxRecords() {
+    return maxRecords;
+  }
+
  @Override
   public <T, X, E extends Throwable> T accept(
    PhysicalVisitor<T, X, E> physicalVisitor, X value) throws E {
@@ -76,7 +85,7 @@ public class HttpSubScan extends AbstractBase implements SubScan {
 
   @Override
   public PhysicalOperator getNewWithChildren(List<PhysicalOperator> children) {
-    return new HttpSubScan(tableSpec, columns, filters);
+    return new HttpSubScan(tableSpec, columns, filters, maxRecords);
   }
 
   @Override
@@ -96,6 +105,7 @@ public class HttpSubScan extends AbstractBase implements SubScan {
       .field("tableSpec", tableSpec)
       .field("columns", columns)
       .field("filters", filters)
+      .field("maxRecords", maxRecords)
       .toString();
   }
 
@@ -115,6 +125,7 @@ public class HttpSubScan extends AbstractBase implements SubScan {
     HttpSubScan other = (HttpSubScan) obj;
     return Objects.equals(tableSpec, other.tableSpec)
       && Objects.equals(columns, other.columns)
-      && Objects.equals(filters, other.filters);
+      && Objects.equals(filters, other.filters)
+      && Objects.equals(maxRecords, other.maxRecords);
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/util/SimpleHttp.java
@@ -206,14 +206,18 @@ public class SimpleHttp {
   private void setupCache(Builder builder) {
     int cacheSize = 10 * 1024 * 1024;   // TODO Add cache size in MB to config
     File cacheDirectory = new File(tempDir, "http-cache");
-    if (!cacheDirectory.mkdirs()) {
-      throw UserException.dataWriteError()
-        .message("Could not create the HTTP cache directory")
-        .addContext("Path", cacheDirectory.getAbsolutePath())
-        .addContext("Please check the temp directory or disable HTTP caching.")
-        .addContext(errorContext)
-        .build(logger);
+    if (!cacheDirectory.exists()) {
+      if (!cacheDirectory.mkdirs()) {
+        throw UserException
+          .dataWriteError()
+          .message("Could not create the HTTP cache directory")
+          .addContext("Path", cacheDirectory.getAbsolutePath())
+          .addContext("Please check the temp directory or disable HTTP caching.")
+          .addContext(errorContext)
+          .build(logger);
+      }
     }
+
     try {
       Cache cache = new Cache(cacheDirectory, cacheSize);
       logger.debug("Caching HTTP Query Results at: {}", cacheDirectory);

--- a/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
+++ b/contrib/storage-http/src/test/java/org/apache/drill/exec/store/http/TestHttpPlugin.java
@@ -452,6 +452,17 @@ public class TestHttpPlugin extends ClusterTest {
   }
 
   @Test
+  public void testLimitPushdown() throws Exception {
+    String sql = "SELECT sunrise, sunset FROM local.sunrise.`?lat=36.7201600&lng=-4.4203400&date=2019-10-02` AS t1 LIMIT 5";
+
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=5")
+      .match();
+  }
+
+  @Test
   public void testSlowResponse() throws Exception {
     try (MockWebServer server = startServer()) {
 


### PR DESCRIPTION
# [DRILL-7799](https://issues.apache.org/jira/browse/DRILL-7799): REST Queries Fail if Caching is Enabled

## Description
This PR fixes a minor bug in the HTTP REST storage plugin where the plugin would attempt to create the cache directory twice, causing queries to fail. This was easily fixed by disabling the cache, but now the caching works properly. 

Additionally this PR addresses [DRILL-7800](https://issues.apache.org/jira/browse/DRILL-7800) which adds a limit pushdown to the storage plugin. 


## Documentation
No user visible changes.

## Testing
Tested caching manually.  Added unit test for limit pushdown.
