### PR TITLE
DRILL-7552: Add Helpful Error Message on Storage Plugin Creation/Update

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/StoragePluginRegistryImpl.java
@@ -420,9 +420,13 @@ public class StoragePluginRegistryImpl implements StoragePluginRegistry {
       PluginHandle entry = restoreFromEphemeral(name, config);
       try {
         entry.plugin();
+      } catch (UserException e) {
+        // Provide helpful error messages.
+        throw new PluginException(e.getOriginalMessage(), e);
       } catch (Exception e) {
         throw new PluginException(String.format(
-            "Invalid plugin config for '%s'", name), e);
+            "Invalid plugin config for '%s', "
+          + "Please switch to Logs panel from the UI then check the log.", name), e);
       }
       oldEntry = pluginCache.put(entry);
     } else {


### PR DESCRIPTION
# [DRILL-7552](https://issues.apache.org/jira/browse/DRILL-7552): Add Helpful Error Message on Storage Plugin Creation/Update

## Description

 We can catch the UserException first and inform users as clearly as possible.

## Documentation
 
There are no changes visible to the user.

## Testing
 TestPluginRegistry#testBadPlugin()
