### PR TITLE
DRILL-7831: Drill Fails To Read XML File with Self Closing Tags

### DIFF
--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLUtils.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLUtils.java
@@ -76,21 +76,18 @@ public class XMLUtils {
    * @param fieldName The nested field name
    * @return The field name
    */
-  public static String removeField(String fieldName) {
-    if (Strings.isNullOrEmpty(fieldName)) {
-      return fieldName;
+  public static String removeField(String prefix, String fieldName) {
+    if (fieldName == null) {
+      return "";
     }
 
-    String[] components = fieldName.split("_");
-    StringBuilder newField = new StringBuilder();
-    for (int i = 0; i < components.length - 1; i++) {
-      if (i > 0) {
-        newField.append("_").append(components[i]);
-      } else {
-        newField = new StringBuilder(components[i]);
-      }
+    int index = prefix.lastIndexOf(fieldName);
+    if (index == 0) {
+      return "";
+    } else if (index < 0) {
+      return prefix;
     }
-    return newField.toString();
+
+    return prefix.substring(0, index-1);
   }
-
 }

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLReader.java
@@ -83,6 +83,51 @@ public class TestXMLReader extends ClusterTest {
     new RowSetComparison(expected).verifyAndClearAll(results);
   }
 
+  @Test
+  public void testSelfClosingTags() throws Exception {
+    String sql = "SELECT * FROM cp.`xml/weather.xml`";
+    RowSet results = client.queryBuilder().sql(sql).rowSet();
+    assertEquals(1, results.rowCount());
+
+      TupleMetadata expectedSchema = new SchemaBuilder()
+        .addMap("attributes")
+          .addNullable("forecast_information_city_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_postal_code_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_latitude_e6_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_longitude_e6_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_forecast_date_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_current_date_time_data", MinorType.VARCHAR)
+          .addNullable("forecast_information_unit_system_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_condition_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_temp_f_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_temp_c_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_humidity_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_icon_data", MinorType.VARCHAR)
+          .addNullable("current_conditions_wind_condition_data", MinorType.VARCHAR)
+        .resumeSchema()
+        .addNullable("city", MinorType.VARCHAR)
+        .addNullable("postal_code", MinorType.VARCHAR)
+        .addNullable("latitude_e6", MinorType.VARCHAR)
+        .addNullable("longitude_e6", MinorType.VARCHAR)
+        .addNullable("forecast_date", MinorType.VARCHAR)
+        .addNullable("current_date_time", MinorType.VARCHAR)
+        .addNullable("unit_system", MinorType.VARCHAR)
+        .addNullable("condition", MinorType.VARCHAR)
+        .addNullable("temp_f", MinorType.VARCHAR)
+        .addNullable("temp_c", MinorType.VARCHAR)
+        .addNullable("humidity", MinorType.VARCHAR)
+        .addNullable("icon", MinorType.VARCHAR)
+        .addNullable("wind_condition", MinorType.VARCHAR)
+        .build();
+
+    RowSet expected = client.rowSetBuilder(expectedSchema)
+      .addRow((Object)strArray("Seattle, WA", "Seattle WA", "", "", "2011-09-29", "2011-09-29 17:53:00 +0000", "US", "Clear", "62", "17", "Humidity: 62%", "/ig/images/weather" +
+        "/sunny.gif", "Wind: N at 4 mph"), null, null, null, null, null, null, null, null, null, null, null, null, null)
+      .build();
+
+    new RowSetComparison(expected).verifyAndClearAll(results);
+  }
+
   /**
    * This unit test tests a simple XML file with no nesting or attributes, but with explicitly selected fields.
    * @throws Exception Throw exception if anything goes wrong

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLUtils.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/TestXMLUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.drill.exec.store.xml;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestXMLUtils {
+
+  @Test
+  public void testRemoveField() {
+    String test1 = "field1_field2_field3";
+    assertEquals(XMLUtils.removeField(test1, "field3"), "field1_field2");
+
+    // Test with underscores
+    String test2 = "field_1_field_2_field_3";
+    assertEquals(XMLUtils.removeField(test2, "field_3"), "field_1_field_2");
+
+    // Test with missing field
+    String test3 = "field_1_field_2_field_3";
+    assertEquals(XMLUtils.removeField(test3, "field_4"), "field_1_field_2_field_3");
+
+    // Test with empty string
+    String test4 = "";
+    assertEquals(XMLUtils.removeField(test4, "field_4"), "");
+  }
+}

--- a/contrib/format-xml/src/test/resources/xml/very-nested-with-attributes.xml
+++ b/contrib/format-xml/src/test/resources/xml/very-nested-with-attributes.xml
@@ -1,0 +1,38 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<book>
+  <field1 f1="a1" f2="a2">
+    <key1>value1</key1>
+    <key2>value2</key2>
+  </field1>
+  <field2>
+    <key3 f3="a3" f4="a4">k1</key3>
+    <nestedField1>
+      <nk1>nk_value1</nk1>
+      <nk2>nk_value2</nk2>
+      <nk3>nk_value3</nk3>
+      <nestedField2>
+        <nk1 f5="a5">nk2_value1</nk1>
+        <nk2>nk2_value2</nk2>
+        <nk3>nk2_value3</nk3>
+      </nestedField2>
+    </nestedField1>
+  </field2>
+</book>

--- a/contrib/format-xml/src/test/resources/xml/weather.xml
+++ b/contrib/format-xml/src/test/resources/xml/weather.xml
@@ -1,0 +1,40 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xml_api_reply version="1">
+  <weather module_id="0" tab_id="0" mobile_row="0" mobile_zipped="1" row="0" section="0">
+    <forecast_information>
+      <city data="Seattle, WA"/>
+      <postal_code data="Seattle WA"/>
+      <latitude_e6 data=""/>
+      <longitude_e6 data=""/>
+      <forecast_date data="2011-09-29"/>
+      <current_date_time data="2011-09-29 17:53:00 +0000"/>
+      <unit_system data="US"/>
+    </forecast_information>
+    <current_conditions>
+      <condition data="Clear"/>
+      <temp_f data="62"/>
+      <temp_c data="17"/>
+      <humidity data="Humidity: 62%"/>
+      <icon data="/ig/images/weather/sunny.gif"/>
+      <wind_condition data="Wind: N at 4 mph"/>
+    </current_conditions>
+  </weather>
+</xml_api_reply>


### PR DESCRIPTION
# [DRILL-7831](https://issues.apache.org/jira/browse/DRILL-7831): Drill Fails To Read XML File with Self Closing Tags

## Description
This PR addresses two issues with the XML plugin for Drill:

1.  In cases where there were self closing tags, Drill was not reading them correctly.  This PR fixes this.
2. Attribute names were not being parsed correctly in the case of addresses with underscores.  This is reported in [DRILL-7832](https://issues.apache.org/jira/browse/DRILL-7832). 

## Documentation
No user facing changes.

## Testing
Several new unit tests added to this PR. 
