### PR TITLE
DRILL-7840: Add OWASP Dependency Report to Pom.XML

### DIFF
--- a/docs/dev/Environment.md
+++ b/docs/dev/Environment.md
@@ -32,6 +32,14 @@ On other systems your success may vary. On Redhat/CentOS based systems no longer
     cd drill
     mvn clean install -DskipTests
 
+## Build Quickly
+This command works to build Drill in about 2 minutes for quick testing. 
+
+    mvn install -T 4 -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Drat.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dmaven.site.skip=true -Denforcer.skip=true -DskipIfEmpty=true -Dmaven.compiler.optimize=true
+
+## Generate Dependency Report
+    mvn clean site
+
 ## Explode tarball in installation directory
    
     mkdir /opt/drill

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,16 @@
     <url>https://issues.apache.org/jira/browse/DRILL</url>
   </issueManagement>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>6.0.4</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
# [DRILL-7840](https://issues.apache.org/jira/browse/DRILL-7840): Add OWASP Dependency Report to Pom.XML

## Description

This PR adds the OWASP Dependency-Check to the master `pom.xml` file. You can generate a report of Drill's dependencies by running the command:
```
mvn clean site
```
This does not affect the regular build process.

## Documentation
No user facing changes.  Developers can check whether new dependencies introduced vulnerabilities by running the above command. 

## Testing
Built Drill normally and generated report using the `mvn clean site` command.