### PR TITLE
DRILL-5405: Add missing operator types without dependency on protobuf enum

### DIFF
--- a/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpFormatPlugin.java
+++ b/contrib/format-esri/src/main/java/org/apache/drill/exec/store/esri/ShpFormatPlugin.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchem
 
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -34,13 +33,7 @@ import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.drill.exec.store.esri.ShpBatchReader.ShpReaderConfig;
 import org.apache.hadoop.conf.Configuration;
 
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ShpFormatPlugin extends EasyFormatPlugin<ShpFormatConfig> {
-
-  private static final Logger logger = LoggerFactory.getLogger(ShpFormatPlugin.class);
 
   public static final String PLUGIN_NAME = "shp";
 
@@ -79,18 +72,17 @@ public class ShpFormatPlugin extends EasyFormatPlugin<ShpFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, ShpFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = false;
-    config.supportsProjectPushdown = true;
-    config.extensions = Lists.newArrayList(pluginConfig.getExtensions());
-    config.fsConf = fsConf;
-    config.defaultName = PLUGIN_NAME;
-    config.readerOperatorType = CoreOperatorType.SHP_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(false)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(PLUGIN_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 }

--- a/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
+++ b/contrib/format-excel/src/main/java/org/apache/drill/exec/store/excel/ExcelFormatPlugin.java
@@ -18,7 +18,6 @@
 
 package org.apache.drill.exec.store.excel;
 
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.types.TypeProtos;
@@ -28,7 +27,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanB
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -66,29 +64,28 @@ public class ExcelFormatPlugin extends EasyFormatPlugin<ExcelFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, ExcelFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = UserBitShared.CoreOperatorType.EXCEL_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override
   public ManagedReader<? extends FileSchemaNegotiator> newBatchReader(
-    EasySubScan scan, OptionManager options) throws ExecutionSetupException {
+    EasySubScan scan, OptionManager options) {
     return new ExcelBatchReader(formatConfig.getReaderConfig(this), scan.getMaxRecords());
   }
 
   @Override
-  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) throws ExecutionSetupException {
+  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanBuilder builder = new FileScanBuilder();
     ExcelReaderConfig readerConfig = new ExcelReaderConfig(this);
 

--- a/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5FormatPlugin.java
+++ b/contrib/format-hdf5/src/main/java/org/apache/drill/exec/store/hdf5/HDF5FormatPlugin.java
@@ -19,7 +19,6 @@
 package org.apache.drill.exec.store.hdf5;
 
 import org.apache.drill.common.config.DrillConfig;
-import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
@@ -28,7 +27,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
@@ -55,23 +53,22 @@ public class HDF5FormatPlugin extends EasyFormatPlugin<HDF5FormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, HDF5FormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = UserBitShared.CoreOperatorType.HDF5_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override
-  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) throws ExecutionSetupException {
+  protected FileScanBuilder frameworkBuilder(OptionManager options, EasySubScan scan) {
     FileScanBuilder builder = new FileScanBuilder();
 
     builder.setReaderFactory(new HDF5ReaderFactory(new HDF5BatchReader.HDF5ReaderConfig(this, formatConfig), scan.getMaxRecords()));

--- a/contrib/format-httpd/src/main/java/org/apache/drill/exec/store/httpd/HttpdLogFormatPlugin.java
+++ b/contrib/format-httpd/src/main/java/org/apache/drill/exec/store/httpd/HttpdLogFormatPlugin.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReaderFactory;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -35,6 +34,8 @@ import org.apache.hadoop.conf.Configuration;
 public class HttpdLogFormatPlugin extends EasyFormatPlugin<HttpdLogFormatConfig> {
 
   protected static final String DEFAULT_NAME = "httpd";
+
+  public static final String OPERATOR_TYPE = "HTPPD_LOG_SUB_SCAN";
 
   private static class HttpLogReaderFactory extends FileReaderFactory {
 
@@ -64,19 +65,19 @@ public class HttpdLogFormatPlugin extends EasyFormatPlugin<HttpdLogFormatConfig>
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, HttpdLogFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = UserBitShared.CoreOperatorType.HTPPD_LOG_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .readerOperatorType(OPERATOR_TYPE)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/contrib/format-ltsv/src/main/java/org/apache/drill/exec/store/ltsv/LTSVFormatPlugin.java
+++ b/contrib/format-ltsv/src/main/java/org/apache/drill/exec/store/ltsv/LTSVFormatPlugin.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.RecordWriter;
@@ -54,14 +53,8 @@ public class LTSVFormatPlugin extends EasyFormatPlugin<LTSVFormatPluginConfig> {
     return new LTSVRecordReader(context, fileWork.getPath(), dfs, columns);
   }
 
-
   @Override
-  public int getReaderOperatorType() {
-    return UserBitShared.CoreOperatorType.LTSV_SUB_SCAN_VALUE;
-  }
-
-  @Override
-  public int getWriterOperatorType() {
+  public String getWriterOperatorType() {
     throw new UnsupportedOperationException("Drill doesn't currently support writing to LTSV files.");
   }
 

--- a/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBSubScan.java
+++ b/contrib/format-maprdb/src/main/java/org/apache/drill/exec/store/mapr/db/MapRDBSubScan.java
@@ -28,7 +28,6 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractDbSubScan;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
@@ -42,6 +41,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 @JsonTypeName("maprdb-sub-scan")
 
 public class MapRDBSubScan extends AbstractDbSubScan {
+
+  public static final String OPERATOR_TYPE = "MAPRDB_SUB_SCAN";
 
   private final MapRDBFormatPlugin formatPlugin;
   private final List<MapRDBSubScanSpec> regionScanSpecList;
@@ -143,8 +144,8 @@ public class MapRDBSubScan extends AbstractDbSubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.MAPRDB_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @JsonIgnore

--- a/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssFormatPlugin.java
+++ b/contrib/format-spss/src/main/java/org/apache/drill/exec/store/spss/SpssFormatPlugin.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanB
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -59,19 +58,18 @@ public class SpssFormatPlugin extends EasyFormatPlugin<SpssFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, SpssFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = UserBitShared.CoreOperatorType.SPSS_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/contrib/format-syslog/src/main/java/org/apache/drill/exec/store/syslog/SyslogFormatPlugin.java
+++ b/contrib/format-syslog/src/main/java/org/apache/drill/exec/store/syslog/SyslogFormatPlugin.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReade
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -61,19 +60,18 @@ public class SyslogFormatPlugin extends EasyFormatPlugin<SyslogFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, SyslogFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = CoreOperatorType.SYSLOG_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLFormatPlugin.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLFormatPlugin.java
@@ -24,14 +24,11 @@ import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
-import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
-
 
 public class XMLFormatPlugin extends EasyFormatPlugin<XMLFormatConfig> {
 
@@ -61,19 +58,18 @@ public class XMLFormatPlugin extends EasyFormatPlugin<XMLFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, XMLFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = Lists.newArrayList(pluginConfig.getExtensions());
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = CoreOperatorType.XML_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.cc
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.cc
@@ -469,7 +469,7 @@ static void InitDefaultsscc_info_UserCredentials_UserBitShared_2eproto() {
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_UserCredentials_UserBitShared_2eproto}, {}};
 
 static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_UserBitShared_2eproto[22];
-static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_UserBitShared_2eproto[8];
+static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_UserBitShared_2eproto[7];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_UserBitShared_2eproto = nullptr;
 
 const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_UserBitShared_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
@@ -742,14 +742,16 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_UserBitShared_2eproto::offsets
   PROTOBUF_FIELD_OFFSET(::exec::shared::OperatorProfile, peak_local_memory_allocated_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::OperatorProfile, metric_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::OperatorProfile, wait_nanos_),
+  PROTOBUF_FIELD_OFFSET(::exec::shared::OperatorProfile, operator_type_name_),
   ~0u,
-  0,
   1,
   2,
   3,
   4,
-  ~0u,
   5,
+  ~0u,
+  6,
+  0,
   PROTOBUF_FIELD_OFFSET(::exec::shared::StreamProfile, _has_bits_),
   PROTOBUF_FIELD_OFFSET(::exec::shared::StreamProfile, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -817,12 +819,12 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 169, 197, sizeof(::exec::shared::QueryProfile)},
   { 220, 227, sizeof(::exec::shared::MajorFragmentProfile)},
   { 229, 245, sizeof(::exec::shared::MinorFragmentProfile)},
-  { 256, 269, sizeof(::exec::shared::OperatorProfile)},
-  { 277, 285, sizeof(::exec::shared::StreamProfile)},
-  { 288, 296, sizeof(::exec::shared::MetricValue)},
-  { 299, 305, sizeof(::exec::shared::Registry)},
-  { 306, 313, sizeof(::exec::shared::Jar)},
-  { 315, 323, sizeof(::exec::shared::SaslMessage)},
+  { 256, 270, sizeof(::exec::shared::OperatorProfile)},
+  { 279, 287, sizeof(::exec::shared::StreamProfile)},
+  { 290, 298, sizeof(::exec::shared::MetricValue)},
+  { 301, 307, sizeof(::exec::shared::Registry)},
+  { 308, 315, sizeof(::exec::shared::Jar)},
+  { 317, 325, sizeof(::exec::shared::SaslMessage)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -935,68 +937,33 @@ const char descriptor_table_protodef_UserBitShared_2eproto[] PROTOBUF_SECTION_VA
   "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n"
   "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022"
   "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 "
-  "\001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_profile"
+  "\001(\003\"\237\002\n\017OperatorProfile\0221\n\rinput_profile"
   "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op"
-  "erator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 \001(\005\022\023"
-  "\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001"
-  "(\003\022#\n\033peak_local_memory_allocated\030\007 \001(\003\022"
-  "(\n\006metric\030\010 \003(\0132\030.exec.shared.MetricValu"
-  "e\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProfile\022\017"
-  "\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007sche"
-  "mas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 "
-  "\001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_value\030"
-  "\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.sh"
-  "ared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022functio"
-  "n_signature\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmech"
-  "anism\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001("
-  "\0162\027.exec.shared.SaslStatus*5\n\nRpcChannel"
-  "\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020"
-  "\002*V\n\tQueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010"
-  "PHYSICAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_ST"
-  "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000"
-  "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014"
-  "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022"
-  "\032\n\026CANCELLATION_REQUESTED\020\006*\260\013\n\020CoreOper"
-  "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST"
-  "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020"
-  "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH"
-  "_PARTITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGIN"
-  "G_RECEIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER"
-  "\020\t\022\013\n\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022"
-  "\032\n\026RANGE_PARTITION_SENDER\020\014\022\n\n\006SCREEN\020\r\022"
-  "\034\n\030SELECTION_VECTOR_REMOVER\020\016\022\027\n\023STREAMI"
-  "NG_AGGREGATE\020\017\022\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERN"
-  "AL_SORT\020\021\022\t\n\005TRACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_S"
-  "ORT\020\024\022\032\n\026PARQUET_ROW_GROUP_SCAN\020\025\022\021\n\rHIV"
-  "E_SUB_SCAN\020\026\022\025\n\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rM"
-  "OCK_SUB_SCAN\020\030\022\022\n\016PARQUET_WRITER\020\031\022\023\n\017DI"
-  "RECT_SUB_SCAN\020\032\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT"
-  "_SUB_SCAN\020\034\022\021\n\rJSON_SUB_SCAN\020\035\022\030\n\024INFO_S"
-  "CHEMA_SUB_SCAN\020\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n"
-  "\021PRODUCER_CONSUMER\020 \022\022\n\016HBASE_SUB_SCAN\020!"
-  "\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOOP_JOIN\020#\022\021\n\rAV"
-  "RO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFK"
-  "A_SUB_SCAN\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATT"
-  "EN\020(\022\020\n\014LATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HI"
-  "VE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN\020+"
-  "\022\r\n\tJDBC_SCAN\020,\022\022\n\016REGEX_SUB_SCAN\020-\022\023\n\017M"
-  "APRDB_SUB_SCAN\020.\022\022\n\016MONGO_SUB_SCAN\020/\022\017\n\013"
-  "KUDU_WRITER\0200\022\026\n\022OPEN_TSDB_SUB_SCAN\0201\022\017\n"
-  "\013JSON_WRITER\0202\022\026\n\022HTPPD_LOG_SUB_SCAN\0203\022\022"
-  "\n\016IMAGE_SUB_SCAN\0204\022\025\n\021SEQUENCE_SUB_SCAN\020"
-  "5\022\023\n\017PARTITION_LIMIT\0206\022\023\n\017PCAPNG_SUB_SCA"
-  "N\0207\022\022\n\016RUNTIME_FILTER\0208\022\017\n\013ROWKEY_JOIN\0209"
-  "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR"
-  "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_"
-  "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>\022\021\n\rHDF5_SUB_S"
-  "CAN\020\?\022\022\n\016EXCEL_SUB_SCAN\020@\022\020\n\014SHP_SUB_SCA"
-  "N\020A\022\024\n\020METADATA_HANDLER\020B\022\027\n\023METADATA_CO"
-  "NTROLLER\020C\022\022\n\016DRUID_SUB_SCAN\020D\022\021\n\rSPSS_S"
-  "UB_SCAN\020E\022\021\n\rHTTP_SUB_SCAN\020F\022\020\n\014XML_SUB_"
-  "SCAN\020G*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016"
-  "\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014"
-  "SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.a"
-  "pache.drill.exec.protoB\rUserBitSharedH\001"
+  "erator_id\030\003 \001(\005\022\031\n\roperator_type\030\004 \001(\005B\002"
+  "\030\001\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos"
+  "\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007 "
+  "\001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metric"
+  "Value\022\022\n\nwait_nanos\030\t \001(\003\022\032\n\022operator_ty"
+  "pe_name\030\n \001(\t\"B\n\rStreamProfile\022\017\n\007record"
+  "s\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001("
+  "\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nl"
+  "ong_value\030\002 \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n"
+  "\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.shared.Jar"
+  "\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022function_signat"
+  "ure\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmechanism\030\001 "
+  "\001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec"
+  ".shared.SaslStatus*5\n\nRpcChannel\022\017\n\013BIT_"
+  "CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQue"
+  "ryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL"
+  "\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEMENT\020"
+  "\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAI"
+  "TING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISH"
+  "ED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCE"
+  "LLATION_REQUESTED\020\006*g\n\nSaslStatus\022\020\n\014SAS"
+  "L_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_P"
+  "ROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAIL"
+  "ED\020\004B.\n\033org.apache.drill.exec.protoB\rUse"
+  "rBitSharedH\001"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_UserBitShared_2eproto_deps[3] = {
   &::descriptor_table_Coordination_2eproto,
@@ -1030,7 +997,7 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_Use
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_UserBitShared_2eproto_once;
 static bool descriptor_table_UserBitShared_2eproto_initialized = false;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_UserBitShared_2eproto = {
-  &descriptor_table_UserBitShared_2eproto_initialized, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto", 5839,
+  &descriptor_table_UserBitShared_2eproto_initialized, descriptor_table_protodef_UserBitShared_2eproto, "UserBitShared.proto", 4412,
   &descriptor_table_UserBitShared_2eproto_once, descriptor_table_UserBitShared_2eproto_sccs, descriptor_table_UserBitShared_2eproto_deps, 22, 3,
   schemas, file_default_instances, TableStruct_UserBitShared_2eproto::offsets,
   file_level_metadata_UserBitShared_2eproto, 22, file_level_enum_descriptors_UserBitShared_2eproto, file_level_service_descriptors_UserBitShared_2eproto,
@@ -1192,93 +1159,9 @@ bool FragmentState_IsValid(int value) {
   }
 }
 
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* CoreOperatorType_descriptor() {
-  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_UserBitShared_2eproto);
-  return file_level_enum_descriptors_UserBitShared_2eproto[6];
-}
-bool CoreOperatorType_IsValid(int value) {
-  switch (value) {
-    case 0:
-    case 1:
-    case 2:
-    case 3:
-    case 4:
-    case 5:
-    case 6:
-    case 7:
-    case 8:
-    case 9:
-    case 10:
-    case 11:
-    case 12:
-    case 13:
-    case 14:
-    case 15:
-    case 16:
-    case 17:
-    case 18:
-    case 19:
-    case 20:
-    case 21:
-    case 22:
-    case 23:
-    case 24:
-    case 25:
-    case 26:
-    case 27:
-    case 28:
-    case 29:
-    case 30:
-    case 31:
-    case 32:
-    case 33:
-    case 34:
-    case 35:
-    case 36:
-    case 37:
-    case 38:
-    case 39:
-    case 40:
-    case 41:
-    case 42:
-    case 43:
-    case 44:
-    case 45:
-    case 46:
-    case 47:
-    case 48:
-    case 49:
-    case 50:
-    case 51:
-    case 52:
-    case 53:
-    case 54:
-    case 55:
-    case 56:
-    case 57:
-    case 58:
-    case 59:
-    case 60:
-    case 61:
-    case 62:
-    case 63:
-    case 64:
-    case 65:
-    case 66:
-    case 67:
-    case 68:
-    case 69:
-    case 70:
-    case 71:
-      return true;
-    default:
-      return false;
-  }
-}
-
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* SaslStatus_descriptor() {
   ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_UserBitShared_2eproto);
-  return file_level_enum_descriptors_UserBitShared_2eproto[7];
+  return file_level_enum_descriptors_UserBitShared_2eproto[6];
 }
 bool SaslStatus_IsValid(int value) {
   switch (value) {
@@ -7454,22 +7337,25 @@ class OperatorProfile::_Internal {
  public:
   using HasBits = decltype(std::declval<OperatorProfile>()._has_bits_);
   static void set_has_operator_id(HasBits* has_bits) {
-    (*has_bits)[0] |= 1u;
-  }
-  static void set_has_operator_type(HasBits* has_bits) {
     (*has_bits)[0] |= 2u;
   }
-  static void set_has_setup_nanos(HasBits* has_bits) {
+  static void set_has_operator_type(HasBits* has_bits) {
     (*has_bits)[0] |= 4u;
   }
-  static void set_has_process_nanos(HasBits* has_bits) {
+  static void set_has_setup_nanos(HasBits* has_bits) {
     (*has_bits)[0] |= 8u;
   }
-  static void set_has_peak_local_memory_allocated(HasBits* has_bits) {
+  static void set_has_process_nanos(HasBits* has_bits) {
     (*has_bits)[0] |= 16u;
   }
-  static void set_has_wait_nanos(HasBits* has_bits) {
+  static void set_has_peak_local_memory_allocated(HasBits* has_bits) {
     (*has_bits)[0] |= 32u;
+  }
+  static void set_has_wait_nanos(HasBits* has_bits) {
+    (*has_bits)[0] |= 64u;
+  }
+  static void set_has_operator_type_name(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
   }
 };
 
@@ -7485,6 +7371,10 @@ OperatorProfile::OperatorProfile(const OperatorProfile& from)
       input_profile_(from.input_profile_),
       metric_(from.metric_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  operator_type_name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (from._internal_has_operator_type_name()) {
+    operator_type_name_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.operator_type_name_);
+  }
   ::memcpy(&operator_id_, &from.operator_id_,
     static_cast<size_t>(reinterpret_cast<char*>(&wait_nanos_) -
     reinterpret_cast<char*>(&operator_id_)) + sizeof(wait_nanos_));
@@ -7493,6 +7383,7 @@ OperatorProfile::OperatorProfile(const OperatorProfile& from)
 
 void OperatorProfile::SharedCtor() {
   ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_OperatorProfile_UserBitShared_2eproto.base);
+  operator_type_name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   ::memset(&operator_id_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&wait_nanos_) -
       reinterpret_cast<char*>(&operator_id_)) + sizeof(wait_nanos_));
@@ -7504,6 +7395,7 @@ OperatorProfile::~OperatorProfile() {
 }
 
 void OperatorProfile::SharedDtor() {
+  operator_type_name_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void OperatorProfile::SetCachedSize(int size) const {
@@ -7524,7 +7416,10 @@ void OperatorProfile::Clear() {
   input_profile_.Clear();
   metric_.Clear();
   cached_has_bits = _has_bits_[0];
-  if (cached_has_bits & 0x0000003fu) {
+  if (cached_has_bits & 0x00000001u) {
+    operator_type_name_.ClearNonDefaultToEmptyNoArena();
+  }
+  if (cached_has_bits & 0x0000007eu) {
     ::memset(&operator_id_, 0, static_cast<size_t>(
         reinterpret_cast<char*>(&wait_nanos_) -
         reinterpret_cast<char*>(&operator_id_)) + sizeof(wait_nanos_));
@@ -7561,7 +7456,7 @@ const char* OperatorProfile::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPAC
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // optional int32 operator_type = 4;
+      // optional int32 operator_type = 4 [deprecated = true];
       case 4:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 32)) {
           _Internal::set_has_operator_type(&has_bits);
@@ -7613,6 +7508,17 @@ const char* OperatorProfile::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPAC
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
+      // optional string operator_type_name = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 82)) {
+          auto str = _internal_mutable_operator_type_name();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          #ifndef NDEBUG
+          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "exec.shared.OperatorProfile.operator_type_name");
+          #endif  // !NDEBUG
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
       default: {
       handle_unusual:
         if ((tag & 7) == 4 || tag == 0) {
@@ -7650,31 +7556,31 @@ failure:
 
   cached_has_bits = _has_bits_[0];
   // optional int32 operator_id = 3;
-  if (cached_has_bits & 0x00000001u) {
+  if (cached_has_bits & 0x00000002u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(3, this->_internal_operator_id(), target);
   }
 
-  // optional int32 operator_type = 4;
-  if (cached_has_bits & 0x00000002u) {
+  // optional int32 operator_type = 4 [deprecated = true];
+  if (cached_has_bits & 0x00000004u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(4, this->_internal_operator_type(), target);
   }
 
   // optional int64 setup_nanos = 5;
-  if (cached_has_bits & 0x00000004u) {
+  if (cached_has_bits & 0x00000008u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt64ToArray(5, this->_internal_setup_nanos(), target);
   }
 
   // optional int64 process_nanos = 6;
-  if (cached_has_bits & 0x00000008u) {
+  if (cached_has_bits & 0x00000010u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt64ToArray(6, this->_internal_process_nanos(), target);
   }
 
   // optional int64 peak_local_memory_allocated = 7;
-  if (cached_has_bits & 0x00000010u) {
+  if (cached_has_bits & 0x00000020u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt64ToArray(7, this->_internal_peak_local_memory_allocated(), target);
   }
@@ -7688,9 +7594,19 @@ failure:
   }
 
   // optional int64 wait_nanos = 9;
-  if (cached_has_bits & 0x00000020u) {
+  if (cached_has_bits & 0x00000040u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt64ToArray(9, this->_internal_wait_nanos(), target);
+  }
+
+  // optional string operator_type_name = 10;
+  if (cached_has_bits & 0x00000001u) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->_internal_operator_type_name().data(), static_cast<int>(this->_internal_operator_type_name().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
+      "exec.shared.OperatorProfile.operator_type_name");
+    target = stream->WriteStringMaybeAliased(
+        10, this->_internal_operator_type_name(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -7724,44 +7640,51 @@ size_t OperatorProfile::ByteSizeLong() const {
   }
 
   cached_has_bits = _has_bits_[0];
-  if (cached_has_bits & 0x0000003fu) {
-    // optional int32 operator_id = 3;
+  if (cached_has_bits & 0x0000007fu) {
+    // optional string operator_type_name = 10;
     if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_operator_type_name());
+    }
+
+    // optional int32 operator_id = 3;
+    if (cached_has_bits & 0x00000002u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
           this->_internal_operator_id());
     }
 
-    // optional int32 operator_type = 4;
-    if (cached_has_bits & 0x00000002u) {
+    // optional int32 operator_type = 4 [deprecated = true];
+    if (cached_has_bits & 0x00000004u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
           this->_internal_operator_type());
     }
 
     // optional int64 setup_nanos = 5;
-    if (cached_has_bits & 0x00000004u) {
+    if (cached_has_bits & 0x00000008u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int64Size(
           this->_internal_setup_nanos());
     }
 
     // optional int64 process_nanos = 6;
-    if (cached_has_bits & 0x00000008u) {
+    if (cached_has_bits & 0x00000010u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int64Size(
           this->_internal_process_nanos());
     }
 
     // optional int64 peak_local_memory_allocated = 7;
-    if (cached_has_bits & 0x00000010u) {
+    if (cached_has_bits & 0x00000020u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int64Size(
           this->_internal_peak_local_memory_allocated());
     }
 
     // optional int64 wait_nanos = 9;
-    if (cached_has_bits & 0x00000020u) {
+    if (cached_has_bits & 0x00000040u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int64Size(
           this->_internal_wait_nanos());
@@ -7802,23 +7725,27 @@ void OperatorProfile::MergeFrom(const OperatorProfile& from) {
   input_profile_.MergeFrom(from.input_profile_);
   metric_.MergeFrom(from.metric_);
   cached_has_bits = from._has_bits_[0];
-  if (cached_has_bits & 0x0000003fu) {
+  if (cached_has_bits & 0x0000007fu) {
     if (cached_has_bits & 0x00000001u) {
-      operator_id_ = from.operator_id_;
+      _has_bits_[0] |= 0x00000001u;
+      operator_type_name_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.operator_type_name_);
     }
     if (cached_has_bits & 0x00000002u) {
-      operator_type_ = from.operator_type_;
+      operator_id_ = from.operator_id_;
     }
     if (cached_has_bits & 0x00000004u) {
-      setup_nanos_ = from.setup_nanos_;
+      operator_type_ = from.operator_type_;
     }
     if (cached_has_bits & 0x00000008u) {
-      process_nanos_ = from.process_nanos_;
+      setup_nanos_ = from.setup_nanos_;
     }
     if (cached_has_bits & 0x00000010u) {
-      peak_local_memory_allocated_ = from.peak_local_memory_allocated_;
+      process_nanos_ = from.process_nanos_;
     }
     if (cached_has_bits & 0x00000020u) {
+      peak_local_memory_allocated_ = from.peak_local_memory_allocated_;
+    }
+    if (cached_has_bits & 0x00000040u) {
       wait_nanos_ = from.wait_nanos_;
     }
     _has_bits_[0] |= cached_has_bits;
@@ -7849,6 +7776,8 @@ void OperatorProfile::InternalSwap(OperatorProfile* other) {
   swap(_has_bits_[0], other->_has_bits_[0]);
   input_profile_.InternalSwap(&other->input_profile_);
   metric_.InternalSwap(&other->metric_);
+  operator_type_name_.Swap(&other->operator_type_name_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   swap(operator_id_, other->operator_id_);
   swap(operator_type_, other->operator_type_);
   swap(setup_nanos_, other->setup_nanos_);

--- a/contrib/native/client/src/protobuf/UserBitShared.pb.h
+++ b/contrib/native/client/src/protobuf/UserBitShared.pb.h
@@ -321,99 +321,6 @@ inline bool FragmentState_Parse(
   return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<FragmentState>(
     FragmentState_descriptor(), name, value);
 }
-enum CoreOperatorType : int {
-  SINGLE_SENDER = 0,
-  BROADCAST_SENDER = 1,
-  FILTER = 2,
-  HASH_AGGREGATE = 3,
-  HASH_JOIN = 4,
-  MERGE_JOIN = 5,
-  HASH_PARTITION_SENDER = 6,
-  LIMIT = 7,
-  MERGING_RECEIVER = 8,
-  ORDERED_PARTITION_SENDER = 9,
-  PROJECT = 10,
-  UNORDERED_RECEIVER = 11,
-  RANGE_PARTITION_SENDER = 12,
-  SCREEN = 13,
-  SELECTION_VECTOR_REMOVER = 14,
-  STREAMING_AGGREGATE = 15,
-  TOP_N_SORT = 16,
-  EXTERNAL_SORT = 17,
-  TRACE = 18,
-  UNION = 19,
-  OLD_SORT = 20,
-  PARQUET_ROW_GROUP_SCAN = 21,
-  HIVE_SUB_SCAN = 22,
-  SYSTEM_TABLE_SCAN = 23,
-  MOCK_SUB_SCAN = 24,
-  PARQUET_WRITER = 25,
-  DIRECT_SUB_SCAN = 26,
-  TEXT_WRITER = 27,
-  TEXT_SUB_SCAN = 28,
-  JSON_SUB_SCAN = 29,
-  INFO_SCHEMA_SUB_SCAN = 30,
-  COMPLEX_TO_JSON = 31,
-  PRODUCER_CONSUMER = 32,
-  HBASE_SUB_SCAN = 33,
-  WINDOW = 34,
-  NESTED_LOOP_JOIN = 35,
-  AVRO_SUB_SCAN = 36,
-  PCAP_SUB_SCAN = 37,
-  KAFKA_SUB_SCAN = 38,
-  KUDU_SUB_SCAN = 39,
-  FLATTEN = 40,
-  LATERAL_JOIN = 41,
-  UNNEST = 42,
-  HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43,
-  JDBC_SCAN = 44,
-  REGEX_SUB_SCAN = 45,
-  MAPRDB_SUB_SCAN = 46,
-  MONGO_SUB_SCAN = 47,
-  KUDU_WRITER = 48,
-  OPEN_TSDB_SUB_SCAN = 49,
-  JSON_WRITER = 50,
-  HTPPD_LOG_SUB_SCAN = 51,
-  IMAGE_SUB_SCAN = 52,
-  SEQUENCE_SUB_SCAN = 53,
-  PARTITION_LIMIT = 54,
-  PCAPNG_SUB_SCAN = 55,
-  RUNTIME_FILTER = 56,
-  ROWKEY_JOIN = 57,
-  SYSLOG_SUB_SCAN = 58,
-  STATISTICS_AGGREGATE = 59,
-  UNPIVOT_MAPS = 60,
-  STATISTICS_MERGE = 61,
-  LTSV_SUB_SCAN = 62,
-  HDF5_SUB_SCAN = 63,
-  EXCEL_SUB_SCAN = 64,
-  SHP_SUB_SCAN = 65,
-  METADATA_HANDLER = 66,
-  METADATA_CONTROLLER = 67,
-  DRUID_SUB_SCAN = 68,
-  SPSS_SUB_SCAN = 69,
-  HTTP_SUB_SCAN = 70,
-  XML_SUB_SCAN = 71
-};
-bool CoreOperatorType_IsValid(int value);
-constexpr CoreOperatorType CoreOperatorType_MIN = SINGLE_SENDER;
-constexpr CoreOperatorType CoreOperatorType_MAX = XML_SUB_SCAN;
-constexpr int CoreOperatorType_ARRAYSIZE = CoreOperatorType_MAX + 1;
-
-const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* CoreOperatorType_descriptor();
-template<typename T>
-inline const std::string& CoreOperatorType_Name(T enum_t_value) {
-  static_assert(::std::is_same<T, CoreOperatorType>::value ||
-    ::std::is_integral<T>::value,
-    "Incorrect type passed to function CoreOperatorType_Name.");
-  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
-    CoreOperatorType_descriptor(), enum_t_value);
-}
-inline bool CoreOperatorType_Parse(
-    const std::string& name, CoreOperatorType* value) {
-  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<CoreOperatorType>(
-    CoreOperatorType_descriptor(), name, value);
-}
 enum SaslStatus : int {
   SASL_UNKNOWN = 0,
   SASL_START = 1,
@@ -4246,6 +4153,7 @@ class OperatorProfile :
   enum : int {
     kInputProfileFieldNumber = 1,
     kMetricFieldNumber = 8,
+    kOperatorTypeNameFieldNumber = 10,
     kOperatorIdFieldNumber = 3,
     kOperatorTypeFieldNumber = 4,
     kSetupNanosFieldNumber = 5,
@@ -4289,6 +4197,26 @@ class OperatorProfile :
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::exec::shared::MetricValue >&
       metric() const;
 
+  // optional string operator_type_name = 10;
+  bool has_operator_type_name() const;
+  private:
+  bool _internal_has_operator_type_name() const;
+  public:
+  void clear_operator_type_name();
+  const std::string& operator_type_name() const;
+  void set_operator_type_name(const std::string& value);
+  void set_operator_type_name(std::string&& value);
+  void set_operator_type_name(const char* value);
+  void set_operator_type_name(const char* value, size_t size);
+  std::string* mutable_operator_type_name();
+  std::string* release_operator_type_name();
+  void set_allocated_operator_type_name(std::string* operator_type_name);
+  private:
+  const std::string& _internal_operator_type_name() const;
+  void _internal_set_operator_type_name(const std::string& value);
+  std::string* _internal_mutable_operator_type_name();
+  public:
+
   // optional int32 operator_id = 3;
   bool has_operator_id() const;
   private:
@@ -4302,14 +4230,14 @@ class OperatorProfile :
   void _internal_set_operator_id(::PROTOBUF_NAMESPACE_ID::int32 value);
   public:
 
-  // optional int32 operator_type = 4;
-  bool has_operator_type() const;
+  // optional int32 operator_type = 4 [deprecated = true];
+  PROTOBUF_DEPRECATED bool has_operator_type() const;
   private:
   bool _internal_has_operator_type() const;
   public:
-  void clear_operator_type();
-  ::PROTOBUF_NAMESPACE_ID::int32 operator_type() const;
-  void set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 value);
+  PROTOBUF_DEPRECATED void clear_operator_type();
+  PROTOBUF_DEPRECATED ::PROTOBUF_NAMESPACE_ID::int32 operator_type() const;
+  PROTOBUF_DEPRECATED void set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 value);
   private:
   ::PROTOBUF_NAMESPACE_ID::int32 _internal_operator_type() const;
   void _internal_set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 value);
@@ -4376,6 +4304,7 @@ class OperatorProfile :
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::exec::shared::StreamProfile > input_profile_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::exec::shared::MetricValue > metric_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr operator_type_name_;
   ::PROTOBUF_NAMESPACE_ID::int32 operator_id_;
   ::PROTOBUF_NAMESPACE_ID::int32 operator_type_;
   ::PROTOBUF_NAMESPACE_ID::int64 setup_nanos_;
@@ -9318,7 +9247,7 @@ OperatorProfile::input_profile() const {
 
 // optional int32 operator_id = 3;
 inline bool OperatorProfile::_internal_has_operator_id() const {
-  bool value = (_has_bits_[0] & 0x00000001u) != 0;
+  bool value = (_has_bits_[0] & 0x00000002u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_operator_id() const {
@@ -9326,7 +9255,7 @@ inline bool OperatorProfile::has_operator_id() const {
 }
 inline void OperatorProfile::clear_operator_id() {
   operator_id_ = 0;
-  _has_bits_[0] &= ~0x00000001u;
+  _has_bits_[0] &= ~0x00000002u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int32 OperatorProfile::_internal_operator_id() const {
   return operator_id_;
@@ -9336,7 +9265,7 @@ inline ::PROTOBUF_NAMESPACE_ID::int32 OperatorProfile::operator_id() const {
   return _internal_operator_id();
 }
 inline void OperatorProfile::_internal_set_operator_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
-  _has_bits_[0] |= 0x00000001u;
+  _has_bits_[0] |= 0x00000002u;
   operator_id_ = value;
 }
 inline void OperatorProfile::set_operator_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
@@ -9344,9 +9273,9 @@ inline void OperatorProfile::set_operator_id(::PROTOBUF_NAMESPACE_ID::int32 valu
   // @@protoc_insertion_point(field_set:exec.shared.OperatorProfile.operator_id)
 }
 
-// optional int32 operator_type = 4;
+// optional int32 operator_type = 4 [deprecated = true];
 inline bool OperatorProfile::_internal_has_operator_type() const {
-  bool value = (_has_bits_[0] & 0x00000002u) != 0;
+  bool value = (_has_bits_[0] & 0x00000004u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_operator_type() const {
@@ -9354,7 +9283,7 @@ inline bool OperatorProfile::has_operator_type() const {
 }
 inline void OperatorProfile::clear_operator_type() {
   operator_type_ = 0;
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int32 OperatorProfile::_internal_operator_type() const {
   return operator_type_;
@@ -9364,7 +9293,7 @@ inline ::PROTOBUF_NAMESPACE_ID::int32 OperatorProfile::operator_type() const {
   return _internal_operator_type();
 }
 inline void OperatorProfile::_internal_set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 value) {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000004u;
   operator_type_ = value;
 }
 inline void OperatorProfile::set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 value) {
@@ -9374,7 +9303,7 @@ inline void OperatorProfile::set_operator_type(::PROTOBUF_NAMESPACE_ID::int32 va
 
 // optional int64 setup_nanos = 5;
 inline bool OperatorProfile::_internal_has_setup_nanos() const {
-  bool value = (_has_bits_[0] & 0x00000004u) != 0;
+  bool value = (_has_bits_[0] & 0x00000008u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_setup_nanos() const {
@@ -9382,7 +9311,7 @@ inline bool OperatorProfile::has_setup_nanos() const {
 }
 inline void OperatorProfile::clear_setup_nanos() {
   setup_nanos_ = PROTOBUF_LONGLONG(0);
-  _has_bits_[0] &= ~0x00000004u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::_internal_setup_nanos() const {
   return setup_nanos_;
@@ -9392,7 +9321,7 @@ inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::setup_nanos() const {
   return _internal_setup_nanos();
 }
 inline void OperatorProfile::_internal_set_setup_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
-  _has_bits_[0] |= 0x00000004u;
+  _has_bits_[0] |= 0x00000008u;
   setup_nanos_ = value;
 }
 inline void OperatorProfile::set_setup_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
@@ -9402,7 +9331,7 @@ inline void OperatorProfile::set_setup_nanos(::PROTOBUF_NAMESPACE_ID::int64 valu
 
 // optional int64 process_nanos = 6;
 inline bool OperatorProfile::_internal_has_process_nanos() const {
-  bool value = (_has_bits_[0] & 0x00000008u) != 0;
+  bool value = (_has_bits_[0] & 0x00000010u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_process_nanos() const {
@@ -9410,7 +9339,7 @@ inline bool OperatorProfile::has_process_nanos() const {
 }
 inline void OperatorProfile::clear_process_nanos() {
   process_nanos_ = PROTOBUF_LONGLONG(0);
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::_internal_process_nanos() const {
   return process_nanos_;
@@ -9420,7 +9349,7 @@ inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::process_nanos() const {
   return _internal_process_nanos();
 }
 inline void OperatorProfile::_internal_set_process_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000010u;
   process_nanos_ = value;
 }
 inline void OperatorProfile::set_process_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
@@ -9430,7 +9359,7 @@ inline void OperatorProfile::set_process_nanos(::PROTOBUF_NAMESPACE_ID::int64 va
 
 // optional int64 peak_local_memory_allocated = 7;
 inline bool OperatorProfile::_internal_has_peak_local_memory_allocated() const {
-  bool value = (_has_bits_[0] & 0x00000010u) != 0;
+  bool value = (_has_bits_[0] & 0x00000020u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_peak_local_memory_allocated() const {
@@ -9438,7 +9367,7 @@ inline bool OperatorProfile::has_peak_local_memory_allocated() const {
 }
 inline void OperatorProfile::clear_peak_local_memory_allocated() {
   peak_local_memory_allocated_ = PROTOBUF_LONGLONG(0);
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::_internal_peak_local_memory_allocated() const {
   return peak_local_memory_allocated_;
@@ -9448,7 +9377,7 @@ inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::peak_local_memory_allocat
   return _internal_peak_local_memory_allocated();
 }
 inline void OperatorProfile::_internal_set_peak_local_memory_allocated(::PROTOBUF_NAMESPACE_ID::int64 value) {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000020u;
   peak_local_memory_allocated_ = value;
 }
 inline void OperatorProfile::set_peak_local_memory_allocated(::PROTOBUF_NAMESPACE_ID::int64 value) {
@@ -9497,7 +9426,7 @@ OperatorProfile::metric() const {
 
 // optional int64 wait_nanos = 9;
 inline bool OperatorProfile::_internal_has_wait_nanos() const {
-  bool value = (_has_bits_[0] & 0x00000020u) != 0;
+  bool value = (_has_bits_[0] & 0x00000040u) != 0;
   return value;
 }
 inline bool OperatorProfile::has_wait_nanos() const {
@@ -9505,7 +9434,7 @@ inline bool OperatorProfile::has_wait_nanos() const {
 }
 inline void OperatorProfile::clear_wait_nanos() {
   wait_nanos_ = PROTOBUF_LONGLONG(0);
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::_internal_wait_nanos() const {
   return wait_nanos_;
@@ -9515,12 +9444,83 @@ inline ::PROTOBUF_NAMESPACE_ID::int64 OperatorProfile::wait_nanos() const {
   return _internal_wait_nanos();
 }
 inline void OperatorProfile::_internal_set_wait_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000040u;
   wait_nanos_ = value;
 }
 inline void OperatorProfile::set_wait_nanos(::PROTOBUF_NAMESPACE_ID::int64 value) {
   _internal_set_wait_nanos(value);
   // @@protoc_insertion_point(field_set:exec.shared.OperatorProfile.wait_nanos)
+}
+
+// optional string operator_type_name = 10;
+inline bool OperatorProfile::_internal_has_operator_type_name() const {
+  bool value = (_has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool OperatorProfile::has_operator_type_name() const {
+  return _internal_has_operator_type_name();
+}
+inline void OperatorProfile::clear_operator_type_name() {
+  operator_type_name_.ClearToEmptyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& OperatorProfile::operator_type_name() const {
+  // @@protoc_insertion_point(field_get:exec.shared.OperatorProfile.operator_type_name)
+  return _internal_operator_type_name();
+}
+inline void OperatorProfile::set_operator_type_name(const std::string& value) {
+  _internal_set_operator_type_name(value);
+  // @@protoc_insertion_point(field_set:exec.shared.OperatorProfile.operator_type_name)
+}
+inline std::string* OperatorProfile::mutable_operator_type_name() {
+  // @@protoc_insertion_point(field_mutable:exec.shared.OperatorProfile.operator_type_name)
+  return _internal_mutable_operator_type_name();
+}
+inline const std::string& OperatorProfile::_internal_operator_type_name() const {
+  return operator_type_name_.GetNoArena();
+}
+inline void OperatorProfile::_internal_set_operator_type_name(const std::string& value) {
+  _has_bits_[0] |= 0x00000001u;
+  operator_type_name_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value);
+}
+inline void OperatorProfile::set_operator_type_name(std::string&& value) {
+  _has_bits_[0] |= 0x00000001u;
+  operator_type_name_.SetNoArena(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:exec.shared.OperatorProfile.operator_type_name)
+}
+inline void OperatorProfile::set_operator_type_name(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _has_bits_[0] |= 0x00000001u;
+  operator_type_name_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:exec.shared.OperatorProfile.operator_type_name)
+}
+inline void OperatorProfile::set_operator_type_name(const char* value, size_t size) {
+  _has_bits_[0] |= 0x00000001u;
+  operator_type_name_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:exec.shared.OperatorProfile.operator_type_name)
+}
+inline std::string* OperatorProfile::_internal_mutable_operator_type_name() {
+  _has_bits_[0] |= 0x00000001u;
+  return operator_type_name_.MutableNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+inline std::string* OperatorProfile::release_operator_type_name() {
+  // @@protoc_insertion_point(field_release:exec.shared.OperatorProfile.operator_type_name)
+  if (!_internal_has_operator_type_name()) {
+    return nullptr;
+  }
+  _has_bits_[0] &= ~0x00000001u;
+  return operator_type_name_.ReleaseNonDefaultNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+inline void OperatorProfile::set_allocated_operator_type_name(std::string* operator_type_name) {
+  if (operator_type_name != nullptr) {
+    _has_bits_[0] |= 0x00000001u;
+  } else {
+    _has_bits_[0] &= ~0x00000001u;
+  }
+  operator_type_name_.SetAllocatedNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), operator_type_name);
+  // @@protoc_insertion_point(field_set_allocated:exec.shared.OperatorProfile.operator_type_name)
 }
 
 // -------------------------------------------------------------------
@@ -10148,11 +10148,6 @@ template <> struct is_proto_enum< ::exec::shared::FragmentState> : ::std::true_t
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::exec::shared::FragmentState>() {
   return ::exec::shared::FragmentState_descriptor();
-}
-template <> struct is_proto_enum< ::exec::shared::CoreOperatorType> : ::std::true_type {};
-template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::exec::shared::CoreOperatorType>() {
-  return ::exec::shared::CoreOperatorType_descriptor();
 }
 template <> struct is_proto_enum< ::exec::shared::SaslStatus> : ::std::true_type {};
 template <>

--- a/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidSubScan.java
+++ b/contrib/storage-druid/src/main/java/org/apache/drill/exec/store/druid/DruidSubScan.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.druid.common.DruidFilter;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
@@ -45,6 +44,9 @@ import static java.util.Collections.emptyIterator;
  */
 @JsonTypeName("druid-datasource-scan")
 public class DruidSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "DRUID_SUB_SCAN";
+
   @JsonIgnore
   private final DruidStoragePlugin druidStoragePlugin;
   private final List<DruidSubScanSpec> scanSpec;
@@ -112,8 +114,8 @@ public class DruidSubScan extends AbstractBase implements SubScan {
 
   @JsonIgnore
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.DRUID_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
+++ b/contrib/storage-hbase/src/main/java/org/apache/drill/exec/store/hbase/HBaseSubScan.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -45,6 +44,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  */
 @JsonTypeName("hbase-region-scan")
 public class HBaseSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "HBASE_SUB_SCAN";
 
   private final HBaseStoragePlugin hbaseStoragePlugin;
   private final List<HBaseSubScanSpec> regionScanSpecList;
@@ -212,7 +213,7 @@ public class HBaseSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.HBASE_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetRowGroupScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveDrillNativeParquetRowGroupScan.java
@@ -29,7 +29,6 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.parquet.AbstractParquetRowGroupScan;
 import org.apache.drill.exec.store.parquet.RowGroupReadEntry;
@@ -44,6 +43,8 @@ import java.util.Map;
 
 @JsonTypeName("hive-drill-native-parquet-row-group-scan")
 public class HiveDrillNativeParquetRowGroupScan extends AbstractParquetRowGroupScan {
+
+  public static final String OPERATOR_TYPE = "HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN";
 
   private final HiveStoragePlugin hiveStoragePlugin;
   private final HiveStoragePluginConfig hiveStoragePluginConfig;
@@ -116,8 +117,8 @@ public class HiveDrillNativeParquetRowGroupScan extends AbstractParquetRowGroupS
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveSubScan.java
+++ b/contrib/storage-hive/core/src/main/java/org/apache/drill/exec/store/hive/HiveSubScan.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.InputSplit;
@@ -47,6 +46,8 @@ import org.apache.drill.shaded.guava.com.google.common.io.ByteStreams;
 
 @JsonTypeName("hive-sub-scan")
 public class HiveSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "HIVE_SUB_SCAN";
 
   private final HiveReadEntry hiveReadEntry;
   private final List<List<InputSplit>> inputSplits = new ArrayList<>();
@@ -175,8 +176,8 @@ public class HiveSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.HIVE_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   private static List<InputSplit> deserializeInputSplit(List<String> base64, String className)

--- a/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
+++ b/contrib/storage-http/src/main/java/org/apache/drill/exec/store/http/HttpSubScan.java
@@ -17,6 +17,7 @@
  */
 package org.apache.drill.exec.store.http;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -32,11 +33,11 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
-import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableSet;
 
 @JsonTypeName("http-sub-scan")
 public class HttpSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "HTTP_SUB_SCAN";
 
   private final HttpScanSpec tableSpec;
   private final List<SchemaPath> columns;
@@ -90,13 +91,13 @@ public class HttpSubScan extends AbstractBase implements SubScan {
 
   @Override
   @JsonIgnore
-  public int getOperatorType() {
-    return CoreOperatorType.HTTP_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override
   public Iterator<PhysicalOperator> iterator() {
-    return ImmutableSet.<PhysicalOperator>of().iterator();
+    return Collections.emptyIterator();
   }
 
   @Override

--- a/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
+++ b/contrib/storage-jdbc/src/main/java/org/apache/drill/exec/store/jdbc/JdbcSubScan.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractSubScan;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -34,6 +33,8 @@ import java.util.List;
 
 @JsonTypeName("jdbc-sub-scan")
 public class JdbcSubScan extends AbstractSubScan {
+
+  public static final String OPERATOR_TYPE = "JDBC_SCAN";
 
   private final String sql;
   private final JdbcStoragePlugin plugin;
@@ -59,8 +60,8 @@ public class JdbcSubScan extends AbstractSubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return UserBitShared.CoreOperatorType.JDBC_SCAN.getNumber();
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   public String getSql() {

--- a/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaSubScan.java
+++ b/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaSubScan.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -40,6 +39,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 @JsonTypeName("kafka-partition-scan")
 public class KafkaSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "KAFKA_SUB_SCAN";
 
   private final KafkaStoragePlugin kafkaStoragePlugin;
   private final List<SchemaPath> columns;
@@ -105,7 +106,7 @@ public class KafkaSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.KAFKA_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduSubScan.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduSubScan.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -43,6 +42,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
  */
 @JsonTypeName("kudu-sub-scan")
 public class KuduSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "KUDU_SUB_SCAN";
 
   private final KuduStoragePlugin kuduStoragePlugin;
   private final List<KuduSubScanSpec> tabletScanSpecList;
@@ -127,7 +128,7 @@ public class KuduSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.KUDU_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduWriter.java
+++ b/contrib/storage-kudu/src/main/java/org/apache/drill/exec/store/kudu/KuduWriter.java
@@ -23,7 +23,6 @@ import org.apache.drill.common.exceptions.ExecutionSetupException;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractWriter;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -32,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class KuduWriter extends AbstractWriter {
+
+  public static final String OPERATOR_TYPE = "KUDU_WRITER";
 
   private final KuduStoragePlugin plugin;
   private final String name;
@@ -55,8 +56,8 @@ public class KuduWriter extends AbstractWriter {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.KUDU_WRITER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
+++ b/contrib/storage-mongo/src/main/java/org/apache/drill/exec/store/mongo/MongoSubScan.java
@@ -30,11 +30,8 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -45,7 +42,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 @JsonTypeName("mongo-shard-read")
 public class MongoSubScan extends AbstractBase implements SubScan {
-  static final Logger logger = LoggerFactory.getLogger(MongoSubScan.class);
+
+  public static final String OPERATOR_TYPE = "MONGO_SUB_SCAN";
 
   @JsonProperty
   private final MongoStoragePluginConfig mongoPluginConfig;
@@ -114,8 +112,8 @@ public class MongoSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.MONGO_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBSubScan.java
+++ b/contrib/storage-opentsdb/src/main/java/org/apache/drill/exec/store/openTSDB/OpenTSDBSubScan.java
@@ -29,7 +29,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import java.util.Collections;
@@ -39,6 +38,8 @@ import java.util.List;
 
 @JsonTypeName("openTSDB-sub-scan")
 public class OpenTSDBSubScan extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "OPEN_TSDB_SUB_SCAN";
 
   public final OpenTSDBStoragePluginConfig storage;
 
@@ -68,8 +69,8 @@ public class OpenTSDBSubScan extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.OPEN_TSDB_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/FragmentStats.java
@@ -32,7 +32,7 @@ import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
 public class FragmentStats {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FragmentStats.class);
 
-  private Map<ImmutablePair<Integer, Integer>, OperatorStats> operators = new LinkedHashMap<>();
+  private final Map<ImmutablePair<Integer, String>, OperatorStats> operators = new LinkedHashMap<>();
   private final long startTime;
   private final DrillbitEndpoint endpoint;
   private final BufferAllocator allocator;
@@ -48,7 +48,7 @@ public class FragmentStats {
     prfB.setMaxMemoryUsed(allocator.getPeakMemoryAllocation());
     prfB.setEndTime(System.currentTimeMillis());
     prfB.setEndpoint(endpoint);
-    for(Entry<ImmutablePair<Integer, Integer>, OperatorStats> o : operators.entrySet()){
+    for(Entry<ImmutablePair<Integer, String>, OperatorStats> o : operators.entrySet()){
       prfB.addOperatorProfile(o.getValue().getProfile());
     }
   }
@@ -62,15 +62,14 @@ public class FragmentStats {
    */
   public OperatorStats newOperatorStats(final OpProfileDef profileDef, final BufferAllocator allocator) {
     final OperatorStats stats = new OperatorStats(profileDef, allocator);
-    if(profileDef.operatorType != -1) {
-      @SuppressWarnings("unused")
-      OperatorStats existingStatsHolder = addOperatorStats(stats);
+    if (profileDef.operatorType != null) {
+      addOperatorStats(stats);
     }
     return stats;
   }
 
-  public OperatorStats addOperatorStats(OperatorStats stats) {
-    return operators.put(new ImmutablePair<>(stats.operatorId, stats.operatorType), stats);
+  public void addOperatorStats(OperatorStats stats) {
+    operators.put(new ImmutablePair<>(stats.operatorId, stats.operatorType), stats);
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OpProfileDef.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OpProfileDef.java
@@ -20,10 +20,10 @@ package org.apache.drill.exec.ops;
 public class OpProfileDef {
 
   public int operatorId;
-  public int operatorType;
+  public String operatorType;
   public int incomingCount;
 
-  public OpProfileDef(int operatorId, int operatorType, int incomingCount) {
+  public OpProfileDef(int operatorId, String operatorType, int incomingCount) {
     this.operatorId = operatorId;
     this.operatorType = operatorType;
     this.incomingCount = incomingCount;
@@ -32,7 +32,7 @@ public class OpProfileDef {
     return operatorId;
   }
 
-  public int getOperatorType(){
+  public String getOperatorType(){
     return operatorType;
   }
   public int getIncomingCount(){

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorMetricRegistry.java
@@ -17,6 +17,21 @@
  */
 package org.apache.drill.exec.ops;
 
+import org.apache.drill.exec.physical.config.BroadcastSender;
+import org.apache.drill.exec.physical.config.ExternalSort;
+import org.apache.drill.exec.physical.config.FlattenPOP;
+import org.apache.drill.exec.physical.config.HashAggregate;
+import org.apache.drill.exec.physical.config.HashJoinPOP;
+import org.apache.drill.exec.physical.config.HashPartitionSender;
+import org.apache.drill.exec.physical.config.LateralJoinPOP;
+import org.apache.drill.exec.physical.config.MergeJoinPOP;
+import org.apache.drill.exec.physical.config.MergingReceiverPOP;
+import org.apache.drill.exec.physical.config.RuntimeFilterPOP;
+import org.apache.drill.exec.physical.config.Screen;
+import org.apache.drill.exec.physical.config.SingleSender;
+import org.apache.drill.exec.physical.config.UnionAll;
+import org.apache.drill.exec.physical.config.UnnestPOP;
+import org.apache.drill.exec.physical.config.UnorderedReceiver;
 import org.apache.drill.exec.physical.impl.ScreenCreator;
 import org.apache.drill.exec.physical.impl.SingleSenderCreator;
 import org.apache.drill.exec.physical.impl.aggregate.HashAggTemplate;
@@ -29,8 +44,8 @@ import org.apache.drill.exec.physical.impl.partitionsender.PartitionSenderRootEx
 import org.apache.drill.exec.physical.impl.unnest.UnnestRecordBatch;
 import org.apache.drill.exec.physical.impl.unorderedreceiver.UnorderedReceiverBatch;
 import org.apache.drill.exec.physical.impl.xsort.ExternalSortBatch;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.AbstractBinaryRecordBatch;
+import org.apache.drill.exec.store.parquet.ParquetRowGroupScan;
 import org.apache.drill.exec.store.parquet.columnreaders.ParquetRecordReader;
 
 import java.util.Arrays;
@@ -44,28 +59,28 @@ public class OperatorMetricRegistry {
 //  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OperatorMetricRegistry.class);
 
   // Mapping: key : operator type, value : metric id --> metric name
-  private static final Map<Integer, String[]> OPERATOR_METRICS = new HashMap<>();
+  private static final Map<String, String[]> OPERATOR_METRICS = new HashMap<>();
 
   static {
-    register(CoreOperatorType.SCREEN_VALUE, ScreenCreator.ScreenRoot.Metric.class);
-    register(CoreOperatorType.SINGLE_SENDER_VALUE, SingleSenderCreator.SingleSenderRootExec.Metric.class);
-    register(CoreOperatorType.BROADCAST_SENDER_VALUE, BroadcastSenderRootExec.Metric.class);
-    register(CoreOperatorType.HASH_PARTITION_SENDER_VALUE, PartitionSenderRootExec.Metric.class);
-    register(CoreOperatorType.MERGING_RECEIVER_VALUE, MergingRecordBatch.Metric.class);
-    register(CoreOperatorType.UNORDERED_RECEIVER_VALUE, UnorderedReceiverBatch.Metric.class);
-    register(CoreOperatorType.HASH_AGGREGATE_VALUE, HashAggTemplate.Metric.class);
-    register(CoreOperatorType.HASH_JOIN_VALUE, HashJoinBatch.Metric.class);
-    register(CoreOperatorType.EXTERNAL_SORT_VALUE, ExternalSortBatch.Metric.class);
-    register(CoreOperatorType.PARQUET_ROW_GROUP_SCAN_VALUE, ParquetRecordReader.Metric.class);
-    register(CoreOperatorType.FLATTEN_VALUE, FlattenRecordBatch.Metric.class);
-    register(CoreOperatorType.MERGE_JOIN_VALUE, AbstractBinaryRecordBatch.Metric.class);
-    register(CoreOperatorType.LATERAL_JOIN_VALUE, AbstractBinaryRecordBatch.Metric.class);
-    register(CoreOperatorType.UNNEST_VALUE, UnnestRecordBatch.Metric.class);
-    register(CoreOperatorType.UNION_VALUE, AbstractBinaryRecordBatch.Metric.class);
-    register(CoreOperatorType.RUNTIME_FILTER_VALUE, RuntimeFilterRecordBatch.Metric.class);
+    register(Screen.OPERATOR_TYPE, ScreenCreator.ScreenRoot.Metric.class);
+    register(SingleSender.OPERATOR_TYPE, SingleSenderCreator.SingleSenderRootExec.Metric.class);
+    register(BroadcastSender.OPERATOR_TYPE, BroadcastSenderRootExec.Metric.class);
+    register(HashPartitionSender.OPERATOR_TYPE, PartitionSenderRootExec.Metric.class);
+    register(MergingReceiverPOP.OPERATOR_TYPE, MergingRecordBatch.Metric.class);
+    register(UnorderedReceiver.OPERATOR_TYPE, UnorderedReceiverBatch.Metric.class);
+    register(HashAggregate.OPERATOR_TYPE, HashAggTemplate.Metric.class);
+    register(HashJoinPOP.OPERATOR_TYPE, HashJoinBatch.Metric.class);
+    register(ExternalSort.OPERATOR_TYPE, ExternalSortBatch.Metric.class);
+    register(ParquetRowGroupScan.OPERATOR_TYPE, ParquetRecordReader.Metric.class);
+    register(FlattenPOP.OPERATOR_TYPE, FlattenRecordBatch.Metric.class);
+    register(MergeJoinPOP.OPERATOR_TYPE, AbstractBinaryRecordBatch.Metric.class);
+    register(LateralJoinPOP.OPERATOR_TYPE, AbstractBinaryRecordBatch.Metric.class);
+    register(UnnestPOP.OPERATOR_TYPE, UnnestRecordBatch.Metric.class);
+    register(UnionAll.OPERATOR_TYPE, AbstractBinaryRecordBatch.Metric.class);
+    register(RuntimeFilterPOP.OPERATOR_TYPE, RuntimeFilterRecordBatch.Metric.class);
   }
 
-  private static void register(final int operatorType, final Class<? extends MetricDef> metricDef) {
+  private static void register(String operatorType, Class<? extends MetricDef> metricDef) {
     // Currently registers a metric def that has enum constants
     MetricDef[] enumConstants = metricDef.getEnumConstants();
     if (enumConstants != null) {
@@ -82,7 +97,7 @@ public class OperatorMetricRegistry {
    * @param operatorType the operator type
    * @return metric names if operator was registered, null otherwise
    */
-  public static String[] getMetricNames(int operatorType) {
+  public static String[] getMetricNames(String operatorType) {
     return OPERATOR_METRICS.get(operatorType);
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/ops/OperatorStats.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.ops;
 import java.util.Iterator;
 
 import org.apache.drill.exec.memory.BufferAllocator;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.proto.UserBitShared.MetricValue;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile.Builder;
@@ -32,19 +31,20 @@ import com.carrotsearch.hppc.cursors.IntDoubleCursor;
 import com.carrotsearch.hppc.cursors.IntLongCursor;
 import com.carrotsearch.hppc.procedures.IntDoubleProcedure;
 import com.carrotsearch.hppc.procedures.IntLongProcedure;
+import org.apache.drill.exec.server.rest.profile.CoreOperatorType;
 import org.apache.drill.shaded.guava.com.google.common.annotations.VisibleForTesting;
 
 public class OperatorStats {
   protected final int operatorId;
-  protected final int operatorType;
+  protected final String operatorType;
   private final BufferAllocator allocator;
 
-  private IntLongHashMap longMetrics = new IntLongHashMap();
-  private IntDoubleHashMap doubleMetrics = new IntDoubleHashMap();
+  private final IntLongHashMap longMetrics = new IntLongHashMap();
+  private final IntDoubleHashMap doubleMetrics = new IntDoubleHashMap();
 
   public long[] recordsReceivedByInput;
   public long[] batchesReceivedByInput;
-  private long[] schemaCountByInput;
+  private final long[] schemaCountByInput;
 
 
   private boolean inProcessing = false;
@@ -59,7 +59,7 @@ public class OperatorStats {
   private long setupMark;
   private long waitMark;
 
-  private int inputCount;
+  private final int inputCount;
 
   public OperatorStats(OpProfileDef def, BufferAllocator allocator){
     this(def.getOperatorId(), def.getOperatorType(), def.getIncomingCount(), allocator);
@@ -88,7 +88,7 @@ public class OperatorStats {
   }
 
   @VisibleForTesting
-  public OperatorStats(int operatorId, int operatorType, int inputCount, BufferAllocator allocator) {
+  public OperatorStats(int operatorId, String operatorType, int inputCount, BufferAllocator allocator) {
     super();
     this.allocator = allocator;
     this.operatorId = operatorId;
@@ -191,23 +191,30 @@ public class OperatorStats {
   }
 
   public String getId() {
-    StringBuilder s = new StringBuilder();
-    return s.append(this.operatorId)
+    return new StringBuilder()
+        .append(this.operatorId)
         .append(":")
         .append("[")
-        .append(UserBitShared.CoreOperatorType.valueOf(operatorType))
+        .append(operatorType)
         .append("]")
         .toString();
   }
 
+  @SuppressWarnings("deprecation")
   public OperatorProfile getProfile() {
-    final OperatorProfile.Builder b = OperatorProfile //
-        .newBuilder() //
-        .setOperatorType(operatorType) //
-        .setOperatorId(operatorId) //
-        .setSetupNanos(setupNanos) //
+    final OperatorProfile.Builder b = OperatorProfile
+        .newBuilder()
+        .setOperatorTypeName(operatorType)
+        .setOperatorId(operatorId)
+        .setSetupNanos(setupNanos)
         .setProcessNanos(processingNanos)
         .setWaitNanos(waitNanos);
+
+    CoreOperatorType coreOperatorType = CoreOperatorType.forName(operatorType);
+
+    if (coreOperatorType != null) {
+      b.setOperatorType(coreOperatorType.getId());
+    }
 
     if (allocator != null) {
       b.setPeakLocalMemoryAllocated(allocator.getPeakMemoryAllocation());
@@ -229,7 +236,7 @@ public class OperatorStats {
     }
   }
 
-  private class LongProc implements IntLongProcedure {
+  private static class LongProc implements IntLongProcedure {
 
     private final OperatorProfile.Builder builder;
 
@@ -250,7 +257,7 @@ public class OperatorStats {
     }
   }
 
-  private class DoubleProc implements IntDoubleProcedure {
+  private static class DoubleProc implements IntDoubleProcedure {
     private final OperatorProfile.Builder builder;
 
     public DoubleProc(Builder builder) {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractExchange.java
@@ -96,7 +96,7 @@ public abstract class AbstractExchange extends AbstractSingle implements Exchang
     return new ArrayList<>(affinityMap.values());
   }
 
-  protected void setupSenders(List<DrillbitEndpoint> senderLocations) throws PhysicalOperatorSetupException {
+  protected void setupSenders(List<DrillbitEndpoint> senderLocations) {
     this.senderLocations = ImmutableList.copyOf(senderLocations);
   }
 
@@ -122,7 +122,7 @@ public abstract class AbstractExchange extends AbstractSingle implements Exchang
   }
 
   @Override
-  public int getOperatorType() {
+  public String getOperatorType() {
     throw new UnsupportedOperationException();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/AbstractGroupScan.java
@@ -138,7 +138,7 @@ public abstract class AbstractGroupScan extends AbstractBase implements GroupSca
   }
 
   @Override
-  public int getOperatorType() {
+  public String getOperatorType() {
     throw new UnsupportedOperationException();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/base/PhysicalOperator.java
@@ -116,5 +116,5 @@ public interface PhysicalOperator extends GraphValue<PhysicalOperator> {
   String getUserName();
 
   @JsonIgnore
-  int getOperatorType();
+  String getOperatorType();
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/BroadcastSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/BroadcastSender.java
@@ -23,7 +23,6 @@ import org.apache.drill.exec.physical.MinorFragmentEndpoint;
 import org.apache.drill.exec.physical.base.AbstractSender;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,7 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("broadcast-sender")
 public class BroadcastSender extends AbstractSender {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BroadcastSender.class);
+
+  public static final String OPERATOR_TYPE = "BROADCAST_SENDER";
 
   @JsonCreator
   public BroadcastSender(@JsonProperty("receiver-major-fragment") int oppositeMajorFragmentId,
@@ -51,8 +51,8 @@ public class BroadcastSender extends AbstractSender {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.BROADCAST_SENDER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ComplexToJson.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ComplexToJson.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.physical.config;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -29,7 +28,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("complex-to-json")
 public class ComplexToJson extends AbstractSingle {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ComplexToJson.class);
+
+  public static final String OPERATOR_TYPE = "COMPLEX_TO_JSON";
 
   @JsonCreator
   public ComplexToJson(@JsonProperty("child") PhysicalOperator child) {
@@ -52,8 +52,8 @@ public class ComplexToJson extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.COMPLEX_TO_JSON_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ExternalSort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ExternalSort.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,9 +29,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("external-sort")
 public class ExternalSort extends Sort {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExternalSort.class);
 
   public static final long DEFAULT_SORT_ALLOCATION = 20_000_000;
+
+  public static final String OPERATOR_TYPE = "EXTERNAL_SORT";
 
   @JsonCreator
   public ExternalSort(@JsonProperty("child") PhysicalOperator child, @JsonProperty("orderings") List<Ordering> orderings, @JsonProperty("reverse") boolean reverse) {
@@ -48,8 +48,8 @@ public class ExternalSort extends Sort {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.EXTERNAL_SORT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Filter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Filter.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -31,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("filter")
 public class Filter extends AbstractSingle {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Filter.class);
+  public static final String OPERATOR_TYPE = "FILTER";
 
   private final LogicalExpression expr;
   private final float selectivity;
@@ -67,8 +66,8 @@ public class Filter extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.FILTER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/FlattenPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/FlattenPOP.java
@@ -25,15 +25,15 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared;
 
 import java.util.Iterator;
 
 @JsonTypeName("flatten")
 public class FlattenPOP extends AbstractSingle {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FlattenPOP.class);
 
-  private SchemaPath column;
+  public static final String OPERATOR_TYPE = "FLATTEN";
+
+  private final SchemaPath column;
 
   @JsonCreator
   public FlattenPOP(
@@ -64,7 +64,7 @@ public class FlattenPOP extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return UserBitShared.CoreOperatorType.FLATTEN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashAggregate.java
@@ -24,7 +24,6 @@ import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.planner.physical.AggPrelBase;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,7 +34,7 @@ import java.util.List;
 @JsonTypeName("hash-aggregate")
 public class HashAggregate extends AbstractSingle {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashAggregate.class);
+  public static final String OPERATOR_TYPE = "HASH_AGGREGATE";
 
   private final AggPrelBase.OperatorPhase aggPhase;
   private final List<NamedExpression> groupByExprs;
@@ -83,8 +82,8 @@ public class HashAggregate extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.HASH_AGGREGATE_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashJoinPOP.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.ops.QueryContext;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.planner.common.JoinControl;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -41,7 +40,8 @@ import org.apache.drill.exec.work.filter.RuntimeFilterDef;
 @JsonTypeName("hash-join")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HashJoinPOP extends AbstractJoinPop {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashJoinPOP.class);
+
+  public static final String OPERATOR_TYPE = "HASH_JOIN";
 
   private RuntimeFilterDef runtimeFilterDef;
 
@@ -134,9 +134,9 @@ public class HashJoinPOP extends AbstractJoinPop {
   }
 
   @Override
-  public int getOperatorType() {
-        return CoreOperatorType.HASH_JOIN_VALUE;
-    }
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
+  }
 
   /**
    *

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashPartitionSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/HashPartitionSender.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.base.AbstractSender;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.impl.partitionsender.Partitioner;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +32,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("hash-partition-sender")
 public class HashPartitionSender extends AbstractSender {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(HashPartitionSender.class);
+
+  public static final String OPERATOR_TYPE = "HASH_PARTITION_SENDER";
 
   private final LogicalExpression expr;
   private final int outgoingBatchSize;
@@ -76,8 +76,8 @@ public class HashPartitionSender extends AbstractSender {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.HASH_PARTITION_SENDER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/IteratorValidator.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/IteratorValidator.java
@@ -22,7 +22,9 @@ import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 
 public class IteratorValidator extends AbstractSingle{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(IteratorValidator.class);
+
+  public static final String OPERATOR_TYPE = "ITERATOR_VALIDATOR";
+
   /* isRepeatable flag will be set to true if this validator is created by a Repeatable pipeline.
    * In a repeatable pipeline some state transitions are valid i.e downstream operator
    * can call the upstream operator even after receiving NONE.
@@ -50,8 +52,7 @@ public class IteratorValidator extends AbstractSingle{
   }
 
   @Override
-  public int getOperatorType() {
-    // TODO: DRILL-6643: this implementation should be revisited
-    return -1;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/LateralJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/LateralJoinPOP.java
@@ -27,13 +27,13 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.exec.physical.base.AbstractJoinPop;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import java.util.List;
 
 @JsonTypeName("lateral-join")
 public class LateralJoinPOP extends AbstractJoinPop {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LateralJoinPOP.class);
+
+  public static final String OPERATOR_TYPE = "LATERAL_JOIN";
 
   @JsonProperty("excludedColumns")
   private List<SchemaPath> excludedColumns;
@@ -87,8 +87,8 @@ public class LateralJoinPOP extends AbstractJoinPop {
   public String getImplicitRIDColumn() { return this.implicitRIDColumn; }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.LATERAL_JOIN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Limit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Limit.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.physical.config;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -29,6 +28,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("limit")
 public class Limit extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "LIMIT";
+
   private final Integer first;
   private final Integer last;
 
@@ -63,7 +65,7 @@ public class Limit extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.LIMIT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MergeJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MergeJoinPOP.java
@@ -26,13 +26,13 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.drill.common.logical.data.JoinCondition;
 import org.apache.drill.exec.physical.base.AbstractJoinPop;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import java.util.List;
 
 @JsonTypeName("merge-join")
-public class MergeJoinPOP extends AbstractJoinPop{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MergeJoinPOP.class);
+public class MergeJoinPOP extends AbstractJoinPop {
+
+  public static final String OPERATOR_TYPE = "MERGE_JOIN";
 
   @JsonCreator
   public MergeJoinPOP(
@@ -66,7 +66,7 @@ public class MergeJoinPOP extends AbstractJoinPop{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.MERGE_JOIN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MergingReceiverPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MergingReceiverPOP.java
@@ -23,7 +23,6 @@ import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.exec.physical.MinorFragmentEndpoint;
 import org.apache.drill.exec.physical.base.AbstractReceiver;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,8 +33,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 // is guaranteed to be in order, so the operator simply merges the incoming
 // batches.  This is accomplished by building and depleting a priority queue.
 @JsonTypeName("merging-receiver")
-public class MergingReceiverPOP extends AbstractReceiver{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MergingReceiverPOP.class);
+public class MergingReceiverPOP extends AbstractReceiver {
+
+  public static final String OPERATOR_TYPE = "MERGING_RECEIVER";
 
   private final List<Ordering> orderings;
 
@@ -63,7 +63,7 @@ public class MergingReceiverPOP extends AbstractReceiver{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.MERGING_RECEIVER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataControllerPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataControllerPOP.java
@@ -24,7 +24,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.metastore.analyze.MetadataControllerContext;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 import java.util.Arrays;
@@ -33,6 +32,9 @@ import java.util.List;
 
 @JsonTypeName("metadataController")
 public class MetadataControllerPOP extends AbstractBase {
+
+  public static final String OPERATOR_TYPE = "METADATA_CONTROLLER";
+
   private final MetadataControllerContext context;
   private final PhysicalOperator left;
   private final PhysicalOperator right;
@@ -57,8 +59,8 @@ public class MetadataControllerPOP extends AbstractBase {
   }
 
   @Override
-  public int getOperatorType() {
-    return UserBitShared.CoreOperatorType.METADATA_CONTROLLER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataHandlerPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/MetadataHandlerPOP.java
@@ -24,10 +24,12 @@ import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.metastore.analyze.MetadataHandlerContext;
-import org.apache.drill.exec.proto.UserBitShared;
 
 @JsonTypeName("metadataHandler")
 public class MetadataHandlerPOP extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "METADATA_HANDLER";
+
   private final MetadataHandlerContext context;
 
   @JsonCreator
@@ -48,8 +50,8 @@ public class MetadataHandlerPOP extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return UserBitShared.CoreOperatorType.METADATA_HANDLER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   public MetadataHandlerContext getContext() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/NestedLoopJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/NestedLoopJoinPOP.java
@@ -25,13 +25,13 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.drill.common.expression.LogicalExpression;
 import org.apache.drill.exec.physical.base.AbstractJoinPop;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import java.util.List;
 
 @JsonTypeName("nested-loop-join")
 public class NestedLoopJoinPOP extends AbstractJoinPop {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NestedLoopJoinPOP.class);
+
+  public static final String OPERATOR_TYPE = "NESTED_LOOP_JOIN";
 
   @JsonCreator
   public NestedLoopJoinPOP(
@@ -50,7 +50,7 @@ public class NestedLoopJoinPOP extends AbstractJoinPop {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.NESTED_LOOP_JOIN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/OrderedPartitionSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/OrderedPartitionSender.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.MinorFragmentEndpoint;
 import org.apache.drill.exec.physical.base.AbstractSender;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,15 +33,16 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 @JsonTypeName("OrderedPartitionSender")
 public class OrderedPartitionSender extends AbstractSender {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OrderedPartitionSender.class);
+
+  public static final String OPERATOR_TYPE = "ORDERED_PARTITION_SENDER";
 
   private final List<Ordering> orderings;
   private final FieldReference ref;
   private final int sendingWidth;
 
-  private int recordsToSample;
-  private int samplingFactor;
-  private float completionFactor;
+  private final int recordsToSample;
+  private final int samplingFactor;
+  private final float completionFactor;
 
   @JsonCreator
   public OrderedPartitionSender(@JsonProperty("orderings") List<Ordering> orderings,
@@ -103,8 +103,8 @@ public class OrderedPartitionSender extends AbstractSender {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.ORDERED_PARTITION_SENDER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/PartitionLimit.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/PartitionLimit.java
@@ -22,11 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 @JsonTypeName("partition-limit")
 public class PartitionLimit extends Limit {
+
+  public static final String OPERATOR_TYPE = "PARTITION_LIMIT";
+
   private final String partitionColumn;
 
   @JsonCreator
@@ -56,8 +58,8 @@ public class PartitionLimit extends Limit {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.PARTITION_LIMIT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ProducerConsumer.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/ProducerConsumer.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.physical.config;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,7 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("producer-consumer")
 public class ProducerConsumer extends AbstractSingle{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProducerConsumer.class);
+
+  public static final String OPERATOR_TYPE = "PRODUCER_CONSUMER";
 
   private final int size;
 
@@ -53,7 +53,7 @@ public class ProducerConsumer extends AbstractSingle{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.PRODUCER_CONSUMER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Project.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Project.java
@@ -23,7 +23,6 @@ import org.apache.drill.common.logical.data.NamedExpression;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -32,7 +31,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("project")
 public class Project extends AbstractSingle{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Project.class);
+
+  public static final String OPERATOR_TYPE = "PROJECT";
 
   private final List<NamedExpression> exprs;
 
@@ -58,7 +58,7 @@ public class Project extends AbstractSingle{
   }
 
   /**
-   * @Return true if Project is for the query's final output. Such Project is added by TopProjectVisitor,
+   * @return true if Project is for the query's final output. Such Project is added by TopProjectVisitor,
    * to handle fast NONE when all the inputs to the query are empty and are skipped.
    */
   public boolean isOutputProj() {
@@ -81,7 +81,7 @@ public class Project extends AbstractSingle{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.PROJECT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RangePartitionSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RangePartitionSender.java
@@ -24,7 +24,6 @@ import org.apache.drill.exec.physical.base.AbstractSender;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.planner.physical.PartitionFunction;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,13 +32,13 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("range-partition-sender")
 public class RangePartitionSender extends AbstractSender{
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RangePartitionSender.class);
-
   // The number of records in the outgoing batch. This is overriding the default value in Partitioner
   public static final int RANGE_PARTITION_OUTGOING_BATCH_SIZE = (1 << 12) - 1;
 
+  public static final String OPERATOR_TYPE = "RANGE_PARTITION_SENDER";
+
   @JsonProperty("partitionFunction")
-  private PartitionFunction partitionFunction;
+  private final PartitionFunction partitionFunction;
 
   @JsonCreator
   public RangePartitionSender(@JsonProperty("receiver-major-fragment") int oppositeMajorFragmentId,
@@ -66,8 +65,8 @@ public class RangePartitionSender extends AbstractSender{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.RANGE_PARTITION_SENDER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RowKeyJoinPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RowKeyJoinPOP.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,7 +34,8 @@ import org.apache.drill.shaded.guava.com.google.common.collect.Iterators;
 
 @JsonTypeName("rowkey-join")
 public class RowKeyJoinPOP extends AbstractBase {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RowKeyJoinPOP.class);
+
+  public static final String OPERATOR_TYPE = "ROWKEY_JOIN";
 
 
   private final PhysicalOperator left;
@@ -90,7 +90,7 @@ public class RowKeyJoinPOP extends AbstractBase {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.ROWKEY_JOIN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RuntimeFilterPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/RuntimeFilterPOP.java
@@ -23,13 +23,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 @JsonTypeName("runtime-filter")
 public class RuntimeFilterPOP extends AbstractSingle {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RuntimeFilterPOP.class);
+  public static final String OPERATOR_TYPE = "RUNTIME_FILTER";
 
   private long identifier;
 
@@ -55,8 +54,8 @@ public class RuntimeFilterPOP extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.RUNTIME_FILTER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Screen.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Screen.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.Store;
 import org.apache.drill.exec.planner.fragment.DistributionAffinity;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -37,7 +36,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("screen")
 public class Screen extends AbstractStore {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Screen.class);
+
+  public static final String OPERATOR_TYPE = "SCREEN";
 
   private final DrillbitEndpoint endpoint;
 
@@ -99,8 +99,8 @@ public class Screen extends AbstractStore {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.SCREEN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SelectionVectorRemover.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SelectionVectorRemover.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.physical.config;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("selection-vector-remover")
 public class SelectionVectorRemover extends AbstractSingle {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SelectionVectorRemover.class);
+  public static final String OPERATOR_TYPE = "SELECTION_VECTOR_REMOVER";
 
   @JsonCreator
   public SelectionVectorRemover(@JsonProperty("child") PhysicalOperator child) {
@@ -53,7 +52,7 @@ public class SelectionVectorRemover extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.SELECTION_VECTOR_REMOVER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SingleSender.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/SingleSender.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.base.AbstractSender;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -37,7 +36,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @JsonTypeName("single-sender")
 public class SingleSender extends AbstractSender {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SingleSender.class);
+
+  public static final String OPERATOR_TYPE = "SINGLE_SENDER";
 
   /**
    * Create a SingleSender which sends data to fragment identified by given MajorFragmentId and MinorFragmentId,
@@ -96,8 +96,8 @@ public class SingleSender extends AbstractSender {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.SINGLE_SENDER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Sort.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Sort.java
@@ -23,7 +23,6 @@ import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -32,10 +31,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("sort")
 public class Sort extends AbstractSingle{
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Sort.class);
+
+  public static final String OPERATOR_TYPE = "OLD_SORT";
 
   protected final List<Ordering> orderings;
-  protected boolean reverse = false;
+  protected boolean reverse;
 
   @JsonCreator
   public Sort(@JsonProperty("child") PhysicalOperator child, @JsonProperty("orderings") List<Ordering> orderings, @JsonProperty("reverse") boolean reverse) {
@@ -68,8 +68,8 @@ public class Sort extends AbstractSingle{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.OLD_SORT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsAggregate.java
@@ -21,7 +21,6 @@ import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +30,9 @@ import java.util.List;
 
 @JsonTypeName("statistics-aggregate")
 public class StatisticsAggregate extends StreamingAggregate {
+
+  public static final String OPERATOR_TYPE = "STATISTICS_AGGREGATE";
+
   private final List<String> functions;
 
   @JsonCreator
@@ -57,8 +59,8 @@ public class StatisticsAggregate extends StreamingAggregate {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.STATISTICS_AGGREGATE_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsMerge.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StatisticsMerge.java
@@ -24,11 +24,12 @@ import java.util.Map;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableMap;
 
 @JsonTypeName("statistics-merge")
 public class StatisticsMerge extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "STATISTICS_MERGE";
 
   private final Map<String, String> functions;
   private final double samplePercent;
@@ -63,7 +64,7 @@ public class StatisticsMerge extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.STATISTICS_MERGE_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StreamingAggregate.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/StreamingAggregate.java
@@ -21,7 +21,6 @@ import org.apache.drill.common.logical.data.NamedExpression;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +30,8 @@ import java.util.List;
 
 @JsonTypeName("streaming-aggregate")
 public class StreamingAggregate extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "STREAMING_AGGREGATE";
 
   private final List<NamedExpression> keys;
   private final List<NamedExpression> exprs;
@@ -63,7 +64,7 @@ public class StreamingAggregate extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.STREAMING_AGGREGATE_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/TopN.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/TopN.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +29,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("top-n")
 public class TopN extends Sort {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TopN.class);
+
+  public static final String OPERATOR_TYPE = "TOP_N_SORT";
 
   private final int limit;
 
@@ -65,8 +65,8 @@ public class TopN extends Sort {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.TOP_N_SORT_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Trace.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Trace.java
@@ -20,7 +20,6 @@ package org.apache.drill.exec.physical.config;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -28,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("trace")
 public class Trace extends AbstractSingle {
 
-    static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Trace.class);
+    public static final String OPERATOR_TYPE = "TRACE";
 
     /* Tag associated with each trace operator
      * Printed along with trace output to distinguish
@@ -52,7 +51,7 @@ public class Trace extends AbstractSingle {
     }
 
     @Override
-    public int getOperatorType() {
-      return CoreOperatorType.TRACE_VALUE;
+    public String getOperatorType() {
+      return OPERATOR_TYPE;
     }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnionAll.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnionAll.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.drill.exec.physical.base.AbstractMultiple;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("union-all")
 
 public class UnionAll extends AbstractMultiple {
+
+  public static final String OPERATOR_TYPE = "UNION";
 
   @JsonCreator
   public UnionAll(@JsonProperty("children") List<PhysicalOperator> children) {
@@ -48,7 +49,7 @@ public class UnionAll extends AbstractMultiple {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.UNION_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnnestPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnnestPOP.java
@@ -33,16 +33,15 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.apache.drill.exec.proto.UserBitShared.CoreOperatorType.UNNEST_VALUE;
-
 @JsonTypeName("unnest")
 public class UnnestPOP extends AbstractBase implements Leaf {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UnnestPOP.class);
+
+  public static final String OPERATOR_TYPE = "UNNEST";
 
   @JsonProperty("implicitColumn")
-  private String implicitColumn;
+  private final String implicitColumn;
 
-  private SchemaPath column;
+  private final SchemaPath column;
 
   @JsonIgnore
   private UnnestRecordBatch unnestBatch;
@@ -91,7 +90,7 @@ public class UnnestPOP extends AbstractBase implements Leaf {
   public String getImplicitColumn() { return this.implicitColumn; }
 
   @Override
-  public int getOperatorType() {
-    return UNNEST_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnorderedReceiver.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnorderedReceiver.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.drill.exec.physical.MinorFragmentEndpoint;
 import org.apache.drill.exec.physical.base.AbstractReceiver;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("unordered-receiver")
 public class UnorderedReceiver extends AbstractReceiver{
+
+  public static final String OPERATOR_TYPE = "UNORDERED_RECEIVER";
 
   @JsonCreator
   public UnorderedReceiver(@JsonProperty("sender-major-fragment") int oppositeMajorFragmentId,
@@ -49,7 +50,7 @@ public class UnorderedReceiver extends AbstractReceiver{
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.UNORDERED_RECEIVER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnpivotMaps.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/UnpivotMaps.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,6 +29,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("unpivot-maps")
 public class UnpivotMaps extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "UNPIVOT_MAPS";
+
   private final List<String> mapFieldNames;
 
   @JsonCreator
@@ -54,7 +56,7 @@ public class UnpivotMaps extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.UNPIVOT_MAPS_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Values.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/Values.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Values extends AbstractBase implements Leaf {
 
-  @SuppressWarnings("unused")
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Values.class);
+  public static final String OPERATOR_TYPE = "VALUES";
 
   private final JSONOptions content;
 
@@ -59,9 +58,8 @@ public class Values extends AbstractBase implements Leaf {
   }
 
   @Override
-  public int getOperatorType() {
-    // TODO: DRILL-6643: this implementation should be revisited
-    return -1;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/WindowPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/physical/config/WindowPOP.java
@@ -26,12 +26,13 @@ import org.apache.drill.common.logical.data.Order;
 import org.apache.drill.exec.physical.base.AbstractSingle;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
-import org.apache.drill.exec.proto.UserBitShared;
 
 import java.util.List;
 
 @JsonTypeName("window")
 public class WindowPOP extends AbstractSingle {
+
+  public static final String OPERATOR_TYPE = "WINDOW";
 
   private final List<NamedExpression> withins;
   private final List<NamedExpression> aggregations;
@@ -67,8 +68,8 @@ public class WindowPOP extends AbstractSingle {
   }
 
   @Override
-  public int getOperatorType() {
-    return UserBitShared.CoreOperatorType.WINDOW_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   public Bound getStart() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/CoreOperatorType.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/CoreOperatorType.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.exec.server.rest.profile;
+
+
+import java.util.Arrays;
+
+/**
+ * This class is used for backward compatibility when reading older query profiles that
+ * stored operator id instead of its name.
+ * <b>Please do not update this class. It will be removed for Drill 2.0</b>
+ */
+public enum CoreOperatorType {
+
+  /**
+   * <code>SINGLE_SENDER = 0;</code>
+   */
+  SINGLE_SENDER(0),
+  /**
+   * <code>BROADCAST_SENDER = 1;</code>
+   */
+  BROADCAST_SENDER(1),
+  /**
+   * <code>FILTER = 2;</code>
+   */
+  FILTER(2),
+  /**
+   * <code>HASH_AGGREGATE = 3;</code>
+   */
+  HASH_AGGREGATE(3),
+  /**
+   * <code>HASH_JOIN = 4;</code>
+   */
+  HASH_JOIN(4),
+  /**
+   * <code>MERGE_JOIN = 5;</code>
+   */
+  MERGE_JOIN(5),
+  /**
+   * <code>HASH_PARTITION_SENDER = 6;</code>
+   */
+  HASH_PARTITION_SENDER(6),
+  /**
+   * <code>LIMIT = 7;</code>
+   */
+  LIMIT(7),
+  /**
+   * <code>MERGING_RECEIVER = 8;</code>
+   */
+  MERGING_RECEIVER(8),
+  /**
+   * <code>ORDERED_PARTITION_SENDER = 9;</code>
+   */
+  ORDERED_PARTITION_SENDER(9),
+  /**
+   * <code>PROJECT = 10;</code>
+   */
+  PROJECT(10),
+  /**
+   * <code>UNORDERED_RECEIVER = 11;</code>
+   */
+  UNORDERED_RECEIVER(11),
+  /**
+   * <code>RANGE_PARTITION_SENDER = 12;</code>
+   */
+  RANGE_PARTITION_SENDER(12),
+  /**
+   * <code>SCREEN = 13;</code>
+   */
+  SCREEN(13),
+  /**
+   * <code>SELECTION_VECTOR_REMOVER = 14;</code>
+   */
+  SELECTION_VECTOR_REMOVER(14),
+  /**
+   * <code>STREAMING_AGGREGATE = 15;</code>
+   */
+  STREAMING_AGGREGATE(15),
+  /**
+   * <code>TOP_N_SORT = 16;</code>
+   */
+  TOP_N_SORT(16),
+  /**
+   * <code>EXTERNAL_SORT = 17;</code>
+   */
+  EXTERNAL_SORT(17),
+  /**
+   * <code>TRACE = 18;</code>
+   */
+  TRACE(18),
+  /**
+   * <code>UNION = 19;</code>
+   */
+  UNION(19),
+  /**
+   * <code>OLD_SORT = 20;</code>
+   */
+  OLD_SORT(20),
+  /**
+   * <code>PARQUET_ROW_GROUP_SCAN = 21;</code>
+   */
+  PARQUET_ROW_GROUP_SCAN(21),
+  /**
+   * <code>HIVE_SUB_SCAN = 22;</code>
+   */
+  HIVE_SUB_SCAN(22),
+  /**
+   * <code>SYSTEM_TABLE_SCAN = 23;</code>
+   */
+  SYSTEM_TABLE_SCAN(23),
+  /**
+   * <code>MOCK_SUB_SCAN = 24;</code>
+   */
+  MOCK_SUB_SCAN(24),
+  /**
+   * <code>PARQUET_WRITER = 25;</code>
+   */
+  PARQUET_WRITER(25),
+  /**
+   * <code>DIRECT_SUB_SCAN = 26;</code>
+   */
+  DIRECT_SUB_SCAN(26),
+  /**
+   * <code>TEXT_WRITER = 27;</code>
+   */
+  TEXT_WRITER(27),
+  /**
+   * <code>TEXT_SUB_SCAN = 28;</code>
+   */
+  TEXT_SUB_SCAN(28),
+  /**
+   * <code>JSON_SUB_SCAN = 29;</code>
+   */
+  JSON_SUB_SCAN(29),
+  /**
+   * <code>INFO_SCHEMA_SUB_SCAN = 30;</code>
+   */
+  INFO_SCHEMA_SUB_SCAN(30),
+  /**
+   * <code>COMPLEX_TO_JSON = 31;</code>
+   */
+  COMPLEX_TO_JSON(31),
+  /**
+   * <code>PRODUCER_CONSUMER = 32;</code>
+   */
+  PRODUCER_CONSUMER(32),
+  /**
+   * <code>HBASE_SUB_SCAN = 33;</code>
+   */
+  HBASE_SUB_SCAN(33),
+  /**
+   * <code>WINDOW = 34;</code>
+   */
+  WINDOW(34),
+  /**
+   * <code>NESTED_LOOP_JOIN = 35;</code>
+   */
+  NESTED_LOOP_JOIN(35),
+  /**
+   * <code>AVRO_SUB_SCAN = 36;</code>
+   */
+  AVRO_SUB_SCAN(36),
+  /**
+   * <code>PCAP_SUB_SCAN = 37;</code>
+   */
+  PCAP_SUB_SCAN(37),
+  /**
+   * <code>KAFKA_SUB_SCAN = 38;</code>
+   */
+  KAFKA_SUB_SCAN(38),
+  /**
+   * <code>KUDU_SUB_SCAN = 39;</code>
+   */
+  KUDU_SUB_SCAN(39),
+  /**
+   * <code>FLATTEN = 40;</code>
+   */
+  FLATTEN(40),
+  /**
+   * <code>LATERAL_JOIN = 41;</code>
+   */
+  LATERAL_JOIN(41),
+  /**
+   * <code>UNNEST = 42;</code>
+   */
+  UNNEST(42),
+  /**
+   * <code>HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;</code>
+   */
+  HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN(43),
+  /**
+   * <code>JDBC_SCAN = 44;</code>
+   */
+  JDBC_SCAN(44),
+  /**
+   * <code>REGEX_SUB_SCAN = 45;</code>
+   */
+  REGEX_SUB_SCAN(45),
+  /**
+   * <code>MAPRDB_SUB_SCAN = 46;</code>
+   */
+  MAPRDB_SUB_SCAN(46),
+  /**
+   * <code>MONGO_SUB_SCAN = 47;</code>
+   */
+  MONGO_SUB_SCAN(47),
+  /**
+   * <code>KUDU_WRITER = 48;</code>
+   */
+  KUDU_WRITER(48),
+  /**
+   * <code>OPEN_TSDB_SUB_SCAN = 49;</code>
+   */
+  OPEN_TSDB_SUB_SCAN(49),
+  /**
+   * <code>JSON_WRITER = 50;</code>
+   */
+  JSON_WRITER(50),
+  /**
+   * <code>HTPPD_LOG_SUB_SCAN = 51;</code>
+   */
+  HTPPD_LOG_SUB_SCAN(51),
+  /**
+   * <code>IMAGE_SUB_SCAN = 52;</code>
+   */
+  IMAGE_SUB_SCAN(52),
+  /**
+   * <code>SEQUENCE_SUB_SCAN = 53;</code>
+   */
+  SEQUENCE_SUB_SCAN(53),
+  /**
+   * <code>PARTITION_LIMIT = 54;</code>
+   */
+  PARTITION_LIMIT(54),
+  /**
+   * <code>PCAPNG_SUB_SCAN = 55;</code>
+   */
+  PCAPNG_SUB_SCAN(55),
+  /**
+   * <code>RUNTIME_FILTER = 56;</code>
+   */
+  RUNTIME_FILTER(56),
+  /**
+   * <code>ROWKEY_JOIN = 57;</code>
+   */
+  ROWKEY_JOIN(57),
+  /**
+   * <code>SYSLOG_SUB_SCAN = 58;</code>
+   */
+  SYSLOG_SUB_SCAN(58),
+  /**
+   * <code>STATISTICS_AGGREGATE = 59;</code>
+   */
+  STATISTICS_AGGREGATE(59),
+  /**
+   * <code>UNPIVOT_MAPS = 60;</code>
+   */
+  UNPIVOT_MAPS(60),
+  /**
+   * <code>STATISTICS_MERGE = 61;</code>
+   */
+  STATISTICS_MERGE(61),
+  /**
+   * <code>LTSV_SUB_SCAN = 62;</code>
+   */
+  LTSV_SUB_SCAN(62),
+  /**
+   * <code>HDF5_SUB_SCAN = 63;</code>
+   */
+  HDF5_SUB_SCAN(63),
+  /**
+   * <code>EXCEL_SUB_SCAN = 64;</code>
+   */
+  EXCEL_SUB_SCAN(64),
+  /**
+   * <code>SHP_SUB_SCAN = 65;</code>
+   */
+  SHP_SUB_SCAN(65),
+  /**
+   * <code>METADATA_HANDLER = 66;</code>
+   */
+  METADATA_HANDLER(66),
+  /**
+   * <code>METADATA_CONTROLLER = 67;</code>
+   */
+  METADATA_CONTROLLER(67),
+  /**
+   * <code>DRUID_SUB_SCAN = 68;</code>
+   */
+  DRUID_SUB_SCAN(68),
+  /**
+   * <code>SPSS_SUB_SCAN = 69;</code>
+   */
+  SPSS_SUB_SCAN(69),
+  /**
+   * <code>HTTP_SUB_SCAN = 70;</code>
+   */
+  HTTP_SUB_SCAN(70),
+  /**
+   * <code>XML_SUB_SCAN = 71;</code>
+   */
+  XML_SUB_SCAN(71);
+
+  private final int value;
+
+  CoreOperatorType(int value) {
+    this.value = value;
+  }
+
+  public int getId() {
+    return value;
+  }
+
+  public static CoreOperatorType valueOf(int id) {
+    if (id >= 0 && id <= XML_SUB_SCAN.getId()) {
+      return values()[id];
+    }
+    return null;
+  }
+
+  public static CoreOperatorType forName(String name) {
+    return Arrays.stream(values())
+        .filter(value -> value.name().equalsIgnoreCase(name))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.drill.common.config.DrillConfig;
 import org.apache.drill.exec.ExecConstants;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.proto.UserBitShared.MajorFragmentProfile;
 import org.apache.drill.exec.proto.UserBitShared.MinorFragmentProfile;
 import org.apache.drill.exec.proto.UserBitShared.OperatorProfile;
@@ -68,7 +67,7 @@ public class ProfileWrapper {
   private Map<String, String> physicalOperatorMap;
   private final String noProgressWarningThreshold;
   private final int defaultAutoLimit;
-  private boolean showEstimatedRows;
+  private final boolean showEstimatedRows;
   private final String csrfToken;
 
   public ProfileWrapper(final QueryProfile profile, DrillConfig drillConfig, HttpServletRequest request) {
@@ -322,16 +321,6 @@ public class ProfileWrapper {
       ow.addSummary(tb, this.majorFragmentTallyMap, this.majorFragmentTallyTotal);
     }
     return tb.build();
-  }
-
-  public String getOperatorsJSON() {
-    final StringBuilder sb = new StringBuilder("{");
-    String sep = "";
-    for (final CoreOperatorType op : CoreOperatorType.values()) {
-      sb.append(String.format("%s\"%d\" : \"%s\"", sep, op.ordinal(), op));
-      sep = ", ";
-    }
-    return sb.append("}").toString();
   }
 
   public Map<String, String> getOptions() {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/avro/AvroFormatPlugin.java
@@ -22,7 +22,6 @@ import org.apache.drill.common.types.TypeProtos;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -45,19 +44,18 @@ public class AvroFormatPlugin extends EasyFormatPlugin<AvroFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, AvroFormatConfig formatConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = true;
-    config.compressible = false;
-    config.supportsProjectPushdown = true;
-    config.extensions = formatConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = DEFAULT_NAME;
-    config.readerOperatorType = CoreOperatorType.AVRO_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(true)
+        .compressible(false)
+        .supportsProjectPushdown(true)
+        .extensions(formatConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(DEFAULT_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyFormatPlugin.java
@@ -18,9 +18,12 @@
 package org.apache.drill.exec.store.dfs.easy;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.drill.common.exceptions.ExecutionSetupException;
@@ -90,34 +93,253 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * vary across uses of the plugin.
    */
   public static class EasyFormatConfig {
-    public BasicFormatMatcher matcher;
-    public boolean readable = true;
-    public boolean writable;
-    public boolean blockSplittable;
-    public boolean compressible;
-    public Configuration fsConf;
-    public List<String> extensions;
-    public String defaultName;
+    private BasicFormatMatcher matcher;
+    private final boolean readable;
+    private final boolean writable;
+    private final boolean blockSplittable;
+    private final boolean compressible;
+    private final Configuration fsConf;
+    private final List<String> extensions;
+    private final String defaultName;
 
     // Config options that, prior to Drill 1.15, required the plugin to
     // override methods. Moving forward, plugins should be migrated to
     // use this simpler form. New plugins should use these options
     // instead of overriding methods.
 
-    public boolean supportsLimitPushdown;
-    public boolean supportsProjectPushdown;
-    public boolean supportsFileImplicitColumns = true;
-    public boolean supportsAutoPartitioning;
-    public boolean supportsStatistics;
-    public int readerOperatorType = -1;
-    public int writerOperatorType = -1;
+    private final boolean supportsLimitPushdown;
+    private final boolean supportsProjectPushdown;
+    private final boolean supportsFileImplicitColumns;
+    private final boolean supportsAutoPartitioning;
+    private final boolean supportsStatistics;
+    private final String readerOperatorType;
+    private final String writerOperatorType;
 
     /**
      *  Choose whether to use the "traditional" or "enhanced" reader
      *  structure. Can also be selected at runtime by overriding
-     *  {@link #useEnhancedScan(OptionManager)}.
+     *  {@link #useEnhancedScan()}.
      */
-    public boolean useEnhancedScan;
+    private final boolean useEnhancedScan;
+
+    public EasyFormatConfig(EasyFormatConfigBuilder builder) {
+      this.matcher = builder.matcher;
+      this.readable = builder.readable;
+      this.writable = builder.writable;
+      this.blockSplittable = builder.blockSplittable;
+      this.compressible = builder.compressible;
+      this.fsConf = builder.fsConf;
+      this.extensions = builder.extensions;
+      this.defaultName = builder.defaultName;
+      this.supportsLimitPushdown = builder.supportsLimitPushdown;
+      this.supportsProjectPushdown = builder.supportsProjectPushdown;
+      this.supportsFileImplicitColumns = builder.supportsFileImplicitColumns;
+      this.supportsAutoPartitioning = builder.supportsAutoPartitioning;
+      this.supportsStatistics = builder.supportsStatistics;
+      this.readerOperatorType = builder.readerOperatorType;
+      this.writerOperatorType = builder.writerOperatorType;
+      this.useEnhancedScan = builder.useEnhancedScan;
+    }
+
+    public BasicFormatMatcher getMatcher() {
+      return matcher;
+    }
+
+    public boolean isReadable() {
+      return readable;
+    }
+
+    public boolean isWritable() {
+      return writable;
+    }
+
+    public boolean isBlockSplittable() {
+      return blockSplittable;
+    }
+
+    public boolean isCompressible() {
+      return compressible;
+    }
+
+    public Configuration getFsConf() {
+      return fsConf;
+    }
+
+    public List<String> getExtensions() {
+      return extensions;
+    }
+
+    public String getDefaultName() {
+      return defaultName;
+    }
+
+    public boolean supportsLimitPushdown() {
+      return supportsLimitPushdown;
+    }
+
+    public boolean supportsProjectPushdown() {
+      return supportsProjectPushdown;
+    }
+
+    public boolean supportsFileImplicitColumns() {
+      return supportsFileImplicitColumns;
+    }
+
+    public boolean supportsAutoPartitioning() {
+      return supportsAutoPartitioning;
+    }
+
+    public boolean supportsStatistics() {
+      return supportsStatistics;
+    }
+
+    public String getReaderOperatorType() {
+      return readerOperatorType;
+    }
+
+    public String getWriterOperatorType() {
+      return writerOperatorType;
+    }
+
+    public boolean useEnhancedScan() {
+      return useEnhancedScan;
+    }
+
+    public static EasyFormatConfigBuilder builder() {
+      return new EasyFormatConfigBuilder();
+    }
+
+    public EasyFormatConfigBuilder toBuilder() {
+      return builder()
+          .matcher(matcher)
+          .readable(readable)
+          .writable(writable)
+          .blockSplittable(blockSplittable)
+          .compressible(compressible)
+          .fsConf(fsConf)
+          .extensions(extensions)
+          .defaultName(defaultName)
+          .supportsLimitPushdown(supportsLimitPushdown)
+          .supportsProjectPushdown(supportsProjectPushdown)
+          .supportsFileImplicitColumns(supportsFileImplicitColumns)
+          .supportsAutoPartitioning(supportsAutoPartitioning)
+          .supportsStatistics(supportsStatistics)
+          .readerOperatorType(readerOperatorType)
+          .writerOperatorType(writerOperatorType)
+          .useEnhancedScan(useEnhancedScan);
+    }
+  }
+
+  public static class EasyFormatConfigBuilder {
+    private BasicFormatMatcher matcher;
+    private boolean readable = true;
+    private boolean writable;
+    private boolean blockSplittable;
+    private boolean compressible;
+    private Configuration fsConf;
+    private List<String> extensions;
+    private String defaultName;
+    private boolean supportsLimitPushdown;
+    private boolean supportsProjectPushdown;
+    private boolean supportsFileImplicitColumns = true;
+    private boolean supportsAutoPartitioning;
+    private boolean supportsStatistics;
+    private String readerOperatorType;
+    private String writerOperatorType = "";
+    private boolean useEnhancedScan;
+
+    public EasyFormatConfigBuilder matcher(BasicFormatMatcher matcher) {
+      this.matcher = matcher;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder readable(boolean readable) {
+      this.readable = readable;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder writable(boolean writable) {
+      this.writable = writable;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder blockSplittable(boolean blockSplittable) {
+      this.blockSplittable = blockSplittable;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder compressible(boolean compressible) {
+      this.compressible = compressible;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder fsConf(Configuration fsConf) {
+      this.fsConf = fsConf;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder extensions(List<String> extensions) {
+      this.extensions = extensions;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder extensions(String... extensions) {
+      this.extensions = Arrays.asList(extensions);
+      return this;
+    }
+
+    public EasyFormatConfigBuilder defaultName(String defaultName) {
+      this.defaultName = defaultName;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder supportsLimitPushdown(boolean supportsLimitPushdown) {
+      this.supportsLimitPushdown = supportsLimitPushdown;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder supportsProjectPushdown(boolean supportsProjectPushdown) {
+      this.supportsProjectPushdown = supportsProjectPushdown;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder supportsFileImplicitColumns(boolean supportsFileImplicitColumns) {
+      this.supportsFileImplicitColumns = supportsFileImplicitColumns;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder supportsAutoPartitioning(boolean supportsAutoPartitioning) {
+      this.supportsAutoPartitioning = supportsAutoPartitioning;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder supportsStatistics(boolean supportsStatistics) {
+      this.supportsStatistics = supportsStatistics;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder readerOperatorType(String readerOperatorType) {
+      this.readerOperatorType = readerOperatorType;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder writerOperatorType(String writerOperatorType) {
+      this.writerOperatorType = writerOperatorType;
+      return this;
+    }
+
+    public EasyFormatConfigBuilder useEnhancedScan(boolean useEnhancedScan) {
+      this.useEnhancedScan = useEnhancedScan;
+      return this;
+    }
+
+    public EasyFormatConfig build() {
+      Objects.requireNonNull(defaultName, "defaultName is not set");
+      readerOperatorType = readerOperatorType == null
+          ? defaultName.toUpperCase(Locale.ROOT) + "_SUB_SCAN"
+          : readerOperatorType;
+      return new EasyFormatConfig(this);
+    }
   }
 
   /**
@@ -163,14 +385,16 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
       boolean blockSplittable,
       boolean compressible, List<String> extensions, String defaultName) {
     this.name = name == null ? defaultName : name;
-    easyConfig = new EasyFormatConfig();
-    easyConfig.matcher = new BasicFormatMatcher(this, fsConf, extensions, compressible);
-    easyConfig.readable = readable;
-    easyConfig.writable = writable;
+    easyConfig = EasyFormatConfig.builder()
+        .matcher(new BasicFormatMatcher(this, fsConf, extensions, compressible))
+        .readable(readable)
+        .writable(writable)
+        .blockSplittable(blockSplittable)
+        .compressible(compressible)
+        .fsConf(fsConf)
+        .defaultName(defaultName)
+        .build();
     this.context = context;
-    easyConfig.blockSplittable = blockSplittable;
-    easyConfig.compressible = compressible;
-    easyConfig.fsConf = fsConf;
     this.storageConfig = storageConfig;
     this.formatConfig = formatConfig;
   }
@@ -203,7 +427,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   }
 
   @Override
-  public Configuration getFsConf() { return easyConfig.fsConf; }
+  public Configuration getFsConf() { return easyConfig.getFsConf(); }
 
   @Override
   public DrillbitContext getContext() { return context; }
@@ -220,7 +444,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * that are identified at the first row.  CSV for example.  If the user only wants 100 rows, it
    * does not make sense to read the entire file.
    */
-  public boolean supportsLimitPushdown() { return easyConfig.supportsLimitPushdown; }
+  public boolean supportsLimitPushdown() { return easyConfig.supportsLimitPushdown(); }
 
   /**
    * Does this plugin support projection push down? That is, can the reader
@@ -230,7 +454,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * @return {@code true} if the plugin supports projection push-down,
    * {@code false} if Drill should do the task by adding a project operator
    */
-  public boolean supportsPushDown() { return easyConfig.supportsProjectPushdown; }
+  public boolean supportsPushDown() { return easyConfig.supportsProjectPushdown(); }
 
   /**
    * Whether this format plugin supports implicit file columns.
@@ -239,7 +463,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * {@code false} otherwise
    */
   public boolean supportsFileImplicitColumns() {
-    return easyConfig.supportsFileImplicitColumns;
+    return easyConfig.supportsFileImplicitColumns();
   }
 
   /**
@@ -249,7 +473,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    *
    * @return {@code true} if splitable.
    */
-  public boolean isBlockSplittable() { return easyConfig.blockSplittable; }
+  public boolean isBlockSplittable() { return easyConfig.isBlockSplittable(); }
 
   /**
    * Indicates whether or not this format could also be in a compression
@@ -259,7 +483,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    *
    * @return {@code true} if it is compressible
    */
-  public boolean isCompressible() { return easyConfig.compressible; }
+  public boolean isCompressible() { return easyConfig.isCompressible(); }
 
   /**
    * Return a record reader for the specific file format, when using the original
@@ -279,7 +503,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
 
   protected CloseableRecordBatch getReaderBatch(FragmentContext context,
       EasySubScan scan) throws ExecutionSetupException {
-    if (useEnhancedScan(context.getOptions())) {
+    if (useEnhancedScan()) {
       return buildScan(context, scan);
     } else {
       return buildScanBatch(context, scan);
@@ -295,8 +519,8 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
    * @return true to use the enhanced scan framework, false for the
    * traditional scan-batch framework
    */
-  protected boolean useEnhancedScan(OptionManager options) {
-    return easyConfig.useEnhancedScan;
+  protected boolean useEnhancedScan() {
+    return easyConfig.useEnhancedScan();
   }
 
   /**
@@ -409,7 +633,7 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
     // Additional error context to identify this plugin
     builder.errorContext(
         currentBuilder -> currentBuilder
-            .addContext("Format plugin", easyConfig.defaultName)
+            .addContext("Format plugin", easyConfig.getDefaultName())
             .addContext("Format plugin", EasyFormatPlugin.this.getClass().getSimpleName())
             .addContext("Plugin config name", getName()));
   }
@@ -498,27 +722,30 @@ public abstract class EasyFormatPlugin<T extends FormatPluginConfig> implements 
   public StoragePluginConfig getStorageConfig() { return storageConfig; }
 
   @Override
-  public boolean supportsRead() { return easyConfig.readable; }
+  public boolean supportsRead() { return easyConfig.isReadable(); }
 
   @Override
-  public boolean supportsWrite() { return easyConfig.writable; }
+  public boolean supportsWrite() { return easyConfig.isWritable(); }
 
   @Override
-  public boolean supportsAutoPartitioning() { return easyConfig.supportsAutoPartitioning; }
+  public boolean supportsAutoPartitioning() { return easyConfig.supportsAutoPartitioning(); }
 
   @Override
-  public FormatMatcher getMatcher() { return easyConfig.matcher; }
+  public FormatMatcher getMatcher() { return easyConfig.getMatcher(); }
 
   @Override
   public Set<StoragePluginOptimizerRule> getOptimizerRules() {
     return ImmutableSet.of();
   }
 
-  public int getReaderOperatorType() { return easyConfig.readerOperatorType; }
-  public int getWriterOperatorType() { return easyConfig.writerOperatorType; }
+  public String getReaderOperatorType() {
+    return easyConfig.getReaderOperatorType();
+  }
+
+  public String getWriterOperatorType() { return easyConfig.getWriterOperatorType(); }
 
   @Override
-  public boolean supportsStatistics() { return easyConfig.supportsStatistics; }
+  public boolean supportsStatistics() { return easyConfig.supportsStatistics(); }
 
   @Override
   public TableStatistics readStatistics(FileSystem fs, Path statsTablePath) throws IOException {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyGroupScan.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.drill.common.PlanStringBuilder;
 import org.apache.drill.common.exceptions.DrillRuntimeException;
 import org.apache.drill.common.expression.SchemaPath;
@@ -87,7 +88,6 @@ public class EasyGroupScan extends AbstractGroupScanWithMetadata<TableMetadataPr
   private List<EndpointAffinity> endpointAffinities;
   private final Path selectionRoot;
   private final int maxRecords;
-  private final boolean supportsLimitPushdown;
 
   @JsonCreator
   public EasyGroupScan(
@@ -106,7 +106,6 @@ public class EasyGroupScan extends AbstractGroupScanWithMetadata<TableMetadataPr
     this.columns = columns == null ? ALL_COLUMNS : columns;
     this.selectionRoot = selectionRoot;
     this.maxRecords = getMaxRecords();
-    this.supportsLimitPushdown = formatPlugin.easyConfig().supportsLimitPushdown;
     this.metadataProvider = defaultTableMetadataProviderBuilder(new FileSystemMetadataProviderManager())
         .withSelection(selection)
         .withSchema(schema)
@@ -142,7 +141,6 @@ public class EasyGroupScan extends AbstractGroupScanWithMetadata<TableMetadataPr
     this.usedMetastore = metadataProviderManager.usesMetastore();
     initFromSelection(selection, formatPlugin);
     checkMetadataConsistency(selection, formatPlugin.getFsConf());
-    this.supportsLimitPushdown = formatPlugin.easyConfig().supportsLimitPushdown;
     this.maxRecords = getMaxRecords();
   }
 
@@ -180,7 +178,6 @@ public class EasyGroupScan extends AbstractGroupScanWithMetadata<TableMetadataPr
     partitionDepth = that.partitionDepth;
     metadataProvider = that.metadataProvider;
     maxRecords = getMaxRecords();
-    supportsLimitPushdown = that.formatPlugin.easyConfig().supportsLimitPushdown;
   }
 
   @JsonIgnore
@@ -402,7 +399,7 @@ public class EasyGroupScan extends AbstractGroupScanWithMetadata<TableMetadataPr
       EasyGroupScan newScan = new EasyGroupScan((EasyGroupScan) source);
       newScan.tableMetadata = tableMetadata;
       // updates common row count and nulls counts for every column
-      if (newScan.getTableMetadata() != null && files != null && newScan.getFilesMetadata().size() != files.size()) {
+      if (newScan.getTableMetadata() != null && MapUtils.isNotEmpty(files) && newScan.getFilesMetadata().size() != files.size()) {
         newScan.tableMetadata = TableMetadataUtils.updateRowCount(newScan.getTableMetadata(), files.values());
       }
       newScan.partitions = partitions;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasySubScan.java
@@ -110,5 +110,5 @@ public class EasySubScan extends AbstractSubScan {
   public int getMaxRecords() { return maxRecords; }
 
   @Override
-  public int getOperatorType() { return formatPlugin.getReaderOperatorType(); }
+  public String getOperatorType() { return formatPlugin.getReaderOperatorType(); }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/easy/EasyWriter.java
@@ -31,12 +31,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @JsonTypeName("fs-writer")
 public class EasyWriter extends AbstractWriter {
-  static final Logger logger = LoggerFactory.getLogger(EasyWriter.class);
 
   private final String location;
   private final List<String> partitionColumns;
@@ -98,7 +95,7 @@ public class EasyWriter extends AbstractWriter {
   }
 
   @Override
-  public int getOperatorType() {
+  public String getOperatorType() {
     return formatPlugin.getWriterOperatorType();
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/DirectSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/direct/DirectSubScan.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.drill.exec.physical.base.AbstractSubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.RecordReader;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -32,7 +31,8 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.WRAPPER_OBJECT;
 @JsonTypeName("direct-sub-scan")
 public class DirectSubScan extends AbstractSubScan {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DirectSubScan.class);
+  public static final String OPERATOR_TYPE = "DIRECT_SUB_SCAN";
+
   @JsonTypeInfo(use=NAME, include=WRAPPER_OBJECT)
   private final RecordReader reader;
 
@@ -43,14 +43,13 @@ public class DirectSubScan extends AbstractSubScan {
   }
 
   @JsonProperty
-  //@JsonGetter("reader")
   public RecordReader getReader() {
     return reader;
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.DIRECT_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/json/JSONFormatPlugin.java
@@ -33,7 +33,6 @@ import org.apache.drill.exec.ops.QueryContext.SqlStatementType;
 import org.apache.drill.exec.planner.common.DrillStatsTable;
 import org.apache.drill.exec.planner.common.DrillStatsTable.TableStatistics;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.RecordWriter;
@@ -61,10 +60,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
+
   private static final Logger logger = LoggerFactory.getLogger(JSONFormatPlugin.class);
   public static final String DEFAULT_NAME = "json";
 
   private static final boolean IS_COMPRESSIBLE = true;
+
+  public static final String OPERATOR_TYPE = "JSON_SUB_SCAN";
 
   public JSONFormatPlugin(String name, DrillbitContext context,
       Configuration fsConf, StoragePluginConfig storageConfig) {
@@ -215,13 +217,13 @@ public class JSONFormatPlugin extends EasyFormatPlugin<JSONFormatConfig> {
   }
 
   @Override
-  public int getReaderOperatorType() {
-    return CoreOperatorType.JSON_SUB_SCAN_VALUE;
+  public String getReaderOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override
-  public int getWriterOperatorType() {
-     return CoreOperatorType.JSON_WRITER_VALUE;
+  public String getWriterOperatorType() {
+     return "JSON_WRITER";
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/sequencefile/SequenceFileFormatPlugin.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReade
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -33,6 +32,8 @@ import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.hadoop.conf.Configuration;
 
 public class SequenceFileFormatPlugin extends EasyFormatPlugin<SequenceFileFormatConfig> {
+
+  public static final String OPERATOR_TYPE = "SEQUENCE_SUB_SCAN";
 
   public SequenceFileFormatPlugin(String name,
                                   DrillbitContext context,
@@ -43,19 +44,19 @@ public class SequenceFileFormatPlugin extends EasyFormatPlugin<SequenceFileForma
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, SequenceFileFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = true;
-    config.compressible = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.readerOperatorType = CoreOperatorType.SEQUENCE_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    config.supportsProjectPushdown = true;
-    config.defaultName = SequenceFileFormatConfig.NAME;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(true)
+        .compressible(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .readerOperatorType(OPERATOR_TYPE)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .supportsProjectPushdown(true)
+        .defaultName(SequenceFileFormatConfig.NAME)
+        .build();
   }
 
   private static class SequenceFileReaderFactory extends FileReaderFactory {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/easy/text/TextFormatPlugin.java
@@ -46,7 +46,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchem
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.ExecProtos.FragmentHandle;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.metadata.Propertied;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
@@ -83,6 +82,7 @@ import java.util.Objects;
  * as to support provided schema.)
  */
 public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextFormatConfig> {
+
   private final static String PLUGIN_NAME = "text";
 
   public static final int MAXIMUM_NUMBER_COLUMNS = 64 * 1024;
@@ -108,6 +108,8 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
   public static final String LINE_DELIM_PROP = TEXT_PREFIX + "lineDelimiter";
   public static final String TRIM_WHITESPACE_PROP = TEXT_PREFIX + "trim";
   public static final String PARSE_UNESCAPED_QUOTES_PROP = TEXT_PREFIX + "parseQuotes";
+
+  public static final String WRITER_OPERATOR_TYPE = "TEXT_WRITER";
 
   @JsonTypeName(PLUGIN_NAME)
   @JsonInclude(Include.NON_DEFAULT)
@@ -143,8 +145,8 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
       this.quote = Strings.isNullOrEmpty(quote) ? '"' : quote.charAt(0);
       this.escape = Strings.isNullOrEmpty(escape) ? '"' : escape.charAt(0);
       this.comment = Strings.isNullOrEmpty(comment) ? '#' : comment.charAt(0);
-      this.skipFirstLine = skipFirstLine == null ? false : skipFirstLine;
-      this.extractHeader = extractHeader == null ? false : extractHeader;
+      this.skipFirstLine = skipFirstLine != null && skipFirstLine;
+      this.extractHeader = extractHeader != null && extractHeader;
     }
 
     public TextFormatConfig() {
@@ -231,20 +233,19 @@ public class TextFormatPlugin extends EasyFormatPlugin<TextFormatPlugin.TextForm
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, TextFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = true;
-    config.blockSplittable = true;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = PLUGIN_NAME;
-    config.readerOperatorType = CoreOperatorType.TEXT_SUB_SCAN_VALUE;
-    config.writerOperatorType = CoreOperatorType.TEXT_WRITER_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(true)
+        .blockSplittable(true)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(PLUGIN_NAME)
+        .writerOperatorType(WRITER_OPERATOR_TYPE)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/image/ImageFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/image/ImageFormatPlugin.java
@@ -26,7 +26,6 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.planner.common.DrillStatsTable;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.RecordReader;
 import org.apache.drill.exec.store.RecordWriter;
@@ -67,12 +66,7 @@ public class ImageFormatPlugin extends EasyFormatPlugin<ImageFormatConfig> {
   }
 
   @Override
-  public int getReaderOperatorType() {
-    return CoreOperatorType.IMAGE_SUB_SCAN_VALUE;
-  }
-
-  @Override
-  public int getWriterOperatorType() {
+  public String getWriterOperatorType() {
     throw new UnsupportedOperationException("Drill doesn't currently support writing to image files.");
   }
 

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaSubScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ischema/InfoSchemaSubScan.java
@@ -20,9 +20,10 @@ package org.apache.drill.exec.store.ischema;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.drill.exec.physical.base.AbstractSubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 
 public class InfoSchemaSubScan extends AbstractSubScan {
+
+  public static final String OPERATOR_TYPE = "INFO_SCHEMA_SUB_SCAN";
 
   private final InfoSchemaTableType table;
   private final InfoSchemaFilter filter;
@@ -46,7 +47,7 @@ public class InfoSchemaSubScan extends AbstractSubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.INFO_SCHEMA_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/log/LogFormatPlugin.java
@@ -28,7 +28,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReade
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.metadata.ColumnMetadata;
 import org.apache.drill.exec.record.metadata.MetadataUtils;
 import org.apache.drill.exec.record.metadata.Propertied;
@@ -44,19 +43,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class LogFormatPlugin extends EasyFormatPlugin<LogFormatConfig> {
+
   private static final Logger logger = LoggerFactory.getLogger(LogFormatPlugin.class);
 
   public static final String PLUGIN_NAME = "logRegex";
   public static final String PROP_PREFIX = Propertied.pluginPrefix(PLUGIN_NAME);
   public static final String REGEX_PROP = PROP_PREFIX + "regex";
   public static final String MAX_ERRORS_PROP = PROP_PREFIX + "maxErrors";
+
+  public static final String OPERATOR_TYPE = "REGEX_SUB_SCAN";
 
   private static class LogReaderFactory extends FileReaderFactory {
     private final LogReaderConfig readerConfig;
@@ -80,20 +81,19 @@ public class LogFormatPlugin extends EasyFormatPlugin<LogFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, LogFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    // Should be block splitable, but logic not yet implemented.
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = Collections.singletonList(pluginConfig.getExtension());
-    config.fsConf = fsConf;
-    config.defaultName = PLUGIN_NAME;
-    config.readerOperatorType = CoreOperatorType.REGEX_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false) // Should be block splitable, but logic not yet implemented.
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtension())
+        .fsConf(fsConf)
+        .defaultName(PLUGIN_NAME)
+        .readerOperatorType(OPERATOR_TYPE)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   /**

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorePOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockStorePOP.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("mock-store")
 public class MockStorePOP extends AbstractStore {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MockStorePOP.class);
 
   @JsonCreator
   public MockStorePOP(@JsonProperty("child") PhysicalOperator child) {
@@ -65,7 +64,7 @@ public class MockStorePOP extends AbstractStore {
   }
 
   @Override
-  public int getOperatorType() {
+  public String getOperatorType() {
     throw new UnsupportedOperationException();
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockSubScanPOP.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/mock/MockSubScanPOP.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.physical.base.PhysicalVisitor;
 import org.apache.drill.exec.physical.base.SubScan;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.mock.MockTableDef.MockScanEntry;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -42,6 +41,8 @@ import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
 @JsonTypeName("mock-sub-scan")
 public class MockSubScanPOP extends AbstractBase implements SubScan {
+
+  public static final String OPERATOR_TYPE = "MOCK_SUB_SCAN";
 
   private final String url;
   protected final List<MockScanEntry> readEntries;
@@ -116,7 +117,7 @@ public class MockSubScanPOP extends AbstractBase implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.MOCK_SUB_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 }

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRowGroupScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetRowGroupScan.java
@@ -26,7 +26,6 @@ import org.apache.drill.common.expression.SchemaPath;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.store.ColumnExplorer;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -43,6 +42,8 @@ import org.apache.hadoop.fs.Path;
 // Class containing information for reading a single parquet row group from HDFS
 @JsonTypeName("parquet-row-group-scan")
 public class ParquetRowGroupScan extends AbstractParquetRowGroupScan {
+
+  public static final String OPERATOR_TYPE = "PARQUET_ROW_GROUP_SCAN";
 
   private final ParquetFormatPlugin formatPlugin;
   private final ParquetFormatConfig formatConfig;
@@ -103,8 +104,8 @@ public class ParquetRowGroupScan extends AbstractParquetRowGroupScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.PARQUET_ROW_GROUP_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetWriter.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/parquet/ParquetWriter.java
@@ -26,9 +26,6 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.physical.base.AbstractWriter;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
 import org.apache.drill.exec.store.StorageStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -39,7 +36,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("parquet-writer")
 public class ParquetWriter extends AbstractWriter {
-  static final Logger logger = LoggerFactory.getLogger(ParquetWriter.class);
 
 /** Version of Drill's Parquet writer. Increment this version (by 1) any time we make any format change to the file.
  * Format changes include:
@@ -52,6 +48,8 @@ public class ParquetWriter extends AbstractWriter {
  * or metadata when that data changes format from one writer version to another.
  */
   public static final int WRITER_VERSION = 3;
+
+  public static final String OPERATOR_TYPE = "PARQUET_WRITER";
 
   private final String location;
   private final List<String> partitionColumns;
@@ -117,8 +115,8 @@ public class ParquetWriter extends AbstractWriter {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.PARQUET_WRITER_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcap/PcapFormatPlugin.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasySubScan;
 import org.apache.drill.common.logical.StoragePluginConfig;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
 import org.apache.hadoop.conf.Configuration;
@@ -59,19 +58,18 @@ public class PcapFormatPlugin extends EasyFormatPlugin<PcapFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, PcapFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.supportsProjectPushdown = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.defaultName = PLUGIN_NAME;
-    config.readerOperatorType = UserBitShared.CoreOperatorType.PCAP_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .supportsProjectPushdown(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .defaultName(PLUGIN_NAME)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .build();
   }
 
   @Override

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngFormatPlugin.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/pcapng/PcapngFormatPlugin.java
@@ -25,7 +25,6 @@ import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileReade
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileScanBuilder;
 import org.apache.drill.exec.physical.impl.scan.file.FileScanFramework.FileSchemaNegotiator;
 import org.apache.drill.exec.physical.impl.scan.framework.ManagedReader;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.options.OptionManager;
 import org.apache.drill.exec.store.dfs.easy.EasyFormatPlugin;
@@ -43,19 +42,18 @@ public class PcapngFormatPlugin extends EasyFormatPlugin<PcapngFormatConfig> {
   }
 
   private static EasyFormatConfig easyConfig(Configuration fsConf, PcapngFormatConfig pluginConfig) {
-    EasyFormatConfig config = new EasyFormatConfig();
-    config.readable = true;
-    config.writable = false;
-    config.blockSplittable = false;
-    config.compressible = true;
-    config.extensions = pluginConfig.getExtensions();
-    config.fsConf = fsConf;
-    config.readerOperatorType = CoreOperatorType.PCAPNG_SUB_SCAN_VALUE;
-    config.useEnhancedScan = true;
-    config.supportsLimitPushdown = true;
-    config.supportsProjectPushdown = true;
-    config.defaultName = PcapngFormatConfig.NAME;
-    return config;
+    return EasyFormatConfig.builder()
+        .readable(true)
+        .writable(false)
+        .blockSplittable(false)
+        .compressible(true)
+        .extensions(pluginConfig.getExtensions())
+        .fsConf(fsConf)
+        .useEnhancedScan(true)
+        .supportsLimitPushdown(true)
+        .supportsProjectPushdown(true)
+        .defaultName(PcapngFormatConfig.NAME)
+        .build();
   }
 
   private static class PcapngReaderFactory extends FileReaderFactory {

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTableScan.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/sys/SystemTableScan.java
@@ -37,11 +37,12 @@ import org.apache.drill.exec.physical.base.ScanStats;
 import org.apache.drill.exec.physical.base.SubScan;
 import org.apache.drill.exec.planner.fragment.DistributionAffinity;
 import org.apache.drill.exec.proto.CoordinationProtos.DrillbitEndpoint;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 
 @JsonTypeName("sys")
 public class SystemTableScan extends AbstractGroupScan implements SubScan {
+
+  public static final String OPERATOR_TYPE = "SYSTEM_TABLE_SCAN";
 
   private final SystemTable table;
   private final SystemTablePlugin plugin;
@@ -137,8 +138,8 @@ public class SystemTableScan extends AbstractGroupScan implements SubScan {
   }
 
   @Override
-  public int getOperatorType() {
-    return CoreOperatorType.SYSTEM_TABLE_SCAN_VALUE;
+  public String getOperatorType() {
+    return OPERATOR_TYPE;
   }
 
   /**

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -37,8 +37,7 @@
 
 <script>
     var globalconfig = {
-        "queryid" : "${model.getQueryId()}",
-        "operators" : ${model.getOperatorsJSON()?no_esc}
+        "queryid" : "${model.getQueryId()}"
     };
 
     $(document).ready(function() {

--- a/exec/java-exec/src/test/java/org/apache/drill/TestOperatorMetrics.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestOperatorMetrics.java
@@ -19,13 +19,15 @@ package org.apache.drill;
 
 import org.apache.drill.categories.OperatorTest;
 import org.apache.drill.exec.ops.OperatorMetricRegistry;
-import org.apache.drill.exec.proto.UserBitShared;
+import org.apache.drill.exec.physical.config.ExternalSort;
+import org.apache.drill.exec.physical.config.NestedLoopJoinPOP;
+import org.apache.drill.exec.physical.config.Screen;
 import org.apache.drill.test.BaseTestQuery;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
 
 @Category(OperatorTest.class)
@@ -33,18 +35,18 @@ public class TestOperatorMetrics extends BaseTestQuery {
 
   @Test
   public void testMetricNames() {
-    assertEquals(new String[]{"BYTES_SENT"},
-              OperatorMetricRegistry.getMetricNames(UserBitShared.CoreOperatorType.SCREEN_VALUE));
+    assertArrayEquals(new String[]{"BYTES_SENT"},
+              OperatorMetricRegistry.getMetricNames(Screen.OPERATOR_TYPE));
 
-    assertEquals(new String[]{"SPILL_COUNT", "NOT_USED", "PEAK_BATCHES_IN_MEMORY", "MERGE_COUNT", "MIN_BUFFER",
+    assertArrayEquals(new String[]{"SPILL_COUNT", "NOT_USED", "PEAK_BATCHES_IN_MEMORY", "MERGE_COUNT", "MIN_BUFFER",
                       "SPILL_MB"},
-              OperatorMetricRegistry.getMetricNames(UserBitShared.CoreOperatorType.EXTERNAL_SORT_VALUE));
+              OperatorMetricRegistry.getMetricNames(ExternalSort.OPERATOR_TYPE));
   }
 
   @Test
   public void testNonExistentMetricNames() {
-    assertNull(OperatorMetricRegistry.getMetricNames(UserBitShared.CoreOperatorType.NESTED_LOOP_JOIN_VALUE));
+    assertNull(OperatorMetricRegistry.getMetricNames(NestedLoopJoinPOP.OPERATOR_TYPE));
 
-    assertNull(OperatorMetricRegistry.getMetricNames(202));
+    assertNull(OperatorMetricRegistry.getMetricNames("FOO_BAR"));
   }
 }

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/memory/TestAllocators.java
@@ -39,16 +39,18 @@ import org.apache.drill.exec.ops.OperatorStats;
 import org.apache.drill.exec.ops.OperatorUtilities;
 import org.apache.drill.exec.physical.PhysicalPlan;
 import org.apache.drill.exec.physical.base.PhysicalOperator;
+import org.apache.drill.exec.physical.config.UnionAll;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory;
 import org.apache.drill.exec.proto.BitControl;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.record.MaterializedField;
 import org.apache.drill.exec.server.Drillbit;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.server.RemoteServiceSet;
 import org.apache.drill.exec.store.StoragePluginRegistry;
 import org.apache.drill.exec.store.StoragePluginRegistryImpl;
+import org.apache.drill.exec.store.easy.text.TextFormatPlugin;
+import org.apache.drill.exec.store.mock.MockSubScanPOP;
 import org.apache.drill.exec.vector.BitVector;
 import org.apache.drill.exec.vector.IntVector;
 import org.apache.drill.test.DrillTest;
@@ -219,7 +221,7 @@ public class TestAllocators extends DrillTest {
       OperatorStats stats;
 
       // Use some bogus operator type to create a new operator context.
-      def = new OpProfileDef(physicalOperator1.getOperatorId(), UserBitShared.CoreOperatorType.MOCK_SUB_SCAN_VALUE,
+      def = new OpProfileDef(physicalOperator1.getOperatorId(), MockSubScanPOP.OPERATOR_TYPE,
           OperatorUtilities.getChildCount(physicalOperator1));
       stats = fragmentContext1.getStats().newOperatorStats(def, fragmentContext1.getAllocator());
 
@@ -233,7 +235,7 @@ public class TestAllocators extends DrillTest {
 
       OperatorContext oContext21 = fragmentContext1.newOperatorContext(physicalOperator3);
 
-      def = new OpProfileDef(physicalOperator4.getOperatorId(), UserBitShared.CoreOperatorType.TEXT_WRITER_VALUE,
+      def = new OpProfileDef(physicalOperator4.getOperatorId(), TextFormatPlugin.WRITER_OPERATOR_TYPE,
           OperatorUtilities.getChildCount(physicalOperator4));
       stats = fragmentContext2.getStats().newOperatorStats(def, fragmentContext2.getAllocator());
       OperatorContext oContext22 = fragmentContext2.newOperatorContext(physicalOperator4, stats);
@@ -247,7 +249,7 @@ public class TestAllocators extends DrillTest {
       FragmentContextImpl fragmentContext3 = new FragmentContextImpl(bitContext, pf3, null, functionRegistry);
 
       // New fragment starts an operator that allocates an amount within the limit
-      def = new OpProfileDef(physicalOperator5.getOperatorId(), UserBitShared.CoreOperatorType.UNION_VALUE,
+      def = new OpProfileDef(physicalOperator5.getOperatorId(), UnionAll.OPERATOR_TYPE,
           OperatorUtilities.getChildCount(physicalOperator5));
       stats = fragmentContext3.getStats().newOperatorStats(def, fragmentContext3.getAllocator());
       OperatorContext oContext31 = fragmentContext3.newOperatorContext(physicalOperator5, stats);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/agg/TestHashAggrSpill.java
@@ -28,6 +28,7 @@ import org.apache.drill.categories.OperatorTest;
 import org.apache.drill.categories.SlowTest;
 import org.apache.drill.common.exceptions.UserRemoteException;
 import org.apache.drill.exec.ExecConstants;
+import org.apache.drill.exec.physical.config.HashAggregate;
 import org.apache.drill.exec.physical.impl.aggregate.HashAggTemplate;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.UserBitShared;
@@ -107,7 +108,7 @@ public class TestHashAggrSpill extends DrillTest {
     }
 
     ProfileParser profile = client.parseProfile(summary.queryIdString());
-    List<ProfileParser.OperatorProfile> ops = profile.getOpsOfType(UserBitShared.CoreOperatorType.HASH_AGGREGATE_VALUE);
+    List<ProfileParser.OperatorProfile> ops = profile.getOpsOfType(HashAggregate.OPERATOR_TYPE);
 
     assertFalse(ops.isEmpty());
     // check for the first op only

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/ScanTestUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/ScanTestUtils.java
@@ -102,8 +102,8 @@ public class ScanTestUtils {
       Scan scanConfig = new AbstractSubScan("bob") {
 
         @Override
-        public int getOperatorType() {
-          return 0;
+        public String getOperatorType() {
+          return "";
         }
       };
       OperatorContext opContext = opFixture.newOperatorContext(scanConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanBatchWriters.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/TestScanBatchWriters.java
@@ -52,8 +52,8 @@ public class TestScanBatchWriters extends SubOperatorTest {
     Scan scanConfig = new AbstractSubScan("bob") {
 
       @Override
-      public int getOperatorType() {
-        return 0;
+      public String getOperatorType() {
+        return "";
       }
     };
     OperatorContext opContext = fixture.newOperatorContext(scanConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/ScanFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/ScanFixture.java
@@ -81,8 +81,8 @@ public class ScanFixture {
       Scan scanConfig = new AbstractSubScan("bob") {
 
         @Override
-        public int getOperatorType() {
-          return 0;
+        public String getOperatorType() {
+          return "";
         }
       };
       OperatorContext opContext = opFixture.newOperatorContext(scanConfig);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/lifecycle/BaseTestScanLifecycle.java
@@ -52,7 +52,7 @@ public class BaseTestScanLifecycle extends SubOperatorTest {
     }
 
     @Override
-    public int getOperatorType() { return 0; }
+    public String getOperatorType() { return "DUMMY_SUB_SCAN"; }
   }
 
   protected static abstract class SingleReaderFactory implements ReaderFactory<SchemaNegotiator> {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestExternalSortExec.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestExternalSortExec.java
@@ -32,7 +32,6 @@ import org.apache.drill.common.logical.data.Order.Ordering;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.base.AbstractBase;
 import org.apache.drill.exec.physical.config.ExternalSort;
-import org.apache.drill.exec.proto.UserBitShared.CoreOperatorType;
 import org.apache.drill.exec.record.BatchSchema.SelectionVectorMode;
 import org.apache.drill.test.DrillTest;
 import org.junit.Test;
@@ -174,7 +173,7 @@ public class TestExternalSortExec extends DrillTest {
     assertSame(ordering, popConfig.getOrderings().get(0));
     assertFalse(popConfig.getReverse());
     assertEquals(SelectionVectorMode.FOUR_BYTE, popConfig.getSVMode());
-    assertEquals(CoreOperatorType.EXTERNAL_SORT_VALUE, popConfig.getOperatorType());
+    assertEquals(ExternalSort.OPERATOR_TYPE, popConfig.getOperatorType());
     assertEquals(ExternalSort.DEFAULT_SORT_ALLOCATION, popConfig.getInitialAllocation());
     assertEquals(AbstractBase.MAX_ALLOCATION, popConfig.getMaxAllocation());
     assertTrue(popConfig.isExecutable());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestExternalSortInternals.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/xsort/TestExternalSortInternals.java
@@ -25,6 +25,7 @@ import org.apache.drill.categories.OperatorTest;
 import org.apache.drill.exec.ExecConstants;
 import org.apache.drill.exec.ops.FragmentContext;
 import org.apache.drill.exec.ops.OperatorStats;
+import org.apache.drill.exec.physical.config.ExternalSort;
 import org.apache.drill.exec.physical.impl.xsort.SortMemoryManager.MergeAction;
 import org.apache.drill.exec.physical.impl.xsort.SortMemoryManager.MergeTask;
 import org.apache.drill.test.BaseDirTestWatcher;
@@ -655,7 +656,7 @@ public class TestExternalSortInternals extends SubOperatorTest {
 
   @Test
   public void testMetrics() {
-    OperatorStats stats = new OperatorStats(100, 101, 0, fixture.allocator());
+    OperatorStats stats = new OperatorStats(100, ExternalSort.OPERATOR_TYPE, 0, fixture.allocator());
     SortMetrics metrics = new SortMetrics(stats);
 
     // Input stats

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/record/TestRecordIterator.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.exec.store.mock.MockSubScanPOP;
 import org.apache.drill.shaded.guava.com.google.common.collect.Lists;
 
 import org.apache.drill.categories.VectorTest;
@@ -41,7 +42,6 @@ import org.apache.drill.exec.planner.PhysicalPlanReaderTestFactory;
 import org.apache.drill.exec.pop.PopUnitTestBase;
 import org.apache.drill.exec.planner.PhysicalPlanReader;
 import org.apache.drill.exec.proto.BitControl;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.rpc.UserClientConnection;
 import org.apache.drill.exec.server.DrillbitContext;
 import org.apache.drill.exec.vector.ValueVector;
@@ -76,7 +76,7 @@ public class TestRecordIterator extends PopUnitTestBase {
 
     RecordBatch singleBatch = exec.getIncoming();
     PhysicalOperator dummyPop = operatorList.iterator().next();
-    OpProfileDef def = new OpProfileDef(dummyPop.getOperatorId(), UserBitShared.CoreOperatorType.MOCK_SUB_SCAN_VALUE,
+    OpProfileDef def = new OpProfileDef(dummyPop.getOperatorId(), MockSubScanPOP.OPERATOR_TYPE,
       OperatorUtilities.getChildCount(dummyPop));
     OperatorStats stats = exec.getContext().getStats().newOperatorStats(def, exec.getContext().getAllocator());
     RecordIterator iter = new RecordIterator(singleBatch, null, exec.getContext().newOperatorContext(dummyPop, stats), 0, false, null);
@@ -132,7 +132,7 @@ public class TestRecordIterator extends PopUnitTestBase {
 
     RecordBatch singleBatch = exec.getIncoming();
     PhysicalOperator dummyPop = operatorList.iterator().next();
-    OpProfileDef def = new OpProfileDef(dummyPop.getOperatorId(), UserBitShared.CoreOperatorType.MOCK_SUB_SCAN_VALUE,
+    OpProfileDef def = new OpProfileDef(dummyPop.getOperatorId(), MockSubScanPOP.OPERATOR_TYPE,
         OperatorUtilities.getChildCount(dummyPop));
     OperatorStats stats = exec.getContext().getStats().newOperatorStats(def, exec.getContext().getAllocator());
     RecordIterator iter = new RecordIterator(singleBatch, null, exec.getContext().newOperatorContext(dummyPop, stats), 0, null);

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestDrillFileSystem.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/dfs/TestDrillFileSystem.java
@@ -68,7 +68,7 @@ public class TestDrillFileSystem extends BaseTest {
     InputStream is = null;
     Configuration conf = new Configuration();
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
-    OpProfileDef profileDef = new OpProfileDef(0 /*operatorId*/, 0 /*operatorType*/, 0 /*inputCount*/);
+    OpProfileDef profileDef = new OpProfileDef(0 /*operatorId*/, "" /*operatorType*/, 0 /*inputCount*/);
     OperatorStats stats = new OperatorStats(profileDef, null /*allocator*/);
 
     // start wait time method in OperatorStats expects the OperatorStats state to be in "processing"

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/store/parquet/TestParquetFilterPushDown.java
@@ -26,7 +26,6 @@ import org.apache.drill.exec.expr.stat.RowsMatch;
 import org.apache.drill.exec.ops.FragmentContextImpl;
 import org.apache.drill.exec.planner.physical.PlannerSettings;
 import org.apache.drill.exec.proto.BitControl;
-import org.apache.drill.exec.proto.UserBitShared;
 import org.apache.drill.exec.store.parquet.columnreaders.ParquetRecordReader;
 import org.apache.drill.exec.store.parquet.metadata.Metadata;
 import org.apache.drill.exec.store.parquet.metadata.MetadataBase;
@@ -59,7 +58,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class TestParquetFilterPushDown extends PlanTestBase {
   private static final String CTAS_TABLE = "order_ctas";
@@ -781,9 +780,9 @@ public class TestParquetFilterPushDown extends PlanTestBase {
     }
 
     ProfileParser profile = client.parseProfile(summary.queryIdString());
-    List<ProfileParser.OperatorProfile> ops = profile.getOpsOfType(UserBitShared.CoreOperatorType.PARQUET_ROW_GROUP_SCAN_VALUE);
+    List<ProfileParser.OperatorProfile> ops = profile.getOpsOfType(ParquetRowGroupScan.OPERATOR_TYPE);
 
-    assertTrue(!ops.isEmpty());
+    assertFalse(ops.isEmpty());
     // check for the first op only
     ProfileParser.OperatorProfile parquestScan0 = ops.get(0);
     long resultNumRowgroups = parquestScan0.getMetric(ParquetRecordReader.Metric.NUM_ROWGROUPS.ordinal());

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorFixture.java
@@ -452,7 +452,7 @@ public class OperatorFixture extends BaseFixture implements AutoCloseable {
                                BufferAllocator allocator,
                                PhysicalOperator config) {
       super(fragContext, allocator, config);
-      this.operatorStats = new OperatorStats(new OpProfileDef(0, 0, 100), allocator);
+      this.operatorStats = new OperatorStats(new OpProfileDef(0, "", 100), allocator);
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/test/OperatorTestBuilderTest.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/OperatorTestBuilderTest.java
@@ -145,8 +145,8 @@ public class OperatorTestBuilderTest extends PhysicalOpUnitTestBase {
     }
 
     @Override
-    public int getOperatorType() {
-      return 0;
+    public String getOperatorType() {
+      return "";
     }
 
     @Override

--- a/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/test/PhysicalOpUnitTestBase.java
@@ -330,8 +330,8 @@ public class PhysicalOpUnitTestBase extends ExecTest {
     }
 
     @Override
-    public int getOperatorType() {
-      return 0;
+    public String getOperatorType() {
+      return "";
     }
 
     @Override

--- a/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/SchemaUserBitShared.java
@@ -2377,6 +2377,8 @@ public final class SchemaUserBitShared
 
                 if(message.hasWaitNanos())
                     output.writeInt64(9, message.getWaitNanos(), false);
+                if(message.hasOperatorTypeName())
+                    output.writeString(10, message.getOperatorTypeName(), false);
             }
             public boolean isInitialized(org.apache.drill.exec.proto.UserBitShared.OperatorProfile message)
             {
@@ -2442,6 +2444,9 @@ public final class SchemaUserBitShared
                         case 9:
                             builder.setWaitNanos(input.readInt64());
                             break;
+                        case 10:
+                            builder.setOperatorTypeName(input.readString());
+                            break;
                         default:
                             input.handleUnknownField(number, this);
                     }
@@ -2490,6 +2495,7 @@ public final class SchemaUserBitShared
                 case 7: return "peakLocalMemoryAllocated";
                 case 8: return "metric";
                 case 9: return "waitNanos";
+                case 10: return "operatorTypeName";
                 default: return null;
             }
         }
@@ -2509,6 +2515,7 @@ public final class SchemaUserBitShared
             fieldMap.put("peakLocalMemoryAllocated", 7);
             fieldMap.put("metric", 8);
             fieldMap.put("waitNanos", 9);
+            fieldMap.put("operatorTypeName", 10);
         }
     }
 

--- a/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
+++ b/protocol/src/main/java/org/apache/drill/exec/proto/UserBitShared.java
@@ -409,732 +409,6 @@ public final class UserBitShared {
   }
 
   /**
-   * Protobuf enum {@code exec.shared.CoreOperatorType}
-   */
-  public enum CoreOperatorType
-      implements com.google.protobuf.ProtocolMessageEnum {
-    /**
-     * <code>SINGLE_SENDER = 0;</code>
-     */
-    SINGLE_SENDER(0),
-    /**
-     * <code>BROADCAST_SENDER = 1;</code>
-     */
-    BROADCAST_SENDER(1),
-    /**
-     * <code>FILTER = 2;</code>
-     */
-    FILTER(2),
-    /**
-     * <code>HASH_AGGREGATE = 3;</code>
-     */
-    HASH_AGGREGATE(3),
-    /**
-     * <code>HASH_JOIN = 4;</code>
-     */
-    HASH_JOIN(4),
-    /**
-     * <code>MERGE_JOIN = 5;</code>
-     */
-    MERGE_JOIN(5),
-    /**
-     * <code>HASH_PARTITION_SENDER = 6;</code>
-     */
-    HASH_PARTITION_SENDER(6),
-    /**
-     * <code>LIMIT = 7;</code>
-     */
-    LIMIT(7),
-    /**
-     * <code>MERGING_RECEIVER = 8;</code>
-     */
-    MERGING_RECEIVER(8),
-    /**
-     * <code>ORDERED_PARTITION_SENDER = 9;</code>
-     */
-    ORDERED_PARTITION_SENDER(9),
-    /**
-     * <code>PROJECT = 10;</code>
-     */
-    PROJECT(10),
-    /**
-     * <code>UNORDERED_RECEIVER = 11;</code>
-     */
-    UNORDERED_RECEIVER(11),
-    /**
-     * <code>RANGE_PARTITION_SENDER = 12;</code>
-     */
-    RANGE_PARTITION_SENDER(12),
-    /**
-     * <code>SCREEN = 13;</code>
-     */
-    SCREEN(13),
-    /**
-     * <code>SELECTION_VECTOR_REMOVER = 14;</code>
-     */
-    SELECTION_VECTOR_REMOVER(14),
-    /**
-     * <code>STREAMING_AGGREGATE = 15;</code>
-     */
-    STREAMING_AGGREGATE(15),
-    /**
-     * <code>TOP_N_SORT = 16;</code>
-     */
-    TOP_N_SORT(16),
-    /**
-     * <code>EXTERNAL_SORT = 17;</code>
-     */
-    EXTERNAL_SORT(17),
-    /**
-     * <code>TRACE = 18;</code>
-     */
-    TRACE(18),
-    /**
-     * <code>UNION = 19;</code>
-     */
-    UNION(19),
-    /**
-     * <code>OLD_SORT = 20;</code>
-     */
-    OLD_SORT(20),
-    /**
-     * <code>PARQUET_ROW_GROUP_SCAN = 21;</code>
-     */
-    PARQUET_ROW_GROUP_SCAN(21),
-    /**
-     * <code>HIVE_SUB_SCAN = 22;</code>
-     */
-    HIVE_SUB_SCAN(22),
-    /**
-     * <code>SYSTEM_TABLE_SCAN = 23;</code>
-     */
-    SYSTEM_TABLE_SCAN(23),
-    /**
-     * <code>MOCK_SUB_SCAN = 24;</code>
-     */
-    MOCK_SUB_SCAN(24),
-    /**
-     * <code>PARQUET_WRITER = 25;</code>
-     */
-    PARQUET_WRITER(25),
-    /**
-     * <code>DIRECT_SUB_SCAN = 26;</code>
-     */
-    DIRECT_SUB_SCAN(26),
-    /**
-     * <code>TEXT_WRITER = 27;</code>
-     */
-    TEXT_WRITER(27),
-    /**
-     * <code>TEXT_SUB_SCAN = 28;</code>
-     */
-    TEXT_SUB_SCAN(28),
-    /**
-     * <code>JSON_SUB_SCAN = 29;</code>
-     */
-    JSON_SUB_SCAN(29),
-    /**
-     * <code>INFO_SCHEMA_SUB_SCAN = 30;</code>
-     */
-    INFO_SCHEMA_SUB_SCAN(30),
-    /**
-     * <code>COMPLEX_TO_JSON = 31;</code>
-     */
-    COMPLEX_TO_JSON(31),
-    /**
-     * <code>PRODUCER_CONSUMER = 32;</code>
-     */
-    PRODUCER_CONSUMER(32),
-    /**
-     * <code>HBASE_SUB_SCAN = 33;</code>
-     */
-    HBASE_SUB_SCAN(33),
-    /**
-     * <code>WINDOW = 34;</code>
-     */
-    WINDOW(34),
-    /**
-     * <code>NESTED_LOOP_JOIN = 35;</code>
-     */
-    NESTED_LOOP_JOIN(35),
-    /**
-     * <code>AVRO_SUB_SCAN = 36;</code>
-     */
-    AVRO_SUB_SCAN(36),
-    /**
-     * <code>PCAP_SUB_SCAN = 37;</code>
-     */
-    PCAP_SUB_SCAN(37),
-    /**
-     * <code>KAFKA_SUB_SCAN = 38;</code>
-     */
-    KAFKA_SUB_SCAN(38),
-    /**
-     * <code>KUDU_SUB_SCAN = 39;</code>
-     */
-    KUDU_SUB_SCAN(39),
-    /**
-     * <code>FLATTEN = 40;</code>
-     */
-    FLATTEN(40),
-    /**
-     * <code>LATERAL_JOIN = 41;</code>
-     */
-    LATERAL_JOIN(41),
-    /**
-     * <code>UNNEST = 42;</code>
-     */
-    UNNEST(42),
-    /**
-     * <code>HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;</code>
-     */
-    HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN(43),
-    /**
-     * <code>JDBC_SCAN = 44;</code>
-     */
-    JDBC_SCAN(44),
-    /**
-     * <code>REGEX_SUB_SCAN = 45;</code>
-     */
-    REGEX_SUB_SCAN(45),
-    /**
-     * <code>MAPRDB_SUB_SCAN = 46;</code>
-     */
-    MAPRDB_SUB_SCAN(46),
-    /**
-     * <code>MONGO_SUB_SCAN = 47;</code>
-     */
-    MONGO_SUB_SCAN(47),
-    /**
-     * <code>KUDU_WRITER = 48;</code>
-     */
-    KUDU_WRITER(48),
-    /**
-     * <code>OPEN_TSDB_SUB_SCAN = 49;</code>
-     */
-    OPEN_TSDB_SUB_SCAN(49),
-    /**
-     * <code>JSON_WRITER = 50;</code>
-     */
-    JSON_WRITER(50),
-    /**
-     * <code>HTPPD_LOG_SUB_SCAN = 51;</code>
-     */
-    HTPPD_LOG_SUB_SCAN(51),
-    /**
-     * <code>IMAGE_SUB_SCAN = 52;</code>
-     */
-    IMAGE_SUB_SCAN(52),
-    /**
-     * <code>SEQUENCE_SUB_SCAN = 53;</code>
-     */
-    SEQUENCE_SUB_SCAN(53),
-    /**
-     * <code>PARTITION_LIMIT = 54;</code>
-     */
-    PARTITION_LIMIT(54),
-    /**
-     * <code>PCAPNG_SUB_SCAN = 55;</code>
-     */
-    PCAPNG_SUB_SCAN(55),
-    /**
-     * <code>RUNTIME_FILTER = 56;</code>
-     */
-    RUNTIME_FILTER(56),
-    /**
-     * <code>ROWKEY_JOIN = 57;</code>
-     */
-    ROWKEY_JOIN(57),
-    /**
-     * <code>SYSLOG_SUB_SCAN = 58;</code>
-     */
-    SYSLOG_SUB_SCAN(58),
-    /**
-     * <code>STATISTICS_AGGREGATE = 59;</code>
-     */
-    STATISTICS_AGGREGATE(59),
-    /**
-     * <code>UNPIVOT_MAPS = 60;</code>
-     */
-    UNPIVOT_MAPS(60),
-    /**
-     * <code>STATISTICS_MERGE = 61;</code>
-     */
-    STATISTICS_MERGE(61),
-    /**
-     * <code>LTSV_SUB_SCAN = 62;</code>
-     */
-    LTSV_SUB_SCAN(62),
-    /**
-     * <code>HDF5_SUB_SCAN = 63;</code>
-     */
-    HDF5_SUB_SCAN(63),
-    /**
-     * <code>EXCEL_SUB_SCAN = 64;</code>
-     */
-    EXCEL_SUB_SCAN(64),
-    /**
-     * <code>SHP_SUB_SCAN = 65;</code>
-     */
-    SHP_SUB_SCAN(65),
-    /**
-     * <code>METADATA_HANDLER = 66;</code>
-     */
-    METADATA_HANDLER(66),
-    /**
-     * <code>METADATA_CONTROLLER = 67;</code>
-     */
-    METADATA_CONTROLLER(67),
-    /**
-     * <code>DRUID_SUB_SCAN = 68;</code>
-     */
-    DRUID_SUB_SCAN(68),
-    /**
-     * <code>SPSS_SUB_SCAN = 69;</code>
-     */
-    SPSS_SUB_SCAN(69),
-    /**
-     * <code>HTTP_SUB_SCAN = 70;</code>
-     */
-    HTTP_SUB_SCAN(70),
-    /**
-     * <code>XML_SUB_SCAN = 71;</code>
-     */
-    XML_SUB_SCAN(71),
-    ;
-
-    /**
-     * <code>SINGLE_SENDER = 0;</code>
-     */
-    public static final int SINGLE_SENDER_VALUE = 0;
-    /**
-     * <code>BROADCAST_SENDER = 1;</code>
-     */
-    public static final int BROADCAST_SENDER_VALUE = 1;
-    /**
-     * <code>FILTER = 2;</code>
-     */
-    public static final int FILTER_VALUE = 2;
-    /**
-     * <code>HASH_AGGREGATE = 3;</code>
-     */
-    public static final int HASH_AGGREGATE_VALUE = 3;
-    /**
-     * <code>HASH_JOIN = 4;</code>
-     */
-    public static final int HASH_JOIN_VALUE = 4;
-    /**
-     * <code>MERGE_JOIN = 5;</code>
-     */
-    public static final int MERGE_JOIN_VALUE = 5;
-    /**
-     * <code>HASH_PARTITION_SENDER = 6;</code>
-     */
-    public static final int HASH_PARTITION_SENDER_VALUE = 6;
-    /**
-     * <code>LIMIT = 7;</code>
-     */
-    public static final int LIMIT_VALUE = 7;
-    /**
-     * <code>MERGING_RECEIVER = 8;</code>
-     */
-    public static final int MERGING_RECEIVER_VALUE = 8;
-    /**
-     * <code>ORDERED_PARTITION_SENDER = 9;</code>
-     */
-    public static final int ORDERED_PARTITION_SENDER_VALUE = 9;
-    /**
-     * <code>PROJECT = 10;</code>
-     */
-    public static final int PROJECT_VALUE = 10;
-    /**
-     * <code>UNORDERED_RECEIVER = 11;</code>
-     */
-    public static final int UNORDERED_RECEIVER_VALUE = 11;
-    /**
-     * <code>RANGE_PARTITION_SENDER = 12;</code>
-     */
-    public static final int RANGE_PARTITION_SENDER_VALUE = 12;
-    /**
-     * <code>SCREEN = 13;</code>
-     */
-    public static final int SCREEN_VALUE = 13;
-    /**
-     * <code>SELECTION_VECTOR_REMOVER = 14;</code>
-     */
-    public static final int SELECTION_VECTOR_REMOVER_VALUE = 14;
-    /**
-     * <code>STREAMING_AGGREGATE = 15;</code>
-     */
-    public static final int STREAMING_AGGREGATE_VALUE = 15;
-    /**
-     * <code>TOP_N_SORT = 16;</code>
-     */
-    public static final int TOP_N_SORT_VALUE = 16;
-    /**
-     * <code>EXTERNAL_SORT = 17;</code>
-     */
-    public static final int EXTERNAL_SORT_VALUE = 17;
-    /**
-     * <code>TRACE = 18;</code>
-     */
-    public static final int TRACE_VALUE = 18;
-    /**
-     * <code>UNION = 19;</code>
-     */
-    public static final int UNION_VALUE = 19;
-    /**
-     * <code>OLD_SORT = 20;</code>
-     */
-    public static final int OLD_SORT_VALUE = 20;
-    /**
-     * <code>PARQUET_ROW_GROUP_SCAN = 21;</code>
-     */
-    public static final int PARQUET_ROW_GROUP_SCAN_VALUE = 21;
-    /**
-     * <code>HIVE_SUB_SCAN = 22;</code>
-     */
-    public static final int HIVE_SUB_SCAN_VALUE = 22;
-    /**
-     * <code>SYSTEM_TABLE_SCAN = 23;</code>
-     */
-    public static final int SYSTEM_TABLE_SCAN_VALUE = 23;
-    /**
-     * <code>MOCK_SUB_SCAN = 24;</code>
-     */
-    public static final int MOCK_SUB_SCAN_VALUE = 24;
-    /**
-     * <code>PARQUET_WRITER = 25;</code>
-     */
-    public static final int PARQUET_WRITER_VALUE = 25;
-    /**
-     * <code>DIRECT_SUB_SCAN = 26;</code>
-     */
-    public static final int DIRECT_SUB_SCAN_VALUE = 26;
-    /**
-     * <code>TEXT_WRITER = 27;</code>
-     */
-    public static final int TEXT_WRITER_VALUE = 27;
-    /**
-     * <code>TEXT_SUB_SCAN = 28;</code>
-     */
-    public static final int TEXT_SUB_SCAN_VALUE = 28;
-    /**
-     * <code>JSON_SUB_SCAN = 29;</code>
-     */
-    public static final int JSON_SUB_SCAN_VALUE = 29;
-    /**
-     * <code>INFO_SCHEMA_SUB_SCAN = 30;</code>
-     */
-    public static final int INFO_SCHEMA_SUB_SCAN_VALUE = 30;
-    /**
-     * <code>COMPLEX_TO_JSON = 31;</code>
-     */
-    public static final int COMPLEX_TO_JSON_VALUE = 31;
-    /**
-     * <code>PRODUCER_CONSUMER = 32;</code>
-     */
-    public static final int PRODUCER_CONSUMER_VALUE = 32;
-    /**
-     * <code>HBASE_SUB_SCAN = 33;</code>
-     */
-    public static final int HBASE_SUB_SCAN_VALUE = 33;
-    /**
-     * <code>WINDOW = 34;</code>
-     */
-    public static final int WINDOW_VALUE = 34;
-    /**
-     * <code>NESTED_LOOP_JOIN = 35;</code>
-     */
-    public static final int NESTED_LOOP_JOIN_VALUE = 35;
-    /**
-     * <code>AVRO_SUB_SCAN = 36;</code>
-     */
-    public static final int AVRO_SUB_SCAN_VALUE = 36;
-    /**
-     * <code>PCAP_SUB_SCAN = 37;</code>
-     */
-    public static final int PCAP_SUB_SCAN_VALUE = 37;
-    /**
-     * <code>KAFKA_SUB_SCAN = 38;</code>
-     */
-    public static final int KAFKA_SUB_SCAN_VALUE = 38;
-    /**
-     * <code>KUDU_SUB_SCAN = 39;</code>
-     */
-    public static final int KUDU_SUB_SCAN_VALUE = 39;
-    /**
-     * <code>FLATTEN = 40;</code>
-     */
-    public static final int FLATTEN_VALUE = 40;
-    /**
-     * <code>LATERAL_JOIN = 41;</code>
-     */
-    public static final int LATERAL_JOIN_VALUE = 41;
-    /**
-     * <code>UNNEST = 42;</code>
-     */
-    public static final int UNNEST_VALUE = 42;
-    /**
-     * <code>HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;</code>
-     */
-    public static final int HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN_VALUE = 43;
-    /**
-     * <code>JDBC_SCAN = 44;</code>
-     */
-    public static final int JDBC_SCAN_VALUE = 44;
-    /**
-     * <code>REGEX_SUB_SCAN = 45;</code>
-     */
-    public static final int REGEX_SUB_SCAN_VALUE = 45;
-    /**
-     * <code>MAPRDB_SUB_SCAN = 46;</code>
-     */
-    public static final int MAPRDB_SUB_SCAN_VALUE = 46;
-    /**
-     * <code>MONGO_SUB_SCAN = 47;</code>
-     */
-    public static final int MONGO_SUB_SCAN_VALUE = 47;
-    /**
-     * <code>KUDU_WRITER = 48;</code>
-     */
-    public static final int KUDU_WRITER_VALUE = 48;
-    /**
-     * <code>OPEN_TSDB_SUB_SCAN = 49;</code>
-     */
-    public static final int OPEN_TSDB_SUB_SCAN_VALUE = 49;
-    /**
-     * <code>JSON_WRITER = 50;</code>
-     */
-    public static final int JSON_WRITER_VALUE = 50;
-    /**
-     * <code>HTPPD_LOG_SUB_SCAN = 51;</code>
-     */
-    public static final int HTPPD_LOG_SUB_SCAN_VALUE = 51;
-    /**
-     * <code>IMAGE_SUB_SCAN = 52;</code>
-     */
-    public static final int IMAGE_SUB_SCAN_VALUE = 52;
-    /**
-     * <code>SEQUENCE_SUB_SCAN = 53;</code>
-     */
-    public static final int SEQUENCE_SUB_SCAN_VALUE = 53;
-    /**
-     * <code>PARTITION_LIMIT = 54;</code>
-     */
-    public static final int PARTITION_LIMIT_VALUE = 54;
-    /**
-     * <code>PCAPNG_SUB_SCAN = 55;</code>
-     */
-    public static final int PCAPNG_SUB_SCAN_VALUE = 55;
-    /**
-     * <code>RUNTIME_FILTER = 56;</code>
-     */
-    public static final int RUNTIME_FILTER_VALUE = 56;
-    /**
-     * <code>ROWKEY_JOIN = 57;</code>
-     */
-    public static final int ROWKEY_JOIN_VALUE = 57;
-    /**
-     * <code>SYSLOG_SUB_SCAN = 58;</code>
-     */
-    public static final int SYSLOG_SUB_SCAN_VALUE = 58;
-    /**
-     * <code>STATISTICS_AGGREGATE = 59;</code>
-     */
-    public static final int STATISTICS_AGGREGATE_VALUE = 59;
-    /**
-     * <code>UNPIVOT_MAPS = 60;</code>
-     */
-    public static final int UNPIVOT_MAPS_VALUE = 60;
-    /**
-     * <code>STATISTICS_MERGE = 61;</code>
-     */
-    public static final int STATISTICS_MERGE_VALUE = 61;
-    /**
-     * <code>LTSV_SUB_SCAN = 62;</code>
-     */
-    public static final int LTSV_SUB_SCAN_VALUE = 62;
-    /**
-     * <code>HDF5_SUB_SCAN = 63;</code>
-     */
-    public static final int HDF5_SUB_SCAN_VALUE = 63;
-    /**
-     * <code>EXCEL_SUB_SCAN = 64;</code>
-     */
-    public static final int EXCEL_SUB_SCAN_VALUE = 64;
-    /**
-     * <code>SHP_SUB_SCAN = 65;</code>
-     */
-    public static final int SHP_SUB_SCAN_VALUE = 65;
-    /**
-     * <code>METADATA_HANDLER = 66;</code>
-     */
-    public static final int METADATA_HANDLER_VALUE = 66;
-    /**
-     * <code>METADATA_CONTROLLER = 67;</code>
-     */
-    public static final int METADATA_CONTROLLER_VALUE = 67;
-    /**
-     * <code>DRUID_SUB_SCAN = 68;</code>
-     */
-    public static final int DRUID_SUB_SCAN_VALUE = 68;
-    /**
-     * <code>SPSS_SUB_SCAN = 69;</code>
-     */
-    public static final int SPSS_SUB_SCAN_VALUE = 69;
-    /**
-     * <code>HTTP_SUB_SCAN = 70;</code>
-     */
-    public static final int HTTP_SUB_SCAN_VALUE = 70;
-    /**
-     * <code>XML_SUB_SCAN = 71;</code>
-     */
-    public static final int XML_SUB_SCAN_VALUE = 71;
-
-
-    public final int getNumber() {
-      return value;
-    }
-
-    /**
-     * @param value The numeric wire value of the corresponding enum entry.
-     * @return The enum associated with the given numeric wire value.
-     * @deprecated Use {@link #forNumber(int)} instead.
-     */
-    @java.lang.Deprecated
-    public static CoreOperatorType valueOf(int value) {
-      return forNumber(value);
-    }
-
-    /**
-     * @param value The numeric wire value of the corresponding enum entry.
-     * @return The enum associated with the given numeric wire value.
-     */
-    public static CoreOperatorType forNumber(int value) {
-      switch (value) {
-        case 0: return SINGLE_SENDER;
-        case 1: return BROADCAST_SENDER;
-        case 2: return FILTER;
-        case 3: return HASH_AGGREGATE;
-        case 4: return HASH_JOIN;
-        case 5: return MERGE_JOIN;
-        case 6: return HASH_PARTITION_SENDER;
-        case 7: return LIMIT;
-        case 8: return MERGING_RECEIVER;
-        case 9: return ORDERED_PARTITION_SENDER;
-        case 10: return PROJECT;
-        case 11: return UNORDERED_RECEIVER;
-        case 12: return RANGE_PARTITION_SENDER;
-        case 13: return SCREEN;
-        case 14: return SELECTION_VECTOR_REMOVER;
-        case 15: return STREAMING_AGGREGATE;
-        case 16: return TOP_N_SORT;
-        case 17: return EXTERNAL_SORT;
-        case 18: return TRACE;
-        case 19: return UNION;
-        case 20: return OLD_SORT;
-        case 21: return PARQUET_ROW_GROUP_SCAN;
-        case 22: return HIVE_SUB_SCAN;
-        case 23: return SYSTEM_TABLE_SCAN;
-        case 24: return MOCK_SUB_SCAN;
-        case 25: return PARQUET_WRITER;
-        case 26: return DIRECT_SUB_SCAN;
-        case 27: return TEXT_WRITER;
-        case 28: return TEXT_SUB_SCAN;
-        case 29: return JSON_SUB_SCAN;
-        case 30: return INFO_SCHEMA_SUB_SCAN;
-        case 31: return COMPLEX_TO_JSON;
-        case 32: return PRODUCER_CONSUMER;
-        case 33: return HBASE_SUB_SCAN;
-        case 34: return WINDOW;
-        case 35: return NESTED_LOOP_JOIN;
-        case 36: return AVRO_SUB_SCAN;
-        case 37: return PCAP_SUB_SCAN;
-        case 38: return KAFKA_SUB_SCAN;
-        case 39: return KUDU_SUB_SCAN;
-        case 40: return FLATTEN;
-        case 41: return LATERAL_JOIN;
-        case 42: return UNNEST;
-        case 43: return HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN;
-        case 44: return JDBC_SCAN;
-        case 45: return REGEX_SUB_SCAN;
-        case 46: return MAPRDB_SUB_SCAN;
-        case 47: return MONGO_SUB_SCAN;
-        case 48: return KUDU_WRITER;
-        case 49: return OPEN_TSDB_SUB_SCAN;
-        case 50: return JSON_WRITER;
-        case 51: return HTPPD_LOG_SUB_SCAN;
-        case 52: return IMAGE_SUB_SCAN;
-        case 53: return SEQUENCE_SUB_SCAN;
-        case 54: return PARTITION_LIMIT;
-        case 55: return PCAPNG_SUB_SCAN;
-        case 56: return RUNTIME_FILTER;
-        case 57: return ROWKEY_JOIN;
-        case 58: return SYSLOG_SUB_SCAN;
-        case 59: return STATISTICS_AGGREGATE;
-        case 60: return UNPIVOT_MAPS;
-        case 61: return STATISTICS_MERGE;
-        case 62: return LTSV_SUB_SCAN;
-        case 63: return HDF5_SUB_SCAN;
-        case 64: return EXCEL_SUB_SCAN;
-        case 65: return SHP_SUB_SCAN;
-        case 66: return METADATA_HANDLER;
-        case 67: return METADATA_CONTROLLER;
-        case 68: return DRUID_SUB_SCAN;
-        case 69: return SPSS_SUB_SCAN;
-        case 70: return HTTP_SUB_SCAN;
-        case 71: return XML_SUB_SCAN;
-        default: return null;
-      }
-    }
-
-    public static com.google.protobuf.Internal.EnumLiteMap<CoreOperatorType>
-        internalGetValueMap() {
-      return internalValueMap;
-    }
-    private static final com.google.protobuf.Internal.EnumLiteMap<
-        CoreOperatorType> internalValueMap =
-          new com.google.protobuf.Internal.EnumLiteMap<CoreOperatorType>() {
-            public CoreOperatorType findValueByNumber(int number) {
-              return CoreOperatorType.forNumber(number);
-            }
-          };
-
-    public final com.google.protobuf.Descriptors.EnumValueDescriptor
-        getValueDescriptor() {
-      return getDescriptor().getValues().get(ordinal());
-    }
-    public final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptorForType() {
-      return getDescriptor();
-    }
-    public static final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptor() {
-      return org.apache.drill.exec.proto.UserBitShared.getDescriptor().getEnumTypes().get(3);
-    }
-
-    private static final CoreOperatorType[] VALUES = values();
-
-    public static CoreOperatorType valueOf(
-        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-      if (desc.getType() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "EnumValueDescriptor is not for this type.");
-      }
-      return VALUES[desc.getIndex()];
-    }
-
-    private final int value;
-
-    private CoreOperatorType(int value) {
-      this.value = value;
-    }
-
-    // @@protoc_insertion_point(enum_scope:exec.shared.CoreOperatorType)
-  }
-
-  /**
    * Protobuf enum {@code exec.shared.SaslStatus}
    */
   public enum SaslStatus
@@ -1234,7 +508,7 @@ public final class UserBitShared {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.apache.drill.exec.proto.UserBitShared.getDescriptor().getEnumTypes().get(4);
+      return org.apache.drill.exec.proto.UserBitShared.getDescriptor().getEnumTypes().get(3);
     }
 
     private static final SaslStatus[] VALUES = values();
@@ -23278,15 +22552,15 @@ public final class UserBitShared {
     int getOperatorId();
 
     /**
-     * <code>optional int32 operator_type = 4;</code>
+     * <code>optional int32 operator_type = 4 [deprecated = true];</code>
      * @return Whether the operatorType field is set.
      */
-    boolean hasOperatorType();
+    @java.lang.Deprecated boolean hasOperatorType();
     /**
-     * <code>optional int32 operator_type = 4;</code>
+     * <code>optional int32 operator_type = 4 [deprecated = true];</code>
      * @return The operatorType.
      */
-    int getOperatorType();
+    @java.lang.Deprecated int getOperatorType();
 
     /**
      * <code>optional int64 setup_nanos = 5;</code>
@@ -23355,6 +22629,23 @@ public final class UserBitShared {
      * @return The waitNanos.
      */
     long getWaitNanos();
+
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return Whether the operatorTypeName field is set.
+     */
+    boolean hasOperatorTypeName();
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return The operatorTypeName.
+     */
+    java.lang.String getOperatorTypeName();
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return The bytes for operatorTypeName.
+     */
+    com.google.protobuf.ByteString
+        getOperatorTypeNameBytes();
   }
   /**
    * Protobuf type {@code exec.shared.OperatorProfile}
@@ -23371,6 +22662,7 @@ public final class UserBitShared {
     private OperatorProfile() {
       inputProfile_ = java.util.Collections.emptyList();
       metric_ = java.util.Collections.emptyList();
+      operatorTypeName_ = "";
     }
 
     @java.lang.Override
@@ -23450,6 +22742,12 @@ public final class UserBitShared {
             case 72: {
               bitField0_ |= 0x00000020;
               waitNanos_ = input.readInt64();
+              break;
+            }
+            case 82: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000040;
+              operatorTypeName_ = bs;
               break;
             }
             default: {
@@ -23546,17 +22844,17 @@ public final class UserBitShared {
     public static final int OPERATOR_TYPE_FIELD_NUMBER = 4;
     private int operatorType_;
     /**
-     * <code>optional int32 operator_type = 4;</code>
+     * <code>optional int32 operator_type = 4 [deprecated = true];</code>
      * @return Whether the operatorType field is set.
      */
-    public boolean hasOperatorType() {
+    @java.lang.Deprecated public boolean hasOperatorType() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional int32 operator_type = 4;</code>
+     * <code>optional int32 operator_type = 4 [deprecated = true];</code>
      * @return The operatorType.
      */
-    public int getOperatorType() {
+    @java.lang.Deprecated public int getOperatorType() {
       return operatorType_;
     }
 
@@ -23663,6 +22961,51 @@ public final class UserBitShared {
       return waitNanos_;
     }
 
+    public static final int OPERATOR_TYPE_NAME_FIELD_NUMBER = 10;
+    private volatile java.lang.Object operatorTypeName_;
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return Whether the operatorTypeName field is set.
+     */
+    public boolean hasOperatorTypeName() {
+      return ((bitField0_ & 0x00000040) != 0);
+    }
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return The operatorTypeName.
+     */
+    public java.lang.String getOperatorTypeName() {
+      java.lang.Object ref = operatorTypeName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          operatorTypeName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string operator_type_name = 10;</code>
+     * @return The bytes for operatorTypeName.
+     */
+    public com.google.protobuf.ByteString
+        getOperatorTypeNameBytes() {
+      java.lang.Object ref = operatorTypeName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        operatorTypeName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -23700,6 +23043,9 @@ public final class UserBitShared {
       }
       if (((bitField0_ & 0x00000020) != 0)) {
         output.writeInt64(9, waitNanos_);
+      }
+      if (((bitField0_ & 0x00000040) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 10, operatorTypeName_);
       }
       unknownFields.writeTo(output);
     }
@@ -23741,6 +23087,9 @@ public final class UserBitShared {
       if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(9, waitNanos_);
+      }
+      if (((bitField0_ & 0x00000040) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, operatorTypeName_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -23791,6 +23140,11 @@ public final class UserBitShared {
         if (getWaitNanos()
             != other.getWaitNanos()) return false;
       }
+      if (hasOperatorTypeName() != other.hasOperatorTypeName()) return false;
+      if (hasOperatorTypeName()) {
+        if (!getOperatorTypeName()
+            .equals(other.getOperatorTypeName())) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -23837,6 +23191,10 @@ public final class UserBitShared {
         hash = (37 * hash) + WAIT_NANOS_FIELD_NUMBER;
         hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
             getWaitNanos());
+      }
+      if (hasOperatorTypeName()) {
+        hash = (37 * hash) + OPERATOR_TYPE_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getOperatorTypeName().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -23997,6 +23355,8 @@ public final class UserBitShared {
         }
         waitNanos_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000080);
+        operatorTypeName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
 
@@ -24067,6 +23427,10 @@ public final class UserBitShared {
           result.waitNanos_ = waitNanos_;
           to_bitField0_ |= 0x00000020;
         }
+        if (((from_bitField0_ & 0x00000100) != 0)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.operatorTypeName_ = operatorTypeName_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -24185,6 +23549,11 @@ public final class UserBitShared {
         }
         if (other.hasWaitNanos()) {
           setWaitNanos(other.getWaitNanos());
+        }
+        if (other.hasOperatorTypeName()) {
+          bitField0_ |= 0x00000100;
+          operatorTypeName_ = other.operatorTypeName_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -24495,35 +23864,35 @@ public final class UserBitShared {
 
       private int operatorType_ ;
       /**
-       * <code>optional int32 operator_type = 4;</code>
+       * <code>optional int32 operator_type = 4 [deprecated = true];</code>
        * @return Whether the operatorType field is set.
        */
-      public boolean hasOperatorType() {
+      @java.lang.Deprecated public boolean hasOperatorType() {
         return ((bitField0_ & 0x00000004) != 0);
       }
       /**
-       * <code>optional int32 operator_type = 4;</code>
+       * <code>optional int32 operator_type = 4 [deprecated = true];</code>
        * @return The operatorType.
        */
-      public int getOperatorType() {
+      @java.lang.Deprecated public int getOperatorType() {
         return operatorType_;
       }
       /**
-       * <code>optional int32 operator_type = 4;</code>
+       * <code>optional int32 operator_type = 4 [deprecated = true];</code>
        * @param value The operatorType to set.
        * @return This builder for chaining.
        */
-      public Builder setOperatorType(int value) {
+      @java.lang.Deprecated public Builder setOperatorType(int value) {
         bitField0_ |= 0x00000004;
         operatorType_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional int32 operator_type = 4;</code>
+       * <code>optional int32 operator_type = 4 [deprecated = true];</code>
        * @return This builder for chaining.
        */
-      public Builder clearOperatorType() {
+      @java.lang.Deprecated public Builder clearOperatorType() {
         bitField0_ = (bitField0_ & ~0x00000004);
         operatorType_ = 0;
         onChanged();
@@ -24914,6 +24283,90 @@ public final class UserBitShared {
       public Builder clearWaitNanos() {
         bitField0_ = (bitField0_ & ~0x00000080);
         waitNanos_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object operatorTypeName_ = "";
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @return Whether the operatorTypeName field is set.
+       */
+      public boolean hasOperatorTypeName() {
+        return ((bitField0_ & 0x00000100) != 0);
+      }
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @return The operatorTypeName.
+       */
+      public java.lang.String getOperatorTypeName() {
+        java.lang.Object ref = operatorTypeName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            operatorTypeName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @return The bytes for operatorTypeName.
+       */
+      public com.google.protobuf.ByteString
+          getOperatorTypeNameBytes() {
+        java.lang.Object ref = operatorTypeName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          operatorTypeName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @param value The operatorTypeName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOperatorTypeName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+        operatorTypeName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOperatorTypeName() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        operatorTypeName_ = getDefaultInstance().getOperatorTypeName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string operator_type_name = 10;</code>
+       * @param value The bytes for operatorTypeName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOperatorTypeNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+        operatorTypeName_ = value;
         onChanged();
         return this;
       }
@@ -29043,68 +28496,33 @@ public final class UserBitShared {
       "y_used\030\007 \001(\003\022\027\n\017max_memory_used\030\010 \001(\003\022(\n" +
       "\010endpoint\030\t \001(\0132\026.exec.DrillbitEndpoint\022" +
       "\023\n\013last_update\030\n \001(\003\022\025\n\rlast_progress\030\013 " +
-      "\001(\003\"\377\001\n\017OperatorProfile\0221\n\rinput_profile" +
+      "\001(\003\"\237\002\n\017OperatorProfile\0221\n\rinput_profile" +
       "\030\001 \003(\0132\032.exec.shared.StreamProfile\022\023\n\013op" +
-      "erator_id\030\003 \001(\005\022\025\n\roperator_type\030\004 \001(\005\022\023" +
-      "\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos\030\006 \001" +
-      "(\003\022#\n\033peak_local_memory_allocated\030\007 \001(\003\022" +
-      "(\n\006metric\030\010 \003(\0132\030.exec.shared.MetricValu" +
-      "e\022\022\n\nwait_nanos\030\t \001(\003\"B\n\rStreamProfile\022\017" +
-      "\n\007records\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007sche" +
-      "mas\030\003 \001(\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 " +
-      "\001(\005\022\022\n\nlong_value\030\002 \001(\003\022\024\n\014double_value\030" +
-      "\003 \001(\001\")\n\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.sh" +
-      "ared.Jar\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022functio" +
-      "n_signature\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmech" +
-      "anism\030\001 \001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(" +
-      "\0162\027.exec.shared.SaslStatus*5\n\nRpcChannel" +
-      "\022\017\n\013BIT_CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020" +
-      "\002*V\n\tQueryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010" +
-      "PHYSICAL\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_ST" +
-      "ATEMENT\020\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000" +
-      "\022\027\n\023AWAITING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014" +
-      "\n\010FINISHED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022" +
-      "\032\n\026CANCELLATION_REQUESTED\020\006*\260\013\n\020CoreOper" +
-      "atorType\022\021\n\rSINGLE_SENDER\020\000\022\024\n\020BROADCAST" +
-      "_SENDER\020\001\022\n\n\006FILTER\020\002\022\022\n\016HASH_AGGREGATE\020" +
-      "\003\022\r\n\tHASH_JOIN\020\004\022\016\n\nMERGE_JOIN\020\005\022\031\n\025HASH" +
-      "_PARTITION_SENDER\020\006\022\t\n\005LIMIT\020\007\022\024\n\020MERGIN" +
-      "G_RECEIVER\020\010\022\034\n\030ORDERED_PARTITION_SENDER" +
-      "\020\t\022\013\n\007PROJECT\020\n\022\026\n\022UNORDERED_RECEIVER\020\013\022" +
-      "\032\n\026RANGE_PARTITION_SENDER\020\014\022\n\n\006SCREEN\020\r\022" +
-      "\034\n\030SELECTION_VECTOR_REMOVER\020\016\022\027\n\023STREAMI" +
-      "NG_AGGREGATE\020\017\022\016\n\nTOP_N_SORT\020\020\022\021\n\rEXTERN" +
-      "AL_SORT\020\021\022\t\n\005TRACE\020\022\022\t\n\005UNION\020\023\022\014\n\010OLD_S" +
-      "ORT\020\024\022\032\n\026PARQUET_ROW_GROUP_SCAN\020\025\022\021\n\rHIV" +
-      "E_SUB_SCAN\020\026\022\025\n\021SYSTEM_TABLE_SCAN\020\027\022\021\n\rM" +
-      "OCK_SUB_SCAN\020\030\022\022\n\016PARQUET_WRITER\020\031\022\023\n\017DI" +
-      "RECT_SUB_SCAN\020\032\022\017\n\013TEXT_WRITER\020\033\022\021\n\rTEXT" +
-      "_SUB_SCAN\020\034\022\021\n\rJSON_SUB_SCAN\020\035\022\030\n\024INFO_S" +
-      "CHEMA_SUB_SCAN\020\036\022\023\n\017COMPLEX_TO_JSON\020\037\022\025\n" +
-      "\021PRODUCER_CONSUMER\020 \022\022\n\016HBASE_SUB_SCAN\020!" +
-      "\022\n\n\006WINDOW\020\"\022\024\n\020NESTED_LOOP_JOIN\020#\022\021\n\rAV" +
-      "RO_SUB_SCAN\020$\022\021\n\rPCAP_SUB_SCAN\020%\022\022\n\016KAFK" +
-      "A_SUB_SCAN\020&\022\021\n\rKUDU_SUB_SCAN\020\'\022\013\n\007FLATT" +
-      "EN\020(\022\020\n\014LATERAL_JOIN\020)\022\n\n\006UNNEST\020*\022,\n(HI" +
-      "VE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN\020+" +
-      "\022\r\n\tJDBC_SCAN\020,\022\022\n\016REGEX_SUB_SCAN\020-\022\023\n\017M" +
-      "APRDB_SUB_SCAN\020.\022\022\n\016MONGO_SUB_SCAN\020/\022\017\n\013" +
-      "KUDU_WRITER\0200\022\026\n\022OPEN_TSDB_SUB_SCAN\0201\022\017\n" +
-      "\013JSON_WRITER\0202\022\026\n\022HTPPD_LOG_SUB_SCAN\0203\022\022" +
-      "\n\016IMAGE_SUB_SCAN\0204\022\025\n\021SEQUENCE_SUB_SCAN\020" +
-      "5\022\023\n\017PARTITION_LIMIT\0206\022\023\n\017PCAPNG_SUB_SCA" +
-      "N\0207\022\022\n\016RUNTIME_FILTER\0208\022\017\n\013ROWKEY_JOIN\0209" +
-      "\022\023\n\017SYSLOG_SUB_SCAN\020:\022\030\n\024STATISTICS_AGGR" +
-      "EGATE\020;\022\020\n\014UNPIVOT_MAPS\020<\022\024\n\020STATISTICS_" +
-      "MERGE\020=\022\021\n\rLTSV_SUB_SCAN\020>\022\021\n\rHDF5_SUB_S" +
-      "CAN\020?\022\022\n\016EXCEL_SUB_SCAN\020@\022\020\n\014SHP_SUB_SCA" +
-      "N\020A\022\024\n\020METADATA_HANDLER\020B\022\027\n\023METADATA_CO" +
-      "NTROLLER\020C\022\022\n\016DRUID_SUB_SCAN\020D\022\021\n\rSPSS_S" +
-      "UB_SCAN\020E\022\021\n\rHTTP_SUB_SCAN\020F\022\020\n\014XML_SUB_" +
-      "SCAN\020G*g\n\nSaslStatus\022\020\n\014SASL_UNKNOWN\020\000\022\016" +
-      "\n\nSASL_START\020\001\022\024\n\020SASL_IN_PROGRESS\020\002\022\020\n\014" +
-      "SASL_SUCCESS\020\003\022\017\n\013SASL_FAILED\020\004B.\n\033org.a" +
-      "pache.drill.exec.protoB\rUserBitSharedH\001"
+      "erator_id\030\003 \001(\005\022\031\n\roperator_type\030\004 \001(\005B\002" +
+      "\030\001\022\023\n\013setup_nanos\030\005 \001(\003\022\025\n\rprocess_nanos" +
+      "\030\006 \001(\003\022#\n\033peak_local_memory_allocated\030\007 " +
+      "\001(\003\022(\n\006metric\030\010 \003(\0132\030.exec.shared.Metric" +
+      "Value\022\022\n\nwait_nanos\030\t \001(\003\022\032\n\022operator_ty" +
+      "pe_name\030\n \001(\t\"B\n\rStreamProfile\022\017\n\007record" +
+      "s\030\001 \001(\003\022\017\n\007batches\030\002 \001(\003\022\017\n\007schemas\030\003 \001(" +
+      "\003\"J\n\013MetricValue\022\021\n\tmetric_id\030\001 \001(\005\022\022\n\nl" +
+      "ong_value\030\002 \001(\003\022\024\n\014double_value\030\003 \001(\001\")\n" +
+      "\010Registry\022\035\n\003jar\030\001 \003(\0132\020.exec.shared.Jar" +
+      "\"/\n\003Jar\022\014\n\004name\030\001 \001(\t\022\032\n\022function_signat" +
+      "ure\030\002 \003(\t\"W\n\013SaslMessage\022\021\n\tmechanism\030\001 " +
+      "\001(\t\022\014\n\004data\030\002 \001(\014\022\'\n\006status\030\003 \001(\0162\027.exec" +
+      ".shared.SaslStatus*5\n\nRpcChannel\022\017\n\013BIT_" +
+      "CONTROL\020\000\022\014\n\010BIT_DATA\020\001\022\010\n\004USER\020\002*V\n\tQue" +
+      "ryType\022\007\n\003SQL\020\001\022\013\n\007LOGICAL\020\002\022\014\n\010PHYSICAL" +
+      "\020\003\022\r\n\tEXECUTION\020\004\022\026\n\022PREPARED_STATEMENT\020" +
+      "\005*\207\001\n\rFragmentState\022\013\n\007SENDING\020\000\022\027\n\023AWAI" +
+      "TING_ALLOCATION\020\001\022\013\n\007RUNNING\020\002\022\014\n\010FINISH" +
+      "ED\020\003\022\r\n\tCANCELLED\020\004\022\n\n\006FAILED\020\005\022\032\n\026CANCE" +
+      "LLATION_REQUESTED\020\006*g\n\nSaslStatus\022\020\n\014SAS" +
+      "L_UNKNOWN\020\000\022\016\n\nSASL_START\020\001\022\024\n\020SASL_IN_P" +
+      "ROGRESS\020\002\022\020\n\014SASL_SUCCESS\020\003\022\017\n\013SASL_FAIL" +
+      "ED\020\004B.\n\033org.apache.drill.exec.protoB\rUse" +
+      "rBitSharedH\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -29214,7 +28632,7 @@ public final class UserBitShared {
     internal_static_exec_shared_OperatorProfile_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_exec_shared_OperatorProfile_descriptor,
-        new java.lang.String[] { "InputProfile", "OperatorId", "OperatorType", "SetupNanos", "ProcessNanos", "PeakLocalMemoryAllocated", "Metric", "WaitNanos", });
+        new java.lang.String[] { "InputProfile", "OperatorId", "OperatorType", "SetupNanos", "ProcessNanos", "PeakLocalMemoryAllocated", "Metric", "WaitNanos", "OperatorTypeName", });
     internal_static_exec_shared_StreamProfile_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_exec_shared_StreamProfile_fieldAccessorTable = new

--- a/protocol/src/main/protobuf/UserBitShared.proto
+++ b/protocol/src/main/protobuf/UserBitShared.proto
@@ -280,12 +280,13 @@ message MinorFragmentProfile {
 message OperatorProfile {
   repeated StreamProfile input_profile = 1;
   optional int32 operator_id = 3;
-  optional int32 operator_type = 4;
+  optional int32 operator_type = 4 [deprecated = true];
   optional int64 setup_nanos = 5;
   optional int64 process_nanos = 6;
   optional int64 peak_local_memory_allocated = 7;
   repeated MetricValue metric = 8;
   optional int64 wait_nanos = 9;
+  optional string operator_type_name = 10;
 }
 
 message StreamProfile {
@@ -308,81 +309,6 @@ enum FragmentState {
   CANCELLED = 4;
   FAILED = 5;
   CANCELLATION_REQUESTED = 6;
-}
-
-enum CoreOperatorType {
-  SINGLE_SENDER = 0;
-  BROADCAST_SENDER = 1;
-  FILTER = 2;
-  HASH_AGGREGATE = 3;
-  HASH_JOIN = 4;
-  MERGE_JOIN = 5;
-  HASH_PARTITION_SENDER = 6;
-  LIMIT = 7;
-  MERGING_RECEIVER = 8;
-  ORDERED_PARTITION_SENDER = 9;
-  PROJECT = 10;
-  UNORDERED_RECEIVER = 11;
-  RANGE_PARTITION_SENDER = 12;
-  SCREEN = 13;
-  SELECTION_VECTOR_REMOVER = 14;
-  STREAMING_AGGREGATE = 15;
-  TOP_N_SORT = 16;
-  EXTERNAL_SORT = 17;
-  TRACE = 18;
-  UNION = 19;
-  OLD_SORT = 20;
-  PARQUET_ROW_GROUP_SCAN = 21;
-  HIVE_SUB_SCAN = 22;
-  SYSTEM_TABLE_SCAN = 23;
-  MOCK_SUB_SCAN = 24;
-  PARQUET_WRITER = 25;
-  DIRECT_SUB_SCAN = 26;
-  TEXT_WRITER = 27;
-  TEXT_SUB_SCAN = 28;
-  JSON_SUB_SCAN = 29;
-  INFO_SCHEMA_SUB_SCAN = 30;
-  COMPLEX_TO_JSON = 31;
-  PRODUCER_CONSUMER = 32;
-  HBASE_SUB_SCAN = 33;
-  WINDOW = 34;
-  NESTED_LOOP_JOIN = 35;
-  AVRO_SUB_SCAN = 36;
-  PCAP_SUB_SCAN = 37;
-  KAFKA_SUB_SCAN = 38;
-  KUDU_SUB_SCAN = 39;
-  FLATTEN = 40;
-  LATERAL_JOIN = 41;
-  UNNEST = 42;
-  HIVE_DRILL_NATIVE_PARQUET_ROW_GROUP_SCAN = 43;
-  JDBC_SCAN = 44;
-  REGEX_SUB_SCAN = 45;
-  MAPRDB_SUB_SCAN = 46;
-  MONGO_SUB_SCAN = 47;
-  KUDU_WRITER = 48;
-  OPEN_TSDB_SUB_SCAN = 49;
-  JSON_WRITER = 50;
-  HTPPD_LOG_SUB_SCAN = 51;
-  IMAGE_SUB_SCAN = 52;
-  SEQUENCE_SUB_SCAN = 53;
-  PARTITION_LIMIT = 54;
-  PCAPNG_SUB_SCAN = 55;
-  RUNTIME_FILTER = 56;
-  ROWKEY_JOIN = 57;
-  SYSLOG_SUB_SCAN = 58;
-  STATISTICS_AGGREGATE = 59;
-  UNPIVOT_MAPS = 60;
-  STATISTICS_MERGE = 61;
-  LTSV_SUB_SCAN = 62;
-  HDF5_SUB_SCAN = 63;
-  EXCEL_SUB_SCAN = 64;
-  SHP_SUB_SCAN = 65;
-  METADATA_HANDLER = 66;
-  METADATA_CONTROLLER = 67;
-  DRUID_SUB_SCAN = 68;
-  SPSS_SUB_SCAN = 69;
-  HTTP_SUB_SCAN = 70;
-  XML_SUB_SCAN = 71;
 }
 
 /* Registry that contains list of jars, each jar contains its name and list of function signatures.


### PR DESCRIPTION
# [DRILL-5405](https://issues.apache.org/jira/browse/DRILL-5405): Add missing operator types without dependency on protobuf enum

## Description
Changed all operators to use string literals to provide operator type instead of int values that correspond to entries in protobuf enum. To preserve backward compatibility, `CoreOperatorType` was moved outside of probufs and used to deserialize older query profiles, so there is no need to update it every time when new operator or plugin is introduced. Newer query profiles will write both int value if the corresponding entry is present in `CoreOperatorType` and a new string value. So with these changes, older versions of Drill will be able to read profiles created by newer versions and newer versions of Drill will be able to read profiles created by older Drill.
Storage plugins that use `EasyFormatConfig` may not specify `operatorType` value, in this case, it will be constructed using the default plugin name. For example, if the default name is `text`, `operatorType` will be `TEXT_SUB_SCAN`.

## Documentation
NA

## Testing
Checked manually different cases for backward compatibility.
