### PR TITLE
DRILL-7771: Order by and limit transactions in RDBMS cannot be pushdown

### DIFF
--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcSort.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/DrillJdbcSort.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.store.jdbc;
+
+import org.apache.calcite.adapter.jdbc.JdbcRules;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rex.RexNode;
+import org.apache.drill.exec.planner.cost.DrillCostBase;
+
+public class DrillJdbcSort extends JdbcRules.JdbcSort {
+  public DrillJdbcSort(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RelCollation collation, RexNode offset, RexNode fetch) {
+    super(cluster, traitSet, input, collation, offset, fetch);
+  }
+
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    if (collation.getFieldCollations().isEmpty()) {
+      // The case when sort node represents a regular limit without actual sort.
+      // Drill separates limit from sort, and they have different formulas for cost calculation.
+      // The cost for the case of the JDBC limit operator should correspond to the cost of the Drill's one.
+      double numRows = mq.getRowCount(this);
+      double cpuCost = DrillCostBase.COMPARE_CPU_COST * numRows;
+      DrillCostBase.DrillCostFactory costFactory = (DrillCostBase.DrillCostFactory) planner.getCostFactory();
+      return costFactory.makeCost(numRows, cpuCost, 0, 0);
+    }
+    return super.computeSelfCost(planner, mq);
+  }
+}

--- a/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
+++ b/contrib/storage-jdbc/src/test/java/org/apache/drill/exec/store/jdbc/TestJdbcPluginWithMySQLIT.java
@@ -324,11 +324,44 @@ public class TestJdbcPluginWithMySQLIT extends ClusterTest {
 
   @Test
   public void testLimitPushDown() throws Exception {
-    String query = "select person_id from mysql.`drill_mysql_test`.person limit 10";
+    String query = "select person_id, first_name, last_name from mysql.`drill_mysql_test`.person limit 100";
     queryBuilder()
         .sql(query)
         .planMatcher()
-        .include("Jdbc\\(.*LIMIT 10")
+        .include("Jdbc\\(.*LIMIT 100")
+        .exclude("Limit\\(")
+        .match();
+  }
+
+  @Test
+  public void testLimitPushDownWithOrderBy() throws Exception {
+    String query = "select person_id from mysql.`drill_mysql_test`.person order by first_name limit 100";
+    queryBuilder()
+        .sql(query)
+        .planMatcher()
+        .include("Jdbc\\(.*ORDER BY `first_name`.*LIMIT 100")
+        .exclude("Limit\\(")
+        .match();
+  }
+
+  @Test
+  public void testLimitPushDownWithOffset() throws Exception {
+    String query = "select person_id, first_name from mysql.`drill_mysql_test`.person limit 100 offset 10";
+    queryBuilder()
+        .sql(query)
+        .planMatcher()
+        .include("Jdbc\\(.*LIMIT 100 OFFSET 10")
+        .exclude("Limit\\(")
+        .match();
+  }
+
+  @Test
+  public void testLimitPushDownWithConvertFromJson() throws Exception {
+    String query = "select convert_fromJSON(first_name)['ppid'] from mysql.`drill_mysql_test`.person LIMIT 100";
+    queryBuilder()
+        .sql(query)
+        .planMatcher()
+        .include("Jdbc\\(.*LIMIT 100")
         .exclude("Limit\\(")
         .match();
   }


### PR DESCRIPTION
# [DRILL-7771](https://issues.apache.org/jira/browse/DRILL-7771): Order by and limit transactions in RDBMS cannot be pushdown

## Description
- Introduced `DrillJdbcSort` to have the cost for limit queries that correspond to Drill's limit cost.
- Provided the ability to apply some JDBC rules after the logical planning phase. All other JDBC rules will be addressed in https://issues.apache.org/jira/browse/CALCITE-4423.
- Added unit tests

## Documentation
NA

## Testing
Added unit tests for the cases that were broken earlier.
