### PR TITLE
DRILL-7712: Fix Issues after ZK upgrade

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
@@ -36,6 +36,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
 public class TestEphemeralStore extends BaseTest {
   private final static String root = "/test";
   private final static String path = "test-key";

--- a/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/coord/zk/TestEphemeralStore.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.listen.ListenerContainer;
+import org.apache.curator.framework.listen.MappingListenerManager;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryNTimes;
@@ -36,7 +36,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 public class TestEphemeralStore extends BaseTest {
   private final static String root = "/test";
   private final static String path = "test-key";
@@ -116,8 +115,8 @@ public class TestEphemeralStore extends BaseTest {
         .when(client.getCache())
         .thenReturn(cache);
 
-    @SuppressWarnings("unchecked")
-    final ListenerContainer<PathChildrenCacheListener> container = Mockito.mock(ListenerContainer.class);
+ @SuppressWarnings("unchecked")
+    final MappingListenerManager<PathChildrenCacheListener,PathChildrenCacheListener> container = Mockito.mock(MappingListenerManager.class);
     Mockito
         .when(cache.getListenable())
         .thenReturn(container);

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <netty.tcnative.classifier />
     <commons.io.version>2.4</commons.io.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
-    <curator.version>4.3.0</curator.version>
+    <curator.version>5.1.0</curator.version>
     <wiremock.standalone.version>2.23.2</wiremock.standalone.version>
     <jmockit.version>1.47</jmockit.version>
     <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
# [DRILL-7712](https://issues.apache.org/jira/browse/DRILL-7712): Fix Issues after ZK upgrade

## Description

Updated unit tests so that it utilizes MappingListenerManager instead of ListenerContainer from Apache Curator which was deprecated in version 5.1.0. Curator v5.1.0 fixes NPE errors in testing phase (also described in DRILL-7843(https://issues.apache.org/jira/browse/DRILL-7843).

Note: Not sure how to mimic the jdbc-all w/ mapR profile behaviour 

## Documentation
N/A

## Testing
Checked mvn test and the errors that were described are no longer there. 

`[INFO] Running org.apache.drill.exec.coord.zk.TestZookeeperClient
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.224 s - in org.apache.drill.exec.coord.zk.TestZookeeperClient

[INFO] Running org.apache.drill.exec.coord.zk.TestEphemeralStore
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.658 s - in org.apache.drill.exec.coord.zk.TestEphemeralStore

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.555 s - in org.apache.drill.yarn.zk.TestAmRegistration

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s - in org.apache.drill.yarn.client.TestCommandLineOptions`
