### PR TITLE
DRILL-7814: Add Limit Pushdown to MongoDB Storage Plugin

### DIFF
--- a/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidPushDownFilterForScan.java
+++ b/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidPushDownFilterForScan.java
@@ -73,8 +73,7 @@ public class DruidPushDownFilterForScan extends StoragePluginOptimizerRule {
             groupScan.getMaxRecordsToRead());
     newGroupsScan.setFilterPushedDown(true);
 
-    final ScanPrel newScanPrel = ScanPrel.create(scan, filter.getTraitSet(),
-      newGroupsScan, scan.getRowType());
+    ScanPrel newScanPrel = scan.copy(filter.getTraitSet(), newGroupsScan);
     if (druidFilterBuilder.isAllExpressionsConverted()) {
       /*
        * Since we could convert the entire filter condition expression into a

--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -45,10 +45,10 @@
   <dependency>
     <groupId>org.mongodb</groupId>
     <artifactId>mongo-java-driver</artifactId>
-    <version>3.12.7</version>
+    <version>3.12.8</version>
   </dependency>
 
-    <!-- Test dependencie -->
+    <!-- Test dependency -->
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
       <artifactId>drill-java-exec</artifactId>

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -522,14 +522,12 @@ public class MongoGroupScan extends AbstractGroupScan implements
 
       if (maxRecords > 0 && numDocs > 0) {
         recordCount = Math.min(maxRecords, numDocs);
-      } else if (maxRecords == -1) {
-        recordCount = numDocs;
       } else {
-        recordCount = maxRecords;
+        recordCount = numDocs;
       }
 
       float approxDiskCost = 0;
-      if (numDocs != 0) {
+      if (recordCount != 0) {
         //toJson should use client's codec, otherwise toJson could fail on
         // some types not known to DocumentCodec, e.g. DBRef.
         final DocumentCodec codec =

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoGroupScan.java
@@ -80,7 +80,7 @@ import com.mongodb.client.MongoDatabase;
 public class MongoGroupScan extends AbstractGroupScan implements
     DrillMongoConstants {
 
-  private static final Integer select = Integer.valueOf(1);
+  private static final Integer select = 1;
 
   private static final Logger logger = LoggerFactory.getLogger(MongoGroupScan.class);
 
@@ -654,5 +654,4 @@ public class MongoGroupScan extends AbstractGroupScan implements
   void setInverseChunsMapping(Map<String, List<ChunkInfo>> chunksInverseMapping) {
     this.chunksInverseMapping = chunksInverseMapping;
   }
-
 }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
@@ -51,7 +51,7 @@ public class MongoPushDownFilterForScan extends StoragePluginOptimizerRule {
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    final DrillScanRel scan = (DrillScanRel) call.rel(1);
+    final DrillScanRelBase scan = (DrillScanRelBase) call.rel(1);
     final Filter filter = (Filter) call.rel(0);
     final RexNode condition = filter.getCondition();
 
@@ -79,7 +79,7 @@ public class MongoPushDownFilterForScan extends StoragePluginOptimizerRule {
     }
     newGroupsScan.setFilterPushedDown(true);
 
-    final ScanPrel newScanPrel = new ScanPrel(scan.getCluster(), filter.getTraitSet(),
+    final DrillScanRelBase newScanPrel = new ScanPrel(scan.getCluster(), filter.getTraitSet(),
         newGroupsScan, scan.getRowType(), scan.getTable());
 
     if (mongoFilterBuilder.isAllExpressionsConverted()) {
@@ -97,7 +97,7 @@ public class MongoPushDownFilterForScan extends StoragePluginOptimizerRule {
 
   @Override
   public boolean matches(RelOptRuleCall call) {
-    final DrillScanRel scan = call.rel(1);
+    final DrillScanRelBase scan = (DrillScanRelBase)call.rel(1);
     if (scan.getGroupScan() instanceof MongoGroupScan) {
       return super.matches(call);
     }

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
@@ -70,7 +70,7 @@ public class MongoPushDownFilterForScan extends StoragePluginOptimizerRule {
     MongoGroupScan newGroupsScan = null;
     try {
       newGroupsScan = new MongoGroupScan(groupScan.getUserName(), groupScan.getStoragePlugin(),
-          newScanSpec, groupScan.getColumns());
+          newScanSpec, groupScan.getColumns(), groupScan.getMaxRecords());
     } catch (IOException e) {
       logger.error(e.getMessage(), e);
       throw new DrillRuntimeException(e.getMessage(), e);

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoPushDownFilterForScan.java
@@ -25,7 +25,6 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.exec.planner.common.DrillScanRelBase;
 import org.apache.drill.exec.planner.logical.DrillOptiq;
 import org.apache.drill.exec.planner.logical.DrillParseContext;
-import org.apache.drill.exec.planner.logical.DrillScanRel;
 import org.apache.drill.exec.planner.logical.RelOptHelper;
 import org.apache.drill.exec.planner.physical.PrelUtil;
 import org.apache.drill.exec.planner.physical.ScanPrel;
@@ -51,8 +50,8 @@ public class MongoPushDownFilterForScan extends StoragePluginOptimizerRule {
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    final DrillScanRelBase scan = (DrillScanRelBase) call.rel(1);
-    final Filter filter = (Filter) call.rel(0);
+    final DrillScanRelBase scan = call.rel(1);
+    final Filter filter = call.rel(0);
     final RexNode condition = filter.getCondition();
 
     MongoGroupScan groupScan = (MongoGroupScan) scan.getGroupScan();

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -75,6 +75,7 @@ public class MongoRecordReader extends AbstractRecordReader {
   private final boolean readNumbersAsDouble;
   private boolean unionEnabled;
   private final boolean isBsonRecordReader;
+  private final int maxRecords;
 
   public MongoRecordReader(MongoSubScan.MongoSubScanSpec subScanSpec, List<SchemaPath> projectedColumns,
       FragmentContext context, MongoStoragePlugin plugin) {
@@ -94,6 +95,7 @@ public class MongoRecordReader extends AbstractRecordReader {
     enableNanInf = fragmentContext.getOptions().getOption(ExecConstants.JSON_READER_NAN_INF_NUMBERS).bool_val;
     readNumbersAsDouble = fragmentContext.getOptions().getOption(ExecConstants.MONGO_READER_READ_NUMBERS_AS_DOUBLE).bool_val;
     isBsonRecordReader = fragmentContext.getOptions().getOption(ExecConstants.MONGO_BSON_RECORD_READER).bool_val;
+    maxRecords = subScanSpec.getMaxRecords();
     logger.debug("BsonRecordReader is enabled? " + isBsonRecordReader);
     init(subScanSpec);
   }
@@ -173,7 +175,13 @@ public class MongoRecordReader extends AbstractRecordReader {
     if (cursor == null) {
       logger.info("Filters Applied : " + filters);
       logger.info("Fields Selected :" + fields);
-      cursor = collection.find(filters).projection(fields).batchSize(100).iterator();
+
+      // Add limit to Mongo query
+      if (maxRecords > 0) {
+        cursor = collection.find(filters).projection(fields).limit(maxRecords).batchSize(100).iterator();
+      } else {
+        cursor = collection.find(filters).projection(fields).batchSize(100).iterator();
+      }
     }
 
     writer.allocate();

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoRecordReader.java
@@ -173,11 +173,12 @@ public class MongoRecordReader extends AbstractRecordReader {
   @Override
   public int next() {
     if (cursor == null) {
-      logger.info("Filters Applied : " + filters);
-      logger.info("Fields Selected :" + fields);
+      logger.debug("Filters Applied : " + filters);
+      logger.debug("Fields Selected :" + fields);
 
       // Add limit to Mongo query
       if (maxRecords > 0) {
+        logger.debug("Limit applied: {}", maxRecords);
         cursor = collection.find(filters).projection(fields).limit(maxRecords).batchSize(100).iterator();
       } else {
         cursor = collection.find(filters).projection(fields).batchSize(100).iterator();

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoStoragePlugin.java
@@ -129,7 +129,7 @@ public class MongoStoragePlugin extends AbstractStoragePlugin {
   public AbstractGroupScan getPhysicalScan(String userName, JSONOptions selection) throws IOException {
     MongoScanSpec mongoScanSpec = selection.getListWith(new ObjectMapper(), new TypeReference<MongoScanSpec>() {
     });
-    return new MongoGroupScan(userName, this, mongoScanSpec, null);
+    return new MongoGroupScan(userName, this, mongoScanSpec, null, -1);
   }
 
   @Override

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
@@ -128,6 +129,7 @@ public class MongoSubScan extends AbstractBase implements SubScan {
     protected List<String> hosts;
     protected Map<String, Object> minFilters;
     protected Map<String, Object> maxFilters;
+    protected int maxRecords;
 
     protected Document filter;
 
@@ -137,13 +139,15 @@ public class MongoSubScan extends AbstractBase implements SubScan {
         @JsonProperty("hosts") List<String> hosts,
         @JsonProperty("minFilters") Map<String, Object> minFilters,
         @JsonProperty("maxFilters") Map<String, Object> maxFilters,
-        @JsonProperty("filters") Document filters) {
+        @JsonProperty("filters") Document filters,
+        @JsonProperty("maxRecords") int maxRecords) {
       this.dbName = dbName;
       this.collectionName = collectionName;
       this.hosts = hosts;
       this.minFilters = minFilters;
       this.maxFilters = maxFilters;
       this.filter = filters;
+      this.maxRecords = maxRecords;
     }
 
     MongoSubScanSpec() {
@@ -177,6 +181,13 @@ public class MongoSubScan extends AbstractBase implements SubScan {
       return this;
     }
 
+    public int getMaxRecords() { return maxRecords; }
+
+    public MongoSubScanSpec setMaxRecords (int maxRecords) {
+      this.maxRecords = maxRecords;
+      return this;
+    }
+
     public Map<String, Object> getMinFilters() {
       return minFilters;
     }
@@ -206,9 +217,16 @@ public class MongoSubScan extends AbstractBase implements SubScan {
 
     @Override
     public String toString() {
-      return "MongoSubScanSpec [dbName=" + dbName + ", collectionName="
-          + collectionName + ", hosts=" + hosts + ", minFilters=" + minFilters
-          + ", maxFilters=" + maxFilters + ", filter=" + filter + "]";
+      return new PlanStringBuilder(this)
+        .field("dbName", dbName)
+        .field("collectionName", collectionName)
+        .field("hosts", hosts)
+        .field("minFilters", minFilters)
+        .field("maxFilters", maxFilters)
+        .field("filter", filter)
+        .field("maxRecords", maxRecords)
+        .toString();
+
     }
 
   }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestConstants.java
@@ -60,7 +60,10 @@ public interface MongoTestConstants {
 
   // test queries
   String TEST_QUERY_1 = "SELECT * FROM mongo.employee.`empinfo` limit 5";
-  String TEST_QUERY_LIMIT = "SELECT first_name, last_name FROM mongo.employee.`empinfo` limit 2;";
+  String TEST_QUERY_LIMIT = "SELECT first_name, last_name FROM mongo.%s.`%s` limit 2";
+  String TEST_LIMIT_QUERY = "select `employee_id` from mongo.%s.`%s` limit %d";
+
+
 
   // test query template1
   String TEST_QUERY_PROJECT_PUSH_DOWN_TEMPLATE_1 = "SELECT `employee_id` FROM mongo.%s.`%s`";

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/MongoTestSuite.java
@@ -70,6 +70,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   TestMongoFilterPushDown.class,
   TestMongoProjectPushDown.class,
   TestMongoQueries.class,
+  TestMongoLimitPushDown.class,
   TestMongoChunkAssignment.class,
   TestMongoStoragePluginUsesCredentialsStore.class,
   TestMongoDrillIssue.class

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
@@ -57,4 +57,14 @@ public class TestMongoLimitPushDown extends MongoTestBase {
       .include("Limit", "maxRecords=9")
       .match();
   }
+
+  @Test
+  public void testLimitWithFilter() throws Exception {
+    String sql = "SELECT `employee_id` FROM mongo.employee.`empinfo` WHERE rating = 52.17 LIMIT 4";
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=4")
+      .match();
+  }
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.drill.exec.store.mongo;
 
 import org.apache.drill.categories.MongoStorageTest;
@@ -8,13 +26,35 @@ import org.junit.experimental.categories.Category;
 @Category({SlowTest.class, MongoStorageTest.class})
 public class TestMongoLimitPushDown extends MongoTestBase {
 
+  @Test
+  public void testLimit() throws Exception {
+    String sql = "SELECT `employee_id` FROM mongo.employee.`empinfo` LIMIT 4";
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=4")
+      .match();
+  }
 
   @Test
-  public void testLimitWithANDOperator() throws Exception {
-    testBuilder()
-      .sqlQuery(String.format(TEST_LIMIT_QUERY, EMPLOYEE_DB, EMPINFO_COLLECTION, 4))
-      .unOrdered()
-      .expectsNumRecords(4)
-      .go();
+  public void testLimitWithOrderBy() throws Exception {
+    // Limit should not be pushed down for this example due to the sort
+    String sql = "SELECT `employee_id` FROM mongo.employee.`empinfo` ORDER BY employee_id LIMIT 4";
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=-1")
+      .match();
+  }
+
+  @Test
+  public void testLimitWithOffset() throws Exception {
+    // Limit should be pushed down and include the offset
+    String sql = "SELECT `employee_id` FROM mongo.employee.`empinfo` LIMIT 4 OFFSET 5";
+    queryBuilder()
+      .sql(sql)
+      .planMatcher()
+      .include("Limit", "maxRecords=9")
+      .match();
   }
 }

--- a/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
+++ b/contrib/storage-mongo/src/test/java/org/apache/drill/exec/store/mongo/TestMongoLimitPushDown.java
@@ -1,0 +1,20 @@
+package org.apache.drill.exec.store.mongo;
+
+import org.apache.drill.categories.MongoStorageTest;
+import org.apache.drill.categories.SlowTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({SlowTest.class, MongoStorageTest.class})
+public class TestMongoLimitPushDown extends MongoTestBase {
+
+
+  @Test
+  public void testLimitWithANDOperator() throws Exception {
+    testBuilder()
+      .sqlQuery(String.format(TEST_LIMIT_QUERY, EMPLOYEE_DB, EMPINFO_COLLECTION, 4))
+      .unOrdered()
+      .expectsNumRecords(4)
+      .go();
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillScanRelBase.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/common/DrillScanRelBase.java
@@ -86,4 +86,6 @@ public abstract class DrillScanRelBase extends TableScan implements DrillRelNode
     double dIo = 0;
     return planner.getCostFactory().makeCost(dRows, dCpu, dIo);
   }
+
+  public abstract DrillScanRelBase copy(RelTraitSet traitSet, GroupScan scan);
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/logical/DrillScanRel.java
@@ -191,4 +191,9 @@ public class DrillScanRel extends DrillScanRelBase implements DrillRel {
 
     return projectedColumns;
   }
+
+  @Override
+  public DrillScanRel copy(RelTraitSet traitSet, GroupScan scan) {
+    return new DrillScanRel(getCluster(), getTraitSet(), getTable(), scan, getRowType(), getColumns(), partitionFilterPushdown());
+  }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ScanPrel.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/planner/physical/ScanPrel.java
@@ -60,6 +60,11 @@ public class ScanPrel extends DrillScanRelBase implements LeafPrel, HasDistribut
   }
 
   @Override
+  public ScanPrel copy(RelTraitSet traitSet, GroupScan scan) {
+    return new ScanPrel(getCluster(), traitSet, scan, getRowType(), getTable());
+  }
+
+  @Override
   protected Object clone() throws CloneNotSupportedException {
     return new ScanPrel(this.getCluster(), this.getTraitSet(), getCopy(this.getGroupScan()),
         this.rowType, this.getTable());
@@ -78,12 +83,6 @@ public class ScanPrel extends DrillScanRelBase implements LeafPrel, HasDistribut
   public PhysicalOperator getPhysicalOperator(PhysicalPlanCreator creator)
       throws IOException {
     return creator.addMetadata(this, this.getGroupScan());
-  }
-
-  public static ScanPrel create(RelNode old, RelTraitSet traitSets,
-      GroupScan scan, RelDataType rowType) {
-    return new ScanPrel(old.getCluster(), traitSets,
-        getCopy(scan), rowType, old.getTable());
   }
 
   @Override


### PR DESCRIPTION
# [DRILL-7814](https://issues.apache.org/jira/browse/DRILL-7814): Add Limit Pushdown to MongoDB Storage Plugin

## Description
This PR adds a limit pushdown capability to the MongoDB storage plugin. 

## Documentation
No user visible changes

## Testing
Added new class of unit tests for the pushdown.