### PR TITLE
DRILL-7836: Format Plugins Hang with Compressed Files

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DrillFileSystem.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.drill.common.AutoCloseables;
 import org.apache.drill.exec.ops.OperatorStats;
 import org.apache.drill.exec.util.AssertionUtil;
 import org.apache.hadoop.classification.InterfaceAudience.LimitedPrivate;
@@ -818,6 +819,7 @@ public class DrillFileSystem extends FileSystem implements OpenFileTracker {
     } else {
       InputStream compressedStream = codec.createInputStream(open(path));
       byte[] bytes = IOUtils.toByteArray(compressedStream);
+      AutoCloseables.closeSilently(compressedStream);
       return new ByteArrayInputStream(bytes);
     }
   }


### PR DESCRIPTION
# [DRILL-7836](https://issues.apache.org/jira/browse/DRILL-7836): Format Plugins Hang with Compressed Files

## Description
The new method `openDecompressedInputStream()` did not close the temp InputStream which caused format plugins to hang. Testing the method by itself did not reveal this, but it became apparent when this method was used in an actual format plugin.

## Documentation
No user facing changes.

## Testing
Tested with two format plugins in development. 
