### PR TITLE
DRILL-7830: Add XML as Supported Format for HTTP Plugin

### DIFF
--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLUtils.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLUtils.java
@@ -72,11 +72,15 @@ public class XMLUtils {
   }
 
   /**
-   * Returns the field name from nested field names
+   * Returns the field name from nested field names.
    * @param fieldName The nested field name
    * @return The field name
    */
   public static String removeField(String fieldName) {
+    if (Strings.isNullOrEmpty(fieldName)) {
+      return fieldName;
+    }
+
     String[] components = fieldName.split("_");
     StringBuilder newField = new StringBuilder();
     for (int i = 0; i < components.length - 1; i++) {

--- a/contrib/storage-http/README.md
+++ b/contrib/storage-http/README.md
@@ -215,6 +215,11 @@ At present, there is no provision to check the `status` code in a response such
 as that shown above. Drill assumes that the server will uses HTTP status codes to
 indicate a bad request or other error.
 
+### Input Type
+The REST plugin accepts three different types of input: `json`, `csv` and `xml`.  The default is `json`.  If you are using `XML` as a data type, there is an additional 
+configuration option called `xmlDataLevel` which reduces the level of unneeded nesting found in XML files.  You can find more information in the documentation for Drill's XML 
+format plugin. 
+
 #### Authorization
 
 `authType`: If your API requires authentication, specify the authentication
@@ -364,7 +369,8 @@ To query this API, set the configuration as follows:
       "authType": "none",
       "userName": null,
       "password": null,
-      "postBody": null
+      "postBody": null, 
+      "inputType": "json",
     }
   }
 
@@ -500,7 +506,7 @@ ORDER BY issue_count DESC
    supported). Join pushdown has the potential to improve performance if you use the HTTP service
    joined to another table.
 
-4. This plugin only reads JSON and CSV responses.
+~~4. This plugin only reads JSON and CSV responses.~~
 
 5. `POST` bodies can only be in the format of key/value pairs. Some APIs accept
     JSON based `POST` bodies but this is not currently supported.

--- a/contrib/storage-http/pom.xml
+++ b/contrib/storage-http/pom.xml
@@ -45,6 +45,13 @@
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.drill.contrib</groupId>
+      <artifactId>drill-format-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.drill.exec</groupId>
@@ -68,7 +75,6 @@
       <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
   <build>
     <plugins>

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpApiConfig.java
@@ -34,6 +34,10 @@ import java.util.Objects;
 public class HttpApiConfig {
   private static final Logger logger = LoggerFactory.getLogger(HttpApiConfig.class);
 
+  protected static final String DEFAULT_INPUT_FORMAT = "json";
+  protected static final String CSV_INPUT_FORMAT = "csv";
+  protected static final String XML_INPUT_FORMAT = "xml";
+
   private final String url;
 
   /**
@@ -68,6 +72,7 @@ public class HttpApiConfig {
   private final String userName;
   private final String password;
   private final String inputType;
+  private final int xmlDataLevel;
 
 
   public enum HttpMethod {
@@ -91,7 +96,8 @@ public class HttpApiConfig {
                        @JsonProperty("params") List<String> params,
                        @JsonProperty("dataPath") String dataPath,
                        @JsonProperty("requireTail") Boolean requireTail,
-                       @JsonProperty("inputType") String inputType) {
+                       @JsonProperty("inputType") String inputType,
+                       @JsonProperty("xmlDataLevel") int xmlDataLevel) {
 
     this.headers = headers;
     this.method = Strings.isNullOrEmpty(method)
@@ -130,7 +136,9 @@ public class HttpApiConfig {
     this.requireTail = requireTail == null ? true : requireTail;
 
     this.inputType = inputType == null
-      ? "json" : inputType.trim().toLowerCase();
+      ? DEFAULT_INPUT_FORMAT : inputType.trim().toLowerCase();
+
+    this.xmlDataLevel = Math.max(1, xmlDataLevel);
   }
 
   @JsonProperty("url")
@@ -160,6 +168,9 @@ public class HttpApiConfig {
   @JsonProperty("dataPath")
   public String dataPath() { return dataPath; }
 
+  @JsonProperty("xmlDataLevel")
+  public int xmlDataLevel() { return xmlDataLevel; }
+
   @JsonProperty("requireTail")
   public boolean requireTail() { return requireTail; }
 
@@ -174,7 +185,7 @@ public class HttpApiConfig {
   @Override
   public int hashCode() {
     return Objects.hash(url, method, requireTail, params, headers,
-        authType, userName, password, postBody, inputType);
+        authType, userName, password, postBody, inputType, xmlDataLevel);
   }
 
   @Override
@@ -191,6 +202,7 @@ public class HttpApiConfig {
       .field("postBody", postBody)
       .field("filterFields", params)
       .field("inputType", inputType)
+      .field("xmlDataLevel", xmlDataLevel)
       .toString();
   }
 
@@ -213,6 +225,7 @@ public class HttpApiConfig {
       && Objects.equals(params, other.params)
       && Objects.equals(dataPath, other.dataPath)
       && Objects.equals(requireTail, other.requireTail)
-      && Objects.equals(inputType, other.inputType);
+      && Objects.equals(inputType, other.inputType)
+      && Objects.equals(xmlDataLevel, other.xmlDataLevel);
   }
 }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpScanBatchCreator.java
@@ -78,7 +78,6 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
   }
 
   private static class HttpReaderFactory implements ReaderFactory {
-
     private final HttpSubScan subScan;
     private int count;
 
@@ -97,8 +96,10 @@ public class HttpScanBatchCreator implements BatchCreator<HttpSubScan> {
 
       // Only a single scan (in a single thread)
       if (count++ == 0) {
-        if (inputType.equalsIgnoreCase("csv")) {
+        if (inputType.equalsIgnoreCase(HttpApiConfig.CSV_INPUT_FORMAT)) {
           return new HttpCSVBatchReader(subScan);
+        } else if (inputType.equalsIgnoreCase(HttpApiConfig.XML_INPUT_FORMAT)) {
+          return new HttpXMLBatchReader(subScan);
         } else {
           return new HttpBatchReader(subScan);
         }

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpXMLBatchReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.http;
+
+
+import okhttp3.HttpUrl;
+import org.apache.drill.common.AutoCloseables;
+import org.apache.drill.common.exceptions.ChildErrorContext;
+import org.apache.drill.common.exceptions.CustomErrorContext;
+import org.apache.drill.common.exceptions.UserException;
+import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.impl.scan.framework.SchemaNegotiator;
+import org.apache.drill.exec.physical.resultSet.ResultSetLoader;
+import org.apache.drill.exec.physical.resultSet.RowSetLoader;
+import org.apache.drill.exec.store.http.util.SimpleHttp;
+import org.apache.drill.exec.store.xml.XMLReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.InputStream;
+
+public class HttpXMLBatchReader extends HttpBatchReader {
+  private static final Logger logger = LoggerFactory.getLogger(HttpXMLBatchReader.class);
+  private final HttpSubScan subScan;
+  private final int maxRecords;
+  private final int dataLevel;
+  private InputStream inStream;
+  private XMLReader xmlReader;
+  private CustomErrorContext errorContext;
+
+  public HttpXMLBatchReader(HttpSubScan subScan) {
+    super(subScan);
+    this.subScan = subScan;
+    this.maxRecords = subScan.maxRecords();
+    this.dataLevel = subScan.tableSpec().connectionConfig().xmlDataLevel();
+  }
+
+  @Override
+  public boolean open(SchemaNegotiator negotiator) {
+
+    HttpUrl url = buildUrl();
+
+    // Result set loader setup
+    String tempDirPath = negotiator.drillConfig().getString(ExecConstants.DRILL_TMP_DIR);
+
+    // Create user-friendly error context
+    errorContext = new ChildErrorContext(negotiator.parentErrorContext()) {
+      @Override
+      public void addContext(UserException.Builder builder) {
+        super.addContext(builder);
+        builder.addContext("URL", url.toString());
+      }
+    };
+    negotiator.setErrorContext(errorContext);
+
+    // Http client setup
+    SimpleHttp http = new SimpleHttp(subScan, url, new File(tempDirPath), proxySettings(negotiator.drillConfig(), url), errorContext);
+
+    // Get the input stream
+    inStream = http.getInputStream();
+    // Initialize the XMLReader the reader
+    try {
+      xmlReader = new XMLReader(inStream, dataLevel, maxRecords);
+      ResultSetLoader resultLoader = negotiator.build();
+      RowSetLoader rootRowWriter = resultLoader.writer();
+      xmlReader.open(rootRowWriter, errorContext);
+    } catch (XMLStreamException e) {
+      throw UserException
+        .dataReadError(e)
+        .message("Error opening XML stream: " + e.getMessage())
+        .addContext(errorContext)
+        .build(logger);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean next() {
+    return xmlReader.next();
+  }
+
+  @Override
+  public void close() {
+    AutoCloseables.closeSilently(inStream);
+    xmlReader.close();
+  }
+}

--- a/contrib/storage-http/src/test/resources/data/response.xml
+++ b/contrib/storage-http/src/test/resources/data/response.xml
@@ -1,0 +1,309 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<CATALOG>
+  <PLANT>
+    <COMMON>Bloodroot</COMMON>
+    <BOTANICAL>Sanguinaria canadensis</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$2.44</PRICE>
+    <AVAILABILITY>031599</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Columbine</COMMON>
+    <BOTANICAL>Aquilegia canadensis</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$9.37</PRICE>
+    <AVAILABILITY>030699</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Marsh Marigold</COMMON>
+    <BOTANICAL>Caltha palustris</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Sunny</LIGHT>
+    <PRICE>$6.81</PRICE>
+    <AVAILABILITY>051799</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Cowslip</COMMON>
+    <BOTANICAL>Caltha palustris</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$9.90</PRICE>
+    <AVAILABILITY>030699</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Dutchman's-Breeches</COMMON>
+    <BOTANICAL>Dicentra cucullaria</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$6.44</PRICE>
+    <AVAILABILITY>012099</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Ginger, Wild</COMMON>
+    <BOTANICAL>Asarum canadense</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$9.03</PRICE>
+    <AVAILABILITY>041899</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Hepatica</COMMON>
+    <BOTANICAL>Hepatica americana</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$4.45</PRICE>
+    <AVAILABILITY>012699</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Liverleaf</COMMON>
+    <BOTANICAL>Hepatica americana</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$3.99</PRICE>
+    <AVAILABILITY>010299</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Jack-In-The-Pulpit</COMMON>
+    <BOTANICAL>Arisaema triphyllum</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$3.23</PRICE>
+    <AVAILABILITY>020199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Mayapple</COMMON>
+    <BOTANICAL>Podophyllum peltatum</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$2.98</PRICE>
+    <AVAILABILITY>060599</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Phlox, Woodland</COMMON>
+    <BOTANICAL>Phlox divaricata</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$2.80</PRICE>
+    <AVAILABILITY>012299</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Phlox, Blue</COMMON>
+    <BOTANICAL>Phlox divaricata</BOTANICAL>
+    <ZONE>3</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$5.59</PRICE>
+    <AVAILABILITY>021699</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Spring-Beauty</COMMON>
+    <BOTANICAL>Claytonia Virginica</BOTANICAL>
+    <ZONE>7</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$6.59</PRICE>
+    <AVAILABILITY>020199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Trillium</COMMON>
+    <BOTANICAL>Trillium grandiflorum</BOTANICAL>
+    <ZONE>5</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$3.90</PRICE>
+    <AVAILABILITY>042999</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Wake Robin</COMMON>
+    <BOTANICAL>Trillium grandiflorum</BOTANICAL>
+    <ZONE>5</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$3.20</PRICE>
+    <AVAILABILITY>022199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Violet, Dog-Tooth</COMMON>
+    <BOTANICAL>Erythronium americanum</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$9.04</PRICE>
+    <AVAILABILITY>020199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Trout Lily</COMMON>
+    <BOTANICAL>Erythronium americanum</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$6.94</PRICE>
+    <AVAILABILITY>032499</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Adder's-Tongue</COMMON>
+    <BOTANICAL>Erythronium americanum</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$9.58</PRICE>
+    <AVAILABILITY>041399</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Anemone</COMMON>
+    <BOTANICAL>Anemone blanda</BOTANICAL>
+    <ZONE>6</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$8.86</PRICE>
+    <AVAILABILITY>122698</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Grecian Windflower</COMMON>
+    <BOTANICAL>Anemone blanda</BOTANICAL>
+    <ZONE>6</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$9.16</PRICE>
+    <AVAILABILITY>071099</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Bee Balm</COMMON>
+    <BOTANICAL>Monarda didyma</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$4.59</PRICE>
+    <AVAILABILITY>050399</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Bergamot</COMMON>
+    <BOTANICAL>Monarda didyma</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$7.16</PRICE>
+    <AVAILABILITY>042799</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Black-Eyed Susan</COMMON>
+    <BOTANICAL>Rudbeckia hirta</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Sunny</LIGHT>
+    <PRICE>$9.80</PRICE>
+    <AVAILABILITY>061899</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Buttercup</COMMON>
+    <BOTANICAL>Ranunculus</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$2.57</PRICE>
+    <AVAILABILITY>061099</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Crowfoot</COMMON>
+    <BOTANICAL>Ranunculus</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$9.34</PRICE>
+    <AVAILABILITY>040399</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Butterfly Weed</COMMON>
+    <BOTANICAL>Asclepias tuberosa</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Sunny</LIGHT>
+    <PRICE>$2.78</PRICE>
+    <AVAILABILITY>063099</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Cinquefoil</COMMON>
+    <BOTANICAL>Potentilla</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$7.06</PRICE>
+    <AVAILABILITY>052599</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Primrose</COMMON>
+    <BOTANICAL>Oenothera</BOTANICAL>
+    <ZONE>3 - 5</ZONE>
+    <LIGHT>Sunny</LIGHT>
+    <PRICE>$6.56</PRICE>
+    <AVAILABILITY>013099</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Gentian</COMMON>
+    <BOTANICAL>Gentiana</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$7.81</PRICE>
+    <AVAILABILITY>051899</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Blue Gentian</COMMON>
+    <BOTANICAL>Gentiana</BOTANICAL>
+    <ZONE>4</ZONE>
+    <LIGHT>Sun or Shade</LIGHT>
+    <PRICE>$8.56</PRICE>
+    <AVAILABILITY>050299</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Jacob's Ladder</COMMON>
+    <BOTANICAL>Polemonium caeruleum</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$9.26</PRICE>
+    <AVAILABILITY>022199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Greek Valerian</COMMON>
+    <BOTANICAL>Polemonium caeruleum</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$4.36</PRICE>
+    <AVAILABILITY>071499</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>California Poppy</COMMON>
+    <BOTANICAL>Eschscholzia californica</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Sun</LIGHT>
+    <PRICE>$7.89</PRICE>
+    <AVAILABILITY>032799</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Shooting Star</COMMON>
+    <BOTANICAL>Dodecatheon</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Mostly Shady</LIGHT>
+    <PRICE>$8.60</PRICE>
+    <AVAILABILITY>051399</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Snakeroot</COMMON>
+    <BOTANICAL>Cimicifuga</BOTANICAL>
+    <ZONE>Annual</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$5.63</PRICE>
+    <AVAILABILITY>071199</AVAILABILITY>
+  </PLANT>
+  <PLANT>
+    <COMMON>Cardinal Flower</COMMON>
+    <BOTANICAL>Lobelia cardinalis</BOTANICAL>
+    <ZONE>2</ZONE>
+    <LIGHT>Shade</LIGHT>
+    <PRICE>$3.02</PRICE>
+    <AVAILABILITY>022299</AVAILABILITY>
+  </PLANT>
+</CATALOG>


### PR DESCRIPTION
# [DRILL-7830](https://issues.apache.org/jira/browse/DRILL-7830): Add XML as Supported Format for HTTP Plugin

## Description
This PR extends the HTTP/REST plugin to accept XML as input. This PR reuses Drill's existing XML reader.

## Documentation
This PR allows the REST plugin to query REST APIs which return XML data.  The REST plugin currently has an option called `inputType`.  The available options are `xml`, `json`, `csv`.   


This PR also adds an additional configuration option of `xmlDataLevel` which sets the starting nesting level for the XML data.  This helps reduce the amount of unhelpful nesting in the data.  You can view the [documentation for the XML plugin here](https://github.com/apache/drill/tree/master/contrib/format-xml).

## Testing
Added additional unit test.
