### PR TITLE
DRILL-7816: bootstrap-storage-plugins.json is an outdated example

### DIFF
--- a/contrib/storage-jdbc/src/main/resources/bootstrap-storage-plugins.json
+++ b/contrib/storage-jdbc/src/main/resources/bootstrap-storage-plugins.json
@@ -8,7 +8,7 @@
       "password": "xxx",
       "caseInsensitiveTableNames": false,
       "sourceParameters" : {
-        "maxIdle" : 8
+        "maximumPoolSize": 10
       },
       "enabled": false
     }


### PR DESCRIPTION
# [DRILL-7816](https://issues.apache.org/jira/projects/DRILL/issues/DRILL-7816): bootstrap-storage-plugins.json is an outdated example

## Description

Before Drill 1.18, we used DBCP2 to manage JDBC connections, and later we replaced it with "HikariCP". However, the parameter name of HikariCP is partly different from that of DBCP, so we need to modify the bootstrap code.

## Documentation
https://github.com/brettwooldridge/HikariCP/tree/HikariCP-3.4.2

## Testing
Create storage by the Web UI and it can be successful.
