### PR TITLE
[Minor Fix] Incorrect Tag Name for Image

### DIFF
--- a/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDirectory.java
+++ b/contrib/format-image/src/main/java/org/apache/drill/exec/store/image/GenericMetadataDirectory.java
@@ -52,7 +52,7 @@ public class GenericMetadataDirectory extends Directory
     _tagNameMap.put(TAG_FORMAT, "Format");
     _tagNameMap.put(TAG_PIXEL_WIDTH, "Pixel Width");
     _tagNameMap.put(TAG_PIXEL_HEIGHT, "Pixel Height");
-    _tagNameMap.put(TAG_ORIENTATION, "Orientaion");
+    _tagNameMap.put(TAG_ORIENTATION, "Orientation");
     _tagNameMap.put(TAG_DPI_WIDTH, "DPI Width");
     _tagNameMap.put(TAG_DPI_HEIGHT, "DPI Height");
     _tagNameMap.put(TAG_COLOR_MODE, "Color Mode");

--- a/contrib/format-image/src/test/java/org/apache/drill/exec/store/image/TestImageRecordReader.java
+++ b/contrib/format-image/src/test/java/org/apache/drill/exec/store/image/TestImageRecordReader.java
@@ -178,7 +178,7 @@ public class TestImageRecordReader extends ClusterTest {
   public void testFileSystemMetadataOption() throws Exception {
     cluster.defineFormat("dfs", "image", new ImageFormatConfig(Arrays.asList("gif"), true, false, null));
     String sql = "select FileSize, Format, PixelWidth, PixelHeight, ColorMode, BitsPerPixel,"
-        + " Orientaion, DPIWidth, DPIHeight, HasAlpha, Duration, VideoCodec, FrameRate, AudioCodec,"
+        + " Orientation, DPIWidth, DPIHeight, HasAlpha, Duration, VideoCodec, FrameRate, AudioCodec,"
         + " AudioSampleSize, AudioSampleRate from dfs.`image/*.gif`";
     QueryBuilder builder = client.queryBuilder().sql(sql);
     RowSet sets = builder.rowSet();
@@ -190,7 +190,7 @@ public class TestImageRecordReader extends ClusterTest {
         .addNullable("PixelHeight", MinorType.INT)
         .addNullable("ColorMode", MinorType.VARCHAR)
         .addNullable("BitsPerPixel", MinorType.INT)
-        .addNullable("Orientaion", MinorType.INT)
+        .addNullable("Orientation", MinorType.INT)
         .addNullable("DPIWidth", MinorType.FLOAT8)
         .addNullable("DPIHeight", MinorType.FLOAT8)
         .addNullable("HasAlpha", MinorType.BIT)

--- a/contrib/format-image/src/test/resources/image/avi.json
+++ b/contrib/format-image/src/test/resources/image/avi.json
@@ -1,6 +1,6 @@
 {
   "Format" : "AVI",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "DPIWidth" : "0",
   "DPIHeight" : "0",
   "PixelWidth" : "320",

--- a/contrib/format-image/src/test/resources/image/bmp.json
+++ b/contrib/format-image/src/test/resources/image/bmp.json
@@ -5,7 +5,7 @@
   "DPIWidth" : "71.984",
   "DPIHeight" : "71.984",
   "BitsPerPixel" : "24",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "ColorMode" : "RGB",
   "HasAlpha" : "false",
   "Duration" : "00:00:00",

--- a/contrib/format-image/src/test/resources/image/eps.json
+++ b/contrib/format-image/src/test/resources/image/eps.json
@@ -1,6 +1,6 @@
 {
   "Format" : "EPS",
-  "Orientaion" : "Top, left side (Horizontal / normal)",
+  "Orientation" : "Top, left side (Horizontal / normal)",
   "DPIWidth" : "101",
   "DPIHeight" : "101",
   "PixelWidth" : "275",

--- a/contrib/format-image/src/test/resources/image/gif.json
+++ b/contrib/format-image/src/test/resources/image/gif.json
@@ -4,7 +4,7 @@
   "PixelHeight" : "174",
   "ColorMode" : "Indexed",
   "BitsPerPixel" : "8",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "DPIWidth" : "0",
   "DPIHeight" : "0",
   "HasAlpha" : "true",

--- a/contrib/format-image/src/test/resources/image/ico.json
+++ b/contrib/format-image/src/test/resources/image/ico.json
@@ -3,7 +3,7 @@
   "PixelWidth" : "32",
   "PixelHeight" : "32",
   "BitsPerPixel" : "32",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "DPIWidth" : "0",
   "DPIHeight" : "0",
   "ColorMode" : "RGB",

--- a/contrib/format-image/src/test/resources/image/jpeg.json
+++ b/contrib/format-image/src/test/resources/image/jpeg.json
@@ -5,7 +5,7 @@
   "BitsPerPixel" : "24",
   "DPIWidth" : "300",
   "DPIHeight" : "300",
-  "Orientaion" : "Top, left side (Horizontal / normal)",
+  "Orientation" : "Top, left side (Horizontal / normal)",
   "ColorMode" : "RGB",
   "HasAlpha" : "false",
   "Duration" : "00:00:00",

--- a/contrib/format-image/src/test/resources/image/mov.json
+++ b/contrib/format-image/src/test/resources/image/mov.json
@@ -11,7 +11,7 @@
   "AudioCodec" : "MPEG-4, Advanced Audio Coding (AAC)",
   "AudioSampleSize" : "16",
   "AudioSampleRate" : "44100",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "ColorMode" : "RGB",
   "HasAlpha" : "false",
   "QuickTime" : {

--- a/contrib/format-image/src/test/resources/image/mp4.json
+++ b/contrib/format-image/src/test/resources/image/mp4.json
@@ -11,7 +11,7 @@
   "AudioCodec" : "MPEG-4, Advanced Audio Coding (AAC)",
   "AudioSampleSize" : "16",
   "AudioSampleRate" : "48000",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "ColorMode" : "RGB",
   "HasAlpha" : "false",
   "MP4" : {

--- a/contrib/format-image/src/test/resources/image/pcx.json
+++ b/contrib/format-image/src/test/resources/image/pcx.json
@@ -6,7 +6,7 @@
   "DPIHeight" : "72",
   "BitsPerPixel" : "24",
   "HasAlpha" : "false",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "ColorMode" : "RGB",
   "Duration" : "00:00:00",
   "VideoCodec" : "Unknown",

--- a/contrib/format-image/src/test/resources/image/png.json
+++ b/contrib/format-image/src/test/resources/image/png.json
@@ -6,7 +6,7 @@
   "BitsPerPixel" : "32",
   "DPIWidth" : "72.009",
   "DPIHeight" : "72.009",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "ColorMode" : "RGB",
   "Duration" : "00:00:00",
   "VideoCodec" : "Unknown",

--- a/contrib/format-image/src/test/resources/image/psd.json
+++ b/contrib/format-image/src/test/resources/image/psd.json
@@ -4,7 +4,7 @@
   "PixelHeight" : "174",
   "BitsPerPixel" : "32",
   "ColorMode" : "RGB",
-  "Orientaion" : "Top, left side (Horizontal / normal)",
+  "Orientation" : "Top, left side (Horizontal / normal)",
   "DPIWidth" : "72",
   "DPIHeight" : "72",
   "HasAlpha" : "false",

--- a/contrib/format-image/src/test/resources/image/tiff.json
+++ b/contrib/format-image/src/test/resources/image/tiff.json
@@ -2,7 +2,7 @@
   "Format" : "ARW",
   "PixelWidth" : "128",
   "PixelHeight" : "174",
-  "Orientaion" : "Top, left side (Horizontal / normal)",
+  "Orientation" : "Top, left side (Horizontal / normal)",
   "DPIWidth" : "72",
   "DPIHeight" : "72",
   "BitsPerPixel" : "24",

--- a/contrib/format-image/src/test/resources/image/wav.json
+++ b/contrib/format-image/src/test/resources/image/wav.json
@@ -1,6 +1,6 @@
 {
   "Format" : "WAV",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "DPIWidth" : "0",
   "DPIHeight" : "0",
   "PixelWidth" : "0",

--- a/contrib/format-image/src/test/resources/image/webp.json
+++ b/contrib/format-image/src/test/resources/image/webp.json
@@ -3,7 +3,7 @@
   "PixelWidth" : "400",
   "PixelHeight" : "301",
   "HasAlpha" : "true",
-  "Orientaion" : "Unknown (0)",
+  "Orientation" : "Unknown (0)",
   "DPIWidth" : "0",
   "DPIHeight" : "0",
   "ColorMode" : "RGB",


### PR DESCRIPTION
Minor Fix: Incorrect Tag Name for Image

## Description

It's unbelievable that the tag name had been incorrect since the image plugin committed.

## Documentation
There are no changes visible to the user.

## Testing
Ran unit tests associated with the Image plugin.
