### PR TITLE
DRILL-7842:Fix BaseTestInheritance test case

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/TestforBaseTestInheritance.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/TestforBaseTestInheritance.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class BaseTestInheritance extends BaseTest {
+public class TestforBaseTestInheritance extends BaseTest {
 
   @Test
   @Category(UnlikelyTest.class)

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStackAnalyzer.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/TestStackAnalyzer.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import org.apache.drill.test.BaseTest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +32,7 @@ import org.junit.Test;
  * an exception call stack. Does the tests using dummy classes
  * (which is why the stack analyzer function is parameterized.)
  */
-public class TestStackAnalyzer {
+public class TestStackAnalyzer extends BaseTest{
 
   private static class OperA {
     public void throwNow() {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestDynamicSchemaFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestDynamicSchemaFilter.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.categories.EvfTest;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -40,7 +41,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(EvfTest.class)
-public class TestDynamicSchemaFilter {
+public class TestDynamicSchemaFilter extends BaseTest{
 
   private static final ColumnMetadata A_COL =
       MetadataUtils.newScalar("a", Types.required(MinorType.INT));

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestProjectedPath.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestProjectedPath.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.impl.scan.v3.schema;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.categories.EvfTest;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
@@ -38,7 +39,7 @@ import org.junit.experimental.categories.Category;
  * verify the consistency checks.
  */
 @Category(EvfTest.class)
-public class TestProjectedPath {
+public class TestProjectedPath extends BaseTest{
 
   // INT is a proxy for all scalar columns.
   private static final ColumnMetadata INT_COLUMN = intSchema().metadata("a");

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestSchemaTrackerDefined.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/impl/scan/v3/schema/TestSchemaTrackerDefined.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.categories.EvfTest;
 import org.apache.drill.common.exceptions.CustomErrorContext;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
@@ -39,7 +40,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(EvfTest.class)
-public class TestSchemaTrackerDefined {
+public class TestSchemaTrackerDefined extends BaseTest{
   private static final CustomErrorContext ERROR_CONTEXT = EmptyErrorContext.INSTANCE;
 
   private boolean isProjected(ProjectionFilter filter, ColumnMetadata col) {

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestProjectionFilter.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/impl/TestProjectionFilter.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.common.exceptions.EmptyErrorContext;
 import org.apache.drill.common.exceptions.UserException;
 import org.apache.drill.common.types.TypeProtos.MinorType;
@@ -41,7 +42,7 @@ import org.apache.drill.exec.record.metadata.TupleMetadata;
 import org.apache.drill.exec.record.metadata.TupleSchema;
 import org.junit.Test;
 
-public class TestProjectionFilter {
+public class TestProjectionFilter extends BaseTest{
   private static final ColumnMetadata A_COL = MetadataUtils.newScalar("a", Types.required(MinorType.INT));
   private static final ColumnMetadata B_COL = MetadataUtils.newScalar("b", Types.optional(MinorType.VARCHAR));
   private static final ColumnMetadata MAP_COL = MetadataUtils.newMap("m", new TupleSchema());

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedPath.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/physical/resultSet/project/TestProjectedPath.java
@@ -20,6 +20,7 @@ package org.apache.drill.exec.physical.resultSet.project;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.drill.test.BaseTest;
 import org.apache.drill.common.types.TypeProtos.MinorType;
 import org.apache.drill.common.types.Types;
 import org.apache.drill.exec.physical.rowSet.RowSetTestUtils;
@@ -34,7 +35,7 @@ import org.junit.Test;
  * to see if the projection path is consistent with the type. Tests here
  * verify the consistency checks.
  */
-public class TestProjectedPath {
+public class TestProjectedPath extends BaseTest{
 
   // INT is a proxy for all scalar columns.
   private static final ColumnMetadata INT_COLUMN = intSchema().metadata("a");


### PR DESCRIPTION
# [DRILL-7842](https://issues.apache.org/jira/projects/DRILL/issues/DRILL-7842)

## Description

Fixed BaseTestInheritance (now called TestforBaseTestInheritance) so that it runs during maven test. Also fixed tests that were not inherited from the BaseTest class:

```
org.apache.drill.exec.physical.impl.scan.v3.schema.TestProjectedPath,
org.apache.drill.exec.physical.impl.TestStackAnalyzer,
 org.apache.drill.exec.physical.resultSet.impl.TestProjectionFilter,
 org.apache.drill.exec.physical.resultSet.project.TestProjectedPath,
 org.apache.drill.exec.physical.impl.scan.v3.schema.TestDynamicSchemaFilter,
 org.apache.drill.exec.physical.impl.scan.v3.schema.TestSchemaTrackerDefined
```

## Documentation
(Please describe user-visible changes similar to what should appear in the Drill documentation.)
I'm fairly certain this is N/A for this issue as it is quite small? 

## Testing
Ran maven test. Confirmed that it runs and no errors.

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 105.013 s - in org.apache.drill.TestforBaseTestInheritance
```

