### PR TITLE
DRILL-7850: Unable to load DrillConnectionImpl class from JDBC driver

### DIFF
--- a/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
+++ b/exec/java-exec/src/test/java/org/apache/drill/exec/util/StoragePluginTestUtils.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.drill.exec.store.SchemaFactory;
 import org.apache.drill.shaded.guava.com.google.common.collect.ImmutableList;
 import org.apache.drill.common.logical.FormatPluginConfig;
 import org.apache.drill.exec.store.StoragePluginRegistry;
@@ -34,9 +33,7 @@ import org.apache.drill.exec.store.easy.sequencefile.SequenceFileFormatConfig;
 import org.apache.drill.exec.store.easy.text.TextFormatPlugin.TextFormatConfig;
 
 /**
- * Utility methods to speed up tests. Some of the production code currently
- * calls this method when the production code is executed as part of the test
- * runs. That's the reason why this code has to be in production module.
+ * Utility methods to speed up tests.
  */
 public class StoragePluginTestUtils {
   public static final String CP_PLUGIN_NAME = "cp";
@@ -46,13 +43,6 @@ public class StoragePluginTestUtils {
   public static final String ROOT_SCHEMA = "root";
 
   public static final String DFS_TMP_SCHEMA = DFS_PLUGIN_NAME + "." + TMP_SCHEMA;
-  public static final String DFS_DEFAULT_SCHEMA = DFS_PLUGIN_NAME + "." + SchemaFactory.DEFAULT_WS_NAME;
-  public static final String DFS_ROOT_SCHEMA = DFS_PLUGIN_NAME + "." + ROOT_SCHEMA;
-
-  public static final String UNIT_TEST_PROP_PREFIX = "drillJDBCUnitTests";
-  public static final String UNIT_TEST_DFS_TMP_PROP = UNIT_TEST_PROP_PREFIX + "." + DFS_TMP_SCHEMA;
-  public static final String UNIT_TEST_DFS_DEFAULT_PROP = UNIT_TEST_PROP_PREFIX + "." + DFS_DEFAULT_SCHEMA;
-  public static final String UNIT_TEST_DFS_ROOT_PROP = UNIT_TEST_PROP_PREFIX + "." + DFS_ROOT_SCHEMA;
 
   /**
    * Update the workspace locations for a plugin.

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/impl/DrillConnectionUtils.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/impl/DrillConnectionUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.drill.jdbc.impl;
+
+import org.apache.drill.exec.store.StoragePluginRegistry;
+
+public class DrillConnectionUtils {
+
+  public static StoragePluginRegistry getStorage(DrillConnectionImpl drillConnection) {
+    return drillConnection.getDrillbit().getContext().getStorage();
+  }
+}

--- a/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
+++ b/exec/jdbc/src/test/java/org/apache/drill/jdbc/test/TestJdbcQuery.java
@@ -62,7 +62,7 @@ public class TestJdbcQuery extends JdbcTestQueryBase {
     // didn't yet receive a terminal message. To test this, we run CTAS then immediately run a query on the newly
     // created table.
 
-    final String tableName = "dfs.tmp.`testDDLs`";
+    final String tableName = "dfs.tmp.`testDDLs3635`";
 
     try (Connection conn = connect()) {
       Statement s = conn.createStatement();


### PR DESCRIPTION
# [DRILL-7850](https://issues.apache.org/jira/browse/DRILL-7850): Unable to load DrillConnectionImpl class from JDBC driver

## Description
Please refer to https://github.com/jpype-project/jpype/issues/913#issuecomment-767789793 for the problem description.

## Documentation
NA

## Testing
Checked manually.
