### PR TITLE
DRILL-7818 SplitPart (SPLIT_PART) UDF work correct only with one-row …

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/expr/fn/impl/TestStringFunctions.java
@@ -55,17 +55,19 @@ public class TestStringFunctions extends BaseTestQuery {
   @Test
   public void testSplitPart() throws Exception {
     testBuilder()
-        .sqlQuery("select split_part('abc~@~def~@~ghi', '~@~', 1) res1 from (values(1))")
+        .sqlQuery("select split_part(a, '~@~', 1) res1 from (values('abc~@~def~@~ghi'), ('qwe~@~rty~@~uio')) as t(a)")
         .ordered()
         .baselineColumns("res1")
         .baselineValues("abc")
+        .baselineValues("qwe")
         .go();
 
     testBuilder()
-        .sqlQuery("select split_part('abc~@~def~@~ghi', '~@~', 2) res1 from (values(1))")
+        .sqlQuery("select split_part(a, '~@~', 2) res1 from (values('abc~@~def~@~ghi'), ('qwe~@~rty~@~uio')) as t(a)")
         .ordered()
         .baselineColumns("res1")
         .baselineValues("def")
+        .baselineValues("rty")
         .go();
 
     // invalid index


### PR DESCRIPTION

# [DRILL-7818](https://issues.apache.org/jira/browse/DRILL-7818): SplitPart (SPLIT_PART) UDF work correct only with one-row data


## Description

Was rewritten `SPLIT_PART` UDF, as the previous version worked correctly only with one-row data

## Documentation
There are no changes visible to the user.

## Testing
`testSplitPart()` from `TestStringFunctions.java` was updated;
