### PR TITLE
DRILL-7787: Apache drill failed to start

### DIFF
--- a/_docs/install/045-distributed-mode-prerequisites.md
+++ b/_docs/install/045-distributed-mode-prerequisites.md
@@ -13,4 +13,6 @@ Before you install Drill on nodes in a cluster, ensure that the cluster meets th
   * (Required) Running Oracle or OpenJDK 8        
   * (Required) Running a [ZooKeeper quorum](https://zookeeper.apache.org/doc/r3.1.2/zookeeperStarted.html#sc_RunningReplicatedZooKeeper)  
   * (Recommended) Running a Hadoop cluster   
-  * (Recommended) Using DNS 
+  * (Recommended) Using DNS
+
+    {% include startnote.html %}Start from Drill 1.18, ZK version is upgraded to 3.5.7. So by default, we can't connect to the old ZK cluster (< 3.5). If we need to use the previous ZK, let's do this: first, delete the zookeeper dependency files in `${DRILL_HOME}/jars/ext`, then copy zookeeper-3.4.x.jar to the directory, and finally restart the cluster.{% include endnote.html %}


### PR DESCRIPTION
# [DRILL-7787](https://issues.apache.org/jira/browse/DRILL-7787): Apache drill failed to start

## Description

 It's not a problem. After many tests, drill 1.18 RC can connect to ZK 3.5 cluster. If you want to connect to the old ZK cluster (< 3.5), you can follow the changed document below.

## Documentation
 Start from Drill 1.18, ZK version is upgraded to 3.5.7. So by default, we can't connect to the old ZK cluster (< 3.5). If we need to use the previous ZK, let's do this: first, delete the zookeeper dependency files in ${DRILL_HOME}/jars/ext, then copy zookeeper-3.4.x.jar to the directory, and finally restart the cluster.

## Testing
1. By default, drill cluster can be started.  (ZK 3.5)
2. After replaced the new client with zookeeper-3.4.x.jar, you can also start the drill cluster.
