### PR TITLE
DRILL-7849: Display error message when cannot enable storage plugin

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/StorageResources.java
@@ -154,8 +154,9 @@ public class StorageResources {
         model);
   }
 
-  @GET
+  @POST
   @Path("/storage/{name}/enable/{val}")
+  @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public JsonResult enablePlugin(@PathParam("name") String name, @PathParam("val") Boolean enable) {
     try {
@@ -167,6 +168,17 @@ public class StorageResources {
       logger.debug("Error in enabling storage name: {} flag: {}",  name, enable);
       return message("Unable to enable/disable plugin:" + e.getMessage());
     }
+  }
+
+  /**
+   * @deprecated use the method with POST request {@link #enablePlugin} instead
+   */
+  @GET
+  @Path("/storage/{name}/enable/{val}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Deprecated
+  public JsonResult enablePluginViaGet(@PathParam("name") String name, @PathParam("val") Boolean enable) {
+    return enablePlugin(name, enable);
   }
 
   /**

--- a/exec/java-exec/src/main/resources/rest/alertModals.ftl
+++ b/exec/java-exec/src/main/resources/rest/alertModals.ftl
@@ -48,26 +48,29 @@
 <script>
     //Populate the alert modal with the right message params and show
     function populateAndShowAlert(errorMsg, inputValues) {
+      let errorModal=$('#errorModal');
+      let title;
+      let body;
       if (!(errorMsg in errorMap)) {
         //Using default errorId to represent message
-        modalHeader.innerHTML=errorMsg;
-        modalBody.innerHTML="[Auto Description] "+JSON.stringify(inputValues);
+        title=errorMsg;
+        body="[Auto Description] "+JSON.stringify(inputValues);
       } else {
-        modalHeader.innerHTML=errorMap[errorMsg].msgHeader;
-        modalBody.innerHTML=errorMap[errorMsg].msgBody;
+        title=errorMap[errorMsg].msgHeader;
+        body=errorMap[errorMsg].msgBody;
       }
       //Check if substitutions are needed
-      let updatedHtml=modalBody.innerHTML;
       if (inputValues != null) {
-        var inputValuesKeys = Object.keys(inputValues);
+        let inputValuesKeys = Object.keys(inputValues);
         for (i=0; i<inputValuesKeys.length; ++i) {
-            let currKey=inputValuesKeys[i];
-            updatedHtml=updatedHtml.replace(currKey, escapeHtml(inputValues[currKey]));
+          let currKey=inputValuesKeys[i];
+          body=body.replace(currKey, escapeHtml(inputValues[currKey]));
         }
-        modalBody.innerHTML=updatedHtml;
       }
+      errorModal.find('.modal-title').text(title);
+      errorModal.find('.modal-body').html(body);
       //Show Alert
-      $('#errorModal').modal('show');
+      errorModal.modal('show');
     }
 
     function escapeHtml(str) {
@@ -104,6 +107,10 @@
         "queryMissing": {
             msgHeader:"   ERROR: No Query to execute",
             msgBody:"Please provide a query. The query textbox cannot be empty."
+        },
+        "pluginEnablingFailure": {
+            msgHeader:"   ERROR: Unable to enable/disable plugin",
+            msgBody:"<span style='font-family:courier;white-space:pre'>_pluginName_</span>: _errorMessage_"
         },
         "errorId": {
             msgHeader:"~header~",

--- a/exec/java-exec/src/main/resources/rest/confirmationModals.ftl
+++ b/exec/java-exec/src/main/resources/rest/confirmationModals.ftl
@@ -44,9 +44,10 @@
 <script>
     //Populate the confirmation modal with the right message params and show
     function showConfirmationDialog(confirmationMessage, okCallback) {
-      modalBody.innerHTML = confirmationMessage;
+      let confirmationModal = $('#confirmationModal');
+      confirmationModal.find('.modal-body').html(confirmationMessage);
       //Show dialog
-      $('#confirmationModal').modal('show');
+      confirmationModal.modal('show');
       $('#confirmationOk').unbind('click')
           .click(okCallback);
       $('#confirmationCancel').focus();

--- a/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
+++ b/exec/java-exec/src/main/resources/rest/static/js/serverMessage.js
@@ -20,6 +20,7 @@ function serverMessage(data) {
             .addClass("alert-info")
             .text(data.result).alert();
         setTimeout(function() { window.location.href = "/storage"; }, 800);
+        return true;
     } else {
         messageEl.addClass("d-none");
         // Wait a fraction of a second before showing the message again. This
@@ -31,5 +32,6 @@ function serverMessage(data) {
                 .addClass("alert-danger")
                 .text("Please retry: " + data.result).alert();
         }, 200);
+        return false;
     }
 }

--- a/exec/java-exec/src/main/resources/rest/storage/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/list.ftl
@@ -210,8 +210,12 @@
         showConfirmationDialog('"' + name + '"' + ' plugin will be disabled. Proceed?', proceed);
       }
       function proceed() {
-        $.get("/storage/" + encodeURIComponent(name) + "/enable/" + flag, function() {
-          location.reload();
+        $.post("/storage/" + encodeURIComponent(name) + "/enable/" + flag, function(data) {
+          if (data.result === "Success") {
+            location.reload();
+          } else {
+              populateAndShowAlert('pluginEnablingFailure', {'_pluginName_': name,'_errorMessage_': data.result});
+          }
         });
       }
     }
@@ -290,6 +294,7 @@
       });
     });
   </script>
+  <#include "*/alertModals.ftl">
 </#macro>
 
 <@page_html/>

--- a/exec/java-exec/src/main/resources/rest/storage/update.ftl
+++ b/exec/java-exec/src/main/resources/rest/storage/update.ftl
@@ -121,9 +121,10 @@
         proceed();
       }
       function proceed() {
-        $.get("/storage/" + encodeURIComponent("${model.getPlugin().getName()}") + "/enable/<#if model.getPlugin().enabled()>false<#else>true</#if>", function(data) {
-          $("#message").removeClass("d-none").text(data.result).alert();
-          setTimeout(function() { location.reload(); }, 800);
+        $.post("/storage/" + encodeURIComponent("${model.getPlugin().getName()}") + "/enable/" + !enabled, function(data) {
+          if (serverMessage(data)) {
+              setTimeout(function() { location.reload(); }, 800);
+          }
         });
       }
     });


### PR DESCRIPTION
# [DRILL-7849](https://issues.apache.org/jira/browse/DRILL-7849): Display error message when cannot enable storage plugin

## Description
- Added POST method for enabling/disabling storage plugins and marked the existing GET method as deprecated.
- Updated template to display a continuous error message on storage plugin configuration page, here is the screenshot with an example:
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/20928429/105613826-a30ab980-5dcd-11eb-8f1d-58885e64a841.png">
- Updated template to display a modal with an error message on plugins page:
<img width="746" alt="image" src="https://user-images.githubusercontent.com/20928429/105614144-0b5a9a80-5dd0-11eb-92f5-d095744971ad.png">

## Documentation
NA

## Testing
NA
