### PR TITLE
DRILL-7094: UnSupported Bson type: DECIMAL128 Mongodb 3.6 onwards

### DIFF
--- a/contrib/storage-mongo/pom.xml
+++ b/contrib/storage-mongo/pom.xml
@@ -45,7 +45,7 @@
   <dependency>
     <groupId>org.mongodb</groupId>
     <artifactId>mongo-java-driver</artifactId>
-    <version>3.8.0</version>
+    <version>3.12.7</version>
   </dependency>
 
     <!-- Test dependencie -->

--- a/exec/java-exec/pom.xml
+++ b/exec/java-exec/pom.xml
@@ -199,7 +199,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.8.0</version>
+      <version>3.12.7</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/bson/TestBsonRecordReader.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 
@@ -37,6 +38,7 @@ import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
 import org.bson.BsonBoolean;
 import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
 import org.bson.BsonDocumentWriter;
@@ -48,6 +50,7 @@ import org.bson.BsonString;
 import org.bson.BsonSymbol;
 import org.bson.BsonTimestamp;
 import org.bson.BsonWriter;
+import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.After;
 import org.junit.Before;
@@ -273,6 +276,16 @@ public class TestBsonRecordReader extends BaseTest {
     FieldReader reader = mapReader.reader("arrayKey");
     assertEquals(3, reader.size());
   }
+
+    @Test
+    public void testDecimal128Type() throws IOException {
+        BsonDocument bsonDoc = new BsonDocument();
+        bsonDoc.append("decimal128Key", new BsonDecimal128(Decimal128.parse("12.12345624")));
+        writer.reset();
+        bsonReader.write(writer, new BsonDocumentReader(bsonDoc));
+        SingleMapReaderImpl mapReader = (SingleMapReaderImpl) writer.getMapVector().getReader();
+        assertEquals(new BigDecimal("12.12345624"), mapReader.reader("decimal128Key").readBigDecimal());
+    }
 
   @After
   public void cleanUp() {


### PR DESCRIPTION
DRILL-7094: UnSupported Bson type: DECIMAL128 Mongodb 3.6 onwards

# [DRILL-7094](https://issues.apache.org/jira/browse/DRILL-7094): UnSupported Bson type: DECIMAL128 Mongodb 3.6 onwards


## Description

Handling the Decimal128 by converting into Double.

## Documentation
Now Bson Decimal128 type will be handled for the SQL queries and Show the result in double value.

## Testing
(Created a Document in Mongo DB with field of Decimal128 type and executing a SQL query using Apache Drill and it return the results. Previously there was a error unsupported Bson Type.)
